### PR TITLE
Map composed Housing Benefit entitlement pipeline to PolicyEngine

### DIFF
--- a/changelog.d/uk-housing-benefit-entitlement-pin.added.md
+++ b/changelog.d/uk-housing-benefit-entitlement-pin.added.md
@@ -1,0 +1,1 @@
+Bump the axiom-oracles pin to pull the composed Housing Benefit entitlement EFRS surfaces (housing-benefit-applicable-amount, housing-benefit-entitlement) and their PolicyEngine oracle-registry mappings, so the composed Housing Benefit entitlement pipeline in rulespec-uk is classified and compared.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1167"
+version = "0.2.1168"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@af4ce442fccdf198d1d7230545e1eb1ae1ba558a",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@a3982909dd38075f006e4ed724ad407cd73cac8b",
     "pydantic>=2.0",
     "pypdf>=6.4.0",
     "pyyaml>=6.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1167"
+__version__ = "0.2.1168"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -4414,10 +4414,14 @@ class hbai_household_net_income(Variable):
     assert by_name["housing_benefit"].surfaces == (
         "housing-benefit-working-age-tariff-income",
         "housing-benefit-pension-age-tariff-income",
+        "housing-benefit-applicable-amount",
+        "housing-benefit-entitlement",
         "housing-benefit-final",
     )
     assert by_name["housing_benefit"].covered_outputs == (
         "housing_benefit_tariff_income",
+        "housing_benefit_applicable_amount",
+        "housing_benefit_entitlement",
         "housing_benefit",
     )
     assert by_name["working_tax_credit"].status == "partial"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1167"
+version = "0.2.1168"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -99,7 +99,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=af4ce442fccdf198d1d7230545e1eb1ae1ba558a" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=a3982909dd38075f006e4ed724ad407cd73cac8b" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -121,7 +121,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=af4ce442fccdf198d1d7230545e1eb1ae1ba558a#af4ce442fccdf198d1d7230545e1eb1ae1ba558a" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=a3982909dd38075f006e4ed724ad407cd73cac8b#a3982909dd38075f006e4ed724ad407cd73cac8b" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

Bumps the axiom-oracles pin to `a3982909` to pull the composed Housing Benefit entitlement work (UK coverage wave item 4):
- the `housing-benefit-applicable-amount` and `housing-benefit-entitlement` EFRS surfaces (TheAxiomFoundation/axiom-oracles#159)
- their PolicyEngine oracle-registry mappings (TheAxiomFoundation/axiom-oracles#161): `hb_pilot_applicable_amount` → `housing_benefit_applicable_amount` and `hb_pilot_entitlement` → `housing_benefit_entitlement` (comparable), plus the non-dependant-deduction and intermediate outputs (not_comparable)

The mappings live in axiom-oracles (`bridges/mappings/uk.yaml`, the authoritative registry that the coverage report loads); this repo's copy is the inert re-export shim, so only the pin bump is needed here.

## Checks

- Coverage for the HB pipeline: **2 comparable (both tested) + 27 known_not_comparable, 0 unmapped** ✓
- ruff ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
