### PR TITLE
Classify CHIP extended postpartum helper

### DIFF
--- a/changelog.d/chip-extended-postpartum-oracle-component.changed.md
+++ b/changelog.d/chip-extended-postpartum-oracle-component.changed.md
@@ -1,0 +1,1 @@
+Classify the generated CHIP extended postpartum period helper as a known non-comparable PolicyEngine oracle component.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1118"
+version = "0.2.1119"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1118"
+__version__ = "0.2.1119"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -396,6 +396,14 @@ mappings:
     policyengine_variable: is_chip_eligible_standard_pregnant_person
     rationale: This RuleSpec output is a federal postpartum-period scalar inside the targeted low-income pregnant woman definition. PolicyEngine exposes final standard pregnant CHIP eligibility, not this statutory timing helper as a one-to-one variable or parameter.
 
+  - legal_id: us:statutes/42/1397ll/d/2#extended_postpartum_period_months
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    candidate_priority: P4
+    policyengine_variable: is_chip_eligible_standard_pregnant_person
+    rationale: This RuleSpec output is the federal extended postpartum period scalar inside the targeted low-income pregnant woman definition. PolicyEngine exposes final standard pregnant CHIP eligibility, not this statutory timing helper as a one-to-one variable or parameter.
+
   - legal_id: us:statutes/42/1397ll/d/2#targeted_low_income_pregnant_woman_extended_postpartum_period_months
     country: us
     program: chip

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2975,6 +2975,7 @@ def test_policyengine_registry_is_legal_id_keyed():
         assert mapping.policyengine_variable == "is_chip_eligible_child"
     pregnant_chip_definition_mappings = [
         "us:statutes/42/1397ll/d/2#standard_postpartum_period_days",
+        "us:statutes/42/1397ll/d/2#extended_postpartum_period_months",
         "us:statutes/42/1397ll/d/2#targeted_low_income_pregnant_woman_extended_postpartum_period_months",
         "us:statutes/42/1397ll/d/2#pregnant_woman_income_floor_rate",
         "us:statutes/42/1397ll/d/2#applicable_pregnant_woman_income_floor_rate",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1118"
+version = "0.2.1119"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify the generated CHIP extended postpartum period helper as a known non-comparable PolicyEngine oracle component
- bump axiom-encode to 0.2.1119 so generated manifests can be signed against the merged encoder

## Checks
- uv run ruff check tests/test_rulespec_validation.py src/axiom_encode/__init__.py
- uv run ruff format --check tests/test_rulespec_validation.py src/axiom_encode/__init__.py
- uv run --extra dev python -m pytest -q tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-chip-eligibility-20260704 --json > /tmp/chip-only-oracle-coverage-1119.json
- parsed focused CHIP coverage: no unmapped outputs