### PR TITLE
Promote Idaho AABD for RuleSpec encoding

### DIFF
--- a/changelog.d/id-aabd-queue.changed.md
+++ b/changelog.d/id-aabd-queue.changed.md
@@ -1,0 +1,1 @@
+Promote Idaho AABD to the PolicyEngine parity RuleSpec encoding queue after ingesting the official IDAPA source.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1119"
+version = "0.2.1120"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1119"
+__version__ = "0.2.1120"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1852,10 +1852,11 @@ surfaces:
   variable: id_aabd
   source_type: state_implementation
   state: ID
-  axiom_status: deferred_jurisdiction
+  axiom_status: pending_rulespec_encoding
   priority: P2
-  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
-    and Georgia law before other jurisdictions.
+  rationale: Official Idaho IDAPA 16.03.05 AABD administrative-rule corpus artifacts are ingested from the Idaho
+    administrative rules source. Encode the source-law AABD eligibility and payment calculation before classifying
+    comparability with PolicyEngine's final `id_aabd` person-level surface.
 - country: us
   program_id: ssi_state_supplement
   program_name: Indiana SSP

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2236,6 +2236,19 @@ def test_policyengine_program_surface_marks_alabama_ssp_known_not_comparable():
     assert "final `al_ssp` surface" in al_ssp["rationale"]
 
 
+def test_policyengine_program_surface_marks_idaho_aabd_pending_rulespec_encoding():
+    report = build_policyengine_program_surface_report(program="id_aabd")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    id_aabd = items_by_variable["id_aabd"]
+
+    assert id_aabd["program_id"] == "ssi_state_supplement"
+    assert id_aabd["state"] == "ID"
+    assert id_aabd["axiom_status"] == "pending_rulespec_encoding"
+    assert id_aabd["mapping_count"] == 0
+    assert "IDAPA 16.03.05" in id_aabd["rationale"]
+
+
 def test_policyengine_program_surface_marks_illinois_tanf_known_not_comparable():
     report = build_policyengine_program_surface_report(program="il_tanf")
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1119"
+version = "0.2.1120"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- promote Idaho AABD from deferred jurisdiction to pending RuleSpec encoding after official IDAPA 16.03.05 corpus ingestion
- add a program-surface regression test for the new queue state
- add a changelog fragment

## Tests
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check tests/test_policyengine_coverage.py
- uv run --extra dev python -m pytest -q tests/test_policyengine_coverage.py
- uv run --extra dev python -m towncrier build --draft --version 0.0.0
- uv run --extra dev axiom-encode cloud-queue --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-parity-next-20260704 --json