### PR TITLE
Add SSA POMS optional supplement common repair

### DIFF
--- a/changelog.d/ssa-poms-optional-supplement-common.fixed.md
+++ b/changelog.d/ssa-poms-optional-supplement-common.fixed.md
@@ -1,0 +1,1 @@
+Add a deterministic repair that upstreams shared SSA POMS SI 01415.058 optional-supplement facts into a US-level RuleSpec module and retargets state payment files to import it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1104"
+version = "0.2.1105"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1104"
+__version__ = "0.2.1105"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -1452,6 +1452,28 @@ def main():
         help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
     )
 
+    repair_ssa_poms_optional_supplement_parser = subparsers.add_parser(
+        "repair-ssa-poms-optional-supplement-common",
+        help=(
+            "Apply signed deterministic repairs that upstream shared SSA POMS "
+            "SI 01415.058 optional-supplement facts into the US-level module"
+        ),
+    )
+    repair_ssa_poms_optional_supplement_parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="Rules repository root used for manifest signing",
+    )
+    repair_ssa_poms_optional_supplement_parser.add_argument(
+        "--axiom-rules-engine-path",
+        dest="axiom_rules_path",
+        metavar="AXIOM_RULES_ENGINE_PATH",
+        type=Path,
+        default=None,
+        help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
+    )
+
     repair_missing_deferred_parser = subparsers.add_parser(
         "repair-missing-deferred-outputs",
         help="Apply signed deterministic repairs for source coverage gaps",
@@ -2599,6 +2621,8 @@ def main():
         cmd_repair_child_fragment_reencoding(args)
     elif args.command == "repair-upstream-placement-duplicates":
         cmd_repair_upstream_placement_duplicates(args)
+    elif args.command == "repair-ssa-poms-optional-supplement-common":
+        cmd_repair_ssa_poms_optional_supplement_common(args)
     elif args.command == "repair-missing-deferred-outputs":
         cmd_repair_missing_deferred_outputs(args)
     elif args.command == "repair-section-172-c-capacity":
@@ -12090,6 +12114,562 @@ def cmd_repair_upstream_placement_duplicates(args):
         success_label="upstream placement duplicate",
         repair=repair,
     )
+
+
+_SSA_POMS_OPTIONAL_SUPPLEMENT_COMMON_RELATIVE_OUTPUT = Path(
+    "us/policies/ssa/poms/si-01415-058/2026/"
+    "federally-administered-optional-supplement-common.yaml"
+)
+_SSA_POMS_OPTIONAL_SUPPLEMENT_COMMON_TARGET_BASE = (
+    "us:policies/ssa/poms/si-01415-058/2026/"
+    "federally-administered-optional-supplement-common"
+)
+_SSA_POMS_OPTIONAL_SUPPLEMENT_COMMON_IMPORTS = {
+    "optional_supplement_waived_os_code_applies": (
+        f"{_SSA_POMS_OPTIONAL_SUPPLEMENT_COMMON_TARGET_BASE}"
+        "#optional_supplement_waived_os_code_applies"
+    ),
+    "federal_code_a_individual_fbr": (
+        f"{_SSA_POMS_OPTIONAL_SUPPLEMENT_COMMON_TARGET_BASE}"
+        "#federal_code_a_individual_fbr"
+    ),
+    "federal_code_a_couple_fbr": (
+        f"{_SSA_POMS_OPTIONAL_SUPPLEMENT_COMMON_TARGET_BASE}#federal_code_a_couple_fbr"
+    ),
+}
+
+
+def cmd_repair_ssa_poms_optional_supplement_common(args):
+    """Upstream shared SSA POMS SI 01415.058 facts out of state files."""
+
+    repo_path = Path(args.repo).resolve()
+    if not repo_path.exists():
+        print(f"Rules repository root not found: {repo_path}")
+        sys.exit(1)
+    signing_key = _require_applied_encoding_manifest_signing_key()
+    axiom_encode_git = _require_clean_axiom_encode_git_provenance()
+    axiom_rules_path = getattr(
+        args, "axiom_rules_path", None
+    ) or _resolve_runtime_axiom_rules_checkout(repo_path)
+
+    common_file = repo_path / _SSA_POMS_OPTIONAL_SUPPLEMENT_COMMON_RELATIVE_OUTPUT
+    common_test_file = _rulespec_test_path(common_file)
+    changed_relative_outputs: list[Path] = []
+    original_contents: dict[Path, str | None] = {}
+
+    candidate_repairs: dict[str, dict[str, tuple[Path, set[str]]]] = {
+        "us-dc": {
+            "dc-ossp-living-arrangement-variations": (
+                Path(
+                    "us-dc/policies/ssa/poms/si-01415-058/2026/"
+                    "dc-ossp-living-arrangement-variations.yaml"
+                ),
+                {"optional_supplement_waived_os_code_applies"},
+            ),
+            "dc-ossp-individual-state-supplement-levels": (
+                Path(
+                    "us-dc/policies/ssa/poms/si-01415-058/2026/"
+                    "dc-ossp-individual-state-supplement-levels.yaml"
+                ),
+                {"federal_code_a_individual_fbr"},
+            ),
+            "dc-ossp-couple-state-supplement-levels": (
+                Path(
+                    "us-dc/policies/ssa/poms/si-01415-058/2026/"
+                    "dc-ossp-couple-state-supplement-levels.yaml"
+                ),
+                {"federal_code_a_couple_fbr"},
+            ),
+        },
+        "us-de": {
+            "de-ssp-living-arrangement-variations": (
+                Path(
+                    "us-de/policies/ssa/poms/si-01415-058/2026/"
+                    "de-ssp-living-arrangement-variations.yaml"
+                ),
+                {"optional_supplement_waived_os_code_applies"},
+            ),
+            "de-ssp-individual-state-supplement-levels": (
+                Path(
+                    "us-de/policies/ssa/poms/si-01415-058/2026/"
+                    "de-ssp-individual-state-supplement-levels.yaml"
+                ),
+                {"federal_code_a_individual_fbr"},
+            ),
+            "de-ssp-couple-state-supplement-levels": (
+                Path(
+                    "us-de/policies/ssa/poms/si-01415-058/2026/"
+                    "de-ssp-couple-state-supplement-levels.yaml"
+                ),
+                {"federal_code_a_couple_fbr"},
+            ),
+        },
+    }
+
+    try:
+        _remember_original_file(common_file, original_contents)
+        _remember_original_file(common_test_file, original_contents)
+        common_file.parent.mkdir(parents=True, exist_ok=True)
+        common_file.write_text(
+            yaml.safe_dump(
+                _ssa_poms_optional_supplement_common_document(),
+                sort_keys=False,
+                allow_unicode=False,
+            )
+        )
+        common_test_file.write_text(
+            yaml.safe_dump(
+                _ssa_poms_optional_supplement_common_tests(),
+                sort_keys=False,
+                allow_unicode=False,
+            )
+        )
+        changed_relative_outputs.append(
+            _SSA_POMS_OPTIONAL_SUPPLEMENT_COMMON_RELATIVE_OUTPUT
+        )
+
+        for jurisdiction, repairs in candidate_repairs.items():
+            for relative_output, duplicate_names in repairs.values():
+                rules_file = repo_path / relative_output
+                if not rules_file.exists():
+                    continue
+                test_file = _rulespec_test_path(rules_file)
+                _remember_original_file(rules_file, original_contents)
+                _remember_original_file(test_file, original_contents)
+                _retarget_ssa_poms_optional_supplement_state_file(
+                    rules_file=rules_file,
+                    test_file=test_file,
+                    duplicate_names=duplicate_names,
+                )
+                changed_relative_outputs.append(relative_output)
+
+            _retarget_ssa_poms_optional_supplement_test_inputs(
+                repo_path=repo_path,
+                jurisdiction=jurisdiction,
+                original_contents=original_contents,
+            )
+
+        changed_relative_outputs = list(dict.fromkeys(changed_relative_outputs))
+        if not changed_relative_outputs:
+            print("No SSA POMS optional supplement common repairs found.")
+            return
+
+        pipeline = ValidatorPipeline(
+            policy_repo_path=repo_path,
+            axiom_rules_path=axiom_rules_path,
+            enable_oracles=False,
+            require_policy_proofs=True,
+        )
+        validation_failures: list[str] = []
+        for relative_output in changed_relative_outputs:
+            validation = pipeline.validate(
+                repo_path / relative_output, skip_reviewers=True
+            )
+            if not validation.all_passed:
+                validation_failures.extend(
+                    result.error
+                    for result in validation.results.values()
+                    if result.error
+                )
+        if validation_failures:
+            raise RuntimeError(
+                "Repair failed validation:\n"
+                + "\n".join(f"- {failure}" for failure in validation_failures)
+            )
+
+        manifest_paths: list[Path] = []
+        for relative_output in changed_relative_outputs:
+            rules_file = repo_path / relative_output
+            test_file = _rulespec_test_path(rules_file)
+            manifest_paths.append(
+                _write_deterministic_repair_manifest_for_rulespec(
+                    repo_path=repo_path,
+                    relative_output=relative_output,
+                    rules_file=rules_file,
+                    test_file=test_file if test_file.exists() else None,
+                    model="ssa-poms-optional-supplement-common-v1",
+                    tool=("axiom-encode repair-ssa-poms-optional-supplement-common"),
+                    signing_key=signing_key,
+                    axiom_encode_git=axiom_encode_git,
+                )
+            )
+    except Exception as exc:
+        _restore_original_files(original_contents)
+        print("Repair failed; restored original files.")
+        print(str(exc))
+        sys.exit(1)
+
+    repaired = ", ".join(str(path) for path in changed_relative_outputs)
+    print(f"Applied SSA POMS optional supplement common repair to: {repaired}")
+    for manifest_path in manifest_paths:
+        print(f"manifest={manifest_path}")
+
+
+def _remember_original_file(
+    path: Path, original_contents: dict[Path, str | None]
+) -> None:
+    if path in original_contents:
+        return
+    original_contents[path] = path.read_text() if path.exists() else None
+
+
+def _restore_original_files(original_contents: dict[Path, str | None]) -> None:
+    for path, content in original_contents.items():
+        if content is None:
+            path.unlink(missing_ok=True)
+        else:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content)
+
+
+def _write_deterministic_repair_manifest_for_rulespec(
+    *,
+    repo_path: Path,
+    relative_output: Path,
+    rules_file: Path,
+    test_file: Path | None,
+    model: str,
+    tool: str,
+    signing_key: str,
+    axiom_encode_git: dict[str, object],
+) -> Path:
+    content_repo_path, manifest_relative_output = (
+        _content_root_relative_output_for_rulespec_path(repo_path, relative_output)
+    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_root = Path(tmpdir)
+        generated_output = (
+            output_root / "deterministic-repair" / manifest_relative_output
+        )
+        generated_output.parent.mkdir(parents=True, exist_ok=True)
+        generated_output.write_text(rules_file.read_text())
+        generated_test = _rulespec_test_path(generated_output)
+        applied_files = [rules_file]
+        if test_file is not None and test_file.exists():
+            generated_test.write_text(test_file.read_text())
+            applied_files.append(test_file)
+        result = argparse.Namespace(
+            output_file=str(generated_output),
+            runner="deterministic-repair",
+            backend="deterministic",
+            model=model,
+            tool=tool,
+            citation=_rulespec_anchor_base_for_output(
+                content_repo_path, manifest_relative_output
+            ),
+            generation_prompt_sha256=None,
+            trace_file=None,
+            context_manifest_file=None,
+        )
+        manifest_path = _write_applied_encoding_manifest(
+            result,
+            output_root=output_root,
+            policy_repo_path=content_repo_path,
+            relative_output=manifest_relative_output,
+            applied_files=applied_files,
+            run_id="deterministic-repair",
+            signing_key=signing_key,
+            axiom_encode_git=axiom_encode_git,
+        )
+    obsolete_manifest_path = repo_path / _applied_encoding_manifest_path(
+        relative_output
+    )
+    if obsolete_manifest_path != manifest_path:
+        obsolete_manifest_path.unlink(missing_ok=True)
+    return manifest_path
+
+
+def _content_root_relative_output_for_rulespec_path(
+    repo_path: Path, relative_output: Path
+) -> tuple[Path, Path]:
+    content_repo_path = _generated_validation_repair_policy_repo_path(
+        repo_path, relative_output
+    )
+    parts = relative_output.parts
+    if (
+        len(parts) >= 2
+        and parts[1] in RULESPEC_SOURCE_ROOTS
+        and parts[0] == _repo_jurisdiction_prefix(content_repo_path)
+    ):
+        return content_repo_path, Path(*parts[1:])
+    return content_repo_path, relative_output
+
+
+def _ssa_poms_optional_supplement_common_document() -> dict[str, object]:
+    return {
+        "format": "rulespec/v1",
+        "module": {
+            "proof_validation": {"required": True},
+            "source_verification": {
+                "corpus_citation_paths": [
+                    "us/guidance/ssa/poms/si-01415-058/2026/block-11",
+                    "us/guidance/ssa/poms/si-01415-058/2026/block-13",
+                    "us/guidance/ssa/poms/si-01415-058/2026/block-14",
+                ],
+                "upstream_source_check": {
+                    "status": "official_parameter_source",
+                    "checked_paths": [
+                        "us/statute/42/1382/b",
+                        "us/statute/42/1382e",
+                        "us/statute/42/1382f",
+                        "us/guidance/ssa/poms/si-01415-058/2026/block-11",
+                        "us/guidance/ssa/poms/si-01415-058/2026/block-13",
+                        "us/guidance/ssa/poms/si-01415-058/2026/block-14",
+                    ],
+                    "rationale": (
+                        "SSA POMS SI 01415.058 is the official current "
+                        "federally administered optional supplementary payment "
+                        "program source for January 2026. Blocks 11, 13, and 14 "
+                        "state the shared optional-supplement waived OS-code "
+                        "predicate and the Federal Code A individual and couple "
+                        "FBR amounts used by state payment tables."
+                    ),
+                },
+            },
+            "summary": (
+                "Shared SSA POMS SI 01415.058 facts for federally administered "
+                "optional supplementary payment programs: OS code Y applies "
+                "when a recipient eligible for an optional supplement waives the "
+                "supplement, the 2026 Federal Code A individual FBR is 994.00, "
+                "and the 2026 Federal Code A couple FBR is 1491.00."
+            ),
+        },
+        "rules": [
+            {
+                "name": "optional_supplement_waived_os_code_applies",
+                "kind": "derived",
+                "entity": "Person",
+                "dtype": "Judgment",
+                "period": "Month",
+                "source": "POMS SI 01415.058, block 11, OS code Y definition",
+                "metadata": {
+                    "proof": {
+                        "atoms": [
+                            {
+                                "path": "versions[0].formula",
+                                "kind": "definition",
+                                "source": {
+                                    "corpus_citation_path": (
+                                        "us/guidance/ssa/poms/si-01415-058/"
+                                        "2026/block-11"
+                                    ),
+                                    "excerpt": ("Optional supplementation waived"),
+                                },
+                            }
+                        ]
+                    }
+                },
+                "versions": [
+                    {
+                        "effective_from": "2026-01-01",
+                        "formula": (
+                            "recipient_eligible_for_optional_supplement\n"
+                            "and recipient_waived_optional_supplement"
+                        ),
+                    }
+                ],
+            },
+            {
+                "name": "federal_code_a_individual_fbr",
+                "kind": "parameter",
+                "dtype": "Money",
+                "unit": "USD",
+                "source": "POMS SI 01415.058, block 13, Federal Code A rows",
+                "metadata": {
+                    "proof": {
+                        "atoms": [
+                            {
+                                "path": "versions[0].formula",
+                                "kind": "amount",
+                                "source": {
+                                    "corpus_citation_path": (
+                                        "us/guidance/ssa/poms/si-01415-058/"
+                                        "2026/block-13"
+                                    ),
+                                    "excerpt": "A A All 994.00 681.00 1675.00",
+                                },
+                            }
+                        ]
+                    }
+                },
+                "versions": [{"effective_from": "2026-01-01", "formula": "994.00"}],
+            },
+            {
+                "name": "federal_code_a_couple_fbr",
+                "kind": "parameter",
+                "dtype": "Money",
+                "unit": "USD",
+                "source": "POMS SI 01415.058, block 14, Federal Code A rows",
+                "metadata": {
+                    "proof": {
+                        "atoms": [
+                            {
+                                "path": "versions[0].formula",
+                                "kind": "amount",
+                                "source": {
+                                    "corpus_citation_path": (
+                                        "us/guidance/ssa/poms/si-01415-058/"
+                                        "2026/block-14"
+                                    ),
+                                    "excerpt": "A A All 1491.00 968.00 2459.00",
+                                },
+                            }
+                        ]
+                    }
+                },
+                "versions": [{"effective_from": "2026-01-01", "formula": "1491.00"}],
+            },
+        ],
+    }
+
+
+def _ssa_poms_optional_supplement_common_tests() -> list[dict[str, object]]:
+    target = _SSA_POMS_OPTIONAL_SUPPLEMENT_COMMON_TARGET_BASE
+    return [
+        {
+            "name": "federal_code_a_fbr_amounts",
+            "period": "2026-01",
+            "input": {},
+            "output": {
+                f"{target}#federal_code_a_individual_fbr": 994.0,
+                f"{target}#federal_code_a_couple_fbr": 1491.0,
+            },
+        },
+        {
+            "name": "optional_supplement_waived_when_eligible_and_waived",
+            "period": "2026-01",
+            "input": {
+                f"{target}#input.recipient_eligible_for_optional_supplement": True,
+                f"{target}#input.recipient_waived_optional_supplement": True,
+            },
+            "output": {f"{target}#optional_supplement_waived_os_code_applies": "holds"},
+        },
+        {
+            "name": "optional_supplement_not_waived_without_waiver",
+            "period": "2026-01",
+            "input": {
+                f"{target}#input.recipient_eligible_for_optional_supplement": True,
+                f"{target}#input.recipient_waived_optional_supplement": False,
+            },
+            "output": {
+                f"{target}#optional_supplement_waived_os_code_applies": "not_holds"
+            },
+        },
+    ]
+
+
+def _retarget_ssa_poms_optional_supplement_state_file(
+    *,
+    rules_file: Path,
+    test_file: Path,
+    duplicate_names: set[str],
+) -> bool:
+    try:
+        document = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, yaml.YAMLError, ValueError):
+        return False
+    if not isinstance(document, dict):
+        return False
+    rules = document.get("rules")
+    if not isinstance(rules, list):
+        return False
+
+    removed_names: set[str] = set()
+    remaining_rules: list[object] = []
+    for rule in rules:
+        name = str(rule.get("name") or "").strip() if isinstance(rule, dict) else ""
+        if name in duplicate_names:
+            removed_names.add(name)
+            continue
+        remaining_rules.append(rule)
+    if not removed_names:
+        return False
+
+    content_root = find_policy_repo_root(rules_file)
+    imports = document.get("imports")
+    if not isinstance(imports, list):
+        imports = []
+        document["imports"] = imports
+    existing_imports = {
+        str(import_ref).strip().strip('"').strip("'")
+        for import_ref in imports
+        if isinstance(import_ref, str)
+    }
+    for name in sorted(removed_names):
+        import_target = _SSA_POMS_OPTIONAL_SUPPLEMENT_COMMON_IMPORTS[name]
+        if import_target not in existing_imports:
+            imports.append(import_target)
+            existing_imports.add(import_target)
+
+    document["rules"] = remaining_rules
+    content = yaml.safe_dump(document, sort_keys=False, allow_unicode=False)
+    if content_root is not None:
+        target_base = _rulespec_anchor_base_for_output(
+            content_root,
+            rules_file.relative_to(content_root),
+        )
+        content, _ = _repair_proof_import_hashes(
+            content,
+            target_base=target_base,
+            rules_file=rules_file,
+            repo_path=content_root,
+        )
+    rules_file.write_text(content)
+
+    if content_root is not None:
+        _remove_local_test_output_refs_for_names(
+            test_file,
+            target_base=target_base,
+            names=removed_names,
+        )
+    return True
+
+
+def _retarget_ssa_poms_optional_supplement_test_inputs(
+    *,
+    repo_path: Path,
+    jurisdiction: str,
+    original_contents: dict[Path, str | None],
+) -> None:
+    poms_dir = repo_path / jurisdiction / "policies/ssa/poms/si-01415-058/2026"
+    if not poms_dir.exists():
+        return
+    common_target = _SSA_POMS_OPTIONAL_SUPPLEMENT_COMMON_TARGET_BASE
+    replacements = {
+        "recipient_eligible_for_optional_supplement": (
+            f"{common_target}#input.recipient_eligible_for_optional_supplement"
+        ),
+        "recipient_waived_optional_supplement": (
+            f"{common_target}#input.recipient_waived_optional_supplement"
+        ),
+    }
+    for test_file in sorted(poms_dir.glob("*.test.yaml")):
+        _remember_original_file(test_file, original_contents)
+        try:
+            cases = yaml.safe_load(test_file.read_text()) or []
+        except (OSError, yaml.YAMLError, ValueError):
+            continue
+        if not isinstance(cases, list):
+            continue
+        changed = False
+        for case in cases:
+            if not isinstance(case, dict):
+                continue
+            inputs = case.get("input")
+            if not isinstance(inputs, dict):
+                continue
+            for input_ref in list(inputs):
+                input_ref_text = str(input_ref).strip().strip('"').strip("'")
+                for input_name, replacement in replacements.items():
+                    if input_ref_text.endswith(f"#input.{input_name}"):
+                        value = inputs.pop(input_ref)
+                        inputs[replacement] = value
+                        changed = True
+                        break
+        if changed:
+            test_file.write_text(
+                yaml.safe_dump(cases, sort_keys=False, allow_unicode=False)
+            )
 
 
 def _try_repair_generated_upstream_placement_duplicates_for_apply(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1104"
+version = "0.2.1105"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a deterministic signed repair command that upstreams shared SSA POMS SI 01415.058 optional-supplement facts into a national common module
- retarget DC/DE state POMS RuleSpec to import common federal facts instead of duplicating executable rules
- sign canonical jurisdiction-local manifests and clean obsolete root-level manifests from this unreleased repair path

## Local checks
- ruff format src/axiom_encode/cli.py
- env -u UV_FROZEN uv run --extra dev ruff check src/axiom_encode/cli.py
- env -u UV_FROZEN uv run --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject
- env -u UV_FROZEN uv run axiom-encode repair-ssa-poms-optional-supplement-common --help

This unblocks rulespec-us PR #532 by giving the generated Delaware SSP branch a primary-source common module for the SSA POMS facts that DC already encoded.