### PR TITLE
Bump axiom-oracles pin for the UK passported-grant oracle mappings; encoder 0.2.1180

### DIFF
--- a/changelog.d/uk-passported-grants-oracles-pin.changed.md
+++ b/changelog.d/uk-passported-grants-oracles-pin.changed.md
@@ -1,0 +1,1 @@
+Bump the axiom-oracles pin to include the UK passported-grant oracle mappings (Sure Start Maternity Grant, Healthy Start, Best Start Foods; axiom-oracles#203), so the PolicyEngine oracle-coverage classifier reads their not_comparable bridge mappings for the companion rulespec-uk pipelines.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1180"
+version = "0.2.1181"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@596071a2d95467fb004137c093a127ed08676e1c",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@c038668b4234c466d5d75fe73e1bd22b81ded548",
     "pydantic>=2.0",
     "pypdf>=6.4.0",
     "pyyaml>=6.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1180"
+__version__ = "0.2.1181"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1180"
+version = "0.2.1181"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -99,7 +99,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=596071a2d95467fb004137c093a127ed08676e1c" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=c038668b4234c466d5d75fe73e1bd22b81ded548" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -121,7 +121,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=596071a2d95467fb004137c093a127ed08676e1c#596071a2d95467fb004137c093a127ed08676e1c" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=c038668b4234c466d5d75fe73e1bd22b81ded548#c038668b4234c466d5d75fe73e1bd22b81ded548" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
Bumps the axiom-oracles dependency pin to `c038668b` (axiom-oracles#203) so the PolicyEngine oracle-coverage classifier resolves the new UK passported-grant pipeline mappings.

The new axiom-oracles commit adds `legal_id_prefix` `not_comparable` classifications for the three composed passported-grant pipelines (Sure Start Maternity Grant, Healthy Start, Best Start Foods) — their outputs reconstruct the UKMOD `bmamt_s` / `bmamt01_s` / `bmascmt01_s` awards rather than adding PolicyEngine UK oracle variables. Required so the paired rulespec-uk encodings pass the changed-file oracle-coverage gate.

Mechanical pin bump (encoder 0.2.1180), same shape as #1067. ruff, ruff format, and towncrier draft pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
