### PR TITLE
Map CHIP postpartum continuation outputs

### DIFF
--- a/changelog.d/chip-f2-oracle-mapping.added.md
+++ b/changelog.d/chip-f2-oracle-mapping.added.md
@@ -1,0 +1,1 @@
+Classify CHIP postpartum continuation RuleSpec outputs in the PolicyEngine oracle mapping.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1126"
+version = "0.2.1127"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1126"
+__version__ = "0.2.1127"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -444,6 +444,22 @@ mappings:
     policyengine_variable: is_chip_eligible_standard_pregnant_person
     rationale: This RuleSpec output is the federal source-level targeted-low-income pregnant woman definition. PolicyEngine exposes final standard pregnant CHIP eligibility after state limits and other category assembly, not this statutory prerequisite as a one-to-one oracle variable.
 
+  - legal_id: us:statutes/42/1397ll/f/2#postpartum_continuation_period_days
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    candidate_priority: P4
+    policyengine_variable: is_chip_fcep_eligible_person
+    rationale: This RuleSpec output is the federal postpartum continuation timing scalar for State-option CHIP coverage. PolicyEngine exposes person-level FCEP eligibility, not this continuation-period helper as a one-to-one oracle variable or parameter.
+
+  - legal_id: us:statutes/42/1397ll/f/2#state_may_continue_child_health_assistance_and_postpartum_services
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    candidate_priority: P4
+    policyengine_variable: is_chip_fcep_eligible_person
+    rationale: This RuleSpec output is the federal State-option authority to continue CHIP assistance and postpartum services after pregnancy. PolicyEngine exposes final FCEP eligibility surfaces, not this statutory continuation-authority predicate as a one-to-one oracle variable.
+
   - legal_id: us:statutes/8/1612/b/2/G#paragraph_1_nonapplication_exception_applies
     country: us
     program: medicaid

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1126"
+version = "0.2.1127"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify the new 42 USC 1397ll(f)(2) CHIP postpartum continuation outputs in the PolicyEngine oracle mapping
- mark them not comparable to PE because they are source-level continuation authority/timing helpers, while PE exposes final FCEP eligibility
- bump axiom-encode to 0.2.1127

## Tests
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py tests/test_policyengine_classifier.py tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q
- uv run --with pyyaml python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('src/axiom_encode/oracles/policyengine/mappings/us.yaml').read_text())"
- git diff --check origin/main...HEAD