### PR TITLE
Add CHIP FCEP PolicyEngine adapter

### DIFF
--- a/changelog.d/chip-fcep-adapter.added.md
+++ b/changelog.d/chip-fcep-adapter.added.md
@@ -1,0 +1,1 @@
+Add the CHIP FCEP helper to the PolicyEngine adapter catalog.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1125"
+version = "0.2.1126"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1125"
+__version__ = "0.2.1126"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/adapters.py
+++ b/src/axiom_encode/oracles/policyengine/adapters.py
@@ -791,6 +791,13 @@ PE_US_CHIP_VAR_ADAPTERS = (
         comparison="decision",
     ),
     PolicyEngineUSVarAdapter(
+        rule_names=("is_chip_fcep_eligible_person",),
+        pe_var="is_chip_fcep_eligible_person",
+        entity="person",
+        period="year",
+        comparison="decision",
+    ),
+    PolicyEngineUSVarAdapter(
         rule_names=("chip",),
         pe_var="chip",
         entity="person",

--- a/tests/test_policyengine_classifier.py
+++ b/tests/test_policyengine_classifier.py
@@ -203,6 +203,18 @@ def test_classify_rulespec_repo_supports_health_program_catalog(tmp_path: Path) 
                         ],
                     },
                     {
+                        "name": "is_chip_fcep_eligible_person",
+                        "kind": "derived",
+                        "dtype": "Judgment",
+                        "source": (
+                            "A pregnant person is eligible through the CHIP "
+                            "from-conception-to-end-of-pregnancy pathway."
+                        ),
+                        "versions": [
+                            {"effective_from": "2025-01-01", "formula": "true"}
+                        ],
+                    },
+                    {
                         "name": "aca_ptc",
                         "kind": "derived",
                         "dtype": "Money",
@@ -272,6 +284,11 @@ def test_classify_rulespec_repo_supports_health_program_catalog(tmp_path: Path) 
     )
     assert by_name["is_medicaid_eligible"].entity == "person"
     assert by_name["is_chip_eligible"].policyengine_variable == "is_chip_eligible"
+    assert (
+        by_name["is_chip_fcep_eligible_person"].policyengine_variable
+        == "is_chip_fcep_eligible_person"
+    )
+    assert by_name["is_chip_fcep_eligible_person"].comparison == "decision"
     assert by_name["aca_ptc"].policyengine_variable == "aca_ptc"
     assert by_name["aca_ptc"].entity == "tax_unit"
     assert by_name["aca_ptc"].unit == "USD"
@@ -293,7 +310,10 @@ def test_classify_rulespec_repo_supports_health_program_catalog(tmp_path: Path) 
         jurisdiction="us-co",
         program="chip",
     )
-    assert [c.legal_id.split("#")[1] for c in chip_only] == ["is_chip_eligible"]
+    assert [c.legal_id.split("#")[1] for c in chip_only] == [
+        "is_chip_eligible",
+        "is_chip_fcep_eligible_person",
+    ]
 
     aca_only = classify_rulespec_repo(
         repo_root=repo,

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1125"
+version = "0.2.1126"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add the CHIP FCEP helper to the PolicyEngine adapter catalog
- extend classifier coverage so CHIP program scans include `is_chip_fcep_eligible_person`

## Tests
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_classifier.py -q`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_executable_outputs -q`
- `uv run ruff check src/axiom_encode/oracles/policyengine/adapters.py tests/test_policyengine_classifier.py`