### PR TITLE
Mark Delaware SSP ready for RuleSpec encoding

### DIFF
--- a/changelog.d/policyengine-delaware-ssp-source-backed.changed.md
+++ b/changelog.d/policyengine-delaware-ssp-source-backed.changed.md
@@ -1,0 +1,1 @@
+Marked Delaware SSP as source-backed and pending RuleSpec encoding in the PolicyEngine parity registry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1114"
+version = "0.2.1115"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1114"
+__version__ = "0.2.1115"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1802,10 +1802,12 @@ surfaces:
   variable: de_ssp
   source_type: state_implementation
   state: DE
-  axiom_status: deferred_jurisdiction
+  axiom_status: pending_rulespec_encoding
   priority: P2
-  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
-    and Georgia law before other jurisdictions.
+  rationale: Axiom corpus now includes upstream Delaware Code Title 31 Chapter 5 authority, Delaware DSSM 13000 state
+    supplement administration rules, and SSA POMS SI 01415.058 Delaware 2026 optional-supplement payment levels.
+    No Delaware SSP RuleSpec output has been generated yet; schedule source-backed encoding rather than deferring the
+    jurisdiction.
 - country: us
   program_id: ssi_state_supplement
   program_name: Florida OSS

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2001,6 +2001,22 @@ def test_policyengine_program_surface_marks_dc_ossp_known_not_comparable():
     assert "final benefit composition" in dc_ossp["rationale"]
 
 
+def test_policyengine_program_surface_marks_delaware_ssp_pending_rulespec_encoding():
+    report = build_policyengine_program_surface_report(program="de_ssp")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    de_ssp = items_by_variable["de_ssp"]
+
+    assert de_ssp["program_id"] == "ssi_state_supplement"
+    assert de_ssp["state"] == "DE"
+    assert de_ssp["axiom_status"] == "pending_rulespec_encoding"
+    assert de_ssp["mapping_count"] == 0
+    assert "Delaware Code Title 31 Chapter 5" in de_ssp["rationale"]
+    assert "DSSM 13000" in de_ssp["rationale"]
+    assert "POMS SI 01415.058" in de_ssp["rationale"]
+    assert "de_ssp" in {item["variable"] for item in report["actionable_surfaces"]}
+
+
 def test_policyengine_coverage_maps_connecticut_ssp_income_cap_rate(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "us-ct" / "statutes/17b-600.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1114"
+version = "0.2.1115"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- mark the Delaware SSP PE surface as source-backed and pending RuleSpec encoding
- cite the upstream source set now present in corpus: Delaware Code Title 31 Chapter 5, DSSM 13000, and SSA POMS SI 01415.058
- add a coverage regression asserting the queue includes de_ssp as actionable RuleSpec work

## Verification
- uv run ruff check tests/test_policyengine_coverage.py
- uv run --extra dev python -m pytest -q tests/test_policyengine_coverage.py tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump
- uv run axiom-encode cloud-queue --root /Users/maxghenis/TheAxiomFoundation --json (de_ssp now encode_rulespec -> rulespec-us)