### PR TITLE
Add Utah FEP R986-200-239 oracle mappings

### DIFF
--- a/changelog.d/ut-fep-r986-239-oracle.changed.md
+++ b/changelog.d/ut-fep-r986-239-oracle.changed.md
@@ -1,0 +1,1 @@
+Add Utah FEP R986-200-239 gross-income and work-expense PolicyEngine oracle mappings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1108"
+version = "0.2.1109"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1108"
+__version__ = "0.2.1109"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -20673,6 +20673,51 @@ mappings:
     comparison: bool
     rationale: Same Utah FEP resource-test eligibility predicate under R986-200-230, represented in PolicyEngine as ut_fep_resources_eligible.
 
+  - legal_id: us-ut:regulations/admin-rules/r986/200/239#gross_countable_income_snb_percentage_limit
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ut.dwf.fep.income.gross_income_limit.rate
+    period: month
+    comparison: rate
+    rationale: Same Utah Administrative Code R986-200-239 gross-income limit rate of 185% of the Standard Needs Budget, represented in PolicyEngine as the Utah FEP gross-income-limit rate parameter.
+
+  - legal_id: us-ut:regulations/admin-rules/r986/200/239#financial_assistance_gross_countable_income_limit
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ut_fep_gross_income_eligible
+    candidate_priority: P4
+    rationale: Axiom exposes the source-level dollar gross-income limit equal to 185% of the household-size Standard Needs Budget. PolicyEngine uses the same rate and SNB table inside ut_fep_gross_income_eligible, but does not expose this calculated threshold as a one-to-one oracle variable.
+
+  - legal_id: us-ut:regulations/admin-rules/r986/200/239#financial_assistance_gross_countable_income_eligible
+    country: us
+    program: tanf
+    mapping_type: direct_variable
+    policyengine_variable: ut_fep_gross_income_eligible
+    entity: spm_unit
+    period: month
+    comparison: bool
+    rationale: Same Utah FEP gross-income eligibility predicate under R986-200-239, represented in PolicyEngine as ut_fep_gross_income_eligible.
+
+  - legal_id: us-ut:regulations/admin-rules/r986/200/239#work_expense_allowance_per_employed_person
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ut.dwf.fep.income.deductions.work_expense_allowance.amount
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Utah Administrative Code R986-200-239 $100 work-expense allowance per employed person, represented in PolicyEngine as the Utah FEP work-expense allowance parameter.
+
+  - legal_id: us-ut:regulations/admin-rules/r986/200/239#work_expense_allowance_deduction
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ut_fep_earned_income_after_work_expense
+    candidate_priority: P4
+    rationale: Axiom exposes the household-level work-expense allowance deduction allowed by R986-200-239 when the gross-income test is satisfied. PolicyEngine exposes person-level earned income after the work-expense allowance, not this household aggregate deduction as a one-to-one oracle target.
+
 prefixes:
   - legal_id_prefix: us-dc:statutes/4/4-205/49#
     country: us

--- a/tests/test_policyengine_coverage_monorepo.py
+++ b/tests/test_policyengine_coverage_monorepo.py
@@ -64,6 +64,56 @@ rules:
         formula: fep_fep_tp_max_assistance
 """
 
+_UT_FEP_R986_239_RULESPEC = """format: rulespec/v1
+rules:
+  - name: gross_countable_income_snb_percentage_limit
+    kind: parameter
+    dtype: Rate
+    period: Month
+    versions:
+      - effective_from: '2022-10-24'
+        formula: |-
+          1.85
+  - name: work_expense_allowance_per_employed_person
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2022-10-24'
+        formula: |-
+          100
+  - name: financial_assistance_gross_countable_income_limit
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2022-10-24'
+        formula: |-
+          gross_countable_income_snb_percentage_limit * standard_needs_budget_for_household_size
+  - name: financial_assistance_gross_countable_income_eligible
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '2022-10-24'
+        formula: |-
+          household_gross_countable_income <= financial_assistance_gross_countable_income_limit
+  - name: work_expense_allowance_deduction
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2022-10-24'
+        formula: |-
+          if financial_assistance_gross_countable_income_eligible: work_expense_allowance_per_employed_person * employed_person_count_in_household_unit else: 0
+"""
+
 _UNMAPPED_UK_RULESPEC = """format: rulespec/v1
 rules:
   - name: brand_new_local_helper_xyz
@@ -253,6 +303,71 @@ def test_utah_fep_payment_standard_is_comparable_but_table_rows_are_not(tmp_path
         "gross_income_test_limit",
         "net_income_test_snb",
         "fep_fep_tp_max_assistance",
+    ):
+        item = items_by_rule[rule_name]
+        assert item["status"] == "known_not_comparable"
+        assert item["mapping_type"] == "not_comparable"
+
+
+def test_utah_fep_r986_200_239_gross_income_and_work_expense_mappings(tmp_path):
+    """R986-200-239 maps exact PE parameters/predicates and classifies helpers."""
+    root = tmp_path / "rulespec-us"
+    rulespec_path = (
+        root / "us-ut" / "regulations" / "admin-rules" / "r986" / "200" / "239.yaml"
+    )
+    _write(rulespec_path, _UT_FEP_R986_239_RULESPEC)
+    _write(
+        rulespec_path.with_name("239.test.yaml"),
+        """- name: Utah FEP gross-income limit rate
+  period: 2024-01
+  input:
+    us-ut:regulations/admin-rules/r986/200/239#input.standard_needs_budget_for_household_size: 1000
+    us-ut:regulations/admin-rules/r986/200/239#input.household_gross_countable_income: 1850
+    us-ut:regulations/admin-rules/r986/200/239#input.employed_person_count_in_household_unit: 2
+  output:
+    us-ut:regulations/admin-rules/r986/200/239#gross_countable_income_snb_percentage_limit: 1.85
+    us-ut:regulations/admin-rules/r986/200/239#financial_assistance_gross_countable_income_eligible: holds
+    us-ut:regulations/admin-rules/r986/200/239#work_expense_allowance_per_employed_person: 100
+""",
+    )
+
+    report = build_policyengine_coverage_report(root, program="tanf")
+    items_by_rule = {item["rule_name"]: item for item in report["items"]}
+
+    assert report["status_counts"] == {
+        "comparable": 3,
+        "known_not_comparable": 2,
+    }
+
+    gross_rate = items_by_rule["gross_countable_income_snb_percentage_limit"]
+    assert gross_rate["status"] == "comparable"
+    assert gross_rate["mapping_type"] == "parameter_value"
+    assert (
+        gross_rate["policyengine_parameter"]
+        == "gov.states.ut.dwf.fep.income.gross_income_limit.rate"
+    )
+    assert gross_rate["tested"] is True
+
+    gross_eligible = items_by_rule[
+        "financial_assistance_gross_countable_income_eligible"
+    ]
+    assert gross_eligible["status"] == "comparable"
+    assert gross_eligible["mapping_type"] == "direct_variable"
+    assert gross_eligible["policyengine_variable"] == "ut_fep_gross_income_eligible"
+    assert gross_eligible["tested"] is True
+
+    work_allowance = items_by_rule["work_expense_allowance_per_employed_person"]
+    assert work_allowance["status"] == "comparable"
+    assert work_allowance["mapping_type"] == "parameter_value"
+    assert (
+        work_allowance["policyengine_parameter"]
+        == "gov.states.ut.dwf.fep.income.deductions.work_expense_allowance.amount"
+    )
+    assert work_allowance["tested"] is True
+
+    for rule_name in (
+        "financial_assistance_gross_countable_income_limit",
+        "work_expense_allowance_deduction",
     ):
         item = items_by_rule[rule_name]
         assert item["status"] == "known_not_comparable"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1108"
+version = "0.2.1109"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map Utah FEP R986-200-239 gross-income limit rate and work-expense allowance parameters to PolicyEngine
- map gross-income eligibility to `ut_fep_gross_income_eligible`
- classify source-level helper outputs without one-to-one PolicyEngine variables as known not comparable
- add monorepo coverage regression for the new mappings

## Validation
- `env -u UV_FROZEN uv run --extra dev ruff check tests/test_policyengine_coverage_monorepo.py src/axiom_encode/oracles/policyengine`
- `env -u UV_FROZEN uv run --extra dev python -m pytest -q tests/test_policyengine_coverage.py tests/test_policyengine_coverage_monorepo.py`

Unblocks TheAxiomFoundation/rulespec-us#533.