### PR TITLE
Mark CHIP eligibility pending rulespec encoding

### DIFF
--- a/changelog.d/chip-eligibility-pending-rulespec.changed.md
+++ b/changelog.d/chip-eligibility-pending-rulespec.changed.md
@@ -1,0 +1,1 @@
+Mark PolicyEngine CHIP final eligibility as pending RuleSpec encoding instead of known-not-comparable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1111"
+version = "0.2.1112"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1111"
+__version__ = "0.2.1112"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -212,12 +212,12 @@ surfaces:
   coverage: US
   variable: is_chip_eligible
   source_type: eligibility
-  axiom_status: known_not_comparable
+  axiom_status: pending_rulespec_encoding
   priority: P1
-  rationale: PolicyBench scores this direct person-level CHIP eligibility variable. Axiom encodes federal CHIP child and
-    targeted-low-income-child source definitions plus mapped state-set income-limit parameters where available; PolicyEngine's
-    is_chip_eligible is a final category aggregate over child, standard pregnant, and FCEP paths, so the currently encoded
-    legal outputs are adjacent rather than a one-to-one oracle target.
+  rationale: PolicyBench scores this direct person-level CHIP eligibility variable, and it is an appropriate final oracle
+    target once Axiom assembles the upstream CHIP category graph. Axiom currently encodes federal CHIP child and
+    targeted-low-income-child source definitions plus mapped state-set income-limit parameters where available, but still
+    needs RuleSpec coverage for the child, standard pregnant, FCEP, and aggregate category paths before Populace comparison.
 - country: us
   program_id: aca_subsidies
   program_name: ACA subsidies

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1152,7 +1152,7 @@ def test_policyengine_program_surface_includes_policybench_person_eligibility_su
     assert medicaid["policybench_household_weight"] == pytest.approx(29.86)
 
     assert chip["program_id"] == "chip"
-    assert chip["axiom_status"] == "known_not_comparable"
+    assert chip["axiom_status"] == "pending_rulespec_encoding"
     assert chip["policybench_output"] == "person_level_chip_eligibility"
     assert chip["policybench_household_weight"] == pytest.approx(0.18)
 
@@ -1190,23 +1190,32 @@ def test_policyengine_program_surface_medicaid_filter_prioritizes_eligibility():
     assert report["actionable_surfaces"] == []
 
 
-def test_policyengine_program_surface_marks_wic_and_chip_final_eligibility_known_not_comparable():
+def test_policyengine_program_surface_marks_wic_final_eligibility_known_not_comparable():
     report = build_policyengine_program_surface_report()
 
     items_by_variable = {item["variable"]: item for item in report["items"]}
     wic = items_by_variable["is_wic_eligible"]
-    chip = items_by_variable["is_chip_eligible"]
     assert wic["axiom_status"] == "known_not_comparable"
     assert wic["mapping_count"] >= 1
     assert wic["comparable_mapping_count"] == 0
     assert "us:regulations/7-cfr/246/7/" in wic["legal_ids"]
-    assert chip["axiom_status"] == "known_not_comparable"
+    assert {item["variable"] for item in report["actionable_surfaces"]}.isdisjoint(
+        {"is_wic_eligible"}
+    )
+
+
+def test_policyengine_program_surface_marks_chip_final_eligibility_pending_rulespec_encoding():
+    report = build_policyengine_program_surface_report()
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    chip = items_by_variable["is_chip_eligible"]
+    assert chip["axiom_status"] == "pending_rulespec_encoding"
     assert chip["mapping_count"] >= 1
     assert chip["comparable_mapping_count"] == 0
     assert "us:statutes/42/1397jj/b/1#" in chip["legal_ids"]
-    assert {item["variable"] for item in report["actionable_surfaces"]}.isdisjoint(
-        {"is_wic_eligible", "is_chip_eligible"}
-    )
+    assert "is_chip_eligible" in {
+        item["variable"] for item in report["actionable_surfaces"]
+    }
 
 
 def test_policyengine_program_surface_marks_medicare_proxy_known_not_comparable():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1111"
+version = "0.2.1112"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- reclassify PolicyEngine CHIP final eligibility from known-not-comparable to pending RuleSpec encoding
- keep WIC final eligibility non-comparable while making CHIP an actionable PE-parity surface
- bump axiom-encode to 0.2.1112 and add changelog entry

## Validation
- uv run --extra dev python -m pytest -q tests/test_policyengine_coverage.py tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --oracle policyengine --include-program-surfaces --json

Coverage delta: known_not_comparable 57 -> 56, pending_rulespec_encoding 19 -> 20; is_chip_eligible is now actionable.