### PR TITLE
Bump axiom-oracles pin past the 26 USC 32(c)(2) input renames

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1173"
+version = "0.2.1174"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@6aca79674ce652dc0231c72e1fc275d3199aa21b",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@b37f0d1958fe2dd462bfe278756933d996af27bb",
     "pydantic>=2.0",
     "pypdf>=6.4.0",
     "pyyaml>=6.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1173"
+__version__ = "0.2.1174"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_policyengine_ecps_tax.py
+++ b/tests/test_policyengine_ecps_tax.py
@@ -723,11 +723,12 @@ def test_eitc_projection_uses_ecps_income_and_demographic_inputs():
         contexts=contexts,
     )
     assert earned_income_inputs == {
-        "wages_salaries_tips_and_other_employee_compensation_includible_in_gross_income": 18_000,
-        "pension_or_annuity_amounts_received": 0,
-        "amounts_to_which_section_871_a_applies": 0,
-        "amounts_received_for_services_while_inmate_at_penal_institution": 0,
-        "subsidized_state_work_activity_amounts_received": 0,
+        "employee_compensation_includible_in_gross_income": 18_000,
+        "net_earnings_from_self_employment_after_self_employment_tax_deduction": 0.0,
+        "pension_or_annuity_amount": 0,
+        "nonresident_alien_income_not_connected_with_united_states_business": 0,
+        "penal_institution_service_compensation": 0,
+        "subsidized_state_work_activity_service_compensation": 0,
         "taxpayer_elects_to_treat_section_112_excluded_amounts_as_earned_income": False,
     }
     assert (
@@ -796,9 +797,7 @@ def test_eitc_projection_matches_policyengine_age_and_identification_edges():
         project_section_32_c_2_tax_unit_inputs(
             persons=persons,
             contexts=contexts,
-        )[
-            "wages_salaries_tips_and_other_employee_compensation_includible_in_gross_income"
-        ]
+        )["employee_compensation_includible_in_gross_income"]
         == 0
     )
 
@@ -871,11 +870,14 @@ def test_eitc_projection_sends_self_employment_to_section_1402_not_earned_income
         persons=persons,
         contexts=contexts,
     ) == {
-        "wages_salaries_tips_and_other_employee_compensation_includible_in_gross_income": 23_000,
-        "pension_or_annuity_amounts_received": 0,
-        "amounts_to_which_section_871_a_applies": 0,
-        "amounts_received_for_services_while_inmate_at_penal_institution": 0,
-        "subsidized_state_work_activity_amounts_received": 0,
+        "employee_compensation_includible_in_gross_income": 23_000,
+        "net_earnings_from_self_employment_after_self_employment_tax_deduction": (
+            3_647.825
+        ),
+        "pension_or_annuity_amount": 0,
+        "nonresident_alien_income_not_connected_with_united_states_business": 0,
+        "penal_institution_service_compensation": 0,
+        "subsidized_state_work_activity_service_compensation": 0,
         "taxpayer_elects_to_treat_section_112_excluded_amounts_as_earned_income": False,
     }
     assert project_section_1402_a_tax_unit_inputs(
@@ -1098,7 +1100,7 @@ def test_build_eitc_request_uses_structural_child_relation_and_component_outputs
     )
     assert (
         input_values[
-            f"{SECTION_32_C_2_BASE}#input.wages_salaries_tips_and_other_employee_compensation_includible_in_gross_income"
+            f"{SECTION_32_C_2_BASE}#input.employee_compensation_includible_in_gross_income"
         ]
         == "18000.0"
     )

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1173"
+version = "0.2.1174"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -99,7 +99,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=6aca79674ce652dc0231c72e1fc275d3199aa21b" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=b37f0d1958fe2dd462bfe278756933d996af27bb" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -121,7 +121,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=6aca79674ce652dc0231c72e1fc275d3199aa21b#6aca79674ce652dc0231c72e1fc275d3199aa21b" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=b37f0d1958fe2dd462bfe278756933d996af27bb#b37f0d1958fe2dd462bfe278756933d996af27bb" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Why

rulespec-us #488 replaced the deferred `us:statutes/26/32/c/2` earned-income stub with a full child-fragment encoding and renamed its inputs. The pinned axiom-oracles bridge (`4a6f01c1`) still emits the draft-era names, so `tax-populace-compare` fails against a fresh rulespec clone:

```
dataset input `us:statutes/26/32/c/2#input.wages_salaries_tips_and_other_employee_compensation_includible_in_gross_income` must use an absolute legal RuleSpec reference that resolves to an input slot, derived rule, or parameter in the compiled program
```

## What

Bumps the `axiom-oracles` git pin (pyproject + uv.lock) to `638c2539`, which:

- renames the five 32(c)(2) earned-income inputs to the final encoded names (`employee_compensation_includible_in_gross_income`, `pension_or_annuity_amount`, `nonresident_alien_income_not_connected_with_united_states_business`, `penal_institution_service_compensation`, `subsidized_state_work_activity_service_compensation`)
- supplies the new required `net_earnings_from_self_employment_after_self_employment_tax_deduction` tax-unit input
- adds the `us:statutes/26/1402/a/12` fragment import so the SECA equivalent-deduction fraction resolves

Verified downstream in axiom-oracles: the Colorado state income tax ECPS suite went from every axiom result erroring to 1,067/1,201 on these renames (residuals documented there). The FIIT run in axiom-oracles is blocked on this pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)