### PR TITLE
Reconcile Kentucky KTAP PolicyEngine surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1093"
+version = "0.2.1094"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1093"
+__version__ = "0.2.1094"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -888,10 +888,15 @@ surfaces:
   variable: ky_ktap
   source_type: state_implementation
   state: KY
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: >-
+    Current upstream Kentucky law supports encoding 921 KAR 2:016 and KRS 205.200(2), but PolicyEngine's active 2025
+    ky_ktap payment maximums are sourced from KY FACES rather than a regulatory instrument. Current 921 KAR 2:016 Section
+    9(2)(a) lists payment maximums of $372, $450, $524, $656, $766, $864, and $964 for one through seven-or-more eligible
+    persons, while PE applies lower 2025 values of $242, $293, $341, $426, $498, $562, and $627 from a KY FACES table
+    labeled by number of children. Treat this as a source-hierarchy conflict rather than an encodeable parity gap until
+    the legal authority for the 2025 reduction or the PE implementation is reconciled.
 - country: us
   program_id: tanf
   program_name: Alabama TANF

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2229,6 +2229,23 @@ def test_policyengine_program_surface_marks_idaho_tafi_source_conflict_known_not
     assert "official current IDAPA 16.03.08 PDF" in idaho_tafi["rationale"]
 
 
+def test_policyengine_program_surface_marks_kentucky_ktap_source_conflict_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="ky_ktap")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    kentucky_ktap = items_by_variable["ky_ktap"]
+
+    assert kentucky_ktap["program_id"] == "tanf"
+    assert kentucky_ktap["state"] == "KY"
+    assert kentucky_ktap["axiom_status"] == "known_not_comparable"
+    assert kentucky_ktap["mapping_count"] == 0
+    assert kentucky_ktap["comparable_mapping_count"] == 0
+    assert "source-hierarchy conflict" in kentucky_ktap["rationale"]
+    assert "Current upstream Kentucky law" in kentucky_ktap["rationale"]
+    assert "921 KAR 2:016 Section 9(2)(a)" in kentucky_ktap["rationale"]
+    assert "KY FACES table labeled by number of children" in kentucky_ktap["rationale"]
+
+
 def test_policyengine_coverage_maps_georgia_ssp_nursing_home_supplement(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "us-ga" / "policies/dfcs/medicaid/2578.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1093"
+version = "0.2.1094"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- mark Kentucky KTAP known-not-comparable instead of pending PE parity encoding
- document the source-hierarchy conflict between current 921 KAR/KRS authority and PE's 2025 KY FACES payment maximums
- add coverage so the PE queue no longer sends ky_ktap to ordinary encoders until the legal authority or PE implementation is reconciled

## Checks
- uv run --project . python -m pytest -q tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_kentucky_ktap_source_conflict_known_not_comparable
- uv run --project . python -m pytest -q tests/test_policyengine_coverage.py tests/test_policyengine_classifier.py
- uv run --project . python -m pytest -q tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump
- uv run --project . ruff check src/ tests/
- uv run --project . ruff format --check src/ tests/
- git diff --check
- uv run --project . axiom-encode cloud-queue --root /Users/maxghenis/TheAxiomFoundation --oracle policyengine --country us --limit 10