### PR TITLE
Classify PIP compare-wrapper outputs in UK oracle mappings

### DIFF
--- a/changelog.d/pip-wrapper-policyengine-coverage.changed.md
+++ b/changelog.d/pip-wrapper-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify the Personal Independence Payment compare-wrapper outputs (daily-living and mobility components, weekly total, and enhanced daily-living receipt) in PolicyEngine oracle coverage, mapping them to pip_dl/pip_m/pip/receives_enhanced_pip_dl and marking the annualization helpers not_comparable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1166"
+version = "0.2.1167"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1166"
+__version__ = "0.2.1167"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -1386,6 +1386,65 @@ mappings:
     comparison: money
     rationale: Same Personal Independence Payment total as the sum of daily-living and mobility components; the UK oracle converts PolicyEngine UK's annual value to a weekly amount for comparison.
 
+  - legal_id: uk:policies/govuk/personal-independence-payment#pip_daily_living_weekly_amount
+    country: uk
+    program: pip
+    mapping_type: direct_variable
+    policyengine_variable: pip_dl
+    entity: person
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same Personal Independence Payment daily-living component after selecting the standard, enhanced, or nil Regulation 24 rate from the frozen award category; the UK oracle converts PolicyEngine UK's annual value to a weekly amount for comparison.
+
+  - legal_id: uk:policies/govuk/personal-independence-payment#pip_mobility_weekly_amount
+    country: uk
+    program: pip
+    mapping_type: direct_variable
+    policyengine_variable: pip_m
+    entity: person
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same Personal Independence Payment mobility component after selecting the standard, enhanced, or nil Regulation 24 rate from the frozen award category; the UK oracle converts PolicyEngine UK's annual value to a weekly amount for comparison.
+
+  - legal_id: uk:policies/govuk/personal-independence-payment#personal_independence_payment_weekly_total
+    country: uk
+    program: pip
+    mapping_type: direct_variable
+    policyengine_variable: pip
+    entity: person
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same Personal Independence Payment total as the sum of daily-living and mobility components; the UK oracle converts PolicyEngine UK's annual value to a weekly amount for comparison.
+
+  - legal_id: uk:policies/govuk/personal-independence-payment#receives_enhanced_daily_living_component
+    country: uk
+    program: pip
+    mapping_type: direct_variable
+    policyengine_variable: receives_enhanced_pip_dl
+    entity: person
+    period: week
+    comparison: boolean
+    rationale: Same enhanced daily-living receipt indicator, with PolicyEngine UK treating the PIP daily-living award category as a person input.
+
+  - legal_id: uk:policies/govuk/personal-independence-payment#personal_independence_payment_annual_amount
+    country: uk
+    program: pip
+    mapping_type: not_comparable
+    comparable: false
+    candidate_priority: P4
+    rationale: Annualization of the weekly Personal Independence Payment total for a final-amount wrapper; the UK oracle compares the weekly total against PolicyEngine UK's annual pip divided by 52, so this annual restatement is not a separate oracle target.
+
+  - legal_id: uk:policies/govuk/personal-independence-payment#personal_independence_payment_weeks_in_year
+    country: uk
+    program: pip
+    mapping_type: not_comparable
+    comparable: false
+    candidate_priority: P4
+    rationale: Source-backed annualization helper for the policy-level final amount wrapper; PolicyEngine exposes the final Personal Independence Payment variable and weekly component rates, not this multiplication factor as a separate oracle target.
+
   - legal_id: uk:regulations/uksi/2026/148/article/14#dla_self_care_higher_substituted_amount
     country: uk
     program: dla

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1166"
+version = "0.2.1167"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Classify PIP compare-wrapper outputs in UK oracle mappings

The Personal Independence Payment compare wrapper landing in rulespec-uk
(`policies/govuk/personal-independence-payment`) selects the Regulation 24
weekly rate for the daily-living and mobility components from the frozen award
band and sums them into the section 77 total, mirroring the child DLA wrapper.

This adds the six wrapper outputs to `uk.yaml` so the changed-file oracle
coverage classifier resolves them:

- `pip_daily_living_weekly_amount` → `pip_dl` (direct_variable)
- `pip_mobility_weekly_amount` → `pip_m` (direct_variable)
- `personal_independence_payment_weekly_total` → `pip` (direct_variable)
- `receives_enhanced_daily_living_component` → `receives_enhanced_pip_dl` (boolean)
- `personal_independence_payment_annual_amount` → not_comparable (annualization helper)
- `personal_independence_payment_weeks_in_year` → not_comparable (helper)

Pairs with TheAxiomFoundation/rulespec-uk#81 (the wrapper) and the axiom-oracles
PIP EFRS surface, which compares the four mapped outputs against PolicyEngine-UK
at 100% match on the Enhanced FRS population.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
