### PR TITLE
Mark Maryland TCA pending source ingestion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1095"
+version = "0.2.1096"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1095"
+__version__ = "0.2.1096"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -478,10 +478,13 @@ surfaces:
   variable: md_tca
   source_type: state_implementation
   state: MD
-  axiom_status: pending_rulespec_encoding
+  axiom_status: pending_source_ingestion
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Primary-source review found that current COMAR 07.03.03.17 still carries the stale November 2013 grant schedule,
+    while PolicyEngine's 2025 benefit table is sourced to Maryland DHS FIA Information Memo 25-12 and Maryland DHS has since
+    published IM 26-13 as a superseding 2026 TCA/TDAP benefit-increase memo. Axiom has ingested the governing Maryland Human
+    Services Article provisions and COMAR 07.03.03, but should not encode current TCA amounts until DHS IM 26-13, IM 25-12 for
+    PE's historical 2025 table, or an equivalent official schedule is ingested through axiom-corpus.
 - country: us
   program_id: tanf
   program_name: South Dakota TANF

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2246,6 +2246,23 @@ def test_policyengine_program_surface_marks_kentucky_ktap_source_conflict_known_
     assert "KY FACES table labeled by number of children" in kentucky_ktap["rationale"]
 
 
+def test_policyengine_program_surface_marks_maryland_tca_pending_source_ingestion():
+    report = build_policyengine_program_surface_report(program="md_tca")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    maryland_tca = items_by_variable["md_tca"]
+
+    assert maryland_tca["program_id"] == "tanf"
+    assert maryland_tca["state"] == "MD"
+    assert maryland_tca["axiom_status"] == "pending_source_ingestion"
+    assert maryland_tca["mapping_count"] == 0
+    assert maryland_tca["comparable_mapping_count"] == 0
+    assert "COMAR 07.03.03.17" in maryland_tca["rationale"]
+    assert "Maryland DHS FIA Information Memo 25-12" in maryland_tca["rationale"]
+    assert "IM 26-13 as a superseding 2026 TCA/TDAP" in maryland_tca["rationale"]
+    assert "should not encode current TCA amounts" in maryland_tca["rationale"]
+
+
 def test_policyengine_coverage_maps_georgia_ssp_nursing_home_supplement(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "us-ga" / "policies/dfcs/medicaid/2578.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1095"
+version = "0.2.1096"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Move Maryland TCA from ready-to-encode to pending source ingestion after primary-source review
- Document that current COMAR carries the stale 2013 schedule while PE's 2025 table depends on DHS FIA IM 25-12
- Add a regression test for the queue classification and bump the encoder version

## Test plan
- `uv run --project . python -m pytest -q tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_maryland_tca_pending_source_ingestion tests/test_policyengine_coverage.py::test_policyengine_cloud_queue_exports_actionable_program_surfaces`
- `COVERAGE_FILE=.coverage.version uv run --project . python -m pytest -q tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`
- `git diff --check HEAD`
- `uv run --project . axiom-encode cloud-queue --country us --program tanf --limit 10 --json`