### PR TITLE
Classify CHIP pregnancy period oracle helper

### DIFF
--- a/changelog.d/chip-pregnancy-period-oracle-component.changed.md
+++ b/changelog.d/chip-pregnancy-period-oracle-component.changed.md
@@ -1,0 +1,1 @@
+Classify the federal CHIP pregnancy/postpartum timing helper against the PolicyEngine oracle surface.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1117"
+version = "0.2.1118"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1117"
+__version__ = "0.2.1118"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -420,6 +420,14 @@ mappings:
     policyengine_variable: is_chip_eligible_standard_pregnant_person
     rationale: This RuleSpec output selects the higher of the statutory 185 percent floor and the subsection (b)(1)(A) floor. PolicyEngine exposes final standard pregnant CHIP eligibility, not this statutory income-floor helper as a standalone oracle variable.
 
+  - legal_id: us:statutes/42/1397ll/d/2#within_pregnancy_or_applicable_postpartum_period
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    candidate_priority: P4
+    policyengine_variable: is_chip_eligible_standard_pregnant_person
+    rationale: This RuleSpec output is the federal pregnancy-or-postpartum timing predicate inside the targeted low-income pregnant woman definition. PolicyEngine exposes final standard pregnant CHIP eligibility, not this statutory timing prerequisite as a one-to-one oracle variable.
+
   - legal_id: us:statutes/42/1397ll/d/2#targeted_low_income_pregnant_woman
     country: us
     program: chip

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2978,6 +2978,7 @@ def test_policyengine_registry_is_legal_id_keyed():
         "us:statutes/42/1397ll/d/2#targeted_low_income_pregnant_woman_extended_postpartum_period_months",
         "us:statutes/42/1397ll/d/2#pregnant_woman_income_floor_rate",
         "us:statutes/42/1397ll/d/2#applicable_pregnant_woman_income_floor_rate",
+        "us:statutes/42/1397ll/d/2#within_pregnancy_or_applicable_postpartum_period",
         "us:statutes/42/1397ll/d/2#targeted_low_income_pregnant_woman",
     ]
     for legal_id in pregnant_chip_definition_mappings:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1117"
+version = "0.2.1118"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify the federal CHIP pregnancy/postpartum timing helper from 42 USC 1397ll(d)(2) as source-level and not directly comparable to PolicyEngine's final standard pregnant CHIP eligibility surface
- bump axiom-encode to 0.2.1118 so rulespec-us can pin the updated registry

## Checks
- uv run ruff check tests/test_rulespec_validation.py src/axiom_encode/__init__.py
- uv run ruff format --check tests/test_rulespec_validation.py src/axiom_encode/__init__.py
- uv run python - <<'PY' ... yaml.safe_load(us.yaml) ... PY
- uv run --extra dev python -m pytest -q tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees --json, then inspected us/statutes/42/1397ll/d/2.yaml outputs: no unmapped rows