### PR TITLE
Fix local corpus text resolution

### DIFF
--- a/changelog.d/local-corpus-text-resolution.fixed.md
+++ b/changelog.d/local-corpus-text-resolution.fixed.md
@@ -1,0 +1,1 @@
+Fix local corpus resolution for official-document rows that store source text in `text`, and prefer the current `data/corpus/provisions` layout over legacy top-level `provisions` directories.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1096"
+version = "0.2.1097"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1096"
+__version__ = "0.2.1097"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -66,6 +66,7 @@ from .validator_pipeline import (
     ValidatorPipeline,
     _candidate_local_corpus_provision_files,
     _fetch_supabase_corpus_source_text,
+    _local_corpus_record_text,
     _read_local_corpus_provision_file,
     _source_text_looks_like_table,
     extract_embedded_source_text,
@@ -2704,7 +2705,7 @@ def _read_local_corpus_descendant_text(
         record_path = str(record.get("citation_path") or "")
         if not record_path.startswith(child_prefix):
             continue
-        body = record.get("body")
+        body = _local_corpus_record_text(record)
         if body is None:
             continue
         descendants.append(
@@ -2713,7 +2714,7 @@ def _read_local_corpus_descendant_text(
                 int(record.get("ordinal") or 0),
                 str(record.get("heading") or ""),
                 record_path,
-                str(body),
+                body,
             )
         )
 
@@ -2731,10 +2732,10 @@ def _read_local_corpus_descendant_text(
 def _corpus_provisions_root(corpus_path: Path) -> Path | None:
     root = Path(corpus_path).expanduser()
     candidates = (
-        root,
-        root / "provisions",
-        root / "data" / "corpus",
         root / "data" / "corpus" / "provisions",
+        root / "data" / "corpus",
+        root / "provisions",
+        root,
     )
     for candidate in candidates:
         provisions_root = (

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -19303,10 +19303,10 @@ def _local_corpus_provisions_roots() -> tuple[Path, ...]:
     seen: set[Path] = set()
     for root in roots:
         for candidate in (
-            root,
-            root / "provisions",
-            root / "data" / "corpus",
             root / "data" / "corpus" / "provisions",
+            root / "data" / "corpus",
+            root / "provisions",
+            root,
         ):
             provisions_root = (
                 candidate
@@ -19382,9 +19382,7 @@ def _read_local_corpus_provision_file(
 def _select_local_corpus_record_body(records: list[dict[str, Any]]) -> str | None:
     """Select the best body when local corpus files contain duplicate citations."""
     body_records = [
-        record
-        for record in records
-        if isinstance(record.get("body"), str) and record["body"].strip()
+        record for record in records if _local_corpus_record_text(record) is not None
     ]
     if not body_records:
         return None
@@ -19397,7 +19395,16 @@ def _select_local_corpus_record_body(records: list[dict[str, Any]]) -> str | Non
         return (source_as_of, official_source, version)
 
     selected = max(body_records, key=record_key)
-    return str(selected["body"])
+    return _local_corpus_record_text(selected)
+
+
+def _local_corpus_record_text(record: dict[str, Any]) -> str | None:
+    """Return local corpus provision text across supported row schemas."""
+    for key in ("body", "text"):
+        value = record.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
 
 
 def _read_local_corpus_descendant_text(
@@ -19424,7 +19431,7 @@ def _read_local_corpus_descendant_text(
         record_path = str(record.get("citation_path") or "")
         if not record_path.startswith(child_prefix):
             continue
-        body = record.get("body")
+        body = _local_corpus_record_text(record)
         if body is None:
             continue
         descendants.append(
@@ -19432,7 +19439,7 @@ def _read_local_corpus_descendant_text(
                 int(record.get("level") or 0),
                 int(record.get("ordinal") or 0),
                 str(record.get("heading") or "") or None,
-                str(body),
+                body,
             )
         )
 

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -30,6 +30,7 @@ from axiom_encode.harness.evals import (
     _command_looks_out_of_bounds,
     _command_uses_policyengine_skill,
     _context_file_executable_surfaces,
+    _corpus_provisions_root,
     _eval_result_from_payload,
     _evaluate_generated_artifact_with_repairs,
     _format_subparagraph_coverage_checklist,
@@ -149,6 +150,80 @@ def test_resolve_corpus_source_unit_normalizes_colon_prefixed_local_citation(tmp
     assert source_unit.source == "local"
     assert source_unit.citation_path == "us-ca/regulation/cdss/eas/49/49-040"
     assert source_unit.body == "CAPI resource limits."
+
+
+def test_resolve_corpus_source_unit_reads_text_field_rows(tmp_path):
+    corpus_path = tmp_path / "axiom-corpus"
+    provisions_dir = (
+        corpus_path / "data" / "corpus" / "provisions" / "us-me" / "regulation"
+    )
+    provisions_dir.mkdir(parents=True)
+    (provisions_dir / "official-documents.jsonl").write_text(
+        json.dumps(
+            {
+                "citation_path": "us-me/regulation/dhhs/ofi/chapter-331/block-4",
+                "text": "Maine TANF grant table source text.",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    source_unit = resolve_corpus_source_unit(
+        "us-me/regulation/dhhs/ofi/chapter-331/block-4",
+        corpus_path,
+    )
+
+    assert source_unit.source == "local"
+    assert source_unit.citation_path == "us-me/regulation/dhhs/ofi/chapter-331/block-4"
+    assert source_unit.body == "Maine TANF grant table source text."
+
+
+def test_resolve_corpus_source_unit_concatenates_descendant_text_rows(tmp_path):
+    corpus_path = tmp_path / "axiom-corpus"
+    provisions_dir = (
+        corpus_path / "data" / "corpus" / "provisions" / "us-me" / "regulation"
+    )
+    provisions_dir.mkdir(parents=True)
+    rows = [
+        {
+            "citation_path": "us-me/regulation/dhhs/ofi/chapter-331",
+        },
+        {
+            "citation_path": "us-me/regulation/dhhs/ofi/chapter-331/block-1",
+            "ordinal": 2,
+            "text": "Second extracted block.",
+        },
+        {
+            "citation_path": "us-me/regulation/dhhs/ofi/chapter-331/block-2",
+            "ordinal": 1,
+            "heading": "Need standards",
+            "text": "First extracted block.",
+        },
+    ]
+    (provisions_dir / "official-documents.jsonl").write_text(
+        "".join(json.dumps(row) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+    source_unit = resolve_corpus_source_unit(
+        "us-me/regulation/dhhs/ofi/chapter-331",
+        corpus_path,
+    )
+
+    assert source_unit.body == (
+        "Need standards\n\nFirst extracted block.\n\nSecond extracted block."
+    )
+
+
+def test_corpus_provisions_root_prefers_current_data_corpus_layout(tmp_path):
+    corpus_path = tmp_path / "axiom-corpus"
+    legacy_root = corpus_path / "provisions"
+    current_root = corpus_path / "data" / "corpus" / "provisions"
+    legacy_root.mkdir(parents=True)
+    current_root.mkdir(parents=True)
+
+    assert _corpus_provisions_root(corpus_path) == current_root.resolve()
 
 
 def test_source_identifier_maps_state_manual_to_policies_repo_path():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1096"
+version = "0.2.1097"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- prefer current data/corpus/provisions over legacy top-level provisions when resolving a local axiom-corpus checkout
- accept official-document corpus rows that store source text in text rather than body
- cover direct text rows, descendant text rows, and mixed corpus-root layouts

## Tests
- uv run --extra dev --project . ruff check src/axiom_encode/harness/evals.py src/axiom_encode/harness/validator_pipeline.py tests/test_evals.py
- uv run --extra dev --project . python -m pytest -q tests/test_evals.py::test_resolve_corpus_source_unit_normalizes_colon_prefixed_local_citation tests/test_evals.py::test_resolve_corpus_source_unit_reads_text_field_rows tests/test_evals.py::test_resolve_corpus_source_unit_concatenates_descendant_text_rows tests/test_evals.py::test_corpus_provisions_root_prefers_current_data_corpus_layout

Unblocks Maine TANF encoding from the newly merged official-document corpus rows.