### PR TITLE
Classify DC OSSP program surface

### DIFF
--- a/changelog.d/dc-ossp-policyengine-surface.changed.md
+++ b/changelog.d/dc-ossp-policyengine-surface.changed.md
@@ -1,0 +1,1 @@
+Classify the DC OSSP PolicyBench program surface as known-not-comparable to source-level RuleSpec payment outputs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1101"
+version = "0.2.1102"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1101"
+__version__ = "0.2.1102"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -2576,8 +2576,9 @@ mappings:
     country: us
     program: ssi_state_supplement
     mapping_type: not_comparable
-    candidate_priority: P4
-    rationale: RuleSpec exposes a source-local selector over POMS SI 01415.058 block 13 total payment levels. PolicyEngine's DC OSSP parameter stores only the District supplement amount, not the federal-plus-District total column.
+    policyengine_variable: dc_ossp
+    candidate_priority: P2
+    rationale: RuleSpec exposes a source-level selector over POMS SI 01415.058 block 13 individual total payment levels. PolicyEngine's final `dc_ossp` person amount composes the District payment standard with eligibility and SSI countable-income offset logic, and does not expose the POMS federal-plus-District total column as the final benefit amount.
 
   - legal_id: us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels#federal_code_a_couple_fbr
     country: us
@@ -2714,8 +2715,9 @@ mappings:
     country: us
     program: ssi_state_supplement
     mapping_type: not_comparable
-    candidate_priority: P4
-    rationale: RuleSpec exposes a source-local selector over POMS SI 01415.058 block 14 total payment levels. PolicyEngine's DC OSSP parameter stores only the District supplement amount, not the federal-plus-District total column.
+    policyengine_variable: dc_ossp
+    candidate_priority: P2
+    rationale: RuleSpec exposes a source-level selector over POMS SI 01415.058 block 14 couple total payment levels. PolicyEngine's final `dc_ossp` person amount composes the District payment standard with eligibility, SSI countable-income offset, and person-level couple allocation logic, and does not expose the POMS federal-plus-District total column as the final benefit amount.
 
   - legal_id: us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_person_living_alone_standard
     country: us

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1777,10 +1777,15 @@ surfaces:
   variable: dc_ossp
   source_type: state_implementation
   state: DC
-  axiom_status: deferred_jurisdiction
+  axiom_status: known_not_comparable
   priority: P2
-  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
-    and Georgia law before other jurisdictions.
+  rationale: >-
+    Axiom encodes POMS SI 01415.058 2026 District payment-level tables and living-arrangement OS-code rules, with
+    upstream source checks against D.C. Code § 4-205.49 and current DC DHCF OSSP payment-level guidance. The encoded
+    RuleSpec outputs map exact monthly state-supplement parameter cells to PolicyEngine, but PolicyEngine's final
+    `dc_ossp` person surface also composes eligibility, living arrangement, countable-income reduction, and person-level
+    couple allocation, so compare encoded payment-level cells separately until Axiom has equivalent final benefit
+    composition.
 - country: us
   program_id: ssi_state_supplement
   program_name: Delaware SSP

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1921,6 +1921,25 @@ def test_policyengine_program_surface_marks_connecticut_ssp_known_not_comparable
     assert "final composition surface" in ct_ssp["rationale"]
 
 
+def test_policyengine_program_surface_marks_dc_ossp_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="dc_ossp")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    dc_ossp = items_by_variable["dc_ossp"]
+
+    assert dc_ossp["program_id"] == "ssi_state_supplement"
+    assert dc_ossp["state"] == "DC"
+    assert dc_ossp["axiom_status"] == "known_not_comparable"
+    assert dc_ossp["mapping_count"] >= 1
+    assert dc_ossp["comparable_mapping_count"] == 0
+    assert (
+        "us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels"
+        "#dc_ossp_individual_total_payment_level" in dc_ossp["legal_ids"]
+    )
+    assert "POMS SI 01415.058" in dc_ossp["rationale"]
+    assert "final benefit composition" in dc_ossp["rationale"]
+
+
 def test_policyengine_coverage_maps_connecticut_ssp_income_cap_rate(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "us-ct" / "statutes/17b-600.yaml",

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -3803,7 +3803,17 @@ def test_policyengine_registry_includes_dc_ossp_payment_level_mappings():
         country="us",
     )
     assert total_column.mapping_type == "not_comparable"
-    assert total_column.candidate_priority == "P4"
+    assert total_column.policyengine_variable == "dc_ossp"
+    assert total_column.candidate_priority == "P2"
+
+    couple_total_column = registry.mapping_for_legal_id(
+        "us-dc:policies/ssa/poms/si-01415-058/2026/"
+        "dc-ossp-couple-state-supplement-levels#dc_ossp_couple_total_payment_level",
+        country="us",
+    )
+    assert couple_total_column.mapping_type == "not_comparable"
+    assert couple_total_column.policyengine_variable == "dc_ossp"
+    assert couple_total_column.candidate_priority == "P2"
 
 
 def test_policyengine_registry_includes_acp_parameter_and_not_comparable_mappings():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1101"
+version = "0.2.1102"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify DC OSSP as source-level known-not-comparable rather than deferred jurisdictional work
- add explicit non-comparable final-surface mappings from the POMS total-payment selectors to PolicyEngine's dc_ossp variable
- keep the existing source-level payment-cell parameter mappings intact and add a regression test for the surface classification

## Verification
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -k 'dc_ossp or state_supplement'
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -k 'registry or dc_ossp or policyengine_program_surface_report'
- uv run --with pytest --with pytest-cov python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --include-program-surfaces --json

Program-surface queue delta: active pending surfaces drop from 109 to 108; DC OSSP is now known_not_comparable with 2 PE final-surface mappings.