### PR TITLE
Add nationwide CMS CHIP oracle mappings

### DIFF
--- a/changelog.d/cms-chip-nationwide-oracle-mappings.fixed.md
+++ b/changelog.d/cms-chip-nationwide-oracle-mappings.fixed.md
@@ -1,0 +1,1 @@
+Classify nationwide generated CMS Medicaid, CHIP, and BHP eligibility-level outputs in PolicyEngine oracle coverage, including comparable effective income-limit parameter mappings for all states.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1136"
+version = "0.2.1137"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1136"
+__version__ = "0.2.1137"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -8093,12 +8093,607 @@ mappings:
     comparison: rate
     rationale: Same 2026 ACA required contribution percentage, represented in PolicyEngine as the top final percentage in the current-law ACA required-contribution percentage table.
 
-  - legal_id: us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#magi_fpl_disregard_rate
+  - legal_id: us:policies/cms/medicaid-chip-bhp-eligibility-levels#magi_fpl_disregard_rate
     country: us
     program: health
     mapping_type: not_comparable
     candidate_priority: P4
     rationale: Axiom exposes the CMS table's separate 5% MAGI FPL disregard. PolicyEngine-US bakes that disregard into Medicaid and CHIP income-limit parameters rather than exposing it as a separate parameter.
+
+  - legal_id: us-ak:policies/cms/alaska-medicaid-chip-bhp-eligibility-levels#alaska_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: AK
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Alaska CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-ak:policies/cms/alaska-medicaid-chip-bhp-eligibility-levels#alaska_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: AK
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Alaska CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ak:policies/cms/alaska-medicaid-chip-bhp-eligibility-levels#alaska_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: AK
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Alaska CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ak:policies/cms/alaska-medicaid-chip-bhp-eligibility-levels#alaska_children_separate_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: AK
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Alaska child CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-ak:policies/cms/alaska-medicaid-chip-bhp-eligibility-levels#alaska_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: AK
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Alaska CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-ak:policies/cms/alaska-medicaid-chip-bhp-eligibility-levels#alaska_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: AK
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Alaska pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-ak:policies/cms/alaska-medicaid-chip-bhp-eligibility-levels#alaska_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: AK
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Alaska CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-ak:policies/cms/alaska-medicaid-chip-bhp-eligibility-levels#alaska_parent_caretaker_standard_uses_dollar_amounts
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table footnote that Alaska's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+
+  - legal_id: us-ak:policies/cms/alaska-medicaid-chip-bhp-eligibility-levels#alaska_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: AK
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Alaska CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-ak:policies/cms/alaska-medicaid-chip-bhp-eligibility-levels#alaska_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: AK
+    period: year
+    comparison: rate
+    rationale: Same effective Alaska infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ak:policies/cms/alaska-medicaid-chip-bhp-eligibility-levels#alaska_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: AK
+    period: year
+    comparison: rate
+    rationale: Same effective Alaska young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ak:policies/cms/alaska-medicaid-chip-bhp-eligibility-levels#alaska_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: AK
+    period: year
+    comparison: rate
+    rationale: Same effective Alaska older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ak:policies/cms/alaska-medicaid-chip-bhp-eligibility-levels#alaska_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: AK
+    period: year
+    comparison: rate
+    rationale: Same effective Alaska pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-al:policies/cms/alabama-medicaid-chip-bhp-eligibility-levels#alabama_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: AL
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Alabama CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-al:policies/cms/alabama-medicaid-chip-bhp-eligibility-levels#alabama_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: AL
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Alabama CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-al:policies/cms/alabama-medicaid-chip-bhp-eligibility-levels#alabama_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: AL
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Alabama CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-al:policies/cms/alabama-medicaid-chip-bhp-eligibility-levels#alabama_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: AL
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Alabama CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-al:policies/cms/alabama-medicaid-chip-bhp-eligibility-levels#alabama_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: AL
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Alabama CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-al:policies/cms/alabama-medicaid-chip-bhp-eligibility-levels#alabama_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: AL
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Alabama pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-al:policies/cms/alabama-medicaid-chip-bhp-eligibility-levels#alabama_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: AL
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Alabama CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-al:policies/cms/alabama-medicaid-chip-bhp-eligibility-levels#alabama_adult_medicaid_expansion_available
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: AL
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Alabama adult Medicaid expansion. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-al:policies/cms/alabama-medicaid-chip-bhp-eligibility-levels#alabama_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: AL
+    period: year
+    comparison: rate
+    rationale: Same effective Alabama infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-al:policies/cms/alabama-medicaid-chip-bhp-eligibility-levels#alabama_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: AL
+    period: year
+    comparison: rate
+    rationale: Same effective Alabama young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-al:policies/cms/alabama-medicaid-chip-bhp-eligibility-levels#alabama_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: AL
+    period: year
+    comparison: rate
+    rationale: Same effective Alabama older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-al:policies/cms/alabama-medicaid-chip-bhp-eligibility-levels#alabama_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: AL
+    period: year
+    comparison: rate
+    rationale: Same effective Alabama child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-al:policies/cms/alabama-medicaid-chip-bhp-eligibility-levels#alabama_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: AL
+    period: year
+    comparison: rate
+    rationale: Same effective Alabama pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ar:policies/cms/arkansas-medicaid-chip-bhp-eligibility-levels#arkansas_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: AR
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Arkansas CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-ar:policies/cms/arkansas-medicaid-chip-bhp-eligibility-levels#arkansas_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: AR
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Arkansas CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ar:policies/cms/arkansas-medicaid-chip-bhp-eligibility-levels#arkansas_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: AR
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Arkansas CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ar:policies/cms/arkansas-medicaid-chip-bhp-eligibility-levels#arkansas_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: AR
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Arkansas CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-ar:policies/cms/arkansas-medicaid-chip-bhp-eligibility-levels#arkansas_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: AR
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Arkansas CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-ar:policies/cms/arkansas-medicaid-chip-bhp-eligibility-levels#arkansas_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: AR
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Arkansas pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-ar:policies/cms/arkansas-medicaid-chip-bhp-eligibility-levels#arkansas_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: AR
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Arkansas CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-ar:policies/cms/arkansas-medicaid-chip-bhp-eligibility-levels#arkansas_parent_caretaker_standard_uses_dollar_amounts
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table footnote that Arkansas's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+
+  - legal_id: us-ar:policies/cms/arkansas-medicaid-chip-bhp-eligibility-levels#arkansas_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: AR
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Arkansas CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-ar:policies/cms/arkansas-medicaid-chip-bhp-eligibility-levels#arkansas_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: AR
+    period: year
+    comparison: rate
+    rationale: Same effective Arkansas infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ar:policies/cms/arkansas-medicaid-chip-bhp-eligibility-levels#arkansas_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: AR
+    period: year
+    comparison: rate
+    rationale: Same effective Arkansas young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ar:policies/cms/arkansas-medicaid-chip-bhp-eligibility-levels#arkansas_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: AR
+    period: year
+    comparison: rate
+    rationale: Same effective Arkansas older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ar:policies/cms/arkansas-medicaid-chip-bhp-eligibility-levels#arkansas_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: AR
+    period: year
+    comparison: rate
+    rationale: Same effective Arkansas child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ar:policies/cms/arkansas-medicaid-chip-bhp-eligibility-levels#arkansas_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: AR
+    period: year
+    comparison: rate
+    rationale: Same effective Arkansas pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-az:policies/cms/arizona-medicaid-chip-bhp-eligibility-levels#arizona_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: AZ
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Arizona CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-az:policies/cms/arizona-medicaid-chip-bhp-eligibility-levels#arizona_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: AZ
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Arizona CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-az:policies/cms/arizona-medicaid-chip-bhp-eligibility-levels#arizona_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: AZ
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Arizona CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-az:policies/cms/arizona-medicaid-chip-bhp-eligibility-levels#arizona_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: AZ
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Arizona CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-az:policies/cms/arizona-medicaid-chip-bhp-eligibility-levels#arizona_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: AZ
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Arizona CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-az:policies/cms/arizona-medicaid-chip-bhp-eligibility-levels#arizona_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: AZ
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Arizona pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-az:policies/cms/arizona-medicaid-chip-bhp-eligibility-levels#arizona_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: AZ
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Arizona CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-az:policies/cms/arizona-medicaid-chip-bhp-eligibility-levels#arizona_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: AZ
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Arizona CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-az:policies/cms/arizona-medicaid-chip-bhp-eligibility-levels#arizona_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: AZ
+    period: year
+    comparison: rate
+    rationale: Same effective Arizona infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-az:policies/cms/arizona-medicaid-chip-bhp-eligibility-levels#arizona_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: AZ
+    period: year
+    comparison: rate
+    rationale: Same effective Arizona young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-az:policies/cms/arizona-medicaid-chip-bhp-eligibility-levels#arizona_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: AZ
+    period: year
+    comparison: rate
+    rationale: Same effective Arizona older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-az:policies/cms/arizona-medicaid-chip-bhp-eligibility-levels#arizona_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: AZ
+    period: year
+    comparison: rate
+    rationale: Same effective Arizona child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-az:policies/cms/arizona-medicaid-chip-bhp-eligibility-levels#arizona_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: AZ
+    period: year
+    comparison: rate
+    rationale: Same effective Arizona pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ca:policies/cms/california-medicaid-chip-bhp-eligibility-levels#california_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: CA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw California CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-ca:policies/cms/california-medicaid-chip-bhp-eligibility-levels#california_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: CA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw California CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ca:policies/cms/california-medicaid-chip-bhp-eligibility-levels#california_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: CA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw California CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ca:policies/cms/california-medicaid-chip-bhp-eligibility-levels#california_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: CA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw California CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-ca:policies/cms/california-medicaid-chip-bhp-eligibility-levels#california_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: CA
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for California pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-ca:policies/cms/california-medicaid-chip-bhp-eligibility-levels#california_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: CA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw California CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-ca:policies/cms/california-medicaid-chip-bhp-eligibility-levels#california_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: CA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw California CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-ca:policies/cms/california-medicaid-chip-bhp-eligibility-levels#california_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: CA
+    period: year
+    comparison: rate
+    rationale: Same effective California infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ca:policies/cms/california-medicaid-chip-bhp-eligibility-levels#california_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: CA
+    period: year
+    comparison: rate
+    rationale: Same effective California young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ca:policies/cms/california-medicaid-chip-bhp-eligibility-levels#california_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: CA
+    period: year
+    comparison: rate
+    rationale: Same effective California older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ca:policies/cms/california-medicaid-chip-bhp-eligibility-levels#california_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: CA
+    period: year
+    comparison: rate
+    rationale: Same effective California pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
 
   - legal_id: us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_children_medicaid_ages_0_to_1_fpl_limit
     country: us
@@ -8153,6 +8748,24 @@ mappings:
     parameter_key: CO
     candidate_priority: P4
     rationale: Axiom exposes the raw Colorado CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person CHIP income limit including that disregard.
+
+  - legal_id: us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: CO
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Colorado CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: CO
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Colorado CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
 
   - legal_id: us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_children_medicaid_ages_0_to_1_effective_fpl_limit
     country: us
@@ -8214,30 +8827,490 @@ mappings:
     comparison: rate
     rationale: Same effective Colorado pregnant-person CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
 
-  - legal_id: us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_parent_caretaker_adults_medicaid_fpl_limit
+  - legal_id: us-ct:policies/cms/connecticut-medicaid-chip-bhp-eligibility-levels#connecticut_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: CT
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Connecticut CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-ct:policies/cms/connecticut-medicaid-chip-bhp-eligibility-levels#connecticut_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: CT
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Connecticut CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ct:policies/cms/connecticut-medicaid-chip-bhp-eligibility-levels#connecticut_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: CT
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Connecticut CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ct:policies/cms/connecticut-medicaid-chip-bhp-eligibility-levels#connecticut_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: CT
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Connecticut CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-ct:policies/cms/connecticut-medicaid-chip-bhp-eligibility-levels#connecticut_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: CT
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Connecticut CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-ct:policies/cms/connecticut-medicaid-chip-bhp-eligibility-levels#connecticut_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: CT
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Connecticut pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-ct:policies/cms/connecticut-medicaid-chip-bhp-eligibility-levels#connecticut_parent_caretaker_adults_medicaid_fpl_limit
     country: us
     program: medicaid
     mapping_type: not_comparable
     policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
-    parameter_key: CO
+    parameter_key: CT
     candidate_priority: P4
-    rationale: Axiom exposes the raw Colorado CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+    rationale: Axiom exposes the raw Connecticut CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
 
-  - legal_id: us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_adult_medicaid_expansion_fpl_limit
+  - legal_id: us-ct:policies/cms/connecticut-medicaid-chip-bhp-eligibility-levels#connecticut_adult_medicaid_expansion_fpl_limit
     country: us
     program: medicaid
     mapping_type: not_comparable
     policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
-    parameter_key: CO
+    parameter_key: CT
     candidate_priority: P4
-    rationale: Axiom exposes the raw Colorado CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+    rationale: Axiom exposes the raw Connecticut CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
 
-  - legal_id: us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#magi_fpl_disregard_rate
+  - legal_id: us-ct:policies/cms/connecticut-medicaid-chip-bhp-eligibility-levels#connecticut_children_medicaid_ages_0_to_1_effective_fpl_limit
     country: us
-    program: health
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: CT
+    period: year
+    comparison: rate
+    rationale: Same effective Connecticut infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ct:policies/cms/connecticut-medicaid-chip-bhp-eligibility-levels#connecticut_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: CT
+    period: year
+    comparison: rate
+    rationale: Same effective Connecticut young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ct:policies/cms/connecticut-medicaid-chip-bhp-eligibility-levels#connecticut_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: CT
+    period: year
+    comparison: rate
+    rationale: Same effective Connecticut older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ct:policies/cms/connecticut-medicaid-chip-bhp-eligibility-levels#connecticut_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: CT
+    period: year
+    comparison: rate
+    rationale: Same effective Connecticut child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ct:policies/cms/connecticut-medicaid-chip-bhp-eligibility-levels#connecticut_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: CT
+    period: year
+    comparison: rate
+    rationale: Same effective Connecticut pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-dc:policies/cms/district-of-columbia-medicaid-chip-bhp-eligibility-levels#district_of_columbia_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: DC
+    candidate_priority: P4
+    rationale: Axiom exposes the raw District Of Columbia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-dc:policies/cms/district-of-columbia-medicaid-chip-bhp-eligibility-levels#district_of_columbia_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: DC
+    candidate_priority: P4
+    rationale: Axiom exposes the raw District Of Columbia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-dc:policies/cms/district-of-columbia-medicaid-chip-bhp-eligibility-levels#district_of_columbia_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: DC
+    candidate_priority: P4
+    rationale: Axiom exposes the raw District Of Columbia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-dc:policies/cms/district-of-columbia-medicaid-chip-bhp-eligibility-levels#district_of_columbia_children_separate_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: DC
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for District Of Columbia child CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-dc:policies/cms/district-of-columbia-medicaid-chip-bhp-eligibility-levels#district_of_columbia_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: DC
+    candidate_priority: P4
+    rationale: Axiom exposes the raw District Of Columbia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-dc:policies/cms/district-of-columbia-medicaid-chip-bhp-eligibility-levels#district_of_columbia_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: DC
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for District Of Columbia pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-dc:policies/cms/district-of-columbia-medicaid-chip-bhp-eligibility-levels#district_of_columbia_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: DC
+    candidate_priority: P4
+    rationale: Axiom exposes the raw District Of Columbia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-dc:policies/cms/district-of-columbia-medicaid-chip-bhp-eligibility-levels#district_of_columbia_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: DC
+    candidate_priority: P4
+    rationale: Axiom exposes the raw District Of Columbia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-dc:policies/cms/district-of-columbia-medicaid-chip-bhp-eligibility-levels#district_of_columbia_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: DC
+    period: year
+    comparison: rate
+    rationale: Same effective District Of Columbia infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-dc:policies/cms/district-of-columbia-medicaid-chip-bhp-eligibility-levels#district_of_columbia_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: DC
+    period: year
+    comparison: rate
+    rationale: Same effective District Of Columbia young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-dc:policies/cms/district-of-columbia-medicaid-chip-bhp-eligibility-levels#district_of_columbia_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: DC
+    period: year
+    comparison: rate
+    rationale: Same effective District Of Columbia older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-dc:policies/cms/district-of-columbia-medicaid-chip-bhp-eligibility-levels#district_of_columbia_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: DC
+    period: year
+    comparison: rate
+    rationale: Same effective District Of Columbia pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-de:policies/cms/delaware-medicaid-chip-bhp-eligibility-levels#delaware_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: DE
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Delaware CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-de:policies/cms/delaware-medicaid-chip-bhp-eligibility-levels#delaware_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: DE
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Delaware CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-de:policies/cms/delaware-medicaid-chip-bhp-eligibility-levels#delaware_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: DE
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Delaware CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-de:policies/cms/delaware-medicaid-chip-bhp-eligibility-levels#delaware_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: DE
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Delaware CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-de:policies/cms/delaware-medicaid-chip-bhp-eligibility-levels#delaware_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: DE
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Delaware CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-de:policies/cms/delaware-medicaid-chip-bhp-eligibility-levels#delaware_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: DE
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Delaware pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-de:policies/cms/delaware-medicaid-chip-bhp-eligibility-levels#delaware_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: DE
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Delaware CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-de:policies/cms/delaware-medicaid-chip-bhp-eligibility-levels#delaware_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: DE
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Delaware CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-de:policies/cms/delaware-medicaid-chip-bhp-eligibility-levels#delaware_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: DE
+    period: year
+    comparison: rate
+    rationale: Same effective Delaware infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-de:policies/cms/delaware-medicaid-chip-bhp-eligibility-levels#delaware_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: DE
+    period: year
+    comparison: rate
+    rationale: Same effective Delaware young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-de:policies/cms/delaware-medicaid-chip-bhp-eligibility-levels#delaware_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: DE
+    period: year
+    comparison: rate
+    rationale: Same effective Delaware older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-de:policies/cms/delaware-medicaid-chip-bhp-eligibility-levels#delaware_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: DE
+    period: year
+    comparison: rate
+    rationale: Same effective Delaware child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-de:policies/cms/delaware-medicaid-chip-bhp-eligibility-levels#delaware_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: DE
+    period: year
+    comparison: rate
+    rationale: Same effective Delaware pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-fl:policies/cms/florida-medicaid-chip-bhp-eligibility-levels#florida_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: FL
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Florida CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-fl:policies/cms/florida-medicaid-chip-bhp-eligibility-levels#florida_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: FL
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Florida CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-fl:policies/cms/florida-medicaid-chip-bhp-eligibility-levels#florida_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: FL
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Florida CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-fl:policies/cms/florida-medicaid-chip-bhp-eligibility-levels#florida_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: FL
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Florida CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-fl:policies/cms/florida-medicaid-chip-bhp-eligibility-levels#florida_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: FL
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Florida CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-fl:policies/cms/florida-medicaid-chip-bhp-eligibility-levels#florida_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: FL
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Florida pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-fl:policies/cms/florida-medicaid-chip-bhp-eligibility-levels#florida_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: FL
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Florida CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-fl:policies/cms/florida-medicaid-chip-bhp-eligibility-levels#florida_parent_caretaker_standard_uses_dollar_amounts
+    country: us
+    program: medicaid
     mapping_type: not_comparable
     candidate_priority: P4
-    rationale: Axiom exposes the CMS table's separate 5% MAGI FPL disregard. PolicyEngine-US bakes that disregard into Medicaid and CHIP income-limit parameters rather than exposing it as a separate parameter.
+    rationale: Axiom exposes the CMS table footnote that Florida's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+
+  - legal_id: us-fl:policies/cms/florida-medicaid-chip-bhp-eligibility-levels#florida_adult_medicaid_expansion_available
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: FL
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Florida adult Medicaid expansion. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-fl:policies/cms/florida-medicaid-chip-bhp-eligibility-levels#florida_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: FL
+    period: year
+    comparison: rate
+    rationale: Same effective Florida infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-fl:policies/cms/florida-medicaid-chip-bhp-eligibility-levels#florida_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: FL
+    period: year
+    comparison: rate
+    rationale: Same effective Florida young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-fl:policies/cms/florida-medicaid-chip-bhp-eligibility-levels#florida_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: FL
+    period: year
+    comparison: rate
+    rationale: Same effective Florida older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-fl:policies/cms/florida-medicaid-chip-bhp-eligibility-levels#florida_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: FL
+    period: year
+    comparison: rate
+    rationale: Same effective Florida child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-fl:policies/cms/florida-medicaid-chip-bhp-eligibility-levels#florida_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: FL
+    period: year
+    comparison: rate
+    rationale: Same effective Florida pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
 
   - legal_id: us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_children_medicaid_ages_0_to_1_fpl_limit
     country: us
@@ -8283,6 +9356,40 @@ mappings:
     parameter_key: GA
     candidate_priority: P4
     rationale: Axiom exposes the raw Georgia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: GA
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Georgia pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: GA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Georgia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_parent_caretaker_standard_uses_dollar_amounts
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table footnote that Georgia's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+
+  - legal_id: us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_adult_medicaid_expansion_available
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: GA
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Georgia adult Medicaid expansion. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
 
   - legal_id: us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_children_medicaid_ages_0_to_1_effective_fpl_limit
     country: us
@@ -8334,40 +9441,4926 @@ mappings:
     comparison: rate
     rationale: Same effective Georgia pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
 
-  - legal_id: us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_parent_caretaker_adults_medicaid_fpl_limit
+  - legal_id: us-hi:policies/cms/hawaii-medicaid-chip-bhp-eligibility-levels#hawaii_children_medicaid_ages_0_to_1_fpl_limit
     country: us
     program: medicaid
     mapping_type: not_comparable
-    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
-    parameter_key: GA
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: HI
     candidate_priority: P4
-    rationale: Axiom exposes the raw Georgia CMS table value and the CMS dollar-amount indicator for parent and caretaker adults. PolicyEngine-US stores an effective parent and caretaker Medicaid income limit including MAGI treatment, so the raw CMS row is not a one-to-one oracle target.
+    rationale: Axiom exposes the raw Hawaii CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
 
-  - legal_id: us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_parent_caretaker_standard_uses_dollar_amounts
+  - legal_id: us-hi:policies/cms/hawaii-medicaid-chip-bhp-eligibility-levels#hawaii_children_medicaid_ages_1_to_5_fpl_limit
     country: us
     program: medicaid
     mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: HI
     candidate_priority: P4
-    rationale: Axiom exposes the CMS table footnote that Georgia's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+    rationale: Axiom exposes the raw Hawaii CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
 
-  - legal_id: us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_pregnant_women_chip_available
+  - legal_id: us-hi:policies/cms/hawaii-medicaid-chip-bhp-eligibility-levels#hawaii_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: HI
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Hawaii CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-hi:policies/cms/hawaii-medicaid-chip-bhp-eligibility-levels#hawaii_children_separate_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: HI
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Hawaii child CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-hi:policies/cms/hawaii-medicaid-chip-bhp-eligibility-levels#hawaii_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: HI
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Hawaii CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-hi:policies/cms/hawaii-medicaid-chip-bhp-eligibility-levels#hawaii_pregnant_women_chip_available
     country: us
     program: chip
     mapping_type: not_comparable
     policyengine_parameter: gov.hhs.chip.pregnant.income_limit
-    parameter_key: GA
+    parameter_key: HI
     candidate_priority: P4
-    rationale: Axiom exposes CMS table availability for separate CHIP coverage of pregnant women. PolicyEngine-US represents unavailable pregnant-women CHIP coverage through its income-limit parameter rather than a separate availability boolean.
+    rationale: Axiom exposes CMS table availability for Hawaii pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
 
-  - legal_id: us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_adult_medicaid_expansion_available
+  - legal_id: us-hi:policies/cms/hawaii-medicaid-chip-bhp-eligibility-levels#hawaii_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: HI
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Hawaii CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-hi:policies/cms/hawaii-medicaid-chip-bhp-eligibility-levels#hawaii_adult_medicaid_expansion_fpl_limit
     country: us
     program: medicaid
     mapping_type: not_comparable
     policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
-    parameter_key: GA
+    parameter_key: HI
     candidate_priority: P4
-    rationale: Axiom exposes CMS table availability for adult Medicaid expansion. PolicyEngine-US represents unavailable adult expansion through its adult Medicaid income-limit parameter rather than a separate availability boolean.
+    rationale: Axiom exposes the raw Hawaii CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
 
+  - legal_id: us-hi:policies/cms/hawaii-medicaid-chip-bhp-eligibility-levels#hawaii_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: HI
+    period: year
+    comparison: rate
+    rationale: Same effective Hawaii infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-hi:policies/cms/hawaii-medicaid-chip-bhp-eligibility-levels#hawaii_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: HI
+    period: year
+    comparison: rate
+    rationale: Same effective Hawaii young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-hi:policies/cms/hawaii-medicaid-chip-bhp-eligibility-levels#hawaii_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: HI
+    period: year
+    comparison: rate
+    rationale: Same effective Hawaii older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-hi:policies/cms/hawaii-medicaid-chip-bhp-eligibility-levels#hawaii_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: HI
+    period: year
+    comparison: rate
+    rationale: Same effective Hawaii pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ia:policies/cms/iowa-medicaid-chip-bhp-eligibility-levels#iowa_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: IA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Iowa CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-ia:policies/cms/iowa-medicaid-chip-bhp-eligibility-levels#iowa_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: IA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Iowa CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ia:policies/cms/iowa-medicaid-chip-bhp-eligibility-levels#iowa_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: IA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Iowa CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ia:policies/cms/iowa-medicaid-chip-bhp-eligibility-levels#iowa_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: IA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Iowa CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-ia:policies/cms/iowa-medicaid-chip-bhp-eligibility-levels#iowa_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: IA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Iowa CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-ia:policies/cms/iowa-medicaid-chip-bhp-eligibility-levels#iowa_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: IA
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Iowa pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-ia:policies/cms/iowa-medicaid-chip-bhp-eligibility-levels#iowa_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: IA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Iowa CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-ia:policies/cms/iowa-medicaid-chip-bhp-eligibility-levels#iowa_parent_caretaker_standard_uses_dollar_amounts
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table footnote that Iowa's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+
+  - legal_id: us-ia:policies/cms/iowa-medicaid-chip-bhp-eligibility-levels#iowa_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: IA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Iowa CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-ia:policies/cms/iowa-medicaid-chip-bhp-eligibility-levels#iowa_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: IA
+    period: year
+    comparison: rate
+    rationale: Same effective Iowa infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ia:policies/cms/iowa-medicaid-chip-bhp-eligibility-levels#iowa_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: IA
+    period: year
+    comparison: rate
+    rationale: Same effective Iowa young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ia:policies/cms/iowa-medicaid-chip-bhp-eligibility-levels#iowa_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: IA
+    period: year
+    comparison: rate
+    rationale: Same effective Iowa older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ia:policies/cms/iowa-medicaid-chip-bhp-eligibility-levels#iowa_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: IA
+    period: year
+    comparison: rate
+    rationale: Same effective Iowa child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ia:policies/cms/iowa-medicaid-chip-bhp-eligibility-levels#iowa_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: IA
+    period: year
+    comparison: rate
+    rationale: Same effective Iowa pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-id:policies/cms/idaho-medicaid-chip-bhp-eligibility-levels#idaho_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: ID
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Idaho CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-id:policies/cms/idaho-medicaid-chip-bhp-eligibility-levels#idaho_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: ID
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Idaho CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-id:policies/cms/idaho-medicaid-chip-bhp-eligibility-levels#idaho_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: ID
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Idaho CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-id:policies/cms/idaho-medicaid-chip-bhp-eligibility-levels#idaho_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: ID
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Idaho CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-id:policies/cms/idaho-medicaid-chip-bhp-eligibility-levels#idaho_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: ID
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Idaho CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-id:policies/cms/idaho-medicaid-chip-bhp-eligibility-levels#idaho_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: ID
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Idaho pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-id:policies/cms/idaho-medicaid-chip-bhp-eligibility-levels#idaho_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: ID
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Idaho CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-id:policies/cms/idaho-medicaid-chip-bhp-eligibility-levels#idaho_parent_caretaker_standard_uses_dollar_amounts
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table footnote that Idaho's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+
+  - legal_id: us-id:policies/cms/idaho-medicaid-chip-bhp-eligibility-levels#idaho_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: ID
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Idaho CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-id:policies/cms/idaho-medicaid-chip-bhp-eligibility-levels#idaho_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: ID
+    period: year
+    comparison: rate
+    rationale: Same effective Idaho infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-id:policies/cms/idaho-medicaid-chip-bhp-eligibility-levels#idaho_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: ID
+    period: year
+    comparison: rate
+    rationale: Same effective Idaho young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-id:policies/cms/idaho-medicaid-chip-bhp-eligibility-levels#idaho_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: ID
+    period: year
+    comparison: rate
+    rationale: Same effective Idaho older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-id:policies/cms/idaho-medicaid-chip-bhp-eligibility-levels#idaho_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: ID
+    period: year
+    comparison: rate
+    rationale: Same effective Idaho child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-id:policies/cms/idaho-medicaid-chip-bhp-eligibility-levels#idaho_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: ID
+    period: year
+    comparison: rate
+    rationale: Same effective Idaho pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-il:policies/cms/illinois-medicaid-chip-bhp-eligibility-levels#illinois_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: IL
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Illinois CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-il:policies/cms/illinois-medicaid-chip-bhp-eligibility-levels#illinois_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: IL
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Illinois CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-il:policies/cms/illinois-medicaid-chip-bhp-eligibility-levels#illinois_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: IL
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Illinois CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-il:policies/cms/illinois-medicaid-chip-bhp-eligibility-levels#illinois_children_separate_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: IL
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Illinois child CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-il:policies/cms/illinois-medicaid-chip-bhp-eligibility-levels#illinois_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: IL
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Illinois CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-il:policies/cms/illinois-medicaid-chip-bhp-eligibility-levels#illinois_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: IL
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Illinois pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-il:policies/cms/illinois-medicaid-chip-bhp-eligibility-levels#illinois_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: IL
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Illinois CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-il:policies/cms/illinois-medicaid-chip-bhp-eligibility-levels#illinois_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: IL
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Illinois CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-il:policies/cms/illinois-medicaid-chip-bhp-eligibility-levels#illinois_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: IL
+    period: year
+    comparison: rate
+    rationale: Same effective Illinois infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-il:policies/cms/illinois-medicaid-chip-bhp-eligibility-levels#illinois_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: IL
+    period: year
+    comparison: rate
+    rationale: Same effective Illinois young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-il:policies/cms/illinois-medicaid-chip-bhp-eligibility-levels#illinois_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: IL
+    period: year
+    comparison: rate
+    rationale: Same effective Illinois older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-il:policies/cms/illinois-medicaid-chip-bhp-eligibility-levels#illinois_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: IL
+    period: year
+    comparison: rate
+    rationale: Same effective Illinois pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-in:policies/cms/indiana-medicaid-chip-bhp-eligibility-levels#indiana_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: IN
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Indiana CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-in:policies/cms/indiana-medicaid-chip-bhp-eligibility-levels#indiana_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: IN
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Indiana CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-in:policies/cms/indiana-medicaid-chip-bhp-eligibility-levels#indiana_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: IN
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Indiana CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-in:policies/cms/indiana-medicaid-chip-bhp-eligibility-levels#indiana_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: IN
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Indiana CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-in:policies/cms/indiana-medicaid-chip-bhp-eligibility-levels#indiana_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: IN
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Indiana CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-in:policies/cms/indiana-medicaid-chip-bhp-eligibility-levels#indiana_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: IN
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Indiana pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-in:policies/cms/indiana-medicaid-chip-bhp-eligibility-levels#indiana_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: IN
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Indiana CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-in:policies/cms/indiana-medicaid-chip-bhp-eligibility-levels#indiana_parent_caretaker_standard_uses_dollar_amounts
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table footnote that Indiana's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+
+  - legal_id: us-in:policies/cms/indiana-medicaid-chip-bhp-eligibility-levels#indiana_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: IN
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Indiana CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-in:policies/cms/indiana-medicaid-chip-bhp-eligibility-levels#indiana_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: IN
+    period: year
+    comparison: rate
+    rationale: Same effective Indiana infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-in:policies/cms/indiana-medicaid-chip-bhp-eligibility-levels#indiana_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: IN
+    period: year
+    comparison: rate
+    rationale: Same effective Indiana young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-in:policies/cms/indiana-medicaid-chip-bhp-eligibility-levels#indiana_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: IN
+    period: year
+    comparison: rate
+    rationale: Same effective Indiana older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-in:policies/cms/indiana-medicaid-chip-bhp-eligibility-levels#indiana_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: IN
+    period: year
+    comparison: rate
+    rationale: Same effective Indiana child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-in:policies/cms/indiana-medicaid-chip-bhp-eligibility-levels#indiana_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: IN
+    period: year
+    comparison: rate
+    rationale: Same effective Indiana pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ks:policies/cms/kansas-medicaid-chip-bhp-eligibility-levels#kansas_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: KS
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Kansas CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-ks:policies/cms/kansas-medicaid-chip-bhp-eligibility-levels#kansas_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: KS
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Kansas CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ks:policies/cms/kansas-medicaid-chip-bhp-eligibility-levels#kansas_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: KS
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Kansas CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ks:policies/cms/kansas-medicaid-chip-bhp-eligibility-levels#kansas_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: KS
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Kansas CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-ks:policies/cms/kansas-medicaid-chip-bhp-eligibility-levels#kansas_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: KS
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Kansas CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-ks:policies/cms/kansas-medicaid-chip-bhp-eligibility-levels#kansas_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: KS
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Kansas pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-ks:policies/cms/kansas-medicaid-chip-bhp-eligibility-levels#kansas_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: KS
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Kansas CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-ks:policies/cms/kansas-medicaid-chip-bhp-eligibility-levels#kansas_adult_medicaid_expansion_available
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: KS
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Kansas adult Medicaid expansion. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-ks:policies/cms/kansas-medicaid-chip-bhp-eligibility-levels#kansas_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: KS
+    period: year
+    comparison: rate
+    rationale: Same effective Kansas infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ks:policies/cms/kansas-medicaid-chip-bhp-eligibility-levels#kansas_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: KS
+    period: year
+    comparison: rate
+    rationale: Same effective Kansas young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ks:policies/cms/kansas-medicaid-chip-bhp-eligibility-levels#kansas_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: KS
+    period: year
+    comparison: rate
+    rationale: Same effective Kansas older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ks:policies/cms/kansas-medicaid-chip-bhp-eligibility-levels#kansas_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: KS
+    period: year
+    comparison: rate
+    rationale: Same effective Kansas child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ks:policies/cms/kansas-medicaid-chip-bhp-eligibility-levels#kansas_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: KS
+    period: year
+    comparison: rate
+    rationale: Same effective Kansas pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ky:policies/cms/kentucky-medicaid-chip-bhp-eligibility-levels#kentucky_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: KY
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Kentucky CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-ky:policies/cms/kentucky-medicaid-chip-bhp-eligibility-levels#kentucky_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: KY
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Kentucky CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ky:policies/cms/kentucky-medicaid-chip-bhp-eligibility-levels#kentucky_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: KY
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Kentucky CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ky:policies/cms/kentucky-medicaid-chip-bhp-eligibility-levels#kentucky_children_separate_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: KY
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Kentucky child CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-ky:policies/cms/kentucky-medicaid-chip-bhp-eligibility-levels#kentucky_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: KY
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Kentucky CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-ky:policies/cms/kentucky-medicaid-chip-bhp-eligibility-levels#kentucky_pregnant_women_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: KY
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Kentucky CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person CHIP income limit including that disregard.
+
+  - legal_id: us-ky:policies/cms/kentucky-medicaid-chip-bhp-eligibility-levels#kentucky_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: KY
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Kentucky CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-ky:policies/cms/kentucky-medicaid-chip-bhp-eligibility-levels#kentucky_parent_caretaker_standard_uses_dollar_amounts
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table footnote that Kentucky's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+
+  - legal_id: us-ky:policies/cms/kentucky-medicaid-chip-bhp-eligibility-levels#kentucky_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: KY
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Kentucky CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-ky:policies/cms/kentucky-medicaid-chip-bhp-eligibility-levels#kentucky_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: KY
+    period: year
+    comparison: rate
+    rationale: Same effective Kentucky infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ky:policies/cms/kentucky-medicaid-chip-bhp-eligibility-levels#kentucky_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: KY
+    period: year
+    comparison: rate
+    rationale: Same effective Kentucky young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ky:policies/cms/kentucky-medicaid-chip-bhp-eligibility-levels#kentucky_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: KY
+    period: year
+    comparison: rate
+    rationale: Same effective Kentucky older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ky:policies/cms/kentucky-medicaid-chip-bhp-eligibility-levels#kentucky_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: KY
+    period: year
+    comparison: rate
+    rationale: Same effective Kentucky pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ky:policies/cms/kentucky-medicaid-chip-bhp-eligibility-levels#kentucky_pregnant_women_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: KY
+    period: year
+    comparison: rate
+    rationale: Same effective Kentucky pregnant-person CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-la:policies/cms/louisiana-medicaid-chip-bhp-eligibility-levels#louisiana_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: LA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Louisiana CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-la:policies/cms/louisiana-medicaid-chip-bhp-eligibility-levels#louisiana_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: LA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Louisiana CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-la:policies/cms/louisiana-medicaid-chip-bhp-eligibility-levels#louisiana_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: LA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Louisiana CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-la:policies/cms/louisiana-medicaid-chip-bhp-eligibility-levels#louisiana_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: LA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Louisiana CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-la:policies/cms/louisiana-medicaid-chip-bhp-eligibility-levels#louisiana_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: LA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Louisiana CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-la:policies/cms/louisiana-medicaid-chip-bhp-eligibility-levels#louisiana_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: LA
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Louisiana pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-la:policies/cms/louisiana-medicaid-chip-bhp-eligibility-levels#louisiana_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: LA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Louisiana CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-la:policies/cms/louisiana-medicaid-chip-bhp-eligibility-levels#louisiana_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: LA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Louisiana CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-la:policies/cms/louisiana-medicaid-chip-bhp-eligibility-levels#louisiana_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: LA
+    period: year
+    comparison: rate
+    rationale: Same effective Louisiana infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-la:policies/cms/louisiana-medicaid-chip-bhp-eligibility-levels#louisiana_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: LA
+    period: year
+    comparison: rate
+    rationale: Same effective Louisiana young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-la:policies/cms/louisiana-medicaid-chip-bhp-eligibility-levels#louisiana_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: LA
+    period: year
+    comparison: rate
+    rationale: Same effective Louisiana older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-la:policies/cms/louisiana-medicaid-chip-bhp-eligibility-levels#louisiana_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: LA
+    period: year
+    comparison: rate
+    rationale: Same effective Louisiana child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-la:policies/cms/louisiana-medicaid-chip-bhp-eligibility-levels#louisiana_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: LA
+    period: year
+    comparison: rate
+    rationale: Same effective Louisiana pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ma:policies/cms/massachusetts-medicaid-chip-bhp-eligibility-levels#massachusetts_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: MA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Massachusetts CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-ma:policies/cms/massachusetts-medicaid-chip-bhp-eligibility-levels#massachusetts_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: MA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Massachusetts CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ma:policies/cms/massachusetts-medicaid-chip-bhp-eligibility-levels#massachusetts_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: MA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Massachusetts CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ma:policies/cms/massachusetts-medicaid-chip-bhp-eligibility-levels#massachusetts_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: MA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Massachusetts CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-ma:policies/cms/massachusetts-medicaid-chip-bhp-eligibility-levels#massachusetts_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: MA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Massachusetts CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-ma:policies/cms/massachusetts-medicaid-chip-bhp-eligibility-levels#massachusetts_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: MA
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Massachusetts pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-ma:policies/cms/massachusetts-medicaid-chip-bhp-eligibility-levels#massachusetts_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: MA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Massachusetts CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-ma:policies/cms/massachusetts-medicaid-chip-bhp-eligibility-levels#massachusetts_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: MA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Massachusetts CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-ma:policies/cms/massachusetts-medicaid-chip-bhp-eligibility-levels#massachusetts_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: MA
+    period: year
+    comparison: rate
+    rationale: Same effective Massachusetts infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ma:policies/cms/massachusetts-medicaid-chip-bhp-eligibility-levels#massachusetts_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: MA
+    period: year
+    comparison: rate
+    rationale: Same effective Massachusetts young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ma:policies/cms/massachusetts-medicaid-chip-bhp-eligibility-levels#massachusetts_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: MA
+    period: year
+    comparison: rate
+    rationale: Same effective Massachusetts older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ma:policies/cms/massachusetts-medicaid-chip-bhp-eligibility-levels#massachusetts_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: MA
+    period: year
+    comparison: rate
+    rationale: Same effective Massachusetts child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ma:policies/cms/massachusetts-medicaid-chip-bhp-eligibility-levels#massachusetts_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: MA
+    period: year
+    comparison: rate
+    rationale: Same effective Massachusetts pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-md:policies/cms/maryland-medicaid-chip-bhp-eligibility-levels#maryland_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: MD
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Maryland CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-md:policies/cms/maryland-medicaid-chip-bhp-eligibility-levels#maryland_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: MD
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Maryland CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-md:policies/cms/maryland-medicaid-chip-bhp-eligibility-levels#maryland_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: MD
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Maryland CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-md:policies/cms/maryland-medicaid-chip-bhp-eligibility-levels#maryland_children_separate_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: MD
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Maryland child CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-md:policies/cms/maryland-medicaid-chip-bhp-eligibility-levels#maryland_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: MD
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Maryland CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-md:policies/cms/maryland-medicaid-chip-bhp-eligibility-levels#maryland_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: MD
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Maryland pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-md:policies/cms/maryland-medicaid-chip-bhp-eligibility-levels#maryland_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: MD
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Maryland CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-md:policies/cms/maryland-medicaid-chip-bhp-eligibility-levels#maryland_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: MD
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Maryland CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-md:policies/cms/maryland-medicaid-chip-bhp-eligibility-levels#maryland_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: MD
+    period: year
+    comparison: rate
+    rationale: Same effective Maryland infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-md:policies/cms/maryland-medicaid-chip-bhp-eligibility-levels#maryland_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: MD
+    period: year
+    comparison: rate
+    rationale: Same effective Maryland young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-md:policies/cms/maryland-medicaid-chip-bhp-eligibility-levels#maryland_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: MD
+    period: year
+    comparison: rate
+    rationale: Same effective Maryland older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-md:policies/cms/maryland-medicaid-chip-bhp-eligibility-levels#maryland_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: MD
+    period: year
+    comparison: rate
+    rationale: Same effective Maryland pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-me:policies/cms/maine-medicaid-chip-bhp-eligibility-levels#maine_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: ME
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Maine CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-me:policies/cms/maine-medicaid-chip-bhp-eligibility-levels#maine_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: ME
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Maine CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-me:policies/cms/maine-medicaid-chip-bhp-eligibility-levels#maine_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: ME
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Maine CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-me:policies/cms/maine-medicaid-chip-bhp-eligibility-levels#maine_children_separate_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: ME
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Maine child CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-me:policies/cms/maine-medicaid-chip-bhp-eligibility-levels#maine_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: ME
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Maine CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-me:policies/cms/maine-medicaid-chip-bhp-eligibility-levels#maine_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: ME
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Maine pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-me:policies/cms/maine-medicaid-chip-bhp-eligibility-levels#maine_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: ME
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Maine CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-me:policies/cms/maine-medicaid-chip-bhp-eligibility-levels#maine_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: ME
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Maine CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-me:policies/cms/maine-medicaid-chip-bhp-eligibility-levels#maine_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: ME
+    period: year
+    comparison: rate
+    rationale: Same effective Maine infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-me:policies/cms/maine-medicaid-chip-bhp-eligibility-levels#maine_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: ME
+    period: year
+    comparison: rate
+    rationale: Same effective Maine young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-me:policies/cms/maine-medicaid-chip-bhp-eligibility-levels#maine_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: ME
+    period: year
+    comparison: rate
+    rationale: Same effective Maine older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-me:policies/cms/maine-medicaid-chip-bhp-eligibility-levels#maine_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: ME
+    period: year
+    comparison: rate
+    rationale: Same effective Maine pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-mi:policies/cms/michigan-medicaid-chip-bhp-eligibility-levels#michigan_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: MI
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Michigan CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-mi:policies/cms/michigan-medicaid-chip-bhp-eligibility-levels#michigan_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: MI
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Michigan CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-mi:policies/cms/michigan-medicaid-chip-bhp-eligibility-levels#michigan_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: MI
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Michigan CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-mi:policies/cms/michigan-medicaid-chip-bhp-eligibility-levels#michigan_children_separate_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: MI
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Michigan child CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-mi:policies/cms/michigan-medicaid-chip-bhp-eligibility-levels#michigan_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: MI
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Michigan CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-mi:policies/cms/michigan-medicaid-chip-bhp-eligibility-levels#michigan_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: MI
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Michigan pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-mi:policies/cms/michigan-medicaid-chip-bhp-eligibility-levels#michigan_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: MI
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Michigan CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-mi:policies/cms/michigan-medicaid-chip-bhp-eligibility-levels#michigan_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: MI
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Michigan CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-mi:policies/cms/michigan-medicaid-chip-bhp-eligibility-levels#michigan_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: MI
+    period: year
+    comparison: rate
+    rationale: Same effective Michigan infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-mi:policies/cms/michigan-medicaid-chip-bhp-eligibility-levels#michigan_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: MI
+    period: year
+    comparison: rate
+    rationale: Same effective Michigan young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-mi:policies/cms/michigan-medicaid-chip-bhp-eligibility-levels#michigan_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: MI
+    period: year
+    comparison: rate
+    rationale: Same effective Michigan older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-mi:policies/cms/michigan-medicaid-chip-bhp-eligibility-levels#michigan_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: MI
+    period: year
+    comparison: rate
+    rationale: Same effective Michigan pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-mn:policies/cms/minnesota-medicaid-chip-bhp-eligibility-levels#minnesota_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: MN
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Minnesota CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-mn:policies/cms/minnesota-medicaid-chip-bhp-eligibility-levels#minnesota_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: MN
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Minnesota CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-mn:policies/cms/minnesota-medicaid-chip-bhp-eligibility-levels#minnesota_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: MN
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Minnesota CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-mn:policies/cms/minnesota-medicaid-chip-bhp-eligibility-levels#minnesota_children_separate_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: MN
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Minnesota child CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-mn:policies/cms/minnesota-medicaid-chip-bhp-eligibility-levels#minnesota_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: MN
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Minnesota CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-mn:policies/cms/minnesota-medicaid-chip-bhp-eligibility-levels#minnesota_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: MN
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Minnesota pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-mn:policies/cms/minnesota-medicaid-chip-bhp-eligibility-levels#minnesota_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: MN
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Minnesota CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-mn:policies/cms/minnesota-medicaid-chip-bhp-eligibility-levels#minnesota_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: MN
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Minnesota CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-mn:policies/cms/minnesota-medicaid-chip-bhp-eligibility-levels#minnesota_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: MN
+    period: year
+    comparison: rate
+    rationale: Same effective Minnesota infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-mn:policies/cms/minnesota-medicaid-chip-bhp-eligibility-levels#minnesota_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: MN
+    period: year
+    comparison: rate
+    rationale: Same effective Minnesota young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-mn:policies/cms/minnesota-medicaid-chip-bhp-eligibility-levels#minnesota_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: MN
+    period: year
+    comparison: rate
+    rationale: Same effective Minnesota older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-mn:policies/cms/minnesota-medicaid-chip-bhp-eligibility-levels#minnesota_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: MN
+    period: year
+    comparison: rate
+    rationale: Same effective Minnesota pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-mo:policies/cms/missouri-medicaid-chip-bhp-eligibility-levels#missouri_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: MO
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Missouri CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-mo:policies/cms/missouri-medicaid-chip-bhp-eligibility-levels#missouri_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: MO
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Missouri CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-mo:policies/cms/missouri-medicaid-chip-bhp-eligibility-levels#missouri_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: MO
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Missouri CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-mo:policies/cms/missouri-medicaid-chip-bhp-eligibility-levels#missouri_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: MO
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Missouri CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-mo:policies/cms/missouri-medicaid-chip-bhp-eligibility-levels#missouri_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: MO
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Missouri CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-mo:policies/cms/missouri-medicaid-chip-bhp-eligibility-levels#missouri_pregnant_women_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: MO
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Missouri CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person CHIP income limit including that disregard.
+
+  - legal_id: us-mo:policies/cms/missouri-medicaid-chip-bhp-eligibility-levels#missouri_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: MO
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Missouri CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-mo:policies/cms/missouri-medicaid-chip-bhp-eligibility-levels#missouri_parent_caretaker_standard_uses_dollar_amounts
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table footnote that Missouri's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+
+  - legal_id: us-mo:policies/cms/missouri-medicaid-chip-bhp-eligibility-levels#missouri_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: MO
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Missouri CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-mo:policies/cms/missouri-medicaid-chip-bhp-eligibility-levels#missouri_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: MO
+    period: year
+    comparison: rate
+    rationale: Same effective Missouri infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-mo:policies/cms/missouri-medicaid-chip-bhp-eligibility-levels#missouri_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: MO
+    period: year
+    comparison: rate
+    rationale: Same effective Missouri young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-mo:policies/cms/missouri-medicaid-chip-bhp-eligibility-levels#missouri_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: MO
+    period: year
+    comparison: rate
+    rationale: Same effective Missouri older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-mo:policies/cms/missouri-medicaid-chip-bhp-eligibility-levels#missouri_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: MO
+    period: year
+    comparison: rate
+    rationale: Same effective Missouri child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-mo:policies/cms/missouri-medicaid-chip-bhp-eligibility-levels#missouri_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: MO
+    period: year
+    comparison: rate
+    rationale: Same effective Missouri pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-mo:policies/cms/missouri-medicaid-chip-bhp-eligibility-levels#missouri_pregnant_women_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: MO
+    period: year
+    comparison: rate
+    rationale: Same effective Missouri pregnant-person CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ms:policies/cms/mississippi-medicaid-chip-bhp-eligibility-levels#mississippi_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: MS
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Mississippi CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-ms:policies/cms/mississippi-medicaid-chip-bhp-eligibility-levels#mississippi_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: MS
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Mississippi CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ms:policies/cms/mississippi-medicaid-chip-bhp-eligibility-levels#mississippi_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: MS
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Mississippi CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ms:policies/cms/mississippi-medicaid-chip-bhp-eligibility-levels#mississippi_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: MS
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Mississippi CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-ms:policies/cms/mississippi-medicaid-chip-bhp-eligibility-levels#mississippi_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: MS
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Mississippi CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-ms:policies/cms/mississippi-medicaid-chip-bhp-eligibility-levels#mississippi_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: MS
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Mississippi pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-ms:policies/cms/mississippi-medicaid-chip-bhp-eligibility-levels#mississippi_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: MS
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Mississippi CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-ms:policies/cms/mississippi-medicaid-chip-bhp-eligibility-levels#mississippi_parent_caretaker_standard_uses_dollar_amounts
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table footnote that Mississippi's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+
+  - legal_id: us-ms:policies/cms/mississippi-medicaid-chip-bhp-eligibility-levels#mississippi_adult_medicaid_expansion_available
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: MS
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Mississippi adult Medicaid expansion. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-ms:policies/cms/mississippi-medicaid-chip-bhp-eligibility-levels#mississippi_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: MS
+    period: year
+    comparison: rate
+    rationale: Same effective Mississippi infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ms:policies/cms/mississippi-medicaid-chip-bhp-eligibility-levels#mississippi_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: MS
+    period: year
+    comparison: rate
+    rationale: Same effective Mississippi young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ms:policies/cms/mississippi-medicaid-chip-bhp-eligibility-levels#mississippi_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: MS
+    period: year
+    comparison: rate
+    rationale: Same effective Mississippi older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ms:policies/cms/mississippi-medicaid-chip-bhp-eligibility-levels#mississippi_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: MS
+    period: year
+    comparison: rate
+    rationale: Same effective Mississippi child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ms:policies/cms/mississippi-medicaid-chip-bhp-eligibility-levels#mississippi_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: MS
+    period: year
+    comparison: rate
+    rationale: Same effective Mississippi pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-mt:policies/cms/montana-medicaid-chip-bhp-eligibility-levels#montana_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: MT
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Montana CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-mt:policies/cms/montana-medicaid-chip-bhp-eligibility-levels#montana_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: MT
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Montana CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-mt:policies/cms/montana-medicaid-chip-bhp-eligibility-levels#montana_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: MT
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Montana CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-mt:policies/cms/montana-medicaid-chip-bhp-eligibility-levels#montana_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: MT
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Montana CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-mt:policies/cms/montana-medicaid-chip-bhp-eligibility-levels#montana_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: MT
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Montana CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-mt:policies/cms/montana-medicaid-chip-bhp-eligibility-levels#montana_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: MT
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Montana pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-mt:policies/cms/montana-medicaid-chip-bhp-eligibility-levels#montana_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: MT
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Montana CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-mt:policies/cms/montana-medicaid-chip-bhp-eligibility-levels#montana_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: MT
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Montana CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-mt:policies/cms/montana-medicaid-chip-bhp-eligibility-levels#montana_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: MT
+    period: year
+    comparison: rate
+    rationale: Same effective Montana infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-mt:policies/cms/montana-medicaid-chip-bhp-eligibility-levels#montana_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: MT
+    period: year
+    comparison: rate
+    rationale: Same effective Montana young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-mt:policies/cms/montana-medicaid-chip-bhp-eligibility-levels#montana_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: MT
+    period: year
+    comparison: rate
+    rationale: Same effective Montana older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-mt:policies/cms/montana-medicaid-chip-bhp-eligibility-levels#montana_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: MT
+    period: year
+    comparison: rate
+    rationale: Same effective Montana child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-mt:policies/cms/montana-medicaid-chip-bhp-eligibility-levels#montana_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: MT
+    period: year
+    comparison: rate
+    rationale: Same effective Montana pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-nc:policies/cms/north-carolina-medicaid-chip-bhp-eligibility-levels#north_carolina_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: NC
+    candidate_priority: P4
+    rationale: Axiom exposes the raw North Carolina CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-nc:policies/cms/north-carolina-medicaid-chip-bhp-eligibility-levels#north_carolina_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: NC
+    candidate_priority: P4
+    rationale: Axiom exposes the raw North Carolina CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-nc:policies/cms/north-carolina-medicaid-chip-bhp-eligibility-levels#north_carolina_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: NC
+    candidate_priority: P4
+    rationale: Axiom exposes the raw North Carolina CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-nc:policies/cms/north-carolina-medicaid-chip-bhp-eligibility-levels#north_carolina_children_separate_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: NC
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for North Carolina child CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-nc:policies/cms/north-carolina-medicaid-chip-bhp-eligibility-levels#north_carolina_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: NC
+    candidate_priority: P4
+    rationale: Axiom exposes the raw North Carolina CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-nc:policies/cms/north-carolina-medicaid-chip-bhp-eligibility-levels#north_carolina_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: NC
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for North Carolina pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-nc:policies/cms/north-carolina-medicaid-chip-bhp-eligibility-levels#north_carolina_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: NC
+    candidate_priority: P4
+    rationale: Axiom exposes the raw North Carolina CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-nc:policies/cms/north-carolina-medicaid-chip-bhp-eligibility-levels#north_carolina_parent_caretaker_standard_uses_dollar_amounts
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table footnote that North Carolina's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+
+  - legal_id: us-nc:policies/cms/north-carolina-medicaid-chip-bhp-eligibility-levels#north_carolina_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: NC
+    candidate_priority: P4
+    rationale: Axiom exposes the raw North Carolina CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-nc:policies/cms/north-carolina-medicaid-chip-bhp-eligibility-levels#north_carolina_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: NC
+    period: year
+    comparison: rate
+    rationale: Same effective North Carolina infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-nc:policies/cms/north-carolina-medicaid-chip-bhp-eligibility-levels#north_carolina_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: NC
+    period: year
+    comparison: rate
+    rationale: Same effective North Carolina young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-nc:policies/cms/north-carolina-medicaid-chip-bhp-eligibility-levels#north_carolina_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: NC
+    period: year
+    comparison: rate
+    rationale: Same effective North Carolina older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-nc:policies/cms/north-carolina-medicaid-chip-bhp-eligibility-levels#north_carolina_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: NC
+    period: year
+    comparison: rate
+    rationale: Same effective North Carolina pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-nd:policies/cms/north-dakota-medicaid-chip-bhp-eligibility-levels#north_dakota_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: ND
+    candidate_priority: P4
+    rationale: Axiom exposes the raw North Dakota CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-nd:policies/cms/north-dakota-medicaid-chip-bhp-eligibility-levels#north_dakota_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: ND
+    candidate_priority: P4
+    rationale: Axiom exposes the raw North Dakota CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-nd:policies/cms/north-dakota-medicaid-chip-bhp-eligibility-levels#north_dakota_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: ND
+    candidate_priority: P4
+    rationale: Axiom exposes the raw North Dakota CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-nd:policies/cms/north-dakota-medicaid-chip-bhp-eligibility-levels#north_dakota_children_separate_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: ND
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for North Dakota child CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-nd:policies/cms/north-dakota-medicaid-chip-bhp-eligibility-levels#north_dakota_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: ND
+    candidate_priority: P4
+    rationale: Axiom exposes the raw North Dakota CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-nd:policies/cms/north-dakota-medicaid-chip-bhp-eligibility-levels#north_dakota_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: ND
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for North Dakota pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-nd:policies/cms/north-dakota-medicaid-chip-bhp-eligibility-levels#north_dakota_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: ND
+    candidate_priority: P4
+    rationale: Axiom exposes the raw North Dakota CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-nd:policies/cms/north-dakota-medicaid-chip-bhp-eligibility-levels#north_dakota_parent_caretaker_standard_uses_dollar_amounts
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table footnote that North Dakota's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+
+  - legal_id: us-nd:policies/cms/north-dakota-medicaid-chip-bhp-eligibility-levels#north_dakota_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: ND
+    candidate_priority: P4
+    rationale: Axiom exposes the raw North Dakota CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-nd:policies/cms/north-dakota-medicaid-chip-bhp-eligibility-levels#north_dakota_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: ND
+    period: year
+    comparison: rate
+    rationale: Same effective North Dakota infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-nd:policies/cms/north-dakota-medicaid-chip-bhp-eligibility-levels#north_dakota_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: ND
+    period: year
+    comparison: rate
+    rationale: Same effective North Dakota young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-nd:policies/cms/north-dakota-medicaid-chip-bhp-eligibility-levels#north_dakota_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: ND
+    period: year
+    comparison: rate
+    rationale: Same effective North Dakota older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-nd:policies/cms/north-dakota-medicaid-chip-bhp-eligibility-levels#north_dakota_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: ND
+    period: year
+    comparison: rate
+    rationale: Same effective North Dakota pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ne:policies/cms/nebraska-medicaid-chip-bhp-eligibility-levels#nebraska_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: NE
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Nebraska CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-ne:policies/cms/nebraska-medicaid-chip-bhp-eligibility-levels#nebraska_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: NE
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Nebraska CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ne:policies/cms/nebraska-medicaid-chip-bhp-eligibility-levels#nebraska_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: NE
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Nebraska CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ne:policies/cms/nebraska-medicaid-chip-bhp-eligibility-levels#nebraska_children_separate_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: NE
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Nebraska child CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-ne:policies/cms/nebraska-medicaid-chip-bhp-eligibility-levels#nebraska_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: NE
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Nebraska CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-ne:policies/cms/nebraska-medicaid-chip-bhp-eligibility-levels#nebraska_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: NE
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Nebraska pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-ne:policies/cms/nebraska-medicaid-chip-bhp-eligibility-levels#nebraska_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: NE
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Nebraska CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-ne:policies/cms/nebraska-medicaid-chip-bhp-eligibility-levels#nebraska_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: NE
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Nebraska CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-ne:policies/cms/nebraska-medicaid-chip-bhp-eligibility-levels#nebraska_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: NE
+    period: year
+    comparison: rate
+    rationale: Same effective Nebraska infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ne:policies/cms/nebraska-medicaid-chip-bhp-eligibility-levels#nebraska_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: NE
+    period: year
+    comparison: rate
+    rationale: Same effective Nebraska young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ne:policies/cms/nebraska-medicaid-chip-bhp-eligibility-levels#nebraska_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: NE
+    period: year
+    comparison: rate
+    rationale: Same effective Nebraska older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ne:policies/cms/nebraska-medicaid-chip-bhp-eligibility-levels#nebraska_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: NE
+    period: year
+    comparison: rate
+    rationale: Same effective Nebraska pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-nh:policies/cms/new-hampshire-medicaid-chip-bhp-eligibility-levels#new_hampshire_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: NH
+    candidate_priority: P4
+    rationale: Axiom exposes the raw New Hampshire CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-nh:policies/cms/new-hampshire-medicaid-chip-bhp-eligibility-levels#new_hampshire_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: NH
+    candidate_priority: P4
+    rationale: Axiom exposes the raw New Hampshire CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-nh:policies/cms/new-hampshire-medicaid-chip-bhp-eligibility-levels#new_hampshire_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: NH
+    candidate_priority: P4
+    rationale: Axiom exposes the raw New Hampshire CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-nh:policies/cms/new-hampshire-medicaid-chip-bhp-eligibility-levels#new_hampshire_children_separate_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: NH
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for New Hampshire child CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-nh:policies/cms/new-hampshire-medicaid-chip-bhp-eligibility-levels#new_hampshire_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: NH
+    candidate_priority: P4
+    rationale: Axiom exposes the raw New Hampshire CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-nh:policies/cms/new-hampshire-medicaid-chip-bhp-eligibility-levels#new_hampshire_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: NH
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for New Hampshire pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-nh:policies/cms/new-hampshire-medicaid-chip-bhp-eligibility-levels#new_hampshire_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: NH
+    candidate_priority: P4
+    rationale: Axiom exposes the raw New Hampshire CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-nh:policies/cms/new-hampshire-medicaid-chip-bhp-eligibility-levels#new_hampshire_parent_caretaker_standard_uses_dollar_amounts
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table footnote that New Hampshire's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+
+  - legal_id: us-nh:policies/cms/new-hampshire-medicaid-chip-bhp-eligibility-levels#new_hampshire_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: NH
+    candidate_priority: P4
+    rationale: Axiom exposes the raw New Hampshire CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-nh:policies/cms/new-hampshire-medicaid-chip-bhp-eligibility-levels#new_hampshire_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: NH
+    period: year
+    comparison: rate
+    rationale: Same effective New Hampshire infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-nh:policies/cms/new-hampshire-medicaid-chip-bhp-eligibility-levels#new_hampshire_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: NH
+    period: year
+    comparison: rate
+    rationale: Same effective New Hampshire young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-nh:policies/cms/new-hampshire-medicaid-chip-bhp-eligibility-levels#new_hampshire_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: NH
+    period: year
+    comparison: rate
+    rationale: Same effective New Hampshire older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-nh:policies/cms/new-hampshire-medicaid-chip-bhp-eligibility-levels#new_hampshire_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: NH
+    period: year
+    comparison: rate
+    rationale: Same effective New Hampshire pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-nj:policies/cms/new-jersey-medicaid-chip-bhp-eligibility-levels#new_jersey_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: NJ
+    candidate_priority: P4
+    rationale: Axiom exposes the raw New Jersey CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-nj:policies/cms/new-jersey-medicaid-chip-bhp-eligibility-levels#new_jersey_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: NJ
+    candidate_priority: P4
+    rationale: Axiom exposes the raw New Jersey CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-nj:policies/cms/new-jersey-medicaid-chip-bhp-eligibility-levels#new_jersey_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: NJ
+    candidate_priority: P4
+    rationale: Axiom exposes the raw New Jersey CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-nj:policies/cms/new-jersey-medicaid-chip-bhp-eligibility-levels#new_jersey_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: NJ
+    candidate_priority: P4
+    rationale: Axiom exposes the raw New Jersey CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-nj:policies/cms/new-jersey-medicaid-chip-bhp-eligibility-levels#new_jersey_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: NJ
+    candidate_priority: P4
+    rationale: Axiom exposes the raw New Jersey CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-nj:policies/cms/new-jersey-medicaid-chip-bhp-eligibility-levels#new_jersey_pregnant_women_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: NJ
+    candidate_priority: P4
+    rationale: Axiom exposes the raw New Jersey CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person CHIP income limit including that disregard.
+
+  - legal_id: us-nj:policies/cms/new-jersey-medicaid-chip-bhp-eligibility-levels#new_jersey_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: NJ
+    candidate_priority: P4
+    rationale: Axiom exposes the raw New Jersey CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-nj:policies/cms/new-jersey-medicaid-chip-bhp-eligibility-levels#new_jersey_parent_caretaker_standard_uses_dollar_amounts
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table footnote that New Jersey's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+
+  - legal_id: us-nj:policies/cms/new-jersey-medicaid-chip-bhp-eligibility-levels#new_jersey_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: NJ
+    candidate_priority: P4
+    rationale: Axiom exposes the raw New Jersey CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-nj:policies/cms/new-jersey-medicaid-chip-bhp-eligibility-levels#new_jersey_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: NJ
+    period: year
+    comparison: rate
+    rationale: Same effective New Jersey infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-nj:policies/cms/new-jersey-medicaid-chip-bhp-eligibility-levels#new_jersey_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: NJ
+    period: year
+    comparison: rate
+    rationale: Same effective New Jersey young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-nj:policies/cms/new-jersey-medicaid-chip-bhp-eligibility-levels#new_jersey_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: NJ
+    period: year
+    comparison: rate
+    rationale: Same effective New Jersey older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-nj:policies/cms/new-jersey-medicaid-chip-bhp-eligibility-levels#new_jersey_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: NJ
+    period: year
+    comparison: rate
+    rationale: Same effective New Jersey child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-nj:policies/cms/new-jersey-medicaid-chip-bhp-eligibility-levels#new_jersey_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: NJ
+    period: year
+    comparison: rate
+    rationale: Same effective New Jersey pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-nj:policies/cms/new-jersey-medicaid-chip-bhp-eligibility-levels#new_jersey_pregnant_women_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: NJ
+    period: year
+    comparison: rate
+    rationale: Same effective New Jersey pregnant-person CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-nm:policies/cms/new-mexico-medicaid-chip-bhp-eligibility-levels#new_mexico_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: NM
+    candidate_priority: P4
+    rationale: Axiom exposes the raw New Mexico CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-nm:policies/cms/new-mexico-medicaid-chip-bhp-eligibility-levels#new_mexico_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: NM
+    candidate_priority: P4
+    rationale: Axiom exposes the raw New Mexico CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-nm:policies/cms/new-mexico-medicaid-chip-bhp-eligibility-levels#new_mexico_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: NM
+    candidate_priority: P4
+    rationale: Axiom exposes the raw New Mexico CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-nm:policies/cms/new-mexico-medicaid-chip-bhp-eligibility-levels#new_mexico_children_separate_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: NM
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for New Mexico child CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-nm:policies/cms/new-mexico-medicaid-chip-bhp-eligibility-levels#new_mexico_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: NM
+    candidate_priority: P4
+    rationale: Axiom exposes the raw New Mexico CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-nm:policies/cms/new-mexico-medicaid-chip-bhp-eligibility-levels#new_mexico_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: NM
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for New Mexico pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-nm:policies/cms/new-mexico-medicaid-chip-bhp-eligibility-levels#new_mexico_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: NM
+    candidate_priority: P4
+    rationale: Axiom exposes the raw New Mexico CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-nm:policies/cms/new-mexico-medicaid-chip-bhp-eligibility-levels#new_mexico_parent_caretaker_standard_uses_dollar_amounts
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table footnote that New Mexico's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+
+  - legal_id: us-nm:policies/cms/new-mexico-medicaid-chip-bhp-eligibility-levels#new_mexico_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: NM
+    candidate_priority: P4
+    rationale: Axiom exposes the raw New Mexico CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-nm:policies/cms/new-mexico-medicaid-chip-bhp-eligibility-levels#new_mexico_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: NM
+    period: year
+    comparison: rate
+    rationale: Same effective New Mexico infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-nm:policies/cms/new-mexico-medicaid-chip-bhp-eligibility-levels#new_mexico_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: NM
+    period: year
+    comparison: rate
+    rationale: Same effective New Mexico young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-nm:policies/cms/new-mexico-medicaid-chip-bhp-eligibility-levels#new_mexico_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: NM
+    period: year
+    comparison: rate
+    rationale: Same effective New Mexico older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-nm:policies/cms/new-mexico-medicaid-chip-bhp-eligibility-levels#new_mexico_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: NM
+    period: year
+    comparison: rate
+    rationale: Same effective New Mexico pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-nv:policies/cms/nevada-medicaid-chip-bhp-eligibility-levels#nevada_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: NV
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Nevada CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-nv:policies/cms/nevada-medicaid-chip-bhp-eligibility-levels#nevada_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: NV
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Nevada CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-nv:policies/cms/nevada-medicaid-chip-bhp-eligibility-levels#nevada_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: NV
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Nevada CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-nv:policies/cms/nevada-medicaid-chip-bhp-eligibility-levels#nevada_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: NV
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Nevada CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-nv:policies/cms/nevada-medicaid-chip-bhp-eligibility-levels#nevada_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: NV
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Nevada CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-nv:policies/cms/nevada-medicaid-chip-bhp-eligibility-levels#nevada_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: NV
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Nevada pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-nv:policies/cms/nevada-medicaid-chip-bhp-eligibility-levels#nevada_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: NV
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Nevada CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-nv:policies/cms/nevada-medicaid-chip-bhp-eligibility-levels#nevada_parent_caretaker_standard_uses_dollar_amounts
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table footnote that Nevada's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+
+  - legal_id: us-nv:policies/cms/nevada-medicaid-chip-bhp-eligibility-levels#nevada_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: NV
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Nevada CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-nv:policies/cms/nevada-medicaid-chip-bhp-eligibility-levels#nevada_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: NV
+    period: year
+    comparison: rate
+    rationale: Same effective Nevada infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-nv:policies/cms/nevada-medicaid-chip-bhp-eligibility-levels#nevada_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: NV
+    period: year
+    comparison: rate
+    rationale: Same effective Nevada young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-nv:policies/cms/nevada-medicaid-chip-bhp-eligibility-levels#nevada_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: NV
+    period: year
+    comparison: rate
+    rationale: Same effective Nevada older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-nv:policies/cms/nevada-medicaid-chip-bhp-eligibility-levels#nevada_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: NV
+    period: year
+    comparison: rate
+    rationale: Same effective Nevada child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-nv:policies/cms/nevada-medicaid-chip-bhp-eligibility-levels#nevada_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: NV
+    period: year
+    comparison: rate
+    rationale: Same effective Nevada pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ny:policies/cms/new-york-medicaid-chip-bhp-eligibility-levels#new_york_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: NY
+    candidate_priority: P4
+    rationale: Axiom exposes the raw New York CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-ny:policies/cms/new-york-medicaid-chip-bhp-eligibility-levels#new_york_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: NY
+    candidate_priority: P4
+    rationale: Axiom exposes the raw New York CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ny:policies/cms/new-york-medicaid-chip-bhp-eligibility-levels#new_york_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: NY
+    candidate_priority: P4
+    rationale: Axiom exposes the raw New York CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ny:policies/cms/new-york-medicaid-chip-bhp-eligibility-levels#new_york_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: NY
+    candidate_priority: P4
+    rationale: Axiom exposes the raw New York CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-ny:policies/cms/new-york-medicaid-chip-bhp-eligibility-levels#new_york_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: NY
+    candidate_priority: P4
+    rationale: Axiom exposes the raw New York CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-ny:policies/cms/new-york-medicaid-chip-bhp-eligibility-levels#new_york_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: NY
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for New York pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-ny:policies/cms/new-york-medicaid-chip-bhp-eligibility-levels#new_york_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: NY
+    candidate_priority: P4
+    rationale: Axiom exposes the raw New York CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-ny:policies/cms/new-york-medicaid-chip-bhp-eligibility-levels#new_york_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: NY
+    candidate_priority: P4
+    rationale: Axiom exposes the raw New York CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-ny:policies/cms/new-york-medicaid-chip-bhp-eligibility-levels#new_york_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: NY
+    period: year
+    comparison: rate
+    rationale: Same effective New York infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ny:policies/cms/new-york-medicaid-chip-bhp-eligibility-levels#new_york_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: NY
+    period: year
+    comparison: rate
+    rationale: Same effective New York young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ny:policies/cms/new-york-medicaid-chip-bhp-eligibility-levels#new_york_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: NY
+    period: year
+    comparison: rate
+    rationale: Same effective New York older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ny:policies/cms/new-york-medicaid-chip-bhp-eligibility-levels#new_york_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: NY
+    period: year
+    comparison: rate
+    rationale: Same effective New York child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ny:policies/cms/new-york-medicaid-chip-bhp-eligibility-levels#new_york_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: NY
+    period: year
+    comparison: rate
+    rationale: Same effective New York pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-oh:policies/cms/ohio-medicaid-chip-bhp-eligibility-levels#ohio_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: OH
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Ohio CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-oh:policies/cms/ohio-medicaid-chip-bhp-eligibility-levels#ohio_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: OH
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Ohio CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-oh:policies/cms/ohio-medicaid-chip-bhp-eligibility-levels#ohio_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: OH
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Ohio CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-oh:policies/cms/ohio-medicaid-chip-bhp-eligibility-levels#ohio_children_separate_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: OH
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Ohio child CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-oh:policies/cms/ohio-medicaid-chip-bhp-eligibility-levels#ohio_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: OH
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Ohio CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-oh:policies/cms/ohio-medicaid-chip-bhp-eligibility-levels#ohio_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: OH
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Ohio pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-oh:policies/cms/ohio-medicaid-chip-bhp-eligibility-levels#ohio_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: OH
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Ohio CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-oh:policies/cms/ohio-medicaid-chip-bhp-eligibility-levels#ohio_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: OH
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Ohio CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-oh:policies/cms/ohio-medicaid-chip-bhp-eligibility-levels#ohio_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: OH
+    period: year
+    comparison: rate
+    rationale: Same effective Ohio infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-oh:policies/cms/ohio-medicaid-chip-bhp-eligibility-levels#ohio_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: OH
+    period: year
+    comparison: rate
+    rationale: Same effective Ohio young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-oh:policies/cms/ohio-medicaid-chip-bhp-eligibility-levels#ohio_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: OH
+    period: year
+    comparison: rate
+    rationale: Same effective Ohio older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-oh:policies/cms/ohio-medicaid-chip-bhp-eligibility-levels#ohio_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: OH
+    period: year
+    comparison: rate
+    rationale: Same effective Ohio pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ok:policies/cms/oklahoma-medicaid-chip-bhp-eligibility-levels#oklahoma_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: OK
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Oklahoma CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-ok:policies/cms/oklahoma-medicaid-chip-bhp-eligibility-levels#oklahoma_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: OK
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Oklahoma CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ok:policies/cms/oklahoma-medicaid-chip-bhp-eligibility-levels#oklahoma_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: OK
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Oklahoma CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ok:policies/cms/oklahoma-medicaid-chip-bhp-eligibility-levels#oklahoma_children_separate_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: OK
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Oklahoma child CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-ok:policies/cms/oklahoma-medicaid-chip-bhp-eligibility-levels#oklahoma_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: OK
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Oklahoma CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-ok:policies/cms/oklahoma-medicaid-chip-bhp-eligibility-levels#oklahoma_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: OK
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Oklahoma pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-ok:policies/cms/oklahoma-medicaid-chip-bhp-eligibility-levels#oklahoma_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: OK
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Oklahoma CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-ok:policies/cms/oklahoma-medicaid-chip-bhp-eligibility-levels#oklahoma_parent_caretaker_standard_uses_dollar_amounts
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table footnote that Oklahoma's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+
+  - legal_id: us-ok:policies/cms/oklahoma-medicaid-chip-bhp-eligibility-levels#oklahoma_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: OK
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Oklahoma CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-ok:policies/cms/oklahoma-medicaid-chip-bhp-eligibility-levels#oklahoma_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: OK
+    period: year
+    comparison: rate
+    rationale: Same effective Oklahoma infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ok:policies/cms/oklahoma-medicaid-chip-bhp-eligibility-levels#oklahoma_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: OK
+    period: year
+    comparison: rate
+    rationale: Same effective Oklahoma young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ok:policies/cms/oklahoma-medicaid-chip-bhp-eligibility-levels#oklahoma_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: OK
+    period: year
+    comparison: rate
+    rationale: Same effective Oklahoma older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ok:policies/cms/oklahoma-medicaid-chip-bhp-eligibility-levels#oklahoma_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: OK
+    period: year
+    comparison: rate
+    rationale: Same effective Oklahoma pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-or:policies/cms/oregon-medicaid-chip-bhp-eligibility-levels#oregon_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: OR
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Oregon CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-or:policies/cms/oregon-medicaid-chip-bhp-eligibility-levels#oregon_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: OR
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Oregon CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-or:policies/cms/oregon-medicaid-chip-bhp-eligibility-levels#oregon_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: OR
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Oregon CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-or:policies/cms/oregon-medicaid-chip-bhp-eligibility-levels#oregon_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: OR
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Oregon CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-or:policies/cms/oregon-medicaid-chip-bhp-eligibility-levels#oregon_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: OR
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Oregon CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-or:policies/cms/oregon-medicaid-chip-bhp-eligibility-levels#oregon_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: OR
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Oregon pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-or:policies/cms/oregon-medicaid-chip-bhp-eligibility-levels#oregon_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: OR
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Oregon CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-or:policies/cms/oregon-medicaid-chip-bhp-eligibility-levels#oregon_parent_caretaker_standard_uses_dollar_amounts
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table footnote that Oregon's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+
+  - legal_id: us-or:policies/cms/oregon-medicaid-chip-bhp-eligibility-levels#oregon_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: OR
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Oregon CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-or:policies/cms/oregon-medicaid-chip-bhp-eligibility-levels#oregon_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: OR
+    period: year
+    comparison: rate
+    rationale: Same effective Oregon infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-or:policies/cms/oregon-medicaid-chip-bhp-eligibility-levels#oregon_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: OR
+    period: year
+    comparison: rate
+    rationale: Same effective Oregon young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-or:policies/cms/oregon-medicaid-chip-bhp-eligibility-levels#oregon_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: OR
+    period: year
+    comparison: rate
+    rationale: Same effective Oregon older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-or:policies/cms/oregon-medicaid-chip-bhp-eligibility-levels#oregon_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: OR
+    period: year
+    comparison: rate
+    rationale: Same effective Oregon child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-or:policies/cms/oregon-medicaid-chip-bhp-eligibility-levels#oregon_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: OR
+    period: year
+    comparison: rate
+    rationale: Same effective Oregon pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-pa:policies/cms/pennsylvania-medicaid-chip-bhp-eligibility-levels#pennsylvania_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: PA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Pennsylvania CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-pa:policies/cms/pennsylvania-medicaid-chip-bhp-eligibility-levels#pennsylvania_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: PA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Pennsylvania CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-pa:policies/cms/pennsylvania-medicaid-chip-bhp-eligibility-levels#pennsylvania_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: PA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Pennsylvania CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-pa:policies/cms/pennsylvania-medicaid-chip-bhp-eligibility-levels#pennsylvania_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: PA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Pennsylvania CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-pa:policies/cms/pennsylvania-medicaid-chip-bhp-eligibility-levels#pennsylvania_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: PA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Pennsylvania CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-pa:policies/cms/pennsylvania-medicaid-chip-bhp-eligibility-levels#pennsylvania_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: PA
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Pennsylvania pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-pa:policies/cms/pennsylvania-medicaid-chip-bhp-eligibility-levels#pennsylvania_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: PA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Pennsylvania CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-pa:policies/cms/pennsylvania-medicaid-chip-bhp-eligibility-levels#pennsylvania_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: PA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Pennsylvania CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-pa:policies/cms/pennsylvania-medicaid-chip-bhp-eligibility-levels#pennsylvania_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: PA
+    period: year
+    comparison: rate
+    rationale: Same effective Pennsylvania infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-pa:policies/cms/pennsylvania-medicaid-chip-bhp-eligibility-levels#pennsylvania_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: PA
+    period: year
+    comparison: rate
+    rationale: Same effective Pennsylvania young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-pa:policies/cms/pennsylvania-medicaid-chip-bhp-eligibility-levels#pennsylvania_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: PA
+    period: year
+    comparison: rate
+    rationale: Same effective Pennsylvania older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-pa:policies/cms/pennsylvania-medicaid-chip-bhp-eligibility-levels#pennsylvania_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: PA
+    period: year
+    comparison: rate
+    rationale: Same effective Pennsylvania child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-pa:policies/cms/pennsylvania-medicaid-chip-bhp-eligibility-levels#pennsylvania_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: PA
+    period: year
+    comparison: rate
+    rationale: Same effective Pennsylvania pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ri:policies/cms/rhode-island-medicaid-chip-bhp-eligibility-levels#rhode_island_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: RI
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Rhode Island CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-ri:policies/cms/rhode-island-medicaid-chip-bhp-eligibility-levels#rhode_island_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: RI
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Rhode Island CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ri:policies/cms/rhode-island-medicaid-chip-bhp-eligibility-levels#rhode_island_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: RI
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Rhode Island CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ri:policies/cms/rhode-island-medicaid-chip-bhp-eligibility-levels#rhode_island_children_separate_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: RI
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Rhode Island child CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-ri:policies/cms/rhode-island-medicaid-chip-bhp-eligibility-levels#rhode_island_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: RI
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Rhode Island CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-ri:policies/cms/rhode-island-medicaid-chip-bhp-eligibility-levels#rhode_island_pregnant_women_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: RI
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Rhode Island CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person CHIP income limit including that disregard.
+
+  - legal_id: us-ri:policies/cms/rhode-island-medicaid-chip-bhp-eligibility-levels#rhode_island_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: RI
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Rhode Island CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-ri:policies/cms/rhode-island-medicaid-chip-bhp-eligibility-levels#rhode_island_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: RI
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Rhode Island CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-ri:policies/cms/rhode-island-medicaid-chip-bhp-eligibility-levels#rhode_island_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: RI
+    period: year
+    comparison: rate
+    rationale: Same effective Rhode Island infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ri:policies/cms/rhode-island-medicaid-chip-bhp-eligibility-levels#rhode_island_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: RI
+    period: year
+    comparison: rate
+    rationale: Same effective Rhode Island young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ri:policies/cms/rhode-island-medicaid-chip-bhp-eligibility-levels#rhode_island_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: RI
+    period: year
+    comparison: rate
+    rationale: Same effective Rhode Island older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ri:policies/cms/rhode-island-medicaid-chip-bhp-eligibility-levels#rhode_island_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: RI
+    period: year
+    comparison: rate
+    rationale: Same effective Rhode Island pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ri:policies/cms/rhode-island-medicaid-chip-bhp-eligibility-levels#rhode_island_pregnant_women_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: RI
+    period: year
+    comparison: rate
+    rationale: Same effective Rhode Island pregnant-person CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-sc:policies/cms/south-carolina-medicaid-chip-bhp-eligibility-levels#south_carolina_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: SC
+    candidate_priority: P4
+    rationale: Axiom exposes the raw South Carolina CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-sc:policies/cms/south-carolina-medicaid-chip-bhp-eligibility-levels#south_carolina_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: SC
+    candidate_priority: P4
+    rationale: Axiom exposes the raw South Carolina CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-sc:policies/cms/south-carolina-medicaid-chip-bhp-eligibility-levels#south_carolina_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: SC
+    candidate_priority: P4
+    rationale: Axiom exposes the raw South Carolina CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-sc:policies/cms/south-carolina-medicaid-chip-bhp-eligibility-levels#south_carolina_children_separate_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: SC
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for South Carolina child CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-sc:policies/cms/south-carolina-medicaid-chip-bhp-eligibility-levels#south_carolina_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: SC
+    candidate_priority: P4
+    rationale: Axiom exposes the raw South Carolina CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-sc:policies/cms/south-carolina-medicaid-chip-bhp-eligibility-levels#south_carolina_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: SC
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for South Carolina pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-sc:policies/cms/south-carolina-medicaid-chip-bhp-eligibility-levels#south_carolina_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: SC
+    candidate_priority: P4
+    rationale: Axiom exposes the raw South Carolina CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-sc:policies/cms/south-carolina-medicaid-chip-bhp-eligibility-levels#south_carolina_adult_medicaid_expansion_available
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: SC
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for South Carolina adult Medicaid expansion. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-sc:policies/cms/south-carolina-medicaid-chip-bhp-eligibility-levels#south_carolina_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: SC
+    period: year
+    comparison: rate
+    rationale: Same effective South Carolina infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-sc:policies/cms/south-carolina-medicaid-chip-bhp-eligibility-levels#south_carolina_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: SC
+    period: year
+    comparison: rate
+    rationale: Same effective South Carolina young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-sc:policies/cms/south-carolina-medicaid-chip-bhp-eligibility-levels#south_carolina_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: SC
+    period: year
+    comparison: rate
+    rationale: Same effective South Carolina older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-sc:policies/cms/south-carolina-medicaid-chip-bhp-eligibility-levels#south_carolina_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: SC
+    period: year
+    comparison: rate
+    rationale: Same effective South Carolina pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-sd:policies/cms/south-dakota-medicaid-chip-bhp-eligibility-levels#south_dakota_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: SD
+    candidate_priority: P4
+    rationale: Axiom exposes the raw South Dakota CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-sd:policies/cms/south-dakota-medicaid-chip-bhp-eligibility-levels#south_dakota_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: SD
+    candidate_priority: P4
+    rationale: Axiom exposes the raw South Dakota CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-sd:policies/cms/south-dakota-medicaid-chip-bhp-eligibility-levels#south_dakota_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: SD
+    candidate_priority: P4
+    rationale: Axiom exposes the raw South Dakota CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-sd:policies/cms/south-dakota-medicaid-chip-bhp-eligibility-levels#south_dakota_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: SD
+    candidate_priority: P4
+    rationale: Axiom exposes the raw South Dakota CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-sd:policies/cms/south-dakota-medicaid-chip-bhp-eligibility-levels#south_dakota_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: SD
+    candidate_priority: P4
+    rationale: Axiom exposes the raw South Dakota CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-sd:policies/cms/south-dakota-medicaid-chip-bhp-eligibility-levels#south_dakota_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: SD
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for South Dakota pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-sd:policies/cms/south-dakota-medicaid-chip-bhp-eligibility-levels#south_dakota_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: SD
+    candidate_priority: P4
+    rationale: Axiom exposes the raw South Dakota CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-sd:policies/cms/south-dakota-medicaid-chip-bhp-eligibility-levels#south_dakota_parent_caretaker_standard_uses_dollar_amounts
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table footnote that South Dakota's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+
+  - legal_id: us-sd:policies/cms/south-dakota-medicaid-chip-bhp-eligibility-levels#south_dakota_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: SD
+    candidate_priority: P4
+    rationale: Axiom exposes the raw South Dakota CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-sd:policies/cms/south-dakota-medicaid-chip-bhp-eligibility-levels#south_dakota_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: SD
+    period: year
+    comparison: rate
+    rationale: Same effective South Dakota infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-sd:policies/cms/south-dakota-medicaid-chip-bhp-eligibility-levels#south_dakota_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: SD
+    period: year
+    comparison: rate
+    rationale: Same effective South Dakota young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-sd:policies/cms/south-dakota-medicaid-chip-bhp-eligibility-levels#south_dakota_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: SD
+    period: year
+    comparison: rate
+    rationale: Same effective South Dakota older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-sd:policies/cms/south-dakota-medicaid-chip-bhp-eligibility-levels#south_dakota_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: SD
+    period: year
+    comparison: rate
+    rationale: Same effective South Dakota child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-sd:policies/cms/south-dakota-medicaid-chip-bhp-eligibility-levels#south_dakota_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: SD
+    period: year
+    comparison: rate
+    rationale: Same effective South Dakota pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-tn:policies/cms/tennessee-medicaid-chip-bhp-eligibility-levels#tennessee_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: TN
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Tennessee CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-tn:policies/cms/tennessee-medicaid-chip-bhp-eligibility-levels#tennessee_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: TN
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Tennessee CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-tn:policies/cms/tennessee-medicaid-chip-bhp-eligibility-levels#tennessee_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: TN
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Tennessee CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-tn:policies/cms/tennessee-medicaid-chip-bhp-eligibility-levels#tennessee_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: TN
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Tennessee CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-tn:policies/cms/tennessee-medicaid-chip-bhp-eligibility-levels#tennessee_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: TN
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Tennessee CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-tn:policies/cms/tennessee-medicaid-chip-bhp-eligibility-levels#tennessee_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: TN
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Tennessee pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-tn:policies/cms/tennessee-medicaid-chip-bhp-eligibility-levels#tennessee_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: TN
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Tennessee CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-tn:policies/cms/tennessee-medicaid-chip-bhp-eligibility-levels#tennessee_parent_caretaker_standard_uses_dollar_amounts
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table footnote that Tennessee's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+
+  - legal_id: us-tn:policies/cms/tennessee-medicaid-chip-bhp-eligibility-levels#tennessee_adult_medicaid_expansion_available
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: TN
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Tennessee adult Medicaid expansion. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-tn:policies/cms/tennessee-medicaid-chip-bhp-eligibility-levels#tennessee_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: TN
+    period: year
+    comparison: rate
+    rationale: Same effective Tennessee infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-tn:policies/cms/tennessee-medicaid-chip-bhp-eligibility-levels#tennessee_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: TN
+    period: year
+    comparison: rate
+    rationale: Same effective Tennessee young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-tn:policies/cms/tennessee-medicaid-chip-bhp-eligibility-levels#tennessee_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: TN
+    period: year
+    comparison: rate
+    rationale: Same effective Tennessee older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-tn:policies/cms/tennessee-medicaid-chip-bhp-eligibility-levels#tennessee_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: TN
+    period: year
+    comparison: rate
+    rationale: Same effective Tennessee child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-tn:policies/cms/tennessee-medicaid-chip-bhp-eligibility-levels#tennessee_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: TN
+    period: year
+    comparison: rate
+    rationale: Same effective Tennessee pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-tx:policies/cms/texas-medicaid-chip-bhp-eligibility-levels#texas_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: TX
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Texas CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-tx:policies/cms/texas-medicaid-chip-bhp-eligibility-levels#texas_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: TX
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Texas CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-tx:policies/cms/texas-medicaid-chip-bhp-eligibility-levels#texas_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: TX
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Texas CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-tx:policies/cms/texas-medicaid-chip-bhp-eligibility-levels#texas_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: TX
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Texas CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-tx:policies/cms/texas-medicaid-chip-bhp-eligibility-levels#texas_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: TX
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Texas CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-tx:policies/cms/texas-medicaid-chip-bhp-eligibility-levels#texas_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: TX
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Texas pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-tx:policies/cms/texas-medicaid-chip-bhp-eligibility-levels#texas_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: TX
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Texas CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-tx:policies/cms/texas-medicaid-chip-bhp-eligibility-levels#texas_parent_caretaker_standard_uses_dollar_amounts
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table footnote that Texas's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+
+  - legal_id: us-tx:policies/cms/texas-medicaid-chip-bhp-eligibility-levels#texas_adult_medicaid_expansion_available
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: TX
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Texas adult Medicaid expansion. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-tx:policies/cms/texas-medicaid-chip-bhp-eligibility-levels#texas_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: TX
+    period: year
+    comparison: rate
+    rationale: Same effective Texas infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-tx:policies/cms/texas-medicaid-chip-bhp-eligibility-levels#texas_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: TX
+    period: year
+    comparison: rate
+    rationale: Same effective Texas young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-tx:policies/cms/texas-medicaid-chip-bhp-eligibility-levels#texas_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: TX
+    period: year
+    comparison: rate
+    rationale: Same effective Texas older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-tx:policies/cms/texas-medicaid-chip-bhp-eligibility-levels#texas_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: TX
+    period: year
+    comparison: rate
+    rationale: Same effective Texas child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-tx:policies/cms/texas-medicaid-chip-bhp-eligibility-levels#texas_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: TX
+    period: year
+    comparison: rate
+    rationale: Same effective Texas pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ut:policies/cms/utah-medicaid-chip-bhp-eligibility-levels#utah_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: UT
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Utah CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-ut:policies/cms/utah-medicaid-chip-bhp-eligibility-levels#utah_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: UT
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Utah CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ut:policies/cms/utah-medicaid-chip-bhp-eligibility-levels#utah_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: UT
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Utah CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ut:policies/cms/utah-medicaid-chip-bhp-eligibility-levels#utah_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: UT
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Utah CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-ut:policies/cms/utah-medicaid-chip-bhp-eligibility-levels#utah_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: UT
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Utah CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-ut:policies/cms/utah-medicaid-chip-bhp-eligibility-levels#utah_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: UT
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Utah pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-ut:policies/cms/utah-medicaid-chip-bhp-eligibility-levels#utah_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: UT
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Utah CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-ut:policies/cms/utah-medicaid-chip-bhp-eligibility-levels#utah_parent_caretaker_standard_uses_dollar_amounts
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table footnote that Utah's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+
+  - legal_id: us-ut:policies/cms/utah-medicaid-chip-bhp-eligibility-levels#utah_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: UT
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Utah CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-ut:policies/cms/utah-medicaid-chip-bhp-eligibility-levels#utah_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: UT
+    period: year
+    comparison: rate
+    rationale: Same effective Utah infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ut:policies/cms/utah-medicaid-chip-bhp-eligibility-levels#utah_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: UT
+    period: year
+    comparison: rate
+    rationale: Same effective Utah young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ut:policies/cms/utah-medicaid-chip-bhp-eligibility-levels#utah_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: UT
+    period: year
+    comparison: rate
+    rationale: Same effective Utah older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ut:policies/cms/utah-medicaid-chip-bhp-eligibility-levels#utah_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: UT
+    period: year
+    comparison: rate
+    rationale: Same effective Utah child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ut:policies/cms/utah-medicaid-chip-bhp-eligibility-levels#utah_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: UT
+    period: year
+    comparison: rate
+    rationale: Same effective Utah pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-va:policies/cms/virginia-medicaid-chip-bhp-eligibility-levels#virginia_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: VA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Virginia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-va:policies/cms/virginia-medicaid-chip-bhp-eligibility-levels#virginia_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: VA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Virginia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-va:policies/cms/virginia-medicaid-chip-bhp-eligibility-levels#virginia_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: VA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Virginia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-va:policies/cms/virginia-medicaid-chip-bhp-eligibility-levels#virginia_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: VA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Virginia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-va:policies/cms/virginia-medicaid-chip-bhp-eligibility-levels#virginia_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: VA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Virginia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-va:policies/cms/virginia-medicaid-chip-bhp-eligibility-levels#virginia_pregnant_women_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: VA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Virginia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person CHIP income limit including that disregard.
+
+  - legal_id: us-va:policies/cms/virginia-medicaid-chip-bhp-eligibility-levels#virginia_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: VA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Virginia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-va:policies/cms/virginia-medicaid-chip-bhp-eligibility-levels#virginia_parent_caretaker_standard_uses_dollar_amounts
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table footnote that Virginia's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+
+  - legal_id: us-va:policies/cms/virginia-medicaid-chip-bhp-eligibility-levels#virginia_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: VA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Virginia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-va:policies/cms/virginia-medicaid-chip-bhp-eligibility-levels#virginia_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: VA
+    period: year
+    comparison: rate
+    rationale: Same effective Virginia infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-va:policies/cms/virginia-medicaid-chip-bhp-eligibility-levels#virginia_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: VA
+    period: year
+    comparison: rate
+    rationale: Same effective Virginia young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-va:policies/cms/virginia-medicaid-chip-bhp-eligibility-levels#virginia_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: VA
+    period: year
+    comparison: rate
+    rationale: Same effective Virginia older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-va:policies/cms/virginia-medicaid-chip-bhp-eligibility-levels#virginia_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: VA
+    period: year
+    comparison: rate
+    rationale: Same effective Virginia child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-va:policies/cms/virginia-medicaid-chip-bhp-eligibility-levels#virginia_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: VA
+    period: year
+    comparison: rate
+    rationale: Same effective Virginia pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-va:policies/cms/virginia-medicaid-chip-bhp-eligibility-levels#virginia_pregnant_women_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: VA
+    period: year
+    comparison: rate
+    rationale: Same effective Virginia pregnant-person CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-vt:policies/cms/vermont-medicaid-chip-bhp-eligibility-levels#vermont_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: VT
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Vermont CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-vt:policies/cms/vermont-medicaid-chip-bhp-eligibility-levels#vermont_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: VT
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Vermont CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-vt:policies/cms/vermont-medicaid-chip-bhp-eligibility-levels#vermont_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: VT
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Vermont CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-vt:policies/cms/vermont-medicaid-chip-bhp-eligibility-levels#vermont_children_separate_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: VT
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Vermont child CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-vt:policies/cms/vermont-medicaid-chip-bhp-eligibility-levels#vermont_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: VT
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Vermont CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-vt:policies/cms/vermont-medicaid-chip-bhp-eligibility-levels#vermont_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: VT
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Vermont pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-vt:policies/cms/vermont-medicaid-chip-bhp-eligibility-levels#vermont_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: VT
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Vermont CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-vt:policies/cms/vermont-medicaid-chip-bhp-eligibility-levels#vermont_parent_caretaker_standard_uses_dollar_amounts
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table footnote that Vermont's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+
+  - legal_id: us-vt:policies/cms/vermont-medicaid-chip-bhp-eligibility-levels#vermont_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: VT
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Vermont CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-vt:policies/cms/vermont-medicaid-chip-bhp-eligibility-levels#vermont_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: VT
+    period: year
+    comparison: rate
+    rationale: Same effective Vermont infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-vt:policies/cms/vermont-medicaid-chip-bhp-eligibility-levels#vermont_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: VT
+    period: year
+    comparison: rate
+    rationale: Same effective Vermont young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-vt:policies/cms/vermont-medicaid-chip-bhp-eligibility-levels#vermont_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: VT
+    period: year
+    comparison: rate
+    rationale: Same effective Vermont older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-vt:policies/cms/vermont-medicaid-chip-bhp-eligibility-levels#vermont_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: VT
+    period: year
+    comparison: rate
+    rationale: Same effective Vermont pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-wa:policies/cms/washington-medicaid-chip-bhp-eligibility-levels#washington_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: WA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Washington CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-wa:policies/cms/washington-medicaid-chip-bhp-eligibility-levels#washington_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: WA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Washington CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-wa:policies/cms/washington-medicaid-chip-bhp-eligibility-levels#washington_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: WA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Washington CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-wa:policies/cms/washington-medicaid-chip-bhp-eligibility-levels#washington_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: WA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Washington CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-wa:policies/cms/washington-medicaid-chip-bhp-eligibility-levels#washington_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: WA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Washington CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-wa:policies/cms/washington-medicaid-chip-bhp-eligibility-levels#washington_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: WA
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Washington pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-wa:policies/cms/washington-medicaid-chip-bhp-eligibility-levels#washington_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: WA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Washington CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-wa:policies/cms/washington-medicaid-chip-bhp-eligibility-levels#washington_parent_caretaker_standard_uses_dollar_amounts
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table footnote that Washington's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+
+  - legal_id: us-wa:policies/cms/washington-medicaid-chip-bhp-eligibility-levels#washington_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: WA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Washington CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-wa:policies/cms/washington-medicaid-chip-bhp-eligibility-levels#washington_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: WA
+    period: year
+    comparison: rate
+    rationale: Same effective Washington infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-wa:policies/cms/washington-medicaid-chip-bhp-eligibility-levels#washington_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: WA
+    period: year
+    comparison: rate
+    rationale: Same effective Washington young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-wa:policies/cms/washington-medicaid-chip-bhp-eligibility-levels#washington_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: WA
+    period: year
+    comparison: rate
+    rationale: Same effective Washington older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-wa:policies/cms/washington-medicaid-chip-bhp-eligibility-levels#washington_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: WA
+    period: year
+    comparison: rate
+    rationale: Same effective Washington child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-wa:policies/cms/washington-medicaid-chip-bhp-eligibility-levels#washington_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: WA
+    period: year
+    comparison: rate
+    rationale: Same effective Washington pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-wi:policies/cms/wisconsin-medicaid-chip-bhp-eligibility-levels#wisconsin_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: WI
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Wisconsin CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-wi:policies/cms/wisconsin-medicaid-chip-bhp-eligibility-levels#wisconsin_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: WI
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Wisconsin CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-wi:policies/cms/wisconsin-medicaid-chip-bhp-eligibility-levels#wisconsin_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: WI
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Wisconsin CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-wi:policies/cms/wisconsin-medicaid-chip-bhp-eligibility-levels#wisconsin_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: WI
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Wisconsin CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-wi:policies/cms/wisconsin-medicaid-chip-bhp-eligibility-levels#wisconsin_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: WI
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Wisconsin CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-wi:policies/cms/wisconsin-medicaid-chip-bhp-eligibility-levels#wisconsin_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: WI
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Wisconsin pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-wi:policies/cms/wisconsin-medicaid-chip-bhp-eligibility-levels#wisconsin_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: WI
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Wisconsin CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-wi:policies/cms/wisconsin-medicaid-chip-bhp-eligibility-levels#wisconsin_adult_medicaid_expansion_available
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: WI
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Wisconsin adult Medicaid expansion. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-wi:policies/cms/wisconsin-medicaid-chip-bhp-eligibility-levels#wisconsin_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: WI
+    period: year
+    comparison: rate
+    rationale: Same effective Wisconsin infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-wi:policies/cms/wisconsin-medicaid-chip-bhp-eligibility-levels#wisconsin_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: WI
+    period: year
+    comparison: rate
+    rationale: Same effective Wisconsin young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-wi:policies/cms/wisconsin-medicaid-chip-bhp-eligibility-levels#wisconsin_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: WI
+    period: year
+    comparison: rate
+    rationale: Same effective Wisconsin older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-wi:policies/cms/wisconsin-medicaid-chip-bhp-eligibility-levels#wisconsin_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: WI
+    period: year
+    comparison: rate
+    rationale: Same effective Wisconsin child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-wi:policies/cms/wisconsin-medicaid-chip-bhp-eligibility-levels#wisconsin_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: WI
+    period: year
+    comparison: rate
+    rationale: Same effective Wisconsin pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-wv:policies/cms/west-virginia-medicaid-chip-bhp-eligibility-levels#west_virginia_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: WV
+    candidate_priority: P4
+    rationale: Axiom exposes the raw West Virginia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-wv:policies/cms/west-virginia-medicaid-chip-bhp-eligibility-levels#west_virginia_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: WV
+    candidate_priority: P4
+    rationale: Axiom exposes the raw West Virginia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-wv:policies/cms/west-virginia-medicaid-chip-bhp-eligibility-levels#west_virginia_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: WV
+    candidate_priority: P4
+    rationale: Axiom exposes the raw West Virginia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-wv:policies/cms/west-virginia-medicaid-chip-bhp-eligibility-levels#west_virginia_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: WV
+    candidate_priority: P4
+    rationale: Axiom exposes the raw West Virginia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-wv:policies/cms/west-virginia-medicaid-chip-bhp-eligibility-levels#west_virginia_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: WV
+    candidate_priority: P4
+    rationale: Axiom exposes the raw West Virginia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-wv:policies/cms/west-virginia-medicaid-chip-bhp-eligibility-levels#west_virginia_pregnant_women_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: WV
+    candidate_priority: P4
+    rationale: Axiom exposes the raw West Virginia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person CHIP income limit including that disregard.
+
+  - legal_id: us-wv:policies/cms/west-virginia-medicaid-chip-bhp-eligibility-levels#west_virginia_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: WV
+    candidate_priority: P4
+    rationale: Axiom exposes the raw West Virginia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-wv:policies/cms/west-virginia-medicaid-chip-bhp-eligibility-levels#west_virginia_parent_caretaker_standard_uses_dollar_amounts
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table footnote that West Virginia's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+
+  - legal_id: us-wv:policies/cms/west-virginia-medicaid-chip-bhp-eligibility-levels#west_virginia_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: WV
+    candidate_priority: P4
+    rationale: Axiom exposes the raw West Virginia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
+  - legal_id: us-wv:policies/cms/west-virginia-medicaid-chip-bhp-eligibility-levels#west_virginia_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: WV
+    period: year
+    comparison: rate
+    rationale: Same effective West Virginia infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-wv:policies/cms/west-virginia-medicaid-chip-bhp-eligibility-levels#west_virginia_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: WV
+    period: year
+    comparison: rate
+    rationale: Same effective West Virginia young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-wv:policies/cms/west-virginia-medicaid-chip-bhp-eligibility-levels#west_virginia_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: WV
+    period: year
+    comparison: rate
+    rationale: Same effective West Virginia older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-wv:policies/cms/west-virginia-medicaid-chip-bhp-eligibility-levels#west_virginia_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: WV
+    period: year
+    comparison: rate
+    rationale: Same effective West Virginia child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-wv:policies/cms/west-virginia-medicaid-chip-bhp-eligibility-levels#west_virginia_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: WV
+    period: year
+    comparison: rate
+    rationale: Same effective West Virginia pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-wv:policies/cms/west-virginia-medicaid-chip-bhp-eligibility-levels#west_virginia_pregnant_women_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: WV
+    period: year
+    comparison: rate
+    rationale: Same effective West Virginia pregnant-person CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-wy:policies/cms/wyoming-medicaid-chip-bhp-eligibility-levels#wyoming_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: WY
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Wyoming CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-wy:policies/cms/wyoming-medicaid-chip-bhp-eligibility-levels#wyoming_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: WY
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Wyoming CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-wy:policies/cms/wyoming-medicaid-chip-bhp-eligibility-levels#wyoming_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: WY
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Wyoming CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-wy:policies/cms/wyoming-medicaid-chip-bhp-eligibility-levels#wyoming_children_separate_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: WY
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Wyoming child CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-wy:policies/cms/wyoming-medicaid-chip-bhp-eligibility-levels#wyoming_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: WY
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Wyoming CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-wy:policies/cms/wyoming-medicaid-chip-bhp-eligibility-levels#wyoming_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: WY
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Wyoming pregnant-women CHIP. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-wy:policies/cms/wyoming-medicaid-chip-bhp-eligibility-levels#wyoming_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: WY
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Wyoming CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-wy:policies/cms/wyoming-medicaid-chip-bhp-eligibility-levels#wyoming_parent_caretaker_standard_uses_dollar_amounts
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table footnote that Wyoming's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+
+  - legal_id: us-wy:policies/cms/wyoming-medicaid-chip-bhp-eligibility-levels#wyoming_adult_medicaid_expansion_available
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: WY
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for Wyoming adult Medicaid expansion. PolicyEngine-US represents unavailable coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-wy:policies/cms/wyoming-medicaid-chip-bhp-eligibility-levels#wyoming_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: WY
+    period: year
+    comparison: rate
+    rationale: Same effective Wyoming infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-wy:policies/cms/wyoming-medicaid-chip-bhp-eligibility-levels#wyoming_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: WY
+    period: year
+    comparison: rate
+    rationale: Same effective Wyoming young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-wy:policies/cms/wyoming-medicaid-chip-bhp-eligibility-levels#wyoming_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: WY
+    period: year
+    comparison: rate
+    rationale: Same effective Wyoming older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-wy:policies/cms/wyoming-medicaid-chip-bhp-eligibility-levels#wyoming_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: WY
+    period: year
+    comparison: rate
+    rationale: Same effective Wyoming pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
   - legal_id: us-ga:policies/dfcs/snap/3210/block-2#assistance_unit_member_receives_tanf_wsp_or_ssi
     country: us
     program: snap

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4355,8 +4355,8 @@ def test_policyengine_coverage_classifies_colorado_medicaid_chip_thresholds(
 ):
     _write_rulespec_file(
         tmp_path
-        / "rulespec-us-co"
-        / "policies/cms/colorado-medicaid-chip-bhp-eligibility-levels.yaml",
+        / "rulespec-us"
+        / "policies/cms/medicaid-chip-bhp-eligibility-levels.yaml",
         """format: rulespec/v1
 rules:
   - name: magi_fpl_disregard_rate
@@ -4364,6 +4364,14 @@ rules:
     versions:
       - effective_from: '2023-12-01'
         formula: 0.05
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-co"
+        / "policies/cms/colorado-medicaid-chip-bhp-eligibility-levels.yaml",
+        """format: rulespec/v1
+rules:
   - name: colorado_children_medicaid_ages_0_to_1_fpl_limit
     kind: parameter
     versions:
@@ -4510,11 +4518,50 @@ rules:
     assert all("5% MAGI FPL disregard" in str(item["rationale"]) for item in raw_items)
 
 
+def test_policyengine_registry_includes_nationwide_cms_medicaid_chip_mappings():
+    registry = load_policyengine_registry()
+
+    shared_disregard = registry.mapping_for_legal_id(
+        "us:policies/cms/medicaid-chip-bhp-eligibility-levels#magi_fpl_disregard_rate",
+        country="us",
+    )
+    assert shared_disregard is not None
+    assert shared_disregard.mapping_type == "not_comparable"
+    assert shared_disregard.program == "health"
+    assert shared_disregard.candidate_priority == "P4"
+
+    dc_infant = registry.mapping_for_legal_id(
+        "us-dc:policies/cms/district-of-columbia-medicaid-chip-bhp-eligibility-levels#district_of_columbia_children_medicaid_ages_0_to_1_effective_fpl_limit",
+        country="us",
+    )
+    assert dc_infant is not None
+    assert dc_infant.mapping_type == "parameter_value"
+    assert (
+        dc_infant.policyengine_parameter
+        == "gov.hhs.medicaid.eligibility.categories.infant.income_limit"
+    )
+    assert dc_infant.parameter_key == "DC"
+    assert dc_infant.period == "year"
+    assert dc_infant.comparison == "rate"
+
+    ohio_chip_available = registry.mapping_for_legal_id(
+        "us-oh:policies/cms/ohio-medicaid-chip-bhp-eligibility-levels#ohio_children_separate_chip_available",
+        country="us",
+    )
+    assert ohio_chip_available is not None
+    assert ohio_chip_available.mapping_type == "not_comparable"
+    assert ohio_chip_available.policyengine_parameter == (
+        "gov.hhs.chip.child.income_limit"
+    )
+    assert ohio_chip_available.parameter_key == "OH"
+    assert ohio_chip_available.candidate_priority == "P4"
+
+
 def test_policyengine_coverage_classifies_georgia_snap_medicaid_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path
-        / "rulespec-us-ga"
-        / "policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml",
+        / "rulespec-us"
+        / "policies/cms/medicaid-chip-bhp-eligibility-levels.yaml",
         """format: rulespec/v1
 rules:
   - name: magi_fpl_disregard_rate
@@ -4522,6 +4569,14 @@ rules:
     versions:
       - effective_from: '2025-01-01'
         formula: 0.05
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-ga"
+        / "policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml",
+        """format: rulespec/v1
+rules:
   - name: georgia_children_medicaid_ages_0_to_1_fpl_limit
     kind: parameter
     versions:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1136"
+version = "0.2.1137"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Replace the Colorado/Georgia-only CMS Medicaid/CHIP/BHP oracle mapping block with nationwide mappings generated from the generated RuleSpec state modules
- Map effective CMS MAGI income limits to PolicyEngine state parameter values and classify raw CMS table values/availability flags as known not comparable
- Move coverage tests to the shared federal MAGI disregard module shape and add a regression check for DC/OH mappings
- Bump axiom-encode to 0.2.1137

## Verification
- uv run python registry check over generated rulespec-us CHIP files: missing=0
- git diff --check
- uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/oracles/policyengine/registry.py
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q
- uv run --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q