### PR TITLE
Classify Belgium as PolicyEngine non-comparable

### DIFF
--- a/changelog.d/be-policyengine-noncomparable.added.md
+++ b/changelog.d/be-policyengine-noncomparable.added.md
@@ -1,0 +1,1 @@
+Classify Belgium RuleSpec legal-ID prefixes as PolicyEngine non-comparable so Belgium uses EUROMOD/FANTASI household-level oracle coverage instead of failing the PolicyEngine registry gate as unmapped.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1097"
+version = "0.2.1098"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1097"
+__version__ = "0.2.1098"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/be.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/be.yaml
@@ -1,0 +1,26 @@
+prefixes:
+  - legal_id_prefix: "be:"
+    country: be
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Belgium RuleSpec outputs are validated against Belgium-specific household-level oracles such as EUROMOD and FANTASI, not PolicyEngine. PolicyEngine does not provide a Belgium runtime surface with one-to-one legal-ID targets for these national outputs; exact PolicyEngine mappings should be added only if a real Belgium PolicyEngine oracle target is implemented.
+  - legal_id_prefix: "be-bru:"
+    country: be
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Belgium regional and community RuleSpec outputs are validated against Belgium-specific household-level oracles such as EUROMOD and FANTASI, not PolicyEngine. PolicyEngine does not provide a Belgium runtime surface with one-to-one legal-ID targets for Brussels outputs; exact PolicyEngine mappings should be added only if a real Belgium PolicyEngine oracle target is implemented.
+  - legal_id_prefix: "be-dg:"
+    country: be
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Belgium regional and community RuleSpec outputs are validated against Belgium-specific household-level oracles such as EUROMOD and FANTASI, not PolicyEngine. PolicyEngine does not provide a Belgium runtime surface with one-to-one legal-ID targets for German-speaking Community outputs; exact PolicyEngine mappings should be added only if a real Belgium PolicyEngine oracle target is implemented.
+  - legal_id_prefix: "be-vlg:"
+    country: be
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Belgium regional and community RuleSpec outputs are validated against Belgium-specific household-level oracles such as EUROMOD and FANTASI, not PolicyEngine. PolicyEngine does not provide a Belgium runtime surface with one-to-one legal-ID targets for Flanders outputs; exact PolicyEngine mappings should be added only if a real Belgium PolicyEngine oracle target is implemented.
+  - legal_id_prefix: "be-wal:"
+    country: be
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Belgium regional and community RuleSpec outputs are validated against Belgium-specific household-level oracles such as EUROMOD and FANTASI, not PolicyEngine. PolicyEngine does not provide a Belgium runtime surface with one-to-one legal-ID targets for Wallonia outputs; exact PolicyEngine mappings should be added only if a real Belgium PolicyEngine oracle target is implemented.

--- a/tests/test_policyengine_coverage_monorepo.py
+++ b/tests/test_policyengine_coverage_monorepo.py
@@ -73,6 +73,15 @@ rules:
         formula: local_input
 """
 
+_BELGIUM_RULESPEC = """format: rulespec/v1
+rules:
+  - name: household_benefit_amount
+    kind: derived
+    versions:
+      - effective_from: '2025-01-01'
+        formula: household_income * 0
+"""
+
 _UK_VAT_RULESPEC = """format: rulespec/v1
 rules:
   - name: vat_registration_threshold
@@ -358,6 +367,36 @@ def test_uk_vat_policy_outputs_are_classified_not_comparable(tmp_path):
         assert item["program"] == "vat"
         assert item["status"] == "known_not_comparable"
         assert item["mapping_type"] == "not_comparable"
+
+
+def test_belgium_outputs_are_policyengine_non_comparable(tmp_path):
+    """Belgium uses EUROMOD/FANTASI household oracles, not PolicyEngine."""
+    root = tmp_path / "mono" / "rulespec-be"
+    jurisdictions = {
+        "be": "statutes/cir-92/article-1.yaml",
+        "be-bru": "regulations/housing/example.yaml",
+        "be-dg": "regulations/family/example.yaml",
+        "be-vlg": "regulations/social-protection/example.yaml",
+        "be-wal": "regulations/housing/example.yaml",
+    }
+    for prefix, relative in jurisdictions.items():
+        _write(root / prefix / relative, _BELGIUM_RULESPEC)
+
+    report = build_policyengine_coverage_report(root.parent)
+
+    assert report["total_outputs"] == 5
+    assert report["status_counts"] == {"known_not_comparable": 5}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    for prefix, relative in jurisdictions.items():
+        legal_id = (
+            f"{prefix}:{Path(relative).with_suffix('').as_posix()}"
+            "#household_benefit_amount"
+        )
+        item = items_by_id[legal_id]
+        assert item["repo"] == f"rulespec-{prefix}"
+        assert item["status"] == "known_not_comparable"
+        assert item["mapping_type"] == "not_comparable"
+        assert item["candidate_priority"] == "P4"
 
 
 def test_monorepo_program_directory_is_not_a_jurisdiction(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1097"
+version = "0.2.1098"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Add Belgium national, regional, and community legal-ID prefixes to the PolicyEngine oracle registry as explicit not-comparable surfaces
- Document that Belgium validation uses household-level EUROMOD/FANTASI oracles rather than PolicyEngine
- Add a regression test covering BE, BE-BRU, BE-DG, BE-VLG, and BE-WAL monorepo outputs

## Verification
- uv run ruff format --check tests/test_policyengine_coverage_monorepo.py
- uv run ruff check tests/test_policyengine_coverage_monorepo.py src/axiom_encode/oracles/policyengine/registry.py
- uv run pytest tests/test_policyengine_coverage_monorepo.py::test_belgium_outputs_are_policyengine_non_comparable tests/test_policyengine_coverage_monorepo.py::test_uk_vat_policy_outputs_are_classified_not_comparable
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/rulespec-be-workbonus --fail-on-unmapped --fail-on-untested-comparable --limit 20