### PR TITLE
Bump oracles pin for SNAP FY2024 helper coverage

### DIFF
--- a/changelog.d/snap-fy2024-helper-oracles-pin.changed.md
+++ b/changelog.d/snap-fy2024-helper-oracles-pin.changed.md
@@ -1,0 +1,1 @@
+Bump the axiom-oracles pin for SNAP FY2024 additional-member helper coverage classification.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1199"
+version = "0.2.1200"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@d74ce0e748f44d08c2e3050d8a72ef6606ee0a37",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@4356d73d61339abe92b39c7ace3a0869f401d9c5",
     "pydantic>=2.0",
     "pypdf>=6.4.0",
     "pyyaml>=6.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1199"
+__version__ = "0.2.1200"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1199"
+version = "0.2.1200"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -99,7 +99,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=d74ce0e748f44d08c2e3050d8a72ef6606ee0a37" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=4356d73d61339abe92b39c7ace3a0869f401d9c5" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -121,7 +121,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=d74ce0e748f44d08c2e3050d8a72ef6606ee0a37#d74ce0e748f44d08c2e3050d8a72ef6606ee0a37" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=4356d73d61339abe92b39c7ace3a0869f401d9c5#4356d73d61339abe92b39c7ace3a0869f401d9c5" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary
- Bump `axiom-oracles` to `4356d73d61339abe92b39c7ace3a0869f401d9c5`.
- Bump encoder version to 0.2.1200.
- Add changelog entry.

## Why
This picks up TheAxiomFoundation/axiom-oracles#259, which keeps signed SNAP FY2024 RuleSpec artifacts unchanged while resolving the changed-file oracle coverage gate for additional-member helper leaves.

## Checks
- `UV_PYTHON=3.13 uv run --extra dev ruff check pyproject.toml src/axiom_encode scripts tests`
- `UV_PYTHON=3.13 uv run --extra dev python -m compileall -q src/axiom_encode scripts`
- `UV_PYTHON=3.13 uv run --extra dev pytest -q tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`
- Local rulespec-us#760 coverage reproduction with this branch: `untested_comparable == 0`.