### PR TITLE
Bump axiom-oracles pin for UK LBTT/LTT oracle-coverage; release 0.2.1190

### DIFF
--- a/changelog.d/uk-lbtt-ltt-oracle-coverage.changed.md
+++ b/changelog.d/uk-lbtt-ltt-oracle-coverage.changed.md
@@ -1,0 +1,1 @@
+Bump the axiom-oracles pin to include the UK LBTT and LTT devolved transaction tax PolicyEngine oracle-coverage mappings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1189"
+version = "0.2.1190"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@7ba7c86aa9eb637f59c6efe2a3e19dbca30ac401",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@980d2ec5789945e6388f0d3b7e0f71c93a02e33d",
     "pydantic>=2.0",
     "pypdf>=6.4.0",
     "pyyaml>=6.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1189"
+__version__ = "0.2.1190"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1189"
+version = "0.2.1190"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -99,7 +99,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=7ba7c86aa9eb637f59c6efe2a3e19dbca30ac401" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=980d2ec5789945e6388f0d3b7e0f71c93a02e33d" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -121,7 +121,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=7ba7c86aa9eb637f59c6efe2a3e19dbca30ac401#7ba7c86aa9eb637f59c6efe2a3e19dbca30ac401" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=980d2ec5789945e6388f0d3b7e0f71c93a02e33d#980d2ec5789945e6388f0d3b7e0f71c93a02e33d" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
Bumps the `axiom-oracles` pin to `980d2ec5` (axiom-oracles#220, merged), which
adds the `uk-lbtt-ltt` PolicyEngine oracle-coverage suite and maps
`land_and_buildings_transaction_tax` and `land_transaction_tax` as
`direct_variable` (the 33 band-split intermediates and parameters
`not_comparable`).

Releases 0.2.1190. This lets rulespec-uk classify the two devolved transaction
tax outputs upstream once it pins 0.2.1190, so the LBTT/LTT modules can land
with their outputs mapped rather than pending.

Same shape as #1083 (the 0.2.1189 capital/property bump): pyproject pin +
version, `__init__.py` version, `uv.lock`, changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
