### PR TITLE
Fix nested Axiom workspace RuleSpec routing

### DIFF
--- a/changelog.d/axiom-workspace-routing.fixed.md
+++ b/changelog.d/axiom-workspace-routing.fixed.md
@@ -1,0 +1,1 @@
+Do not treat nested `_axiom` dependency workspaces inside country RuleSpec monorepos as canonical RuleSpec checkouts during upstream-placement validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1103"
+version = "0.2.1104"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1103"
+__version__ = "0.2.1104"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/repo_routing.py
+++ b/src/axiom_encode/repo_routing.py
@@ -113,11 +113,12 @@ def canonical_rulespec_repo_name(path: Path) -> str | None:
         return None
 
     if root is not None:
-        subdir = _jurisdiction_subdir_under(
-            root, current, suffix=checkout_name.removeprefix("rulespec-")
-        )
+        suffix = checkout_name.removeprefix("rulespec-")
+        subdir = _jurisdiction_subdir_under(root, current, suffix=suffix)
         if subdir is not None:
             return f"rulespec-{subdir}"
+        if current != root and jurisdiction_subdir_names(root):
+            return None
     return checkout_name
 
 

--- a/tests/test_repo_routing.py
+++ b/tests/test_repo_routing.py
@@ -11,7 +11,10 @@ from axiom_encode.harness.validator_pipeline import (
     _candidate_rulespec_repo_roots,
     _canonical_rulespec_compile_path,
 )
-from axiom_encode.repo_routing import canonical_rulespec_repo_name
+from axiom_encode.repo_routing import (
+    candidate_jurisdiction_content_dirs,
+    canonical_rulespec_repo_name,
+)
 
 
 def _init_checkout(path: Path, origin: str) -> None:
@@ -32,6 +35,21 @@ def test_canonical_rulespec_repo_name_uses_origin_for_temp_checkout_name(tmp_pat
     assert canonical_rulespec_repo_name(checkout) == "rulespec-us"
     assert canonical_rulespec_repo_name(checkout / "statutes" / "26") == "rulespec-us"
     assert jurisdiction_prefix(checkout) == "us"
+
+
+def test_axiom_workspace_inside_monorepo_is_not_canonical_checkout(tmp_path):
+    checkout = tmp_path / "rulespec-us"
+    _init_checkout(checkout, "https://github.com/TheAxiomFoundation/rulespec-us.git")
+    (checkout / "us").mkdir()
+    (checkout / "us-dc").mkdir()
+    axiom_workspace = checkout / "_axiom"
+    (axiom_workspace / "rulespec-us" / "us").mkdir(parents=True)
+
+    assert canonical_rulespec_repo_name(axiom_workspace) is None
+    assert candidate_jurisdiction_content_dirs(axiom_workspace, "us") == [
+        axiom_workspace / "rulespec-us" / "us",
+        axiom_workspace / "rulespec-us",
+    ]
 
 
 def test_candidate_roots_include_temp_checkout_when_origin_matches(tmp_path):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -13217,6 +13217,56 @@ rules:
     )
 
 
+def test_upstream_placement_ignores_nested_axiom_dependency_in_git_monorepo(tmp_path):
+    repo_parent = tmp_path / "repos"
+    checkout = repo_parent / "rulespec-us"
+    subprocess.run(["git", "init", checkout], check=True, capture_output=True)
+    subprocess.run(
+        [
+            "git",
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/TheAxiomFoundation/rulespec-us.git",
+        ],
+        cwd=checkout,
+        check=True,
+        capture_output=True,
+    )
+    duplicate_content = """format: rulespec/v1
+rules:
+  - name: federal_code_a_individual_fbr
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '994'
+"""
+    rules_file = _write_rulespec_file(
+        checkout
+        / "us-de"
+        / "policies/ssa/poms/si-01415-058/2026/de-ssp-individual.yaml",
+        duplicate_content,
+    )
+    _write_rulespec_file(
+        checkout
+        / "_axiom"
+        / "rulespec-us"
+        / "us-dc"
+        / "policies/ssa/poms/si-01415-058/2026/dc-ossp-individual.yaml",
+        duplicate_content,
+    )
+
+    assert (
+        find_upstream_placement_issues(
+            rules_file.read_text(encoding="utf-8"),
+            rules_file=rules_file,
+        )
+        == []
+    )
+
+
 def test_upstream_placement_ignores_sibling_jurisdiction_duplicates(tmp_path):
     repo_parent = tmp_path / "repos"
     _write_rulespec_file(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1103"
+version = "0.2.1104"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- prevent nested _axiom dependency workspaces inside country RuleSpec monorepos from inheriting the parent checkout's RuleSpec identity
- add routing and upstream-placement regressions for Git-origin monorepo checkouts
- bump axiom-encode to 0.2.1104

## Tests
- env -u UV_FROZEN uv run --extra dev python -m pytest tests/test_repo_routing.py tests/test_rulespec_validation.py::test_upstream_placement_ignores_nested_axiom_dependency_in_git_monorepo tests/test_rulespec_validation.py::test_upstream_placement_ignores_nested_axiom_dependency_checkout
- env -u UV_FROZEN uv run --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject
- env -u UV_FROZEN uv run --extra dev ruff check src/axiom_encode/repo_routing.py tests/test_repo_routing.py tests/test_rulespec_validation.py