### PR TITLE
Detach OCR'd range hyphens glued to band bounds (0.2.1197)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1196"
+version = "0.2.1197"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1196"
+__version__ = "0.2.1197"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -3631,6 +3631,14 @@ def _clean_source_text_for_numeric_extraction(text: str) -> str:
     # over-detaching a rare non-currency "K2" only adds a harmless
     # candidate value to numeric extraction.
     text = re.sub(r"(?<![A-Za-z0-9])[Kk](?=\d)", lambda m: m.group(0) + " ", text)
+    # OCR'd schedule tables render band ranges with the hyphen glued to
+    # the upper bound ("0 -2,000 0%" in the Ethiopia Proclamation
+    # 1395/2025 scan), so the bound parses as a negative amount. A
+    # hyphen preceded by digit-plus-space and followed by a digit is a
+    # range separator, not a minus - detach it. True negative amounts
+    # ("a loss of -2,000") lose the sign only when directly preceded by
+    # a spaced digit, which statutory prose does not produce.
+    text = re.sub(r"(?<=\d )-(?=\d)", "- ", text)
     # Ugandan prints denominate shillings with a "/=" (or plain "=") suffix
     # glued to the amount ("200,000/=" and "200,000=" in the Local
     # Governments (Amendment) (No. 2) Act 2008 local-service-tax tables).

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6430,6 +6430,16 @@ def test_numeric_extraction_handles_uganda_shilling_suffix():
     assert 5.0 in eq and 7.0 in eq
 
 
+def test_numeric_extraction_handles_ocr_range_hyphen():
+    # OCR'd band tables glue the range hyphen to the upper bound
+    # ("0 -2,000 0%" in the Ethiopia Proclamation 1395/2025 scan),
+    # which would otherwise parse as a negative amount.
+    numbers = extract_numbers_from_text("Tax Rate 0 -2,000 0% 2,001-4,000 15%")
+    assert 2000.0 in numbers
+    assert -2000.0 not in numbers
+    assert 2001.0 in numbers
+
+
 def test_numeric_extraction_handles_zambia_kwacha_ascii_prefix():
     # Zambian prints glue an ASCII "K" (or "k") to kwacha amounts
     # ("K452" per mille cigarettes, "K2.34/ltr" petrol, "k0.25/ltr"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1196"
+version = "0.2.1197"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
Ethiopia lane blocker ([rulespec-et#1](https://github.com/TheAxiomFoundation/rulespec-et/issues/1)): the 1395/2025 MoF scan OCRs band ranges as `0 -2,000 0%`, so the exempt bound parses as −2,000 and the grounding gate rejects the encoded 2,000. A hyphen preceded by digit+space and followed by a digit is a range separator — detached like the cedi/naira/kwacha/`=` lineage. Test beside the kwacha one. Version 0.2.1197 in one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)