### PR TITLE
Repair remaining SSA POMS common federal facts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1106"
+version = "0.2.1107"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1106"
+__version__ = "0.2.1107"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -12137,12 +12137,24 @@ _SSA_POMS_OPTIONAL_SUPPLEMENT_COMMON_IMPORTS = {
         f"{_SSA_POMS_OPTIONAL_SUPPLEMENT_COMMON_TARGET_BASE}"
         "#federal_code_b_individual_fbr_less_vtr"
     ),
+    "federal_code_c_individual_fbr": (
+        f"{_SSA_POMS_OPTIONAL_SUPPLEMENT_COMMON_TARGET_BASE}"
+        "#federal_code_c_individual_fbr"
+    ),
+    "federal_code_d_individual_title_xix_payment_cap": (
+        f"{_SSA_POMS_OPTIONAL_SUPPLEMENT_COMMON_TARGET_BASE}"
+        "#federal_code_d_individual_title_xix_payment_cap"
+    ),
     "federal_code_a_couple_fbr": (
         f"{_SSA_POMS_OPTIONAL_SUPPLEMENT_COMMON_TARGET_BASE}#federal_code_a_couple_fbr"
     ),
     "federal_code_b_couple_fbr_less_vtr": (
         f"{_SSA_POMS_OPTIONAL_SUPPLEMENT_COMMON_TARGET_BASE}"
         "#federal_code_b_couple_fbr_less_vtr"
+    ),
+    "federal_code_d_couple_title_xix_payment_cap": (
+        f"{_SSA_POMS_OPTIONAL_SUPPLEMENT_COMMON_TARGET_BASE}"
+        "#federal_code_d_couple_title_xix_payment_cap"
     ),
 }
 
@@ -12182,6 +12194,8 @@ def cmd_repair_ssa_poms_optional_supplement_common(args):
                 {
                     "federal_code_a_individual_fbr",
                     "federal_code_b_individual_fbr_less_vtr",
+                    "federal_code_c_individual_fbr",
+                    "federal_code_d_individual_title_xix_payment_cap",
                 },
             ),
             "dc-ossp-couple-state-supplement-levels": (
@@ -12192,6 +12206,7 @@ def cmd_repair_ssa_poms_optional_supplement_common(args):
                 {
                     "federal_code_a_couple_fbr",
                     "federal_code_b_couple_fbr_less_vtr",
+                    "federal_code_d_couple_title_xix_payment_cap",
                 },
             ),
         },
@@ -12211,6 +12226,8 @@ def cmd_repair_ssa_poms_optional_supplement_common(args):
                 {
                     "federal_code_a_individual_fbr",
                     "federal_code_b_individual_fbr_less_vtr",
+                    "federal_code_c_individual_fbr",
+                    "federal_code_d_individual_title_xix_payment_cap",
                 },
             ),
             "de-ssp-couple-state-supplement-levels": (
@@ -12221,6 +12238,7 @@ def cmd_repair_ssa_poms_optional_supplement_common(args):
                 {
                     "federal_code_a_couple_fbr",
                     "federal_code_b_couple_fbr_less_vtr",
+                    "federal_code_d_couple_title_xix_payment_cap",
                 },
             ),
         },
@@ -12441,9 +12459,8 @@ def _ssa_poms_optional_supplement_common_document() -> dict[str, object]:
                         "federally administered optional supplementary payment "
                         "program source for January 2026. Blocks 11, 13, and 14 "
                         "state the shared optional-supplement waived OS-code "
-                        "predicate and the shared Federal Code A and Code B "
-                        "individual and couple FBR amounts used by state "
-                        "payment tables."
+                        "predicate and the shared federal SSI table inputs "
+                        "used by state payment tables."
                     ),
                 },
             },
@@ -12453,9 +12470,12 @@ def _ssa_poms_optional_supplement_common_document() -> dict[str, object]:
                 "when a recipient eligible for an optional supplement waives the "
                 "supplement, the 2026 Federal Code A individual FBR is 994.00, "
                 "the 2026 Federal Code B individual FBR less the VTR reduction "
-                "is 662.67, the 2026 Federal Code A couple FBR is 1491.00, "
-                "and the 2026 Federal Code B couple FBR less the VTR reduction "
-                "is 994.00."
+                "is 662.67, the 2026 Federal Code C individual FBR is 994.00, "
+                "the 2026 Federal Code D individual Title XIX payment cap is "
+                "30.00, the 2026 Federal Code A couple FBR is 1491.00, "
+                "the 2026 Federal Code B couple FBR less the VTR reduction is "
+                "994.00, and the 2026 Federal Code D couple Title XIX payment "
+                "cap is 60.00."
             ),
         },
         "rules": [
@@ -12547,6 +12567,61 @@ def _ssa_poms_optional_supplement_common_document() -> dict[str, object]:
                 "versions": [{"effective_from": "2026-01-01", "formula": "662.67"}],
             },
             {
+                "name": "federal_code_c_individual_fbr",
+                "kind": "parameter",
+                "dtype": "Money",
+                "unit": "USD",
+                "source": (
+                    "POMS SI 01415.058, block 13, Federal Code C / State OS Code Z row"
+                ),
+                "metadata": {
+                    "proof": {
+                        "atoms": [
+                            {
+                                "path": "versions[0].formula",
+                                "kind": "amount",
+                                "source": {
+                                    "corpus_citation_path": (
+                                        "us/guidance/ssa/poms/si-01415-058/"
+                                        "2026/block-13"
+                                    ),
+                                    "excerpt": "C Z All 994.00 0.00 994.00",
+                                },
+                            }
+                        ]
+                    }
+                },
+                "versions": [{"effective_from": "2026-01-01", "formula": "994.00"}],
+            },
+            {
+                "name": "federal_code_d_individual_title_xix_payment_cap",
+                "kind": "parameter",
+                "dtype": "Money",
+                "unit": "USD",
+                "source": (
+                    "POMS SI 01415.058, block 13, Federal Code D / "
+                    "State OS Code G row and footnote 2"
+                ),
+                "metadata": {
+                    "proof": {
+                        "atoms": [
+                            {
+                                "path": "versions[0].formula",
+                                "kind": "amount",
+                                "source": {
+                                    "corpus_citation_path": (
+                                        "us/guidance/ssa/poms/si-01415-058/"
+                                        "2026/block-13"
+                                    ),
+                                    "excerpt": "D G All 30.00 2 79.00 109.00",
+                                },
+                            }
+                        ]
+                    }
+                },
+                "versions": [{"effective_from": "2026-01-01", "formula": "30.00"}],
+            },
+            {
                 "name": "federal_code_a_couple_fbr",
                 "kind": "parameter",
                 "dtype": "Money",
@@ -12599,6 +12674,38 @@ def _ssa_poms_optional_supplement_common_document() -> dict[str, object]:
                 },
                 "versions": [{"effective_from": "2026-01-01", "formula": "994.00"}],
             },
+            {
+                "name": "federal_code_d_couple_title_xix_payment_cap",
+                "kind": "parameter",
+                "dtype": "Money",
+                "unit": "USD",
+                "source": (
+                    "POMS SI 01415.058, block 14, Federal Code D / "
+                    "State OS Code G row and footnote 2"
+                ),
+                "metadata": {
+                    "proof": {
+                        "atoms": [
+                            {
+                                "path": "versions[0].formula",
+                                "kind": "amount",
+                                "source": {
+                                    "corpus_citation_path": (
+                                        "us/guidance/ssa/poms/si-01415-058/"
+                                        "2026/block-14"
+                                    ),
+                                    "excerpt": (
+                                        "D G All 60.00 ... 2 Not the FBR; the "
+                                        "amount represents a payment cap to "
+                                        "recipients in a Title XIX institution."
+                                    ),
+                                },
+                            }
+                        ]
+                    }
+                },
+                "versions": [{"effective_from": "2026-01-01", "formula": "60.00"}],
+            },
         ],
     }
 
@@ -12613,8 +12720,11 @@ def _ssa_poms_optional_supplement_common_tests() -> list[dict[str, object]]:
             "output": {
                 f"{target}#federal_code_a_individual_fbr": 994.0,
                 f"{target}#federal_code_b_individual_fbr_less_vtr": 662.67,
+                f"{target}#federal_code_c_individual_fbr": 994.0,
+                f"{target}#federal_code_d_individual_title_xix_payment_cap": 30.0,
                 f"{target}#federal_code_a_couple_fbr": 1491.0,
                 f"{target}#federal_code_b_couple_fbr_less_vtr": 994.0,
+                f"{target}#federal_code_d_couple_title_xix_payment_cap": 60.0,
             },
         },
         {

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -2441,6 +2441,20 @@ mappings:
     candidate_priority: P4
     rationale: RuleSpec exposes the POMS SI 01415.058 block 13 Federal Code B FBR-less-VTR amount as a source-table input to state SSP payment levels. PolicyEngine's state SSP surfaces store state supplement amounts separately and do not expose this federal SSI source-table column.
 
+  - legal_id: us:policies/ssa/poms/si-01415-058/2026/federally-administered-optional-supplement-common#federal_code_c_individual_fbr
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the POMS SI 01415.058 block 13 federal SSI FBR column for Federal Code C as a source-table input to state SSP payment levels. PolicyEngine's state SSP surfaces store state supplement amounts separately from federal SSI rates.
+
+  - legal_id: us:policies/ssa/poms/si-01415-058/2026/federally-administered-optional-supplement-common#federal_code_d_individual_title_xix_payment_cap
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the POMS SI 01415.058 block 13 Federal Code D Title XIX payment cap column as a source-table input to state SSP payment levels. PolicyEngine's state SSP surfaces store state supplement amounts separately and do not expose this federal payment cap.
+
   - legal_id: us:policies/ssa/poms/si-01415-058/2026/federally-administered-optional-supplement-common#federal_code_a_couple_fbr
     country: us
     program: ssi_state_supplement
@@ -2454,6 +2468,13 @@ mappings:
     mapping_type: not_comparable
     candidate_priority: P4
     rationale: RuleSpec exposes the POMS SI 01415.058 block 14 Federal Code B couple FBR-less-VTR amount as a source-table input to state SSP payment levels. PolicyEngine's state SSP surfaces store state supplement amounts separately and do not expose this federal SSI source-table column.
+
+  - legal_id: us:policies/ssa/poms/si-01415-058/2026/federally-administered-optional-supplement-common#federal_code_d_couple_title_xix_payment_cap
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the POMS SI 01415.058 block 14 Federal Code D Title XIX couple payment cap column as a source-table input to state SSP payment levels. PolicyEngine's state SSP surfaces store state supplement amounts separately and do not expose this federal payment cap.
 
   - legal_id: us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#federal_code_a_individual_fbr
     country: us

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1106"
+version = "0.2.1107"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- extend the SSA POMS optional supplement common repair to lift the remaining shared Code C/D federal table inputs
- retarget DC/DE SSP tables to import the shared common facts instead of duplicating them locally
- classify the new common source-table outputs as not comparable to PolicyEngine surfaces

## Verification
- git diff --check
- env -u UV_FROZEN uv run --extra dev python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_policyengine_classifier.py -q