### PR TITLE
Promote Indiana SSP for RuleSpec encoding

### DIFF
--- a/changelog.d/in-ssp-queue.changed.md
+++ b/changelog.d/in-ssp-queue.changed.md
@@ -1,0 +1,1 @@
+Promote Indiana SSP to pending RuleSpec encoding now that official Indiana Code and FSSA SAPN corpus sources are available.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1120"
+version = "0.2.1121"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1120"
+__version__ = "0.2.1121"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1867,10 +1867,12 @@ surfaces:
   variable: in_ssp
   source_type: state_implementation
   state: IN
-  axiom_status: deferred_jurisdiction
+  axiom_status: pending_rulespec_encoding
   priority: P2
-  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
-    and Georgia law before other jurisdictions.
+  rationale: Indiana Code is already available through the source-first Indiana Code corpus release, and official Indiana
+    FSSA Medicaid Policy Manual Chapter 5000 SAPN corpus artifacts are ingested from the FSSA OMPP source. Encode the
+    source-law SAPN eligibility and benefit-calculation rules before classifying comparability with PolicyEngine's final
+    `in_ssp` person-level surface.
 - country: us
   program_id: ssi_state_supplement
   program_name: Massachusetts SSP

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2249,6 +2249,20 @@ def test_policyengine_program_surface_marks_idaho_aabd_pending_rulespec_encoding
     assert "IDAPA 16.03.05" in id_aabd["rationale"]
 
 
+def test_policyengine_program_surface_marks_indiana_ssp_pending_rulespec_encoding():
+    report = build_policyengine_program_surface_report(program="in_ssp")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    in_ssp = items_by_variable["in_ssp"]
+
+    assert in_ssp["program_id"] == "ssi_state_supplement"
+    assert in_ssp["state"] == "IN"
+    assert in_ssp["axiom_status"] == "pending_rulespec_encoding"
+    assert in_ssp["mapping_count"] == 0
+    assert "Indiana Code" in in_ssp["rationale"]
+    assert "FSSA Medicaid Policy Manual Chapter 5000" in in_ssp["rationale"]
+
+
 def test_policyengine_program_surface_marks_illinois_tanf_known_not_comparable():
     report = build_policyengine_program_surface_report(program="il_tanf")
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1120"
+version = "0.2.1121"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- promote the Indiana SSP PolicyEngine surface from `deferred_jurisdiction` to `pending_rulespec_encoding`
- record the official source basis: existing Indiana Code corpus plus the merged FSSA Medicaid Policy Manual Chapter 5000 SAPN corpus artifacts
- add regression coverage for the surface report state and bump axiom-encode to `0.2.1121`

## Validation
- `env -u UV_FROZEN uv run --extra dev ruff check .`
- `env -u UV_FROZEN uv run --extra dev ruff format --check tests/test_policyengine_coverage.py`
- `env -u UV_FROZEN uv run --extra dev python -m compileall -q src/axiom_encode scripts`
- `env -u UV_FROZEN uv run --extra dev python -m pytest -q tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_indiana_ssp_pending_rulespec_encoding tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`
- `env -u UV_FROZEN uv run --extra dev python -m pytest -q tests/test_policyengine_coverage.py`
- `env -u UV_FROZEN uv run --extra dev python -m towncrier build --draft --version 0.0.0`
- `env -u UV_FROZEN uv run --extra dev pytest`

## Review cycle
- Independent read-only review found no actionable issues.
- Residual risk noted: this PR assumes the Indiana Code and FSSA SAPN corpus artifacts are available in the corpus repository; the SAPN corpus source PR was merged before this queue promotion.
