### PR TITLE
Add CMS effective MAGI repair command

### DIFF
--- a/changelog.d/cms-effective-magi-repair.added.md
+++ b/changelog.d/cms-effective-magi-repair.added.md
@@ -1,0 +1,1 @@
+Add a generic signed repair command for CMS effective MAGI eligibility limits.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1129"
+version = "0.2.1130"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1129"
+__version__ = "0.2.1130"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -1887,6 +1887,39 @@ def main():
         help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
     )
 
+    repair_cms_effective_parser = subparsers.add_parser(
+        "repair-cms-effective-magi-limits",
+        help="Apply signed deterministic CMS effective MAGI limit repairs",
+    )
+    repair_cms_effective_parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="rulespec-us repository root used for manifest signing",
+    )
+    repair_cms_effective_parser.add_argument(
+        "--target",
+        type=Path,
+        required=True,
+        help="CMS eligibility-level RuleSpec file to repair, relative to the repo root",
+    )
+    repair_cms_effective_parser.add_argument(
+        "--axiom-rules-engine-path",
+        dest="axiom_rules_path",
+        metavar="AXIOM_RULES_ENGINE_PATH",
+        type=Path,
+        default=None,
+        help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
+    )
+    repair_cms_effective_parser.add_argument(
+        "--refresh-manifest",
+        action="store_true",
+        help=(
+            "Validate and rewrite the signed apply manifest even when the "
+            "target already contains the deterministic effective MAGI repairs"
+        ),
+    )
+
     repair_medicaid_optional_parser = subparsers.add_parser(
         "repair-medicaid-optional-senior-composition",
         help="Apply signed deterministic Medicaid optional senior/disabled composition repairs",
@@ -2704,6 +2737,8 @@ def main():
         cmd_repair_georgia_cms_medicaid_availability(args)
     elif args.command == "repair-georgia-cms-effective-magi-limits":
         cmd_repair_georgia_cms_effective_magi_limits(args)
+    elif args.command == "repair-cms-effective-magi-limits":
+        cmd_repair_cms_effective_magi_limits(args)
     elif args.command == "repair-medicaid-optional-senior-composition":
         cmd_repair_medicaid_optional_senior_composition(args)
     elif args.command == "repair-medicaid-primary-category-composition":
@@ -7681,6 +7716,17 @@ GEORGIA_CMS_EFFECTIVE_MAGI_LIMIT_RULES = (
 )
 
 
+CMS_ELIGIBILITY_LEVELS_CORPUS_PATH = "us/form/cms/medicaid-chip-bhp-eligibility-levels"
+CMS_EFFECTIVE_MAGI_LIMIT_SUFFIXES = (
+    "children_medicaid_ages_0_to_1",
+    "children_medicaid_ages_1_to_5",
+    "children_medicaid_ages_6_to_18",
+    "children_separate_chip",
+    "pregnant_women_medicaid",
+    "pregnant_women_chip",
+)
+
+
 def _rulespec_rule_names(content: str) -> set[str]:
     try:
         payload = yaml.safe_load(content) or {}
@@ -7759,6 +7805,147 @@ def _repair_georgia_cms_medicaid_availability_tests(
             f"    {GEORGIA_CMS_MEDICAID_CITATION}#{rule['name']}: "
             f"{rule['test_value']}\n"
         )
+    return repaired, [rule["name"] for rule in missing]
+
+
+def _first_version_formula(rule: dict[str, Any]) -> Any:
+    versions = rule.get("versions")
+    if not isinstance(versions, list) or not versions:
+        return None
+    first = versions[0]
+    if not isinstance(first, dict):
+        return None
+    return first.get("formula")
+
+
+def _cms_rate_formula_decimal(rule: dict[str, Any]) -> Decimal | None:
+    formula = _first_version_formula(rule)
+    if formula is None:
+        return None
+    try:
+        return Decimal(str(formula).strip())
+    except Exception:
+        return None
+
+
+def _format_cms_effective_rate(value: Decimal) -> str:
+    return format(value.quantize(Decimal("0.01")), "f")
+
+
+def _cms_state_label_from_rule_name(rule_name: str, suffix: str) -> str:
+    state_slug = rule_name[: -len(f"_{suffix}_fpl_limit")]
+    return state_slug.replace("_", " ").title()
+
+
+def _cms_effective_magi_limit_repairs(
+    content: str,
+) -> tuple[list[dict[str, str]], str | None]:
+    payload = yaml.safe_load(content) or {}
+    if not isinstance(payload, dict):
+        return [], "RuleSpec file is not a mapping"
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return [], "RuleSpec file has no rules list"
+
+    rules_by_name = {
+        str(rule.get("name") or "").strip(): rule
+        for rule in rules
+        if isinstance(rule, dict) and str(rule.get("name") or "").strip()
+    }
+    disregard_rule = rules_by_name.get("magi_fpl_disregard_rate")
+    if not isinstance(disregard_rule, dict):
+        return [], "CMS file has no magi_fpl_disregard_rate rule"
+    disregard = _cms_rate_formula_decimal(disregard_rule)
+    if disregard is None:
+        return [], "magi_fpl_disregard_rate is not a numeric scalar"
+
+    repairs: list[dict[str, str]] = []
+    for raw_name, rule in sorted(rules_by_name.items()):
+        if raw_name.endswith("_effective_fpl_limit"):
+            continue
+        suffix = next(
+            (
+                candidate
+                for candidate in CMS_EFFECTIVE_MAGI_LIMIT_SUFFIXES
+                if raw_name.endswith(f"_{candidate}_fpl_limit")
+            ),
+            None,
+        )
+        if suffix is None:
+            continue
+        if not isinstance(rule, dict):
+            continue
+        effective_name = raw_name.removesuffix("_fpl_limit") + "_effective_fpl_limit"
+        if effective_name in rules_by_name:
+            continue
+        raw_value = _cms_rate_formula_decimal(rule)
+        if raw_value is None:
+            continue
+        state_label = _cms_state_label_from_rule_name(raw_name, suffix)
+        repairs.append(
+            {
+                "name": effective_name,
+                "raw_limit": raw_name,
+                "source": (
+                    "CMS Medicaid, CHIP and BHP Eligibility Levels table, "
+                    f"{state_label} row, including the MAGI 5% FPL disregard"
+                ),
+                "test_value": _format_cms_effective_rate(raw_value + disregard),
+            }
+        )
+    return repairs, None
+
+
+def _cms_effective_magi_limit_rule_block(rule: dict[str, str]) -> str:
+    return f"""  - name: {rule["name"]}
+    kind: derived
+    dtype: Rate
+    source: {rule["source"]}
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: {CMS_ELIGIBILITY_LEVELS_CORPUS_PATH}
+              excerpt: "5% FPL disregard"
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          {rule["raw_limit"]} + magi_fpl_disregard_rate
+"""
+
+
+def _repair_cms_effective_magi_limit_rules(
+    content: str,
+) -> tuple[str, list[dict[str, str]], str | None]:
+    missing, issue = _cms_effective_magi_limit_repairs(content)
+    if issue is not None:
+        return content, [], issue
+    if not missing:
+        return content, [], None
+
+    repaired = content.rstrip() + "\n\n"
+    repaired += "\n".join(
+        _cms_effective_magi_limit_rule_block(rule).rstrip() for rule in missing
+    )
+    repaired += "\n"
+    return repaired, missing, None
+
+
+def _repair_cms_effective_magi_limit_tests(
+    content: str,
+    *,
+    citation: str,
+    rules: list[dict[str, str]],
+) -> tuple[str, list[str]]:
+    missing = [rule for rule in rules if f"{citation}#{rule['name']}" not in content]
+    if not missing:
+        return content, []
+
+    repaired = content.rstrip() + "\n"
+    for rule in missing:
+        repaired += f"    {citation}#{rule['name']}: {rule['test_value']}\n"
     return repaired, [rule["name"] for rule in missing]
 
 
@@ -9142,6 +9329,169 @@ def _repair_medicaid_community_engagement_effective_date_rules(
         ),
         ["is_medicaid_eligible"],
     )
+
+
+def _cms_effective_magi_limit_relative_target(
+    repo_path: Path,
+    target: Path,
+) -> Path:
+    if target.is_absolute():
+        try:
+            relative = target.resolve().relative_to(repo_path)
+        except ValueError as exc:
+            raise RuntimeError(f"Target is not inside repo: {target}") from exc
+    else:
+        relative = target
+    if ".." in relative.parts or not relative.parts:
+        raise RuntimeError(f"Invalid target path: {target}")
+    if relative.suffix != ".yaml":
+        raise RuntimeError(f"Target must be a RuleSpec YAML file: {target}")
+    return relative
+
+
+def cmd_repair_cms_effective_magi_limits(args):
+    """Apply signed deterministic CMS effective MAGI limit repairs."""
+    repo_path = Path(args.repo).resolve()
+    if _repo_jurisdiction_prefix(repo_path) != "us":
+        print(
+            "repair-cms-effective-magi-limits must run against "
+            f"rulespec-us; got {repo_path}"
+        )
+        sys.exit(1)
+
+    try:
+        relative_output = _cms_effective_magi_limit_relative_target(
+            repo_path,
+            Path(args.target),
+        )
+    except RuntimeError as exc:
+        print(str(exc))
+        sys.exit(1)
+
+    rules_file = repo_path / relative_output
+    test_file = _rulespec_test_path(rules_file)
+    if not rules_file.exists():
+        print(f"RuleSpec file not found: {rules_file}")
+        sys.exit(1)
+    if not test_file.exists():
+        print(f"RuleSpec companion test file not found: {test_file}")
+        sys.exit(1)
+
+    original_content = rules_file.read_text()
+    original_test_content = test_file.read_text()
+    repaired_content, repaired_rules, issue = _repair_cms_effective_magi_limit_rules(
+        original_content
+    )
+    if issue is not None:
+        print(issue)
+        sys.exit(1)
+    citation = _rulespec_anchor_base_for_output(repo_path, relative_output)
+    repaired_test_content, repaired_tests = _repair_cms_effective_magi_limit_tests(
+        original_test_content,
+        citation=citation,
+        rules=repaired_rules,
+    )
+    applied_files = [rules_file, test_file]
+
+    content_changed = (
+        repaired_content != original_content
+        or repaired_test_content != original_test_content
+    )
+    if not content_changed and not getattr(args, "refresh_manifest", False):
+        print("No CMS effective MAGI limit repairs found.")
+        return
+
+    signing_key = _require_applied_encoding_manifest_signing_key()
+    axiom_encode_git = _require_clean_axiom_encode_git_provenance()
+    axiom_rules_path = getattr(
+        args, "axiom_rules_path", None
+    ) or _resolve_runtime_axiom_rules_checkout(repo_path)
+    _ensure_no_unmanifested_preexisting_rulespec_changes(
+        repo_path,
+        [(relative_output, applied_files)],
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_root = Path(tmpdir)
+        generated_output = output_root / "deterministic-repair" / relative_output
+        generated_output.parent.mkdir(parents=True, exist_ok=True)
+        generated_output.write_text(repaired_content)
+        generated_test = _rulespec_test_path(generated_output)
+        generated_test.write_text(repaired_test_content)
+
+        rules_file.write_text(repaired_content)
+        test_file.write_text(repaired_test_content)
+
+        try:
+            validation = ValidatorPipeline(
+                policy_repo_path=repo_path,
+                axiom_rules_path=axiom_rules_path,
+                enable_oracles=False,
+                require_policy_proofs=True,
+            ).validate(rules_file, skip_reviewers=True)
+            if not validation.all_passed:
+                issues = [
+                    result.error
+                    for result in validation.results.values()
+                    if result.error
+                ]
+                print("Repair failed validation; restored original files.")
+                for issue in issues:
+                    print(f"- {issue}")
+                sys.exit(1)
+
+            test_failures = _rulespec_companion_test_failures(
+                test_file,
+                root=repo_path,
+                axiom_rules_path=axiom_rules_path,
+            )
+            if test_failures:
+                print("Repair failed companion tests; restored original files.")
+                for failure in test_failures[:20]:
+                    case_name = failure.get("case") or "<unknown case>"
+                    print(f"- {case_name}: {failure.get('message')}")
+                sys.exit(1)
+        finally:
+            validation_passed = "validation" in locals() and validation.all_passed
+            tests_passed = "test_failures" in locals() and not test_failures
+            if not validation_passed or not tests_passed:
+                rules_file.write_text(original_content)
+                test_file.write_text(original_test_content)
+
+        result = argparse.Namespace(
+            output_file=str(generated_output),
+            runner="deterministic-repair",
+            backend="deterministic",
+            model="cms-effective-magi-limits-v1",
+            tool="axiom-encode repair-cms-effective-magi-limits",
+            citation=citation,
+            generation_prompt_sha256=None,
+            trace_file=None,
+            context_manifest_file=None,
+        )
+        manifest_path = _write_applied_encoding_manifest(
+            result,
+            output_root=output_root,
+            policy_repo_path=repo_path,
+            relative_output=relative_output,
+            applied_files=applied_files,
+            run_id="deterministic-repair",
+            signing_key=signing_key,
+            axiom_encode_git=axiom_encode_git,
+        )
+
+    changed_names = sorted(
+        {rule["name"] for rule in repaired_rules} | set(repaired_tests)
+    )
+    if content_changed:
+        print("Applied CMS effective MAGI limit repair")
+    else:
+        print("Refreshed CMS effective MAGI limit repair manifest")
+    if changed_names:
+        print(f"changed_rules={', '.join(changed_names)}")
+    print(f"changed={relative_output}")
+    print(f"changed={_rulespec_test_path(relative_output)}")
+    print(f"manifest={manifest_path}")
 
 
 def cmd_repair_georgia_cms_effective_magi_limits(args):

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -8154,6 +8154,66 @@ mappings:
     candidate_priority: P4
     rationale: Axiom exposes the raw Colorado CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person CHIP income limit including that disregard.
 
+  - legal_id: us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: CO
+    period: year
+    comparison: rate
+    rationale: Same effective Colorado infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: CO
+    period: year
+    comparison: rate
+    rationale: Same effective Colorado young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: CO
+    period: year
+    comparison: rate
+    rationale: Same effective Colorado older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: CO
+    period: year
+    comparison: rate
+    rationale: Same effective Colorado child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: CO
+    period: year
+    comparison: rate
+    rationale: Same effective Colorado pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_pregnant_women_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: CO
+    period: year
+    comparison: rate
+    rationale: Same effective Colorado pregnant-person CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
   - legal_id: us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_parent_caretaker_adults_medicaid_fpl_limit
     country: us
     program: medicaid

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -192,6 +192,7 @@ from axiom_encode.cli import (
     cmd_oracle_coverage,
     cmd_repair_arizona_snap_composition,
     cmd_repair_bare_snapunit_entities,
+    cmd_repair_cms_effective_magi_limits,
     cmd_repair_colorado_tax_validation,
     cmd_repair_companion_test_references,
     cmd_repair_current_year_final_amounts,
@@ -27301,6 +27302,191 @@ rules:
         assert payload["model"] == "georgia-cms-effective-magi-limits-v1"
         assert (
             payload["tool"] == "axiom-encode repair-georgia-cms-effective-magi-limits"
+        )
+
+    def test_repair_cms_effective_magi_limits_writes_colorado_signed_manifest(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        target = (
+            policy_repo
+            / "us-co/policies/cms/colorado-medicaid-chip-bhp-eligibility-levels.yaml"
+        )
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+  summary: |-
+    Colorado row: Children Medicaid Ages 0-1 142%; Ages 1-5 142%; Ages 6-18 142%; Children Separate CHIP 260%; Pregnant Women Medicaid 195%; Pregnant Women CHIP 260%. The MAGI-based rules generally include a 5% FPL disregard.
+rules:
+  - name: magi_fpl_disregard_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          0.05
+  - name: colorado_children_medicaid_ages_0_to_1_fpl_limit
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          1.42
+  - name: colorado_children_medicaid_ages_1_to_5_fpl_limit
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          1.42
+  - name: colorado_children_medicaid_ages_6_to_18_fpl_limit
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          1.42
+  - name: colorado_children_separate_chip_fpl_limit
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          2.60
+  - name: colorado_pregnant_women_medicaid_fpl_limit
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          1.95
+  - name: colorado_pregnant_women_chip_fpl_limit
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          2.60
+"""
+        )
+        test_file = (
+            policy_repo
+            / "us-co/policies/cms/colorado-medicaid-chip-bhp-eligibility-levels.test.yaml"
+        )
+        test_file.write_text(
+            """- name: colorado_magi_eligibility_level_parameters_as_of_december_2023
+  period:
+    period_kind: custom
+    name: day
+    start: '2023-12-01'
+    end: '2023-12-01'
+  input: {}
+  output:
+    us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#magi_fpl_disregard_rate: 0.05
+    us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_children_separate_chip_fpl_limit: 2.60
+"""
+        )
+        args = SimpleNamespace(
+            repo=policy_repo,
+            target=Path(
+                "us-co/policies/cms/colorado-medicaid-chip-bhp-eligibility-levels.yaml"
+            ),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == target.resolve()
+                assert skip_reviewers is True
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._rulespec_companion_test_failures",
+                return_value=[],
+            ),
+            patch(
+                "axiom_encode.cli._ensure_no_unmanifested_preexisting_rulespec_changes"
+            ),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_cms_effective_magi_limits(args)
+
+        rules_payload = yaml.safe_load(target.read_text())
+        rules_by_name = {rule["name"]: rule for rule in rules_payload["rules"]}
+        assert (
+            rules_by_name["colorado_children_separate_chip_effective_fpl_limit"][
+                "versions"
+            ][0]["formula"]
+            == "colorado_children_separate_chip_fpl_limit + magi_fpl_disregard_rate"
+        )
+        assert "colorado_pregnant_women_chip_effective_fpl_limit" in rules_by_name
+        test_content = test_file.read_text()
+        assert (
+            "us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels"
+            "#colorado_children_separate_chip_effective_fpl_limit: 2.65"
+        ) in test_content
+        assert (
+            "us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels"
+            "#colorado_pregnant_women_chip_effective_fpl_limit: 2.65"
+        ) in test_content
+        manifest = (
+            policy_repo / ".axiom/encoding-manifests/us-co/policies/cms/"
+            "colorado-medicaid-chip-bhp-eligibility-levels.json"
+        )
+        payload = json.loads(manifest.read_text())
+        assert payload["schema_version"] == APPLIED_ENCODING_MANIFEST_SCHEMA
+        assert payload["model"] == "cms-effective-magi-limits-v1"
+        assert payload["tool"] == "axiom-encode repair-cms-effective-magi-limits"
+        assert payload["citation"] == (
+            "us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels"
+        )
+
+        args.refresh_manifest = True
+        first_rules_content = target.read_text()
+        first_test_content = test_file.read_text()
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._rulespec_companion_test_failures",
+                return_value=[],
+            ),
+            patch(
+                "axiom_encode.cli._ensure_no_unmanifested_preexisting_rulespec_changes"
+            ),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "def456", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_cms_effective_magi_limits(args)
+
+        assert target.read_text() == first_rules_content
+        assert test_file.read_text() == first_test_content
+        refreshed_payload = json.loads(manifest.read_text())
+        assert refreshed_payload["axiom_encode_git"]["commit"] == "def456"
+        assert (
+            refreshed_payload["tool"] == "axiom-encode repair-cms-effective-magi-limits"
         )
 
     def test_repair_snap_273_10_allotment_restores_files_when_validation_raises(

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4393,6 +4393,36 @@ rules:
     versions:
       - effective_from: '2023-12-01'
         formula: 2.60
+  - name: colorado_children_medicaid_ages_0_to_1_effective_fpl_limit
+    kind: derived
+    versions:
+      - effective_from: '2023-12-01'
+        formula: colorado_children_medicaid_ages_0_to_1_fpl_limit + magi_fpl_disregard_rate
+  - name: colorado_children_medicaid_ages_1_to_5_effective_fpl_limit
+    kind: derived
+    versions:
+      - effective_from: '2023-12-01'
+        formula: colorado_children_medicaid_ages_1_to_5_fpl_limit + magi_fpl_disregard_rate
+  - name: colorado_children_medicaid_ages_6_to_18_effective_fpl_limit
+    kind: derived
+    versions:
+      - effective_from: '2023-12-01'
+        formula: colorado_children_medicaid_ages_6_to_18_fpl_limit + magi_fpl_disregard_rate
+  - name: colorado_children_separate_chip_effective_fpl_limit
+    kind: derived
+    versions:
+      - effective_from: '2023-12-01'
+        formula: colorado_children_separate_chip_fpl_limit + magi_fpl_disregard_rate
+  - name: colorado_pregnant_women_medicaid_effective_fpl_limit
+    kind: derived
+    versions:
+      - effective_from: '2023-12-01'
+        formula: colorado_pregnant_women_medicaid_fpl_limit + magi_fpl_disregard_rate
+  - name: colorado_pregnant_women_chip_effective_fpl_limit
+    kind: derived
+    versions:
+      - effective_from: '2023-12-01'
+        formula: colorado_pregnant_women_chip_fpl_limit + magi_fpl_disregard_rate
   - name: colorado_parent_caretaker_adults_medicaid_fpl_limit
     kind: parameter
     versions:
@@ -4405,18 +4435,33 @@ rules:
         formula: 1.33
 """,
     )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-co"
+        / "policies/cms/colorado-medicaid-chip-bhp-eligibility-levels.test.yaml",
+        """- name: colorado_effective_magi_limits
+  output:
+    us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_children_medicaid_ages_0_to_1_effective_fpl_limit: 1.47
+    us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_children_medicaid_ages_1_to_5_effective_fpl_limit: 1.47
+    us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_children_medicaid_ages_6_to_18_effective_fpl_limit: 1.47
+    us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_children_separate_chip_effective_fpl_limit: 2.65
+    us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_pregnant_women_medicaid_effective_fpl_limit: 2.00
+    us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_pregnant_women_chip_effective_fpl_limit: 2.65
+""",
+    )
 
     medicaid = build_policyengine_coverage_report(tmp_path, program="medicaid")
     chip = build_policyengine_coverage_report(tmp_path, program="chip")
     health = build_policyengine_coverage_report(tmp_path, program="health")
 
-    assert medicaid["total_outputs"] == 6
-    assert chip["total_outputs"] == 2
-    assert health["total_outputs"] == 9
-    assert health["status_counts"] == {"known_not_comparable": 9}
+    assert medicaid["total_outputs"] == 10
+    assert chip["total_outputs"] == 4
+    assert health["total_outputs"] == 15
+    assert health["status_counts"] == {
+        "comparable": 6,
+        "known_not_comparable": 9,
+    }
     assert health["untested_comparable"] == 0
-    assert {item["mapping_type"] for item in health["items"]} == {"not_comparable"}
-    assert {item["candidate_priority"] for item in health["items"]} == {"P4"}
 
     items_by_name = {item["rule_name"]: item for item in health["items"]}
     assert items_by_name["magi_fpl_disregard_rate"]["program"] == "health"
@@ -4438,9 +4483,30 @@ rules:
         ]
         == "gov.hhs.chip.child.income_limit"
     )
-    assert all(
-        "5% MAGI FPL disregard" in str(item["rationale"]) for item in health["items"]
+    effective_chip_child = items_by_name[
+        "colorado_children_separate_chip_effective_fpl_limit"
+    ]
+    assert effective_chip_child["status"] == "comparable"
+    assert effective_chip_child["mapping_type"] == "parameter_value"
+    assert effective_chip_child["policyengine_parameter"] == (
+        "gov.hhs.chip.child.income_limit"
     )
+    assert effective_chip_child["tested"] is True
+    effective_pregnant_chip = items_by_name[
+        "colorado_pregnant_women_chip_effective_fpl_limit"
+    ]
+    assert effective_pregnant_chip["status"] == "comparable"
+    assert effective_pregnant_chip["mapping_type"] == "parameter_value"
+    assert effective_pregnant_chip["policyengine_parameter"] == (
+        "gov.hhs.chip.pregnant.income_limit"
+    )
+    assert effective_pregnant_chip["tested"] is True
+    raw_items = [
+        item for item in health["items"] if item["status"] == "known_not_comparable"
+    ]
+    assert {item["mapping_type"] for item in raw_items} == {"not_comparable"}
+    assert {item["candidate_priority"] for item in raw_items} == {"P4"}
+    assert all("5% MAGI FPL disregard" in str(item["rationale"]) for item in raw_items)
 
 
 def test_policyengine_coverage_classifies_georgia_snap_medicaid_outputs(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1129"
+version = "0.2.1130"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a deterministic `repair-cms-effective-magi-limits` encoder command for CMS Medicaid/CHIP/BHP eligibility tables
- map Colorado effective MAGI outputs to PolicyEngine CHIP/Medicaid oracle parameters while leaving raw CMS limits non-comparable
- cover manifest refresh, generated RuleSpec guard behavior, and Colorado oracle coverage fixtures

## Validation
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_cli.py -k 'cms_effective_magi_limits or current_encoder_affecting_changes_are_behind_version_bump or package_versions_match'`\n- `uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -k 'colorado_medicaid_chip_thresholds or georgia_snap_medicaid_outputs'`\n- `uv run ruff check src/axiom_encode/cli.py tests/test_cli.py tests/test_policyengine_coverage.py`