### PR TITLE
Bump axiom-oracles pin to pull composed Pension Credit classification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1164"
+version = "0.2.1165"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@4b76dd119cccae5a4dda96ffeba91a6ae36611a2",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@3d918c064d0d3e4b0c0e3067e83c649da60ebf79",
     "pydantic>=2.0",
     "pypdf>=6.4.0",
     "pyyaml>=6.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1164"
+__version__ = "0.2.1165"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1164"
+version = "0.2.1165"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -99,7 +99,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=4b76dd119cccae5a4dda96ffeba91a6ae36611a2" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=3d918c064d0d3e4b0c0e3067e83c649da60ebf79" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -121,7 +121,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=4b76dd119cccae5a4dda96ffeba91a6ae36611a2#4b76dd119cccae5a4dda96ffeba91a6ae36611a2" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=3d918c064d0d3e4b0c0e3067e83c649da60ebf79#3d918c064d0d3e4b0c0e3067e83c649da60ebf79" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
Bumps the `axiom-oracles` pin to `3d918c0` (TheAxiomFoundation/axiom-oracles#154) so the changed-file oracle-coverage classifier recognises the composed rulespec-uk Pension Credit pipeline outputs (`pc_pilot_*`) as `known_not_comparable` rather than `unmapped`.

The composed pipeline re-wires the separately mapped State Pension Credit Regulations 2002 regulation 6 rate rules and the State Pension Credit Act 2002 section 2 guarantee credit for the UKMOD `boamt_s` comparison, so its stage/award outputs are not new PolicyEngine oracle variables. Verified: all 13 `pc_pilot_*` outputs classify as `known_not_comparable` (0 unmapped) with the new pin.

Bumps the encoder version to `0.2.1164`. This unblocks the rulespec-uk Pension Credit pipeline PR (TheAxiomFoundation/rulespec-uk#80), whose changed-file oracle-coverage gate resolves the classification through this pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)