### PR TITLE
Re-land unicode sanitizer for golden-regeneration publish (dropped by #1102 squash)

### DIFF
--- a/changelog.d/golden-regeneration-unicode-safety.fixed.md
+++ b/changelog.d/golden-regeneration-unicode-safety.fixed.md
@@ -1,0 +1,1 @@
+Escape unsafe Unicode in golden-regeneration reports and isolate per-module GitHub issue publication failures so one malformed finding cannot suppress unrelated issues.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1203"
+version = "0.2.1204"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1203"
+__version__ = "0.2.1204"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/judges/cli_commands.py
+++ b/src/axiom_encode/judges/cli_commands.py
@@ -597,32 +597,37 @@ def _create_drift_issues(report, repo: str) -> list[str]:
         capture_output=True,
         text=True,
         env=github_env,
+        shell=False,
     )
 
     # File an issue for every drifted module AND every regeneration error — a
     # regeneration error is the least-visible outcome otherwise, and the drift
     # check's whole point is that failures are never silent.
-    items = [
-        (r, drift.drift_issue_body(r), drift.drift_issue_title(r))
-        for r in report.drifted
-    ]
-    items += [
-        (
-            r,
-            drift.drift_error_issue_body(r),
-            drift.drift_issue_title(r, regeneration_error=True),
-        )
-        for r in report.errors
-    ]
+    items = [(result, False) for result in report.drifted]
+    items.extend((result, True) for result in report.errors)
 
     created: list[str] = []
-    for _result, body, title in items:
-        body = drift.enforce_github_issue_body_budget(redact_sensitive_text(body))
-        title = drift.enforce_github_issue_title_budget(redact_sensitive_text(title))
-        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as fh:
-            fh.write(body)
-            body_path = fh.name
+    for result, regeneration_error in items:
+        body_path: str | None = None
         try:
+            if regeneration_error:
+                body = drift.drift_error_issue_body(result)
+                title = drift.drift_issue_title(result, regeneration_error=True)
+            else:
+                body = drift.drift_issue_body(result)
+                title = drift.drift_issue_title(result)
+            body = drift.enforce_github_issue_body_budget(redact_sensitive_text(body))
+            title = drift.enforce_github_issue_title_budget(
+                redact_sensitive_text(title)
+            )
+            with tempfile.NamedTemporaryFile(
+                "w",
+                suffix=".md",
+                delete=False,
+                encoding="utf-8",
+            ) as fh:
+                fh.write(body)
+                body_path = fh.name
             proc = subprocess.run(
                 [
                     "gh",
@@ -640,6 +645,7 @@ def _create_drift_issues(report, repo: str) -> list[str]:
                 capture_output=True,
                 text=True,
                 env=github_env,
+                shell=False,
             )
             if proc.returncode == 0:
                 created.append(proc.stdout.strip())
@@ -649,8 +655,23 @@ def _create_drift_issues(report, repo: str) -> list[str]:
                     f"{title}: {redact_sensitive_text(proc.stderr)}",
                     file=sys.stderr,
                 )
+        except Exception as exc:  # noqa: BLE001 - isolate every publication
+            diagnostic = ascii(redact_sensitive_text(str(exc)))
+            print(
+                f"failed to create issue for {ascii(result.module)}: {diagnostic}",
+                file=sys.stderr,
+            )
         finally:
-            os.unlink(body_path)
+            if body_path is not None:
+                try:
+                    os.unlink(body_path)
+                except OSError as exc:
+                    diagnostic = ascii(redact_sensitive_text(str(exc)))
+                    print(
+                        "failed to remove temporary issue body for "
+                        f"{ascii(result.module)}: {diagnostic}",
+                        file=sys.stderr,
+                    )
     return created
 
 

--- a/src/axiom_encode/judges/drift.py
+++ b/src/axiom_encode/judges/drift.py
@@ -17,11 +17,14 @@ import hashlib
 import html
 import json
 import random
+import unicodedata
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Any, Callable, Optional
 
 import yaml
+
+from .regeneration import _SAFE_PATH_PART
 
 MIN_SAMPLE = 3
 MAX_SAMPLE = 5
@@ -35,6 +38,7 @@ MAX_ERROR_CHARS = 4096
 MAX_GITHUB_ISSUE_BODY_BYTES = 60_000
 MAX_GITHUB_ISSUE_TITLE_CHARS = 240
 MAX_GITHUB_ISSUE_PATH_PREVIEW_CHARS = 256
+_UNSAFE_DISPLAY_CATEGORIES = frozenset({"Cc", "Cf", "Cs", "Zl", "Zp"})
 
 
 def _safe_load_drift_yaml(yaml_text: str) -> Any:
@@ -111,13 +115,61 @@ def semantic_key(yaml_text: str) -> str:
     )
 
 
+def _is_unsafe_display_character(
+    character: str,
+    *,
+    preserve_lf_tab: bool = False,
+) -> bool:
+    """Return whether a character must not cross a display trust boundary raw."""
+
+    if preserve_lf_tab and character in {"\n", "\t"}:
+        return False
+    return unicodedata.category(character) in _UNSAFE_DISPLAY_CATEGORIES
+
+
+def _contains_unsafe_display_characters(
+    value: str,
+    *,
+    preserve_lf_tab: bool = False,
+) -> bool:
+    """Return whether text contains controls or display-direction metadata."""
+
+    return any(
+        _is_unsafe_display_character(
+            character,
+            preserve_lf_tab=preserve_lf_tab,
+        )
+        for character in value
+    )
+
+
+def _sanitize_display_text(
+    value: str,
+    *,
+    preserve_lf_tab: bool = False,
+) -> str:
+    """Render unsafe Unicode categories as visible, UTF-8-safe escapes."""
+
+    sanitized: list[str] = []
+    for character in value:
+        if not _is_unsafe_display_character(
+            character,
+            preserve_lf_tab=preserve_lf_tab,
+        ):
+            sanitized.append(character)
+            continue
+        code_point = ord(character)
+        if code_point <= 0xFFFF:
+            sanitized.append(f"\\u{code_point:04X}")
+        else:
+            sanitized.append(f"\\U{code_point:08X}")
+    return "".join(sanitized)
+
+
 def _bounded_diff_path(path: str) -> str:
     """Return one control-free, bounded display path while traversing YAML."""
 
-    escaped = (
-        "".join(f"\\u{ord(char):04x}" if ord(char) < 32 else char for char in path)
-        or "(root)"
-    )
+    escaped = _sanitize_display_text(path) or "(root)"
     if len(escaped) <= MAX_DIFF_PATH_CHARS:
         return escaped
     digest = hashlib.sha256(escaped.encode("utf-8")).hexdigest()[:12]
@@ -140,11 +192,12 @@ def _bounded_diff_value(value: Any) -> Any:
 def _bounded_error(error: str) -> str:
     """Bound diagnostics so every producer report satisfies publisher schema."""
 
-    if len(error) <= MAX_ERROR_CHARS:
-        return error
-    digest = hashlib.sha256(error.encode("utf-8")).hexdigest()[:12]
+    sanitized = _sanitize_display_text(error, preserve_lf_tab=True)
+    if len(sanitized) <= MAX_ERROR_CHARS:
+        return sanitized
+    digest = hashlib.sha256(sanitized.encode("utf-8")).hexdigest()[:12]
     suffix = f"…[truncated; sha256:{digest}]"
-    return error[: MAX_ERROR_CHARS - len(suffix)] + suffix
+    return sanitized[: MAX_ERROR_CHARS - len(suffix)] + suffix
 
 
 def _record_diff(
@@ -299,9 +352,7 @@ class DriftReport:
             if (
                 not isinstance(module, str)
                 or not module
-                or len(module) > 4096
-                or "\\" in module
-                or any(ord(char) < 32 for char in module)
+                or len(module) > MAX_DIFF_PATH_CHARS
             ):
                 raise ValueError("drift report result has an invalid module")
             module_path = PurePosixPath(module)
@@ -310,6 +361,10 @@ class DriftReport:
                 or module_path.suffix != ".yaml"
                 or module_path.as_posix() != module
                 or any(part in {"", ".", ".."} for part in module_path.parts)
+                or any(
+                    _SAFE_PATH_PART.fullmatch(part) is None
+                    for part in module_path.parts
+                )
                 or module in seen_modules
             ):
                 raise ValueError(
@@ -319,7 +374,13 @@ class DriftReport:
             if not isinstance(drifted, bool):
                 raise ValueError("drift report result has a non-boolean drifted field")
             if error is not None and (
-                not isinstance(error, str) or not error or len(error) > 4096
+                not isinstance(error, str)
+                or not error
+                or len(error) > MAX_ERROR_CHARS
+                or _contains_unsafe_display_characters(
+                    error,
+                    preserve_lf_tab=True,
+                )
             ):
                 raise ValueError("drift report result has an invalid error")
             if not isinstance(diffs, list):
@@ -339,8 +400,8 @@ class DriftReport:
                 if (
                     not isinstance(path, str)
                     or not path
-                    or len(path) > 4096
-                    or any(ord(char) < 32 for char in path)
+                    or len(path) > MAX_DIFF_PATH_CHARS
+                    or _contains_unsafe_display_characters(path)
                     or not isinstance(change, str)
                     or change
                     not in {"added", "removed", "list_changed", "value_changed"}
@@ -462,7 +523,7 @@ def drift_error_issue_body(result: DriftResult) -> str:
     body = (
         "Golden regeneration could not check "
         f"{_github_inline_code(result.module)}:\n\n"
-        f"<pre>{_github_safe_text(result.error or '')}</pre>\n"
+        f"<pre>{_github_safe_text(result.error or '', preserve_lf_tab=True)}</pre>\n"
     )
     return _bounded_utf8(body, MAX_GITHUB_ISSUE_BODY_BYTES)
 
@@ -480,19 +541,21 @@ def drift_issue_title(result: DriftResult, *, regeneration_error: bool = False) 
 def _bounded_text_with_digest(value: str, max_chars: int) -> str:
     """Truncate display text with a stable identity-preserving digest."""
 
-    if len(value) <= max_chars:
-        return value
-    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:12]
+    sanitized = _sanitize_display_text(value)
+    if len(sanitized) <= max_chars:
+        return sanitized
+    digest = hashlib.sha256(sanitized.encode("utf-8")).hexdigest()[:12]
     suffix = f"…[sha256:{digest}]"
-    return value[: max_chars - len(suffix)] + suffix
+    return sanitized[: max_chars - len(suffix)] + suffix
 
 
 def _bounded_utf8(value: str, max_bytes: int) -> str:
     """Apply a final byte budget to text passed to an external publisher."""
 
-    encoded = value.encode("utf-8")
+    sanitized = _sanitize_display_text(value, preserve_lf_tab=True)
+    encoded = sanitized.encode("utf-8")
     if len(encoded) <= max_bytes:
-        return value
+        return sanitized
     digest = hashlib.sha256(encoded).hexdigest()[:12]
     suffix = f"\n\n[truncated; sha256:{digest}]"
     available = max_bytes - len(suffix.encode("utf-8"))
@@ -512,10 +575,13 @@ def enforce_github_issue_title_budget(value: str) -> str:
     return _bounded_text_with_digest(value, MAX_GITHUB_ISSUE_TITLE_CHARS)
 
 
-def _github_safe_text(value: object) -> str:
+def _github_safe_text(value: object, *, preserve_lf_tab: bool = False) -> str:
     """Escape untrusted report text and neutralize GitHub mentions."""
 
-    safe = html.escape(str(value), quote=True)
+    safe = html.escape(
+        _sanitize_display_text(str(value), preserve_lf_tab=preserve_lf_tab),
+        quote=True,
+    )
     for character, entity in (
         ("@", "&#64;"),
         ("`", "&#96;"),

--- a/tests/test_judges.py
+++ b/tests/test_judges.py
@@ -1250,6 +1250,9 @@ def test_drift_workflow_isolates_model_and_github_credentials_by_job():
     assert all(step["with"]["version"] == "0.11.7" for step in setup_uv_steps)
 
 
+_UNSAFE_DRIFT_CODE_POINTS = (0xD800, 0x202E, 0x009B, 0x007F, 0x2028)
+
+
 def test_drift_ignores_order_and_comments_catches_change():
     a = "outputs:\n  r:\n    value: 0.34\ninputs: [x, y]\n"
     reordered = "inputs: [y, x]  # comment\noutputs:\n  r:\n    value: 0.34\n"
@@ -1272,6 +1275,112 @@ def test_drift_rejects_yaml_alias_expansion_bomb():
 
     with pytest.raises(ValueError, match="aliases are not allowed"):
         drift.semantic_diff(bomb, bomb)
+
+
+@pytest.mark.parametrize("code_point", _UNSAFE_DRIFT_CODE_POINTS)
+def test_drift_unicode_is_escaped_through_report_and_issue_body(code_point):
+    dangerous = chr(code_point)
+    regenerated = f"{json.dumps(dangerous)}: 1\n"
+    result = drift.check_module(
+        "us/statutes/1.yaml",
+        "safe: 1\n",
+        lambda _module, _merged: regenerated,
+    )
+
+    payload = json.loads(json.dumps(drift.DriftReport([result]).to_dict()))
+    loaded = drift.DriftReport.from_dict(payload)
+    body = drift.drift_issue_body(loaded.drifted[0])
+    expected_escape = f"\\u{code_point:04X}"
+
+    assert result.drifted
+    assert body.encode("utf-8")
+    assert dangerous not in body
+    assert expected_escape in body
+
+
+@pytest.mark.parametrize("code_point", _UNSAFE_DRIFT_CODE_POINTS)
+@pytest.mark.parametrize("field", ("module", "path", "error"))
+def test_drift_report_rejects_raw_unsafe_unicode_in_strict_fields(
+    code_point,
+    field,
+):
+    dangerous = chr(code_point)
+    if field == "error":
+        payload = drift.DriftReport(
+            [
+                drift.DriftResult(
+                    module="us/statutes/1.yaml",
+                    drifted=False,
+                    error="safe error",
+                )
+            ]
+        ).to_dict()
+        payload["results"][0]["error"] = f"unsafe{dangerous}error"
+    else:
+        payload = drift.DriftReport(
+            [
+                drift.DriftResult(
+                    module="us/statutes/1.yaml",
+                    drifted=True,
+                    diffs=[
+                        {
+                            "path": "safe",
+                            "change": "value_changed",
+                            "merged": 1,
+                            "regenerated": 2,
+                        }
+                    ],
+                )
+            ]
+        ).to_dict()
+        if field == "module":
+            payload["results"][0]["module"] = f"us/statutes/unsafe{dangerous}.yaml"
+        else:
+            payload["results"][0]["diffs"][0]["path"] = f"unsafe{dangerous}path"
+
+    with pytest.raises(ValueError):
+        drift.DriftReport.from_dict(payload)
+
+
+def test_drift_report_module_uses_regenerator_ascii_component_allowlist():
+    payload = drift.DriftReport(
+        [drift.DriftResult(module="us/statutes/1.yaml", drifted=False)]
+    ).to_dict()
+    payload["results"][0]["module"] = "us/statutes/café.yaml"
+
+    with pytest.raises(ValueError, match="unsafe or duplicate module"):
+        drift.DriftReport.from_dict(payload)
+
+
+def test_drift_error_allows_intentional_line_feed_and_tab():
+    error = "first line\n\tindented line"
+    payload = drift.DriftReport(
+        [
+            drift.DriftResult(
+                module="us/statutes/1.yaml",
+                drifted=False,
+                error=error,
+            )
+        ]
+    ).to_dict()
+
+    loaded = drift.DriftReport.from_dict(payload)
+
+    assert loaded.errors[0].error == error
+
+
+def test_drift_display_sanitizer_uses_long_escape_above_bmp():
+    dangerous = chr(0xE0001)
+
+    assert drift._sanitize_display_text(dangerous) == "\\U000E0001"
+    assert drift._sanitize_display_text("\n\t") == "\\u000A\\u0009"
+    assert (
+        drift._sanitize_display_text(
+            "\n\t",
+            preserve_lf_tab=True,
+        )
+        == "\n\t"
+    )
 
 
 def test_drift_report_round_trip_bounds_paths_values_and_diff_count():
@@ -1401,6 +1510,127 @@ def test_drift_issue_publisher_bounds_body_and_title_at_report_maxima():
     assert len(title) <= drift.MAX_GITHUB_ISSUE_TITLE_CHARS
     assert "sha256:" in title
     assert drift.drift_issue_title(result) == title
+
+
+def test_drift_issue_publisher_uses_fixed_gh_argv(monkeypatch):
+    result = drift.DriftResult(
+        module="us/statutes/1.yaml",
+        drifted=True,
+        diffs=[
+            {
+                "path": "value",
+                "change": "value_changed",
+                "merged": 1,
+                "regenerated": 2,
+            }
+        ],
+    )
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def fake_github(command, **kwargs):
+        calls.append((command, kwargs))
+        if command[1:3] == ["issue", "create"]:
+            body_path = Path(command[command.index("--body-file") + 1])
+            assert body_path.is_file()
+            return types.SimpleNamespace(returncode=0, stdout="issue-url\n", stderr="")
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(cli_commands.subprocess, "run", fake_github)
+
+    assert cli_commands._create_drift_issues(
+        drift.DriftReport([result]),
+        "owner/repo",
+    ) == ["issue-url"]
+    assert len(calls) == 2
+    label_argv, label_kwargs = calls[0]
+    issue_argv, issue_kwargs = calls[1]
+    assert label_argv == [
+        "gh",
+        "label",
+        "create",
+        "drift",
+        "-R",
+        "owner/repo",
+        "--color",
+        "B60205",
+        "--description",
+        "Golden-regeneration drift",
+        "--force",
+    ]
+    assert issue_argv == [
+        "gh",
+        "issue",
+        "create",
+        "-R",
+        "owner/repo",
+        "--title",
+        drift.drift_issue_title(result),
+        "--label",
+        "drift",
+        "--body-file",
+        issue_argv[-1],
+    ]
+    assert isinstance(label_argv, list)
+    assert isinstance(issue_argv, list)
+    assert label_kwargs["shell"] is False
+    assert issue_kwargs["shell"] is False
+
+
+def test_drift_issue_publisher_isolates_body_rendering_failures(
+    monkeypatch,
+    capsys,
+):
+    poisoned = drift.DriftResult(
+        module="us/statutes/poisoned.yaml",
+        drifted=True,
+        diffs=[
+            {
+                "path": "poisoned",
+                "change": "value_changed",
+                "merged": 1,
+                "regenerated": 2,
+            }
+        ],
+    )
+    healthy = drift.DriftResult(
+        module="us/statutes/healthy.yaml",
+        drifted=True,
+        diffs=[
+            {
+                "path": "healthy",
+                "change": "value_changed",
+                "merged": 1,
+                "regenerated": 2,
+            }
+        ],
+    )
+    original_body_builder = drift.drift_issue_body
+
+    def render_body(result):
+        if result is poisoned:
+            raise UnicodeEncodeError("utf-8", "\ud800", 0, 1, "surrogate")
+        return original_body_builder(result)
+
+    issue_commands: list[list[str]] = []
+
+    def fake_github(command, **_kwargs):
+        if command[1:3] == ["issue", "create"]:
+            issue_commands.append(command)
+            return types.SimpleNamespace(returncode=0, stdout="issue-url\n", stderr="")
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(drift, "drift_issue_body", render_body)
+    monkeypatch.setattr(cli_commands.subprocess, "run", fake_github)
+
+    created = cli_commands._create_drift_issues(
+        drift.DriftReport([poisoned, healthy]),
+        "owner/repo",
+    )
+
+    assert created == ["issue-url"]
+    assert len(issue_commands) == 1
+    assert "healthy.yaml" in issue_commands[0][issue_commands[0].index("--title") + 1]
+    assert "poisoned.yaml" in capsys.readouterr().err
 
 
 def test_drift_publisher_reapplies_budgets_after_redaction(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1203"
+version = "0.2.1204"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

Re-lands commit `45c2c6fc` — the unicode-sanitization fix for the golden-regeneration publish path — which was **dropped by the #1102 squash**: auto-merge fired against GitHub's stale view of the PR head (`4aea911d`) while the fix commit was already on the branch ref, so main received the RCE hardening but not the sanitizer.

Content is byte-identical to the independently re-verified commit (clean-context gpt-5.6-sol defensive audit: SHIP — see [#1102 verdict comment](https://github.com/TheAxiomFoundation/axiom-encode/pull/1102#issuecomment-below)):

- Category-based unicode sanitizer (`Cc/Cf/Cs/Zl/Zp` → visible ASCII escapes) applied to every report-derived field and whole bodies/titles before UTF-8 encoding
- Strict `from_dict` validation reusing `_SAFE_PATH_PART`
- Per-result publish isolation (one poisoned item no longer suppresses later drift issues)
- Explicit `shell=False` on both `gh` calls; UTF-8 temp body file with `finally` cleanup
- Full-chain tests for U+D800 / U+202E / U+009B / U+007F / U+2028 + argv shape + poisoned-item continuation

## Verification

- Cherry-pick applied clean onto `main` (main's content == the fix's parent state); version 0.2.1203 → 0.2.1204
- Post-merge check to run before closing: `git grep -c unicodedata.category origin/main -- src/axiom_encode/judges/drift.py` == 1

Closes #1099

🤖 Generated with [Claude Code](https://claude.com/claude-code)
