### PR TITLE
Preserve numeric grounding components

### DIFF
--- a/changelog.d/numeric-component-grounding.fixed.md
+++ b/changelog.d/numeric-component-grounding.fixed.md
@@ -1,0 +1,1 @@
+Preserve source-stated component numbers when grounding digit-scale amounts and mixed ASCII fractional percentages.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1130"
+version = "0.2.1131"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1130"
+__version__ = "0.2.1131"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -2970,6 +2970,7 @@ def extract_numbers_from_text(text: str) -> set[float]:
             continue
         numbers.add(value)
         occupied_spans.append(span)
+    numbers.update(_iter_ascii_mixed_fraction_percentage_component_values(text))
     numbers.update(_extract_percentage_context_values(text))
     for span, value in _iter_standalone_fraction_word_matches(text):
         if _span_overlaps(span, occupied_spans):
@@ -2986,10 +2987,11 @@ def extract_numbers_from_text(text: str) -> set[float]:
             continue
         numbers.add(value)
         occupied_spans.append(span)
-    for span, value in _iter_digit_scale_number_matches(text):
+    for span, value, raw_value in _iter_digit_scale_number_matches(text):
         if _span_overlaps(span, occupied_spans):
             continue
         numbers.add(value)
+        numbers.add(raw_value)
         occupied_spans.append(span)
     for span, value in _iter_french_cardinal_phrase_matches(text):
         if _span_overlaps(span, occupied_spans):
@@ -3244,9 +3246,9 @@ def _iter_cardinal_word_number_matches(
 
 def _iter_digit_scale_number_matches(
     text: str,
-) -> list[tuple[tuple[int, int], float]]:
+) -> list[tuple[tuple[int, int], float, float]]:
     """Return numeric scale phrases such as "20 million" or "10.2 million"."""
-    matches: list[tuple[tuple[int, int], float]] = []
+    matches: list[tuple[tuple[int, int], float, float]] = []
     for match in _DIGIT_SCALE_NUMBER_PATTERN.finditer(text):
         scale_word = match.group("scale").lower().removesuffix("s")
         scale = _CARDINAL_SCALE_WORD_VALUES.get(scale_word)
@@ -3254,8 +3256,23 @@ def _iter_digit_scale_number_matches(
             continue
         with contextlib.suppress(ValueError):
             number = float(match.group("number").replace(",", ""))
-            matches.append((match.span(), number * scale))
+            matches.append((match.span(), number * scale, number))
     return matches
+
+
+def _iter_ascii_mixed_fraction_percentage_component_values(text: str) -> list[float]:
+    """Return component numbers from phrases like "2 6/7 per cent"."""
+    values: list[float] = []
+    for match in re.finditer(
+        r"(-?[\d,]+)\s+(\d+)\s*/\s*(\d+)"
+        r"(?:\s+|-)(?:percent|per\s*cent(?:um)?)",
+        text,
+        re.IGNORECASE,
+    ):
+        for group_index in (1, 2, 3):
+            with contextlib.suppress(ValueError):
+                values.append(float(match.group(group_index).replace(",", "")))
+    return values
 
 
 def _iter_french_cardinal_phrase_matches(
@@ -3884,7 +3901,7 @@ def extract_numeric_occurrences_from_text(text: str) -> list[float]:
             )
             spans.append(span)
 
-    for span, value in _iter_digit_scale_number_matches(cleaned):
+    for span, value, raw_value in _iter_digit_scale_number_matches(cleaned):
         if _span_overlaps(span, spans):
             continue
         if value not in GROUNDING_ALLOWED_VALUES:

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -4424,6 +4424,85 @@ rules:
         assert metrics.missing_source_numeric_occurrence_count == 0
         assert metrics.numeric_occurrence_issues == []
 
+    def test_numeric_occurrence_check_does_not_require_digit_scale_components(
+        self, tmp_path
+    ):
+        rulespec_file = tmp_path / "example.yaml"
+        rulespec_file.write_text(
+            """format: rulespec/v1
+module:
+  summary: The maximum amount is 10 million Euros.
+rules:
+  - name: maximum_fixed_penalty_amount
+    kind: parameter
+    dtype: Money
+    unit: EUR
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 10000000
+"""
+        )
+
+        compile_result = ValidationResult("compile", True, issues=[])
+        ci_result = ValidationResult("ci", True, issues=[])
+
+        with (
+            patch.object(
+                ValidatorPipeline, "_run_compile_check", return_value=compile_result
+            ),
+            patch.object(ValidatorPipeline, "_run_ci", return_value=ci_result),
+        ):
+            metrics = evaluate_artifact(
+                rulespec_file=rulespec_file,
+                policy_repo_root=tmp_path,
+                axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+                source_text="The maximum amount is 10 million Euros.",
+            )
+
+        assert metrics.ci_pass
+        assert metrics.source_numeric_occurrence_count == 1
+        assert metrics.missing_source_numeric_occurrence_count == 0
+        assert metrics.numeric_occurrence_issues == []
+
+    def test_numeric_occurrence_check_does_not_require_mixed_fraction_components(
+        self, tmp_path
+    ):
+        rulespec_file = tmp_path / "example.yaml"
+        rulespec_file.write_text(
+            """format: rulespec/v1
+module:
+  summary: Amount B is 2 6/7 per cent of the difference.
+rules:
+  - name: daily_excess_income_taper_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.02857142857142857
+"""
+        )
+
+        compile_result = ValidationResult("compile", True, issues=[])
+        ci_result = ValidationResult("ci", True, issues=[])
+
+        with (
+            patch.object(
+                ValidatorPipeline, "_run_compile_check", return_value=compile_result
+            ),
+            patch.object(ValidatorPipeline, "_run_ci", return_value=ci_result),
+        ):
+            metrics = evaluate_artifact(
+                rulespec_file=rulespec_file,
+                policy_repo_root=tmp_path,
+                axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+                source_text="Amount B is 2 6/7 per cent of the difference.",
+            )
+
+        assert metrics.ci_pass
+        assert metrics.source_numeric_occurrence_count == 1
+        assert metrics.missing_source_numeric_occurrence_count == 0
+        assert metrics.numeric_occurrence_issues == []
+
     def test_numeric_occurrence_check_skips_empty_deferred_artifact(self, tmp_path):
         rulespec_file = tmp_path / "statutes" / "wic" / "18901" / "5.yaml"
         rulespec_file.parent.mkdir(parents=True)

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6085,9 +6085,37 @@ rules:
     source_values = extract_numbers_from_text(source_text)
     assert 20000000 in source_values
     assert 10000000 in source_values
+    assert 20 in source_values
+    assert 10 in source_values
     occurrences = extract_numeric_occurrences_from_text(source_text)
     assert 20000000 in occurrences
     assert 10000000 in occurrences
+    assert 20 not in occurrences
+    assert 10 not in occurrences
+
+
+def test_rulespec_grounding_accepts_digit_scale_source_components():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: uk/regulation/uksi/2015/980/4
+rules:
+  - name: small_company_annual_turnover_threshold
+    kind: parameter
+    dtype: Decimal
+    versions:
+      - effective_from: '2016-01-01'
+        formula: '10.2'
+"""
+
+    source_text = (
+        "for “Not more than £6.5 million” substitute “Not more than £10.2 million”"
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    source_values = extract_numbers_from_text(source_text)
+    assert 10.2 in source_values
+    assert 10200000 in source_values
 
 
 def test_rulespec_grounding_rejects_unrelated_power_of_ten():
@@ -26317,6 +26345,32 @@ rules:
         math.isclose(value, 0.02857142857142857)
         for value in extract_numeric_occurrences_from_text(source_text)
     )
+
+
+def test_ungrounded_numeric_accepts_mixed_ascii_fraction_percentage_components():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: uk/regulation/uksi/2012/2885/schedule/1/paragraph/3
+rules:
+  - name: council_tax_reduction_taper_fraction_numerator
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '2013-04-01'
+        formula: |-
+          6
+"""
+
+    source_text = "amount B is 2 6/7 per cent of the difference"
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    source_values = extract_numbers_from_text(source_text)
+    assert 6 in source_values
+    assert 7 in source_values
+    occurrences = extract_numeric_occurrences_from_text(source_text)
+    assert 6 not in occurrences
+    assert 7 not in occurrences
 
 
 def test_ungrounded_numeric_accepts_spelled_hundredths_percentage():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1130"
+version = "0.2.1131"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Preserve digit-scale source components for generated numeric grounding, so values like 10.2 from “£10.2 million” remain grounded while the scaled amount is also recognized.
- Preserve ASCII mixed-fraction percentage components for generated numeric grounding, so values like the numerator in “2 6/7 per cent” remain grounded.
- Keep source numeric occurrence extraction focused on substantive normalized occurrences so eval coverage does not require those helper components.

## Validation
- uv run --extra dev ruff check pyproject.toml src/axiom_encode scripts tests
- uv run python -m compileall -q src/axiom_encode scripts
- uv run --extra dev python -m pytest -q tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_rulespec_validation.py::test_rulespec_grounding_accepts_digit_scale_money_phrases tests/test_rulespec_validation.py::test_rulespec_grounding_accepts_digit_scale_source_components tests/test_rulespec_validation.py::test_ungrounded_numeric_accepts_mixed_ascii_fraction_percentage_components tests/test_evals.py::TestEvaluateArtifact::test_numeric_occurrence_check_does_not_require_digit_scale_components tests/test_evals.py::TestEvaluateArtifact::test_numeric_occurrence_check_does_not_require_mixed_fraction_components tests/test_policyengine_coverage_monorepo.py::test_uk_dpa_2018_s157_penalty_cap_outputs_are_not_comparable
- clean /tmp worktree: uv run --extra dev python -m pytest (2627 passed, 27 skipped)
- rulespec-uk local validates: DPA 2018 s.157, Companies Act s.382, council-tax-reduction all pass

## Review
- Independent review found an occurrence-coverage risk in the first draft; fixed by keeping component expansion out of source occurrence extraction and adding eval regression tests.
- Follow-up independent review found no actionable issues.