### PR TITLE
Reject duplicate YAML mapping keys during validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1089"
+version = "0.2.1090"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1089"
+__version__ = "0.2.1090"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -89,6 +89,50 @@ DEFAULT_AXIOM_SUPABASE_ANON_KEY = (
 )
 
 
+class _UniqueKeySafeLoader(yaml.SafeLoader):
+    """PyYAML safe loader that rejects duplicate mapping keys."""
+
+
+def _construct_mapping_without_duplicate_keys(
+    loader: yaml.SafeLoader,
+    node: yaml.nodes.MappingNode,
+    deep: bool = False,
+) -> dict[Any, Any]:
+    loader.flatten_mapping(node)
+    seen: set[Any] = set()
+    for key_node, _value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        try:
+            duplicate = key in seen
+        except TypeError:
+            key = repr(key)
+            duplicate = key in seen
+        if duplicate:
+            raise yaml.constructor.ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                f"found duplicate key {key!r}",
+                key_node.start_mark,
+            )
+        seen.add(key)
+    return loader.construct_mapping(node, deep=deep)
+
+
+_UniqueKeySafeLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_mapping_without_duplicate_keys,
+)
+
+
+def _safe_load_unique_keys(content: str) -> Any:
+    """Load YAML with duplicate mapping keys treated as parse errors."""
+    return yaml.load(content, Loader=_UniqueKeySafeLoader)
+
+
+def _yaml_parse_issue(path: Path, exc: BaseException) -> str:
+    return f"{path.name} YAML parse failed: {exc}"
+
+
 def run_claude_code(
     prompt: str,
     model: str = REVIEWER_CLI_MODEL,
@@ -20756,10 +20800,22 @@ class ValidatorPipeline:
         ):
             return False
         try:
-            payload = yaml.safe_load(rules_file.read_text())
+            payload = _safe_load_unique_keys(rules_file.read_text())
         except (OSError, yaml.YAMLError, ValueError):
             return False
         return isinstance(payload, dict) and payload.get("format") == "rulespec/v1"
+
+    def _rulespec_yaml_preflight_issue(self, rules_file: Path) -> str | None:
+        """Return a parse/shape issue before invoking compile or CI validators."""
+        try:
+            payload = _safe_load_unique_keys(rules_file.read_text())
+        except OSError as exc:
+            return f"RuleSpec YAML read failed: {exc}"
+        except (yaml.YAMLError, ValueError) as exc:
+            return _yaml_parse_issue(rules_file, exc)
+        if not isinstance(payload, dict) or payload.get("format") != "rulespec/v1":
+            return "RuleSpec YAML artifacts are required."
+        return None
 
     def _rulespec_test_path(self, rules_file: Path) -> Path:
         """Return the companion RuleSpec test file path."""
@@ -20862,12 +20918,13 @@ class ValidatorPipeline:
 
     def _run_compile_check(self, rulespec_file: Path) -> ValidationResult:
         """Tier 0: Compile check against the Axiom rules engine RuleSpec."""
-        if not self._is_rulespec_file(rulespec_file):
+        yaml_issue = self._rulespec_yaml_preflight_issue(rulespec_file)
+        if yaml_issue:
             return ValidationResult(
                 validator_name="compile",
                 passed=False,
-                issues=["RuleSpec YAML artifacts are required."],
-                error="RuleSpec YAML artifacts are required",
+                issues=[yaml_issue],
+                error=yaml_issue,
             )
 
         return self._run_rulespec_compile_check(rulespec_file)
@@ -22097,9 +22154,9 @@ class ValidatorPipeline:
         test_path = self._rulespec_test_path(rules_file)
         if test_path.exists():
             try:
-                payload = yaml.safe_load(test_path.read_text())
+                payload = _safe_load_unique_keys(test_path.read_text())
             except (yaml.YAMLError, ValueError) as exc:
-                issues.append(f"Test YAML parse failed: {exc}")
+                issues.append(_yaml_parse_issue(test_path, exc))
             else:
                 if payload in (None, ""):
                     if not self._is_nonassertable_rulespec_artifact(rules_file):
@@ -22193,12 +22250,13 @@ class ValidatorPipeline:
 
     def _run_ci(self, rulespec_file: Path) -> ValidationResult:
         """Run CI checks for RuleSpec artifacts."""
-        if not self._is_rulespec_file(rulespec_file):
+        yaml_issue = self._rulespec_yaml_preflight_issue(rulespec_file)
+        if yaml_issue:
             return ValidationResult(
                 validator_name="ci",
                 passed=False,
-                issues=["RuleSpec YAML artifacts are required."],
-                error="RuleSpec YAML artifacts are required",
+                issues=[yaml_issue],
+                error=yaml_issue,
             )
         return self._run_rulespec_ci(rulespec_file)
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -117,6 +117,45 @@ AXIOM_RULES_PATH = Path("/Users/maxghenis/TheAxiomFoundation/axiom-rules-engine"
 AXIOM_RULES_ENGINE_BINARY = AXIOM_RULES_PATH / "target" / "debug" / "axiom-rules-engine"
 
 
+def test_validator_rejects_duplicate_rulespec_mapping_keys(tmp_path):
+    repo = tmp_path / "rulespec-us"
+    rules_file = (
+        repo / "us-ia" / "regulations" / "iac" / "441" / "41" / "41" / "28.yaml"
+    )
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+rules:
+  - name: shelter_basic_needs_component
+    kind: parameter
+    entity: Household
+    dtype: Money
+    period: Month
+    values:
+      10: 20.58
+      10: 20.58
+"""
+    )
+
+    pipeline = ValidatorPipeline(
+        policy_repo_path=repo / "us-ia",
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+    )
+
+    result = pipeline.validate(rules_file, skip_reviewers=True)
+
+    assert result.all_passed is False
+    assert any(
+        "duplicate key" in issue and "10" in issue
+        for issue in result.results["compile"].issues
+    )
+    assert any(
+        "duplicate key" in issue and "10" in issue
+        for issue in result.results["ci"].issues
+    )
+
+
 def test_rulespec_numeric_output_comparison_tolerates_decimal_residue(tmp_path):
     pipeline = ValidatorPipeline(
         policy_repo_path=tmp_path / "rulespec-us",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1089"
+version = "0.2.1090"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- reject duplicate mapping keys while loading RuleSpec YAML during validator preflight
- surface duplicate-key failures in both compile and CI validation paths
- add a regression test and bump axiom-encode to 0.2.1090

## Tests
- uv run --extra dev python -m pytest -q tests/test_rulespec_validation.py::test_validator_rejects_duplicate_rulespec_mapping_keys tests/test_cli.py::TestCmdValidate::test_validate_fail_json_output
- uv run --extra dev ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py