### PR TITLE
Accept digit scale numeric grounding

### DIFF
--- a/changelog.d/digit-scale-numeric-grounding.fixed.md
+++ b/changelog.d/digit-scale-numeric-grounding.fixed.md
@@ -1,0 +1,1 @@
+Accept digit-plus-scale monetary source phrases such as "20 million Euros" when grounding expanded numeric RuleSpec literals.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1128"
+version = "0.2.1129"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1128"
+__version__ = "0.2.1129"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -1266,6 +1266,11 @@ _CARDINAL_NUMBER_WORD_PATTERN = re.compile(
     + r"))*\b",
     re.IGNORECASE,
 )
+_DIGIT_SCALE_NUMBER_PATTERN = re.compile(
+    r"(?<![\w.])(?P<number>-?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?)\s+"
+    r"(?P<scale>thousands?|millions?|billions?)\b",
+    re.IGNORECASE,
+)
 _CARDINAL_VALUE_WORDS = {
     int(value): word
     for word, value in _CARDINAL_WORD_VALUES.items()
@@ -2981,6 +2986,11 @@ def extract_numbers_from_text(text: str) -> set[float]:
             continue
         numbers.add(value)
         occupied_spans.append(span)
+    for span, value in _iter_digit_scale_number_matches(text):
+        if _span_overlaps(span, occupied_spans):
+            continue
+        numbers.add(value)
+        occupied_spans.append(span)
     for span, value in _iter_french_cardinal_phrase_matches(text):
         if _span_overlaps(span, occupied_spans):
             continue
@@ -3229,6 +3239,22 @@ def _iter_cardinal_word_number_matches(
         if value is None:
             continue
         matches.append((match.span(), value))
+    return matches
+
+
+def _iter_digit_scale_number_matches(
+    text: str,
+) -> list[tuple[tuple[int, int], float]]:
+    """Return numeric scale phrases such as "20 million" or "10.2 million"."""
+    matches: list[tuple[tuple[int, int], float]] = []
+    for match in _DIGIT_SCALE_NUMBER_PATTERN.finditer(text):
+        scale_word = match.group("scale").lower().removesuffix("s")
+        scale = _CARDINAL_SCALE_WORD_VALUES.get(scale_word)
+        if scale is None:
+            continue
+        with contextlib.suppress(ValueError):
+            number = float(match.group("number").replace(",", ""))
+            matches.append((match.span(), number * scale))
     return matches
 
 
@@ -3857,6 +3883,13 @@ def extract_numeric_occurrences_from_text(text: str) -> list[float]:
                 float(_normalize_grouped_thousands_number(match.group(1)))
             )
             spans.append(span)
+
+    for span, value in _iter_digit_scale_number_matches(cleaned):
+        if _span_overlaps(span, spans):
+            continue
+        if value not in GROUNDING_ALLOWED_VALUES:
+            occurrences.append(value)
+        spans.append(span)
 
     for match in SOURCE_TEXT_NUMBER_PATTERN.finditer(cleaned):
         span = match.span(1)

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6056,6 +6056,40 @@ def test_numeric_extraction_prefers_english_compound_cardinals_over_single_words
     )
 
 
+def test_rulespec_grounding_accepts_digit_scale_money_phrases():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: uk/statute/ukpga/2018/12/157/enacted
+rules:
+  - name: higher_maximum_fixed_penalty_amount
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2018-05-25'
+        formula: '20000000'
+  - name: standard_maximum_fixed_penalty_amount
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2018-05-25'
+        formula: '10000000'
+"""
+
+    source_text = (
+        "The higher maximum amount is 20 million Euros. "
+        "The standard maximum amount is 10 million Euros."
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    source_values = extract_numbers_from_text(source_text)
+    assert 20000000 in source_values
+    assert 10000000 in source_values
+    occurrences = extract_numeric_occurrences_from_text(source_text)
+    assert 20000000 in occurrences
+    assert 10000000 in occurrences
+
+
 def test_rulespec_grounding_rejects_unrelated_power_of_ten():
     content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1128"
+version = "0.2.1129"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Accept digit-plus-scale source phrases such as "20 million Euros" when grounding expanded numeric RuleSpec literals.
- Add a regression test for the DPA-style fixed penalty amounts.
- Bump axiom-encode to 0.2.1129 and add a changelog fragment.

## Review
- Independent review: no actionable findings.

## Checks
- uv run --extra dev ruff check pyproject.toml src/axiom_encode scripts tests
- uv run python -m compileall -q src/axiom_encode scripts
- uv run --extra dev python -m pytest -q tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_rulespec_validation.py::test_rulespec_grounding_accepts_digit_scale_money_phrases
- uv run --extra dev python -m pytest (clean /tmp worktree): 2622 passed, 27 skipped

Note: the full suite in the nested rulespec-uk/_axiom checkout scans a local sibling rulespec-us checkout and reports pre-existing cross-statute import failures. The same committed branch passes in a clean worktree where that optional sibling is absent.