### PR TITLE
Classify Idaho AABD oracle mappings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1138"
+version = "0.2.1139"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1138"
+__version__ = "0.2.1139"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -26091,6 +26091,77 @@ mappings:
     mapping_type: not_comparable
     rationale: "Source-specific intermediate output (rule `reapplying_household_requires_postponed_proof_for_expedited`, grounded against `IDAPA 16.03.04.160.05`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
+  - legal_id: us-id:regulations/idapa/16/03/05/514#single_participant_maximum_payment
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.id.dhw.aabd.payment.amount
+    parameter_key: SINGLE
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same IDAPA 16.03.05.514.01 monthly AABD cash-payment maximum for a single participant.
+
+  - legal_id: us-id:regulations/idapa/16/03/05/514#couple_maximum_payment
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.id.dhw.aabd.payment.amount
+    parameter_key: COUPLE
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same IDAPA 16.03.05.514.02(a) monthly AABD cash-payment maximum for a couple, stored as the couple-level row.
+
+  - legal_id: us-id:regulations/idapa/16/03/05/514#essential_person_maximum_payment
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.id.dhw.aabd.payment.amount
+    parameter_key: ESSENTIAL_PERSON
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same IDAPA 16.03.05.514.02(b) monthly AABD cash-payment maximum for a participant living with an essential person.
+
+  - legal_id: us-id:regulations/idapa/16/03/05/514#semi_independent_group_maximum_payment
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.id.dhw.aabd.payment.amount
+    parameter_key: SIGRIF
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same IDAPA 16.03.05.514.03 monthly AABD cash-payment maximum for a semi-independent group residential facility participant.
+
+  - legal_id: us-id:regulations/idapa/16/03/05/514#room_and_board_maximum_payment
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.id.dhw.aabd.payment.amount
+    parameter_key: ROOM_AND_BOARD
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same IDAPA 16.03.05.514.04 monthly AABD cash-payment maximum for a room-and-board participant.
+
+  - legal_id: us-id:regulations/idapa/16/03/05/514#aabd_living_arrangement_maximum_payment
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    policyengine_variable: id_aabd
+    candidate_priority: P4
+    rationale: RuleSpec exposes a source-level selector over IDAPA 16.03.05.514 cash-payment maximums. PolicyEngine's final `id_aabd` surface also composes eligibility, basic allowances, SSI countable income, and person-level couple allocation, so compare the encoded maximum-payment rows separately.
+
+  - legal_id: us-id:regulations/idapa/16/03/05/514#aabd_cash_payment
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    policyengine_variable: id_aabd
+    candidate_priority: P2
+    rationale: RuleSpec encodes IDAPA 16.03.05.514 as a source-level AABD cash-payment rule at the cash-payment-unit level, using financial need, countable income, next-dollar rounding, and source-law couple-level maximums. PolicyEngine's final `id_aabd` variable is a person-level surface that additionally computes financial need from IDAPA 16.03.05.501 and .512 allowances, uses `ssi_countable_income`, applies living-arrangement exclusions, and divides the couple amount per person, so it is reviewed but not one-to-one.
+
   - legal_id: us-al:regulations/660-4/1/03/block-1#first_violation_minimum_disqualification_months
     country: us
     program: snap

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1852,11 +1852,12 @@ surfaces:
   variable: id_aabd
   source_type: state_implementation
   state: ID
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P2
-  rationale: Official Idaho IDAPA 16.03.05 AABD administrative-rule corpus artifacts are ingested from the Idaho
-    administrative rules source. Encode the source-law AABD eligibility and payment calculation before classifying
-    comparability with PolicyEngine's final `id_aabd` person-level surface.
+  rationale: Axiom encodes IDAPA 16.03.05.514 source-law AABD cash-payment maximums and the cash-payment rule from
+    Idaho's administrative rules. PolicyEngine's final `id_aabd` person-level surface additionally composes basic
+    allowances from IDAPA 16.03.05.501 and .512, SSI countable income, living-arrangement exclusions, and per-person
+    couple allocation, so the final variable is reviewed but not one-to-one with the source-level RuleSpec output.
 - country: us
   program_id: ssi_state_supplement
   program_name: Indiana SSP

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2236,7 +2236,7 @@ def test_policyengine_program_surface_marks_alabama_ssp_known_not_comparable():
     assert "final `al_ssp` surface" in al_ssp["rationale"]
 
 
-def test_policyengine_program_surface_marks_idaho_aabd_pending_rulespec_encoding():
+def test_policyengine_program_surface_marks_idaho_aabd_known_not_comparable():
     report = build_policyengine_program_surface_report(program="id_aabd")
 
     items_by_variable = {item["variable"]: item for item in report["items"]}
@@ -2244,9 +2244,37 @@ def test_policyengine_program_surface_marks_idaho_aabd_pending_rulespec_encoding
 
     assert id_aabd["program_id"] == "ssi_state_supplement"
     assert id_aabd["state"] == "ID"
-    assert id_aabd["axiom_status"] == "pending_rulespec_encoding"
-    assert id_aabd["mapping_count"] == 0
-    assert "IDAPA 16.03.05" in id_aabd["rationale"]
+    assert id_aabd["axiom_status"] == "known_not_comparable"
+    assert id_aabd["mapping_count"] >= 1
+    assert id_aabd["comparable_mapping_count"] == 0
+    assert (
+        "us-id:regulations/idapa/16/03/05/514#aabd_cash_payment" in id_aabd["legal_ids"]
+    )
+    assert "IDAPA 16.03.05.514" in id_aabd["rationale"]
+    assert "final `id_aabd` person-level surface" in id_aabd["rationale"]
+
+
+def test_policyengine_registry_maps_idaho_aabd_514_maximum_payment_parameters():
+    registry = load_policyengine_registry()
+
+    expected_keys = {
+        "single_participant_maximum_payment": "SINGLE",
+        "couple_maximum_payment": "COUPLE",
+        "essential_person_maximum_payment": "ESSENTIAL_PERSON",
+        "semi_independent_group_maximum_payment": "SIGRIF",
+        "room_and_board_maximum_payment": "ROOM_AND_BOARD",
+    }
+
+    for rule_name, parameter_key in expected_keys.items():
+        mapping = registry.mapping_for_legal_id(
+            f"us-id:regulations/idapa/16/03/05/514#{rule_name}",
+            country="us",
+        )
+        assert mapping is not None
+        assert mapping.program == "ssi_state_supplement"
+        assert mapping.mapping_type == "parameter_value"
+        assert mapping.policyengine_parameter == "gov.states.id.dhw.aabd.payment.amount"
+        assert mapping.parameter_key == parameter_key
 
 
 def test_policyengine_program_surface_marks_indiana_ssp_pending_rulespec_encoding():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1138"
+version = "0.2.1139"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Maps Idaho IDAPA 16.03.05.514 maximum-payment rows to the PolicyEngine Idaho AABD amount parameter.
- Marks the source-level §514 cash-payment and living-arrangement selector as reviewed non-comparable to the final person-level `id_aabd` surface.
- Updates the Idaho AABD program surface and regression tests so it no longer appears as pending once §514 is encoded.
- Bumps axiom-encode to `0.2.1139` because oracle metadata is encoder-affecting under the apply provenance gate.

## Validation
- `uv run --extra dev ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run --extra dev ruff format --check pyproject.toml src/axiom_encode scripts tests`
- `uv run --extra dev python -m compileall -q src/axiom_encode scripts`
- `uv run --extra dev python -m pytest -q tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump --no-cov`
- `uv run --extra dev python -m pytest -q tests/test_policyengine_coverage.py --no-cov`
- `uv run --extra dev axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-id-aabd-20260705 --oracle policyengine --program ssi_state_supplement --include-program-surfaces --json`
- registry validate via `load_policyengine_registry().validate()`: registry ok

## Review cycle
- Independent read-only review found no actionable findings before the mechanical format/version-bump amendment.
- Reviewer residual risk: `policyengine_us` was checked from local source rather than imported in this worktree environment.

## Companion RuleSpec PR
- The generated Idaho AABD RuleSpec was merged in TheAxiomFoundation/rulespec-us#545.
