### PR TITLE
Route state corpus sources to country RuleSpec root

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1087"
+version = "0.2.1088"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1087"
+__version__ = "0.2.1088"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -242,6 +242,11 @@ def _resolve_policy_repo_for_corpus_source(
     jurisdiction = corpus_citation_path.strip().split("/", 1)[0] or "us"
     if override is not None:
         override = Path(override)
+        country_content_root = _country_content_root_for_corpus_jurisdiction(
+            override, jurisdiction
+        )
+        if country_content_root is not None:
+            return country_content_root.resolve()
         content_root = jurisdiction_content_dir(override, jurisdiction)
         if (
             create_missing_monorepo_content_root
@@ -252,6 +257,24 @@ def _resolve_policy_repo_for_corpus_source(
             content_root.mkdir(parents=True, exist_ok=True)
         return content_root.resolve()
     return _resolve_policy_repo_for_prefix(jurisdiction)
+
+
+def _country_content_root_for_corpus_jurisdiction(
+    override: Path, jurisdiction: str
+) -> Path | None:
+    """Return a country content root for subdivision corpus sources when present."""
+    country = jurisdiction.split("-", 1)[0]
+    if country == jurisdiction:
+        return None
+    repo_name = canonical_rulespec_repo_name(override) or override.name
+    if repo_name != monorepo_checkout_name(jurisdiction):
+        return None
+    if override.name == country:
+        return override
+    content_root = override / country
+    if content_root.is_dir():
+        return content_root
+    return None
 
 
 def _override_is_country_monorepo_for_jurisdiction(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -115,6 +115,7 @@ from axiom_encode.cli import (
     _repair_unit_scoped_person_definition_entities,
     _repair_upstream_placement_duplicate_imports,
     _require_axiom_encode_version_provenance,
+    _resolve_policy_repo_for_corpus_source,
     _rewrite_gpt_runner_backend,
     _rewrite_import_output_test_input_refs,
     _rewrite_judgment_conditional_formulas,
@@ -254,6 +255,56 @@ from axiom_encode.oracles.policyengine.ecps_snap import (
 from axiom_encode.statute import citation_to_citation_path, parse_usc_citation
 
 TEST_APPLY_SIGNING_KEY = "test-apply-signing-key"
+
+
+def test_resolve_policy_repo_for_state_corpus_source_uses_country_content_root(
+    tmp_path,
+):
+    repo = tmp_path / "rulespec-us"
+    country_root = repo / "us"
+    country_root.mkdir(parents=True)
+
+    resolved = _resolve_policy_repo_for_corpus_source(
+        "us-ia/regulation/iac/441/41/41.28",
+        repo,
+        create_missing_monorepo_content_root=True,
+    )
+
+    assert resolved == country_root.resolve()
+    assert not (repo / "us-ia").exists()
+
+
+def test_resolve_policy_repo_for_state_corpus_source_keeps_country_content_override(
+    tmp_path,
+):
+    repo = tmp_path / "rulespec-us"
+    country_root = repo / "us"
+    country_root.mkdir(parents=True)
+
+    resolved = _resolve_policy_repo_for_corpus_source(
+        "us-ia/regulation/iac/441/41/41.28",
+        country_root,
+        create_missing_monorepo_content_root=True,
+    )
+
+    assert resolved == country_root.resolve()
+    assert not (country_root / "us-ia").exists()
+
+
+def test_resolve_policy_repo_for_state_corpus_source_preserves_legacy_fallback(
+    tmp_path,
+):
+    repo = tmp_path / "rulespec-us"
+    repo.mkdir()
+
+    resolved = _resolve_policy_repo_for_corpus_source(
+        "us-ia/regulation/iac/441/41/41.28",
+        repo,
+        create_missing_monorepo_content_root=True,
+    )
+
+    assert resolved == (repo / "us-ia").resolve()
+    assert (repo / "us-ia").is_dir()
 
 
 def test_package_version_metadata_matches_pyproject():
@@ -4029,7 +4080,7 @@ class TestCmdEncode:
             == args.axiom_rules_path
         )
 
-    def test_encode_routes_state_corpus_citation_to_monorepo_jurisdiction_dir(
+    def test_encode_routes_state_corpus_citation_to_country_content_root(
         self, capsys, tmp_path
     ):
         policy_repo_path = tmp_path / "rulespec-us"
@@ -4044,9 +4095,9 @@ class TestCmdEncode:
         mock_run, exit_code = self._run_encode(args, self._make_eval_result(True))
 
         assert exit_code == 0
-        assert mock_run.call_args.kwargs["policy_path"] == policy_repo_path / "us-co"
+        assert mock_run.call_args.kwargs["policy_path"] == policy_repo_path / "us"
 
-    def test_encode_creates_missing_state_monorepo_jurisdiction_dir(
+    def test_encode_uses_existing_country_root_for_missing_state_dir(
         self, capsys, tmp_path
     ):
         policy_repo_path = tmp_path / "rulespec-us"
@@ -4060,8 +4111,8 @@ class TestCmdEncode:
         mock_run, exit_code = self._run_encode(args, self._make_eval_result(True))
 
         assert exit_code == 0
-        assert mock_run.call_args.kwargs["policy_path"] == policy_repo_path / "us-ks"
-        assert (policy_repo_path / "us-ks").is_dir()
+        assert mock_run.call_args.kwargs["policy_path"] == policy_repo_path / "us"
+        assert not (policy_repo_path / "us-ks").exists()
 
     def test_encode_passes_skip_reviewers_to_model_eval(self, capsys, tmp_path):
         args = self._make_args(tmp_path, skip_reviewers=True)

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1087"
+version = "0.2.1088"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- route subdivision corpus citations such as us-ia/... into the unified country content root when rulespec-us/us exists
- keep explicit country-content overrides working
- preserve legacy per-subdivision fallback only when no country content root is present

## Tests
- uv run --extra dev python -m pytest -q tests/test_cli.py -k resolve_policy_repo_for_state_corpus_source
- uv run --extra dev python -m pytest -q tests/test_repo_routing.py tests/test_cli.py -k resolve_policy_repo_for_state_corpus_source