### PR TITLE
Bump axiom-oracles pin to include UK worker pilot oracle mappings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1153"
+version = "0.2.1154"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@e4951dd8303d087fe5fc127f460a4c8fc54a75de",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@d64a022b578d7db92debb8896b3774e7f7436777",
     "pydantic>=2.0",
     "pypdf>=6.4.0",
     "pyyaml>=6.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1153"
+__version__ = "0.2.1154"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1153"
+version = "0.2.1154"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -99,7 +99,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=e4951dd8303d087fe5fc127f460a4c8fc54a75de" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=d64a022b578d7db92debb8896b3774e7f7436777" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -121,7 +121,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.0"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=e4951dd8303d087fe5fc127f460a4c8fc54a75de#e4951dd8303d087fe5fc127f460a4c8fc54a75de" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=d64a022b578d7db92debb8896b3774e7f7436777#d64a022b578d7db92debb8896b3774e7f7436777" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary
Advances the pinned `axiom-oracles` commit (the shared PolicyEngine/Populace oracle-bridge layer that `src/axiom_encode/oracles/policyengine/` shims re-export) from `e4951dd` to `d64a022`, and bumps the encoder version `0.2.1153 → 0.2.1154` (pyproject, `__init__`, uv.lock) as the version-provenance gate requires.

`d64a022` (TheAxiomFoundation/axiom-oracles#127) adds `not_comparable` classifications for the composed rulespec-uk UKMOD worker pilot pipelines:
- `uk:statutes/income_tax/individual/pilot_worker_oracle_pipeline#`
- `uk:statutes/social_security/workers/pilot_worker_class_1_nic_pipeline#`

Without this bump, the changed-file PolicyEngine oracle-coverage classifier (which the shared `validate-rulespec.yml` runs from axiom-encode `main`) reports those pilot outputs as `unmapped`, blocking TheAxiomFoundation/rulespec-uk#71. The pin also pulls the intervening Belgium EUROMOD rerun (#125) and first-class mismatch dispositions (#126).

## Verification
- `uv lock` refreshed; `axiom-oracles @ …@d64a022` resolves and builds.
- `uv run ruff check pyproject.toml` — clean.
- `uv run pytest tests/test_cli.py` — 591 passed (incl. the version-provenance gate).
- `axiom-encode oracle-coverage` over the rulespec-uk tree now classifies all pilot pipeline outputs as `known_not_comparable` (0 unmapped).

## Cycle
Mechanical dependency SHA + version bump (no source logic changed). Lightweight cycle: focused checks above are green; no actionable review findings for a pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)