### PR TITLE
Resolve sub-paragraph deferrals for unitary jurisdictions; release 0.2.1192

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1191"
+version = "0.2.1192"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1191"
+__version__ = "0.2.1192"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -11030,6 +11030,19 @@ def _rulespec_base_parts_for_corpus_path(citation_path: str) -> tuple[str, ...]:
         and parts[1] in _RULESPEC_DOCUMENT_CLASS_DIRS
     ):
         return (_RULESPEC_DOCUMENT_CLASS_DIRS[parts[1]], *parts[2:])
+    generic_class_dirs = {
+        "statute": "statutes",
+        "regulation": "regulations",
+        **_RULESPEC_DOCUMENT_CLASS_DIRS,
+    }
+    if len(parts) >= 3 and len(parts[0]) == 2 and parts[1] in generic_class_dirs:
+        # Unitary jurisdictions (gh, ug, ng, be, uk, ...) mirror the corpus
+        # class directly under the country code; the rulespec layout uses the
+        # pluralized class dir. Without this branch the sub-paragraph
+        # coverage gate fires for these jurisdictions but deferred_outputs
+        # entries can never satisfy it (the base resolves empty), making the
+        # gate unsatisfiable outside the US.
+        return (generic_class_dirs[parts[1]], *parts[2:])
     return ()
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6371,6 +6371,42 @@ def test_numeric_extraction_handles_ghana_cedi_grouped_thousands():
     assert 50.0 in extract_numbers_from_text("costs 50¢ per unit")
 
 
+def test_deferred_outputs_cover_subparagraphs_for_unitary_jurisdictions():
+    # The sub-paragraph coverage gate fires for every jurisdiction, so its
+    # deferred_outputs matcher must resolve non-US corpus paths too. Before
+    # the generic branch, ug/statute/... resolved to an empty base and no
+    # deferral could ever satisfy the gate outside the US.
+    from axiom_encode.harness.validator_pipeline import (
+        _deferred_output_covered_subparagraphs,
+        _rulespec_base_parts_for_corpus_path,
+    )
+
+    assert _rulespec_base_parts_for_corpus_path(
+        "ug/statute/act-2008-8/local-governments-amendment-no2-2008"
+    ) == ("statutes", "act-2008-8", "local-governments-amendment-no2-2008")
+    assert _rulespec_base_parts_for_corpus_path(
+        "gh/policy/mogcsp-leap/payment-cycle-97-2025"
+    ) == ("policies", "mogcsp-leap", "payment-cycle-97-2025")
+
+    payload = {
+        "module": {
+            "deferred_outputs": [
+                {
+                    "output": (
+                        "ug:statutes/act-2008-8/"
+                        "local-governments-amendment-no2-2008/f#exemption"
+                    ),
+                    "reason": "out of scope",
+                }
+            ]
+        }
+    }
+    covered = _deferred_output_covered_subparagraphs(
+        payload, "ug/statute/act-2008-8/local-governments-amendment-no2-2008"
+    )
+    assert ("f",) in covered
+
+
 def test_numeric_extraction_handles_uganda_shilling_suffix():
     # Ugandan prints glue a "/=" (or plain "=") shilling suffix to amounts
     # ("Exceeding 100,000= but not exceeding 200,000= 5,000=" in the Local

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1191"
+version = "0.2.1192"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
The sub-paragraph coverage gate (0.2.1189+) fires jurisdiction-agnostically, but its `deferred_outputs` matcher resolved only US corpus paths — `ug/statute/...` returned an empty base, so no deferral could ever satisfy the gate and the rulespec-ug LST module failed unfixably (`...(f) has no rule citing it and no entry in module.deferred_outputs` even with the entry present). Adds the generic unitary-jurisdiction branch (statute→statutes, regulation→regulations + the existing class map) with a test covering ug statute and gh policy paths and the end-to-end deferral coverage. Version provenance bumped in the same commit (pyproject + __version__ + lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)