### PR TITLE
Mark Utah FEP blocked on source ingestion

### DIFF
--- a/changelog.d/ut-fep-source-ingestion-status.changed.md
+++ b/changelog.d/ut-fep-source-ingestion-status.changed.md
@@ -1,0 +1,1 @@
+Mark Utah FEP blocked on source ingestion until current upstream R986-200-239 text is available in corpus.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1110"
+version = "0.2.1111"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1110"
+__version__ = "0.2.1111"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -884,11 +884,14 @@ surfaces:
   variable: ut_fep
   source_type: state_implementation
   state: UT
-  axiom_status: pending_rulespec_encoding
+  axiom_status: pending_source_ingestion
   priority: P1
-  rationale: Axiom has a source-backed Utah DWS Table 1 payment-standard encoding and oracle mapping for
-    ut_fep_payment_standard. Final ut_fep parity still requires encoding the remaining income, eligibility, assistance-unit,
-    and benefit-composition rules from Utah's upstream R986-200/DWS sources before claiming full program parity.
+  rationale: >-
+    Axiom has a source-backed Utah DWS Table 1 payment-standard encoding and oracle mapping for
+    ut_fep_payment_standard. Final ut_fep parity still requires R986-200-239 income and work-expense RuleSpec, but
+    the current Utah Administrative Code R986-200-239 source is not yet present in the local corpus and direct official
+    Utah admin-rules endpoints were inaccessible during source-first verification. Ingest the maximally upstream current
+    Utah source before encoding the remaining income, eligibility, assistance-unit, and benefit-composition rules.
 - country: us
   program_id: tanf
   program_name: Kentucky K-TAP

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1110"
+version = "0.2.1111"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Move the Utah FEP PolicyEngine parity surface from pending RuleSpec encoding to pending source ingestion.
- Document that final ut_fep parity needs current upstream R986-200-239 in corpus before encoding the remaining income/work-expense path.
- Bump axiom-encode to 0.2.1111 for the tracker-affecting change.

## Verification
- uv run --extra dev python -m pytest -q tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_policyengine_coverage.py
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --oracle policyengine --include-program-surfaces --json

Coverage count change: pending_rulespec_encoding 20 -> 19; pending_source_ingestion 2 -> 3.