### PR TITLE
Classify NJ WFNJ oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1100"
+version = "0.2.1101"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1100"
+__version__ = "0.2.1101"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -22886,6 +22886,12 @@ prefixes:
     candidate_priority: P4
     rationale: PolicyEngine-US does not model NH agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
 
+  - legal_id_prefix: "us-nj:"
+    country: us
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: PolicyEngine-US does not model NJ agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
+
   - legal_id_prefix: "us-ny:"
     country: us
     mapping_type: not_comparable

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -372,10 +372,12 @@ surfaces:
   variable: nj_wfnj
   source_type: state_implementation
   state: NJ
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Axiom now has current N.J.A.C. 10:90 source-regulation coverage for WFNJ financial eligibility, payment
+    standards, income exclusions, disregards, and resource-limit slices. PolicyEngine's nj_wfnj is a final SPM-unit
+    benefit variable with its own graph and composition boundaries, so keep this source-regulation coverage known-not-comparable
+    until a full legal WFNJ program bridge composes the final benefit and any exact PE helper mappings are reconciled.
 - country: us
   program_id: tanf
   program_name: Texas TANF

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1100"
+version = "0.2.1101"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add NJ to the state regulation/manual PolicyEngine oracle coverage prefix classifications
- mark the New Jersey WFNJ PolicyBench surface as source-regulation covered but known-not-comparable to PolicyEngine's final nj_wfnj benefit surface

## Validation
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-nj-wfnj-20260703 --json
- uv run --with pytest --with pytest-cov python -m pytest tests/test_cli.py -k oracle_coverage