### PR TITLE
Bump axiom-oracles pin to pull UC award reconciliation classification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1163"
+version = "0.2.1164"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@cf21147111e3f0f1bf894095c981453664a741a4",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@4b76dd119cccae5a4dda96ffeba91a6ae36611a2",
     "pydantic>=2.0",
     "pypdf>=6.4.0",
     "pyyaml>=6.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1163"
+__version__ = "0.2.1164"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1163"
+version = "0.2.1164"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -99,7 +99,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=cf21147111e3f0f1bf894095c981453664a741a4" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=4b76dd119cccae5a4dda96ffeba91a6ae36611a2" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -121,7 +121,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=cf21147111e3f0f1bf894095c981453664a741a4#cf21147111e3f0f1bf894095c981453664a741a4" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=4b76dd119cccae5a4dda96ffeba91a6ae36611a2#4b76dd119cccae5a4dda96ffeba91a6ae36611a2" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## What

Bump the `axiom-oracles` pin from `cf211471` to `4b76dd11` and the encoder version `0.2.1163` → `0.2.1164`.

## Why

[axiom-oracles#153](https://github.com/TheAxiomFoundation/axiom-oracles/pull/153) (merged) adds a `not_comparable` prefix mapping for `uk:policies/universal_credit_award_reconciliation#`, the reconciliation guard between the two rulespec-uk Universal Credit award paths added in [rulespec-uk#79](https://github.com/TheAxiomFoundation/rulespec-uk/pull/79).

The changed-file PolicyEngine oracle coverage classifier runs `axiom-encode@main`, so its axiom-oracles pin determines the available classifications. Without this bump, the guard's six internal agreement outputs (`uc_reconcile_*`) classify as `unmapped` and fail rulespec-uk#79's `validate (uk)` step.

## Verification

- `4b76dd11` is a **forward** bump from `cf211471` (the UKMOD Child Benefit classification from #1046 is preserved — confirmed `cf211471` is an ancestor of `4b76dd11`).
- Running the exact CI classifier (`axiom-encode oracle-coverage --root … --json`) against rulespec-uk#79's branch now returns `known_not_comparable` for all six `uc_reconcile_*` outputs (0 `unmapped`).
- `ruff check` clean; `compileall` clean; `tests/test_rulespec_validation.py -k "oracle or coverage or classif"` → 65 passed.

Routine pin bump, same shape as #1042–#1046.
