### PR TITLE
Route deferred PE surfaces to source ingestion

### DIFF
--- a/changelog.d/policyengine-deferred-source-routing.changed.md
+++ b/changelog.d/policyengine-deferred-source-routing.changed.md
@@ -1,0 +1,1 @@
+PolicyEngine cloud queue deferred jurisdiction items now route to source ingestion instead of stale jurisdiction bootstrap work.

--- a/docs/policyengine-oracle-registry.md
+++ b/docs/policyengine-oracle-registry.md
@@ -259,8 +259,8 @@ axiom-encode/policyengine-cloud-queue/v1
 
 Each item includes:
 
-- `action`: one of `ingest_source`, `encode_rulespec`, `wire_oracle_mapping`, or
-  `bootstrap_jurisdiction`
+- `action`: one of `ingest_source`, `encode_rulespec`, or
+  `wire_oracle_mapping`
 - `priority`: the program-surface priority such as `P1` or `P2`
 - `target_repo` and `target_prefix`: where generated RuleSpec or source work
   should eventually land
@@ -273,8 +273,10 @@ By default the queue includes `pending_source_ingestion`,
 `pending_rulespec_encoding`, `pending_oracle_mapping`, and
 `deferred_jurisdiction` surfaces. Deferred jurisdiction surfaces are still
 PolicyEngine-modeled parity gaps and should not be hidden unless a caller is
-explicitly planning only ready-to-encode work. Use
-`--exclude-deferred-jurisdictions` to omit repo/bootstrap tasks.
+explicitly planning only ready-to-encode work. Because Axiom now uses
+country-level RuleSpec repositories, deferred jurisdiction surfaces queue as
+source-ingestion work rather than repo bootstrap work. Use
+`--exclude-deferred-jurisdictions` to omit those source-ingestion tasks.
 
 Cloud workers should emit artifacts using the companion run-artifact schema:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1113"
+version = "0.2.1114"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1113"
+__version__ = "0.2.1114"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -877,7 +877,7 @@ def main():
     cloud_queue_parser.add_argument(
         "--exclude-deferred-jurisdictions",
         action="store_true",
-        help="Exclude deferred jurisdiction bootstrap tasks from the queue",
+        help="Exclude deferred jurisdiction source-ingestion tasks from the queue",
     )
     cloud_queue_parser.add_argument(
         "--limit",

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -68,7 +68,7 @@ CLOUD_QUEUE_STATUS_ACTIONS = {
     "pending_oracle_mapping": "wire_oracle_mapping",
     "pending_rulespec_encoding": "encode_rulespec",
     "pending_source_ingestion": "ingest_source",
-    "deferred_jurisdiction": "bootstrap_jurisdiction",
+    "deferred_jurisdiction": "ingest_source",
 }
 _PROGRAM_TOKEN_RE = {
     token: re.compile(rf"(^|[^a-z0-9]){token}([^a-z0-9]|$)")
@@ -788,17 +788,14 @@ def _cloud_queue_oracle_expectation(action: str) -> str:
         return "ingest source before scheduling RuleSpec encoding"
     if action == "wire_oracle_mapping":
         return "classify existing legal outputs in the oracle registry"
-    if action == "bootstrap_jurisdiction":
-        return "prepare jurisdiction repo/source routing before encoding"
     return "classify outcome before merge"
 
 
 def _cloud_queue_action_rank(action: str) -> int:
     return {
         "ingest_source": 0,
-        "bootstrap_jurisdiction": 1,
-        "encode_rulespec": 2,
-        "wire_oracle_mapping": 3,
+        "encode_rulespec": 1,
+        "wire_oracle_mapping": 2,
     }.get(action, 99)
 
 

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -884,7 +884,7 @@ surfaces:
     state: DC
     axiom_status: deferred_jurisdiction
     priority: P1
-    rationale: Stale jurisdiction bootstrap status.
+    rationale: Stale deferred-jurisdiction status.
   - country: us
     program_id: tanf
     program_name: Vermont Reach Up
@@ -1468,9 +1468,8 @@ surfaces:
     )
     assert report["total_items"] == 4
     assert report["action_counts"] == {
-        "bootstrap_jurisdiction": 1,
         "encode_rulespec": 2,
-        "ingest_source": 1,
+        "ingest_source": 2,
     }
     assert [item["policyengine_variable"] for item in report["items"]] == [
         "new_tax_surface",
@@ -1483,7 +1482,8 @@ surfaces:
     }
 
     mt_snap = items_by_variable["mt_snap"]
-    assert mt_snap["action"] == "bootstrap_jurisdiction"
+    assert mt_snap["action"] == "ingest_source"
+    assert mt_snap["target_repo"] == "axiom-corpus"
     assert mt_snap["policybench_output"] == "snap"
     assert mt_snap["policybench_household_weight"] == pytest.approx(4.15)
 
@@ -1547,8 +1547,8 @@ surfaces:
 
     assert report["total_items"] == 1
     item = report["items"][0]
-    assert item["action"] == "bootstrap_jurisdiction"
-    assert item["target_repo"] == "rulespec-us"
+    assert item["action"] == "ingest_source"
+    assert item["target_repo"] == "axiom-corpus"
     assert item["target_prefix"] == "us-mt"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1113"
+version = "0.2.1114"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Route deferred PolicyEngine jurisdiction surfaces to source-ingestion work instead of stale jurisdiction bootstrap work.
- Update cloud-queue docs/help/tests to reflect country-level RuleSpec routing.
- Bump axiom-encode to 0.2.1114.

## Queue impact
- Command: uv run axiom-encode cloud-queue --root /Users/maxghenis/TheAxiomFoundation --json
- Before: 88 bootstrap_jurisdiction, 3 ingest_source, 20 encode_rulespec.
- After: 91 ingest_source, 20 encode_rulespec.
- Top items now route SSI state supplement source ingestion to axiom-corpus rather than fake repo bootstrap work.

## Tests
- uv run ruff check src/axiom_encode/oracles/policyengine/coverage.py src/axiom_encode/cli.py tests/test_policyengine_coverage.py
- uv run --extra dev python -m pytest -q tests/test_policyengine_coverage.py tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump