### PR TITLE
Ground Ghana cedi grouped-thousands amounts in numeric validation

### DIFF
--- a/changelog.d/gh-cedi-grounding.fixed.md
+++ b/changelog.d/gh-cedi-grounding.fixed.md
@@ -1,0 +1,1 @@
+Ground Ghana cedi grouped-thousands amounts: numeric grounding now detaches the cedi symbol (`¢`/`₵`/`￠`) glued to a following amount, so `GH¢5,880` extracts `5880` instead of the trailing `880`. Fixes ungrounded-literal failures on Ghana income-tax rate-schedule values.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1171"
+version = "0.2.1172"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1171"
+__version__ = "0.2.1172"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -3598,6 +3598,12 @@ def _clean_source_text_for_numeric_extraction(text: str) -> str:
     """Strip structural source scaffolding before numeric extraction."""
     text = re.sub(r"\\r\\n|\\n|\\r", "\n", text)
     text = text.replace(r"\t", "\t")
+    # Detach the Ghana cedi symbol (and other cent/currency glyphs) glued to a
+    # following amount so grouped-thousands parsing sees a clean boundary:
+    # "GH¢5,880" -> "GH¢ 5,880". Without the space the digit run starts right
+    # after ¢, the grouped-thousands matcher's currency lookbehind never fires,
+    # and "5,880" is misread as the trailing "880".
+    text = re.sub(r"([¢₵])(?=\d)", r"\1 ", text)
     cleaned_lines: list[str] = []
     preserve_split_schedule_value = False
     for line in text.splitlines():

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -3602,8 +3602,10 @@ def _clean_source_text_for_numeric_extraction(text: str) -> str:
     # following amount so grouped-thousands parsing sees a clean boundary:
     # "GH¢5,880" -> "GH¢ 5,880". Without the space the digit run starts right
     # after ¢, the grouped-thousands matcher's currency lookbehind never fires,
-    # and "5,880" is misread as the trailing "880".
-    text = re.sub(r"([¢₵])(?=\d)", r"\1 ", text)
+    # and "5,880" is misread as the trailing "880". The lookbehind fires only
+    # when the glyph precedes a digit, so cent-suffixed values ("50¢") are left
+    # untouched. Covers the cent sign, cedi sign, and fullwidth cent sign.
+    text = re.sub(r"([¢₵￠])(?=\d)", r"\1 ", text)
     cleaned_lines: list[str] = []
     preserve_split_schedule_value = False
     for line in text.splitlines():

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6206,6 +6206,50 @@ def test_numeric_extraction_prefers_english_compound_cardinals_over_single_words
     )
 
 
+def test_numeric_extraction_handles_ghana_cedi_grouped_thousands():
+    # The Ghana cedi symbol glued to a grouped-thousands amount ("GH¢5,880")
+    # must still yield the full value, not just the trailing "880". Mirrors
+    # how $/£/€ grouped amounts already extract.
+    numbers = extract_numbers_from_text(
+        "1. First GH¢5,880 Nil 2. Next GH¢1,320 5 per cent "
+        "7. Exceeding GH¢600,000 35 per cent"
+    )
+    assert 5880.0 in numbers
+    assert 1320.0 in numbers
+    assert 600000.0 in numbers
+    assert 880.0 not in numbers
+    # Bare cedi glyph forms resolve the same way.
+    assert 5880.0 in extract_numbers_from_text("₵5,880")
+
+
+def test_rulespec_grounding_accepts_ghana_cedi_rate_schedule():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: gh/statute/act-1111/income-tax-amendment-no2-2023/first-schedule-rates-of-income-tax-for-individuals
+rules:
+  - name: first_band_upper_chargeable_income
+    kind: parameter
+    dtype: Money
+    unit: GHS
+    versions:
+      - effective_from: '2024-01-01'
+        formula: '5880'
+  - name: top_band_lower_chargeable_income
+    kind: parameter
+    dtype: Money
+    unit: GHS
+    versions:
+      - effective_from: '2024-01-01'
+        formula: '600000'
+"""
+    source_text = (
+        "1. First GH¢5,880 Nil 2. Next GH¢1,320 5 per cent "
+        "7. Exceeding GH¢600,000 35 per cent"
+    )
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+
+
 def test_rulespec_grounding_accepts_digit_scale_money_phrases():
     content = """format: rulespec/v1
 module:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6220,6 +6220,11 @@ def test_numeric_extraction_handles_ghana_cedi_grouped_thousands():
     assert 880.0 not in numbers
     # Bare cedi glyph forms resolve the same way.
     assert 5880.0 in extract_numbers_from_text("₵5,880")
+    # A decimal tail after a glued cedi amount still parses fully.
+    assert 5880.5 in extract_numbers_from_text("GH¢5,880.50")
+    # The lookbehind is deliberately one-directional: a cent-*suffixed* amount
+    # ("50¢") must be untouched and still extract 50, not gain a stray space.
+    assert 50.0 in extract_numbers_from_text("costs 50¢ per unit")
 
 
 def test_rulespec_grounding_accepts_ghana_cedi_rate_schedule():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1171"
+version = "0.2.1172"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
`_clean_source_text_for_numeric_extraction` now detaches the cedi symbol (`¢` / `₵`) glued to a following amount so grouped-thousands parsing sees a clean boundary: `GH¢5,880` → `GH¢ 5,880`.

### Why
Without this, the digit run starts immediately after `¢`, the grouped-thousands matcher's currency lookbehind (which already covers `$ £ €`) never fires, and `5,880` is misread as the trailing `880`. That made **every** Ghana income-tax rate-schedule literal (5,880 / 1,320 / 1,560 / 38,000 / 192,000 / 366,240 / 600,000) read as ungrounded even though the corpus source states each verbatim — blocking `rulespec-gh` encoding at the CI grounding gate.

### Change
- `validator_pipeline.py`: one normalization line at the top of `_clean_source_text_for_numeric_extraction`.
- `tests/test_rulespec_validation.py`: `test_numeric_extraction_handles_ghana_cedi_grouped_thousands` and `test_rulespec_grounding_accepts_ghana_cedi_rate_schedule`.

### Checks
- 142 grounding/numeric tests pass (`-k "ground or numeric or extract"`); no regressions.
- `ruff check` clean on changed files.

Draft pending a `/cycle` review pass per repo PR discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)