### PR TITLE
Bump axiom-oracles pin to pull composed UC pipeline classification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1156"
+version = "0.2.1157"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@c683d1738043405e17d236f50f6095f52dc63eea",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@0ee3d24a290a99091c5e47f588fd720ef723119a",
     "pydantic>=2.0",
     "pypdf>=6.4.0",
     "pyyaml>=6.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1156"
+__version__ = "0.2.1157"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1156"
+version = "0.2.1157"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -99,7 +99,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=c683d1738043405e17d236f50f6095f52dc63eea" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=0ee3d24a290a99091c5e47f588fd720ef723119a" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -120,8 +120,8 @@ provides-extras = ["api", "observability", "dev", "all"]
 
 [[package]]
 name = "axiom-oracles"
-version = "0.2.0"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=c683d1738043405e17d236f50f6095f52dc63eea#c683d1738043405e17d236f50f6095f52dc63eea" }
+version = "0.2.1"
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=0ee3d24a290a99091c5e47f588fd720ef723119a#0ee3d24a290a99091c5e47f588fd720ef723119a" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary
SHA-only bump of the `axiom-oracles` dependency pin (`c683d17` -> `0ee3d24`) so axiom-encode's changed-file PolicyEngine oracle-coverage classifier resolves the rulespec-uk composed Universal Credit award pipeline (`uk:policies/universal_credit_composed_award_pipeline`) as `known_not_comparable` rather than `unmapped`. The new axiom-oracles commit adds the `legal_id_prefix` classification block for the composed UC pipeline (TheAxiomFoundation/axiom-oracles#133), the same mechanism used for the income-tax/NIC pilots (#127).

- `pyproject.toml`: pin SHA bumped.
- `uv.lock`: regenerated (`uv lock`); `axiom-oracles v0.2.0 (c683d17) -> v0.2.1 (0ee3d24)`.
- Encoder version bumped `0.2.1156` -> `0.2.1157` across `pyproject.toml`, `src/axiom_encode/__init__.py` and `uv.lock`, as required by `test_current_encoder_affecting_changes_are_behind_version_bump` when encoder-affecting files change.

## Verification
- `uv lock` regenerated deterministically.
- `uv sync`; `import axiom_encode.oracles.policyengine.coverage` and `axiom_oracles.bridges.coverage` import cleanly with the new pin.
- The pinned `axiom_oracles/bridges/mappings/uk.yaml` now carries the `universal_credit_composed_award_pipeline` prefix.
- `ruff check pyproject.toml` — clean.
- `pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump` — passes locally after the version bump.

## Cycle
Lightweight cycle for a mechanical pin + version-bump change (no source/prompt/harness logic touched): checks above rerun after the edit; the version-provenance guard was the one actionable finding and is resolved. Mirrors the #127 pin-bump precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)