### PR TITLE
Bump axiom-oracles pin to pull Scottish income-tax classification (#214)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1161"
+version = "0.2.1162"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@2b67b8cf3e06c2e40b8e2862dbdad2cf023ee839",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@4342f849d54d165a82ee82bb145e85c84f8772e6",
     "pydantic>=2.0",
     "pypdf>=6.4.0",
     "pyyaml>=6.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1161"
+__version__ = "0.2.1162"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1161"
+version = "0.2.1162"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -99,7 +99,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=2b67b8cf3e06c2e40b8e2862dbdad2cf023ee839" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=4342f849d54d165a82ee82bb145e85c84f8772e6" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -121,7 +121,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=2b67b8cf3e06c2e40b8e2862dbdad2cf023ee839#2b67b8cf3e06c2e40b8e2862dbdad2cf023ee839" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=4342f849d54d165a82ee82bb145e85c84f8772e6#4342f849d54d165a82ee82bb145e85c84f8772e6" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

Bumps the pinned `axiom-oracles` dependency from `2b67b8c` to `4342f84` so the PolicyEngine oracle-coverage classifier resolves the composed Scottish income-tax oracle pipeline outputs (`uk:statutes/income_tax/individual/scottish_income_tax_oracle_pipeline#*`) as `not_comparable` — mirroring the existing savings/dividend and worker-pilot pipeline classifications. This is the standard oracles-pin bump (cf. #1043, #1044).

Without this bump, the rulespec-uk Scottish income-tax pipeline PR's changed-file oracle-coverage gate would report those outputs as `unmapped` and fail. The bump also carries the already-merged intervening axiom-oracles changes (#144, #145, #146).

## Change

- `pyproject.toml` + `uv.lock`: `axiom-oracles@2b67b8c` → `axiom-oracles@4342f84`.

## Verification

- `uv lock` resolves cleanly (axiom-oracles v0.2.1 2b67b8c → 4342f84).
- The Scottish prefix resolves via the encode bridge: `load_policyengine_registry().mapping_for_legal_id(...)` returns `not_comparable`.
- ruff clean; the classification/coverage/registry test subset passes (912 passed, 26 skipped, 0 failed).

Part of #214.

## Cycle

Mechanical dependency-SHA bump identical to the merged #1043/#1044 pattern (no source/logic changes); lightweight cycle — focused ruff + classification/coverage tests run and green above.
