### PR TITLE
Keep ISO-4217 currency-code amounts in numeric grounding (0.2.1201)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1200"
+version = "0.2.1201"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1200"
+__version__ = "0.2.1201"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -981,7 +981,14 @@ _SOURCE_REFERENCE_PATTERNS = (
         re.IGNORECASE,
     ),
     re.compile(
-        r"\b[A-Z]{2,6}[ \t]+\d+(?:\.\d+)*(?:\([^)]+\))*",
+        # An all-caps token followed by a number reads as a document
+        # reference ("HB 1234", "HS 322"), but an ISO 4217 currency code
+        # in that position denominates an amount ("FRW 322/kg" in the
+        # Rwanda excise schedule, "RWF 3,000", "GHS 100") - the amount
+        # must survive for numeric grounding, so currency codes are
+        # excluded from the reference pattern.
+        r"\b(?!(?:FRW|RWF|GHS|GHP|NGN|UGX|ZMW|ETB|USD|EUR|GBP|CAD|AUD|"
+        r"KES|TZS|XAF|XOF|ZAR)\b)[A-Z]{2,6}[ \t]+\d+(?:\.\d+)*(?:\([^)]+\))*",
     ),
     re.compile(r"\b(?:Act|Order|Regulations?)\s+\d{4}\b"),
 )

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -27244,3 +27244,25 @@ rules:
         )
         == []
     )
+
+
+def test_numeric_extraction_keeps_currency_code_denominated_amounts():
+    # An ISO 4217 currency code before a number denominates an amount,
+    # not a document reference: the Rwanda excise schedule states
+    # "Sweets and chewing gums FRW 322/kg" (and the CBHI orders state
+    # premiums as "FRW 3,000"), where the all-caps-reference pattern
+    # used to swallow the amount and numeric grounding failed.
+    numbers = extract_numbers_from_text(
+        "Sweets and chewing gums FRW 322/kg 1704.10.00; "
+        "an annual contribution of FRW 3,000 per person; "
+        "a value of GHS 100 per unit"
+    )
+    assert 322.0 in numbers
+    assert 3000.0 in numbers
+    assert 100.0 in numbers
+    # Genuine all-caps references keep being stripped.
+    stripped = extract_numbers_from_text(
+        "as provided in HB 1234 and HS 322 of the tariff nomenclature"
+    )
+    assert 1234.0 not in stripped
+    assert 322.0 not in stripped

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1200"
+version = "0.2.1201"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
The all-caps-reference cleaner pattern (`\b[A-Z]{2,6}[ \t]+\d+...`, for "HB 1234" / "HS 322" style references) also matched **ISO 4217 currency codes followed by amounts**. In the Rwanda excise schedule (Law nº 011/2025), after dotted HS codes collapse, the row "Sweets and chewing gums FRW 322/kg" left "…HS 322 FRW/kg…" and the 322 was stripped before numeric extraction — so the ungrounded-literal gate rejected a correctly grounded encoding ("Ungrounded generated numeric literal: 322"). Same failure shape for "RWF 3,000" (CBHI orders) and "GHS 100".

Fix: exclude a set of ISO 4217 currency codes from the reference pattern via negative lookahead. Genuine references ("HB 1234", "HS 322 of the tariff nomenclature") still strip — covered in the regression test.

Cycle (lightweight, 2-line pattern change + test):
- `ruff check` clean, `compileall` clean
- Focused suite: `pytest tests/test_rulespec_validation.py -k "currency_code_denominated or kwacha"` → 2 passed (new regression + the adjacent kwacha-prefix regression)
- Sibling regressions consulted: #1093 (K-prefix detach), #1094 (range-hyphen detach) — same family, same test file.

Found live by the rulespec-rw SOUTHMOD lane (fifth country); unblocks the Rwanda excise module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
