### PR TITLE
Queue Kansas SSPP for RuleSpec encoding

### DIFF
--- a/changelog.d/ks-sspp-queue.changed.md
+++ b/changelog.d/ks-sspp-queue.changed.md
@@ -1,0 +1,1 @@
+Promote Kansas SSPP to the source-backed RuleSpec encoding queue after Kansas statute and KHPA policy-memo corpus ingestion.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1121"
+version = "0.2.1122"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1121"
+__version__ = "0.2.1122"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1985,10 +1985,11 @@ surfaces:
   variable: ks_sspp
   source_type: state_implementation
   state: KS
-  axiom_status: deferred_jurisdiction
+  axiom_status: pending_rulespec_encoding
   priority: P2
-  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
-    and Georgia law before other jurisdictions.
+  rationale: Official Kansas K.S.A. 39-972 statute corpus artifacts and KHPA Policy No. 2007-05-01 SSPP guidance corpus
+    artifacts are ingested from Kansas Revisor and KDHE official sources. Encode the source-law institutional SSI recipient
+    eligibility and payment rules before classifying comparability with PolicyEngine's final `ks_sspp` person-level surface.
 - country: us
   program_id: ssi_state_supplement
   program_name: Louisiana OSS

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2263,6 +2263,20 @@ def test_policyengine_program_surface_marks_indiana_ssp_pending_rulespec_encodin
     assert "FSSA Medicaid Policy Manual Chapter 5000" in in_ssp["rationale"]
 
 
+def test_policyengine_program_surface_marks_kansas_sspp_pending_rulespec_encoding():
+    report = build_policyengine_program_surface_report(program="ks_sspp")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    ks_sspp = items_by_variable["ks_sspp"]
+
+    assert ks_sspp["program_id"] == "ssi_state_supplement"
+    assert ks_sspp["state"] == "KS"
+    assert ks_sspp["axiom_status"] == "pending_rulespec_encoding"
+    assert ks_sspp["mapping_count"] == 0
+    assert "K.S.A. 39-972" in ks_sspp["rationale"]
+    assert "KHPA Policy No. 2007-05-01" in ks_sspp["rationale"]
+
+
 def test_policyengine_program_surface_marks_illinois_tanf_known_not_comparable():
     report = build_policyengine_program_surface_report(program="il_tanf")
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1121"
+version = "0.2.1122"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- promote the PolicyEngine `ks_sspp` surface from `deferred_jurisdiction` to `pending_rulespec_encoding`
- document that Kansas SSPP now has official Kansas statute and KHPA policy memo corpus artifacts from axiom-corpus PR #202
- add coverage so the status and source rationale do not regress

## Validation
- `env -u UV_FROZEN uv lock --check`
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python3 -m compileall -q src/axiom_encode scripts`
- `uv run --extra dev python -m pytest -q`
- `uv run --extra dev python -m towncrier.check`

## Notes
This does not hand-edit generated RuleSpec. It only moves Kansas SSPP into the source-backed RuleSpec encoding queue after corpus ingestion.