### PR TITLE
Classify CHIP FCEP authority outputs for PE coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1140"
+version = "0.2.1141"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1140"
+__version__ = "0.2.1141"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -444,6 +444,22 @@ mappings:
     policyengine_variable: is_chip_eligible_standard_pregnant_person
     rationale: This RuleSpec output is the federal source-level targeted-low-income pregnant woman definition. PolicyEngine exposes final standard pregnant CHIP eligibility after state limits and other category assembly, not this statutory prerequisite as a one-to-one oracle variable.
 
+  - legal_id: us:statutes/42/1397ll/f/1#child_health_assistance_option_through_specified_regulations_not_limited
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    candidate_priority: P4
+    policyengine_variable: is_chip_eligible_child
+    rationale: Section 1397ll(f)(1) preserves state authority to provide child health assistance through specified regulations; it is not itself a person-level CHIP eligibility rule or threshold. PolicyEngine's child CHIP variable represents final person eligibility after state option, category, and income-threshold rules are applied.
+
+  - legal_id: us:statutes/42/1397ll/f/1#pregnancy_related_services_option_through_waiver_authority_not_limited
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    candidate_priority: P4
+    policyengine_variable: is_chip_fcep_eligible_person
+    rationale: Section 1397ll(f)(1) preserves state waiver authority for pregnancy-related services; it does not determine FCEP eligibility for a person. PolicyEngine's FCEP variable is a final eligibility surface that depends on state adoption and income limits from downstream state CHIP authorities.
+
   - legal_id: us:statutes/42/1397ll/f/2#postpartum_continuation_period_days
     country: us
     program: chip

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1255,6 +1255,18 @@ def test_policyengine_registry_resolves_wic_and_chip_eligibility_prefixes():
         assert mapping.mapping_type == "not_comparable"
         assert mapping.policyengine_variable == variable
 
+    expected_exact_mappings = {
+        "us:statutes/42/1397ll/f/1#child_health_assistance_option_through_specified_regulations_not_limited": "is_chip_eligible_child",
+        "us:statutes/42/1397ll/f/1#pregnancy_related_services_option_through_waiver_authority_not_limited": "is_chip_fcep_eligible_person",
+    }
+    for legal_id, variable in expected_exact_mappings.items():
+        mapping = registry.mapping_for_legal_id(legal_id, country="us")
+
+        assert mapping is not None
+        assert mapping.match_type == "exact"
+        assert mapping.mapping_type == "not_comparable"
+        assert mapping.policyengine_variable == variable
+
 
 def test_policyengine_coverage_classifies_uk_vat_act_firm_outputs(tmp_path):
     _write_rulespec_file(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1140"
+version = "0.2.1141"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify the new 42 USC 1397ll(f)(1) CHIP authority outputs as exact not-comparable PolicyEngine mappings
- keep adjacent PE variables visible for triage without treating authority-preservation predicates as final eligibility variables
- add registry coverage assertions for the exact legal IDs

## Validation
- env -u UV_FROZEN uv run --extra dev python -m pytest tests/test_policyengine_coverage.py::test_policyengine_registry_resolves_wic_and_chip_eligibility_prefixes -q
- env -u UV_FROZEN uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q
- env -u UV_FROZEN uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-chip-fcep-aggregate-20260705 --oracle policyengine --program chip --json
- env -u UV_FROZEN uv run python YAML parse for src/axiom_encode/oracles/policyengine/mappings/us.yaml
- git diff --check