### PR TITLE
Ground word-form half percentage rates ("five and half per centum")

### DIFF
--- a/changelog.d/act-766-word-half-percent-grounding.fixed.md
+++ b/changelog.d/act-766-word-half-percent-grounding.fixed.md
@@ -1,0 +1,1 @@
+Ground word-form half percentage rates ("five and half per centum", "eighteen and a half per centum") in source-text numeric extraction; bare "half"/"a half" are accepted only next to an explicit percentage marker. Unblocks the Ghana Act 766 SSNIT contribution rates (5.5/13.5/18.5%).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1185"
+version = "0.2.1186"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1185"
+__version__ = "0.2.1186"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -825,6 +825,8 @@ _UNICODE_FRACTION_VALUES = {
 _FRACTION_WORD_VALUES = {
     "half time": 0.5,
     "one half": 0.5,
+    "a half": 0.5,
+    "half": 0.5,
     "one third": 1 / 3,
     "two thirds": 2 / 3,
     "one quarter": 0.25,
@@ -844,6 +846,10 @@ _STANDALONE_FRACTION_WORD_PATTERN = re.compile(
     rf"\b({_FRACTION_WORD_PATTERN})\b",
     re.IGNORECASE,
 )
+# Bare "half"/"a half" ground only inside an explicit percentage marker
+# ("five and half per centum", "eighteen and a half per centum"); outside
+# one they would over-extract ordinary prose such as "half of the year".
+_PERCENT_FRACTION_WORD_PATTERN = rf"(?:{_FRACTION_WORD_PATTERN}|a[-\s]+half|half)"
 IMPORT_ITEM_PATTERN = re.compile(r"^\s*-\s*(['\"]?)([^'\"]+?)\1\s*$")
 IMPORT_MAPPING_PATTERN = re.compile(r"^\s*[A-Za-z_]\w*:\s*(['\"]?)([^'\"]+?)\1\s*$")
 _EMBEDDED_SCALAR_DIRECT_VALUE = re.compile(r"-?[\d,]+(?:\.\d+)?")
@@ -3109,7 +3115,7 @@ def _iter_normalized_special_numeric_matches(
 
     for match in re.finditer(
         rf"\b(?:(?P<whole>{_CARDINAL_WORD_SEQUENCE})\s+and\s+)?"
-        rf"(?P<fraction>{_FRACTION_WORD_PATTERN})\s+"
+        rf"(?P<fraction>{_PERCENT_FRACTION_WORD_PATTERN})\s+"
         r"(?:percent|per\s*cent(?:um)?)\b",
         text,
         re.IGNORECASE,

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6280,6 +6280,76 @@ def test_numeric_extraction_prefers_english_compound_cardinals_over_single_words
     )
 
 
+def test_rulespec_grounding_accepts_word_form_half_percentage_rates():
+    # Ghana's National Pensions Act, 2008 (Act 766) s.3 drafts every half
+    # rate in words, in two variants within the same section: "five and half
+    # per centum" and "eighteen and a half per centum".
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: gh/statute/act-766/national-pensions-2008/section-3-contributions-to-the-scheme
+rules:
+  - name: worker_contribution_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2008-12-12'
+        formula: '0.055'
+  - name: employer_contribution_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2008-12-12'
+        formula: '0.13'
+  - name: total_contribution_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2008-12-12'
+        formula: '0.185'
+  - name: first_tier_remittance_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2008-12-12'
+        formula: '0.135'
+  - name: second_tier_remittance_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2008-12-12'
+        formula: '0.05'
+"""
+
+    source_text = (
+        "a worker's contribution of an amount equal to five and half per "
+        "centum of the worker's salary for the period. "
+        "an employer's contribution of an amount equal to thirteen per "
+        "centum of the worker's salary during the month. "
+        "Out of the total contribution of eighteen and a half per centum an "
+        "employer shall transfer thirteen and half per centum to the first "
+        "tier mandatory basic national social security scheme; and five per "
+        "centum to the second tier mandatory occupational pension scheme."
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    numbers = extract_numbers_from_text(source_text)
+    for expected in (0.055, 0.135, 0.185):
+        assert any(math.isclose(value, expected) for value in numbers)
+
+
+def test_numeric_extraction_word_half_requires_percentage_context():
+    # A bare fraction word grounds 0.5% only next to a percentage marker;
+    # ordinary prose halves stay unextracted.
+    assert any(
+        math.isclose(value, 0.005)
+        for value in extract_numbers_from_text("a levy of half per centum")
+    )
+    prose_numbers = extract_numbers_from_text("during the first half of the year")
+    assert not any(math.isclose(value, 0.5) for value in prose_numbers)
+    assert not any(math.isclose(value, 0.005) for value in prose_numbers)
+
+
 def test_numeric_extraction_handles_ghana_cedi_grouped_thousands():
     # The Ghana cedi symbol glued to a grouped-thousands amount ("GH¢5,880")
     # must still yield the full value, not just the trailing "880". Mirrors

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1185"
+version = "0.2.1186"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Why

Ghana's National Pensions Act, 2008 (Act 766) s.3 drafts every half-rate in words, in two variants within one section: "five and half per centum" (5.5%), "thirteen and half per centum" (13.5%), and "eighteen and a half per centum" (18.5%). The fraction vocabulary only carried "one half"/"half time", so none of these rates could ground and validation hard-failed with no per-module override — blocking the rulespec-gh SSNIT slice (rulespec-gh#10, step 3).

## What

- Adds `"a half"` and `"half"` to `_FRACTION_WORD_VALUES`.
- New `_PERCENT_FRACTION_WORD_PATTERN` (existing fraction words + `a half` + bare `half`) used **only** in the percentage-context matcher inside `_iter_normalized_special_numeric_matches`. The standalone fraction matcher is deliberately unchanged: bare halves in ordinary prose ("half of the year") stay unextracted, so grounding gains no laxity outside an explicit percentage marker. Verified the dict additions cannot leak: `_FRACTION_WORD_VALUES` is only consumed via `_parse_fraction_word`, whose callers are the percent matcher and the unchanged standalone matcher.
- Regression tests: verbatim Act 766 s.3 phrasing grounds all five rates (0.055/0.13/0.185/0.135/0.05); "half per centum" alone yields 0.005; prose halves yield nothing.
- Encoder 0.2.1186.

## Validation

- `uv run ruff check` clean; `python -m compileall` clean.
- Focused suite: 806 passed (`test_cli.py test_rulespec_validation.py test_evals.py -k "rulespec or EncoderPrompt"`); fraction/cardinal selection 29 passed.
- End-to-end: `axiom-encode validate` on the rulespec-gh Act 766 module now passes CI/grounding (was a hard fail); a fresh codex-gpt-5.5 encode of the same provision grounds 7/7 atoms (run 90952000).

## Review cycle

Independent review by local Codex CLI in progress (Anthropic-billed subagents unavailable this session — account spend limit); findings will be addressed before marking ready. Self-review of alternation ordering ("half time" > bare "half"), whole+fraction composition ("eighteen and a half" → 18.5 not 0.5), and i18n patterns (French/Dutch untouched) recorded above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
