### PR TITLE
Bump oracle bridge for Canada coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@c683d1738043405e17d236f50f6095f52dc63eea",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@ae9bc8afa433a73fb2a023d80a3e7c445a31f0ab",
     "pydantic>=2.0",
     "pypdf>=6.4.0",
     "pyyaml>=6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1155"
+version = "0.2.1156"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1155"
+__version__ = "0.2.1156"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -99,7 +99,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=c683d1738043405e17d236f50f6095f52dc63eea" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=ae9bc8afa433a73fb2a023d80a3e7c445a31f0ab" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -121,7 +121,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.0"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=c683d1738043405e17d236f50f6095f52dc63eea#c683d1738043405e17d236f50f6095f52dc63eea" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=ae9bc8afa433a73fb2a023d80a3e7c445a31f0ab#ae9bc8afa433a73fb2a023d80a3e7c445a31f0ab" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1155"
+version = "0.2.1156"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- bump the git-pinned `axiom-oracles` dependency to merged oracle bridge commit `ae9bc8afa433a73fb2a023d80a3e7c445a31f0ab`
- picks up TheAxiomFoundation/axiom-oracles#132, which classifies Canada `ca:` RuleSpec outputs as known not comparable for PolicyEngine coverage
- bump `axiom-encode` from `0.2.1155` to `0.2.1156` so the dependency change is behind a committed encoder version bump
- unblocks rulespec-ca changed-file oracle coverage by eliminating the broad Canada `unmapped` status

## Checks
- GitHub CI on `b402f25b8b03c47be8f43acf07b972097b055f5d` -> green (`lint`, `test (3.13)`)
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest tests/test_policyengine_coverage_monorepo.py tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q` -> 19 passed
- `uv run pytest` -> 2,623 passed, 70 skipped
- `uv run axiom-encode oracle-coverage --root /Users/pavelmakarchuk --json` then filtered `rulespec-ca`: 3,725 outputs, `known_not_comparable=3725`, no unmapped outputs

## Review cycle
- Independent review requested from MaxGhenis and nikhilwoodruff; PR remains draft until actionable findings are resolved or review is complete.
