### PR TITLE
Scope hinted table encodes to target surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1132"
+version = "0.2.1133"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1132"
+__version__ = "0.2.1133"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -4947,6 +4947,14 @@ Preferred principal output:
   because the source is broad or cites many sibling provisions when an
   executable formula can be composed from source-stated facts, scalar
   parameters, or imported primary-source RuleSpec exports supplied in context.
+- When the source slice contains multiple independent table columns or
+  sibling figures but the PolicyEngine hint names one oracle-facing output,
+  encode only the column, parameters, and boundary facts needed to compute
+  that hinted output. Do not create executable rules for unrelated sibling
+  columns, recoupment schedules, deemed-income amounts, administrative counts,
+  or documentary table fields unless the formula for the hinted output depends
+  on them or the requested source identifier explicitly names that sibling
+  surface.
 - If the hinted output would otherwise depend on broad placeholders such as
   `person_is_described_in_*`, `person_is_in_*_category`, `*_determined_for_*`,
   `*_mandatory_subclauses*`, or `person_is_qualified_*_group`, first look for

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -4048,6 +4048,16 @@ def extract_named_scalar_occurrences(content: str) -> list[NamedScalarOccurrence
                     table_values = version.get("values")
                     if isinstance(table_values, dict):
                         for key, table_value in table_values.items():
+                            extracted_key = _numeric_rule_value(key)
+                            if extracted_key is not None:
+                                _, key_value = extracted_key
+                                occurrences.append(
+                                    NamedScalarOccurrence(
+                                        line=1,
+                                        name=f"{name}[{key}]",
+                                        value=key_value,
+                                    )
+                                )
                             extracted = _numeric_rule_value(table_value)
                             if extracted is None:
                                 continue
@@ -6997,12 +7007,21 @@ def _formula_has_unsupported_chained_conditional(formula: str) -> bool:
 
 
 def _source_text_looks_like_table(source_text: str) -> bool:
+    money_cells = re.findall(r"\$\s*[\d,]+(?:\.\d+)?", source_text)
     return bool(
         re.search(r"\btable\b", source_text, flags=re.IGNORECASE)
         or source_text.count("|") >= 6
         or (
             re.search(r"\bschedule\b", source_text, flags=re.IGNORECASE)
             and source_text.count("|") >= 2
+        )
+        or (
+            re.search(
+                r"\b(?:household|family|assistance\s+unit)\s+size\b",
+                source_text,
+                flags=re.IGNORECASE,
+            )
+            and len(money_cells) >= 2
         )
     )
 

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -4765,8 +4765,7 @@ rules:
                 policy_repo_root=tmp_path,
                 axiom_rules_path=Path("/tmp/axiom-rules-engine"),
                 source_text=(
-                    "Household Size Allowable TCA Monthly Payment "
-                    "1 $348 2 $612 3 $773"
+                    "Household Size Allowable TCA Monthly Payment 1 $348 2 $612 3 $773"
                 ),
             )
 

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -4707,6 +4707,76 @@ rules:
         assert metrics.ungrounded_numeric_count == 0
         assert metrics.source_numeric_occurrence_count == 0
 
+    def test_collapsed_household_size_schedule_treats_row_keys_as_structural(
+        self, tmp_path
+    ):
+        rulespec_file = (
+            tmp_path
+            / "policies"
+            / "dhs"
+            / "fia"
+            / "im-26-13"
+            / "allowable-tca-monthly-payment.yaml"
+        )
+        rulespec_file.parent.mkdir(parents=True)
+        rulespec_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-md/guidance/dhs/fia/im-26-13/fip-schedule
+rules:
+  - name: allowable_tca_monthly_payment
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: household_size
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-md/guidance/dhs/fia/im-26-13/fip-schedule
+              excerpt: Household Size Allowable TCA Monthly Payment
+              table:
+                header: Household Size Allowable TCA Monthly Payment
+                row_key: Household Size
+                column_key: Allowable TCA Monthly Payment
+    versions:
+      - effective_from: '2026-01-01'
+        values:
+          1: 348
+          2: 612
+          3: 773
+"""
+        )
+
+        compile_result = ValidationResult("compile", True, issues=[])
+        ci_result = ValidationResult("ci", True, issues=[])
+
+        with (
+            patch.object(
+                ValidatorPipeline, "_run_compile_check", return_value=compile_result
+            ),
+            patch.object(ValidatorPipeline, "_run_ci", return_value=ci_result),
+        ):
+            metrics = evaluate_artifact(
+                rulespec_file=rulespec_file,
+                policy_repo_root=tmp_path,
+                axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+                source_text=(
+                    "Household Size Allowable TCA Monthly Payment "
+                    "1 $348 2 $612 3 $773"
+                ),
+            )
+
+        assert metrics.ci_pass
+        assert metrics.grounded_numeric_count == 3
+        assert metrics.ungrounded_numeric_count == 0
+        assert metrics.source_numeric_occurrence_count == 6
+        assert metrics.covered_source_numeric_occurrence_count == 6
+        assert metrics.missing_source_numeric_occurrence_count == 0
+
     def test_numeric_occurrence_check_counts_imported_named_scalars(self, tmp_path):
         policy_repo = tmp_path / "rulespec-us"
         child = policy_repo / "statutes" / "7" / "2015" / "d" / "2" / "B.yaml"

--- a/tests/test_prompt_concept_injection.py
+++ b/tests/test_prompt_concept_injection.py
@@ -242,3 +242,37 @@ def test_build_rulespec_eval_prompt_treats_dotted_policyengine_hint_as_oracle_co
     assert "dotted PolicyEngine parameter path" in prompt
     assert "Never emit a RuleSpec rule whose `name:` is a" in prompt
     assert "gov.states.dc.dhcf.ossp.payment.individual" in prompt
+
+
+def test_build_rulespec_eval_prompt_scopes_multi_column_tables_to_hint(
+    tmp_path: Path,
+):
+    source_text = (
+        "Household Size Allowable TCA Monthly Payment Used for Stepparent "
+        "Deemed Income 50% of the Monthly Poverty Level Total Children with "
+        "One Caretaker 1 $348 $665 0 3 $773 $1,138 2"
+    )
+    workspace = _minimal_workspace(tmp_path, source_text)
+
+    prompt = _build_rulespec_eval_prompt(
+        citation=(
+            "us-md/guidance/dhs/fia/im-26-13/2026-tca-tdap-benefit-increase/"
+            "fip-schedule-effective-2026-01-01"
+        ),
+        mode="repo-augmented",
+        workspace=workspace,
+        context_files=[],
+        target_file_name="allowable-tca-monthly-payment.yaml",
+        target_ref_prefix=(
+            "us-md:policies/dhs/fia/im-26-13/2026-tca-tdap-benefit-increase/"
+            "allowable-tca-monthly-payment"
+        ),
+        include_tests=True,
+        runner_backend="codex",
+        policyengine_rule_hint="md_tca_maximum_benefit",
+    )
+
+    assert "multiple independent table columns" in prompt
+    assert "encode only the column" in prompt
+    assert "Do not create executable rules for unrelated sibling" in prompt
+    assert "deemed-income amounts" in prompt

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1132"
+version = "0.2.1133"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- scope hinted multi-column table encodes to the requested oracle-facing surface
- treat collapsed household-size money schedules as table-like source text
- count numeric parameter table row keys as structural source coverage

## Verification
- uv run --project . --extra dev python -m pytest -q tests/test_prompt_concept_injection.py tests/test_evals.py::TestEvaluateArtifact::test_collapsed_household_size_schedule_treats_row_keys_as_structural tests/test_evals.py::TestEvaluateArtifact::test_parameter_table_grounding_uses_corpus_source_with_compact_summary tests/test_rulespec_validation.py::test_rulespec_grounding_treats_table_lookup_keys_as_structural