### PR TITLE
Route state corpus encodes to RuleSpec state roots

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1088"
+version = "0.2.1089"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1088"
+__version__ = "0.2.1089"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -242,39 +242,19 @@ def _resolve_policy_repo_for_corpus_source(
     jurisdiction = corpus_citation_path.strip().split("/", 1)[0] or "us"
     if override is not None:
         override = Path(override)
-        country_content_root = _country_content_root_for_corpus_jurisdiction(
-            override, jurisdiction
-        )
-        if country_content_root is not None:
-            return country_content_root.resolve()
-        content_root = jurisdiction_content_dir(override, jurisdiction)
-        if (
-            create_missing_monorepo_content_root
-            and content_root == override
-            and _override_is_country_monorepo_for_jurisdiction(override, jurisdiction)
+        candidate_roots = candidate_jurisdiction_content_dirs(override, jurisdiction)
+        for candidate_root in candidate_roots:
+            if candidate_root.is_dir():
+                return candidate_root.resolve()
+        if create_missing_monorepo_content_root and (
+            _override_is_country_monorepo_for_jurisdiction(override, jurisdiction)
         ):
-            content_root = override / jurisdiction
+            content_root = candidate_roots[0] if candidate_roots else override
             content_root.mkdir(parents=True, exist_ok=True)
+        else:
+            content_root = jurisdiction_content_dir(override, jurisdiction)
         return content_root.resolve()
     return _resolve_policy_repo_for_prefix(jurisdiction)
-
-
-def _country_content_root_for_corpus_jurisdiction(
-    override: Path, jurisdiction: str
-) -> Path | None:
-    """Return a country content root for subdivision corpus sources when present."""
-    country = jurisdiction.split("-", 1)[0]
-    if country == jurisdiction:
-        return None
-    repo_name = canonical_rulespec_repo_name(override) or override.name
-    if repo_name != monorepo_checkout_name(jurisdiction):
-        return None
-    if override.name == country:
-        return override
-    content_root = override / country
-    if content_root.is_dir():
-        return content_root
-    return None
 
 
 def _override_is_country_monorepo_for_jurisdiction(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -257,12 +257,12 @@ from axiom_encode.statute import citation_to_citation_path, parse_usc_citation
 TEST_APPLY_SIGNING_KEY = "test-apply-signing-key"
 
 
-def test_resolve_policy_repo_for_state_corpus_source_uses_country_content_root(
+def test_resolve_policy_repo_for_state_corpus_source_uses_state_monorepo_root(
     tmp_path,
 ):
     repo = tmp_path / "rulespec-us"
-    country_root = repo / "us"
-    country_root.mkdir(parents=True)
+    state_root = repo / "us-ia"
+    state_root.mkdir(parents=True)
 
     resolved = _resolve_policy_repo_for_corpus_source(
         "us-ia/regulation/iac/441/41/41.28",
@@ -270,28 +270,10 @@ def test_resolve_policy_repo_for_state_corpus_source_uses_country_content_root(
         create_missing_monorepo_content_root=True,
     )
 
-    assert resolved == country_root.resolve()
-    assert not (repo / "us-ia").exists()
+    assert resolved == state_root.resolve()
 
 
-def test_resolve_policy_repo_for_state_corpus_source_keeps_country_content_override(
-    tmp_path,
-):
-    repo = tmp_path / "rulespec-us"
-    country_root = repo / "us"
-    country_root.mkdir(parents=True)
-
-    resolved = _resolve_policy_repo_for_corpus_source(
-        "us-ia/regulation/iac/441/41/41.28",
-        country_root,
-        create_missing_monorepo_content_root=True,
-    )
-
-    assert resolved == country_root.resolve()
-    assert not (country_root / "us-ia").exists()
-
-
-def test_resolve_policy_repo_for_state_corpus_source_preserves_legacy_fallback(
+def test_resolve_policy_repo_for_state_corpus_source_creates_state_monorepo_root(
     tmp_path,
 ):
     repo = tmp_path / "rulespec-us"
@@ -305,6 +287,40 @@ def test_resolve_policy_repo_for_state_corpus_source_preserves_legacy_fallback(
 
     assert resolved == (repo / "us-ia").resolve()
     assert (repo / "us-ia").is_dir()
+
+
+def test_resolve_policy_repo_for_state_corpus_source_uses_sibling_for_country_content_override(
+    tmp_path,
+):
+    repo = tmp_path / "rulespec-us"
+    country_root = repo / "us"
+    country_root.mkdir(parents=True)
+
+    resolved = _resolve_policy_repo_for_corpus_source(
+        "us-ia/regulation/iac/441/41/41.28",
+        country_root,
+        create_missing_monorepo_content_root=True,
+    )
+
+    assert resolved == (repo / "us-ia").resolve()
+    assert (repo / "us-ia").is_dir()
+    assert not (country_root / "us-ia").exists()
+
+
+def test_resolve_policy_repo_for_state_corpus_source_preserves_legacy_override(
+    tmp_path,
+):
+    repo = tmp_path / "rulespec-us-ia"
+    repo.mkdir()
+
+    resolved = _resolve_policy_repo_for_corpus_source(
+        "us-ia/regulation/iac/441/41/41.28",
+        repo,
+        create_missing_monorepo_content_root=True,
+    )
+
+    assert resolved == repo.resolve()
+    assert not (repo / "us-ia").exists()
 
 
 def test_package_version_metadata_matches_pyproject():
@@ -4080,7 +4096,7 @@ class TestCmdEncode:
             == args.axiom_rules_path
         )
 
-    def test_encode_routes_state_corpus_citation_to_country_content_root(
+    def test_encode_routes_state_corpus_citation_to_state_monorepo_root(
         self, capsys, tmp_path
     ):
         policy_repo_path = tmp_path / "rulespec-us"
@@ -4095,9 +4111,9 @@ class TestCmdEncode:
         mock_run, exit_code = self._run_encode(args, self._make_eval_result(True))
 
         assert exit_code == 0
-        assert mock_run.call_args.kwargs["policy_path"] == policy_repo_path / "us"
+        assert mock_run.call_args.kwargs["policy_path"] == policy_repo_path / "us-co"
 
-    def test_encode_uses_existing_country_root_for_missing_state_dir(
+    def test_encode_creates_state_monorepo_root_for_missing_state_dir(
         self, capsys, tmp_path
     ):
         policy_repo_path = tmp_path / "rulespec-us"
@@ -4111,8 +4127,8 @@ class TestCmdEncode:
         mock_run, exit_code = self._run_encode(args, self._make_eval_result(True))
 
         assert exit_code == 0
-        assert mock_run.call_args.kwargs["policy_path"] == policy_repo_path / "us"
-        assert not (policy_repo_path / "us-ks").exists()
+        assert mock_run.call_args.kwargs["policy_path"] == policy_repo_path / "us-ks"
+        assert (policy_repo_path / "us-ks").is_dir()
 
     def test_encode_passes_skip_reviewers_to_model_eval(self, capsys, tmp_path):
         args = self._make_args(tmp_path, skip_reviewers=True)

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1088"
+version = "0.2.1089"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- route state corpus citations in the country monorepo to jurisdiction subdirectories such as rulespec-us/us-ia
- preserve legacy per-jurisdiction overrides and country-content-root override handling
- bump axiom-encode to 0.2.1089

## Tests
- uv run --extra dev python -m pytest -q tests/test_cli.py -k "state_corpus_source or encode_routes_state_corpus_citation_to_state_monorepo_root or encode_creates_state_monorepo_root_for_missing_state_dir or current_encoder_affecting_changes_are_behind_version_bump or package_version_metadata_matches_pyproject"
- uv run --extra dev ruff check src/axiom_encode/cli.py tests/test_cli.py