### PR TITLE
Recognize Kansas SSPP oracle mappings

### DIFF
--- a/changelog.d/ks-sspp-oracle-mappings.changed.md
+++ b/changelog.d/ks-sspp-oracle-mappings.changed.md
@@ -1,0 +1,1 @@
+Recognize Kansas SSPP oracle mappings: map the SSPP minimum-age parameter to PolicyEngine as a comparable value, and mark the final `ks_sspp` benefit and the 2007 monthly-payment amount known-not-comparable because the corpus substantiates the 20.00 dollar 2006-2007 amount while PolicyEngine pays a later administrative value of 32.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1151"
+version = "0.2.1152"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1151"
+__version__ = "0.2.1152"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -3057,6 +3057,38 @@ mappings:
     candidate_priority: P2
     rationale: RuleSpec exposes a source-level selector over POMS SI 01415.058 Delaware couple total payment levels. PolicyEngine's final `de_ssp` person amount composes the Delaware couple payment standard with eligibility, SSI countable-income offset, and person-level couple allocation, and does not expose the POMS federal-plus-state total column as the final benefit amount.
 
+  - legal_id: us-ks:policies/khpa/policy-memo/2007-05-01/state-supplemental-payment-program#ks_sspp_minimum_age
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ks.kdhe.sspp.eligibility.age_threshold
+    comparison: count
+    tested_by_legal_ids:
+      - us-ks:policies/khpa/policy-memo/2007-05-01/state-supplemental-payment-program#ks_sspp_eligible
+    rationale: Both Axiom's KHPA Policy Memo 2007-05-01 Section III(4) minimum-age parameter and PolicyEngine's Kansas SSPP age threshold set 18 as the minimum age for State Supplemental Payment Program eligibility.
+
+  - legal_id: us-ks:policies/khpa/policy-memo/2007-05-01/state-supplemental-payment-program#ks_sspp_monthly_payment
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the 20.00 dollar SSPP monthly benefit stated in KHPA Policy Memo 2007-05-01 Section IV, the amount the corpus source text substantiates for the 2006-2007 program period. PolicyEngine's `gov.states.ks.kdhe.sspp.payment.amount` parameter stores a later administrative value of 32 effective 2009, so the two amounts are not comparable at a shared date. The memo's Section XI notes the benefit level changes after July 2007.
+
+  - legal_id: us-ks:policies/khpa/policy-memo/2007-05-01/state-supplemental-payment-program#ks_sspp_eligible
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes a source-level SSPP eligibility predicate over exogenous institution, reduced-institutional-SSI, full-Medicaid, and age inputs from KHPA Policy Memo 2007-05-01 Section III. PolicyEngine's `ks_sspp_eligible` composes SSI receipt, the SSI federal living arrangement being a medical treatment facility, Medicaid enrollment, and the age threshold, so the source predicate is not a one-to-one eligibility oracle.
+
+  - legal_id: us-ks:policies/khpa/policy-memo/2007-05-01/state-supplemental-payment-program#ks_sspp
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    policyengine_variable: ks_sspp
+    candidate_priority: P2
+    rationale: RuleSpec exposes the final Kansas SSPP monthly benefit as the 20.00 dollar amount stated in KHPA Policy Memo 2007-05-01 for the 2006-2007 program period. PolicyEngine's final `ks_sspp` person amount pays a later administrative value of 32 effective 2009, so the encoded corpus-substantiated benefit is not a one-to-one final benefit oracle at a shared date. Map the SSPP minimum-age parameter separately.
+
   - legal_id: us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_person_living_alone_standard
     country: us
     program: ssi_state_supplement

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1991,11 +1991,14 @@ surfaces:
   variable: ks_sspp
   source_type: state_implementation
   state: KS
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P2
-  rationale: Official Kansas K.S.A. 39-972 statute corpus artifacts and KHPA Policy No. 2007-05-01 SSPP guidance corpus
-    artifacts are ingested from Kansas Revisor and KDHE official sources. Encode the source-law institutional SSI recipient
-    eligibility and payment rules before classifying comparability with PolicyEngine's final `ks_sspp` person-level surface.
+  rationale: Axiom encodes the Kansas SSPP institutional SSI recipient eligibility and flat monthly payment rules from
+    KHPA Policy No. 2007-05-01 and K.S.A. 39-972, ingested from KDHE and Kansas Revisor official sources. The SSPP
+    minimum-age parameter maps to PolicyEngine as a comparable value (both set age 18). The final benefit is not
+    comparable at a shared date because the corpus source text substantiates the 20.00 dollar amount for the 2006-2007
+    program period, while PolicyEngine's `ks_sspp` pays a later administrative value of 32 effective 2009; the memo's
+    Section XI flags that the benefit level changes after July 2007.
 - country: us
   program_id: ssi_state_supplement
   program_name: Louisiana OSS

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2342,7 +2342,7 @@ def test_policyengine_registry_maps_indiana_sapn_parameters():
     assert benefit.policyengine_variable == "in_ssp_sapn"
 
 
-def test_policyengine_program_surface_marks_kansas_sspp_pending_rulespec_encoding():
+def test_policyengine_program_surface_marks_kansas_sspp_known_not_comparable():
     report = build_policyengine_program_surface_report(program="ks_sspp")
 
     items_by_variable = {item["variable"]: item for item in report["items"]}
@@ -2350,8 +2350,13 @@ def test_policyengine_program_surface_marks_kansas_sspp_pending_rulespec_encodin
 
     assert ks_sspp["program_id"] == "ssi_state_supplement"
     assert ks_sspp["state"] == "KS"
-    assert ks_sspp["axiom_status"] == "pending_rulespec_encoding"
-    assert ks_sspp["mapping_count"] == 0
+    assert ks_sspp["axiom_status"] == "known_not_comparable"
+    assert ks_sspp["mapping_count"] >= 1
+    assert ks_sspp["comparable_mapping_count"] == 0
+    assert (
+        "us-ks:policies/khpa/policy-memo/2007-05-01/"
+        "state-supplemental-payment-program#ks_sspp" in ks_sspp["legal_ids"]
+    )
     assert "K.S.A. 39-972" in ks_sspp["rationale"]
     assert "KHPA Policy No. 2007-05-01" in ks_sspp["rationale"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1151"
+version = "0.2.1152"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Add PolicyEngine oracle mappings for the Kansas SSPP outputs encoded in TheAxiomFoundation/rulespec-us#550.
- Map `ks_sspp_minimum_age` to `gov.states.ks.kdhe.sspp.eligibility.age_threshold` as a comparable value (both set age 18), tested by the `ks_sspp_eligible` companion cases.
- Mark the final `ks_sspp` benefit, the 2007 `ks_sspp_monthly_payment` amount, and the source-level `ks_sspp_eligible` predicate not-comparable.
- Flip the Kansas SSPP program surface to `known_not_comparable` and bump to 0.2.1150.

## Why not-comparable for the benefit
The corpus (KHPA Policy Memo 2007-05-01, Section IV) substantiates a 20.00 dollar monthly benefit for the 2006-2007 program period. PolicyEngine's `ks_sspp` pays a later administrative value of 32 effective 2009. The two are not one-to-one oracles at a shared date, so the RuleSpec encodes the corpus-substantiated amount and the final surface is declined honestly, following the Delaware SSP (#1005) pattern. The comparable age-threshold parameter is mapped separately.

## Verification
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run ruff format --check tests/test_policyengine_coverage.py`
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py tests/test_rulespec_validation.py -k "kansas or registry or mapping or policyengine or coverage"` (523 passed)
- `uv run --extra dev python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`
- `axiom-encode oracle-coverage --root <workspace> --json`: all four `ks_sspp*` outputs are mapped; `ks_sspp_minimum_age` is comparable and tested; the not-comparable outputs pass the changed-coverage gate. This is the exact check that TheAxiomFoundation/rulespec-us#550 CI runs, so this PR unblocks it.

## Cross-links
- Encodes the surface in: TheAxiomFoundation/rulespec-us#550

🤖 Generated with [Claude Code](https://claude.com/claude-code)
