### PR TITLE
Bump axiom-oracles pin for UC reg 90 MIF mappings and encoder to 0.2.1171

### DIFF
--- a/changelog.d/oracles-pin-uc-mif-reg90.changed.md
+++ b/changelog.d/oracles-pin-uc-mif-reg90.changed.md
@@ -1,0 +1,1 @@
+Bump the axiom-oracles pin to pull the UC regulation 90 minimum-income-floor and NMW regulation 4A `not_comparable` mappings (axiom-oracles#176) so the changed-file oracle-coverage classifier recognises the rulespec-uk MIF encodings. The pin applies those two additive mapping/disposition files on top of the current pin base to keep the PolicyEngine oracle pair unchanged.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1170"
+version = "0.2.1171"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@0ac4d40edb1c1718f907422eb9ee073c744b9251",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@babae926aece39f906d69d5e7b8ff806509fb4a8",
     "pydantic>=2.0",
     "pypdf>=6.4.0",
     "pyyaml>=6.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1170"
+__version__ = "0.2.1171"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1170"
+version = "0.2.1171"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -99,7 +99,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=0ac4d40edb1c1718f907422eb9ee073c744b9251" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=babae926aece39f906d69d5e7b8ff806509fb4a8" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -121,7 +121,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=0ac4d40edb1c1718f907422eb9ee073c744b9251#0ac4d40edb1c1718f907422eb9ee073c744b9251" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=babae926aece39f906d69d5e7b8ff806509fb4a8#babae926aece39f906d69d5e7b8ff806509fb4a8" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

Bumps the `axiom-oracles` pin to add the UC regulation 90 minimum-income-floor and NMW regulation 4A `not_comparable` mappings plus the `uk-universal-credit` disposition note on the self-employed MIF suite decision (axiom-oracles#176), and the encoder version to `0.2.1171`.

This unblocks the changed-file PolicyEngine oracle-coverage classifier for TheAxiomFoundation/rulespec-uk#87 (the MIF encodings): without the bump the classifier reads the older pinned mappings and reports the new reg 90 / reg 4A outputs as unmapped.

## Decoupled pin

The pin points to a commit (`babae92`) that applies only the two additive mapping/disposition files on top of the **current** pin base, rather than to the axiom-oracles main merge of #176. This is deliberate: the main merge also drags in the PolicyEngine 4.18.9 oracle-pair regeneration and the 26 USC 32(c)(2) EITC input renames, which are handled separately in #1055 and would otherwise break the US EITC ecps-tax tests here. Keeping the PE oracle pair unchanged limits this PR to the UK MIF mapping surface. When #1055 (the PE 4.18.9 / EITC bump) lands, the pin can move forward to a main commit that includes both.

## Validation

- `pytest tests/test_cli.py tests/test_policyengine_ecps_tax.py`: 670 passed, 23 skipped (the previously-failing version-metadata and EITC-projection tests pass).
- pyproject, `src/axiom_encode/__init__.py`, and `uv.lock` bumped to `0.2.1171` together (version-provenance check passes).
- `oracle-coverage` over the rulespec-uk MIF worktree classifies all reg 90 + reg 4A outputs as `known_not_comparable` (0 unmapped) with this pin installed.

Dependency + version bump; no encoder source logic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
