### PR TITLE
Cover broad version table proof atoms

### DIFF
--- a/changelog.d/money-atom-versions-path-coverage.fixed.md
+++ b/changelog.d/money-atom-versions-path-coverage.fixed.md
@@ -1,0 +1,1 @@
+Treat cited `parameter_table` proof atoms at `path: versions` as covering each table-valued version in the money-atom gate, preserving compatibility with signed RuleSpec outputs that use the broader table anchor.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1198"
+version = "0.2.1199"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1198"
+__version__ = "0.2.1199"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/proof_validator.py
+++ b/src/axiom_encode/harness/proof_validator.py
@@ -786,8 +786,23 @@ def _cited_proof_atom_paths(rule: dict[str, Any]) -> set[str]:
         if not path:
             continue
         if _atom_cites_provision(atom):
-            paths.add(_normalize_atom_path(path))
+            normalized = _normalize_atom_path(path)
+            paths.add(normalized)
+            if normalized == "versions" and atom.get("kind") == "parameter_table":
+                paths.update(_version_table_atom_paths(rule))
     return paths
+
+
+def _version_table_atom_paths(rule: dict[str, Any]) -> set[str]:
+    """Return table-value paths covered by a broad ``path: versions`` atom."""
+    versions = rule.get("versions")
+    if not isinstance(versions, list):
+        return set()
+    return {
+        f"versions[{index}].values"
+        for index, version in enumerate(versions)
+        if isinstance(version, dict) and isinstance(version.get("values"), dict)
+    }
 
 
 def _atom_cites_provision(atom: dict[str, Any]) -> bool:

--- a/tests/test_money_proof_atoms.py
+++ b/tests/test_money_proof_atoms.py
@@ -241,6 +241,36 @@ rules:
     assert report.missing_count == 0
 
 
+def test_versions_path_parameter_table_atom_covers_each_table_version():
+    table = """format: rulespec/v1
+rules:
+  - name: allotment_table
+    kind: parameter
+    dtype: Money
+    unit: EUR
+    indexed_by: household_size
+    metadata:
+      proof:
+        atoms:
+          - path: versions
+            kind: parameter_table
+            source:
+              corpus_citation_path: be/statute/x
+    versions:
+      - effective_from: '2025-01-01'
+        values:
+          "1": "186.51"
+      - effective_from: '2026-01-01'
+        values:
+          "1": "198.94"
+"""
+
+    report = find_missing_money_proof_atoms(table)
+
+    assert report.obligation_count == 2
+    assert report.missing_count == 0
+
+
 def test_derived_formula_with_currency_literal_creates_obligation():
     content = """format: rulespec/v1
 rules:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1198"
+version = "0.2.1199"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- Treat a cited `parameter_table` proof atom at `path: versions` as covering each table-valued version entry for money-atom validation.
- Add a regression test for broad version-table proof atoms.
- Bump encoder to 0.2.1199.

## Why
This unblocks TheAxiomFoundation/rulespec-us#638 without editing the signed Arizona RuleSpec YAML. The AZ encoding already cites the relevant table proof atom broadly at `path: versions`; the validator was only accepting exact `versions[i].values` paths.

## Checks
- `UV_PYTHON=3.13 uv run --extra dev ruff check pyproject.toml src/axiom_encode scripts tests`
- `UV_PYTHON=3.13 uv run --extra dev python -m compileall -q src/axiom_encode scripts`
- `UV_PYTHON=3.13 uv run --extra dev pytest -q tests/test_money_proof_atoms.py tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`
- `UV_PYTHON=3.13 uv run --extra dev pytest`
- RuleSpec replay in `/tmp/rulespec-us-work`: `axiom-encode proof-validate ... --money-atoms-only --ratchet-file known-missing-money-atoms.yaml` now passes at 113 missing / 1802 obligations, under allowance 151.