### PR TITLE
Generate CHIP FCEP composition from CMS SPA corpus

### DIFF
--- a/changelog.d/chip-fcep-availability-formula.fixed.md
+++ b/changelog.d/chip-fcep-availability-formula.fixed.md
@@ -1,0 +1,1 @@
+Generate CHIP FCEP eligibility formulas only for source-backed FCEP states instead of consuming a same-module availability flag at execution time.

--- a/changelog.d/chip-fcep-derived-availability.fixed.md
+++ b/changelog.d/chip-fcep-derived-availability.fixed.md
@@ -1,0 +1,1 @@
+Generate CHIP FCEP availability as a derived source-backed boolean so FCEP judgment formulas can execute with state-set FPL parameters.

--- a/changelog.d/chip-fcep-negative-coverage.fixed.md
+++ b/changelog.d/chip-fcep-negative-coverage.fixed.md
@@ -1,0 +1,1 @@
+Generate factual negative CHIP FCEP companion coverage so FCEP eligibility rules are covered without stubbing state-set parameters.

--- a/changelog.d/chip-fcep-parameter-input-tests.fixed.md
+++ b/changelog.d/chip-fcep-parameter-input-tests.fixed.md
@@ -1,0 +1,1 @@
+Generate CHIP FCEP companion tests that pass state-set FCEP parameters as inputs when formulas depend on them.

--- a/changelog.d/chip-fcep-parameter-only-tests.fixed.md
+++ b/changelog.d/chip-fcep-parameter-only-tests.fixed.md
@@ -1,0 +1,1 @@
+Generate CHIP FCEP companion tests as source-backed parameter assertions instead of stubbing generated parameter outputs into eligibility tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1144"
+version = "0.2.1145"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1143"
+version = "0.2.1144"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1145"
+version = "0.2.1146"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1148"
+version = "0.2.1149"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1147"
+version = "0.2.1148"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1142"
+version = "0.2.1143"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1146"
+version = "0.2.1147"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1141"
+version = "0.2.1142"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1147"
+__version__ = "0.2.1148"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1146"
+__version__ = "0.2.1147"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1142"
+__version__ = "0.2.1143"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1145"
+__version__ = "0.2.1146"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1141"
+__version__ = "0.2.1142"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1148"
+__version__ = "0.2.1149"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1144"
+__version__ = "0.2.1145"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1143"
+__version__ = "0.2.1144"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -9463,24 +9463,26 @@ def _cms_chip_build_composition_file(
         ]
     )
     if fcep_source is not None:
+        formatted_fcep_raw_limit = _cms_format_rate(fcep_source.raw_fpl_limit)
+        formatted_fcep_effective_limit = _cms_format_rate(
+            fcep_source.raw_fpl_limit + CMS_MAGI_FPL_DISREGARD_RATE
+        )
         test_lines.extend(
             [
                 "",
-                f"- name: {state_slug}_fcep_availability",
+                f"- name: {state_slug}_fcep_effective_limit",
                 "  period:",
                 "    period_kind: custom",
                 "    name: calendar_year",
                 "    start: '2026-01-01'",
                 "    end: '2026-12-31'",
-                "  input: {}",
+                "  input:",
+                f"    {citation}#{fcep_raw_limit}: {formatted_fcep_raw_limit}",
+                f"    {CMS_MAGI_FPL_DISREGARD_TARGET}: "
+                + _cms_format_rate(CMS_MAGI_FPL_DISREGARD_RATE),
                 "  output:",
-                f"    {citation}#{fcep_availability}: true",
-                f"    {citation}#{fcep_raw_limit}: "
-                + _cms_format_rate(fcep_source.raw_fpl_limit),
                 f"    {citation}#{fcep_effective_limit}: "
-                + _cms_format_rate(
-                    fcep_source.raw_fpl_limit + CMS_MAGI_FPL_DISREGARD_RATE
-                ),
+                + formatted_fcep_effective_limit,
                 "",
                 f"- name: {state_slug}_fcep_eligible_under_source_limit",
                 "  period:",
@@ -9493,6 +9495,10 @@ def _cms_chip_build_composition_file(
                 f"    {citation}#input.medicaid_income_level: 0.00",
                 f"    {citation}#input."
                 "found_eligible_for_medical_assistance_under_subchapter_xix: false",
+                f"    {citation}#{fcep_availability}: true",
+                f"    {citation}#{fcep_raw_limit}: {formatted_fcep_raw_limit}",
+                f"    {CMS_MAGI_FPL_DISREGARD_TARGET}: "
+                + _cms_format_rate(CMS_MAGI_FPL_DISREGARD_RATE),
                 "  output:",
                 f"    {citation}#is_chip_fcep_eligible_person: holds",
             ]

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -8858,9 +8858,7 @@ def _cms_chip_fcep_text_segments(body: str) -> list[str]:
     segments: list[str] = []
     for part in re.split(r"(?<=[.;])\s+", normalized):
         if len(part) > 900:
-            segments.extend(
-                re.split(r"(?=\d+\.\d+(?:\.\d+)?(?:-[A-Z]+)?\s)", part)
-            )
+            segments.extend(re.split(r"(?=\d+\.\d+(?:\.\d+)?(?:-[A-Z]+)?\s)", part))
         else:
             segments.append(part)
     return [segment.strip() for segment in segments if segment.strip()]
@@ -8890,8 +8888,10 @@ def _cms_chip_fcep_segment_score(
     if "/summary/block-" in citation_path:
         score += 230
     page_number = metadata.get("page_number")
-    if isinstance(page_number, int) and page_number <= 2 and any(
-        marker in lowered for marker in ("approved", "amendment", "spa")
+    if (
+        isinstance(page_number, int)
+        and page_number <= 2
+        and any(marker in lowered for marker in ("approved", "amendment", "spa"))
     ):
         score += 170
 
@@ -8942,9 +8942,7 @@ def _cms_chip_fcep_segment_score(
         score += 25
     if "title xxi" in lowered or "chip" in lowered:
         score += 15
-    if any(
-        marker in lowered for marker in ("premium", "copayment", "cost sharing")
-    ):
+    if any(marker in lowered for marker in ("premium", "copayment", "cost sharing")):
         score -= 55
     if any(
         marker in lowered
@@ -9314,12 +9312,9 @@ def _cms_chip_build_composition_file(
             "and not found_eligible_for_medical_assistance_under_subchapter_xix\n"
             f"and medicaid_income_level <= {fcep_effective_limit}"
         )
-        fcep_atoms = (
-            fcep_source_atom
-            + _cms_chip_formula_source_atom(
-                corpus_citation_path=CMS_CHIP_FCEP_FORMULA_CORPUS_PATH,
-                excerpt="through the application of sections 457.10",
-            )
+        fcep_atoms = fcep_source_atom + _cms_chip_formula_source_atom(
+            corpus_citation_path=CMS_CHIP_FCEP_FORMULA_CORPUS_PATH,
+            excerpt="through the application of sections 457.10",
         )
         rules.append(
             _cms_chip_composition_rule_block(

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -9311,7 +9311,6 @@ def _cms_chip_build_composition_file(
         )
         fcep_formula = (
             "person_is_pregnant\n"
-            f"and {fcep_availability}\n"
             "and not found_eligible_for_medical_assistance_under_subchapter_xix\n"
             f"and medicaid_income_level <= {fcep_effective_limit}"
         )

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -9482,6 +9482,20 @@ def _cms_chip_build_composition_file(
                 f"    {citation}#{fcep_raw_limit}: {formatted_fcep_raw_limit}",
                 f"    {citation}#{fcep_effective_limit}: "
                 + formatted_fcep_effective_limit,
+                "",
+                f"- name: {state_slug}_fcep_not_pregnant",
+                "  period:",
+                "    period_kind: custom",
+                "    name: calendar_year",
+                "    start: '2026-01-01'",
+                "    end: '2026-12-31'",
+                "  input:",
+                f"    {citation}#input.person_is_pregnant: false",
+                f"    {citation}#input.medicaid_income_level: 0.00",
+                f"    {citation}#input."
+                "found_eligible_for_medical_assistance_under_subchapter_xix: false",
+                "  output:",
+                f"    {citation}#is_chip_fcep_eligible_person: not_holds",
             ]
         )
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -9262,7 +9262,6 @@ def _cms_chip_build_composition_file(
             _cms_chip_composition_rule_block(
                 name=fcep_availability,
                 source=f"CMS CHIP FCEP SPA source, {state_name}",
-                kind="parameter",
                 dtype="Boolean",
                 entity=None,
                 proof_atoms=fcep_source_atom,
@@ -9496,6 +9495,20 @@ def _cms_chip_build_composition_file(
                 "found_eligible_for_medical_assistance_under_subchapter_xix: false",
                 "  output:",
                 f"    {citation}#is_chip_fcep_eligible_person: not_holds",
+                "",
+                f"- name: {state_slug}_fcep_eligible_under_source_limit",
+                "  period:",
+                "    period_kind: custom",
+                "    name: calendar_year",
+                "    start: '2026-01-01'",
+                "    end: '2026-12-31'",
+                "  input:",
+                f"    {citation}#input.person_is_pregnant: true",
+                f"    {citation}#input.medicaid_income_level: 0.00",
+                f"    {citation}#input."
+                "found_eligible_for_medical_assistance_under_subchapter_xix: false",
+                "  output:",
+                f"    {citation}#is_chip_fcep_eligible_person: holds",
             ]
         )
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -9476,31 +9476,12 @@ def _cms_chip_build_composition_file(
                 "    name: calendar_year",
                 "    start: '2026-01-01'",
                 "    end: '2026-12-31'",
-                "  input:",
-                f"    {citation}#{fcep_raw_limit}: {formatted_fcep_raw_limit}",
-                f"    {CMS_MAGI_FPL_DISREGARD_TARGET}: "
-                + _cms_format_rate(CMS_MAGI_FPL_DISREGARD_RATE),
+                "  input: {}",
                 "  output:",
-                f"    {citation}#{fcep_effective_limit}: "
-                + formatted_fcep_effective_limit,
-                "",
-                f"- name: {state_slug}_fcep_eligible_under_source_limit",
-                "  period:",
-                "    period_kind: custom",
-                "    name: calendar_year",
-                "    start: '2026-01-01'",
-                "    end: '2026-12-31'",
-                "  input:",
-                f"    {citation}#input.person_is_pregnant: true",
-                f"    {citation}#input.medicaid_income_level: 0.00",
-                f"    {citation}#input."
-                "found_eligible_for_medical_assistance_under_subchapter_xix: false",
                 f"    {citation}#{fcep_availability}: true",
                 f"    {citation}#{fcep_raw_limit}: {formatted_fcep_raw_limit}",
-                f"    {CMS_MAGI_FPL_DISREGARD_TARGET}: "
-                + _cms_format_rate(CMS_MAGI_FPL_DISREGARD_RATE),
-                "  output:",
-                f"    {citation}#is_chip_fcep_eligible_person: holds",
+                f"    {citation}#{fcep_effective_limit}: "
+                + formatted_fcep_effective_limit,
             ]
         )
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -2042,6 +2042,17 @@ def main():
         ),
     )
     generate_cms_chip_composition_parser.add_argument(
+        "--fcep-corpus-jsonl",
+        type=Path,
+        default=None,
+        help=(
+            "Optional official CMS CHIP FCEP SPA provisions JSONL. When "
+            "provided, state CHIP composition files include source-backed "
+            "FCEP availability and income-limit rules for states with a "
+            "matched FCEP threshold."
+        ),
+    )
+    generate_cms_chip_composition_parser.add_argument(
         "--overwrite-existing",
         action="store_true",
         help="Replace existing state CHIP eligibility composition files",
@@ -8167,6 +8178,15 @@ class _CmsGeneratedChipCompositionFile(NamedTuple):
     test_content: str
 
 
+class _CmsChipFcepSource(NamedTuple):
+    state_code: str
+    raw_fpl_limit: Decimal
+    effective_from: str
+    corpus_citation_path: str
+    excerpt: str
+    score: int
+
+
 class _CmsEligibilityHtmlTableParser(HTMLParser):
     """Extract the first HTML table while ignoring footnote superscripts."""
 
@@ -8651,6 +8671,12 @@ CMS_CHIP_CHILD_SOURCE_RELATIVE = (
 CMS_CHIP_CHILD_TARGET = "us:statutes/42/1397jj/c/1#child"
 CMS_CHIP_CHILD_FORMULA_CORPUS_PATH = "us/statute/42/1397jj/b/1"
 CMS_CHIP_PREGNANT_FORMULA_CORPUS_PATH = "us/statute/42/1397ll/d/2"
+CMS_CHIP_FCEP_FORMULA_CORPUS_PATH = "us/statute/42/1397ll/f/1"
+CMS_CHIP_FCEP_DEFINITION_CORPUS_PATH = "us/regulation/42/457/10"
+CMS_CHIP_FCEP_PERCENT_PATTERN = re.compile(
+    r"(\d+(?:\.\d+)?)\s*(?:%|percent)",
+    re.IGNORECASE,
+)
 
 
 def _cms_state_code_aliases() -> dict[str, str]:
@@ -8779,12 +8805,14 @@ def _cms_chip_composition_rule_block(
     source: str,
     proof_atoms: str,
     formula: str,
+    kind: str = "derived",
     dtype: str = "Judgment",
     entity: str | None = "Person",
+    effective_from: str = CMS_MEDICAID_CHIP_EFFECTIVE_DATE,
 ) -> str:
     entity_line = f"    entity: {entity}\n" if entity else ""
     return f"""  - name: {name}
-    kind: derived
+    kind: {kind}
 {entity_line}    dtype: {dtype}
     period: Year
     source: {source}
@@ -8793,16 +8821,248 @@ def _cms_chip_composition_rule_block(
         atoms:
 {proof_atoms.rstrip()}
     versions:
-      - effective_from: '{CMS_MEDICAID_CHIP_EFFECTIVE_DATE}'
+      - effective_from: '{effective_from}'
         formula: |-
 {_indent_block(formula, 10)}
 """
+
+
+def _cms_chip_fcep_record_state_code(record: dict[str, Any]) -> str | None:
+    metadata = record.get("metadata")
+    if isinstance(metadata, dict):
+        code = str(metadata.get("state_abbr") or "").strip().upper()
+        if code:
+            return code
+    citation_path = str(record.get("citation_path") or "")
+    match = re.search(r"/chip-spa/([a-z]{2})/", citation_path)
+    if match:
+        return match.group(1).upper()
+    return None
+
+
+def _cms_chip_fcep_effective_from(record: dict[str, Any]) -> str:
+    metadata = record.get("metadata")
+    if isinstance(metadata, dict):
+        for key in ("effective_date", "approval_date"):
+            value = str(metadata.get(key) or "").strip()
+            if re.fullmatch(r"\d{4}-\d{2}-\d{2}", value):
+                return value
+    value = str(record.get("expression_date") or "").strip()
+    if re.fullmatch(r"\d{4}-\d{2}-\d{2}", value):
+        return value
+    return CMS_MEDICAID_CHIP_EFFECTIVE_DATE
+
+
+def _cms_chip_fcep_text_segments(body: str) -> list[str]:
+    normalized = _cms_normalize_cell_text(body)
+    segments: list[str] = []
+    for part in re.split(r"(?<=[.;])\s+", normalized):
+        if len(part) > 900:
+            segments.extend(
+                re.split(r"(?=\d+\.\d+(?:\.\d+)?(?:-[A-Z]+)?\s)", part)
+            )
+        else:
+            segments.append(part)
+    return [segment.strip() for segment in segments if segment.strip()]
+
+
+def _cms_chip_fcep_segment_score(
+    *,
+    segment: str,
+    citation_path: str,
+    metadata: dict[str, Any],
+) -> int:
+    lowered = segment.lower()
+    if not any(
+        marker in lowered
+        for marker in (
+            "fpl",
+            "fpf",
+            "federal poverty",
+            "poverty guideline",
+            "poverty level",
+        )
+    ):
+        return 0
+
+    score = 0
+    anchor_score = 0
+    if "/summary/block-" in citation_path:
+        score += 230
+    page_number = metadata.get("page_number")
+    if isinstance(page_number, int) and page_number <= 2 and any(
+        marker in lowered for marker in ("approved", "amendment", "spa")
+    ):
+        score += 170
+
+    anchors = (
+        ("fcep", 180),
+        ("from-conception-to", 160),
+        ("from conception to", 160),
+        ("from conception through", 160),
+        ("from conception to the end of pregnancy", 160),
+        ("coverage from conception to birth", 160),
+        ("conception to birth", 125),
+        ("conception through birth", 125),
+        ("unborn child option", 145),
+        ("unborn option", 145),
+        ("unborn children", 120),
+        ("unborn child", 120),
+        ("unborn-chip", 120),
+        ("4.1.3.1-pc", 100),
+        ("famis prenatal", 90),
+        ("soon-to-be-sooners", 90),
+        ("show-me healthy babies", 90),
+        ("mcap", 90),
+    )
+    for marker, weight in anchors:
+        if marker in lowered:
+            score += weight
+            anchor_score += weight
+
+    if anchor_score == 0:
+        return 0
+    if "pregnant" in lowered:
+        score += 35
+    if "income" in lowered or "incomes" in lowered:
+        score += 45
+    if any(
+        marker in lowered
+        for marker in (
+            "not otherwise eligible for medicaid",
+            "not eligible for medicaid",
+            "ineligible for medicaid",
+        )
+    ):
+        score += 55
+    if any(
+        marker in lowered
+        for marker in ("up to", "through", "including", "less than or equal")
+    ):
+        score += 25
+    if "title xxi" in lowered or "chip" in lowered:
+        score += 15
+    if any(
+        marker in lowered for marker in ("premium", "copayment", "cost sharing")
+    ):
+        score -= 55
+    if any(
+        marker in lowered
+        for marker in (
+            "birth through eighteen",
+            "children birth to",
+            "targeted low-income children",
+            "children ages 0 to 19",
+        )
+    ):
+        score -= 80
+    if (
+        "as described in appendix" in lowered
+        and "unborn children (conception to birth)" not in lowered
+    ):
+        score -= 80
+    return score
+
+
+def _cms_chip_fcep_source_excerpt(segment: str) -> str:
+    excerpt = _cms_normalize_cell_text(segment)
+    if len(excerpt) <= 500:
+        return excerpt
+    return excerpt[:497].rstrip() + "..."
+
+
+def _cms_chip_fcep_sources_from_jsonl(path: Path) -> dict[str, _CmsChipFcepSource]:
+    if not path.exists():
+        raise RuntimeError(f"CMS CHIP FCEP corpus JSONL not found: {path}")
+
+    candidates: dict[str, list[_CmsChipFcepSource]] = defaultdict(list)
+    for line_number, line in enumerate(path.read_text().splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"Invalid CMS CHIP FCEP corpus JSONL at line {line_number}: {exc}"
+            ) from exc
+        if not isinstance(record, dict):
+            continue
+        state_code = _cms_chip_fcep_record_state_code(record)
+        if not state_code:
+            continue
+        body = str(record.get("body") or "")
+        if not body.strip():
+            continue
+        metadata = record.get("metadata")
+        if not isinstance(metadata, dict):
+            metadata = {}
+        citation_path = str(record.get("citation_path") or "").strip()
+        if not citation_path:
+            continue
+        effective_from = _cms_chip_fcep_effective_from(record)
+        segments = _cms_chip_fcep_text_segments(body)
+        for index, segment in enumerate(segments):
+            scoring_segment = segment
+            if index:
+                scoring_segment = f"{segments[index - 1]} {segment}"
+            raw_percentages = [
+                Decimal(match)
+                for match in CMS_CHIP_FCEP_PERCENT_PATTERN.findall(segment)
+            ]
+            percentages = [
+                value
+                for value in raw_percentages
+                if Decimal("0") < value <= Decimal("500")
+            ]
+            if not percentages:
+                continue
+            score = _cms_chip_fcep_segment_score(
+                segment=scoring_segment,
+                citation_path=citation_path,
+                metadata=metadata,
+            )
+            if score < 60:
+                continue
+            candidates[state_code].append(
+                _CmsChipFcepSource(
+                    state_code=state_code,
+                    raw_fpl_limit=max(percentages) / Decimal("100"),
+                    effective_from=effective_from,
+                    corpus_citation_path=citation_path,
+                    excerpt=_cms_chip_fcep_source_excerpt(segment),
+                    score=score,
+                )
+            )
+
+    best_by_state: dict[str, _CmsChipFcepSource] = {}
+    for state_code, state_candidates in candidates.items():
+        state_candidates.sort(
+            key=lambda source: (
+                source.score,
+                source.effective_from,
+                source.raw_fpl_limit,
+            ),
+            reverse=True,
+        )
+        best = state_candidates[0]
+        same_limit = [
+            source
+            for source in state_candidates
+            if source.raw_fpl_limit == best.raw_fpl_limit
+        ]
+        same_limit.sort(
+            key=lambda source: (source.effective_from, source.score),
+            reverse=True,
+        )
+        best_by_state[state_code] = same_limit[0]
+    return best_by_state
 
 
 def _cms_chip_build_composition_file(
     *,
     repo_path: Path,
     cms_relative_output: Path,
+    fcep_source: _CmsChipFcepSource | None = None,
 ) -> _CmsGeneratedChipCompositionFile:
     cms_file = repo_path / cms_relative_output
     rules_by_name = _cms_rule_names_by_name(cms_file.read_text())
@@ -8822,6 +9082,9 @@ def _cms_chip_build_composition_file(
     child_availability = f"{state_slug}_separate_chip_child_eligibility_available"
     pregnant_limit = f"{state_slug}_pregnant_women_chip_fpl_limit"
     pregnant_availability = f"{state_slug}_standard_pregnant_chip_eligibility_available"
+    fcep_availability = f"{state_slug}_fcep_eligibility_available"
+    fcep_raw_limit = f"{state_slug}_fcep_fpl_limit"
+    fcep_effective_limit = f"{state_slug}_fcep_effective_fpl_limit"
 
     imports = []
     if child_limit in rules_by_name:
@@ -8839,6 +9102,16 @@ def _cms_chip_build_composition_file(
         and source_pregnant_availability in rules_by_name
     ):
         imports.append(f"{cms_target}#{source_pregnant_availability}")
+    magi_disregard_hash = None
+    if fcep_source is not None:
+        magi_disregard_file = repo_path / CMS_MAGI_FPL_DISREGARD_RELATIVE_OUTPUT
+        if not magi_disregard_file.exists():
+            raise RuntimeError(
+                "Required CMS MAGI disregard RuleSpec file not found: "
+                f"{magi_disregard_file}"
+            )
+        magi_disregard_hash = _sha256_file(magi_disregard_file)
+        imports.append(CMS_MAGI_FPL_DISREGARD_TARGET)
 
     rules: list[str] = []
     if child_limit in rules_by_name:
@@ -8980,6 +9253,118 @@ def _cms_chip_build_composition_file(
         )
     )
 
+    if fcep_source is not None:
+        fcep_source_atom = _cms_chip_formula_source_atom(
+            corpus_citation_path=fcep_source.corpus_citation_path,
+            excerpt=fcep_source.excerpt,
+        )
+        rules.append(
+            _cms_chip_composition_rule_block(
+                name=fcep_availability,
+                source=f"CMS CHIP FCEP SPA source, {state_name}",
+                kind="parameter",
+                dtype="Boolean",
+                entity=None,
+                proof_atoms=fcep_source_atom,
+                formula="true",
+                effective_from=fcep_source.effective_from,
+            )
+        )
+        rules.append(
+            _cms_chip_composition_rule_block(
+                name=fcep_raw_limit,
+                source=f"CMS CHIP FCEP SPA source, {state_name}",
+                kind="parameter",
+                dtype="Rate",
+                entity=None,
+                proof_atoms=fcep_source_atom,
+                formula=_cms_format_rate(fcep_source.raw_fpl_limit),
+                effective_from=fcep_source.effective_from,
+            )
+        )
+        if magi_disregard_hash is None:
+            raise RuntimeError("Internal error: missing MAGI disregard hash")
+        fcep_effective_atoms = (
+            _cms_chip_import_atom(
+                target=CMS_MAGI_FPL_DISREGARD_TARGET,
+                output="magi_fpl_disregard_rate",
+                digest=magi_disregard_hash,
+            )
+            + _cms_chip_formula_source_atom(
+                corpus_citation_path="us/regulation/42/435/603/d",
+                excerpt="5 percentage points of the Federal poverty level",
+            )
+            + fcep_source_atom
+        )
+        rules.append(
+            _cms_chip_composition_rule_block(
+                name=fcep_effective_limit,
+                source=(
+                    f"CMS CHIP FCEP SPA source, {state_name}, including the "
+                    "MAGI 5% FPL disregard"
+                ),
+                dtype="Rate",
+                entity=None,
+                proof_atoms=fcep_effective_atoms,
+                formula=f"{fcep_raw_limit} + magi_fpl_disregard_rate",
+                effective_from=fcep_source.effective_from,
+            )
+        )
+        fcep_formula = (
+            "person_is_pregnant\n"
+            f"and {fcep_availability}\n"
+            "and not found_eligible_for_medical_assistance_under_subchapter_xix\n"
+            f"and medicaid_income_level <= {fcep_effective_limit}"
+        )
+        fcep_atoms = (
+            fcep_source_atom
+            + _cms_chip_formula_source_atom(
+                corpus_citation_path=CMS_CHIP_FCEP_FORMULA_CORPUS_PATH,
+                excerpt="through the application of sections 457.10",
+            )
+        )
+        rules.append(
+            _cms_chip_composition_rule_block(
+                name="is_chip_fcep_eligible_person",
+                source=(
+                    "42 USC 1397ll(f)(1), 42 CFR 457.10, and CMS CHIP "
+                    f"FCEP SPA source for {state_name}"
+                ),
+                proof_atoms=fcep_atoms,
+                formula=fcep_formula,
+                effective_from=fcep_source.effective_from,
+            )
+        )
+
+    source_verification_paths = [
+        CMS_ELIGIBILITY_LEVELS_CORPUS_PATH,
+        CMS_CHIP_CHILD_FORMULA_CORPUS_PATH,
+        CMS_CHIP_PREGNANT_FORMULA_CORPUS_PATH,
+    ]
+    summary = (
+        f"{state_name} CHIP eligibility composition applies the federal CHIP "
+        "child and standard-pregnant eligibility framework to the CMS state "
+        "eligibility-level outputs."
+    )
+    if fcep_source is not None:
+        source_verification_paths.extend(
+            [
+                fcep_source.corpus_citation_path,
+                CMS_CHIP_FCEP_FORMULA_CORPUS_PATH,
+                CMS_CHIP_FCEP_DEFINITION_CORPUS_PATH,
+                "us/regulation/42/435/603/d",
+            ]
+        )
+        summary += (
+            " It also applies the CMS CHIP FCEP SPA source for state-set "
+            "coverage from conception to birth income eligibility."
+        )
+    else:
+        summary += (
+            " It intentionally does not encode FCEP state income limits until "
+            "primary state-plan or CMS source coverage is available."
+        )
+
     rules_content = (
         "format: rulespec/v1\n"
         "imports:\n"
@@ -8989,12 +9374,10 @@ def _cms_chip_build_composition_file(
         + "    required: true\n"
         + "  source_verification:\n"
         + "    corpus_citation_paths:\n"
-        + f"      - {CMS_ELIGIBILITY_LEVELS_CORPUS_PATH}\n"
-        + f"      - {CMS_CHIP_CHILD_FORMULA_CORPUS_PATH}\n"
-        + f"      - {CMS_CHIP_PREGNANT_FORMULA_CORPUS_PATH}\n"
+        + "".join(f"      - {path}\n" for path in source_verification_paths)
         + f"{CMS_ELIGIBILITY_LEVELS_UPSTREAM_SOURCE_CHECK_BLOCK}"
         + "  summary: |-\n"
-        + f"    {state_name} CHIP eligibility composition applies the federal CHIP child and standard-pregnant eligibility framework to the CMS state eligibility-level outputs. It intentionally does not encode FCEP state income limits until primary state-plan or CMS source coverage is available.\n"
+        + f"    {summary}\n"
         + "rules:\n"
         + "\n".join(rule.rstrip() for rule in rules)
         + "\n"
@@ -9079,6 +9462,41 @@ def _cms_chip_build_composition_file(
             + ("holds" if pregnant_limit in rules_by_name else "not_holds"),
         ]
     )
+    if fcep_source is not None:
+        test_lines.extend(
+            [
+                "",
+                f"- name: {state_slug}_fcep_availability",
+                "  period:",
+                "    period_kind: custom",
+                "    name: calendar_year",
+                "    start: '2026-01-01'",
+                "    end: '2026-12-31'",
+                "  input: {}",
+                "  output:",
+                f"    {citation}#{fcep_availability}: true",
+                f"    {citation}#{fcep_raw_limit}: "
+                + _cms_format_rate(fcep_source.raw_fpl_limit),
+                f"    {citation}#{fcep_effective_limit}: "
+                + _cms_format_rate(
+                    fcep_source.raw_fpl_limit + CMS_MAGI_FPL_DISREGARD_RATE
+                ),
+                "",
+                f"- name: {state_slug}_fcep_eligible_under_source_limit",
+                "  period:",
+                "    period_kind: custom",
+                "    name: calendar_year",
+                "    start: '2026-01-01'",
+                "    end: '2026-12-31'",
+                "  input:",
+                f"    {citation}#input.person_is_pregnant: true",
+                f"    {citation}#input.medicaid_income_level: 0.00",
+                f"    {citation}#input."
+                "found_eligible_for_medical_assistance_under_subchapter_xix: false",
+                "  output:",
+                f"    {citation}#is_chip_fcep_eligible_person: holds",
+            ]
+        )
 
     return _CmsGeneratedChipCompositionFile(
         relative_output=relative_output,
@@ -11048,6 +11466,17 @@ def cmd_generate_cms_chip_eligibility_composition(args):
         print(f"Required CHIP child statute RuleSpec file not found: {child_source}")
         sys.exit(1)
 
+    fcep_sources: dict[str, _CmsChipFcepSource] = {}
+    fcep_corpus_jsonl = getattr(args, "fcep_corpus_jsonl", None)
+    if fcep_corpus_jsonl is not None:
+        try:
+            fcep_sources = _cms_chip_fcep_sources_from_jsonl(
+                Path(fcep_corpus_jsonl).resolve()
+            )
+        except RuntimeError as exc:
+            print(str(exc))
+            sys.exit(1)
+
     cms_state_files = _cms_existing_state_eligibility_files(repo_path)
     selected = [
         relative
@@ -11064,6 +11493,9 @@ def cmd_generate_cms_chip_eligibility_composition(args):
             _cms_chip_build_composition_file(
                 repo_path=repo_path,
                 cms_relative_output=relative,
+                fcep_source=fcep_sources.get(
+                    _cms_state_code_from_relative_output(relative)
+                ),
             )
             for relative in selected
         ]

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -8974,6 +8974,34 @@ _MEDICAID_MAGI_SINGLE_INCOME_HELPER_FORMULA_PATTERN = re.compile(
     r"^[A-Za-z_][A-Za-z0-9_]*(?:income|magi|fpl)[A-Za-z0-9_]*(?:\s*\([^()]*\))?$",
     flags=re.IGNORECASE,
 )
+_CHIP_PERSON_ELIGIBILITY_CONTEXT_PATTERN = re.compile(
+    r"\b(?:unborn\s+children?|pregnant\s+(?:individuals?|woman|women)|"
+    r"birth\s+parents?|targeted\s+low-income\s+(?:children?|pregnant\s+women)|"
+    r"children?|from[-\s]conception[-\s]to[-\s](?:birth|end[-\s]of[-\s]pregnancy)|"
+    r"fcep)\b"
+    r"[\s\S]{0,700}\b(?:family|families|household)s?\s+income[s]?\b"
+    r"|"
+    r"\b(?:family|families|household)s?\s+income[s]?\b"
+    r"[\s\S]{0,700}\b(?:unborn\s+children?|pregnant\s+(?:individuals?|woman|women)|"
+    r"birth\s+parents?|targeted\s+low-income\s+(?:children?|pregnant\s+women)|"
+    r"children?|from[-\s]conception[-\s]to[-\s](?:birth|end[-\s]of[-\s]pregnancy)|"
+    r"fcep)\b",
+    flags=re.IGNORECASE,
+)
+_CHIP_RULE_CITATION_PATTERN = re.compile(
+    r"\b42\s*(?:USC|U\.?\s*S\.?\s*C\.?)\s*(?:§\s*)?1397j[jl]\b"
+    r"|"
+    r"\bus/statute/42/1397j[jl]\b"
+    r"|"
+    r"\b42\s*(?:CFR|C\.?\s*F\.?\s*R\.?)\s*(?:§\s*)?457\.\d+\b"
+    r"|"
+    r"\bus/regulation/42/457/\d+\b",
+    flags=re.IGNORECASE,
+)
+_CHIP_ELIGIBILITY_RULE_NAME_PATTERN = re.compile(
+    r"(?=.*(?:^|_)chip(?:_|$))(?=.*(?:^|_)(?:eligible|eligibility)(?:_|$))",
+    flags=re.IGNORECASE,
+)
 _FORMULA_BOOLEAN_CONNECTIVE_PATTERN = re.compile(
     r"\b(?:and|or|not)\b",
     flags=re.IGNORECASE,
@@ -9219,6 +9247,38 @@ def _person_rule_can_use_unit_scoped_medicaid_magi_source(
     )
 
 
+def _person_rule_can_use_unit_scoped_chip_income_source(
+    rule: dict[str, Any],
+    *,
+    fallback_source_text: str,
+) -> bool:
+    """Allow CHIP person eligibility to include family or household income."""
+    name = str(rule.get("name") or "")
+    if not _CHIP_ELIGIBILITY_RULE_NAME_PATTERN.search(name):
+        return False
+    if _MEDICAID_MAGI_INCOME_HELPER_RULE_NAME_PATTERN.search(name):
+        return False
+    if str(rule.get("dtype") or "").strip().lower() != "judgment":
+        return False
+    if _medicaid_magi_rule_has_income_only_formula(rule):
+        return False
+    if not _medicaid_magi_rule_has_income_formula_reference(rule):
+        return False
+    proof_contexts = _rule_proof_source_contexts(rule)
+    citation_context = "\n".join(
+        [
+            str(rule.get("source") or ""),
+            *(text for _key, text in proof_contexts),
+        ]
+    )
+    if not _CHIP_RULE_CITATION_PATTERN.search(citation_context):
+        return False
+    proof_excerpts = [text for key, text in proof_contexts if key == "excerpt"]
+    classified_texts = proof_excerpts or [fallback_source_text]
+    eligibility_context = "\n".join([*classified_texts, fallback_source_text])
+    return bool(_CHIP_PERSON_ELIGIBILITY_CONTEXT_PATTERN.search(eligibility_context))
+
+
 def _medicaid_magi_rule_has_income_only_formula(rule: dict[str, Any]) -> bool:
     versions = rule.get("versions")
     if not isinstance(versions, list):
@@ -9377,6 +9437,11 @@ def find_source_scope_consistency_issues(content: str) -> list[str]:
             )
         elif source_scope == _SOURCE_SCOPE_UNIT and normalized_entity == "person":
             if _person_rule_can_use_unit_scoped_medicaid_magi_source(
+                rule,
+                fallback_source_text=source_text,
+            ):
+                continue
+            if _person_rule_can_use_unit_scoped_chip_income_source(
                 rule,
                 fallback_source_text=source_text,
             ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11463,14 +11463,56 @@ rules:
           2.60
 """
         )
+        shared_cms_file = (
+            policy_repo / "us/policies/cms/medicaid-chip-bhp-eligibility-levels.yaml"
+        )
+        shared_cms_file.parent.mkdir(parents=True)
+        shared_cms_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: magi_fpl_disregard_rate
+    kind: parameter
+    dtype: Rate
+    source: 42 CFR 435.603(d)(4)
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          0.05
+"""
+        )
         _git(policy_repo, "add", ".")
         _git(policy_repo, "commit", "-m", "initial")
+
+        fcep_corpus_jsonl = tmp_path / "cms-chip-fcep.jsonl"
+        fcep_corpus_jsonl.write_text(
+            json.dumps(
+                {
+                    "body": (
+                        "Through this SPA, Colorado extends CHIP eligibility "
+                        "for children from conception to birth with family "
+                        "incomes up to 260 percent of the federal poverty "
+                        "level (FPL) whose parents are not otherwise eligible "
+                        "for Medicaid."
+                    ),
+                    "citation_path": (
+                        "us/policy/cms/chip-spa/co/co-24-0001/summary/block-1"
+                    ),
+                    "expression_date": "2024-01-01",
+                    "metadata": {
+                        "effective_date": "2024-01-01",
+                        "state_abbr": "CO",
+                    },
+                }
+            )
+            + "\n"
+        )
 
         target = policy_repo / "us-co/policies/cms/colorado-chip-eligibility.yaml"
         test_file = target.with_name("colorado-chip-eligibility.test.yaml")
         args = SimpleNamespace(
             repo=policy_repo,
             states=["CO"],
+            fcep_corpus_jsonl=fcep_corpus_jsonl,
             overwrite_existing=False,
             axiom_rules_path=tmp_path / "axiom-rules-engine",
         )
@@ -11509,8 +11551,16 @@ rules:
             "us/form/cms/medicaid-chip-bhp-eligibility-levels",
             "us/statute/42/1397jj/b/1",
             "us/statute/42/1397ll/d/2",
+            "us/policy/cms/chip-spa/co/co-24-0001/summary/block-1",
+            "us/statute/42/1397ll/f/1",
+            "us/regulation/42/457/10",
+            "us/regulation/42/435/603/d",
         ]
         assert "us:statutes/42/1397jj/c/1#child" in rules_content
+        assert (
+            "us:policies/cms/medicaid-chip-bhp-eligibility-levels"
+            "#magi_fpl_disregard_rate" in rules_content
+        )
         assert (
             "us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels"
             "#colorado_children_separate_chip_effective_fpl_limit" in rules_content
@@ -11521,7 +11571,10 @@ rules:
         )
         assert "is_chip_eligible_child" in rules_content
         assert "is_chip_eligible_standard_pregnant_person" in rules_content
-        assert "is_chip_fcep_eligible_person" not in rules_content
+        assert "colorado_fcep_eligibility_available" in rules_content
+        assert "colorado_fcep_fpl_limit" in rules_content
+        assert "colorado_fcep_effective_fpl_limit" in rules_content
+        assert "is_chip_fcep_eligible_person" in rules_content
         assert "name: is_chip_eligible\n" not in rules_content
         assert (
             "medicaid_income_level <= "
@@ -11532,7 +11585,11 @@ rules:
             in rules_content
         )
         assert (
-            "It intentionally does not encode FCEP state income limits" in rules_content
+            "medicaid_income_level <= colorado_fcep_effective_fpl_limit"
+            in rules_content
+        )
+        assert (
+            "It also applies the CMS CHIP FCEP SPA source" in rules_content
         )
 
         test_content = test_file.read_text()
@@ -11543,6 +11600,22 @@ rules:
         assert (
             "us-co:policies/cms/colorado-chip-eligibility"
             "#is_chip_eligible_standard_pregnant_person: holds" in test_content
+        )
+        assert (
+            "us-co:policies/cms/colorado-chip-eligibility"
+            "#colorado_fcep_raw_fpl_limit: 2.60" not in test_content
+        )
+        assert (
+            "us-co:policies/cms/colorado-chip-eligibility"
+            "#colorado_fcep_fpl_limit: 2.60" in test_content
+        )
+        assert (
+            "us-co:policies/cms/colorado-chip-eligibility"
+            "#colorado_fcep_effective_fpl_limit: 2.65" in test_content
+        )
+        assert (
+            "us-co:policies/cms/colorado-chip-eligibility"
+            "#is_chip_fcep_eligible_person: holds" in test_content
         )
 
         manifest = (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11621,6 +11621,10 @@ rules:
             "us-co:policies/cms/colorado-chip-eligibility"
             "#is_chip_fcep_eligible_person: holds" not in test_content
         )
+        assert (
+            "us-co:policies/cms/colorado-chip-eligibility"
+            "#is_chip_fcep_eligible_person: not_holds" in test_content
+        )
 
         manifest = (
             policy_repo

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11619,11 +11619,7 @@ rules:
         )
         assert (
             "us-co:policies/cms/colorado-chip-eligibility"
-            "#is_chip_fcep_eligible_person: holds" not in test_content
-        )
-        assert (
-            "us-co:policies/cms/colorado-chip-eligibility"
-            "#is_chip_fcep_eligible_person: not_holds" in test_content
+            "#is_chip_fcep_eligible_person: holds" in test_content
         )
 
         manifest = (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11588,9 +11588,7 @@ rules:
             "medicaid_income_level <= colorado_fcep_effective_fpl_limit"
             in rules_content
         )
-        assert (
-            "It also applies the CMS CHIP FCEP SPA source" in rules_content
-        )
+        assert "It also applies the CMS CHIP FCEP SPA source" in rules_content
 
         test_content = test_file.read_text()
         assert (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11615,7 +11615,11 @@ rules:
         )
         assert (
             "us-co:policies/cms/colorado-chip-eligibility"
-            "#is_chip_fcep_eligible_person: holds" in test_content
+            "#colorado_fcep_eligibility_available: true" in test_content
+        )
+        assert (
+            "us-co:policies/cms/colorado-chip-eligibility"
+            "#is_chip_fcep_eligible_person: holds" not in test_content
         )
 
         manifest = (

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -18393,6 +18393,44 @@ rules:
     ]
 
 
+def test_source_scope_consistency_accepts_chip_person_eligibility_with_family_income():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    Alabama CHIP FCEP eligibility applies family income to a person-level
+    pregnancy/FCEP eligibility judgment.
+rules:
+  - name: is_chip_fcep_eligible_person
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 42 USC 1397ll(f)(1), 42 CFR 457.10, and CMS CHIP FCEP SPA source
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/policy/cms/chip-spa/al/example
+              excerpt: "Alabama expands CHIP eligibility statewide for the from-conception-to-end-of-pregnancy (FCEP) coverage group with family incomes up to and including 312 percent of the federal poverty level whose birth parent is not otherwise eligible for Medicaid or CHIP."
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/42/1397ll/f/1
+              excerpt: "through the application of sections 457.10"
+    versions:
+      - effective_from: '2024-10-01'
+        formula: |-
+          person_is_pregnant
+          and alabama_fcep_eligibility_available
+          and not found_eligible_for_medical_assistance_under_subchapter_xix
+          and medicaid_income_level <= alabama_fcep_effective_fpl_limit
+"""
+
+    assert find_source_scope_consistency_issues(content) == []
+
+
 def test_source_scope_consistency_accepts_federal_tax_taxpayer_as_taxunit_rule():
     content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1147"
+version = "0.2.1148"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1142"
+version = "0.2.1143"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1146"
+version = "0.2.1147"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1144"
+version = "0.2.1145"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1145"
+version = "0.2.1146"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1141"
+version = "0.2.1142"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1143"
+version = "0.2.1144"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1148"
+version = "0.2.1149"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- extend the CMS CHIP composition generator to consume CMS CHIP FCEP SPA corpus records
- derive source-backed FCEP availability, raw/effective FPL limits, and FCEP person eligibility companion tests
- add a narrow source-scope validator allowance for CHIP person eligibility formulas that use unit income surfaces

## Verification
- `uv run python -m pytest tests/test_cli.py -k generate_cms_chip_composition -q`
- `uv run python -m pytest tests/test_rulespec_validation.py -k "source_scope_consistency_accepts_chip_person_eligibility_with_family_income or source_scope_consistency_names_family_unit_for_person_rule" -q`
- `uv run ruff check src/axiom_encode/cli.py src/axiom_encode/harness/validator_pipeline.py tests/test_cli.py tests/test_rulespec_validation.py`
- generated 15 CMS CHIP FCEP state files in `rulespec-us` from local CMS corpus and ran RuleSpec validation/proof/test/guard checks there
