### PR TITLE
Bump axiom-oracles pin for UK capital gains tax and business rates oracle-coverage

### DIFF
--- a/changelog.d/uk-capital-property-oracle-coverage.changed.md
+++ b/changelog.d/uk-capital-property-oracle-coverage.changed.md
@@ -1,0 +1,1 @@
+Bump the axiom-oracles pin to include the UK capital gains tax and business rates PolicyEngine oracle-coverage mappings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1188"
+version = "0.2.1189"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@905058cbd5ddd0e71b9c849c0a0df39b01aa7c26",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@7ba7c86aa9eb637f59c6efe2a3e19dbca30ac401",
     "pydantic>=2.0",
     "pypdf>=6.4.0",
     "pyyaml>=6.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1188"
+__version__ = "0.2.1189"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1188"
+version = "0.2.1189"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -99,7 +99,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=905058cbd5ddd0e71b9c849c0a0df39b01aa7c26" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=7ba7c86aa9eb637f59c6efe2a3e19dbca30ac401" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -121,7 +121,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=905058cbd5ddd0e71b9c849c0a0df39b01aa7c26#905058cbd5ddd0e71b9c849c0a0df39b01aa7c26" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=7ba7c86aa9eb637f59c6efe2a3e19dbca30ac401#7ba7c86aa9eb637f59c6efe2a3e19dbca30ac401" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
Advances the git-pinned axiom-oracles dependency to `7ba7c86a` (axiom-oracles main) so the PolicyEngine oracle-coverage gate sees the new UK capital gains tax and business rates mappings (bridges/mappings/uk.yaml) and classifies the rulespec-uk#111 / #114 outputs as mapped rather than unmapped. Mappings-only bump; additive.