### PR TITLE
Bump axiom-oracles pin to pull UKMOD Child Benefit classification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1162"
+version = "0.2.1163"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@4342f849d54d165a82ee82bb145e85c84f8772e6",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@cf21147111e3f0f1bf894095c981453664a741a4",
     "pydantic>=2.0",
     "pypdf>=6.4.0",
     "pyyaml>=6.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1162"
+__version__ = "0.2.1163"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1162"
+version = "0.2.1163"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -99,7 +99,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=4342f849d54d165a82ee82bb145e85c84f8772e6" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=cf21147111e3f0f1bf894095c981453664a741a4" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -121,7 +121,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=4342f849d54d165a82ee82bb145e85c84f8772e6#4342f849d54d165a82ee82bb145e85c84f8772e6" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=cf21147111e3f0f1bf894095c981453664a741a4#cf21147111e3f0f1bf894095c981453664a741a4" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
Pulls axiom-oracles `cf21147` (#151), classifying the composed rulespec-uk Child Benefit oracle pipeline outputs (`uk:statutes/child_benefit/pilot_child_benefit_oracle_pipeline#*`) as `not_comparable` for PolicyEngine oracle coverage.

This unblocks the changed-file oracle-coverage check on the companion **rulespec-uk#76**, whose new pipeline outputs are otherwise reported `unmapped`. Verified locally: the freshly-pinned `axiom_oracles.bridges` registry classifies all 7 CB outputs as `not_comparable`.

Encoder version bumped 0.2.1162 -> 0.2.1163 in the same commit, per the encoder-affecting-changes guard for pyproject.toml/uv.lock changes. Follows the mechanical pin-bump pattern of #1043/#1044/#1045.

🤖 Generated with [Claude Code](https://claude.com/claude-code)