### PR TITLE
Repair SSA POMS common Code B facts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1105"
+version = "0.2.1106"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1105"
+__version__ = "0.2.1106"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -12133,8 +12133,16 @@ _SSA_POMS_OPTIONAL_SUPPLEMENT_COMMON_IMPORTS = {
         f"{_SSA_POMS_OPTIONAL_SUPPLEMENT_COMMON_TARGET_BASE}"
         "#federal_code_a_individual_fbr"
     ),
+    "federal_code_b_individual_fbr_less_vtr": (
+        f"{_SSA_POMS_OPTIONAL_SUPPLEMENT_COMMON_TARGET_BASE}"
+        "#federal_code_b_individual_fbr_less_vtr"
+    ),
     "federal_code_a_couple_fbr": (
         f"{_SSA_POMS_OPTIONAL_SUPPLEMENT_COMMON_TARGET_BASE}#federal_code_a_couple_fbr"
+    ),
+    "federal_code_b_couple_fbr_less_vtr": (
+        f"{_SSA_POMS_OPTIONAL_SUPPLEMENT_COMMON_TARGET_BASE}"
+        "#federal_code_b_couple_fbr_less_vtr"
     ),
 }
 
@@ -12171,14 +12179,20 @@ def cmd_repair_ssa_poms_optional_supplement_common(args):
                     "us-dc/policies/ssa/poms/si-01415-058/2026/"
                     "dc-ossp-individual-state-supplement-levels.yaml"
                 ),
-                {"federal_code_a_individual_fbr"},
+                {
+                    "federal_code_a_individual_fbr",
+                    "federal_code_b_individual_fbr_less_vtr",
+                },
             ),
             "dc-ossp-couple-state-supplement-levels": (
                 Path(
                     "us-dc/policies/ssa/poms/si-01415-058/2026/"
                     "dc-ossp-couple-state-supplement-levels.yaml"
                 ),
-                {"federal_code_a_couple_fbr"},
+                {
+                    "federal_code_a_couple_fbr",
+                    "federal_code_b_couple_fbr_less_vtr",
+                },
             ),
         },
         "us-de": {
@@ -12194,14 +12208,20 @@ def cmd_repair_ssa_poms_optional_supplement_common(args):
                     "us-de/policies/ssa/poms/si-01415-058/2026/"
                     "de-ssp-individual-state-supplement-levels.yaml"
                 ),
-                {"federal_code_a_individual_fbr"},
+                {
+                    "federal_code_a_individual_fbr",
+                    "federal_code_b_individual_fbr_less_vtr",
+                },
             ),
             "de-ssp-couple-state-supplement-levels": (
                 Path(
                     "us-de/policies/ssa/poms/si-01415-058/2026/"
                     "de-ssp-couple-state-supplement-levels.yaml"
                 ),
-                {"federal_code_a_couple_fbr"},
+                {
+                    "federal_code_a_couple_fbr",
+                    "federal_code_b_couple_fbr_less_vtr",
+                },
             ),
         },
     }
@@ -12287,7 +12307,7 @@ def cmd_repair_ssa_poms_optional_supplement_common(args):
                     relative_output=relative_output,
                     rules_file=rules_file,
                     test_file=test_file if test_file.exists() else None,
-                    model="ssa-poms-optional-supplement-common-v1",
+                    model="ssa-poms-optional-supplement-common-v2",
                     tool=("axiom-encode repair-ssa-poms-optional-supplement-common"),
                     signing_key=signing_key,
                     axiom_encode_git=axiom_encode_git,
@@ -12421,8 +12441,9 @@ def _ssa_poms_optional_supplement_common_document() -> dict[str, object]:
                         "federally administered optional supplementary payment "
                         "program source for January 2026. Blocks 11, 13, and 14 "
                         "state the shared optional-supplement waived OS-code "
-                        "predicate and the Federal Code A individual and couple "
-                        "FBR amounts used by state payment tables."
+                        "predicate and the shared Federal Code A and Code B "
+                        "individual and couple FBR amounts used by state "
+                        "payment tables."
                     ),
                 },
             },
@@ -12431,7 +12452,10 @@ def _ssa_poms_optional_supplement_common_document() -> dict[str, object]:
                 "optional supplementary payment programs: OS code Y applies "
                 "when a recipient eligible for an optional supplement waives the "
                 "supplement, the 2026 Federal Code A individual FBR is 994.00, "
-                "and the 2026 Federal Code A couple FBR is 1491.00."
+                "the 2026 Federal Code B individual FBR less the VTR reduction "
+                "is 662.67, the 2026 Federal Code A couple FBR is 1491.00, "
+                "and the 2026 Federal Code B couple FBR less the VTR reduction "
+                "is 994.00."
             ),
         },
         "rules": [
@@ -12495,6 +12519,34 @@ def _ssa_poms_optional_supplement_common_document() -> dict[str, object]:
                 "versions": [{"effective_from": "2026-01-01", "formula": "994.00"}],
             },
             {
+                "name": "federal_code_b_individual_fbr_less_vtr",
+                "kind": "parameter",
+                "dtype": "Money",
+                "unit": "USD",
+                "source": (
+                    "POMS SI 01415.058, block 13, Federal Code B / "
+                    "State OS Code Z row and footnote 1"
+                ),
+                "metadata": {
+                    "proof": {
+                        "atoms": [
+                            {
+                                "path": "versions[0].formula",
+                                "kind": "amount",
+                                "source": {
+                                    "corpus_citation_path": (
+                                        "us/guidance/ssa/poms/si-01415-058/"
+                                        "2026/block-13"
+                                    ),
+                                    "excerpt": "B Z All 662.67 0.00 662.67",
+                                },
+                            }
+                        ]
+                    }
+                },
+                "versions": [{"effective_from": "2026-01-01", "formula": "662.67"}],
+            },
+            {
                 "name": "federal_code_a_couple_fbr",
                 "kind": "parameter",
                 "dtype": "Money",
@@ -12519,6 +12571,34 @@ def _ssa_poms_optional_supplement_common_document() -> dict[str, object]:
                 },
                 "versions": [{"effective_from": "2026-01-01", "formula": "1491.00"}],
             },
+            {
+                "name": "federal_code_b_couple_fbr_less_vtr",
+                "kind": "parameter",
+                "dtype": "Money",
+                "unit": "USD",
+                "source": (
+                    "POMS SI 01415.058, block 14, Federal Code B / "
+                    "State OS Code Z row and footnote 1"
+                ),
+                "metadata": {
+                    "proof": {
+                        "atoms": [
+                            {
+                                "path": "versions[0].formula",
+                                "kind": "amount",
+                                "source": {
+                                    "corpus_citation_path": (
+                                        "us/guidance/ssa/poms/si-01415-058/"
+                                        "2026/block-14"
+                                    ),
+                                    "excerpt": "B Z All 994.00 0.00 994.00",
+                                },
+                            }
+                        ]
+                    }
+                },
+                "versions": [{"effective_from": "2026-01-01", "formula": "994.00"}],
+            },
         ],
     }
 
@@ -12527,12 +12607,14 @@ def _ssa_poms_optional_supplement_common_tests() -> list[dict[str, object]]:
     target = _SSA_POMS_OPTIONAL_SUPPLEMENT_COMMON_TARGET_BASE
     return [
         {
-            "name": "federal_code_a_fbr_amounts",
+            "name": "federal_code_fbr_amounts",
             "period": "2026-01",
             "input": {},
             "output": {
                 f"{target}#federal_code_a_individual_fbr": 994.0,
+                f"{target}#federal_code_b_individual_fbr_less_vtr": 662.67,
                 f"{target}#federal_code_a_couple_fbr": 1491.0,
+                f"{target}#federal_code_b_couple_fbr_less_vtr": 994.0,
             },
         },
         {

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -2420,6 +2420,41 @@ mappings:
     candidate_priority: P4
     rationale: RuleSpec exposes a source-local selector over attachment 660-2-4-.19a Maximum Budgeted amounts. PolicyEngine's Alabama SSP surface does not expose that separate maximum-budgeted column.
 
+  - legal_id: us:policies/ssa/poms/si-01415-058/2026/federally-administered-optional-supplement-common#optional_supplement_waived_os_code_applies
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the POMS SI 01415.058 block 11 source-level OS Code Y waived-optional-supplement predicate used to select state payment-table rows. PolicyEngine's state SSP surfaces store payment amounts and final benefit composition, not this POMS row-selection predicate as a one-to-one oracle output.
+
+  - legal_id: us:policies/ssa/poms/si-01415-058/2026/federally-administered-optional-supplement-common#federal_code_a_individual_fbr
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the POMS SI 01415.058 block 13 federal SSI FBR column for Federal Code A as a source-table input to state SSP payment levels. PolicyEngine's state SSP surfaces store state supplement amounts separately from federal SSI rates.
+
+  - legal_id: us:policies/ssa/poms/si-01415-058/2026/federally-administered-optional-supplement-common#federal_code_b_individual_fbr_less_vtr
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the POMS SI 01415.058 block 13 Federal Code B FBR-less-VTR amount as a source-table input to state SSP payment levels. PolicyEngine's state SSP surfaces store state supplement amounts separately and do not expose this federal SSI source-table column.
+
+  - legal_id: us:policies/ssa/poms/si-01415-058/2026/federally-administered-optional-supplement-common#federal_code_a_couple_fbr
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the POMS SI 01415.058 block 14 federal SSI couple FBR column for Federal Code A as a source-table input to state SSP payment levels. PolicyEngine's state SSP surfaces store state supplement amounts separately from federal SSI rates.
+
+  - legal_id: us:policies/ssa/poms/si-01415-058/2026/federally-administered-optional-supplement-common#federal_code_b_couple_fbr_less_vtr
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the POMS SI 01415.058 block 14 Federal Code B couple FBR-less-VTR amount as a source-table input to state SSP payment levels. PolicyEngine's state SSP surfaces store state supplement amounts separately and do not expose this federal SSI source-table column.
+
   - legal_id: us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#federal_code_a_individual_fbr
     country: us
     program: ssi_state_supplement

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1105"
+version = "0.2.1106"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- extend the SSA POMS optional supplement common repair to lift shared Federal Code B FBR-less-VTR amounts into the US-level module
- retarget DC and Delaware SSP state files to import those shared Code B facts
- classify the generated common POMS outputs in the PolicyEngine oracle registry
- bump axiom-encode to 0.2.1106

## Tests
- env -u UV_FROZEN uv run --extra dev python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_policyengine_classifier.py -q