### PR TITLE
Bump axiom-oracles pin to pull PIP suite and wrapper mappings

### DIFF
--- a/changelog.d/uk-pip-suite-pin.added.md
+++ b/changelog.d/uk-pip-suite-pin.added.md
@@ -1,0 +1,1 @@
+Pin axiom-oracles to 4a6f01c (TheAxiomFoundation/axiom-oracles#157) so the Personal Independence Payment compare-wrapper outputs classify (pip daily-living/mobility components, weekly total, and enhanced daily-living receipt comparable; the annualization helpers not_comparable) and the personal-independence-payment-final EFRS surface runs at 100% match against PolicyEngine-UK.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1168"
+version = "0.2.1169"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@a3982909dd38075f006e4ed724ad407cd73cac8b",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@4a6f01c1c77299f8495e70abe11850e627153176",
     "pydantic>=2.0",
     "pypdf>=6.4.0",
     "pyyaml>=6.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1168"
+__version__ = "0.2.1169"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1168"
+version = "0.2.1169"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -99,7 +99,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=a3982909dd38075f006e4ed724ad407cd73cac8b" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=4a6f01c1c77299f8495e70abe11850e627153176" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -121,7 +121,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=a3982909dd38075f006e4ed724ad407cd73cac8b#a3982909dd38075f006e4ed724ad407cd73cac8b" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=4a6f01c1c77299f8495e70abe11850e627153176#4a6f01c1c77299f8495e70abe11850e627153176" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Bump axiom-oracles pin to pull PIP suite and wrapper mappings

Pins axiom-oracles to `4a6f01c` (TheAxiomFoundation/axiom-oracles#157) so:

- The PIP compare-wrapper outputs classify in PolicyEngine oracle coverage — `pip_daily_living_weekly_amount`/`pip_mobility_weekly_amount`/`personal_independence_payment_weekly_total`/`receives_enhanced_daily_living_component` map to `pip_dl`/`pip_m`/`pip`/`receives_enhanced_pip_dl`; the annualization helpers are `not_comparable`.
- The `personal-independence-payment-final` EFRS surface runs, comparing PIP against PolicyEngine-UK at **100% match** (14,216 comparisons across 3,554 recipients, 0 mismatches) on the Enhanced FRS population.

Bumps the encoder version to 0.2.1169 for the pin change.

Unblocks the rulespec-uk PIP wrapper (TheAxiomFoundation/rulespec-uk#81) once its toolchain re-pins to this encoder version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
