### PR TITLE
Register UK income-tax and NIC Class 1 threshold parameter mappings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1157"
+version = "0.2.1158"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1157"
+__version__ = "0.2.1158"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -409,6 +409,82 @@ mappings:
     comparison: rate
     rationale: Same Class 4 additional contribution percentage.
 
+  # NIC Class 1 earnings thresholds (SSCBA 1992 via the Social Security
+  # (Contributions) Regulations 2001, reg. 10). PolicyEngine-UK holds these as
+  # weekly scalar parameters. Exact entries; they take precedence over the
+  # uk:regulations/uksi/2001/1004/10# not_comparable prefix below.
+  - legal_id: uk:regulations/uksi/2001/1004/10#lower_earnings_limit
+    country: uk
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.national_insurance.class_1.thresholds.lower_earnings_limit
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same Class 1 lower earnings limit (weekly).
+
+  - legal_id: uk:regulations/uksi/2001/1004/10#primary_threshold
+    country: uk
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.national_insurance.class_1.thresholds.primary_threshold
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same Class 1 primary threshold (weekly), above which employees pay the main primary contribution.
+
+  - legal_id: uk:regulations/uksi/2001/1004/10#secondary_threshold
+    country: uk
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.national_insurance.class_1.thresholds.secondary_threshold
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same Class 1 secondary threshold (weekly), above which employers pay secondary contributions.
+
+  - legal_id: uk:regulations/uksi/2001/1004/10#upper_earnings_limit
+    country: uk
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.national_insurance.class_1.thresholds.upper_earnings_limit
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same Class 1 upper earnings limit (weekly), above which the additional primary rate applies.
+
+  # Income Tax basic and higher rate limits (Income Tax Act 2007 s. 10).
+  # PolicyEngine-UK holds these as thresholds of the annual income tax rate
+  # scale gov.hmrc.income_tax.rates.uk: the basic-rate limit is the top of the
+  # basic band (scale threshold index 1) and the higher-rate limit is the top
+  # of the higher band (scale threshold index 2). Exact entries; they take
+  # precedence over the uk:statutes/ukpga/2007/3/10# not_comparable prefix.
+  - legal_id: uk:statutes/ukpga/2007/3/10#basic_rate_limit
+    country: uk
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.income_tax.rates.uk
+    parameter_key_path:
+      - thresholds
+      - 1
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same basic rate limit — the top of the basic-rate band, held as threshold index 1 of the annual income tax rate scale.
+
+  - legal_id: uk:statutes/ukpga/2007/3/10#higher_rate_limit
+    country: uk
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.income_tax.rates.uk
+    parameter_key_path:
+      - thresholds
+      - 2
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same higher rate limit — the top of the higher-rate band, held as threshold index 2 of the annual income tax rate scale.
+
   - legal_id: uk:statutes/ukpga/1992/4/15#main_class_4_contribution
     country: uk
     program: tax
@@ -2729,7 +2805,7 @@ prefixes:
     country: uk
     program: tax
     mapping_type: not_comparable
-    rationale: Section 10 outputs not listed above are the basic and higher rate limit parameters; PolicyEngine UK carries these in its parameter tree rather than as simulated variables, and parameter-level comparisons are not yet registered.
+    rationale: Section 10 outputs not listed above are intra-section rate-application helpers; PolicyEngine UK carries these in its parameter tree rather than as simulated variables. The basic and higher rate limits themselves are now registered above as exact parameter_value comparisons against the income tax rate scale.
 
   - legal_id_prefix: uk:statutes/ukpga/2007/3/12#
     country: uk
@@ -2801,7 +2877,7 @@ prefixes:
     country: uk
     program: tax
     mapping_type: not_comparable
-    rationale: Regulation 10 outputs are the National Insurance earnings limits and thresholds; PolicyEngine UK carries these in its parameter tree rather than as simulated variables, and parameter-level comparisons are not yet registered.
+    rationale: Regulation 10 outputs not listed above are apprentice/under-21 upper secondary threshold variants; PolicyEngine UK carries these in its parameter tree rather than as simulated variables. The Class 1 lower earnings limit, primary threshold, secondary threshold, and upper earnings limit are now registered above as exact parameter_value comparisons.
   # Council-level schemes are outside PolicyEngine-UK's model; exact
   # mappings take precedence. Added for rulespec-uk#43.
   - legal_id_prefix: "uk-kingston-upon-thames:"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1157"
+version = "0.2.1158"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

Registers exact `parameter_value` PolicyEngine-UK mappings for six threshold-bearing rulespec-uk outputs. These thresholds were previously covered only by `not_comparable` prefix catch-alls, so the axiom-corpus concept registry carried no PolicyEngine edge for them — and the axiom-oracles boundary-case generator therefore emitted zero UK suggestions for them.

This is the UKMOD-parity M1 enabler: it lets the concept registry (built from this file) carry `policyengine_uk` edges for the UK income-tax band and NIC Class 1 thresholds, which the boundary generator straddles.

## Mappings added

| rulespec-uk legal id | policyengine-uk parameter | period |
|---|---|---|
| `uk:statutes/ukpga/2007/3/10#basic_rate_limit` | `gov.hmrc.income_tax.rates.uk` (threshold idx 1) | year |
| `uk:statutes/ukpga/2007/3/10#higher_rate_limit` | `gov.hmrc.income_tax.rates.uk` (threshold idx 2) | year |
| `uk:regulations/uksi/2001/1004/10#lower_earnings_limit` | `gov.hmrc.national_insurance.class_1.thresholds.lower_earnings_limit` | week |
| `uk:regulations/uksi/2001/1004/10#primary_threshold` | `gov.hmrc.national_insurance.class_1.thresholds.primary_threshold` | week |
| `uk:regulations/uksi/2001/1004/10#secondary_threshold` | `gov.hmrc.national_insurance.class_1.thresholds.secondary_threshold` | week |
| `uk:regulations/uksi/2001/1004/10#upper_earnings_limit` | `gov.hmrc.national_insurance.class_1.thresholds.upper_earnings_limit` | week |

Every parameter verified to exist in policyengine-uk. Basic/higher rate limits point at threshold indices 1 and 2 of the annual income tax rate scale via `parameter_key_path`. NIC Class 1 thresholds are weekly scalar parameters, matching both the PE parameter period and the rulespec-uk weekly formulas.

Exact entries take precedence over the existing `uk:statutes/ukpga/2007/3/10#` and `uk:regulations/uksi/2001/1004/10#` `not_comparable` prefixes; both prefix rationales are updated so the remaining unmapped outputs stay accurately described.

## Checks

- `ruff check src/ tests/` — clean
- `pytest tests/test_policyengine_coverage.py tests/test_policyengine_efrs_uk.py` — 560 passed
- Bridge registry `validate()` over the full file — 0 issues; precedence confirmed (new entries resolve to `parameter_value`; unlisted outputs still hit the `not_comparable` prefix)

No RuleSpec, PolicyEngine, or numeric values invented — this file references existing rulespec-uk legal ids and existing policyengine-uk parameters only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
