### PR TITLE
Share CMS CHIP MAGI disregard generator output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1135"
+version = "0.2.1136"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1135"
+__version__ = "0.2.1136"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -7989,6 +7989,7 @@ CMS_ELIGIBILITY_LEVELS_UPSTREAM_SOURCE_CHECK_BLOCK = """    upstream_source_chec
         - us/statute/42/1397jj/c/8
         - us/statute/42/1397ll/d/2
         - us/statute/42/1397ll/f/2
+        - us/regulation/42/435/603/d
         - us/regulation/42/457/340
         - us/regulation/42/457/344
       rationale: |-
@@ -8001,6 +8002,12 @@ CMS_ELIGIBILITY_LEVELS_UPSTREAM_SOURCE_CHECK_BLOCK = """    upstream_source_chec
 """
 CMS_MEDICAID_CHIP_EFFECTIVE_DATE = "2023-12-01"
 CMS_MAGI_FPL_DISREGARD_RATE = Decimal("0.05")
+CMS_MAGI_FPL_DISREGARD_RELATIVE_OUTPUT = (
+    Path("us") / "policies" / "cms" / "medicaid-chip-bhp-eligibility-levels.yaml"
+)
+CMS_MAGI_FPL_DISREGARD_TARGET = (
+    "us:policies/cms/medicaid-chip-bhp-eligibility-levels#magi_fpl_disregard_rate"
+)
 CMS_MEDICAID_CHIP_AVAILABILITY_SUFFIXES = {
     "children_separate_chip",
     "pregnant_women_chip",
@@ -8346,6 +8353,7 @@ def _cms_effective_rule_block(
     name: str,
     raw_name: str,
     row: _CmsEligibilityRow,
+    magi_disregard_hash: str,
 ) -> str:
     return f"""  - name: {name}
     kind: derived
@@ -8354,6 +8362,12 @@ def _cms_effective_rule_block(
     metadata:
       proof:
         atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: {CMS_MAGI_FPL_DISREGARD_TARGET}
+              output: magi_fpl_disregard_rate
+              hash: sha256:{magi_disregard_hash}
           - path: versions[0].formula
             kind: formula
             source:
@@ -8370,15 +8384,15 @@ def _cms_magi_disregard_rule_block() -> str:
     return f"""  - name: magi_fpl_disregard_rate
     kind: parameter
     dtype: Rate
-    source: CMS Medicaid, CHIP and BHP Eligibility Levels, introductory text
+    source: 42 CFR 435.603(d)(4)
     metadata:
       proof:
         atoms:
           - path: versions[0].formula
             kind: amount
             source:
-              corpus_citation_path: {CMS_ELIGIBILITY_LEVELS_CORPUS_PATH}
-              excerpt: "5% FPL disregard"
+              corpus_citation_path: us/regulation/42/435/603/d
+              excerpt: "5 percentage points of the Federal poverty level"
     versions:
       - effective_from: '{CMS_MEDICAID_CHIP_EFFECTIVE_DATE}'
         formula: |-
@@ -8386,8 +8400,53 @@ def _cms_magi_disregard_rule_block() -> str:
 """
 
 
+def _cms_build_magi_disregard_file() -> _CmsGeneratedEligibilityFile:
+    citation = _rulespec_anchor_base_for_output(
+        Path("rulespec-us"),
+        CMS_MAGI_FPL_DISREGARD_RELATIVE_OUTPUT,
+    )
+    output_values = {
+        "magi_fpl_disregard_rate": _cms_format_rate(CMS_MAGI_FPL_DISREGARD_RATE),
+    }
+    rules_content = (
+        "format: rulespec/v1\n"
+        "module:\n"
+        "  proof_validation:\n"
+        "    required: true\n"
+        "  source_verification:\n"
+        "    corpus_citation_path: us/regulation/42/435/603/d\n"
+        "  summary: |-\n"
+        "    Effective January 1, 2014, 42 CFR 435.603(d)(4) directs States to "
+        "subtract an amount equivalent to 5 percentage points of FPL only for "
+        "the highest MAGI-based income-standard Medicaid eligibility group.\n"
+        "rules:\n"
+        f"{_cms_magi_disregard_rule_block().rstrip()}\n"
+    )
+    test_lines = [
+        "- name: cms_magi_fpl_disregard_rate_as_of_december_2023",
+        "  period:",
+        "    period_kind: custom",
+        "    name: day",
+        f"    start: '{CMS_MEDICAID_CHIP_EFFECTIVE_DATE}'",
+        f"    end: '{CMS_MEDICAID_CHIP_EFFECTIVE_DATE}'",
+        "  input: {}",
+        "  output:",
+    ]
+    for name, value in output_values.items():
+        test_lines.append(f"    {citation}#{name}: {value}")
+
+    return _CmsGeneratedEligibilityFile(
+        relative_output=CMS_MAGI_FPL_DISREGARD_RELATIVE_OUTPUT,
+        rules_content=rules_content,
+        test_content="\n".join(test_lines) + "\n",
+        output_values=output_values,
+    )
+
+
 def _cms_build_medicaid_chip_eligibility_file(
     row: _CmsEligibilityRow,
+    *,
+    magi_disregard_hash: str,
 ) -> _CmsGeneratedEligibilityFile:
     state_slug = _cms_state_slug(row.state)
     state_file_slug = _cms_file_slug(row.state)
@@ -8400,10 +8459,8 @@ def _cms_build_medicaid_chip_eligibility_file(
     )
     citation = _rulespec_anchor_base_for_output(Path("rulespec-us"), relative_output)
 
-    rules: list[str] = [_cms_magi_disregard_rule_block()]
-    output_values: dict[str, str] = {
-        "magi_fpl_disregard_rate": _cms_format_rate(CMS_MAGI_FPL_DISREGARD_RATE),
-    }
+    rules: list[str] = []
+    output_values: dict[str, str] = {}
     raw_rates: dict[str, Decimal] = {}
 
     for column in CMS_MEDICAID_CHIP_ELIGIBILITY_COLUMNS:
@@ -8476,12 +8533,15 @@ def _cms_build_medicaid_chip_eligibility_file(
                 name=effective_name,
                 raw_name=raw_name,
                 row=row,
+                magi_disregard_hash=magi_disregard_hash,
             )
         )
         output_values[effective_name] = effective_formula
 
     rules_content = (
         "format: rulespec/v1\n"
+        "imports:\n"
+        f"  - {CMS_MAGI_FPL_DISREGARD_TARGET}\n"
         "module:\n"
         "  proof_validation:\n"
         "    required: true\n"
@@ -10311,8 +10371,19 @@ def cmd_generate_cms_medicaid_chip_eligibility_levels(args):
         print("No matching CMS state rows found.")
         sys.exit(1)
 
+    shared_magi_disregard_file = _cms_build_magi_disregard_file()
+    magi_disregard_hash = hashlib.sha256(
+        shared_magi_disregard_file.rules_content.encode()
+    ).hexdigest()
     generated_files = [
-        _cms_build_medicaid_chip_eligibility_file(row) for row in selected_rows
+        shared_magi_disregard_file,
+        *[
+            _cms_build_medicaid_chip_eligibility_file(
+                row,
+                magi_disregard_hash=magi_disregard_hash,
+            )
+            for row in selected_rows
+        ],
     ]
     planned: list[tuple[_CmsGeneratedEligibilityFile, Path, Path]] = []
     skipped_existing: list[Path] = []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11280,6 +11280,9 @@ rules:
             policy_repo
             / "us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml"
         )
+        shared_target = (
+            policy_repo / "us/policies/cms/medicaid-chip-bhp-eligibility-levels.yaml"
+        )
         test_file = target.with_name(
             "georgia-medicaid-chip-bhp-eligibility-levels.test.yaml"
         )
@@ -11296,7 +11299,7 @@ rules:
                 assert kwargs["require_policy_proofs"] is True
 
             def validate(self, path, *, skip_reviewers):
-                assert path == target.resolve()
+                assert path in {shared_target.resolve(), target.resolve()}
                 assert skip_reviewers is True
                 return SimpleNamespace(all_passed=True, results={})
 
@@ -11317,20 +11320,50 @@ rules:
         ):
             cmd_generate_cms_medicaid_chip_eligibility_levels(args)
 
+        shared_rules_content = shared_target.read_text()
+        assert "source: 42 CFR 435.603(d)(4)" in shared_rules_content
+        assert (
+            "corpus_citation_path: us/regulation/42/435/603/d" in shared_rules_content
+        )
+        assert "magi_fpl_disregard_rate" in shared_rules_content
+        shared_test_file = shared_target.with_name(
+            "medicaid-chip-bhp-eligibility-levels.test.yaml"
+        )
+        assert (
+            "us:policies/cms/medicaid-chip-bhp-eligibility-levels"
+            "#magi_fpl_disregard_rate: 0.05" in shared_test_file.read_text()
+        )
+
         rules_content = target.read_text()
+        assert (
+            "imports:\n"
+            "  - us:policies/cms/medicaid-chip-bhp-eligibility-levels"
+            "#magi_fpl_disregard_rate\n"
+        ) in rules_content
+        state_payload = yaml.safe_load(rules_content)
+        state_rule_names = {rule["name"] for rule in state_payload["rules"]}
+        assert "magi_fpl_disregard_rate" not in state_rule_names
         assert "georgia_children_separate_chip_fpl_limit" in rules_content
         assert "georgia_pregnant_women_chip_available" in rules_content
         assert "georgia_adult_medicaid_expansion_available" in rules_content
         assert "georgia_parent_caretaker_standard_uses_dollar_amounts" in rules_content
         assert "georgia_children_separate_chip_effective_fpl_limit" in rules_content
+        assert (
+            "target: us:policies/cms/medicaid-chip-bhp-eligibility-levels"
+            in rules_content
+        )
+        assert "output: magi_fpl_disregard_rate" in rules_content
+        assert "hash: sha256:" in rules_content
         assert "georgia_adult_medicaid_expansion_fpl_limit" not in rules_content
         assert 'excerpt: "28%($)"' in rules_content
         assert "upstream_source_check:" in rules_content
         assert "status: official_parameter_source" in rules_content
         assert "- us/statute/42/1397jj/b/1" in rules_content
+        assert "- us/regulation/42/435/603/d" in rules_content
         assert "- us/regulation/42/457/340" in rules_content
 
         test_content = test_file.read_text()
+        assert "#magi_fpl_disregard_rate" not in test_content
         assert (
             "us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels"
             "#georgia_children_separate_chip_fpl_limit: 2.47" in test_content
@@ -11364,6 +11397,23 @@ rules:
         assert [applied_file["path"] for applied_file in payload["applied_files"]] == [
             "us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml",
             "us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.test.yaml",
+        ]
+
+        shared_manifest = (
+            policy_repo / ".axiom/encoding-manifests/us/policies/cms/"
+            "medicaid-chip-bhp-eligibility-levels.json"
+        )
+        shared_payload = json.loads(shared_manifest.read_text())
+        assert shared_payload["schema_version"] == APPLIED_ENCODING_MANIFEST_SCHEMA
+        assert shared_payload["model"] == "cms-medicaid-chip-eligibility-levels-v1"
+        assert shared_payload["citation"] == (
+            "us:policies/cms/medicaid-chip-bhp-eligibility-levels"
+        )
+        assert [
+            applied_file["path"] for applied_file in shared_payload["applied_files"]
+        ] == [
+            "us/policies/cms/medicaid-chip-bhp-eligibility-levels.yaml",
+            "us/policies/cms/medicaid-chip-bhp-eligibility-levels.test.yaml",
         ]
 
     def test_repair_minnesota_mfip_source_check_writes_signed_manifest(self, tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1135"
+version = "0.2.1136"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Generate one shared federal CMS MAGI FPL disregard module instead of copying the same executable rule into every state CMS Medicaid/CHIP eligibility-level file.
- Import that shared target from generated state files and include proof import hashes on derived effective FPL limit rules.
- Cite 42 CFR 435.603(d) for the shared 5 percentage point disregard and keep CMS as the official state-level parameter table source.

## Tests
- `uv run ruff check src/axiom_encode/cli.py tests/test_cli.py`
- `uv run --extra dev python -m pytest tests/test_cli.py::TestCmdEncode::test_generate_cms_medicaid_chip_table_writes_signed_state_file -q`