### PR TITLE
Prioritize PE parity queue by PolicyBench impact

### DIFF
--- a/changelog.d/policyengine-queue-impact-routing.changed.md
+++ b/changelog.d/policyengine-queue-impact-routing.changed.md
@@ -1,0 +1,1 @@
+Include deferred jurisdiction surfaces in the PolicyEngine parity cloud queue by default and sort queue items by PolicyBench household impact.

--- a/docs/policyengine-oracle-registry.md
+++ b/docs/policyengine-oracle-registry.md
@@ -270,9 +270,11 @@ Each item includes:
 - `oracle_expectation`: what a successful worker should prove or classify
 
 By default the queue includes `pending_source_ingestion`,
-`pending_rulespec_encoding`, and `pending_oracle_mapping` surfaces. Add
-`--include-deferred-jurisdictions` when planning repo/bootstrap work for
-jurisdictions that do not have a ready RuleSpec target yet.
+`pending_rulespec_encoding`, `pending_oracle_mapping`, and
+`deferred_jurisdiction` surfaces. Deferred jurisdiction surfaces are still
+PolicyEngine-modeled parity gaps and should not be hidden unless a caller is
+explicitly planning only ready-to-encode work. Use
+`--exclude-deferred-jurisdictions` to omit repo/bootstrap tasks.
 
 Cloud workers should emit artifacts using the companion run-artifact schema:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1112"
+version = "0.2.1113"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1112"
+__version__ = "0.2.1113"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -869,7 +869,15 @@ def main():
     cloud_queue_parser.add_argument(
         "--include-deferred-jurisdictions",
         action="store_true",
-        help="Include repo/bootstrap tasks for deferred jurisdictions",
+        help=(
+            "Deprecated compatibility flag; deferred jurisdiction surfaces are "
+            "included by default because they are actionable PE-parity work."
+        ),
+    )
+    cloud_queue_parser.add_argument(
+        "--exclude-deferred-jurisdictions",
+        action="store_true",
+        help="Exclude deferred jurisdiction bootstrap tasks from the queue",
     )
     cloud_queue_parser.add_argument(
         "--limit",
@@ -4260,7 +4268,7 @@ def cmd_cloud_queue(args):
         root,
         country=args.country,
         program=args.program,
-        include_deferred_jurisdictions=args.include_deferred_jurisdictions,
+        include_deferred_jurisdictions=not args.exclude_deferred_jurisdictions,
     )
     if args.json:
         print(json.dumps(report, indent=2, sort_keys=True))

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -59,6 +59,7 @@ POLICYENGINE_CLOUD_RUN_ARTIFACT_SCHEMA = (
     "axiom-encode/policyengine-cloud-run-artifact/v1"
 )
 CLOUD_QUEUE_STATUSES = {
+    "deferred_jurisdiction",
     "pending_oracle_mapping",
     "pending_rulespec_encoding",
     "pending_source_ingestion",
@@ -403,12 +404,14 @@ class PolicyEngineCloudQueueItem:
     source_type: str
     agency: str | None = None
     state: str | None = None
+    policybench_output: str | None = None
+    policybench_household_weight: float | None = None
     oracle_expectation: str | None = None
     lock_scopes: tuple[str, ...] = ()
     legal_ids: tuple[str, ...] = ()
     rationale: str | None = None
 
-    def as_dict(self) -> dict[str, str | list[str] | None]:
+    def as_dict(self) -> dict[str, str | float | list[str] | None]:
         return {
             "id": self.id,
             "action": self.action,
@@ -426,6 +429,8 @@ class PolicyEngineCloudQueueItem:
             "policyengine_status": self.policyengine_status,
             "coverage": self.coverage,
             "source_type": self.source_type,
+            "policybench_output": self.policybench_output,
+            "policybench_household_weight": self.policybench_household_weight,
             "oracle_expectation": self.oracle_expectation,
             "lock_scopes": list(self.lock_scopes),
             "legal_ids": list(self.legal_ids),
@@ -521,7 +526,7 @@ def build_policyengine_cloud_queue_report(
     country: str = "us",
     program: str | None = None,
     manifest_path: Path | None = None,
-    include_deferred_jurisdictions: bool = False,
+    include_deferred_jurisdictions: bool = True,
 ) -> dict[str, Any]:
     """Export a deterministic work queue from PolicyEngine program surfaces.
 
@@ -536,8 +541,8 @@ def build_policyengine_cloud_queue_report(
         manifest_path=manifest_path,
     )
     statuses = set(CLOUD_QUEUE_STATUSES)
-    if include_deferred_jurisdictions:
-        statuses.add("deferred_jurisdiction")
+    if not include_deferred_jurisdictions:
+        statuses.discard("deferred_jurisdiction")
     raw_items = [
         _cloud_queue_item_from_program_surface(item)
         for item in surface_report["items"]
@@ -546,6 +551,7 @@ def build_policyengine_cloud_queue_report(
     items = sorted(
         raw_items,
         key=lambda item: (
+            -(item.policybench_household_weight or 0.0),
             _candidate_priority_rank(item.priority or ""),
             _cloud_queue_action_rank(item.action),
             item.target_repo,
@@ -760,6 +766,8 @@ def _cloud_queue_item_from_program_surface(
         policyengine_status=str(item.get("policyengine_status") or ""),
         coverage=str(item.get("coverage") or ""),
         source_type=str(item.get("source_type") or "program"),
+        policybench_output=item.get("policybench_output"),
+        policybench_household_weight=item.get("policybench_household_weight"),
         oracle_expectation=_cloud_queue_oracle_expectation(action),
         lock_scopes=tuple(dict.fromkeys(lock_scopes)),
         legal_ids=legal_ids,

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1466,19 +1466,35 @@ surfaces:
         report["run_artifact_schema"]
         == "axiom-encode/policyengine-cloud-run-artifact/v1"
     )
-    assert report["total_items"] == 3
+    assert report["total_items"] == 4
     assert report["action_counts"] == {
+        "bootstrap_jurisdiction": 1,
         "encode_rulespec": 2,
         "ingest_source": 1,
     }
+    assert [item["policyengine_variable"] for item in report["items"]] == [
+        "new_tax_surface",
+        "mt_snap",
+        "al_tanf_fixture",
+        "az_source_ingestion_fixture",
+    ]
     items_by_variable = {
         item["policyengine_variable"]: item for item in report["items"]
     }
+
+    mt_snap = items_by_variable["mt_snap"]
+    assert mt_snap["action"] == "bootstrap_jurisdiction"
+    assert mt_snap["policybench_output"] == "snap"
+    assert mt_snap["policybench_household_weight"] == pytest.approx(4.15)
 
     new_tax_surface = items_by_variable["new_tax_surface"]
     assert new_tax_surface["action"] == "encode_rulespec"
     assert new_tax_surface["target_repo"] == "rulespec-us"
     assert new_tax_surface["target_prefix"] == "us"
+    assert new_tax_surface["policybench_output"] == (
+        "federal_tax_before_refundable_credits"
+    )
+    assert new_tax_surface["policybench_household_weight"] == pytest.approx(19.14)
     assert "repo:rulespec-us" in new_tax_surface["lock_scopes"]
     assert new_tax_surface["oracle_expectation"].startswith("encode source-law output")
 
@@ -1486,6 +1502,8 @@ surfaces:
     assert al_tanf["action"] == "encode_rulespec"
     assert al_tanf["target_repo"] == "rulespec-us"
     assert al_tanf["target_prefix"] == "us-al"
+    assert al_tanf["policybench_output"] == "tanf"
+    assert al_tanf["policybench_household_weight"] == pytest.approx(0.26)
     assert "repo:rulespec-us" in al_tanf["lock_scopes"]
     assert "target-prefix:us-al" in al_tanf["lock_scopes"]
 
@@ -1493,10 +1511,12 @@ surfaces:
     assert az_ccap["action"] == "ingest_source"
     assert az_ccap["target_repo"] == "axiom-corpus"
     assert az_ccap["target_prefix"] == "us-az"
+    assert az_ccap["policybench_output"] is None
+    assert az_ccap["policybench_household_weight"] is None
     assert "corpus-source:us:ccdf:az_source_ingestion_fixture" in az_ccap["lock_scopes"]
 
 
-def test_policyengine_cloud_queue_can_include_deferred_jurisdictions(tmp_path):
+def test_policyengine_cloud_queue_includes_deferred_jurisdictions_by_default(tmp_path):
     manifest = tmp_path / "program_surfaces.yaml"
     manifest.write_text(
         """source:
@@ -1523,7 +1543,6 @@ surfaces:
     report = build_policyengine_cloud_queue_report(
         tmp_path,
         manifest_path=manifest,
-        include_deferred_jurisdictions=True,
     )
 
     assert report["total_items"] == 1
@@ -1531,6 +1550,39 @@ surfaces:
     assert item["action"] == "bootstrap_jurisdiction"
     assert item["target_repo"] == "rulespec-us"
     assert item["target_prefix"] == "us-mt"
+
+
+def test_policyengine_cloud_queue_can_exclude_deferred_jurisdictions(tmp_path):
+    manifest = tmp_path / "program_surfaces.yaml"
+    manifest.write_text(
+        """source:
+  repository: PolicyEngine/policyengine-us
+  ref: test
+  path: policyengine_us/programs.yaml
+surfaces:
+  - country: us
+    program_id: snap
+    program_name: Montana SNAP
+    category: Benefits
+    policyengine_status: complete
+    coverage: MT
+    variable: mt_snap
+    source_type: state_implementation
+    state: MT
+    axiom_status: deferred_jurisdiction
+    priority: P2
+    rationale: Needs jurisdiction setup.
+""",
+        encoding="utf-8",
+    )
+
+    report = build_policyengine_cloud_queue_report(
+        tmp_path,
+        manifest_path=manifest,
+        include_deferred_jurisdictions=False,
+    )
+
+    assert report["total_items"] == 0
 
 
 def test_policyengine_program_surface_marks_colorado_ccap_final_subsidy_known_not_comparable():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1112"
+version = "0.2.1113"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- include deferred jurisdiction surfaces in the PE parity cloud queue by default
- add PolicyBench output/household-weight fields to cloud queue items
- sort cloud queue work by PolicyBench household impact before priority/action tie-breakers
- add `--exclude-deferred-jurisdictions` as the explicit opt-out and document the default

## Live queue impact
- total queue items increase from the ready-only set to 111 items
- 88 deferred jurisdiction bootstrap tasks are now visible by default
- highest-weight visible gaps are SSI state supplement surfaces (`weight=1.97`), followed by WA Head Start surfaces (`weight=1.18`) and lower-weight TANF/source-ingestion work

## Tests
- `uv run ruff check src/axiom_encode/oracles/policyengine/coverage.py src/axiom_encode/cli.py tests/test_policyengine_coverage.py`
- `uv run --extra dev python -m pytest -q tests/test_policyengine_coverage.py tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`