### PR TITLE
Accept compound cardinal words in numeric grounding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1099"
+version = "0.2.1100"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1099"
+__version__ = "0.2.1100"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -2976,6 +2976,11 @@ def extract_numbers_from_text(text: str) -> set[float]:
             continue
         numbers.add(value)
         occupied_spans.append(span)
+    for span, value in _iter_cardinal_word_number_matches(text, compound_only=True):
+        if _span_overlaps(span, occupied_spans):
+            continue
+        numbers.add(value)
+        occupied_spans.append(span)
     for span, value in _iter_french_cardinal_phrase_matches(text):
         if _span_overlaps(span, occupied_spans):
             continue
@@ -3205,11 +3210,15 @@ def _parse_cardinal_word_sequence(text: str) -> float | None:
 
 def _iter_cardinal_word_number_matches(
     text: str,
+    *,
+    compound_only: bool = False,
 ) -> list[tuple[tuple[int, int], float]]:
     """Return English cardinal number phrases such as "five hundred thousand"."""
     matches: list[tuple[tuple[int, int], float]] = []
     for match in _CARDINAL_NUMBER_WORD_PATTERN.finditer(text):
         phrase = match.group(0)
+        if compound_only and not re.search(r"[-\s]", phrase):
+            continue
         split_values = _split_flat_coordinated_cardinal_phrase(
             phrase, offset=match.start()
         )
@@ -3906,6 +3915,13 @@ def extract_numeric_occurrences_from_text(text: str) -> list[float]:
 
     for glyph, value in _UNICODE_FRACTION_VALUES.items():
         occurrences.extend(value for _ in re.finditer(re.escape(glyph), cleaned))
+
+    for span, value in _iter_cardinal_word_number_matches(cleaned, compound_only=True):
+        if _span_overlaps(span, spans):
+            continue
+        if value not in GROUNDING_ALLOWED_VALUES:
+            occurrences.append(value)
+        spans.append(span)
 
     for span, value in _iter_french_cardinal_phrase_matches(cleaned):
         if _span_overlaps(span, spans):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5920,6 +5920,51 @@ rules:
     assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
 
 
+def test_rulespec_grounding_accepts_english_compound_cardinal_words():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/example/compound-cardinals
+rules:
+  - name: month_limit
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '2024-01-01'
+        formula: '36'
+  - name: middle_credit_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: '2024-01-01'
+        formula: '600'
+  - name: high_credit_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: '2024-01-01'
+        formula: '1200'
+"""
+
+    source_text = (
+        "benefits shall be provided for not longer than thirty-six months. "
+        "The middle credit amount is Six hundred dollars. "
+        "The high credit amount is one thousand two hundred dollars."
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+
+
+def test_numeric_extraction_prefers_english_compound_cardinals_over_single_words():
+    assert 36.0 in extract_numbers_from_text("not longer than thirty-six months")
+    assert 600.0 in extract_numbers_from_text("The amount is Six hundred dollars")
+    assert 1200.0 in extract_numeric_occurrences_from_text(
+        "One thousand two hundred dollars"
+    )
+
+
 def test_rulespec_grounding_rejects_unrelated_power_of_ten():
     content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1099"
+version = "0.2.1100"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary\n- parse full English compound cardinal phrases before language-specific single-word matches claim the span\n- bump axiom-encode to 0.2.1100\n- add regression coverage for thirty-six, six hundred, and one thousand two hundred source wording\n\n## Tests\n- env -u UV_FROZEN uv run pytest tests/test_cli.py tests/test_rulespec_validation.py -q -k 'compound_cardinal or ungrounded_numeric or version_lock_matches_package_version'