### PR TITLE
Recognize Delaware SSP oracle mappings

### DIFF
--- a/changelog.d/policyengine-delaware-ssp-oracle-mappings.changed.md
+++ b/changelog.d/policyengine-delaware-ssp-oracle-mappings.changed.md
@@ -1,0 +1,1 @@
+Recognize Delaware SSP RuleSpec payment-level mappings in the PolicyEngine oracle registry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1115"
+version = "0.2.1116"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1115"
+__version__ = "0.2.1116"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -2810,6 +2810,165 @@ mappings:
     candidate_priority: P2
     rationale: RuleSpec exposes a source-level selector over POMS SI 01415.058 block 14 couple total payment levels. PolicyEngine's final `dc_ossp` person amount composes the District payment standard with eligibility, SSI countable-income offset, and person-level couple allocation logic, and does not expose the POMS federal-plus-District total column as the final benefit amount.
 
+  - legal_id: us-de:policies/ssa/poms/si-01415-058/2026/de-ssp-living-arrangement-variations#adult_residential_care_os_code_applies
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the POMS SI 01415.058 Delaware State OS Code A residential-care predicate. PolicyEngine's Delaware SSP surface stores a household living-arrangement input and final person-level payment formula rather than exposing this source-specific OS-code predicate as a one-to-one variable.
+
+  - legal_id: us-de:policies/ssa/poms/si-01415-058/2026/de-ssp-living-arrangement-variations#assisted_living_facility_os_code_applies
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the POMS SI 01415.058 Delaware State OS Code A assisted-living predicate. PolicyEngine's Delaware SSP surface does not expose this OS-code predicate separately from the living-arrangement input and final payment formula.
+
+  - legal_id: us-de:policies/ssa/poms/si-01415-058/2026/de-ssp-living-arrangement-variations#adult_foster_care_home_os_code_applies
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the POMS SI 01415.058 Delaware State OS Code A adult-foster-care predicate. PolicyEngine's Delaware SSP surface does not expose this source-specific OS-code predicate as a one-to-one oracle target.
+
+  - legal_id: us-de:policies/ssa/poms/si-01415-058/2026/de-ssp-living-arrangement-variations#os_code_a_applies
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the source-level Delaware State OS Code A selector over certified residential care settings. PolicyEngine uses a broader Delaware SSP living-arrangement input and final eligibility/payment graph, not this POMS selector as a standalone output.
+
+  - legal_id: us-de:policies/ssa/poms/si-01415-058/2026/de-ssp-living-arrangement-variations#no_supplement_os_code_applies
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the source-level Delaware State OS Code Z/no-supplement selector. PolicyEngine represents no-supplement cases through its living-arrangement input and final eligibility/payment graph rather than a separate OS Code Z oracle variable.
+
+  - legal_id: us-de:policies/ssa/poms/si-01415-058/2026/de-ssp-living-arrangement-variations#de_ssp_living_arrangement
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    policyengine_variable: de_ssp_living_arrangement
+    candidate_priority: P4
+    rationale: RuleSpec emits the POMS State OS Code value A, Y, or Z. PolicyEngine's Delaware SSP living-arrangement input is a simplified household enum with RESIDENTIAL_CARE and NONE, so the source OS-code string is adjacent but not a one-to-one oracle output.
+
+  - legal_id: us-de:policies/ssa/poms/si-01415-058/2026/de-ssp-individual-state-supplement-levels#certified_care_individual_state_supplement_level
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.de.dhss.ssp.amount.individual
+    period: month
+    unit: USD
+    comparison: money
+    tested_by_legal_ids:
+      - us-de:policies/ssa/poms/si-01415-058/2026/de-ssp-individual-state-supplement-levels#de_ssp
+    rationale: Same Delaware monthly individual state supplement for POMS Federal Code A / State OS Code A certified-care cases, represented by PolicyEngine's Delaware individual SSP amount parameter.
+
+  - legal_id: us-de:policies/ssa/poms/si-01415-058/2026/de-ssp-individual-state-supplement-levels#no_supplement_individual_state_supplement_level
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the zero Delaware POMS State OS Code Z individual supplement cell. PolicyEngine's Delaware SSP parameter table stores only the positive certified-care amount; zero no-supplement cases are represented through final eligibility and living-arrangement logic.
+
+  - legal_id: us-de:policies/ssa/poms/si-01415-058/2026/de-ssp-individual-state-supplement-levels#title_xix_individual_state_supplement_level
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the zero Delaware POMS Title XIX institution individual supplement cell. PolicyEngine's Delaware SSP amount parameter stores the positive certified-care supplement rather than separate zero source-table cells.
+
+  - legal_id: us-de:policies/ssa/poms/si-01415-058/2026/de-ssp-individual-state-supplement-levels#certified_care_individual_total_payment_level
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the POMS SI 01415.058 Delaware total payment level, which sums the federal SSI FBR and Delaware supplement. PolicyEngine's Delaware SSP parameter stores only the state supplement amount, not the federal-plus-state total.
+
+  - legal_id: us-de:policies/ssa/poms/si-01415-058/2026/de-ssp-individual-state-supplement-levels#title_xix_individual_total_payment_level
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the POMS Title XIX individual total payment cap. PolicyEngine's Delaware SSP surface stores state supplement amounts and final offset logic separately from federal SSI institution payment caps.
+
+  - legal_id: us-de:policies/ssa/poms/si-01415-058/2026/de-ssp-individual-state-supplement-levels#de_ssp_individual_federal_payment_level
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes a source-local selector over the Delaware POMS federal SSI payment column. PolicyEngine's Delaware SSP variable models only the state supplementary payment amount after eligibility and SSI offset logic.
+
+  - legal_id: us-de:policies/ssa/poms/si-01415-058/2026/de-ssp-individual-state-supplement-levels#de_ssp
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    policyengine_variable: de_ssp
+    candidate_priority: P2
+    rationale: RuleSpec exposes the POMS SI 01415.058 Delaware individual state supplement selector. PolicyEngine's final `de_ssp` person amount composes SSP eligibility, individual-vs-couple payment selection, SSI countable-income offset, and person-level couple allocation, so the POMS individual selector is not a one-to-one final benefit oracle.
+
+  - legal_id: us-de:policies/ssa/poms/si-01415-058/2026/de-ssp-individual-state-supplement-levels#de_ssp_individual_total_payment_level
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    policyengine_variable: de_ssp
+    candidate_priority: P2
+    rationale: RuleSpec exposes a source-level selector over POMS SI 01415.058 Delaware individual total payment levels. PolicyEngine's final `de_ssp` person amount is the state supplement after eligibility, SSI offset, and couple allocation, not the federal-plus-state total payment column.
+
+  - legal_id: us-de:policies/ssa/poms/si-01415-058/2026/de-ssp-couple-state-supplement-levels#certified_care_couple_state_supplement_level
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.de.dhss.ssp.amount.couple
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Delaware monthly couple state supplement for POMS Federal Code A / State OS Code A certified-care cases, represented by PolicyEngine's Delaware couple SSP amount parameter.
+
+  - legal_id: us-de:policies/ssa/poms/si-01415-058/2026/de-ssp-couple-state-supplement-levels#no_supplement_couple_state_supplement_level
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the zero Delaware POMS State OS Code Z couple supplement cell. PolicyEngine's Delaware SSP parameter table stores only the positive certified-care couple amount; zero no-supplement cases are represented through final eligibility and living-arrangement logic.
+
+  - legal_id: us-de:policies/ssa/poms/si-01415-058/2026/de-ssp-couple-state-supplement-levels#title_xix_couple_state_supplement_level
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the zero Delaware POMS Title XIX institution couple supplement cell. PolicyEngine's Delaware SSP amount parameter stores the positive certified-care couple supplement rather than separate zero source-table cells.
+
+  - legal_id: us-de:policies/ssa/poms/si-01415-058/2026/de-ssp-couple-state-supplement-levels#certified_care_couple_total_payment_level
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the POMS SI 01415.058 Delaware couple total payment level, which sums the federal SSI couple FBR and Delaware supplement. PolicyEngine's Delaware SSP parameter stores only the state supplement amount.
+
+  - legal_id: us-de:policies/ssa/poms/si-01415-058/2026/de-ssp-couple-state-supplement-levels#title_xix_couple_total_payment_level
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the POMS Title XIX couple total payment cap. PolicyEngine's Delaware SSP surface stores state supplement amounts and final offset logic separately from federal SSI institution payment caps.
+
+  - legal_id: us-de:policies/ssa/poms/si-01415-058/2026/de-ssp-couple-state-supplement-levels#de_ssp_couple_federal_payment_level
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes a source-local selector over the Delaware POMS federal SSI couple payment column. PolicyEngine's Delaware SSP variable models only the state supplementary payment amount after eligibility and SSI offset logic.
+
+  - legal_id: us-de:policies/ssa/poms/si-01415-058/2026/de-ssp-couple-state-supplement-levels#de_ssp_couple_total_payment_level
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    policyengine_variable: de_ssp
+    candidate_priority: P2
+    rationale: RuleSpec exposes a source-level selector over POMS SI 01415.058 Delaware couple total payment levels. PolicyEngine's final `de_ssp` person amount composes the Delaware couple payment standard with eligibility, SSI countable-income offset, and person-level couple allocation, and does not expose the POMS federal-plus-state total column as the final benefit amount.
+
   - legal_id: us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_person_living_alone_standard
     country: us
     program: ssi_state_supplement

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1802,12 +1802,14 @@ surfaces:
   variable: de_ssp
   source_type: state_implementation
   state: DE
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P2
-  rationale: Axiom corpus now includes upstream Delaware Code Title 31 Chapter 5 authority, Delaware DSSM 13000 state
-    supplement administration rules, and SSA POMS SI 01415.058 Delaware 2026 optional-supplement payment levels.
-    No Delaware SSP RuleSpec output has been generated yet; schedule source-backed encoding rather than deferring the
-    jurisdiction.
+  rationale: Axiom encodes SSA POMS SI 01415.058 2026 Delaware payment-level tables and living-arrangement OS-code
+    rules, with upstream source context from Delaware Code Title 31 Chapter 5 and Delaware DSSM 13000 state supplement
+    administration rules. The encoded RuleSpec outputs map exact monthly individual and couple state-supplement
+    parameter cells to PolicyEngine, but PolicyEngine's final `de_ssp` person surface also composes eligibility,
+    individual-vs-couple payment selection, SSI countable-income reduction, and person-level couple allocation, so compare
+    encoded payment-level cells separately until Axiom has equivalent final benefit composition.
 - country: us
   program_id: ssi_state_supplement
   program_name: Florida OSS

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2001,7 +2001,7 @@ def test_policyengine_program_surface_marks_dc_ossp_known_not_comparable():
     assert "final benefit composition" in dc_ossp["rationale"]
 
 
-def test_policyengine_program_surface_marks_delaware_ssp_pending_rulespec_encoding():
+def test_policyengine_program_surface_marks_delaware_ssp_known_not_comparable():
     report = build_policyengine_program_surface_report(program="de_ssp")
 
     items_by_variable = {item["variable"]: item for item in report["items"]}
@@ -2009,12 +2009,17 @@ def test_policyengine_program_surface_marks_delaware_ssp_pending_rulespec_encodi
 
     assert de_ssp["program_id"] == "ssi_state_supplement"
     assert de_ssp["state"] == "DE"
-    assert de_ssp["axiom_status"] == "pending_rulespec_encoding"
-    assert de_ssp["mapping_count"] == 0
+    assert de_ssp["axiom_status"] == "known_not_comparable"
+    assert de_ssp["mapping_count"] >= 1
+    assert de_ssp["comparable_mapping_count"] == 0
+    assert (
+        "us-de:policies/ssa/poms/si-01415-058/2026/"
+        "de-ssp-individual-state-supplement-levels#de_ssp" in de_ssp["legal_ids"]
+    )
     assert "Delaware Code Title 31 Chapter 5" in de_ssp["rationale"]
     assert "DSSM 13000" in de_ssp["rationale"]
     assert "POMS SI 01415.058" in de_ssp["rationale"]
-    assert "de_ssp" in {item["variable"] for item in report["actionable_surfaces"]}
+    assert "final benefit composition" in de_ssp["rationale"]
 
 
 def test_policyengine_coverage_maps_connecticut_ssp_income_cap_rate(tmp_path):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -3855,8 +3855,7 @@ def test_policyengine_registry_includes_delaware_ssp_payment_level_mappings():
     )
     assert couple_amount.mapping_type == "parameter_value"
     assert (
-        couple_amount.policyengine_parameter
-        == "gov.states.de.dhss.ssp.amount.couple"
+        couple_amount.policyengine_parameter == "gov.states.de.dhss.ssp.amount.couple"
     )
     assert couple_amount.period == "month"
     assert couple_amount.unit == "USD"

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -3816,6 +3816,71 @@ def test_policyengine_registry_includes_dc_ossp_payment_level_mappings():
     assert couple_total_column.candidate_priority == "P2"
 
 
+def test_policyengine_registry_includes_delaware_ssp_payment_level_mappings():
+    registry = load_policyengine_registry()
+
+    living_arrangement = registry.mapping_for_legal_id(
+        "us-de:policies/ssa/poms/si-01415-058/2026/"
+        "de-ssp-living-arrangement-variations#de_ssp_living_arrangement",
+        country="us",
+    )
+    assert living_arrangement.mapping_type == "not_comparable"
+    assert living_arrangement.policyengine_variable == "de_ssp_living_arrangement"
+    assert living_arrangement.candidate_priority == "P4"
+
+    individual_amount = registry.mapping_for_legal_id(
+        "us-de:policies/ssa/poms/si-01415-058/2026/"
+        "de-ssp-individual-state-supplement-levels"
+        "#certified_care_individual_state_supplement_level",
+        country="us",
+    )
+    assert individual_amount.mapping_type == "parameter_value"
+    assert (
+        individual_amount.policyengine_parameter
+        == "gov.states.de.dhss.ssp.amount.individual"
+    )
+    assert individual_amount.period == "month"
+    assert individual_amount.unit == "USD"
+    assert individual_amount.comparison == "money"
+    assert individual_amount.tested_by_legal_ids == (
+        "us-de:policies/ssa/poms/si-01415-058/2026/"
+        "de-ssp-individual-state-supplement-levels#de_ssp",
+    )
+
+    couple_amount = registry.mapping_for_legal_id(
+        "us-de:policies/ssa/poms/si-01415-058/2026/"
+        "de-ssp-couple-state-supplement-levels"
+        "#certified_care_couple_state_supplement_level",
+        country="us",
+    )
+    assert couple_amount.mapping_type == "parameter_value"
+    assert (
+        couple_amount.policyengine_parameter
+        == "gov.states.de.dhss.ssp.amount.couple"
+    )
+    assert couple_amount.period == "month"
+    assert couple_amount.unit == "USD"
+    assert couple_amount.comparison == "money"
+
+    final_individual_selector = registry.mapping_for_legal_id(
+        "us-de:policies/ssa/poms/si-01415-058/2026/"
+        "de-ssp-individual-state-supplement-levels#de_ssp",
+        country="us",
+    )
+    assert final_individual_selector.mapping_type == "not_comparable"
+    assert final_individual_selector.policyengine_variable == "de_ssp"
+    assert final_individual_selector.candidate_priority == "P2"
+
+    couple_total = registry.mapping_for_legal_id(
+        "us-de:policies/ssa/poms/si-01415-058/2026/"
+        "de-ssp-couple-state-supplement-levels#de_ssp_couple_total_payment_level",
+        country="us",
+    )
+    assert couple_total.mapping_type == "not_comparable"
+    assert couple_total.policyengine_variable == "de_ssp"
+    assert couple_total.candidate_priority == "P2"
+
+
 def test_policyengine_registry_includes_acp_parameter_and_not_comparable_mappings():
     registry = load_policyengine_registry()
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1115"
+version = "0.2.1116"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add Delaware SSP POMS payment-level mappings to the PolicyEngine oracle registry
- mark final PE de_ssp as known-not-comparable while mapping exact individual/couple supplement parameters
- update tests and bump axiom-encode to 0.2.1116

## Verification
- uv run ruff check tests/test_policyengine_coverage.py tests/test_rulespec_validation.py
- uv run --extra dev python -m pytest -q tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_delaware_ssp_known_not_comparable tests/test_rulespec_validation.py::test_policyengine_registry_includes_delaware_ssp_payment_level_mappings tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump
- uv run axiom-encode cloud-queue --root /Users/maxghenis/TheAxiomFoundation --json > /tmp/axiom-queue-de-ssp-mapping-postcommit.json

Queue result: de_ssp no longer appears; encode_rulespec count is now 20 and CHIP remains as the is_chip_eligible encode item.