### PR TITLE
Mark NC TANF blocked on source ingestion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1109"
+version = "0.2.1110"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1109"
+__version__ = "0.2.1110"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -358,10 +358,13 @@ surfaces:
   variable: nc_tanf
   source_type: state_implementation
   state: NC
-  axiom_status: pending_rulespec_encoding
+  axiom_status: pending_source_ingestion
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: PolicyEngine models this program variable. Axiom now has an official NCDHHS Work First Manual 114 corpus slice
+    for the operational payment calculation, but the upstream statute source, N.C. Gen. Stat. 108A-27.01, is still blocked
+    from unattended ingestion by HTTP 403 on the official NC General Assembly endpoint. Do not encode this surface from the
+    manual alone; first ingest the primary-official statute or approve an official-source workaround, then encode the full
+    Work First benefit graph and add legal-ID oracle mappings.
 - country: us
   program_id: tanf
   program_name: New Jersey WFNJ

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1109"
+version = "0.2.1110"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- move the North Carolina TANF PolicyEngine surface back to `pending_source_ingestion`
- document that Work First Manual 114 is ingested, but N.C. Gen. Stat. 108A-27.01 remains blocked by HTTP 403 from the official NC General Assembly endpoint
- make clear that agents should not encode NC TANF from the manual alone before primary statute ingestion or an approved official-source workaround

## Validation
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --oracle policyengine --include-program-surfaces --json`
- `uv run --extra dev python -m pytest -q tests/test_policyengine_coverage.py`
