### PR TITLE
Bump axiom-oracles for Canada dashboard coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1174"
+version = "0.2.1175"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@95272d89e8fb755e83ea3889dd5dbb8cb4854ed0",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@20e7e516d97382e67375b852da4592b9074c805e",
     "pydantic>=2.0",
     "pypdf>=6.4.0",
     "pyyaml>=6.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1174"
+__version__ = "0.2.1175"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1174"
+version = "0.2.1175"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -99,7 +99,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=95272d89e8fb755e83ea3889dd5dbb8cb4854ed0" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=20e7e516d97382e67375b852da4592b9074c805e" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -121,7 +121,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=95272d89e8fb755e83ea3889dd5dbb8cb4854ed0#95272d89e8fb755e83ea3889dd5dbb8cb4854ed0" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=20e7e516d97382e67375b852da4592b9074c805e#20e7e516d97382e67375b852da4592b9074c805e" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary
- bump the `axiom-oracles` git pin from `95272d89e8fb755e83ea3889dd5dbb8cb4854ed0` to `20e7e516d97382e67375b852da4592b9074c805e`, which includes Canada dashboard coverage support from axiom-oracles#186
- bump `axiom-encode` from `0.2.1174` to `0.2.1175` because the dependency update is treated as encoder-affecting by the provenance guard
- update `uv.lock` for the same pin and package version
- this wires the Canada coverage/dashboard work through the main encoder application dependency graph

## Review cycle
- rebased over current `main`; main had already absorbed the bridge-test compatibility refresh
- resolved the dependency-pin conflict by keeping the newer Canada-dashboard oracles commit
- CI found the required encoder version bump; fixed it and reran the focused provenance guard plus the full local suite
- no actionable findings remain after the fix

## Checks
- `uv run pytest -q tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest` -> 2618 passed, 70 skipped, 12 warnings
