### PR TITLE
Fix dotted percentage grounding

### DIFF
--- a/changelog.d/dotted-percentage-grounding.fixed.md
+++ b/changelog.d/dotted-percentage-grounding.fixed.md
@@ -1,0 +1,1 @@
+Recognize dotted fractional percentage rates such as `1.435%` and `0.171%` during RuleSpec numeric grounding.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1175"
+version = "0.2.1176"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1175"
+__version__ = "0.2.1176"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -3318,13 +3318,19 @@ def _parse_belgian_numeric_phrase(raw: str) -> float | None:
     return _DUTCH_CARDINAL_PHRASE_VALUES.get(normalized)
 
 
-def _parse_percentage_numeric_phrase(raw: str) -> float | None:
+def _iter_percentage_numeric_phrase_values(raw: str) -> list[float]:
+    values: list[float] = []
     cleaned = re.sub(r"\s+", "", raw.strip())
-    dot_grouped = re.fullmatch(r"-?\d{1,3}(?:\.\d{3})+", cleaned)
-    if "." in cleaned and "," not in cleaned and not dot_grouped:
+    if "." in cleaned and "," not in cleaned:
         with contextlib.suppress(ValueError):
-            return float(cleaned)
-    return _parse_belgian_numeric_phrase(raw)
+            dotted_decimal = float(cleaned)
+            values.append(dotted_decimal)
+        if not re.fullmatch(r"-?[1-9]\d{0,2}(?:\.0{3})+", cleaned):
+            return values
+    parsed = _parse_belgian_numeric_phrase(raw)
+    if parsed is not None and not any(math.isclose(parsed, value) for value in values):
+        values.append(parsed)
+    return values
 
 
 def _iter_raw_european_money_value_matches(
@@ -3358,8 +3364,7 @@ def _iter_direct_percentage_rate_matches(
 ) -> list[tuple[tuple[int, int], float]]:
     values: list[tuple[tuple[int, int], float]] = []
     for match in _DIRECT_PERCENTAGE_PATTERN.finditer(text):
-        value = _parse_percentage_numeric_phrase(match.group("number"))
-        if value is not None:
+        for value in _iter_percentage_numeric_phrase_values(match.group("number")):
             values.append((match.span("number"), value / 100))
     return values
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6139,6 +6139,80 @@ rules:
     )
 
 
+def test_rulespec_grounding_accepts_dotted_fractional_percentage_rates():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ny/statute/NYC/11-1701
+rules:
+  - name: nyc_second_bracket_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2025-01-01'
+        formula: '0.01435'
+  - name: nyc_school_credit_low_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2025-01-01'
+        formula: '0.00171'
+"""
+
+    source_text = (
+        "$255 plus 1.435% of excess over $21,600. "
+        "$0 to $21,600 uses 0.171% of taxable income."
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    numbers = extract_numbers_from_text(source_text)
+    assert any(math.isclose(value, 0.01435) for value in numbers)
+    assert any(math.isclose(value, 0.00171) for value in numbers)
+
+
+def test_rulespec_grounding_rejects_grouped_reading_of_fractional_dotted_rate():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ny/statute/NYC/11-1701
+rules:
+  - name: nyc_second_bracket_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2025-01-01'
+        formula: '14.35'
+"""
+
+    issues = find_ungrounded_numeric_issues(
+        content,
+        source_text="$255 plus 1.435% of excess over $21,600.",
+    )
+
+    assert any("14.35" in issue for issue in issues)
+
+
+def test_rulespec_grounding_preserves_dotted_grouped_percentage_rates():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: be/regulation/example/article/1
+rules:
+  - name: grouped_percentage_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '10'
+"""
+
+    source_text = "Le taux applicable est de 1.000 %."
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    numbers = extract_numbers_from_text(source_text)
+    assert any(math.isclose(value, 10.0) for value in numbers)
+
+
 def test_rulespec_grounding_accepts_decimal_place_scale_derivation():
     content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1175"
+version = "0.2.1176"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- parse dotted fractional percentages such as `1.435%` and `0.171%` as decimal rates during numeric grounding
- preserve the existing grouped zero-thousands percentage case such as `1.000%`
- reject the false grouped reading of fractional dotted rates, so `1.435%` does not ground `14.35`
- bump `axiom-encode` to `0.2.1176`

## Verification
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest -q tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_rulespec_validation.py::test_numeric_occurrence_extraction_ignores_bare_dotted_regulatory_reference tests/test_rulespec_validation.py::test_numeric_occurrence_extraction_ignores_section_symbol_reference tests/test_rulespec_validation.py::test_rulespec_grounding_accepts_dotted_fractional_percentage_rates tests/test_rulespec_validation.py::test_rulespec_grounding_rejects_grouped_reading_of_fractional_dotted_rate tests/test_rulespec_validation.py::test_rulespec_grounding_preserves_dotted_grouped_percentage_rates`
- `uv run pytest` -> 2621 passed, 70 skipped, 12 warnings

## Review Cycle
- Independent review found a grouped-percentage regression; fixed and added `1.000%` coverage.
- Follow-up review found an over-permissive `1.435%` -> `14.35` grounding path; fixed and added negative coverage.
- Final independent review: no actionable findings.