### PR TITLE
Clarify corpus citation paths in copied context

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1102"
+version = "0.2.1103"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1102"
+__version__ = "0.2.1103"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -5043,6 +5043,10 @@ RuleSpec requirements:
   RuleSpec target that was checked, and `rationale` explaining why the lower
   source is still used. If no higher-authority check is available, stop and
   emit a typed request `upstream_source_check_required` instead of encoding.
+- When higher-authority context is supplied through copied JSONL, inventory, or
+  ingest-run files, cite the embedded corpus `citation_path` values in
+  `checked_paths` and proof atoms. Do not cite the copied `external/...`
+  workspace filename as legal authority.
 - Include `module.proof_validation.required: true` and add
   `metadata.proof.atoms` to every `parameter`, `derived`, and
   `derived_relation` rule. Each atom

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -211,6 +211,10 @@ Hard requirements:
   RuleSpec target that was checked, and `rationale` explaining why the lower
   source is still used. If no higher-authority check is available, stop and
   emit a typed request `upstream_source_check_required` instead of encoding.
+- When higher-authority context is supplied through copied JSONL, inventory, or
+  ingest-run files, cite the embedded corpus `citation_path` values in
+  `checked_paths` and proof atoms. Do not cite the copied `external/...`
+  workspace filename as legal authority.
 - If accepted source claims are supplied, include their IDs under
   `module.source_claims`; do not inline claim bodies, values, formulas,
   evidence, or review metadata in RuleSpec.

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -143,6 +143,7 @@ def _assert_encoder_prompt_topics(prompt: str) -> None:
         "Do not\n  reconstruct the cited section's amount locally",
         "Only include `blocked_by` entries when you know the exact RuleSpec output",
         "us:statutes/us-ca/17000",
+        "Do not cite the copied `external/...`",
     ]
     for topic in required_topics:
         assert topic in prompt

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -6563,6 +6563,7 @@ class TestEvalPrompt:
         )
         assert "entity:" in prompt
         assert "period:" in prompt
+        assert "Do not cite the copied `external/...`" in prompt
         assert "dtype:" in prompt
         assert "RuleSpec requirements:" in prompt
         assert "The RuleSpec file must begin with `format: rulespec/v1`" in prompt

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1102"
+version = "0.2.1103"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Tell encoder prompts to cite embedded corpus citation_path values from copied JSONL/inventory/ingest context rather than external workspace filenames
- Apply the same guidance to source-eval prompts used by axiom-encode encode
- Add focused prompt regression assertions

## Validation
- uv run --with pytest --with pytest-cov python -m pytest tests/test_encoder_backend.py::test_generic_encoder_prompt_includes_durable_rule_spec_guidance tests/test_evals.py::TestEvalPrompt::test_build_eval_prompt_includes_rulespec_schema_guardrails
- uv run ruff check src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py tests/test_encoder_backend.py tests/test_evals.py