### PR TITLE
Track Indiana SAPN PE parity metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1139"
+version = "0.2.1140"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1139"
+__version__ = "0.2.1140"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -26162,6 +26162,42 @@ mappings:
     candidate_priority: P2
     rationale: RuleSpec encodes IDAPA 16.03.05.514 as a source-level AABD cash-payment rule at the cash-payment-unit level, using financial need, countable income, next-dollar rounding, and source-law couple-level maximums. PolicyEngine's final `id_aabd` variable is a person-level surface that additionally computes financial need from IDAPA 16.03.05.501 and .512 allowances, uses `ssi_countable_income`, applies living-arrangement exclusions, and divides the couple amount per person, so it is reviewed but not one-to-one.
 
+  - legal_id: us-in:statutes/12-15-32-6#medicaid_facility_resident_personal_allowance_amount
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.in.fssa.ssp.personal_needs_allowance
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Indiana monthly personal-needs allowance amount for Medicaid facility residents.
+
+  - legal_id: us-in:policies/fssa/medicaid-policy-manual/chapter-5000/5005/05/00#sapn_maximum_benefit_amount
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.in.fssa.ssp.sapn.amount.individual
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same FSSA Chapter 5000 individual SAPN maximum payment amount of $22 per month.
+
+  - legal_id: us-in:policies/fssa/medicaid-policy-manual/chapter-5000/5005/05/00#sapn_benefit_amount
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    policyengine_variable: in_ssp_sapn
+    candidate_priority: P3
+    rationale: RuleSpec encodes the FSSA Chapter 5000 SAPN source-law benefit calculation from budgeted earned and unearned income, bounded by the manual's $1-to-$22 range. PolicyEngine's `in_ssp_sapn` uses SSI payment and SSI countable income as a proxy for that budgeted-income calculation and includes marital-unit couple handling, so this is adjacent but not a one-to-one oracle comparison.
+
+  - legal_id: us-in:statutes/12-15-32-6/5#in_ssp_sapn
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    policyengine_variable: in_ssp
+    candidate_priority: P2
+    rationale: RuleSpec encodes the Indiana Code facility-resident supplement payment as a source-level SAPN component. PolicyEngine's final `in_ssp` surface adds RCAP and relies on the FSSA manual SAPN calculation, so the statute-level SAPN component is reviewed but not one-to-one with the final aggregate variable.
+
   - legal_id: us-al:regulations/660-4/1/03/block-1#first_violation_minimum_disqualification_months
     country: us
     program: snap

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1868,12 +1868,17 @@ surfaces:
   variable: in_ssp
   source_type: state_implementation
   state: IN
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P2
-  rationale: Indiana Code is already available through the source-first Indiana Code corpus release, and official Indiana
-    FSSA Medicaid Policy Manual Chapter 5000 SAPN corpus artifacts are ingested from the FSSA OMPP source. Encode the
-    source-law SAPN eligibility and benefit-calculation rules before classifying comparability with PolicyEngine's final
-    `in_ssp` person-level surface.
+  rationale: Axiom encodes the Indiana Code SAPN personal-needs allowance and facility-resident supplement framework,
+    plus FSSA Medicaid Policy Manual Chapter 5000 SAPN eligibility and benefit-calculation rules. PolicyEngine's final
+    `in_ssp` person-level surface also composes RCAP, and its SAPN subformula uses PolicyEngine SSI/countable-income
+    proxies rather than the manual's budgeted earned and unearned income inputs, so the final aggregate is reviewed but
+    not a one-to-one oracle target.
+  populace_validation:
+    status: pending_validator
+    rationale: Needs either RCAP RuleSpec coverage plus a final `in_ssp` composition, or a narrower Populace adapter for
+      the SAPN source-law budgeted-income inputs before a meaningful full-surface comparison can run.
 - country: us
   program_id: ssi_state_supplement
   program_name: Massachusetts SSP

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2277,7 +2277,7 @@ def test_policyengine_registry_maps_idaho_aabd_514_maximum_payment_parameters():
         assert mapping.parameter_key == parameter_key
 
 
-def test_policyengine_program_surface_marks_indiana_ssp_pending_rulespec_encoding():
+def test_policyengine_program_surface_marks_indiana_ssp_known_not_comparable():
     report = build_policyengine_program_surface_report(program="in_ssp")
 
     items_by_variable = {item["variable"]: item for item in report["items"]}
@@ -2285,10 +2285,49 @@ def test_policyengine_program_surface_marks_indiana_ssp_pending_rulespec_encodin
 
     assert in_ssp["program_id"] == "ssi_state_supplement"
     assert in_ssp["state"] == "IN"
-    assert in_ssp["axiom_status"] == "pending_rulespec_encoding"
-    assert in_ssp["mapping_count"] == 0
+    assert in_ssp["axiom_status"] == "known_not_comparable"
+    assert in_ssp["mapping_count"] >= 1
+    assert in_ssp["comparable_mapping_count"] == 0
+    assert "us-in:statutes/12-15-32-6/5#in_ssp_sapn" in in_ssp["legal_ids"]
     assert "Indiana Code" in in_ssp["rationale"]
     assert "FSSA Medicaid Policy Manual Chapter 5000" in in_ssp["rationale"]
+    assert "RCAP" in in_ssp["rationale"]
+    assert in_ssp["populace_validation_status"] == "pending_validator"
+
+
+def test_policyengine_registry_maps_indiana_sapn_parameters():
+    registry = load_policyengine_registry()
+
+    pna = registry.mapping_for_legal_id(
+        "us-in:statutes/12-15-32-6#medicaid_facility_resident_personal_allowance_amount",
+        country="us",
+    )
+    assert pna is not None
+    assert pna.program == "ssi_state_supplement"
+    assert pna.mapping_type == "parameter_value"
+    assert (
+        pna.policyengine_parameter == "gov.states.in.fssa.ssp.personal_needs_allowance"
+    )
+
+    maximum = registry.mapping_for_legal_id(
+        "us-in:policies/fssa/medicaid-policy-manual/chapter-5000/5005/05/00#sapn_maximum_benefit_amount",
+        country="us",
+    )
+    assert maximum is not None
+    assert maximum.program == "ssi_state_supplement"
+    assert maximum.mapping_type == "parameter_value"
+    assert (
+        maximum.policyengine_parameter
+        == "gov.states.in.fssa.ssp.sapn.amount.individual"
+    )
+
+    benefit = registry.mapping_for_legal_id(
+        "us-in:policies/fssa/medicaid-policy-manual/chapter-5000/5005/05/00#sapn_benefit_amount",
+        country="us",
+    )
+    assert benefit is not None
+    assert benefit.mapping_type == "not_comparable"
+    assert benefit.policyengine_variable == "in_ssp_sapn"
 
 
 def test_policyengine_program_surface_marks_kansas_sspp_pending_rulespec_encoding():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1139"
+version = "0.2.1140"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- mark Indiana SSP as reviewed/known-not-comparable instead of pending RuleSpec encoding
- add PolicyEngine oracle mappings for Indiana SAPN personal-needs allowance and individual maximum amount parameters
- classify SAPN benefit/final Indiana SSP surfaces as non-comparable where PE uses proxy inputs or adds RCAP
- add coverage tests for the Indiana SAPN metadata

Rulespec companion: TheAxiomFoundation/rulespec-us#546

## Validation
- `/Users/maxghenis/TheAxiomFoundation/axiom-encode/.venv/bin/python -m pytest -q tests/test_policyengine_coverage.py -k "indiana_ssp or indiana_sapn or idaho_aabd"`
- `uv run ruff check src/axiom_encode/oracles/policyengine tests/test_policyengine_coverage.py`
- `/Users/maxghenis/TheAxiomFoundation/axiom-encode/.venv/bin/python -m compileall -q src/axiom_encode/oracles/policyengine`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-in-ssp-20260705 --oracle policyengine --program in_ssp --include-program-surfaces --json`
