### PR TITLE
Reconcile TANF oracle surface queue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1091"
+version = "0.2.1092"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1091"
+__version__ = "0.2.1092"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -21010,12 +21010,21 @@ prefixes:
     candidate_priority: P4
     rationale: Hawaii HAR §17-680-12 outputs decompose the source-level monthly assistance payment, initial-month proration, quotient truncation, whole-dollar rounding, and no-payment thresholds. PolicyEngine-US exposes hi_tanf as a final SPM-unit TANF benefit built from its own eligibility, income, and maximum-benefit graph; it does not expose this section's source-specific payment-determination helpers as one-to-one oracle variables.
 
+  - legal_id: us-de:regulations/title-16/4000-financial-responsibility/4008/1/2#de_tanf
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: de_tanf
+    candidate_priority: P1
+    rationale: Axiom's Delaware TANF output follows 16 DE Admin. Code 4008.1.2's income test, earned-income deductions, 50 percent deficit remainder, and payment-standard cap using source-local standard-of-need and payment-standard inputs. PolicyEngine's de_tanf is a final monthly SPM-unit benefit gated by PE demographic, immigration, resource, standard/payment, and income helper graphs, so this source slice is adjacent rather than a one-to-one final-benefit oracle.
+
   - legal_id_prefix: us-ia:regulations/iac/441/41/41/28#
     country: us
     program: tanf
     mapping_type: not_comparable
+    policyengine_variable: ia_fip
     candidate_priority: P4
-    rationale: Iowa IAC 441-41.28 outputs decompose Family Investment Program basic-needs, living-cost, special-needs, school-expense, guardian-fee, and related need-standard source mechanics. PolicyEngine-US does not currently expose an Iowa FIP/TANF final benefit surface or these source-specific Iowa regulation helpers as one-to-one oracle variables.
+    rationale: Iowa IAC 441-41.28 outputs decompose Family Investment Program basic-needs, living-cost, special-needs, school-expense, guardian-fee, and related need-standard source mechanics. PolicyEngine-US exposes ia_fip as a final SPM-unit benefit built from PE eligibility, countable-income, payment-standard, and standard-of-need graphs, not these source-specific Iowa regulation helpers as one-to-one oracle variables.
 
   - legal_id_prefix: us-ks:policies/dcf/keesm/keesm7410#
     country: us

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -634,10 +634,12 @@ surfaces:
   variable: de_tanf
   source_type: state_implementation
   state: DE
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Axiom encodes 16 DE Admin. Code 4008.1.2's TANF gross-income, countable-income, deficit-remainder,
+    and grant-cap mechanics as a source-local legal output. PolicyEngine's de_tanf is a final monthly SPM-unit benefit
+    gated by PE demographic, immigration, resource, standard-of-need, payment-standard, and income helper graphs, so
+    this Delaware source slice is adjacent progress rather than a one-to-one final-benefit oracle.
 - country: us
   program_id: tanf
   program_name: Oregon TANF
@@ -948,10 +950,12 @@ surfaces:
   variable: ia_fip
   source_type: state_implementation
   state: IA
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Axiom encodes Iowa IAC 441-41.28 Family Investment Program need-standard components from the primary
+    regulation. PolicyEngine's ia_fip is a final monthly SPM-unit benefit using PE eligibility, countable-income,
+    payment-standard, and standard-of-need graphs, so the encoded Iowa source mechanics are adjacent coverage rather
+    than a one-to-one final-benefit oracle.
 - country: us
   program_id: tanf
   program_name: Louisiana FITAP

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2175,6 +2175,41 @@ def test_policyengine_program_surface_marks_indiana_tanf_known_not_comparable():
     assert "source-local monthly benefit entitlement" in indiana_tanf["rationale"]
 
 
+def test_policyengine_program_surface_marks_delaware_tanf_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="de_tanf")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    delaware_tanf = items_by_variable["de_tanf"]
+
+    assert delaware_tanf["program_id"] == "tanf"
+    assert delaware_tanf["state"] == "DE"
+    assert delaware_tanf["axiom_status"] == "known_not_comparable"
+    assert delaware_tanf["mapping_count"] >= 1
+    assert delaware_tanf["comparable_mapping_count"] == 0
+    assert (
+        "us-de:regulations/title-16/4000-financial-responsibility/4008/1/2#de_tanf"
+        in delaware_tanf["legal_ids"]
+    )
+    assert "16 DE Admin. Code 4008.1.2" in delaware_tanf["rationale"]
+    assert "final monthly SPM-unit benefit" in delaware_tanf["rationale"]
+
+
+def test_policyengine_program_surface_marks_iowa_fip_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="ia_fip")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    iowa_fip = items_by_variable["ia_fip"]
+
+    assert iowa_fip["program_id"] == "tanf"
+    assert iowa_fip["state"] == "IA"
+    assert iowa_fip["axiom_status"] == "known_not_comparable"
+    assert iowa_fip["mapping_count"] >= 1
+    assert iowa_fip["comparable_mapping_count"] == 0
+    assert "us-ia:regulations/iac/441/41/41/28#" in iowa_fip["legal_ids"]
+    assert "Iowa IAC 441-41.28" in iowa_fip["rationale"]
+    assert "final monthly SPM-unit benefit" in iowa_fip["rationale"]
+
+
 def test_policyengine_coverage_maps_georgia_ssp_nursing_home_supplement(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "us-ga" / "policies/dfcs/medicaid/2578.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1091"
+version = "0.2.1092"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- mark Delaware TANF and Iowa FIP as known-not-comparable PE surfaces now that Axiom has adjacent primary-source RuleSpec coverage
- add exact/prefix not-comparable mappings so the PE cloud queue no longer treats those surfaces as pending encoding work
- add coverage tests and bump axiom-encode to 0.2.1092

## Verification
- `uv run --project . python -m pytest -q tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_delaware_tanf_known_not_comparable tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_iowa_fip_known_not_comparable`
- `uv run --project . axiom-encode cloud-queue --root /Users/maxghenis/TheAxiomFoundation --oracle policyengine --country us --limit 10` (P1 queue now 26; Delaware and Iowa removed)
- `uv run --project . python -m pytest -q tests/test_policyengine_coverage.py tests/test_policyengine_classifier.py`
- `git diff --check`
- `uv run --project . ruff check src/ tests/`
- `uv run --project . ruff format --check src/ tests/`
- `uv run --project . python -m pytest -q tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`