### PR TITLE
Update Maryland TCA parity status

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1133"
+version = "0.2.1134"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1133"
+__version__ = "0.2.1134"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -483,13 +483,13 @@ surfaces:
   variable: md_tca
   source_type: state_implementation
   state: MD
-  axiom_status: pending_source_ingestion
+  axiom_status: pending_rulespec_encoding
   priority: P1
   rationale: Primary-source review found that current COMAR 07.03.03.17 still carries the stale November 2013 grant schedule,
-    while PolicyEngine's 2025 benefit table is sourced to Maryland DHS FIA Information Memo 25-12 and Maryland DHS has since
-    published IM 26-13 as a superseding 2026 TCA/TDAP benefit-increase memo. Axiom has ingested the governing Maryland Human
-    Services Article provisions and COMAR 07.03.03, but should not encode current TCA amounts until DHS IM 26-13, IM 25-12 for
-    PE's historical 2025 table, or an equivalent official schedule is ingested through axiom-corpus.
+    while Maryland DHS FIA Information Memo 26-13 is the superseding official 2026 TCA/TDAP benefit-increase schedule. Axiom has
+    ingested the governing Maryland Human Services Article provisions, COMAR 07.03.03, and IM 26-13; rulespec-us now encodes the
+    2026 allowable monthly payment table for md_tca_maximum_benefit. Final PE parity for md_tca still needs the remaining governing
+    TCA benefit-calculation, eligibility, and oracle-wiring surfaces before it can be marked wired.
 - country: us
   program_id: tanf
   program_name: South Dakota TANF

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2388,7 +2388,7 @@ def test_policyengine_program_surface_marks_kentucky_ktap_source_conflict_known_
     assert "KY FACES table labeled by number of children" in kentucky_ktap["rationale"]
 
 
-def test_policyengine_program_surface_marks_maryland_tca_pending_source_ingestion():
+def test_policyengine_program_surface_marks_maryland_tca_pending_rulespec_encoding():
     report = build_policyengine_program_surface_report(program="md_tca")
 
     items_by_variable = {item["variable"]: item for item in report["items"]}
@@ -2396,13 +2396,14 @@ def test_policyengine_program_surface_marks_maryland_tca_pending_source_ingestio
 
     assert maryland_tca["program_id"] == "tanf"
     assert maryland_tca["state"] == "MD"
-    assert maryland_tca["axiom_status"] == "pending_source_ingestion"
+    assert maryland_tca["axiom_status"] == "pending_rulespec_encoding"
     assert maryland_tca["mapping_count"] == 0
     assert maryland_tca["comparable_mapping_count"] == 0
     assert "COMAR 07.03.03.17" in maryland_tca["rationale"]
-    assert "Maryland DHS FIA Information Memo 25-12" in maryland_tca["rationale"]
-    assert "IM 26-13 as a superseding 2026 TCA/TDAP" in maryland_tca["rationale"]
-    assert "should not encode current TCA amounts" in maryland_tca["rationale"]
+    assert "Maryland DHS FIA Information Memo 26-13" in maryland_tca["rationale"]
+    assert "rulespec-us now encodes" in maryland_tca["rationale"]
+    assert "md_tca_maximum_benefit" in maryland_tca["rationale"]
+    assert "Final PE parity for md_tca still needs" in maryland_tca["rationale"]
 
 
 def test_policyengine_coverage_maps_georgia_ssp_nursing_home_supplement(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1133"
+version = "0.2.1134"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- move Maryland TCA from `pending_source_ingestion` to `pending_rulespec_encoding` after the IM 26-13 source ingestion and RuleSpec max-benefit encode merged
- keep `md_tca` out of `wired` status because only `md_tca_maximum_benefit` is encoded so far, not the final PE benefit surface
- update the registry regression test

## Validation
- `uv run --extra dev python -m pytest -q tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_maryland_tca_pending_rulespec_encoding`
- `uv run --extra dev python -m pytest -q tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`
- `uv run ruff format --check src/ tests/`