### PR TITLE
Default encode backend to codex/gpt-5.5 with an auth preflight (#1054)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ generation. Local `axiom-corpus/data/corpus/provisions` artifacts are used first
 Supabase is the fallback. If no corpus provision exists, encoding stops before
 calling a model.
 
+`encode` defaults to `--backend codex` with `gpt-5.5`; Claude/Fable capacity is
+reserved for orchestration, gating, and review rather than YAML generation. The
+Codex backend authenticates through the Codex CLI's `~/.codex/auth.json`
+(created by `codex login`, or an `OPENAI_API_KEY` recorded there); `CODEX_HOME`
+overrides the directory and `OPENAI_API_KEY` in the environment also satisfies
+the check. When neither is present `encode` stops with a clear error before
+starting a run. Other backends stay available explicitly with
+`--backend claude` or `--backend openai`.
+
 `proof-validate` checks explicit RuleSpec proof trees without reviewers or
 oracles. It also resolves declared source-claim IDs against local
 `axiom-corpus/claims` artifacts and rejects missing, unaccepted, executable, or

--- a/changelog.d/codex-default-encode-backend.changed.md
+++ b/changelog.d/codex-default-encode-backend.changed.md
@@ -1,7 +1,8 @@
-Default `axiom-encode encode` to the Codex backend with `gpt-5.5` and add a
-pre-run auth check: when the resolved backend is `codex` and neither
-`~/.codex/auth.json` (honoring `CODEX_HOME`) nor `OPENAI_API_KEY` is present,
-the command now stops with an actionable error instead of failing deep inside
-the Codex subprocess. Other backends stay available explicitly via
-`--backend claude` or `--backend openai`. Reserves Claude/Fable capacity for
+Enforce the Codex backend default for `axiom-encode encode` with a pre-run
+auth check. `encode` already defaulted to `--backend codex` with `gpt-5.5`;
+now, when the resolved backend is `codex` and neither `~/.codex/auth.json`
+(honoring `CODEX_HOME`) nor `OPENAI_API_KEY` is present, the command stops with
+an actionable error instead of failing deep inside the Codex subprocess. Other
+backends stay available explicitly via `--backend claude` or `--backend openai`.
+Documents the default and the auth path, reserving Claude/Fable capacity for
 orchestration, gating, and review (encode#1054).

--- a/changelog.d/codex-default-encode-backend.changed.md
+++ b/changelog.d/codex-default-encode-backend.changed.md
@@ -1,0 +1,7 @@
+Default `axiom-encode encode` to the Codex backend with `gpt-5.5` and add a
+pre-run auth check: when the resolved backend is `codex` and neither
+`~/.codex/auth.json` (honoring `CODEX_HOME`) nor `OPENAI_API_KEY` is present,
+the command now stops with an actionable error instead of failing deep inside
+the Codex subprocess. Other backends stay available explicitly via
+`--backend claude` or `--backend openai`. Reserves Claude/Fable capacity for
+orchestration, gating, and review (encode#1054).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1177"
+version = "0.2.1178"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1177"
+__version__ = "0.2.1178"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -43,6 +43,7 @@ from yaml.nodes import MappingNode, ScalarNode, SequenceNode
 
 from axiom_encode import __version__
 
+from .codex_cli import codex_auth_error
 from .concepts import (
     audit_corpus as audit_concept_corpus,
 )
@@ -2248,9 +2249,12 @@ def main():
         choices=["codex", "openai", "claude"],
         default="codex",
         help=(
-            "Backend: 'codex' uses the Codex CLI/ChatGPT path, "
-            "'openai' uses OpenAI Responses API, "
-            "'claude' uses Claude CLI"
+            "Backend (default: codex): 'codex' uses the Codex CLI/ChatGPT "
+            f"path with {DEFAULT_OPENAI_MODEL} (auth via ~/.codex/auth.json "
+            "or OPENAI_API_KEY), 'openai' uses OpenAI Responses API, "
+            "'claude' uses Claude CLI. Claude tiers are reserved for "
+            "orchestration and review; net-new statutory encoding runs "
+            "through codex."
         ),
     )
     encode_parser.add_argument(
@@ -26426,6 +26430,11 @@ def cmd_encode(args):
     """Encode a corpus-backed source unit through the RuleSpec eval pipeline."""
     model = args.model or DEFAULT_OPENAI_MODEL
     runner = f"{args.backend}:{model}"
+    if args.backend == "codex":
+        auth_error = codex_auth_error()
+        if auth_error:
+            print(auth_error)
+            sys.exit(1)
     corpus_path = args.corpus_path or _resolve_repo_checkout("axiom-corpus")
     axiom_rules_path = args.axiom_rules_path or _resolve_repo_checkout(
         "axiom-rules-engine"

--- a/src/axiom_encode/codex_cli.py
+++ b/src/axiom_encode/codex_cli.py
@@ -18,3 +18,32 @@ def resolve_codex_cli() -> str:
         return str(app_binary)
 
     return shutil.which("codex") or "codex"
+
+
+def codex_auth_json_path() -> Path:
+    """Return the Codex CLI auth file, honoring the CODEX_HOME override."""
+    override = os.getenv("CODEX_HOME")
+    home = Path(override) if override else Path.home() / ".codex"
+    return home / "auth.json"
+
+
+def codex_auth_error() -> str | None:
+    """Return a clear error when the Codex CLI has no usable auth file.
+
+    ``axiom-encode encode`` defaults to the Codex backend (gpt-5.5), which
+    authenticates through the Codex CLI's ``auth.json`` (ChatGPT sign-in or
+    an ``OPENAI_API_KEY`` recorded by ``codex login``). When neither that
+    file nor ``OPENAI_API_KEY`` is present, encoding fails deep inside the
+    subprocess with an opaque message; surface an actionable one instead.
+    Returns ``None`` when auth is available.
+    """
+    if os.getenv("OPENAI_API_KEY"):
+        return None
+    auth_path = codex_auth_json_path()
+    if auth_path.is_file():
+        return None
+    return (
+        f"Codex backend requires authentication but {auth_path} was not found. "
+        "Run `codex login` (ChatGPT sign-in) to create it, set OPENAI_API_KEY, "
+        "or pass an explicit backend such as `--backend claude`."
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4028,6 +4028,21 @@ class TestCmdRuns:
 
 
 class TestCmdEncode:
+    @pytest.fixture(autouse=True)
+    def _neutralize_codex_auth_preflight(self):
+        """Default the codex auth preflight to "authenticated" for this class.
+
+        `cmd_encode` now runs a Codex auth preflight when the backend is
+        `codex` (the default in these tests). The dispatch/apply tests here
+        assert eval behavior, not auth, and must not depend on a Codex auth
+        file existing in the environment (CI has none). Tests that exercise
+        the preflight itself patch `codex_auth_error` again inside their own
+        `with` block (the inner patch wins). The real helper logic is covered
+        by tests/test_encoder_backend.py::TestCodexAuthPreflight.
+        """
+        with patch("axiom_encode.cli.codex_auth_error", return_value=None):
+            yield
+
     def _make_args(self, tmp_path, **overrides):
         """Helper to create args with sensible defaults."""
         corpus_path = tmp_path / "axiom-corpus"
@@ -4081,13 +4096,7 @@ class TestCmdEncode:
         with patch(
             "axiom_encode.cli.run_model_eval", return_value=[result]
         ) as mock_run:
-            # The codex-auth preflight is exercised by dedicated tests below;
-            # neutralize it here so these dispatch assertions do not depend on
-            # a Codex auth file existing in the test environment (CI has none).
-            with (
-                patch("axiom_encode.cli.codex_auth_error", return_value=None),
-                patch.dict(os.environ, {}, clear=True),
-            ):
+            with patch.dict(os.environ, {}, clear=True):
                 with pytest.raises(SystemExit) as exc_info:
                     cmd_encode(args)
             return mock_run, exc_info.value.code
@@ -4110,17 +4119,25 @@ class TestCmdEncode:
     def test_encode_codex_backend_without_auth_stops_before_running(
         self, capsys, tmp_path
     ):
-        """Negative: codex default + no auth file/key exits 1 before any eval."""
+        """Negative: codex default + failing auth preflight exits 1, no eval.
+
+        Overrides the class autouse fixture by patching ``codex_auth_error``
+        to return an error string, proving ``cmd_encode`` acts on a non-None
+        preflight result before any eval runs. (The real filesystem logic is
+        covered by TestCodexAuthPreflight.)
+        """
         args = self._make_args(tmp_path, backend="codex")
-        codex_home = tmp_path / "codex-home-empty"
-        codex_home.mkdir()
+        auth_message = (
+            "Codex backend requires authentication but ~/.codex/auth.json "
+            "was not found."
+        )
         with (
             patch("axiom_encode.cli.run_model_eval") as mock_run,
-            patch.dict(
-                os.environ,
-                {"CODEX_HOME": str(codex_home)},
-                clear=True,
+            patch(
+                "axiom_encode.cli.codex_auth_error",
+                return_value=auth_message,
             ),
+            patch.dict(os.environ, {}, clear=True),
         ):
             with pytest.raises(SystemExit) as exc_info:
                 cmd_encode(args)
@@ -4130,43 +4147,16 @@ class TestCmdEncode:
         assert "Codex backend requires authentication" in out
         assert "auth.json" in out
 
-    def test_encode_codex_backend_with_auth_json_runs(self, capsys, tmp_path):
-        """Positive: a present ~/.codex/auth.json satisfies the preflight."""
+    def test_encode_codex_backend_with_auth_runs(self, capsys, tmp_path):
+        """Positive: a passing preflight lets the codex-default encode proceed."""
         args = self._make_args(tmp_path, backend="codex")
-        codex_home = tmp_path / "codex-home-authed"
-        codex_home.mkdir()
-        (codex_home / "auth.json").write_text('{"OPENAI_API_KEY": "sk-test"}\n')
         with (
             patch(
                 "axiom_encode.cli.run_model_eval",
                 return_value=[self._make_eval_result(True)],
             ) as mock_run,
-            patch.dict(
-                os.environ,
-                {"CODEX_HOME": str(codex_home)},
-                clear=True,
-            ),
-        ):
-            with pytest.raises(SystemExit) as exc_info:
-                cmd_encode(args)
-        assert exc_info.value.code == 0
-        mock_run.assert_called_once()
-
-    def test_encode_codex_backend_with_openai_api_key_runs(self, capsys, tmp_path):
-        """Positive: OPENAI_API_KEY satisfies the preflight without auth.json."""
-        args = self._make_args(tmp_path, backend="codex")
-        codex_home = tmp_path / "codex-home-nofile"
-        codex_home.mkdir()
-        with (
-            patch(
-                "axiom_encode.cli.run_model_eval",
-                return_value=[self._make_eval_result(True)],
-            ) as mock_run,
-            patch.dict(
-                os.environ,
-                {"CODEX_HOME": str(codex_home), "OPENAI_API_KEY": "sk-test"},
-                clear=True,
-            ),
+            patch("axiom_encode.cli.codex_auth_error", return_value=None),
+            patch.dict(os.environ, {}, clear=True),
         ):
             with pytest.raises(SystemExit) as exc_info:
                 cmd_encode(args)
@@ -4177,26 +4167,27 @@ class TestCmdEncode:
     def test_encode_non_codex_backend_skips_auth_preflight(
         self, capsys, tmp_path, backend
     ):
-        """Explicit non-codex backends do not require a Codex auth file.
+        """Explicit non-codex backends do not consult the Codex auth check.
 
-        Note: this does not go through the ``_run_encode`` helper, which
-        blanket-patches ``codex_auth_error`` to ``None`` — so it genuinely
-        proves the ``args.backend == "codex"`` guard skips the check for
-        both ``claude`` and ``openai`` in an unauthenticated environment.
+        Patches ``codex_auth_error`` with a ``side_effect`` that would fail
+        the test if called, proving the ``args.backend == "codex"`` guard
+        short-circuits the preflight for both ``claude`` and ``openai``.
         """
+
+        def _must_not_be_called():
+            raise AssertionError("codex_auth_error called for non-codex backend")
+
         args = self._make_args(tmp_path, backend=backend)
-        codex_home = tmp_path / f"codex-home-empty-{backend}"
-        codex_home.mkdir()
         with (
             patch(
                 "axiom_encode.cli.run_model_eval",
                 return_value=[self._make_eval_result(True)],
             ) as mock_run,
-            patch.dict(
-                os.environ,
-                {"CODEX_HOME": str(codex_home)},
-                clear=True,
+            patch(
+                "axiom_encode.cli.codex_auth_error",
+                side_effect=_must_not_be_called,
             ),
+            patch.dict(os.environ, {}, clear=True),
         ):
             with pytest.raises(SystemExit) as exc_info:
                 cmd_encode(args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4173,10 +4173,19 @@ class TestCmdEncode:
         assert exc_info.value.code == 0
         mock_run.assert_called_once()
 
-    def test_encode_non_codex_backend_skips_auth_preflight(self, capsys, tmp_path):
-        """Explicit non-codex backends do not require a Codex auth file."""
-        args = self._make_args(tmp_path, backend="claude")
-        codex_home = tmp_path / "codex-home-empty2"
+    @pytest.mark.parametrize("backend", ["claude", "openai"])
+    def test_encode_non_codex_backend_skips_auth_preflight(
+        self, capsys, tmp_path, backend
+    ):
+        """Explicit non-codex backends do not require a Codex auth file.
+
+        Note: this does not go through the ``_run_encode`` helper, which
+        blanket-patches ``codex_auth_error`` to ``None`` — so it genuinely
+        proves the ``args.backend == "codex"`` guard skips the check for
+        both ``claude`` and ``openai`` in an unauthenticated environment.
+        """
+        args = self._make_args(tmp_path, backend=backend)
+        codex_home = tmp_path / f"codex-home-empty-{backend}"
         codex_home.mkdir()
         with (
             patch(
@@ -4193,7 +4202,7 @@ class TestCmdEncode:
                 cmd_encode(args)
         assert exc_info.value.code == 0
         mock_run.assert_called_once()
-        assert mock_run.call_args.kwargs["runner_specs"] == ["claude:test-model"]
+        assert mock_run.call_args.kwargs["runner_specs"] == [f"{backend}:test-model"]
 
     def test_encode_routes_state_corpus_citation_to_state_monorepo_root(
         self, capsys, tmp_path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4081,7 +4081,13 @@ class TestCmdEncode:
         with patch(
             "axiom_encode.cli.run_model_eval", return_value=[result]
         ) as mock_run:
-            with patch.dict(os.environ, {}, clear=True):
+            # The codex-auth preflight is exercised by dedicated tests below;
+            # neutralize it here so these dispatch assertions do not depend on
+            # a Codex auth file existing in the test environment (CI has none).
+            with (
+                patch("axiom_encode.cli.codex_auth_error", return_value=None),
+                patch.dict(os.environ, {}, clear=True),
+            ):
                 with pytest.raises(SystemExit) as exc_info:
                     cmd_encode(args)
             return mock_run, exc_info.value.code
@@ -4100,6 +4106,94 @@ class TestCmdEncode:
             mock_run.call_args.kwargs["runtime_axiom_rules_path"]
             == args.axiom_rules_path
         )
+
+    def test_encode_codex_backend_without_auth_stops_before_running(
+        self, capsys, tmp_path
+    ):
+        """Negative: codex default + no auth file/key exits 1 before any eval."""
+        args = self._make_args(tmp_path, backend="codex")
+        codex_home = tmp_path / "codex-home-empty"
+        codex_home.mkdir()
+        with (
+            patch("axiom_encode.cli.run_model_eval") as mock_run,
+            patch.dict(
+                os.environ,
+                {"CODEX_HOME": str(codex_home)},
+                clear=True,
+            ),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_encode(args)
+        assert exc_info.value.code == 1
+        mock_run.assert_not_called()
+        out = capsys.readouterr().out
+        assert "Codex backend requires authentication" in out
+        assert "auth.json" in out
+
+    def test_encode_codex_backend_with_auth_json_runs(self, capsys, tmp_path):
+        """Positive: a present ~/.codex/auth.json satisfies the preflight."""
+        args = self._make_args(tmp_path, backend="codex")
+        codex_home = tmp_path / "codex-home-authed"
+        codex_home.mkdir()
+        (codex_home / "auth.json").write_text('{"OPENAI_API_KEY": "sk-test"}\n')
+        with (
+            patch(
+                "axiom_encode.cli.run_model_eval",
+                return_value=[self._make_eval_result(True)],
+            ) as mock_run,
+            patch.dict(
+                os.environ,
+                {"CODEX_HOME": str(codex_home)},
+                clear=True,
+            ),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_encode(args)
+        assert exc_info.value.code == 0
+        mock_run.assert_called_once()
+
+    def test_encode_codex_backend_with_openai_api_key_runs(self, capsys, tmp_path):
+        """Positive: OPENAI_API_KEY satisfies the preflight without auth.json."""
+        args = self._make_args(tmp_path, backend="codex")
+        codex_home = tmp_path / "codex-home-nofile"
+        codex_home.mkdir()
+        with (
+            patch(
+                "axiom_encode.cli.run_model_eval",
+                return_value=[self._make_eval_result(True)],
+            ) as mock_run,
+            patch.dict(
+                os.environ,
+                {"CODEX_HOME": str(codex_home), "OPENAI_API_KEY": "sk-test"},
+                clear=True,
+            ),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_encode(args)
+        assert exc_info.value.code == 0
+        mock_run.assert_called_once()
+
+    def test_encode_non_codex_backend_skips_auth_preflight(self, capsys, tmp_path):
+        """Explicit non-codex backends do not require a Codex auth file."""
+        args = self._make_args(tmp_path, backend="claude")
+        codex_home = tmp_path / "codex-home-empty2"
+        codex_home.mkdir()
+        with (
+            patch(
+                "axiom_encode.cli.run_model_eval",
+                return_value=[self._make_eval_result(True)],
+            ) as mock_run,
+            patch.dict(
+                os.environ,
+                {"CODEX_HOME": str(codex_home)},
+                clear=True,
+            ),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_encode(args)
+        assert exc_info.value.code == 0
+        mock_run.assert_called_once()
+        assert mock_run.call_args.kwargs["runner_specs"] == ["claude:test-model"]
 
     def test_encode_routes_state_corpus_citation_to_state_monorepo_root(
         self, capsys, tmp_path

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -717,3 +717,46 @@ class TestBackendContract:
             )
 
             assert isinstance(resp, EncoderResponse)
+
+
+class TestCodexAuthPreflight:
+    """Codex-backend auth preflight helpers (encode#1054)."""
+
+    def test_auth_path_defaults_to_home_codex(self):
+        from axiom_encode.codex_cli import codex_auth_json_path
+
+        with patch.dict(os.environ, {}, clear=True):
+            assert codex_auth_json_path() == Path.home() / ".codex" / "auth.json"
+
+    def test_auth_path_honors_codex_home(self, tmp_path):
+        from axiom_encode.codex_cli import codex_auth_json_path
+
+        with patch.dict(os.environ, {"CODEX_HOME": str(tmp_path)}, clear=True):
+            assert codex_auth_json_path() == tmp_path / "auth.json"
+
+    def test_auth_error_when_no_file_and_no_key(self, tmp_path):
+        from axiom_encode.codex_cli import codex_auth_error
+
+        with patch.dict(os.environ, {"CODEX_HOME": str(tmp_path)}, clear=True):
+            error = codex_auth_error()
+        assert error is not None
+        assert "Codex backend requires authentication" in error
+        assert str(tmp_path / "auth.json") in error
+
+    def test_auth_ok_when_file_present(self, tmp_path):
+        from axiom_encode.codex_cli import codex_auth_error
+
+        (tmp_path / "auth.json").write_text('{"OPENAI_API_KEY": "sk-test"}\n')
+        with patch.dict(os.environ, {"CODEX_HOME": str(tmp_path)}, clear=True):
+            assert codex_auth_error() is None
+
+    def test_auth_ok_when_openai_api_key_set(self, tmp_path):
+        from axiom_encode.codex_cli import codex_auth_error
+
+        # No auth.json, but OPENAI_API_KEY is enough for the Codex CLI.
+        with patch.dict(
+            os.environ,
+            {"CODEX_HOME": str(tmp_path), "OPENAI_API_KEY": "sk-test"},
+            clear=True,
+        ):
+            assert codex_auth_error() is None

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1177"
+version = "0.2.1178"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
Closes #1054.

## What

`axiom-encode encode` already defaulted to `--backend codex` (and `--model`
resolves to `gpt-5.5`), but there was no authentication check — a missing Codex
sign-in failed deep inside the `codex exec` subprocess with an opaque message.

This PR:

1. Adds a pre-run auth check in `cmd_encode`: when the resolved backend is
   `codex` and neither `~/.codex/auth.json` (honoring `CODEX_HOME`) nor
   `OPENAI_API_KEY` is present, the command stops with an actionable error
   before starting a run.
2. Keeps other backends available explicitly (`--backend claude`,
   `--backend openai`) — only the default is asserted, nothing is removed.
3. Documents the default and the auth path in the README and the `--backend`
   help text, and reserves Claude/Fable capacity for orchestration, gating,
   and review.

Manifests already record `backend`/`model` per run, so the encoder-% census
(encode#1053) will show the policy taking effect.

## Tests

- `TestCodexAuthPreflight` (unit): `codex_auth_json_path` default and
  `CODEX_HOME` override; `codex_auth_error` returns an error when no file/key,
  and `None` when either `auth.json` or `OPENAI_API_KEY` is present.
- `TestCmdEncode`: **negative** — codex default with no auth exits 1 and never
  calls the eval; **positive** — `auth.json` present, `OPENAI_API_KEY` present,
  and a non-codex backend all proceed.

Version trio bumped to 0.2.1178 (pyproject + `__init__` + uv.lock) with a
towncrier fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
