### PR TITLE
Strip the glued Ugandan shilling suffix in numeric extraction; release 0.2.1191

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1190"
+version = "0.2.1191"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1190"
+__version__ = "0.2.1191"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -3624,6 +3624,12 @@ def _clean_source_text_for_numeric_extraction(text: str) -> str:
     # of a longer token) and the amount is comma-grouped, so identifiers like
     # "N95" or gazette references like "N26" stay untouched.
     text = re.sub(r"(?<![A-Za-z0-9])N(?=\d{1,3},\d{3})", "N ", text)
+    # Ugandan prints denominate shillings with a "/=" (or plain "=") suffix
+    # glued to the amount ("200,000/=" and "200,000=" in the Local
+    # Governments (Amendment) (No. 2) Act 2008 local-service-tax tables).
+    # Strip the glued suffix so grouped-thousands parsing sees a clean
+    # boundary; a spaced "=" (a real equation, "x = 5") is left untouched.
+    text = re.sub(r"(?<=\d)/?=(?=\s|$)", "", text)
     cleaned_lines: list[str] = []
     preserve_split_schedule_value = False
     for line in text.splitlines():

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6371,6 +6371,29 @@ def test_numeric_extraction_handles_ghana_cedi_grouped_thousands():
     assert 50.0 in extract_numbers_from_text("costs 50¢ per unit")
 
 
+def test_numeric_extraction_handles_uganda_shilling_suffix():
+    # Ugandan prints glue a "/=" (or plain "=") shilling suffix to amounts
+    # ("Exceeding 100,000= but not exceeding 200,000= 5,000=" in the Local
+    # Governments (Amendment) (No. 2) Act 2008 local-service-tax table).
+    # The suffixed amounts must extract fully.
+    numbers = extract_numbers_from_text(
+        "1 | Exceeding 100,000= but not exceeding 200,000= 5,000= "
+        "9 | Exceeding 900,000= but not exceeding 1,000,000= 90,000= "
+        "10 | Exceeding 1,000,000= on wards 100,000="
+    )
+    assert 100000.0 in numbers
+    assert 200000.0 in numbers
+    assert 5000.0 in numbers
+    assert 900000.0 in numbers
+    assert 1000000.0 in numbers
+    assert 90000.0 in numbers
+    # The slashed form resolves the same way.
+    assert 25000.0 in extract_numbers_from_text("a grant of 25,000/= per month")
+    # A spaced "=" is a real equation and stays untouched.
+    eq = extract_numbers_from_text("where x = 5 and y = 7")
+    assert 5.0 in eq and 7.0 in eq
+
+
 def test_numeric_extraction_handles_nigeria_naira_ascii_prefix():
     # Nigerian gazette prints glue an ASCII "N" to naira amounts
     # ("N800,000" in the Nigeria Tax Act 2025 Fourth Schedule). The full

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1190"
+version = "0.2.1191"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
Ugandan prints glue a `/=` (or plain `=`) shilling suffix to amounts — the Act 8 of 2008 local-service-tax table reads `Exceeding 100,000= but not exceeding 200,000= 5,000=`. The glued suffix broke grouped-thousands parsing (the amount read as an equation head), so `200,000` never grounded and the rulespec-ug LST module failed the numeric-source gate. This strips the suffix when glued to a digit and followed by whitespace/EOL; spaced equations stay untouched. Mirrors the GH¢ detach (#1059) and the Nigerian N-prefix detach. New test covers both notations + the equation guard; full validation module green (773 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)