### PR TITLE
Block non-comparable PolicyEngine source overclaims

### DIFF
--- a/changelog.d/chip-final-variable-overclaim.fixed.md
+++ b/changelog.d/chip-final-variable-overclaim.fixed.md
@@ -1,0 +1,1 @@
+Prevent PolicyEngine classifier promotion when generated source-level RuleSpec uses a final PolicyEngine variable name under a curated not-comparable legal-id prefix for that same variable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1124"
+version = "0.2.1125"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1124"
+__version__ = "0.2.1125"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/classifier.py
+++ b/src/axiom_encode/oracles/policyengine/classifier.py
@@ -31,6 +31,7 @@ from axiom_encode.oracles.policyengine.adapters import (
     PE_US_VAR_ADAPTERS,
     PolicyEngineUSVarAdapter,
 )
+from axiom_encode.oracles.policyengine.registry import load_policyengine_registry
 
 # RuleSpec dtypes that align with money-amount PolicyEngine variables.
 _MONEY_DTYPES = frozenset({"Money", "USD", "Integer", "Decimal", "Number"})
@@ -142,6 +143,29 @@ def _classify_one(
             return _not_comparable(legal_id, rule_name, source_text)
 
     entity, period = _adapter_entity_period(adapter)
+    registry_mapping = load_policyengine_registry().mapping_for_legal_id(
+        legal_id, country="us"
+    )
+    if (
+        registry_mapping is not None
+        and registry_mapping.mapping_type == "not_comparable"
+        and registry_mapping.policyengine_variable == adapter.pe_var
+    ):
+        return Classification(
+            legal_id=legal_id,
+            mapping_type="not_comparable",
+            policyengine_variable=adapter.pe_var,
+            entity=None,
+            period=None,
+            unit=None,
+            comparison=None,
+            rationale=registry_mapping.rationale
+            or (
+                f"Registry classifies `{legal_id}` as not comparable to "
+                f"`{adapter.pe_var}` despite the matching rule name."
+            ),
+            matched_adapter=rule_name,
+        )
 
     return Classification(
         legal_id=legal_id,

--- a/tests/test_policyengine_classifier.py
+++ b/tests/test_policyengine_classifier.py
@@ -303,6 +303,70 @@ def test_classify_rulespec_repo_supports_health_program_catalog(tmp_path: Path) 
     assert [c.legal_id.split("#")[1] for c in aca_only] == ["aca_ptc"]
 
 
+def test_classify_respects_not_comparable_prefix_for_matching_pe_name(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "rulespec-us"
+    source_dir = repo / "statutes" / "42" / "1397jj" / "b"
+    source_dir.mkdir(parents=True)
+    (source_dir / "1.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "format": "rulespec/v1",
+                "module": {},
+                "rules": [
+                    {
+                        "name": "is_chip_eligible",
+                        "kind": "derived",
+                        "dtype": "Judgment",
+                        "source": "A generated source-level CHIP child prerequisite.",
+                        "versions": [
+                            {"effective_from": "2025-01-01", "formula": "true"}
+                        ],
+                    },
+                ],
+            }
+        )
+    )
+    program_dir = repo / "programs" / "chip"
+    program_dir.mkdir(parents=True)
+    (program_dir / "fy-2026.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "format": "rulespec/v1",
+                "module": {},
+                "rules": [
+                    {
+                        "name": "is_chip_eligible",
+                        "kind": "derived",
+                        "dtype": "Judgment",
+                        "source": "A composed CHIP program eligibility output.",
+                        "versions": [
+                            {"effective_from": "2026-01-01", "formula": "true"}
+                        ],
+                    },
+                ],
+            }
+        )
+    )
+
+    classifications = classify_rulespec_repo(
+        repo_root=repo,
+        jurisdiction="us",
+        program="chip",
+    )
+
+    by_legal_id = {c.legal_id: c for c in classifications}
+    source_claim = by_legal_id["us:statutes/42/1397jj/b/1#is_chip_eligible"]
+    assert source_claim.mapping_type == "not_comparable"
+    assert source_claim.policyengine_variable == "is_chip_eligible"
+    assert "source-level CHIP eligibility prerequisites" in source_claim.rationale
+
+    program_claim = by_legal_id["us:programs/chip/fy-2026#is_chip_eligible"]
+    assert program_claim.mapping_type == "direct_variable"
+    assert program_claim.policyengine_variable == "is_chip_eligible"
+
+
 def test_classify_splits_combined_medicaid_chip_sources_by_rule_name(
     tmp_path: Path,
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1124"
+version = "0.2.1125"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- honor curated `not_comparable` PolicyEngine registry mappings before promoting matching RuleSpec names to direct variables
- prevent source-level CHIP statutory prerequisite encodings from being treated as final `is_chip_eligible` parity claims
- add a regression test proving the source-level CHIP claim is blocked while a program-level `is_chip_eligible` output still maps directly

## Tests
- `uv run --extra dev python -m pytest -q tests/test_policyengine_classifier.py tests/test_policyengine_coverage.py tests/test_policyengine_coverage_monorepo.py tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`
- `uv run ruff check pyproject.toml src/axiom_encode tests`
- `env -u UV_FROZEN uv lock --check && python3 -m compileall -q src/axiom_encode scripts && uv run --extra dev python -m towncrier.check`
- `uv run --extra dev python -m pytest -q`