### PR TITLE
Ground Nigerian gazette naira amounts (ASCII N prefix) in numeric extraction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1178"
+version = "0.2.1179"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@7451468ed40c4c9cb18a7f02f2af3bde7b3046df",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@9accc64098b511c421e2c86f253e34eacea33c7c",
     "pydantic>=2.0",
     "pypdf>=6.4.0",
     "pyyaml>=6.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1178"
+__version__ = "0.2.1179"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -3609,8 +3609,15 @@ def _clean_source_text_for_numeric_extraction(text: str) -> str:
     # after ¢, the grouped-thousands matcher's currency lookbehind never fires,
     # and "5,880" is misread as the trailing "880". The lookbehind fires only
     # when the glyph precedes a digit, so cent-suffixed values ("50¢") are left
-    # untouched. Covers the cent sign, cedi sign, and fullwidth cent sign.
-    text = re.sub(r"([¢₵￠])(?=\d)", r"\1 ", text)
+    # untouched. Covers the cent sign, cedi sign, fullwidth cent sign, and
+    # naira sign.
+    text = re.sub(r"([¢₵￠₦])(?=\d)", r"\1 ", text)
+    # Nigerian gazette prints denominate naira with an ASCII "N" glued to the
+    # amount ("N800,000" in the Nigeria Tax Act 2025 Fourth Schedule). Detach
+    # it the same way, but only when the N is a standalone prefix (not part
+    # of a longer token) and the amount is comma-grouped, so identifiers like
+    # "N95" or gazette references like "N26" stay untouched.
+    text = re.sub(r"(?<![A-Za-z0-9])N(?=\d{1,3},\d{3})", "N ", text)
     cleaned_lines: list[str] = []
     preserve_split_schedule_value = False
     for line in text.splitlines():

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6301,6 +6301,33 @@ def test_numeric_extraction_handles_ghana_cedi_grouped_thousands():
     assert 50.0 in extract_numbers_from_text("costs 50¢ per unit")
 
 
+def test_numeric_extraction_handles_nigeria_naira_ascii_prefix():
+    # Nigerian gazette prints glue an ASCII "N" to naira amounts
+    # ("N800,000" in the Nigeria Tax Act 2025 Fourth Schedule). The full
+    # grouped value must extract, not just the trailing group.
+    numbers = extract_numbers_from_text(
+        "(a) First N800,000 at 0%; (b) Next N2,200,000 at 15%; "
+        "(f) Above N50,000,000 at 25%."
+    )
+    assert 800000.0 in numbers
+    assert 2200000.0 in numbers
+    assert 50000000.0 in numbers
+    assert 800.0 not in numbers
+    # The naira glyph resolves the same way as the cedi glyph.
+    assert 500000.0 in extract_numbers_from_text("a maximum of \u20a6500,000")
+    # A comma-grouped decimal tail still parses fully.
+    assert 7500.0 in extract_numbers_from_text("Present issue N7,500.00 per copy")
+    # Ungrouped N-prefixed tokens are identifiers, not amounts: no stray
+    # space, no phantom value.
+    n95 = extract_numbers_from_text("wear an N95 respirator")
+    assert 95.0 not in n95
+    # An N glued to a preceding letter is not a naira prefix: the
+    # (?<![A-Za-z0-9]) guard must block the detach. The bare form is the
+    # positive control proving the guard (not something else) is what blocks.
+    assert 2000.0 not in extract_numbers_from_text("code XN2,000 here")
+    assert 2000.0 in extract_numbers_from_text("code N2,000 here")
+
+
 def test_rulespec_grounding_accepts_ghana_cedi_rate_schedule():
     content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1178"
+version = "0.2.1179"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -99,7 +99,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=7451468ed40c4c9cb18a7f02f2af3bde7b3046df" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=9accc64098b511c421e2c86f253e34eacea33c7c" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -121,7 +121,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=7451468ed40c4c9cb18a7f02f2af3bde7b3046df#7451468ed40c4c9cb18a7f02f2af3bde7b3046df" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=9accc64098b511c421e2c86f253e34eacea33c7c#9accc64098b511c421e2c86f253e34eacea33c7c" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
Unblocks rulespec-ng: the numeric-grounding gate missed naira amounts as printed in the Nigeria Tax Act 2025 gazette ("N800,000" — ASCII N glued to the grouped amount), so every Nigeria module literal failed as ungrounded. Mirrors the Ghana cedi fix (#1059): naira sign added to the glyph-detach class, plus a conservative standalone-N detach requiring a comma-grouped amount ((?<![A-Za-z0-9])N(?=\d{1,3},\d{3})) so "N95"/"N26"-style tokens stay untouched.

**Review cycle (repo discipline):** independent reviewer traced the change through the extraction pipeline and the consuming gate, ran ~30 adversarial probes (multi-group amounts, ₦ adjacency, European dot-grouping N1.234,56, legacy =N=800,000 — already covered via the = lookbehind, letter-glued XN2,000, line starts). Verdict APPROVE with one test-quality finding (the glued-token assertion passed via a trailing-X word boundary rather than the lookbehind) — applied: the test now uses the XN2,000 / N2,000 pair that distinguishes the guard.

Checks: ruff ✓, compileall ✓, focused suite (test_cli + test_rulespec_validation + test_evals -k "rulespec or EncoderPrompt") 804 passed ✓.

Version 0.2.1177 → 0.2.1178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)