### PR TITLE
Reconcile Idaho TAFI PolicyEngine surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1092"
+version = "0.2.1093"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1092"
+__version__ = "0.2.1093"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -805,10 +805,15 @@ surfaces:
   variable: id_tafi
   source_type: state_implementation
   state: ID
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: >-
+    Current official Idaho sources do not support PolicyEngine's id_tafi final-benefit formula as cited. PE references
+    historical Cornell pages for IDAPA 16.03.08.248-.252, but the official current IDAPA 16.03.08 PDF published July 1,
+    2026 only contains TANF sections 100-115 and LIHEAP sections 200-205. Idaho DHW's current TAFI pages substantiate the
+    $309 cap and partial July 2002 household income table, but not the full 60%-earned-income/work-incentive formula or
+    9+/10+/over-10 table PE applies. Treat this as a source-hierarchy conflict rather than an encodeable parity gap until
+    the current upstream Idaho policy source or PE implementation is reconciled.
 - country: us
   program_id: tanf
   program_name: Nebraska ADC

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2210,6 +2210,25 @@ def test_policyengine_program_surface_marks_iowa_fip_known_not_comparable():
     assert "final monthly SPM-unit benefit" in iowa_fip["rationale"]
 
 
+def test_policyengine_program_surface_marks_idaho_tafi_source_conflict_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="id_tafi")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    idaho_tafi = items_by_variable["id_tafi"]
+
+    assert idaho_tafi["program_id"] == "tanf"
+    assert idaho_tafi["state"] == "ID"
+    assert idaho_tafi["axiom_status"] == "known_not_comparable"
+    assert idaho_tafi["mapping_count"] == 0
+    assert idaho_tafi["comparable_mapping_count"] == 0
+    assert "source-hierarchy conflict" in idaho_tafi["rationale"]
+    assert (
+        "historical Cornell pages for IDAPA 16.03.08.248-.252"
+        in idaho_tafi["rationale"]
+    )
+    assert "official current IDAPA 16.03.08 PDF" in idaho_tafi["rationale"]
+
+
 def test_policyengine_coverage_maps_georgia_ssp_nursing_home_supplement(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "us-ga" / "policies/dfcs/medicaid/2578.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1092"
+version = "0.2.1093"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- mark Idaho TAFI as known-not-comparable instead of pending PE parity encoding
- document the source-hierarchy conflict: PE cites historical Cornell IDAPA 16.03.08.248-.252, while the current official Idaho rule PDF only includes TANF sections 100-115 and LIHEAP 200-205
- add coverage so the PE queue keeps Idaho TAFI out of ordinary encodeable work until the upstream Idaho source or PE implementation is reconciled

## Checks
- uv run --project . python -m pytest -q tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_idaho_tafi_source_conflict_known_not_comparable
- uv run --project . python -m pytest -q tests/test_policyengine_coverage.py tests/test_policyengine_classifier.py
- uv run --project . python -m pytest -q tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump
- uv run --project . ruff check src/ tests/
- uv run --project . ruff format --check src/ tests/
- git diff --check
- uv run --project . axiom-encode cloud-queue --root /Users/maxghenis/TheAxiomFoundation --oracle policyengine --country us --limit 10