### PR TITLE
Bump axiom-oracles pin to include 42 USC Title II OASDI mappings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1154"
+version = "0.2.1155"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@d64a022b578d7db92debb8896b3774e7f7436777",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@c683d1738043405e17d236f50f6095f52dc63eea",
     "pydantic>=2.0",
     "pypdf>=6.4.0",
     "pyyaml>=6.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1154"
+__version__ = "0.2.1155"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1154"
+version = "0.2.1155"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -99,7 +99,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=d64a022b578d7db92debb8896b3774e7f7436777" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=c683d1738043405e17d236f50f6095f52dc63eea" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -121,7 +121,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.0"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=d64a022b578d7db92debb8896b3774e7f7436777#d64a022b578d7db92debb8896b3774e7f7436777" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=c683d1738043405e17d236f50f6095f52dc63eea#c683d1738043405e17d236f50f6095f52dc63eea" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
Bumps the `axiom-oracles` git dependency pin to `c683d17` (TheAxiomFoundation/axiom-oracles#131), which classifies the Social Security Title II benefit-formula outputs (42 USC 415, 416(l), 402(q)/(w), 2026 COLA) as PolicyEngine `not_comparable`.

## Why

`axiom-encode oracle-coverage --fail-on-unmapped` (run under a full-toolchain-bump) classifies every executable RuleSpec output against the PolicyEngine registry, which now lives in `axiom_oracles.bridges`. Without these mappings the 69 Title II outputs in rulespec-us#541 are `unmapped` and the gate fails.

Encoder version bumped 0.2.1154 → 0.2.1155 (pyproject, `__init__`, uv.lock).

## Unblocks

rulespec-us#541. After this merges, `rulespec-us/.axiom/toolchain.toml` `axiom_encode_ref` and `axiom_encode_version` are bumped to this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
