### PR TITLE
Bump oracles pin for SNAP FY2024 coverage

### DIFF
--- a/changelog.d/snap-fy2024-oracle-coverage-pin.changed.md
+++ b/changelog.d/snap-fy2024-oracle-coverage-pin.changed.md
@@ -1,0 +1,1 @@
+Bump the axiom-oracles pin so PolicyEngine oracle coverage classifies the USDA SNAP FY 2024 COLA parameter modules.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1197"
+version = "0.2.1198"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@980d2ec5789945e6388f0d3b7e0f71c93a02e33d",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@d74ce0e748f44d08c2e3050d8a72ef6606ee0a37",
     "pydantic>=2.0",
     "pypdf>=6.4.0",
     "pyyaml>=6.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1197"
+__version__ = "0.2.1198"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1197"
+version = "0.2.1198"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -99,7 +99,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=980d2ec5789945e6388f0d3b7e0f71c93a02e33d" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=d74ce0e748f44d08c2e3050d8a72ef6606ee0a37" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -121,7 +121,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=980d2ec5789945e6388f0d3b7e0f71c93a02e33d#980d2ec5789945e6388f0d3b7e0f71c93a02e33d" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=d74ce0e748f44d08c2e3050d8a72ef6606ee0a37#d74ce0e748f44d08c2e3050d8a72ef6606ee0a37" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary
- bump the axiom-oracles git pin to d74ce0e748f44d08c2e3050d8a72ef6606ee0a37
- consume the merged SNAP FY 2024 COLA oracle coverage classifications from axiom-oracles#258
- add a changelog entry for the dependency refresh

## Checks
- uv run ruff check pyproject.toml src/axiom_encode scripts tests
- python -m compileall -q src/axiom_encode scripts
- uv run pytest -q tests/test_policyengine_coverage.py tests/test_policyengine_classifier.py
- SNAP FY2024 oracle mapping smoke check
- uv run pytest

## Cycle
- Pending independent review/fix cycle before merge per AGENTS.md.