### PR TITLE
Add CMS CHIP eligibility composition generator

### DIFF
--- a/changelog.d/cms-chip-composition.added.md
+++ b/changelog.d/cms-chip-composition.added.md
@@ -1,0 +1,1 @@
+Add a signed CMS CHIP eligibility composition generator for source-backed child and standard-pregnant CHIP surfaces.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1137"
+version = "0.2.1138"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1137"
+__version__ = "0.2.1138"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -2018,6 +2018,43 @@ def main():
         help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
     )
 
+    generate_cms_chip_composition_parser = subparsers.add_parser(
+        "generate-cms-chip-eligibility-composition",
+        help=(
+            "Generate signed state CHIP eligibility composition RuleSpec "
+            "files from federal CHIP law and CMS eligibility-level modules"
+        ),
+    )
+    generate_cms_chip_composition_parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="rulespec-us repository root used for manifest signing",
+    )
+    generate_cms_chip_composition_parser.add_argument(
+        "--state",
+        dest="states",
+        action="append",
+        default=[],
+        help=(
+            "State name or postal abbreviation to generate; may be repeated. "
+            "Defaults to every existing state CMS eligibility-level file."
+        ),
+    )
+    generate_cms_chip_composition_parser.add_argument(
+        "--overwrite-existing",
+        action="store_true",
+        help="Replace existing state CHIP eligibility composition files",
+    )
+    generate_cms_chip_composition_parser.add_argument(
+        "--axiom-rules-engine-path",
+        dest="axiom_rules_path",
+        metavar="AXIOM_RULES_ENGINE_PATH",
+        type=Path,
+        default=None,
+        help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
+    )
+
     repair_medicaid_optional_parser = subparsers.add_parser(
         "repair-medicaid-optional-senior-composition",
         help="Apply signed deterministic Medicaid optional senior/disabled composition repairs",
@@ -2839,6 +2876,8 @@ def main():
         cmd_repair_cms_effective_magi_limits(args)
     elif args.command == "generate-cms-medicaid-chip-eligibility-levels":
         cmd_generate_cms_medicaid_chip_eligibility_levels(args)
+    elif args.command == "generate-cms-chip-eligibility-composition":
+        cmd_generate_cms_chip_eligibility_composition(args)
     elif args.command == "repair-medicaid-optional-senior-composition":
         cmd_repair_medicaid_optional_senior_composition(args)
     elif args.command == "repair-medicaid-primary-category-composition":
@@ -8122,6 +8161,12 @@ class _CmsGeneratedEligibilityFile(NamedTuple):
     output_values: dict[str, str]
 
 
+class _CmsGeneratedChipCompositionFile(NamedTuple):
+    relative_output: Path
+    rules_content: str
+    test_content: str
+
+
 class _CmsEligibilityHtmlTableParser(HTMLParser):
     """Extract the first HTML table while ignoring footnote superscripts."""
 
@@ -8200,6 +8245,11 @@ def _cms_file_slug(state: str) -> str:
 
 def _cms_yaml_double(value: str) -> str:
     return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def _indent_block(value: str, spaces: int) -> str:
+    prefix = " " * spaces
+    return "\n".join(f"{prefix}{line}" if line else prefix for line in value.splitlines())
 
 
 def _cms_rate_from_table_cell(cell: str) -> Decimal | None:
@@ -8590,6 +8640,395 @@ def _rulespec_rule_names(content: str) -> set[str]:
         for rule in rules
         if isinstance(rule, dict) and str(rule.get("name") or "").strip()
     }
+
+
+CMS_CHIP_COMPOSITION_MODEL = "cms-chip-eligibility-composition-v1"
+CMS_CHIP_CHILD_SOURCE_RELATIVE = Path("us") / "statutes" / "42" / "1397jj" / "c" / "1.yaml"
+CMS_CHIP_CHILD_TARGET = "us:statutes/42/1397jj/c/1#child"
+
+
+def _cms_state_code_aliases() -> dict[str, str]:
+    aliases: dict[str, str] = {}
+    for state, code in CMS_MEDICAID_CHIP_STATE_CODES.items():
+        aliases[code.lower()] = code
+        aliases[state.lower()] = code
+        aliases[_cms_state_slug(state)] = code
+        aliases[_cms_state_slug(state).replace("_", "-")] = code
+    return aliases
+
+
+def _cms_state_name_from_code(code: str) -> str:
+    for state, candidate_code in CMS_MEDICAID_CHIP_STATE_CODES.items():
+        if candidate_code == code:
+            return state
+    return code
+
+
+def _cms_state_slug_from_rules(
+    *,
+    rules_by_name: dict[str, dict[str, Any]],
+    relative_output: Path,
+) -> str:
+    suffixes = [
+        "children_medicaid_ages_0_to_1_fpl_limit",
+        "children_separate_chip_fpl_limit",
+        "pregnant_women_chip_fpl_limit",
+        "adult_medicaid_expansion_available",
+    ]
+    for rule_name in sorted(rules_by_name):
+        for suffix in suffixes:
+            tail = f"_{suffix}"
+            if rule_name.endswith(tail):
+                return rule_name[: -len(tail)]
+    stem = relative_output.stem.removesuffix("-medicaid-chip-bhp-eligibility-levels")
+    return stem.replace("-", "_")
+
+
+def _cms_state_code_from_relative_output(relative_output: Path) -> str:
+    prefix = relative_output.parts[0]
+    if not prefix.startswith("us-"):
+        raise RuntimeError(f"CMS state file must be under us-XX: {relative_output}")
+    return prefix.removeprefix("us-").upper()
+
+
+def _cms_chip_composition_relative_output(cms_relative_output: Path) -> Path:
+    stem = cms_relative_output.stem.removesuffix(
+        "-medicaid-chip-bhp-eligibility-levels"
+    )
+    return cms_relative_output.with_name(f"{stem}-chip-eligibility.yaml")
+
+
+def _cms_existing_state_eligibility_files(repo_path: Path) -> list[Path]:
+    return sorted(
+        path.relative_to(repo_path)
+        for path in repo_path.glob(
+            "us-*/policies/cms/*-medicaid-chip-bhp-eligibility-levels.yaml"
+        )
+    )
+
+
+def _cms_requested_state_codes_for_existing_files(raw_states: list[str]) -> set[str] | None:
+    if not raw_states:
+        return None
+    aliases = _cms_state_code_aliases()
+    requested: set[str] = set()
+    unknown: list[str] = []
+    for raw in raw_states:
+        code = aliases.get(raw.strip().lower())
+        if code is None:
+            unknown.append(raw)
+        else:
+            requested.add(code)
+    if unknown:
+        raise RuntimeError(f"Unknown CMS table state(s): {', '.join(unknown)}")
+    return requested
+
+
+def _cms_rule_names_by_name(content: str) -> dict[str, dict[str, Any]]:
+    payload = yaml.safe_load(content) or {}
+    if not isinstance(payload, dict):
+        raise RuntimeError("CMS eligibility-level RuleSpec file is not a mapping")
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        raise RuntimeError("CMS eligibility-level RuleSpec file has no rules list")
+    by_name: dict[str, dict[str, Any]] = {}
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        name = str(rule.get("name") or "").strip()
+        if name:
+            by_name[name] = rule
+    return by_name
+
+
+def _cms_chip_import_atom(
+    *,
+    target: str,
+    output: str,
+    digest: str,
+) -> str:
+    return f"""          - path: versions[0].formula
+            kind: import
+            import:
+              target: {target}
+              output: {output}
+              hash: sha256:{digest}
+"""
+
+
+def _cms_chip_formula_source_atom(*, corpus_citation_path: str, excerpt: str) -> str:
+    return f"""          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: {corpus_citation_path}
+              excerpt: {_cms_yaml_double(excerpt)}
+"""
+
+
+def _cms_chip_composition_rule_block(
+    *,
+    name: str,
+    source: str,
+    proof_atoms: str,
+    formula: str,
+) -> str:
+    return f"""  - name: {name}
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: {source}
+    metadata:
+      proof:
+        atoms:
+{proof_atoms.rstrip()}
+    versions:
+      - effective_from: '{CMS_MEDICAID_CHIP_EFFECTIVE_DATE}'
+        formula: |-
+{_indent_block(formula, 10)}
+"""
+
+
+def _cms_chip_build_composition_file(
+    *,
+    repo_path: Path,
+    cms_relative_output: Path,
+) -> _CmsGeneratedChipCompositionFile:
+    cms_file = repo_path / cms_relative_output
+    rules_by_name = _cms_rule_names_by_name(cms_file.read_text())
+    state_code = _cms_state_code_from_relative_output(cms_relative_output)
+    state_name = _cms_state_name_from_code(state_code)
+    state_slug = _cms_state_slug_from_rules(
+        rules_by_name=rules_by_name,
+        relative_output=cms_relative_output,
+    )
+    relative_output = _cms_chip_composition_relative_output(cms_relative_output)
+    citation = _rulespec_anchor_base_for_output(repo_path, relative_output)
+    cms_target = _rulespec_anchor_base_for_output(repo_path, cms_relative_output)
+    cms_hash = _sha256_file(cms_file)
+    child_hash = _sha256_file(repo_path / CMS_CHIP_CHILD_SOURCE_RELATIVE)
+
+    child_limit = f"{state_slug}_children_separate_chip_effective_fpl_limit"
+    child_availability = f"{state_slug}_separate_chip_child_eligibility_available"
+    pregnant_limit = f"{state_slug}_pregnant_women_chip_fpl_limit"
+    pregnant_availability = f"{state_slug}_standard_pregnant_chip_eligibility_available"
+
+    imports = [CMS_CHIP_CHILD_TARGET]
+    if child_limit in rules_by_name:
+        imports.append(f"{cms_target}#{child_limit}")
+    source_child_availability = f"{state_slug}_children_separate_chip_available"
+    if child_limit not in rules_by_name and source_child_availability in rules_by_name:
+        imports.append(f"{cms_target}#{source_child_availability}")
+    if pregnant_limit in rules_by_name:
+        imports.append(f"{cms_target}#{pregnant_limit}")
+    source_pregnant_availability = f"{state_slug}_pregnant_women_chip_available"
+    if pregnant_limit not in rules_by_name and source_pregnant_availability in rules_by_name:
+        imports.append(f"{cms_target}#{source_pregnant_availability}")
+
+    rules: list[str] = []
+    if child_limit in rules_by_name:
+        child_available_formula = "true"
+        child_available_atoms = _cms_chip_import_atom(
+            target=f"{cms_target}#{child_limit}",
+            output=child_limit,
+            digest=cms_hash,
+        )
+        child_formula = (
+            f"{child_availability}\n"
+            "and child\n"
+            "and person_meets_chip_immigration_requirement\n"
+            "and not found_eligible_for_medical_assistance_under_subchapter_xix\n"
+            f"and medicaid_income_level <= {child_limit}"
+        )
+        child_atoms = (
+            _cms_chip_import_atom(
+                target=CMS_CHIP_CHILD_TARGET,
+                output="child",
+                digest=child_hash,
+            )
+            + _cms_chip_import_atom(
+                target=f"{cms_target}#{child_limit}",
+                output=child_limit,
+                digest=cms_hash,
+            )
+            + _cms_chip_formula_source_atom(
+                corpus_citation_path="us/statute/42/1397jj/b/1",
+                excerpt="not found eligible for medical assistance under subchapter XIX",
+            )
+            + _cms_chip_formula_source_atom(
+                corpus_citation_path=CMS_ELIGIBILITY_LEVELS_CORPUS_PATH,
+                excerpt="Children Separate CHIP",
+            )
+        )
+    elif source_child_availability in rules_by_name:
+        child_available_formula = source_child_availability
+        child_available_atoms = _cms_chip_import_atom(
+            target=f"{cms_target}#{source_child_availability}",
+            output=source_child_availability,
+            digest=cms_hash,
+        )
+        child_formula = child_availability
+        child_atoms = child_available_atoms
+    else:
+        child_available_formula = "false"
+        child_available_atoms = _cms_chip_formula_source_atom(
+            corpus_citation_path=CMS_ELIGIBILITY_LEVELS_CORPUS_PATH,
+            excerpt="Children Separate CHIP",
+        )
+        child_formula = child_availability
+        child_atoms = child_available_atoms
+
+    rules.append(
+        _cms_chip_composition_rule_block(
+            name=child_availability,
+            source=f"CMS Medicaid, CHIP and BHP Eligibility Levels table, {state_name} row",
+            proof_atoms=child_available_atoms,
+            formula=child_available_formula,
+        )
+    )
+    rules.append(
+        _cms_chip_composition_rule_block(
+            name="is_chip_eligible_child",
+            source="42 USC 1397jj(b)(1), 42 USC 1397jj(c)(1), and CMS state CHIP eligibility levels",
+            proof_atoms=child_atoms,
+            formula=child_formula,
+        )
+    )
+
+    if pregnant_limit in rules_by_name:
+        pregnant_available_formula = "true"
+        pregnant_available_atoms = _cms_chip_import_atom(
+            target=f"{cms_target}#{pregnant_limit}",
+            output=pregnant_limit,
+            digest=cms_hash,
+        )
+        pregnant_formula = (
+            f"{pregnant_availability}\n"
+            "and person_is_pregnant\n"
+            "and person_meets_chip_immigration_requirement\n"
+            "and not found_eligible_for_medical_assistance_under_subchapter_xix\n"
+            f"and medicaid_income_level <= {pregnant_limit}"
+        )
+        pregnant_atoms = (
+            _cms_chip_import_atom(
+                target=f"{cms_target}#{pregnant_limit}",
+                output=pregnant_limit,
+                digest=cms_hash,
+            )
+            + _cms_chip_formula_source_atom(
+                corpus_citation_path="us/statute/42/1397ll/d/2",
+                excerpt="targeted low-income pregnant woman",
+            )
+            + _cms_chip_formula_source_atom(
+                corpus_citation_path=CMS_ELIGIBILITY_LEVELS_CORPUS_PATH,
+                excerpt="Pregnant Women CHIP",
+            )
+        )
+    elif source_pregnant_availability in rules_by_name:
+        pregnant_available_formula = source_pregnant_availability
+        pregnant_available_atoms = _cms_chip_import_atom(
+            target=f"{cms_target}#{source_pregnant_availability}",
+            output=source_pregnant_availability,
+            digest=cms_hash,
+        )
+        pregnant_formula = pregnant_availability
+        pregnant_atoms = pregnant_available_atoms
+    else:
+        pregnant_available_formula = "false"
+        pregnant_available_atoms = _cms_chip_formula_source_atom(
+            corpus_citation_path=CMS_ELIGIBILITY_LEVELS_CORPUS_PATH,
+            excerpt="Pregnant Women CHIP",
+        )
+        pregnant_formula = pregnant_availability
+        pregnant_atoms = pregnant_available_atoms
+
+    rules.append(
+        _cms_chip_composition_rule_block(
+            name=pregnant_availability,
+            source=f"CMS Medicaid, CHIP and BHP Eligibility Levels table, {state_name} row",
+            proof_atoms=pregnant_available_atoms,
+            formula=pregnant_available_formula,
+        )
+    )
+    rules.append(
+        _cms_chip_composition_rule_block(
+            name="is_chip_eligible_standard_pregnant_person",
+            source="42 USC 1397ll(d)(2) and CMS state CHIP eligibility levels",
+            proof_atoms=pregnant_atoms,
+            formula=pregnant_formula,
+        )
+    )
+
+    rules_content = (
+        "format: rulespec/v1\n"
+        "imports:\n"
+        + "".join(f"  - {target}\n" for target in imports)
+        + "module:\n"
+        + "  proof_validation:\n"
+        + "    required: true\n"
+        + "  source_verification:\n"
+        + f"    corpus_citation_path: {CMS_ELIGIBILITY_LEVELS_CORPUS_PATH}\n"
+        + f"{CMS_ELIGIBILITY_LEVELS_UPSTREAM_SOURCE_CHECK_BLOCK}"
+        + "  summary: |-\n"
+        + f"    {state_name} CHIP eligibility composition applies the federal CHIP child and standard-pregnant eligibility framework to the CMS state eligibility-level outputs. It intentionally does not encode FCEP state income limits until primary state-plan or CMS source coverage is available.\n"
+        + "rules:\n"
+        + "\n".join(rule.rstrip() for rule in rules)
+        + "\n"
+    )
+
+    common_true_inputs = {
+        f"{citation}#input.person_meets_chip_immigration_requirement": "true",
+        f"{citation}#input.found_eligible_for_medical_assistance_under_subchapter_xix": "false",
+    }
+    test_lines = [
+        f"- name: {state_slug}_chip_child_eligible_under_cms_limit",
+        "  period:",
+        "    period_kind: custom",
+        "    name: calendar_year",
+        "    start: '2026-01-01'",
+        "    end: '2026-12-31'",
+        "  input:",
+        f"    {CMS_CHIP_CHILD_TARGET.removesuffix('#child')}#input.age: 10",
+        f"    {citation}#input.medicaid_income_level: 0",
+    ]
+    for key, value in common_true_inputs.items():
+        test_lines.append(f"    {key}: {value}")
+    if child_limit in rules_by_name:
+        test_lines[-(len(common_true_inputs) + 1)] = (
+            f"    {citation}#input.medicaid_income_level: 2.00"
+        )
+    test_lines.extend(
+        [
+            "  output:",
+            f"    {citation}#is_chip_eligible_child: "
+            + ("holds" if child_limit in rules_by_name else "not_holds"),
+            "",
+            f"- name: {state_slug}_standard_pregnant_chip_eligible_under_cms_limit",
+            "  period:",
+            "    period_kind: custom",
+            "    name: calendar_year",
+            "    start: '2026-01-01'",
+            "    end: '2026-12-31'",
+            "  input:",
+            f"    {citation}#input.person_is_pregnant: true",
+            f"    {citation}#input.medicaid_income_level: 2.00",
+        ]
+    )
+    for key, value in common_true_inputs.items():
+        test_lines.append(f"    {key}: {value}")
+    test_lines.extend(
+        [
+            "  output:",
+            f"    {citation}#is_chip_eligible_standard_pregnant_person: "
+            + ("holds" if pregnant_limit in rules_by_name else "not_holds"),
+        ]
+    )
+
+    return _CmsGeneratedChipCompositionFile(
+        relative_output=relative_output,
+        rules_content=rules_content,
+        test_content="\n".join(test_lines) + "\n",
+    )
 
 
 def _georgia_cms_medicaid_availability_rule_block(rule: dict[str, str]) -> str:
@@ -10521,6 +10960,196 @@ def cmd_generate_cms_medicaid_chip_eligibility_levels(args):
             changed_outputs.append(generated.relative_output)
 
     print("Generated CMS Medicaid/CHIP eligibility-level RuleSpec files")
+    for relative_output in skipped_existing:
+        print(f"skipped_existing={relative_output}")
+    for relative_output in changed_outputs:
+        print(f"changed={relative_output}")
+        print(f"changed={_rulespec_test_path(relative_output)}")
+    for manifest_path in manifest_paths:
+        print(f"manifest={manifest_path}")
+
+
+def cmd_generate_cms_chip_eligibility_composition(args):
+    """Generate signed state CHIP eligibility composition files."""
+    repo_path = Path(args.repo).resolve()
+    if _repo_jurisdiction_prefix(repo_path) != "us":
+        print(
+            "generate-cms-chip-eligibility-composition must run against "
+            f"rulespec-us; got {repo_path}"
+        )
+        sys.exit(1)
+
+    try:
+        requested_codes = _cms_requested_state_codes_for_existing_files(
+            list(args.states or [])
+        )
+    except RuntimeError as exc:
+        print(str(exc))
+        sys.exit(1)
+
+    child_source = repo_path / CMS_CHIP_CHILD_SOURCE_RELATIVE
+    if not child_source.exists():
+        print(f"Required CHIP child statute RuleSpec file not found: {child_source}")
+        sys.exit(1)
+
+    cms_state_files = _cms_existing_state_eligibility_files(repo_path)
+    selected = [
+        relative
+        for relative in cms_state_files
+        if requested_codes is None
+        or _cms_state_code_from_relative_output(relative) in requested_codes
+    ]
+    if not selected:
+        print("No matching CMS Medicaid/CHIP eligibility-level files found.")
+        sys.exit(1)
+
+    try:
+        generated_files = [
+            _cms_chip_build_composition_file(
+                repo_path=repo_path,
+                cms_relative_output=relative,
+            )
+            for relative in selected
+        ]
+    except RuntimeError as exc:
+        print(str(exc))
+        sys.exit(1)
+
+    planned: list[tuple[_CmsGeneratedChipCompositionFile, Path, Path]] = []
+    skipped_existing: list[Path] = []
+    for generated in generated_files:
+        rules_file = repo_path / generated.relative_output
+        test_file = _rulespec_test_path(rules_file)
+        if (rules_file.exists() or test_file.exists()) and not getattr(
+            args, "overwrite_existing", False
+        ):
+            skipped_existing.append(generated.relative_output)
+            continue
+        planned.append((generated, rules_file, test_file))
+
+    if not planned:
+        print("No CMS CHIP eligibility composition files to generate.")
+        for relative_output in skipped_existing:
+            print(f"skipped_existing={relative_output}")
+        return
+
+    signing_key = _require_applied_encoding_manifest_signing_key()
+    axiom_encode_git = _require_clean_axiom_encode_git_provenance()
+    axiom_rules_path = getattr(
+        args, "axiom_rules_path", None
+    ) or _resolve_runtime_axiom_rules_checkout(repo_path)
+    _ensure_no_unmanifested_preexisting_rulespec_changes(
+        repo_path,
+        [
+            (generated.relative_output, [rules_file, test_file])
+            for generated, rules_file, test_file in planned
+        ],
+    )
+
+    manifest_paths: list[Path] = []
+    changed_outputs: list[Path] = []
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_root = Path(tmpdir)
+        for generated, rules_file, test_file in planned:
+            original_content = rules_file.read_text() if rules_file.exists() else None
+            original_test_content = (
+                test_file.read_text() if test_file.exists() else None
+            )
+            generated_output = (
+                output_root
+                / "deterministic-cms-chip-eligibility-composition"
+                / generated.relative_output
+            )
+            generated_output.parent.mkdir(parents=True, exist_ok=True)
+            generated_output.write_text(generated.rules_content)
+            generated_test = _rulespec_test_path(generated_output)
+            generated_test.write_text(generated.test_content)
+
+            rules_file.parent.mkdir(parents=True, exist_ok=True)
+            rules_file.write_text(generated.rules_content)
+            test_file.write_text(generated.test_content)
+
+            validation_passed = False
+            tests_passed = False
+            try:
+                validation = ValidatorPipeline(
+                    policy_repo_path=repo_path,
+                    axiom_rules_path=axiom_rules_path,
+                    enable_oracles=False,
+                    require_policy_proofs=True,
+                ).validate(rules_file, skip_reviewers=True)
+                validation_passed = validation.all_passed
+                if not validation_passed:
+                    issues = [
+                        result.error
+                        for result in validation.results.values()
+                        if result.error
+                    ]
+                    print(
+                        "CMS CHIP eligibility composition generation failed "
+                        "validation; restored original files."
+                    )
+                    for issue in issues:
+                        print(f"- {issue}")
+                    sys.exit(1)
+
+                test_failures = _rulespec_companion_test_failures(
+                    test_file,
+                    root=repo_path,
+                    axiom_rules_path=axiom_rules_path,
+                )
+                tests_passed = not test_failures
+                if test_failures:
+                    print(
+                        "CMS CHIP eligibility composition generation failed "
+                        "companion tests; restored original files."
+                    )
+                    for failure in test_failures[:20]:
+                        case_name = failure.get("case") or "<unknown case>"
+                        print(f"- {case_name}: {failure.get('message')}")
+                    sys.exit(1)
+            finally:
+                if not validation_passed or not tests_passed:
+                    if original_content is None:
+                        if rules_file.exists():
+                            rules_file.unlink()
+                    else:
+                        rules_file.write_text(original_content)
+                    if original_test_content is None:
+                        if test_file.exists():
+                            test_file.unlink()
+                    else:
+                        test_file.write_text(original_test_content)
+
+            citation = _rulespec_anchor_base_for_output(
+                repo_path,
+                generated.relative_output,
+            )
+            result = argparse.Namespace(
+                output_file=str(generated_output),
+                runner="deterministic-generator",
+                backend="deterministic",
+                model=CMS_CHIP_COMPOSITION_MODEL,
+                tool="axiom-encode generate-cms-chip-eligibility-composition",
+                citation=citation,
+                generation_prompt_sha256=None,
+                trace_file=None,
+                context_manifest_file=None,
+            )
+            manifest_path = _write_applied_encoding_manifest(
+                result,
+                output_root=output_root,
+                policy_repo_path=repo_path,
+                relative_output=generated.relative_output,
+                applied_files=[rules_file, test_file],
+                run_id="deterministic-cms-chip-eligibility-composition",
+                signing_key=signing_key,
+                axiom_encode_git=axiom_encode_git,
+            )
+            manifest_paths.append(manifest_path)
+            changed_outputs.append(generated.relative_output)
+
+    print("Generated CMS CHIP eligibility composition RuleSpec files")
     for relative_output in skipped_existing:
         print(f"skipped_existing={relative_output}")
     for relative_output in changed_outputs:

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -8249,7 +8249,9 @@ def _cms_yaml_double(value: str) -> str:
 
 def _indent_block(value: str, spaces: int) -> str:
     prefix = " " * spaces
-    return "\n".join(f"{prefix}{line}" if line else prefix for line in value.splitlines())
+    return "\n".join(
+        f"{prefix}{line}" if line else prefix for line in value.splitlines()
+    )
 
 
 def _cms_rate_from_table_cell(cell: str) -> Decimal | None:
@@ -8643,8 +8645,12 @@ def _rulespec_rule_names(content: str) -> set[str]:
 
 
 CMS_CHIP_COMPOSITION_MODEL = "cms-chip-eligibility-composition-v1"
-CMS_CHIP_CHILD_SOURCE_RELATIVE = Path("us") / "statutes" / "42" / "1397jj" / "c" / "1.yaml"
+CMS_CHIP_CHILD_SOURCE_RELATIVE = (
+    Path("us") / "statutes" / "42" / "1397jj" / "c" / "1.yaml"
+)
 CMS_CHIP_CHILD_TARGET = "us:statutes/42/1397jj/c/1#child"
+CMS_CHIP_CHILD_FORMULA_CORPUS_PATH = "us/statute/42/1397jj/b/1"
+CMS_CHIP_PREGNANT_FORMULA_CORPUS_PATH = "us/statute/42/1397ll/d/2"
 
 
 def _cms_state_code_aliases() -> dict[str, str]:
@@ -8707,7 +8713,9 @@ def _cms_existing_state_eligibility_files(repo_path: Path) -> list[Path]:
     )
 
 
-def _cms_requested_state_codes_for_existing_files(raw_states: list[str]) -> set[str] | None:
+def _cms_requested_state_codes_for_existing_files(
+    raw_states: list[str],
+) -> set[str] | None:
     if not raw_states:
         return None
     aliases = _cms_state_code_aliases()
@@ -8771,11 +8779,13 @@ def _cms_chip_composition_rule_block(
     source: str,
     proof_atoms: str,
     formula: str,
+    dtype: str = "Judgment",
+    entity: str | None = "Person",
 ) -> str:
+    entity_line = f"    entity: {entity}\n" if entity else ""
     return f"""  - name: {name}
     kind: derived
-    entity: Person
-    dtype: Judgment
+{entity_line}    dtype: {dtype}
     period: Year
     source: {source}
     metadata:
@@ -8813,7 +8823,9 @@ def _cms_chip_build_composition_file(
     pregnant_limit = f"{state_slug}_pregnant_women_chip_fpl_limit"
     pregnant_availability = f"{state_slug}_standard_pregnant_chip_eligibility_available"
 
-    imports = [CMS_CHIP_CHILD_TARGET]
+    imports = []
+    if child_limit in rules_by_name:
+        imports.append(CMS_CHIP_CHILD_TARGET)
     if child_limit in rules_by_name:
         imports.append(f"{cms_target}#{child_limit}")
     source_child_availability = f"{state_slug}_children_separate_chip_available"
@@ -8822,20 +8834,21 @@ def _cms_chip_build_composition_file(
     if pregnant_limit in rules_by_name:
         imports.append(f"{cms_target}#{pregnant_limit}")
     source_pregnant_availability = f"{state_slug}_pregnant_women_chip_available"
-    if pregnant_limit not in rules_by_name and source_pregnant_availability in rules_by_name:
+    if (
+        pregnant_limit not in rules_by_name
+        and source_pregnant_availability in rules_by_name
+    ):
         imports.append(f"{cms_target}#{source_pregnant_availability}")
 
     rules: list[str] = []
     if child_limit in rules_by_name:
         child_available_formula = "true"
-        child_available_atoms = _cms_chip_import_atom(
-            target=f"{cms_target}#{child_limit}",
-            output=child_limit,
-            digest=cms_hash,
+        child_available_atoms = _cms_chip_formula_source_atom(
+            corpus_citation_path=CMS_ELIGIBILITY_LEVELS_CORPUS_PATH,
+            excerpt="Children Separate CHIP",
         )
         child_formula = (
-            f"{child_availability}\n"
-            "and child\n"
+            "child\n"
             "and person_meets_chip_immigration_requirement\n"
             "and not found_eligible_for_medical_assistance_under_subchapter_xix\n"
             f"and medicaid_income_level <= {child_limit}"
@@ -8852,7 +8865,7 @@ def _cms_chip_build_composition_file(
                 digest=cms_hash,
             )
             + _cms_chip_formula_source_atom(
-                corpus_citation_path="us/statute/42/1397jj/b/1",
+                corpus_citation_path=CMS_CHIP_CHILD_FORMULA_CORPUS_PATH,
                 excerpt="not found eligible for medical assistance under subchapter XIX",
             )
             + _cms_chip_formula_source_atom(
@@ -8867,21 +8880,26 @@ def _cms_chip_build_composition_file(
             output=source_child_availability,
             digest=cms_hash,
         )
-        child_formula = child_availability
-        child_atoms = child_available_atoms
+        child_formula = "false"
+        child_atoms = _cms_chip_formula_source_atom(
+            corpus_citation_path=CMS_ELIGIBILITY_LEVELS_CORPUS_PATH,
+            excerpt="Children Separate CHIP",
+        )
     else:
         child_available_formula = "false"
         child_available_atoms = _cms_chip_formula_source_atom(
             corpus_citation_path=CMS_ELIGIBILITY_LEVELS_CORPUS_PATH,
             excerpt="Children Separate CHIP",
         )
-        child_formula = child_availability
+        child_formula = "false"
         child_atoms = child_available_atoms
 
     rules.append(
         _cms_chip_composition_rule_block(
             name=child_availability,
             source=f"CMS Medicaid, CHIP and BHP Eligibility Levels table, {state_name} row",
+            dtype="Boolean",
+            entity=None,
             proof_atoms=child_available_atoms,
             formula=child_available_formula,
         )
@@ -8897,14 +8915,12 @@ def _cms_chip_build_composition_file(
 
     if pregnant_limit in rules_by_name:
         pregnant_available_formula = "true"
-        pregnant_available_atoms = _cms_chip_import_atom(
-            target=f"{cms_target}#{pregnant_limit}",
-            output=pregnant_limit,
-            digest=cms_hash,
+        pregnant_available_atoms = _cms_chip_formula_source_atom(
+            corpus_citation_path=CMS_ELIGIBILITY_LEVELS_CORPUS_PATH,
+            excerpt="Pregnant Women CHIP",
         )
         pregnant_formula = (
-            f"{pregnant_availability}\n"
-            "and person_is_pregnant\n"
+            "person_is_pregnant\n"
             "and person_meets_chip_immigration_requirement\n"
             "and not found_eligible_for_medical_assistance_under_subchapter_xix\n"
             f"and medicaid_income_level <= {pregnant_limit}"
@@ -8916,7 +8932,7 @@ def _cms_chip_build_composition_file(
                 digest=cms_hash,
             )
             + _cms_chip_formula_source_atom(
-                corpus_citation_path="us/statute/42/1397ll/d/2",
+                corpus_citation_path=CMS_CHIP_PREGNANT_FORMULA_CORPUS_PATH,
                 excerpt="targeted low-income pregnant woman",
             )
             + _cms_chip_formula_source_atom(
@@ -8931,21 +8947,26 @@ def _cms_chip_build_composition_file(
             output=source_pregnant_availability,
             digest=cms_hash,
         )
-        pregnant_formula = pregnant_availability
-        pregnant_atoms = pregnant_available_atoms
+        pregnant_formula = "false"
+        pregnant_atoms = _cms_chip_formula_source_atom(
+            corpus_citation_path=CMS_ELIGIBILITY_LEVELS_CORPUS_PATH,
+            excerpt="Pregnant Women CHIP",
+        )
     else:
         pregnant_available_formula = "false"
         pregnant_available_atoms = _cms_chip_formula_source_atom(
             corpus_citation_path=CMS_ELIGIBILITY_LEVELS_CORPUS_PATH,
             excerpt="Pregnant Women CHIP",
         )
-        pregnant_formula = pregnant_availability
+        pregnant_formula = "false"
         pregnant_atoms = pregnant_available_atoms
 
     rules.append(
         _cms_chip_composition_rule_block(
             name=pregnant_availability,
             source=f"CMS Medicaid, CHIP and BHP Eligibility Levels table, {state_name} row",
+            dtype="Boolean",
+            entity=None,
             proof_atoms=pregnant_available_atoms,
             formula=pregnant_available_formula,
         )
@@ -8967,7 +8988,10 @@ def _cms_chip_build_composition_file(
         + "  proof_validation:\n"
         + "    required: true\n"
         + "  source_verification:\n"
-        + f"    corpus_citation_path: {CMS_ELIGIBILITY_LEVELS_CORPUS_PATH}\n"
+        + "    corpus_citation_paths:\n"
+        + f"      - {CMS_ELIGIBILITY_LEVELS_CORPUS_PATH}\n"
+        + f"      - {CMS_CHIP_CHILD_FORMULA_CORPUS_PATH}\n"
+        + f"      - {CMS_CHIP_PREGNANT_FORMULA_CORPUS_PATH}\n"
         + f"{CMS_ELIGIBILITY_LEVELS_UPSTREAM_SOURCE_CHECK_BLOCK}"
         + "  summary: |-\n"
         + f"    {state_name} CHIP eligibility composition applies the federal CHIP child and standard-pregnant eligibility framework to the CMS state eligibility-level outputs. It intentionally does not encode FCEP state income limits until primary state-plan or CMS source coverage is available.\n"
@@ -8981,27 +9005,52 @@ def _cms_chip_build_composition_file(
         f"{citation}#input.found_eligible_for_medical_assistance_under_subchapter_xix": "false",
     }
     test_lines = [
+        f"- name: {state_slug}_separate_chip_child_availability",
+        "  period:",
+        "    period_kind: custom",
+        "    name: calendar_year",
+        "    start: '2026-01-01'",
+        "    end: '2026-12-31'",
+        "  input: {}",
+        "  output:",
+        f"    {citation}#{child_availability}: "
+        + ("true" if child_limit in rules_by_name else "false"),
+        "",
         f"- name: {state_slug}_chip_child_eligible_under_cms_limit",
         "  period:",
         "    period_kind: custom",
         "    name: calendar_year",
         "    start: '2026-01-01'",
         "    end: '2026-12-31'",
-        "  input:",
-        f"    {CMS_CHIP_CHILD_TARGET.removesuffix('#child')}#input.age: 10",
-        f"    {citation}#input.medicaid_income_level: 0",
     ]
-    for key, value in common_true_inputs.items():
-        test_lines.append(f"    {key}: {value}")
     if child_limit in rules_by_name:
-        test_lines[-(len(common_true_inputs) + 1)] = (
-            f"    {citation}#input.medicaid_income_level: 2.00"
+        test_lines.extend(
+            [
+                "  input:",
+                f"    {CMS_CHIP_CHILD_TARGET.removesuffix('#child')}#input.age: 10",
+                f"    {citation}#input.medicaid_income_level: 0.00",
+            ]
         )
+        for key, value in common_true_inputs.items():
+            test_lines.append(f"    {key}: {value}")
+    else:
+        test_lines.append("  input: {}")
     test_lines.extend(
         [
             "  output:",
             f"    {citation}#is_chip_eligible_child: "
             + ("holds" if child_limit in rules_by_name else "not_holds"),
+            "",
+            f"- name: {state_slug}_standard_pregnant_chip_availability",
+            "  period:",
+            "    period_kind: custom",
+            "    name: calendar_year",
+            "    start: '2026-01-01'",
+            "    end: '2026-12-31'",
+            "  input: {}",
+            "  output:",
+            f"    {citation}#{pregnant_availability}: "
+            + ("true" if pregnant_limit in rules_by_name else "false"),
             "",
             f"- name: {state_slug}_standard_pregnant_chip_eligible_under_cms_limit",
             "  period:",
@@ -9009,13 +9058,20 @@ def _cms_chip_build_composition_file(
             "    name: calendar_year",
             "    start: '2026-01-01'",
             "    end: '2026-12-31'",
-            "  input:",
-            f"    {citation}#input.person_is_pregnant: true",
-            f"    {citation}#input.medicaid_income_level: 2.00",
         ]
     )
-    for key, value in common_true_inputs.items():
-        test_lines.append(f"    {key}: {value}")
+    if pregnant_limit in rules_by_name:
+        test_lines.extend(
+            [
+                "  input:",
+                f"    {citation}#input.person_is_pregnant: true",
+                f"    {citation}#input.medicaid_income_level: 0.00",
+            ]
+        )
+        for key, value in common_true_inputs.items():
+            test_lines.append(f"    {key}: {value}")
+    else:
+        test_lines.append("  input: {}")
     test_lines.extend(
         [
             "  output:",

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -26960,6 +26960,10 @@ print("BENCHMARK:" + json.dumps(result))
                 *adapter.monthly_person_inputs,
                 *adapter.boolean_person_inputs,
                 *adapter.monthly_boolean_person_inputs,
+                *(
+                    (rule_key, pe_key)
+                    for rule_key, pe_key, *_ in adapter.boolean_enum_person_inputs
+                ),
                 *adapter.direct_household_overrides,
                 *adapter.inverted_boolean_household_overrides,
                 *adapter.annual_direct_household_overrides,
@@ -28001,6 +28005,21 @@ print(f'RESULT:{{float(value)}}')
                         else adult_attrs
                     )
                     attrs.append(f"'{pe_attr}': {{'{period}': {bool(value)}}}")
+            for (
+                rule_key,
+                pe_attr,
+                true_value,
+                false_value,
+            ) in adapter.boolean_enum_person_inputs:
+                value = self._rulespec_test_input_value(inputs, rule_key)
+                if value is not None:
+                    attrs = (
+                        target_person_attrs
+                        if target_person_attrs is not None
+                        else adult_attrs
+                    )
+                    enum_value = true_value if bool(value) else false_value
+                    attrs.append(f"'{pe_attr}': {{'{year}': {pe_literal(enum_value)}}}")
             for (
                 pe_attr,
                 operation,

--- a/src/axiom_encode/oracles/policyengine/adapters.py
+++ b/src/axiom_encode/oracles/policyengine/adapters.py
@@ -791,6 +791,13 @@ PE_US_CHIP_VAR_ADAPTERS = (
         comparison="decision",
     ),
     PolicyEngineUSVarAdapter(
+        rule_names=("is_chip_eligible_standard_pregnant_person",),
+        pe_var="is_chip_eligible_standard_pregnant_person",
+        entity="person",
+        period="year",
+        comparison="decision",
+    ),
+    PolicyEngineUSVarAdapter(
         rule_names=("is_chip_fcep_eligible_person",),
         pe_var="is_chip_fcep_eligible_person",
         entity="person",

--- a/src/axiom_encode/oracles/policyengine/adapters.py
+++ b/src/axiom_encode/oracles/policyengine/adapters.py
@@ -22,6 +22,7 @@ class PolicyEngineUSVarAdapter:
     monthly_person_inputs: tuple[tuple[str, str], ...] = ()
     boolean_person_inputs: tuple[tuple[str, str], ...] = ()
     monthly_boolean_person_inputs: tuple[tuple[str, str], ...] = ()
+    boolean_enum_person_inputs: tuple[tuple[str, str, str, str], ...] = ()
     monthly_derived_boolean_person_inputs: tuple[
         tuple[str, str, tuple[str, ...]], ...
     ] = ()
@@ -781,6 +782,21 @@ PE_US_CHIP_VAR_ADAPTERS = (
         entity="person",
         period="year",
         comparison="decision",
+        direct_person_inputs=(("medicaid_income_level", "medicaid_income_level"),),
+        boolean_person_inputs=(
+            (
+                "found_eligible_for_medical_assistance_under_subchapter_xix",
+                "is_medicaid_eligible",
+            ),
+        ),
+        boolean_enum_person_inputs=(
+            (
+                "person_meets_chip_immigration_requirement",
+                "immigration_status",
+                "CITIZEN",
+                "UNDOCUMENTED",
+            ),
+        ),
         target_person_role="child",
     ),
     PolicyEngineUSVarAdapter(
@@ -796,6 +812,22 @@ PE_US_CHIP_VAR_ADAPTERS = (
         entity="person",
         period="year",
         comparison="decision",
+        direct_person_inputs=(("medicaid_income_level", "medicaid_income_level"),),
+        boolean_person_inputs=(
+            ("person_is_pregnant", "is_pregnant"),
+            (
+                "found_eligible_for_medical_assistance_under_subchapter_xix",
+                "is_medicaid_eligible",
+            ),
+        ),
+        boolean_enum_person_inputs=(
+            (
+                "person_meets_chip_immigration_requirement",
+                "immigration_status",
+                "CITIZEN",
+                "UNDOCUMENTED",
+            ),
+        ),
     ),
     PolicyEngineUSVarAdapter(
         rule_names=("is_chip_fcep_eligible_person",),

--- a/src/axiom_encode/oracles/policyengine/registry.py
+++ b/src/axiom_encode/oracles/policyengine/registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
@@ -106,6 +107,11 @@ class PolicyEngineOracleRegistry:
         mapping = self.mappings_by_legal_id.get(legal_id_text)
         if mapping is not None and (country is None or mapping.country == country):
             return mapping
+        synthetic_mapping = _cms_chip_composition_mapping(legal_id_text)
+        if synthetic_mapping is not None and (
+            country is None or synthetic_mapping.country == country
+        ):
+            return synthetic_mapping
         for prefix_mapping in self.prefix_mappings:
             if country and prefix_mapping.country != country:
                 continue
@@ -243,6 +249,80 @@ class PolicyEngineOracleRegistry:
                         f"canonical legal IDs: {legal_id} -> {evidence_legal_id}"
                     )
         return issues
+
+
+_CMS_CHIP_COMPOSITION_LEGAL_ID_RE = re.compile(
+    r"^(?P<jurisdiction>us-[a-z]{2}|us-dc):policies/cms/"
+    r"(?P<state_slug>[a-z-]+)-chip-eligibility#(?P<rule>[a-z0-9_]+)$"
+)
+
+
+def _cms_chip_composition_mapping(legal_id: str) -> PolicyEngineMapping | None:
+    match = _CMS_CHIP_COMPOSITION_LEGAL_ID_RE.match(legal_id)
+    if not match:
+        return None
+    rule = match.group("rule")
+    if rule == "is_chip_eligible_child":
+        return PolicyEngineMapping(
+            legal_id=legal_id,
+            country="us",
+            program="chip",
+            mapping_type="direct_variable",
+            policyengine_variable="is_chip_eligible_child",
+            entity="Person",
+            period="year",
+            rationale=(
+                "CMS CHIP composition output for final child CHIP eligibility; "
+                "mapped directly to the PolicyEngine-US child CHIP eligibility "
+                "variable."
+            ),
+        )
+    if rule == "is_chip_eligible_standard_pregnant_person":
+        return PolicyEngineMapping(
+            legal_id=legal_id,
+            country="us",
+            program="chip",
+            mapping_type="direct_variable",
+            policyengine_variable="is_chip_eligible_standard_pregnant_person",
+            entity="Person",
+            period="year",
+            rationale=(
+                "CMS CHIP composition output for final standard pregnant-person "
+                "CHIP eligibility; mapped directly to the PolicyEngine-US "
+                "standard pregnant CHIP eligibility variable."
+            ),
+        )
+    if rule.endswith("_separate_chip_child_eligibility_available"):
+        return PolicyEngineMapping(
+            legal_id=legal_id,
+            country="us",
+            program="chip",
+            mapping_type="not_comparable",
+            policyengine_variable="is_chip_eligible_child",
+            candidate_priority="P4",
+            rationale=(
+                "Axiom exposes the source-level CMS child CHIP availability "
+                "fact used by the state composition. PolicyEngine-US exposes "
+                "final child CHIP eligibility rather than a separate availability "
+                "boolean."
+            ),
+        )
+    if rule.endswith("_standard_pregnant_chip_eligibility_available"):
+        return PolicyEngineMapping(
+            legal_id=legal_id,
+            country="us",
+            program="chip",
+            mapping_type="not_comparable",
+            policyengine_variable="is_chip_eligible_standard_pregnant_person",
+            candidate_priority="P4",
+            rationale=(
+                "Axiom exposes the source-level CMS standard pregnant CHIP "
+                "availability fact used by the state composition. "
+                "PolicyEngine-US exposes final standard pregnant CHIP "
+                "eligibility rather than a separate availability boolean."
+            ),
+        )
+    return None
 
 
 @lru_cache(maxsize=1)

--- a/src/axiom_encode/oracles/policyengine/us_populace.py
+++ b/src/axiom_encode/oracles/policyengine/us_populace.py
@@ -581,6 +581,10 @@ def source_variables_for_adapters(
             *adapter.monthly_person_inputs,
             *adapter.boolean_person_inputs,
             *adapter.monthly_boolean_person_inputs,
+            *(
+                (rule_key, pe_key)
+                for rule_key, pe_key, *_ in adapter.boolean_enum_person_inputs
+            ),
         ):
             person_vars[pe_key] = None
         for _rule_key, pe_key in (
@@ -648,6 +652,15 @@ def project_case_inputs(
         inputs[rule_key] = bool_value(row_value(row, pe_key))
     for rule_key, pe_key in adapter.monthly_boolean_person_inputs:
         inputs[rule_key] = bool_value(row_value(row, pe_key))
+    for (
+        rule_key,
+        pe_key,
+        _true_value,
+        false_value,
+    ) in adapter.boolean_enum_person_inputs:
+        raw_value = row_value(row, pe_key)
+        raw_text = str(raw_value).strip().upper()
+        inputs[rule_key] = raw_text != false_value.strip().upper()
     for rule_key, pe_key in adapter.direct_spm_overrides:
         inputs[rule_key] = money(row_value(spm_row, pe_key))
     for rule_key, pe_key in adapter.annual_direct_spm_overrides:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11502,6 +11502,14 @@ rules:
             cmd_generate_cms_chip_eligibility_composition(args)
 
         rules_content = target.read_text()
+        rules_payload = yaml.safe_load(rules_content)
+        assert rules_payload["module"]["source_verification"][
+            "corpus_citation_paths"
+        ] == [
+            "us/form/cms/medicaid-chip-bhp-eligibility-levels",
+            "us/statute/42/1397jj/b/1",
+            "us/statute/42/1397ll/d/2",
+        ]
         assert "us:statutes/42/1397jj/c/1#child" in rules_content
         assert (
             "us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels"
@@ -11523,7 +11531,9 @@ rules:
             "medicaid_income_level <= colorado_pregnant_women_chip_fpl_limit"
             in rules_content
         )
-        assert "It intentionally does not encode FCEP state income limits" in rules_content
+        assert (
+            "It intentionally does not encode FCEP state income limits" in rules_content
+        )
 
         test_content = test_file.read_text()
         assert (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -183,6 +183,7 @@ from axiom_encode.cli import (
     cmd_eval_suite_archive,
     cmd_eval_suite_report,
     cmd_eval_suite_revalidate,
+    cmd_generate_cms_chip_eligibility_composition,
     cmd_generate_cms_medicaid_chip_eligibility_levels,
     cmd_guard_generated,
     cmd_interval_table_audit,
@@ -11415,6 +11416,218 @@ rules:
             "us/policies/cms/medicaid-chip-bhp-eligibility-levels.yaml",
             "us/policies/cms/medicaid-chip-bhp-eligibility-levels.test.yaml",
         ]
+
+    def test_generate_cms_chip_composition_writes_signed_state_file(self, tmp_path):
+        policy_repo = tmp_path / "rulespec-us"
+        _init_test_git_repo(policy_repo)
+        child_source = policy_repo / "us/statutes/42/1397jj/c/1.yaml"
+        child_source.parent.mkdir(parents=True)
+        child_source.write_text(
+            """format: rulespec/v1
+rules:
+  - name: child
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Day
+    source: 42 USC 1397jj(c)(1)
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          age < 19
+"""
+        )
+        cms_file = (
+            policy_repo
+            / "us-co/policies/cms/colorado-medicaid-chip-bhp-eligibility-levels.yaml"
+        )
+        cms_file.parent.mkdir(parents=True)
+        cms_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: colorado_children_separate_chip_effective_fpl_limit
+    kind: derived
+    dtype: Rate
+    source: CMS table
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          2.65
+  - name: colorado_pregnant_women_chip_fpl_limit
+    kind: parameter
+    dtype: Rate
+    source: CMS table
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          2.60
+"""
+        )
+        _git(policy_repo, "add", ".")
+        _git(policy_repo, "commit", "-m", "initial")
+
+        target = policy_repo / "us-co/policies/cms/colorado-chip-eligibility.yaml"
+        test_file = target.with_name("colorado-chip-eligibility.test.yaml")
+        args = SimpleNamespace(
+            repo=policy_repo,
+            states=["CO"],
+            overwrite_existing=False,
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == target.resolve()
+                assert skip_reviewers is True
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._rulespec_companion_test_failures",
+                return_value=[],
+            ),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_generate_cms_chip_eligibility_composition(args)
+
+        rules_content = target.read_text()
+        assert "us:statutes/42/1397jj/c/1#child" in rules_content
+        assert (
+            "us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels"
+            "#colorado_children_separate_chip_effective_fpl_limit" in rules_content
+        )
+        assert (
+            "us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels"
+            "#colorado_pregnant_women_chip_fpl_limit" in rules_content
+        )
+        assert "is_chip_eligible_child" in rules_content
+        assert "is_chip_eligible_standard_pregnant_person" in rules_content
+        assert "is_chip_fcep_eligible_person" not in rules_content
+        assert "name: is_chip_eligible\n" not in rules_content
+        assert (
+            "medicaid_income_level <= "
+            "colorado_children_separate_chip_effective_fpl_limit" in rules_content
+        )
+        assert (
+            "medicaid_income_level <= colorado_pregnant_women_chip_fpl_limit"
+            in rules_content
+        )
+        assert "It intentionally does not encode FCEP state income limits" in rules_content
+
+        test_content = test_file.read_text()
+        assert (
+            "us-co:policies/cms/colorado-chip-eligibility"
+            "#is_chip_eligible_child: holds" in test_content
+        )
+        assert (
+            "us-co:policies/cms/colorado-chip-eligibility"
+            "#is_chip_eligible_standard_pregnant_person: holds" in test_content
+        )
+
+        manifest = (
+            policy_repo
+            / ".axiom/encoding-manifests/us-co/policies/cms/colorado-chip-eligibility.json"
+        )
+        payload = json.loads(manifest.read_text())
+        assert payload["schema_version"] == APPLIED_ENCODING_MANIFEST_SCHEMA
+        assert payload["model"] == "cms-chip-eligibility-composition-v1"
+        assert payload["tool"] == (
+            "axiom-encode generate-cms-chip-eligibility-composition"
+        )
+        assert payload["citation"] == "us-co:policies/cms/colorado-chip-eligibility"
+        assert [applied_file["path"] for applied_file in payload["applied_files"]] == [
+            "us-co/policies/cms/colorado-chip-eligibility.yaml",
+            "us-co/policies/cms/colorado-chip-eligibility.test.yaml",
+        ]
+
+    def test_generate_cms_chip_composition_keeps_unavailable_pregnant_path_false(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        _init_test_git_repo(policy_repo)
+        child_source = policy_repo / "us/statutes/42/1397jj/c/1.yaml"
+        child_source.parent.mkdir(parents=True)
+        child_source.write_text("format: rulespec/v1\nrules: []\n")
+        cms_file = (
+            policy_repo
+            / "us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml"
+        )
+        cms_file.parent.mkdir(parents=True)
+        cms_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: georgia_children_separate_chip_effective_fpl_limit
+    kind: derived
+    dtype: Rate
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          2.52
+  - name: georgia_pregnant_women_chip_available
+    kind: parameter
+    dtype: Boolean
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          false
+"""
+        )
+        _git(policy_repo, "add", ".")
+        _git(policy_repo, "commit", "-m", "initial")
+
+        target = policy_repo / "us-ga/policies/cms/georgia-chip-eligibility.yaml"
+        args = SimpleNamespace(
+            repo=policy_repo,
+            states=["GA"],
+            overwrite_existing=False,
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        with (
+            patch(
+                "axiom_encode.cli.ValidatorPipeline",
+                return_value=SimpleNamespace(
+                    validate=lambda path, skip_reviewers: SimpleNamespace(
+                        all_passed=True,
+                        results={},
+                    )
+                ),
+            ),
+            patch(
+                "axiom_encode.cli._rulespec_companion_test_failures",
+                return_value=[],
+            ),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_generate_cms_chip_eligibility_composition(args)
+
+        rules_content = target.read_text()
+        assert "georgia_standard_pregnant_chip_eligibility_available" in rules_content
+        assert "georgia_pregnant_women_chip_available" in rules_content
+        assert "georgia_pregnant_women_chip_fpl_limit" not in rules_content
+        assert (
+            "us-ga:policies/cms/georgia-chip-eligibility"
+            "#is_chip_eligible_standard_pregnant_person: not_holds"
+            in target.with_name("georgia-chip-eligibility.test.yaml").read_text()
+        )
 
     def test_repair_minnesota_mfip_source_check_writes_signed_manifest(self, tmp_path):
         policy_repo = tmp_path / "rulespec-us"

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2990,6 +2990,42 @@ def test_policyengine_registry_is_legal_id_keyed():
         assert (
             mapping.policyengine_variable == "is_chip_eligible_standard_pregnant_person"
         )
+    child_chip_composition_mapping = registry.mapping_for_legal_id(
+        "us-co:policies/cms/colorado-chip-eligibility#is_chip_eligible_child",
+        country="us",
+    )
+    assert child_chip_composition_mapping.mapping_type == "direct_variable"
+    assert child_chip_composition_mapping.program == "chip"
+    assert (
+        child_chip_composition_mapping.policyengine_variable == "is_chip_eligible_child"
+    )
+    pregnant_chip_composition_mapping = registry.mapping_for_legal_id(
+        "us-co:policies/cms/colorado-chip-eligibility#is_chip_eligible_standard_pregnant_person",
+        country="us",
+    )
+    assert pregnant_chip_composition_mapping.mapping_type == "direct_variable"
+    assert (
+        pregnant_chip_composition_mapping.policyengine_variable
+        == "is_chip_eligible_standard_pregnant_person"
+    )
+    child_chip_availability_mapping = registry.mapping_for_legal_id(
+        "us-ca:policies/cms/california-chip-eligibility#california_separate_chip_child_eligibility_available",
+        country="us",
+    )
+    assert child_chip_availability_mapping.mapping_type == "not_comparable"
+    assert (
+        child_chip_availability_mapping.policyengine_variable
+        == "is_chip_eligible_child"
+    )
+    pregnant_chip_availability_mapping = registry.mapping_for_legal_id(
+        "us-co:policies/cms/colorado-chip-eligibility#colorado_standard_pregnant_chip_eligibility_available",
+        country="us",
+    )
+    assert pregnant_chip_availability_mapping.mapping_type == "not_comparable"
+    assert (
+        pregnant_chip_availability_mapping.policyengine_variable
+        == "is_chip_eligible_standard_pregnant_person"
+    )
     residential_clean_energy_mapping = registry.mapping_for_legal_id(
         "us:statutes/26/25D#residential_clean_energy_credit",
         country="us",
@@ -5022,6 +5058,85 @@ def test_policyengine_health_child_variable_applies_top_level_age_to_child(
     assert "'adult': {'age': {'2026': 30}" in script
     assert "'child0': {'age': {'2026': 19}" in script
     assert "result_index = 1" in script
+
+
+def test_policyengine_chip_child_composition_projects_legal_inputs(tmp_path):
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=False,
+    )
+    inputs = {
+        "period": "2026",
+        "state_code_str": "CO",
+        "us:statutes/42/1397jj/c/1#input.age": 10,
+        "us-co:policies/cms/colorado-chip-eligibility#input.medicaid_income_level": 0.0,
+        "us-co:policies/cms/colorado-chip-eligibility#input.person_meets_chip_immigration_requirement": True,
+        "us-co:policies/cms/colorado-chip-eligibility#input.found_eligible_for_medical_assistance_under_subchapter_xix": False,
+    }
+
+    projected = ValidatorPipeline._pe_us_projectable_inputs_for_mappability(
+        inputs,
+        "is_chip_eligible_child",
+    )
+    mappable, reason = pipeline._is_pe_test_mappable(
+        "us",
+        "is_chip_eligible_child",
+        projected,
+        pe_var="is_chip_eligible_child",
+    )
+    script = pipeline._build_pe_us_scenario_script(
+        "is_chip_eligible_child",
+        inputs,
+        "2026",
+    )
+
+    assert mappable is True, reason
+    assert "'state_code_str': {'2026': 'CO'}" in script
+    assert "'child0': {'age': {'2026': 10}" in script
+    assert "'medicaid_income_level': {'2026': 0.0}" in script
+    assert "'immigration_status': {'2026': 'CITIZEN'}" in script
+    assert "'is_medicaid_eligible': {'2026': False}" in script
+    assert "result_index = 1" in script
+
+
+def test_policyengine_chip_pregnant_composition_projects_legal_inputs(tmp_path):
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=False,
+    )
+    inputs = {
+        "period": "2026",
+        "state_code_str": "CO",
+        "us-co:policies/cms/colorado-chip-eligibility#input.person_is_pregnant": True,
+        "us-co:policies/cms/colorado-chip-eligibility#input.medicaid_income_level": 0.0,
+        "us-co:policies/cms/colorado-chip-eligibility#input.person_meets_chip_immigration_requirement": True,
+        "us-co:policies/cms/colorado-chip-eligibility#input.found_eligible_for_medical_assistance_under_subchapter_xix": False,
+    }
+
+    projected = ValidatorPipeline._pe_us_projectable_inputs_for_mappability(
+        inputs,
+        "is_chip_eligible_standard_pregnant_person",
+    )
+    mappable, reason = pipeline._is_pe_test_mappable(
+        "us",
+        "is_chip_eligible_standard_pregnant_person",
+        projected,
+        pe_var="is_chip_eligible_standard_pregnant_person",
+    )
+    script = pipeline._build_pe_us_scenario_script(
+        "is_chip_eligible_standard_pregnant_person",
+        inputs,
+        "2026",
+    )
+
+    assert mappable is True, reason
+    assert "'state_code_str': {'2026': 'CO'}" in script
+    assert "'is_pregnant': {'2026': True}" in script
+    assert "'medicaid_income_level': {'2026': 0.0}" in script
+    assert "'immigration_status': {'2026': 'CITIZEN'}" in script
+    assert "'is_medicaid_eligible': {'2026': False}" in script
 
 
 def test_policyengine_tax_scenario_builds_capital_gains_inputs(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1137"
+version = "0.2.1138"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a deterministic CMS CHIP eligibility composition generator
- generate child and standard-pregnant CHIP eligibility from federal CHIP framework plus CMS state eligibility-level outputs
- add a PolicyEngine adapter for standard pregnant CHIP eligibility
- keep FCEP out of generated composition until primary state-plan/CMS source coverage exists

## Validation
- uv run --extra dev python -m pytest tests/test_cli.py -q -k 'generate_cms_chip_composition' --no-cov
- uv run --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject -q --no-cov
- uv run --extra dev ruff check src/axiom_encode/cli.py tests/test_cli.py