### PR TITLE
Bump axiom-oracles pin for Ghana oracle classification; encoder to 0.2.1173

### DIFF
--- a/changelog.d/bump-encoder-0-2-1173.changed.md
+++ b/changelog.d/bump-encoder-0-2-1173.changed.md
@@ -1,0 +1,1 @@
+Bumped the axiom-oracles pin to add the Ghana (gh:) PolicyEngine oracle-coverage classification, so `oracle-coverage --fail-on-unmapped` treats Ghana RuleSpec outputs as known-not-comparable; encoder to 0.2.1173. Pinned to a minimal oracles commit (gh.yaml on the previously pinned base) to avoid unrelated bridge changes; the same classification is on axiom-oracles main via #184.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1172"
+version = "0.2.1173"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@babae926aece39f906d69d5e7b8ff806509fb4a8",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@6aca79674ce652dc0231c72e1fc275d3199aa21b",
     "pydantic>=2.0",
     "pypdf>=6.4.0",
     "pyyaml>=6.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1172"
+__version__ = "0.2.1173"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1172"
+version = "0.2.1173"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -99,7 +99,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=babae926aece39f906d69d5e7b8ff806509fb4a8" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=6aca79674ce652dc0231c72e1fc275d3199aa21b" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -121,7 +121,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=babae926aece39f906d69d5e7b8ff806509fb4a8#babae926aece39f906d69d5e7b8ff806509fb4a8" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=6aca79674ce652dc0231c72e1fc275d3199aa21b#6aca79674ce652dc0231c72e1fc275d3199aa21b" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Bump axiom-oracles pin for Ghana oracle classification; encoder to 0.2.1173

Advances the `axiom-oracles` git pin to add the `gh:` prefix mapping classifying Ghana (`rulespec-gh`) RuleSpec outputs as `not_comparable` to PolicyEngine.

### Why
PolicyEngine has no Ghana model, so Ghana outputs have no one-to-one oracle target (the intended household oracle is GHAMOD, pending licensing). Without the `gh:` classification, the shared `validate-rulespec` CI step `axiom-encode oracle-coverage --fail-on-unmapped` fails on the first encoded Ghana module — its outputs are neither mapped nor explicitly not-comparable. This blocks [rulespec-gh#1](https://github.com/TheAxiomFoundation/rulespec-gh/pull/1) (Act 1111 First Schedule individual income-tax rate schedule).

### Minimal pin
Pinned to `6aca796` — the `gh.yaml` classification added on top of the **previously pinned** oracles base (`babae926`) — rather than to axiom-oracles `main`. Since the last pin, main renamed EITC / IRC §32 PolicyEngine variable names (oracles `e1a8890`, rulespec #488 EITC re-encoding), which the encoder's ECPS-tax golden tests (`test_policyengine_ecps_tax.py`) are pinned against. A full-main bump would break those tests, which is unrelated to the Ghana lane and out of scope here. The identical `gh.yaml` is also on axiom-oracles `main` via [axiom-oracles#184](https://github.com/TheAxiomFoundation/axiom-oracles/pull/184); reconciling the ECPS variable-name rename against main is a separate follow-up.

### Changes
- `pyproject.toml` + `uv.lock`: axiom-oracles pin `babae926` → `6aca796`.
- Version `0.2.1172` → `0.2.1173`.
- Changelog fragment.

### Verification
Installed this build and ran `oracle-coverage --fail-on-unmapped --fail-on-untested-comparable` against a rulespec-gh checkout carrying the Act 1111 module: all 14 Ghana outputs report `known_not_comparable`, exit 0. The full ECPS-tax suite passes (79 passed); 631 oracle/coverage/classify/ecps tests pass; towncrier draft renders; ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
