### PR TITLE
Repair unit-scope apply for CHIP encoding

### DIFF
--- a/changelog.d/chip-family-unit-apply-repair.fixed.md
+++ b/changelog.d/chip-family-unit-apply-repair.fixed.md
@@ -1,0 +1,1 @@
+Preserve explicit source-stated unit scope when apply repairs generated person-level rules.

--- a/changelog.d/chip-pregnant-oracle-components.changed.md
+++ b/changelog.d/chip-pregnant-oracle-components.changed.md
@@ -1,0 +1,1 @@
+Classify federal CHIP pregnant-woman source components against the PolicyEngine oracle surface.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1116"
+version = "0.2.1117"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1116"
+__version__ = "0.2.1117"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -34339,7 +34339,8 @@ _SOURCE_SCOPE_PERSON_MISMATCH_ISSUE_PATTERN = re.compile(
 )
 _SOURCE_SCOPE_UNIT_MISMATCH_PERSON_ISSUE_PATTERN = re.compile(
     r"Source scope mismatch: `([^`]+)` is declared on `Person`, but the "
-    r"embedded source states a household/unit-scoped test\."
+    r"embedded source states (?:a `([^`]+)` unit-scoped|a household/unit-scoped) "
+    r"test\."
 )
 _EMPLOYER_SCOPE_ISSUE_PATTERN = re.compile(
     r"Employer-scoped rule at non-employer scope: `([^`]+)`"
@@ -37030,6 +37031,7 @@ def _try_repair_generated_unit_scoped_person_definition_for_apply(
     return _repair_unit_scoped_person_definition_entities(
         rules_file=rules_file,
         target_names=target_names,
+        unit_entities_by_name=_unit_scoped_person_definition_issue_units(issues),
     )
 
 
@@ -37042,10 +37044,32 @@ def _unit_scoped_person_definition_issue_names(issues: list[str]) -> list[str]:
     return names
 
 
+def _unit_scoped_person_definition_issue_units(
+    issues: list[str],
+) -> dict[str, str]:
+    canonical = {
+        "family": "Family",
+        "household": "Household",
+        "snapunit": "SnapUnit",
+        "spmunit": "SPMUnit",
+        "taxunit": "TaxUnit",
+    }
+    units: dict[str, str] = {}
+    for issue in issues:
+        match = _SOURCE_SCOPE_UNIT_MISMATCH_PERSON_ISSUE_PATTERN.search(str(issue))
+        if match is None:
+            continue
+        unit = str(match.group(2) or "").replace("_", "").lower()
+        if unit in canonical:
+            units[match.group(1)] = canonical[unit]
+    return units
+
+
 def _repair_unit_scoped_person_definition_entities(
     *,
     rules_file: Path,
     target_names: list[str],
+    unit_entities_by_name: dict[str, str] | None = None,
 ) -> list[str]:
     if not rules_file.exists():
         return []
@@ -37072,7 +37096,10 @@ def _repair_unit_scoped_person_definition_entities(
         target_rule = by_name.get(target_name)
         if not isinstance(target_rule, dict):
             continue
-        if _set_rule_entity_to_unit(target_rule, unit_entity=unit_entity):
+        target_unit_entity = (unit_entities_by_name or {}).get(
+            target_name
+        ) or unit_entity
+        if _set_rule_entity_to_unit(target_rule, unit_entity=target_unit_entity):
             repaired.append(target_name)
 
     if not repaired:

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -9319,6 +9319,16 @@ def find_source_scope_consistency_issues(content: str) -> list[str]:
                 unit_relation_aggregate_helper_names=unit_relation_aggregate_helper_names,
             ):
                 continue
+            if source_unit_entity is not None:
+                issues.append(
+                    "Source scope mismatch: "
+                    f"`{name}` is declared on `Person`, but the embedded source "
+                    f"states a `{_UNIT_SCOPED_ENTITY_LABELS[source_unit_entity]}` "
+                    "unit-scoped test. Encode the rule at the source-stated "
+                    "unit scope or cite source text that states the person-level "
+                    "test."
+                )
+                continue
             issues.append(
                 "Source scope mismatch: "
                 f"`{name}` is declared on `Person`, but the embedded source "

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -388,6 +388,46 @@ mappings:
     policyengine_variable: is_chip_eligible_child
     rationale: This RuleSpec output is the federal uncovered-child definition. PolicyEngine exposes final CHIP eligibility and insurance-status inputs, not this statutory prerequisite as a standalone oracle variable.
 
+  - legal_id: us:statutes/42/1397ll/d/2#standard_postpartum_period_days
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    candidate_priority: P4
+    policyengine_variable: is_chip_eligible_standard_pregnant_person
+    rationale: This RuleSpec output is a federal postpartum-period scalar inside the targeted low-income pregnant woman definition. PolicyEngine exposes final standard pregnant CHIP eligibility, not this statutory timing helper as a one-to-one variable or parameter.
+
+  - legal_id: us:statutes/42/1397ll/d/2#targeted_low_income_pregnant_woman_extended_postpartum_period_months
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    candidate_priority: P4
+    policyengine_variable: is_chip_eligible_standard_pregnant_person
+    rationale: This RuleSpec output imports the federal extended postpartum coverage period used by the targeted low-income pregnant woman definition. PolicyEngine exposes final standard pregnant CHIP eligibility, not this statutory period helper as a standalone oracle target.
+
+  - legal_id: us:statutes/42/1397ll/d/2#pregnant_woman_income_floor_rate
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    candidate_priority: P4
+    policyengine_variable: is_chip_eligible_standard_pregnant_person
+    rationale: This RuleSpec output is the federal lower income floor for targeted low-income pregnant women. PolicyEngine uses state effective CHIP pregnant income limits in final eligibility, not this federal source-level floor as a one-to-one parameter.
+
+  - legal_id: us:statutes/42/1397ll/d/2#applicable_pregnant_woman_income_floor_rate
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    candidate_priority: P4
+    policyengine_variable: is_chip_eligible_standard_pregnant_person
+    rationale: This RuleSpec output selects the higher of the statutory 185 percent floor and the subsection (b)(1)(A) floor. PolicyEngine exposes final standard pregnant CHIP eligibility, not this statutory income-floor helper as a standalone oracle variable.
+
+  - legal_id: us:statutes/42/1397ll/d/2#targeted_low_income_pregnant_woman
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    candidate_priority: P4
+    policyengine_variable: is_chip_eligible_standard_pregnant_person
+    rationale: This RuleSpec output is the federal source-level targeted-low-income pregnant woman definition. PolicyEngine exposes final standard pregnant CHIP eligibility after state limits and other category assembly, not this statutory prerequisite as a one-to-one oracle variable.
+
   - legal_id: us:statutes/8/1612/b/2/G#paragraph_1_nonapplication_exception_applies
     country: us
     program: medicaid

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -172,6 +172,7 @@ from axiom_encode.cli import (
     _try_repair_generated_upstream_placement_duplicates_and_proofs_for_apply,
     _try_repair_generated_upstream_placement_duplicates_for_apply,
     _unit_scoped_person_definition_issue_names,
+    _unit_scoped_person_definition_issue_units,
     _validate_generated_encoding_in_policy_overlay,
     _write_applied_encoding_manifest,
     _write_overlay_eval_source_metadata_for_generated_output,
@@ -9474,6 +9475,22 @@ rules:
         assert _unit_scoped_person_definition_issue_names(issues) == [
             "llc_or_s_corporation_owner_earned_income"
         ]
+        assert _unit_scoped_person_definition_issue_units(issues) == {}
+
+    def test_unit_scoped_person_definition_issue_units_captures_source_unit(self):
+        issues = [
+            "Source scope mismatch: `targeted_low_income_pregnant_woman` "
+            "is declared on `Person`, but the embedded source states a "
+            "`Family` unit-scoped test. Encode the rule at the source-stated "
+            "unit scope or cite source text that states the person-level test."
+        ]
+
+        assert _unit_scoped_person_definition_issue_names(issues) == [
+            "targeted_low_income_pregnant_woman"
+        ]
+        assert _unit_scoped_person_definition_issue_units(issues) == {
+            "targeted_low_income_pregnant_woman": "Family"
+        }
 
     def test_repair_unit_scoped_person_definition_entities_uses_dominant_unit(
         self, tmp_path
@@ -9513,6 +9530,35 @@ rules:
             "Household",
             "Household",
         ]
+
+    def test_repair_unit_scoped_person_definition_entities_uses_explicit_source_unit(
+        self, tmp_path
+    ):
+        rules_file = tmp_path / "statutes/42/1397ll/d/2.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: targeted_low_income_pregnant_woman
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Day
+  versions:
+  - effective_from: '1974-01-01'
+    formula: family_income > pregnant_woman_income_floor
+"""
+        )
+
+        repaired = _repair_unit_scoped_person_definition_entities(
+            rules_file=rules_file,
+            target_names=["targeted_low_income_pregnant_woman"],
+            unit_entities_by_name={"targeted_low_income_pregnant_woman": "Family"},
+        )
+
+        assert repaired == ["targeted_low_income_pregnant_woman"]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert payload["rules"][0]["entity"] == "Family"
 
     def test_inline_medicaid_magi_income_helpers_removes_one_use_income_helper(
         self, tmp_path

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2973,6 +2973,21 @@ def test_policyengine_registry_is_legal_id_keyed():
         assert mapping.program == "chip"
         assert mapping.candidate_priority == "P4"
         assert mapping.policyengine_variable == "is_chip_eligible_child"
+    pregnant_chip_definition_mappings = [
+        "us:statutes/42/1397ll/d/2#standard_postpartum_period_days",
+        "us:statutes/42/1397ll/d/2#targeted_low_income_pregnant_woman_extended_postpartum_period_months",
+        "us:statutes/42/1397ll/d/2#pregnant_woman_income_floor_rate",
+        "us:statutes/42/1397ll/d/2#applicable_pregnant_woman_income_floor_rate",
+        "us:statutes/42/1397ll/d/2#targeted_low_income_pregnant_woman",
+    ]
+    for legal_id in pregnant_chip_definition_mappings:
+        mapping = registry.mapping_for_legal_id(legal_id, country="us")
+        assert mapping.mapping_type == "not_comparable"
+        assert mapping.program == "chip"
+        assert mapping.candidate_priority == "P4"
+        assert (
+            mapping.policyengine_variable == "is_chip_eligible_standard_pregnant_person"
+        )
     residential_clean_energy_mapping = registry.mapping_for_legal_id(
         "us:statutes/26/25D#residential_clean_energy_credit",
         country="us",
@@ -17309,7 +17324,7 @@ rules:
 
     assert issues == [
         "Source scope mismatch: `snap_member_resource_eligible` is declared on "
-        "`Person`, but the embedded source states a household/unit-scoped test. "
+        "`Person`, but the embedded source states a `Household` unit-scoped test. "
         "Encode the rule at the source-stated unit scope or cite source text "
         "that states the person-level test."
     ]
@@ -17385,9 +17400,9 @@ rules:
     assert issues == [
         "Source scope mismatch: "
         "`t_snap_member_snap_ineligibility_criterion` is declared on `Person`, "
-        "but the embedded source states a household/unit-scoped test. Encode "
-        "the rule at the source-stated unit scope or cite source text that "
-        "states the person-level test."
+        "but the embedded source states a `Household` unit-scoped test. "
+        "Encode the rule at the source-stated unit scope or cite source text "
+        "that states the person-level test."
     ]
 
 
@@ -17435,9 +17450,9 @@ rules:
     assert issues == [
         "Source scope mismatch: "
         "`t_snap_member_snap_ineligibility_criterion` is declared on `Person`, "
-        "but the embedded source states a household/unit-scoped test. Encode "
-        "the rule at the source-stated unit scope or cite source text that "
-        "states the person-level test."
+        "but the embedded source states a `Household` unit-scoped test. "
+        "Encode the rule at the source-stated unit scope or cite source text "
+        "that states the person-level test."
     ]
 
 
@@ -18048,9 +18063,9 @@ rules:
 
     assert issues == [
         "Source scope mismatch: `adult_group_resource_eligible` is declared "
-        "on `Person`, but the embedded source states a household/unit-scoped "
-        "test. Encode the rule at the source-stated unit scope or cite source "
-        "text that states the person-level test."
+        "on `Person`, but the embedded source states a `Household` "
+        "unit-scoped test. Encode the rule at the source-stated unit scope or "
+        "cite source text that states the person-level test."
     ]
 
 
@@ -18169,6 +18184,36 @@ rules:
     ]
 
 
+def test_source_scope_consistency_names_family_unit_for_person_rule():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    Family income eligibility requires family income to exceed the lower floor
+    and not exceed the State child health plan income eligibility level.
+rules:
+  - name: targeted_low_income_pregnant_woman
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Day
+    source: 42 USC 1397ll(d)(2)
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          family_income > pregnant_woman_income_floor
+          and family_income <= state_child_health_plan_income_level
+"""
+
+    issues = find_source_scope_consistency_issues(content)
+
+    assert issues == [
+        "Source scope mismatch: `targeted_low_income_pregnant_woman` is "
+        "declared on `Person`, but the embedded source states a `Family` "
+        "unit-scoped test. Encode the rule at the source-stated unit scope or "
+        "cite source text that states the person-level test."
+    ]
+
+
 def test_source_scope_consistency_accepts_federal_tax_taxpayer_as_taxunit_rule():
     content = """format: rulespec/v1
 module:
@@ -18279,7 +18324,7 @@ rules:
 
     assert issues == [
         "Source scope mismatch: `taxpayer_is_applicable_taxpayer` is declared "
-        "on `Person`, but the embedded source states a household/unit-scoped "
+        "on `Person`, but the embedded source states a `TaxUnit` unit-scoped "
         "test. Encode the rule at the source-stated unit scope or cite source "
         "text that states the person-level test."
     ]

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1116"
+version = "0.2.1117"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- repair apply-time unit-scope fixes when the validator reports a specific Family/household source unit for a Person rule
- include the explicit source unit in source-scope validation messages
- classify the new federal CHIP pregnant-woman source components against the PolicyEngine oracle registry as source-level, not directly comparable final eligibility outputs

## Checks
- uv run ruff check tests/test_rulespec_validation.py src/axiom_encode/cli.py src/axiom_encode/harness/validator_pipeline.py
- uv run ruff format --check tests/test_rulespec_validation.py src/axiom_encode/cli.py src/axiom_encode/harness/validator_pipeline.py
- uv run --extra dev python -m pytest -q tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_cli.py::TestCmdEncode::test_unit_scoped_person_definition_issue_names tests/test_cli.py::TestCmdEncode::test_unit_scoped_person_definition_issue_units_captures_source_unit tests/test_cli.py::TestCmdEncode::test_repair_unit_scoped_person_definition_entities_uses_dominant_unit tests/test_cli.py::TestCmdEncode::test_repair_unit_scoped_person_definition_entities_uses_explicit_source_unit tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed tests/test_rulespec_validation.py::test_source_scope_consistency_names_family_unit_for_person_rule
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees --json, then inspected us/statutes/42/1397ll/d/2.yaml outputs as known_not_comparable