### PR TITLE
Classify Maine TANF Rule 125A oracle coverage

### DIFF
--- a/changelog.d/me-tanf-rule-125a-oracle-coverage.changed.md
+++ b/changelog.d/me-tanf-rule-125a-oracle-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify Maine TANF Rule 125A source-table outputs for PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1098"
+version = "0.2.1099"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1098"
+__version__ = "0.2.1099"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -21050,6 +21050,14 @@ prefixes:
     candidate_priority: P4
     rationale: Louisiana FITAP B-640 outputs decompose source-local income-limit, flat-grant, 18+ household, minimum-payment, and rounded-deficit grant rules. PolicyEngine-US exposes la_fitap as a final monthly benefit surface, but currently omits the B-640 rounded-down deficit and under-$10 no-payment rules, so these source-faithful RuleSpec outputs are not one-to-one comparable.
 
+  - legal_id_prefix: us-me:regulations/dhhs/ofi/chapter-331/tanf-rule-125a/maximum-benefit-and-standard-of-need#
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: me_tanf
+    candidate_priority: P4
+    rationale: Maine TANF Rule 125A outputs expose the FFY 2022-2026 Adult Included and Child Only standard-of-need and maximum-grant table, add-member rows, and special-need housing addition as source-level legal table mechanics. PolicyEngine's me_tanf surface is a final SPM-unit benefit graph with older 2024 Rule 121A parameter references and no separate child-only/adult-included table boundary, so these current Rule 125A outputs are adjacent coverage rather than one-to-one oracle targets.
+
   - legal_id: us-nv:policies/dwss/eligibility-payments/a-600/page-38#tanf_minimum_issuable_benefit
     country: us
     program: tanf

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -574,10 +574,13 @@ surfaces:
   variable: me_tanf
   source_type: state_implementation
   state: ME
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Axiom now has source-level Maine TANF Rule 125A coverage for current FFY 2022-2026 adult-included
+    and child-only standard-of-need and maximum-grant table mechanics. PolicyEngine's me_tanf is a final SPM-unit
+    benefit graph with older Rule 121A parameter references and no separate child-only/adult-included table boundary,
+    so keep it known-not-comparable until the remaining eligibility, income, resource, and final-benefit graph is
+    encoded and PE exposes or updates matching current-source boundaries.
 - country: us
   program_id: tanf
   program_name: Nevada TANF

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -3976,6 +3976,124 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_maine_tanf_rule_125a_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us"
+        / "us-me"
+        / "regulations/dhhs/ofi/chapter-331/tanf-rule-125a"
+        / "maximum-benefit-and-standard-of-need.yaml",
+        """format: rulespec/v1
+rules:
+  - name: tanf_table_max_household_size
+    kind: parameter
+    versions:
+      - effective_from: '2021-10-01'
+        formula: 8
+  - name: special_need_housing_addition
+    kind: parameter
+    versions:
+      - effective_from: '2021-10-01'
+        formula: 300
+  - name: adult_included_standard_of_need_base
+    kind: parameter
+    versions:
+      - effective_from: '2021-10-01'
+        formula: 362
+  - name: adult_included_maximum_grant_base
+    kind: parameter
+    versions:
+      - effective_from: '2021-10-01'
+        formula: 298
+  - name: child_only_standard_of_need_base
+    kind: parameter
+    versions:
+      - effective_from: '2021-10-01'
+        formula: 214
+  - name: child_only_maximum_grant_base
+    kind: parameter
+    versions:
+      - effective_from: '2021-10-01'
+        formula: 178
+  - name: adult_included_standard_of_need_add_member
+    kind: parameter
+    versions:
+      - effective_from: '2021-10-01'
+        formula: 195
+  - name: adult_included_maximum_grant_add_member
+    kind: parameter
+    versions:
+      - effective_from: '2021-10-01'
+        formula: 160
+  - name: child_only_standard_of_need_add_member
+    kind: parameter
+    versions:
+      - effective_from: '2021-10-01'
+        formula: 195
+  - name: child_only_maximum_grant_add_member
+    kind: parameter
+    versions:
+      - effective_from: '2021-10-01'
+        formula: 160
+  - name: adult_included_standard_of_need
+    kind: derived
+    versions:
+      - effective_from: '2021-10-01'
+        formula: adult_included_standard_of_need_base
+  - name: adult_included_maximum_grant
+    kind: derived
+    versions:
+      - effective_from: '2021-10-01'
+        formula: adult_included_maximum_grant_base
+  - name: child_only_standard_of_need
+    kind: derived
+    versions:
+      - effective_from: '2021-10-01'
+        formula: child_only_standard_of_need_base
+  - name: child_only_maximum_grant
+    kind: derived
+    versions:
+      - effective_from: '2021-10-01'
+        formula: child_only_maximum_grant_base
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tanf")
+
+    assert report["total_outputs"] == 14
+    assert report["status_counts"] == {"known_not_comparable": 14}
+    assert report["untested_comparable"] == 0
+    assert {item["program"] for item in report["items"]} == {"tanf"}
+    assert {item["mapping_type"] for item in report["items"]} == {"not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {"me_tanf"}
+    assert all(
+        "Maine TANF Rule 125A outputs expose the FFY 2022-2026"
+        in str(item["rationale"])
+        for item in report["items"]
+    )
+
+
+def test_policyengine_program_surface_marks_maine_tanf_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="tanf")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    maine_tanf = items_by_variable["me_tanf"]
+
+    assert maine_tanf["program_id"] == "tanf"
+    assert maine_tanf["state"] == "ME"
+    assert maine_tanf["axiom_status"] == "known_not_comparable"
+    assert maine_tanf["mapping_count"] == 1
+    assert maine_tanf["comparable_mapping_count"] == 0
+    assert (
+        "us-me:regulations/dhhs/ofi/chapter-331/tanf-rule-125a/"
+        "maximum-benefit-and-standard-of-need#" in maine_tanf["legal_ids"]
+    )
+    assert "Rule 125A coverage" in maine_tanf["rationale"]
+    assert "older Rule 121A parameter references" in maine_tanf["rationale"]
+
+
 def test_policyengine_coverage_infers_health_programs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us-co" / "regulations/hcpf/health-coverage.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1098"
+version = "0.2.1099"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify Maine TANF Rule 125A source-table outputs as known-not-comparable against PolicyEngine's final me_tanf surface
- mark the Maine TANF program surface accordingly
- add regression coverage for the Rule 125A outputs and bump axiom-encode to 0.2.1099

## Checks
- uv run --extra dev --project . ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py
- uv run --extra dev --project . python - <<'PY'
from pathlib import Path
import yaml
for rel in ['src/axiom_encode/oracles/policyengine/mappings/us.yaml', 'src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml']:
    with Path(rel).open() as f:
        yaml.safe_load(f)
PY
- uv run --extra dev --project . pytest -q tests/test_policyengine_coverage.py -k "maine_tanf"
- uv run --extra dev --project . python -m pytest -q tests/test_policyengine_coverage_monorepo.py tests/test_rulespec_validation.py::test_policyengine_oracle_does_not_score_unmapped_outputs