### PR TITLE
Classify Iowa FIP oracle mappings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1090"
+version = "0.2.1091"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1090"
+__version__ = "0.2.1091"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -21010,6 +21010,13 @@ prefixes:
     candidate_priority: P4
     rationale: Hawaii HAR §17-680-12 outputs decompose the source-level monthly assistance payment, initial-month proration, quotient truncation, whole-dollar rounding, and no-payment thresholds. PolicyEngine-US exposes hi_tanf as a final SPM-unit TANF benefit built from its own eligibility, income, and maximum-benefit graph; it does not expose this section's source-specific payment-determination helpers as one-to-one oracle variables.
 
+  - legal_id_prefix: us-ia:regulations/iac/441/41/41/28#
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Iowa IAC 441-41.28 outputs decompose Family Investment Program basic-needs, living-cost, special-needs, school-expense, guardian-fee, and related need-standard source mechanics. PolicyEngine-US does not currently expose an Iowa FIP/TANF final benefit surface or these source-specific Iowa regulation helpers as one-to-one oracle variables.
+
   - legal_id_prefix: us-ks:policies/dcf/keesm/keesm7410#
     country: us
     program: tanf

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1090"
+version = "0.2.1091"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Add a PolicyEngine oracle registry prefix for Iowa IAC 441-41.28 FIP outputs.
- Classify those source-level Iowa FIP need-standard outputs as not comparable because PolicyEngine-US does not expose Iowa FIP/TANF final or helper surfaces.

## Validation
- uv run --project . python - <<'PY' ... load_policyengine_registry() and resolve Iowa legal IDs
- uv run --project . axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ia-fip-20260703 --program tanf --fail-on-unmapped --limit 60
- uv run --project . python -m pytest -q tests/test_policyengine_classifier.py tests/test_policyengine_us_populace.py
- uv run --project . python -m pytest -q tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump

Note: I also ran ruff against the YAML file by mistake; ruff treats YAML as Python, so that output is not a relevant validation signal.