### PR TITLE
Add strict validation failure waivers

### DIFF
--- a/changelog.d/782-validation-gap-ratchet.fixed.md
+++ b/changelog.d/782-validation-gap-ratchet.fixed.md
@@ -1,0 +1,2 @@
+Add strict, expiring validation-failure waivers with protected-base approval,
+deterministic full-failure fingerprints, and independent companion execution.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1212"
+version = "0.2.1213"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1211"
+version = "0.2.1212"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1212"
+__version__ = "0.2.1213"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1211"
+__version__ = "0.2.1212"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3811,7 +3811,7 @@ def _fingerprint_validation_waiver_modules(
 
 def _validation_waiver_repo_relative_path(raw: str, *, label: str) -> str:
     """Validate and normalize an opinionated POSIX repository-relative path."""
-    value = str(raw).strip()
+    value = str(raw)
     if not value:
         raise ValueError(f"{label} must not be empty")
     if _validation_waivers._contains_control_or_format(value):
@@ -3819,6 +3819,8 @@ def _validation_waiver_repo_relative_path(raw: str, *, label: str) -> str:
             f"{label} must not contain control characters or Unicode format "
             f"characters: {raw!r}"
         )
+    if value != value.strip():
+        raise ValueError(f"{label} must not contain surrounding whitespace: {raw!r}")
     if "\\" in value:
         raise ValueError(f"{label} must use POSIX separators: {raw}")
     if value.startswith("/") or value.endswith("/"):
@@ -3835,13 +3837,9 @@ def _validation_waiver_changed_paths(path: Path) -> set[str]:
     if path.is_symlink() or not path.is_file():
         raise ValueError(f"changed-paths input must be a regular file: {path}")
     changed: set[str] = set()
-    for line_number, raw in enumerate(path.read_text().splitlines(), 1):
-        if not raw.strip():
+    for line_number, raw in enumerate(path.read_text().split("\n"), 1):
+        if raw == "":
             continue
-        if raw != raw.strip():
-            raise ValueError(
-                f"changed path line {line_number} has surrounding whitespace"
-            )
         changed.add(
             _validation_waiver_repo_relative_path(
                 raw,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -741,21 +741,15 @@ def main():
         help="RuleSpec repository root (default: current directory)",
     )
     validation_waivers_audit_parser.add_argument(
-        "--waivers",
-        type=Path,
-        default=None,
-        help="Waiver YAML (default: ROOT/known-validation-gaps.yaml)",
-    )
-    validation_waivers_audit_parser.add_argument(
         "--protected-base",
         type=Path,
-        default=None,
+        required=True,
         help="Strict waiver YAML from the protected base revision",
     )
     validation_waivers_audit_parser.add_argument(
         "--changed-paths",
         type=Path,
-        default=None,
+        required=True,
         help="File containing one repository-relative changed path per line",
     )
     validation_waivers_audit_parser.add_argument(
@@ -780,12 +774,6 @@ def main():
         type=Path,
         default=Path.cwd(),
         help="RuleSpec repository root (default: current directory)",
-    )
-    validation_waivers_paths_parser.add_argument(
-        "--waivers",
-        type=Path,
-        default=None,
-        help="Waiver YAML (default: ROOT/known-validation-gaps.yaml)",
     )
     validation_waivers_paths_parser.add_argument(
         "--json",
@@ -3640,13 +3628,7 @@ def _validation_waiver_companion_outcome(
     companion = _validation_waiver_companion_path(module)
     relative = companion.relative_to(root).as_posix()
     if companion.is_symlink():
-        resolved_companion = companion.resolve(strict=True)
-        try:
-            resolved_companion.relative_to(root)
-        except ValueError as error:
-            raise ValueError(
-                f"RuleSpec companion is outside repository root: {relative}"
-            ) from error
+        raise ValueError(f"RuleSpec companion must not be a symlink: {relative}")
     if not companion.exists():
         return {
             "present": False,
@@ -3832,8 +3814,11 @@ def _validation_waiver_repo_relative_path(raw: str, *, label: str) -> str:
     value = str(raw).strip()
     if not value:
         raise ValueError(f"{label} must not be empty")
-    if any(ord(character) < 0x20 or ord(character) == 0x7F for character in value):
-        raise ValueError(f"{label} must not contain control characters: {raw!r}")
+    if _validation_waivers._contains_control_or_format(value):
+        raise ValueError(
+            f"{label} must not contain control characters or Unicode format "
+            f"characters: {raw!r}"
+        )
     if "\\" in value:
         raise ValueError(f"{label} must use POSIX separators: {raw}")
     if value.startswith("/") or value.endswith("/"):
@@ -3846,8 +3831,11 @@ def _validation_waiver_repo_relative_path(raw: str, *, label: str) -> str:
 
 def _validation_waiver_changed_paths(path: Path) -> set[str]:
     """Read the strict one-repository-relative-path-per-line transition input."""
+    path = Path(path)
+    if path.is_symlink() or not path.is_file():
+        raise ValueError(f"changed-paths input must be a regular file: {path}")
     changed: set[str] = set()
-    for line_number, raw in enumerate(Path(path).read_text().splitlines(), 1):
+    for line_number, raw in enumerate(path.read_text().splitlines(), 1):
         if not raw.strip():
             continue
         if raw != raw.strip():
@@ -3861,14 +3849,6 @@ def _validation_waiver_changed_paths(path: Path) -> set[str]:
             )
         )
     return changed
-
-
-def _validation_waiver_file(args, *, root: Path) -> Path:
-    configured = getattr(args, "waivers", None)
-    if configured is None:
-        return root / "known-validation-gaps.yaml"
-    path = Path(configured)
-    return path if path.is_absolute() else root / path
 
 
 def _emit_validation_waiver_error(args, error: Exception | str) -> None:
@@ -3906,7 +3886,7 @@ def _cmd_validation_waivers_fingerprint(args) -> int:
 
 def _cmd_validation_waivers_active_paths(args) -> int:
     root = Path(args.root).resolve()
-    waiver_file = _validation_waiver_file(args, root=root)
+    waiver_file = root / _validation_waivers.DEFAULT_WAIVER_PATH
     waivers = _validation_waivers.load_validation_waivers(
         waiver_file,
         repo_root=root,
@@ -3924,41 +3904,31 @@ def _cmd_validation_waivers_audit(args) -> int:
     root = Path(args.root).resolve()
     if not root.is_dir():
         raise ValueError(f"RuleSpec repository root does not exist: {root}")
-    waiver_file = _validation_waiver_file(args, root=root).resolve()
-    try:
-        waiver_path = waiver_file.relative_to(root).as_posix()
-    except ValueError as error:
-        raise ValueError(
-            "head waiver YAML must be inside the repository root"
-        ) from error
+    waiver_path = _validation_waivers.DEFAULT_WAIVER_PATH
+    waiver_file = root / waiver_path
 
     protected_base_path = getattr(args, "protected_base", None)
     changed_paths_file = getattr(args, "changed_paths", None)
-    if (protected_base_path is None) != (changed_paths_file is None):
-        raise ValueError(
-            "--protected-base and --changed-paths must be supplied together"
-        )
+    if protected_base_path is None or changed_paths_file is None:
+        raise ValueError("--protected-base and --changed-paths are required")
 
     head = _validation_waivers.load_validation_waivers(
         waiver_file,
         repo_root=root,
     )
-    base = None
-    transition_issues: tuple[str, ...] = ()
-    if protected_base_path is not None:
-        base = _validation_waivers.load_validation_waivers(
-            Path(protected_base_path),
-            repo_root=root,
-            allow_expired=True,
-            require_paths=False,
-        )
-        changed_paths = _validation_waiver_changed_paths(Path(changed_paths_file))
-        transition_issues = _validation_waivers.protected_base_transition_issues(
-            base,
-            head,
-            changed_paths=changed_paths,
-            waiver_path=waiver_path,
-        )
+    base = _validation_waivers.load_validation_waivers(
+        Path(protected_base_path),
+        repo_root=root,
+        allow_expired=True,
+        require_paths=False,
+    )
+    changed_paths = _validation_waiver_changed_paths(Path(changed_paths_file))
+    transition_issues = _validation_waivers.protected_base_transition_issues(
+        base,
+        head,
+        changed_paths=changed_paths,
+        waiver_path=waiver_path,
+    )
 
     if transition_issues:
         report = {
@@ -3974,9 +3944,7 @@ def _cmd_validation_waivers_audit(args) -> int:
 
     active_paths = set(head.active_paths)
     pending_only_paths = set(head.pending_paths) - active_paths
-    removed_active_paths = (
-        set(base.active_paths) - active_paths if base is not None else set()
-    )
+    removed_active_paths = set(base.active_paths) - active_paths
     classified: dict[str, str] = {path: "active" for path in active_paths}
     classified.update({path: "pending" for path in pending_only_paths})
     for path in removed_active_paths:

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -44,6 +44,7 @@ from yaml.nodes import MappingNode, ScalarNode, SequenceNode
 
 from axiom_encode import __version__
 
+from . import validation_waivers as _validation_waivers
 from .codex_cli import codex_auth_error
 from .concepts import (
     audit_corpus as audit_concept_corpus,
@@ -205,6 +206,7 @@ from .repo_routing import (
     canonical_rulespec_repo_name,
     find_policy_repo_root,
     jurisdiction_content_dir,
+    jurisdiction_subdir_names,
     monorepo_checkout_name,
     resolve_jurisdiction_content_dir,
 )
@@ -342,11 +344,24 @@ def _override_is_country_monorepo_for_jurisdiction(
     return jurisdiction != repo_name.removeprefix("rulespec-")
 
 
+def _canonical_validation_checkout_root(rulespec_file: Path) -> Path:
+    """Require and return ``rulespec-country/jurisdiction/...`` checkout root."""
+    content_root = find_policy_repo_root(rulespec_file)
+    if content_root is None:
+        raise ValueError(
+            f"RuleSpec module is not inside a canonical country checkout: {rulespec_file}"
+        )
+    if content_root.name not in jurisdiction_subdir_names(content_root.parent):
+        raise ValueError(
+            "validation requires the country-monorepo layout "
+            f"(<rulespec-country>/<jurisdiction>/...): {rulespec_file}"
+        )
+    return content_root.parent
+
+
 def _resolve_validation_repo_roots(rulespec_file: Path) -> tuple[Path, Path]:
-    """Resolve the policy repo root plus the Axiom rules engine for validation."""
-    policy_repo_root = find_policy_repo_root(
-        rulespec_file
-    ) or _resolve_policy_repo_for_prefix("us")
+    """Resolve validation against one canonical RuleSpec checkout root."""
+    policy_repo_root = _canonical_validation_checkout_root(rulespec_file)
     return policy_repo_root, _resolve_runtime_axiom_rules_checkout(policy_repo_root)
 
 
@@ -675,6 +690,107 @@ def main():
         "--require-oracle-classification",
         action="store_true",
         help="Fail oracle validation when oracle coverage reports unclassified legal IDs",
+    )
+
+    validation_waivers_parser = subparsers.add_parser(
+        "validation-waivers",
+        help="Fingerprint and audit strictly declared RuleSpec validation waivers",
+    )
+    validation_waivers_subparsers = validation_waivers_parser.add_subparsers(
+        dest="validation_waivers_command",
+        required=True,
+    )
+
+    validation_waivers_fingerprint_parser = validation_waivers_subparsers.add_parser(
+        "fingerprint",
+        help="Run validation and companion tests and fingerprint their failures",
+    )
+    validation_waivers_fingerprint_parser.add_argument(
+        "modules",
+        type=Path,
+        nargs="+",
+        help="Repository-relative RuleSpec module paths to fingerprint",
+    )
+    validation_waivers_fingerprint_parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path.cwd(),
+        help="RuleSpec repository root (default: current directory)",
+    )
+    validation_waivers_fingerprint_parser.add_argument(
+        "--axiom-rules-engine-path",
+        dest="axiom_rules_path",
+        type=Path,
+        default=None,
+        help="Path to axiom-rules-engine (defaults to a sibling checkout)",
+    )
+    validation_waivers_fingerprint_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output deterministic outcomes and fingerprints as JSON",
+    )
+
+    validation_waivers_audit_parser = validation_waivers_subparsers.add_parser(
+        "audit",
+        help="Audit every active and pending validation waiver in a repository",
+    )
+    validation_waivers_audit_parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path.cwd(),
+        help="RuleSpec repository root (default: current directory)",
+    )
+    validation_waivers_audit_parser.add_argument(
+        "--waivers",
+        type=Path,
+        default=None,
+        help="Waiver YAML (default: ROOT/known-validation-gaps.yaml)",
+    )
+    validation_waivers_audit_parser.add_argument(
+        "--protected-base",
+        type=Path,
+        default=None,
+        help="Strict waiver YAML from the protected base revision",
+    )
+    validation_waivers_audit_parser.add_argument(
+        "--changed-paths",
+        type=Path,
+        default=None,
+        help="File containing one repository-relative changed path per line",
+    )
+    validation_waivers_audit_parser.add_argument(
+        "--axiom-rules-engine-path",
+        dest="axiom_rules_path",
+        type=Path,
+        default=None,
+        help="Path to axiom-rules-engine (defaults to a sibling checkout)",
+    )
+    validation_waivers_audit_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output the complete audit report as JSON",
+    )
+
+    validation_waivers_paths_parser = validation_waivers_subparsers.add_parser(
+        "active-paths",
+        help="Print repository-relative paths with active validation waivers",
+    )
+    validation_waivers_paths_parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path.cwd(),
+        help="RuleSpec repository root (default: current directory)",
+    )
+    validation_waivers_paths_parser.add_argument(
+        "--waivers",
+        type=Path,
+        default=None,
+        help="Waiver YAML (default: ROOT/known-validation-gaps.yaml)",
+    )
+    validation_waivers_paths_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output the paths as a JSON array",
     )
 
     proof_validate_parser = subparsers.add_parser(
@@ -3074,6 +3190,8 @@ def main():
 
     if args.command == "validate":
         cmd_validate(args)
+    elif args.command == "validation-waivers":
+        cmd_validation_waivers(args)
     elif args.command == "proof-validate":
         cmd_proof_validate(args)
     elif args.command == "compile":
@@ -3471,6 +3589,527 @@ def _validate_one(args, pipeline, rulespec_file):
     return all_passed, None
 
 
+def _validation_waiver_module_path(
+    module: Path,
+    *,
+    root: Path,
+) -> tuple[Path, str]:
+    """Resolve one module using the canonical waiver-schema path contract."""
+    return _validation_waivers.resolve_validation_waiver_module(
+        root,
+        Path(module).as_posix(),
+    )
+
+
+def _validation_waiver_companion_path(module: Path) -> Path:
+    """Return the canonical adjacent companion path for a RuleSpec module."""
+    return module.with_name(f"{module.stem}.test.yaml")
+
+
+def _validation_waiver_validate_outcome(result) -> dict[str, Any]:
+    """Extract only deterministic, complete failed-validator details."""
+    validators: dict[str, dict[str, Any]] = {}
+    for name, validation in sorted(result.results.items()):
+        if bool(validation.passed):
+            continue
+        validators[str(name)] = {
+            "passed": False,
+            "issues": [str(issue) for issue in (validation.issues or [])],
+            "error": str(validation.error) if validation.error is not None else None,
+        }
+    passed = bool(result.all_passed)
+    if (passed and validators) or (not passed and not validators):
+        raise RuntimeError(
+            "ValidatorPipeline returned an inconsistent aggregate validation result"
+        )
+    return {"passed": passed, "validators": validators}
+
+
+def _validation_waiver_companion_outcome(
+    module: Path,
+    *,
+    root: Path,
+    policy_repo_path: Path,
+    binary: Path,
+    axiom_rules_path: Path,
+    env: dict[str, str],
+    tmp_path: Path,
+    compiled_cache: dict[Path, tuple[Path, dict]],
+) -> dict[str, Any]:
+    """Execute an adjacent companion independently, including parse failures."""
+    companion = _validation_waiver_companion_path(module)
+    relative = companion.relative_to(root).as_posix()
+    if companion.is_symlink():
+        resolved_companion = companion.resolve(strict=True)
+        try:
+            resolved_companion.relative_to(root)
+        except ValueError as error:
+            raise ValueError(
+                f"RuleSpec companion is outside repository root: {relative}"
+            ) from error
+    if not companion.exists():
+        return {
+            "present": False,
+            "path": relative,
+            "passed": True,
+            "cases": 0,
+            "failures": [],
+        }
+    if not companion.is_file():
+        raise ValueError(f"RuleSpec companion is not a file: {relative}")
+
+    try:
+        result = _execute_rulespec_test_file(
+            companion,
+            binary=binary,
+            axiom_rules_path=axiom_rules_path,
+            env=env,
+            tmp_path=tmp_path,
+            compiled_cache=compiled_cache,
+            policy_repo_path=policy_repo_path,
+        )
+    except (ValueError, yaml.YAMLError) as error:
+        result = {
+            "cases": 0,
+            "compiled": 0,
+            "failures": [
+                {
+                    "file": relative,
+                    "case": None,
+                    "message": f"{type(error).__name__}: {error}",
+                }
+            ],
+        }
+    failures = [
+        {
+            "file": str(failure.get("file") or relative),
+            "case": (str(failure["case"]) if failure.get("case") is not None else None),
+            "message": str(failure.get("message") or "companion test failed"),
+        }
+        for failure in result.get("failures", [])
+    ]
+    return {
+        "present": True,
+        "path": relative,
+        "passed": not failures,
+        "cases": int(result.get("cases", 0) or 0),
+        "failures": failures,
+    }
+
+
+def _validation_waiver_path_replacements(
+    *,
+    root: Path,
+    axiom_rules_paths: list[Path],
+    binaries: list[Path],
+    tmp_path: Path,
+    envs: list[dict[str, str]],
+    pipelines: list[ValidatorPipeline],
+) -> dict[str, str]:
+    """Return runtime-specific path prefixes that must not enter a fingerprint."""
+    replacements: dict[str, str] = {}
+
+    def add_path(path: str | Path, replacement: str, *, override: bool = False) -> None:
+        raw = str(path)
+        resolved = str(Path(path).resolve())
+        for value in (raw, resolved):
+            if override:
+                replacements[value] = replacement
+            else:
+                replacements.setdefault(value, replacement)
+
+    add_path(Path.home(), "<home>")
+    add_path(tempfile.gettempdir(), "<system-tmp>")
+    for env in envs:
+        rulespec_roots = env.get("AXIOM_RULESPEC_REPO_ROOTS", "")
+        for rulespec_root in rulespec_roots.split(os.pathsep):
+            if not rulespec_root:
+                continue
+            add_path(rulespec_root, "<rulespec-root>")
+    corpus_paths = {
+        *(env.get("AXIOM_CORPUS_REPO") for env in envs),
+        *(env.get("AXIOM_CORPUS_ARTIFACT_ROOT") for env in envs),
+        *(
+            str(pipeline.local_corpus_root)
+            if getattr(pipeline, "local_corpus_root", None)
+            else None
+            for pipeline in pipelines
+        ),
+    }
+    for corpus_path in sorted(path for path in corpus_paths if path):
+        add_path(corpus_path, "<corpus>", override=True)
+    add_path(Path(__file__).resolve().parents[2], "<encoder>", override=True)
+    add_path(root, "<repo>", override=True)
+    for axiom_rules_path in axiom_rules_paths:
+        add_path(axiom_rules_path, "<engine>", override=True)
+    for binary in binaries:
+        add_path(binary, "<engine-binary>", override=True)
+    add_path(tmp_path, "<tmp>", override=True)
+    return dict(sorted(replacements.items(), key=lambda item: (-len(item[0]), item[0])))
+
+
+def _fingerprint_validation_waiver_modules(
+    modules: list[Path],
+    *,
+    root: Path,
+    axiom_rules_path: Path | None = None,
+) -> list[dict[str, Any]]:
+    """Execute validation and companions against one canonical checkout root."""
+    root = Path(root).resolve()
+    if not root.is_dir():
+        raise ValueError(f"RuleSpec repository root does not exist: {root}")
+
+    resolved_modules: dict[str, Path] = {}
+    for module in modules:
+        resolved, relative = _validation_waiver_module_path(module, root=root)
+        canonical_root = _canonical_validation_checkout_root(resolved).resolve()
+        if canonical_root != root:
+            raise ValueError(
+                f"waiver root must be the canonical country checkout: {canonical_root}"
+            )
+        resolved_modules[relative] = resolved
+
+    engine_root = Path(
+        axiom_rules_path or _resolve_runtime_axiom_rules_checkout(root)
+    ).resolve()
+    pipeline = ValidatorPipeline(
+        policy_repo_path=root,
+        axiom_rules_path=engine_root,
+        enable_oracles=False,
+    )
+    binary = pipeline._axiom_rules_binary()
+    env = pipeline._rulespec_compile_env()
+
+    fingerprints: list[dict[str, Any]] = []
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        compiled_cache: dict[Path, tuple[Path, dict]] = {}
+        replacements = _validation_waiver_path_replacements(
+            root=root,
+            axiom_rules_paths=[engine_root],
+            binaries=[binary],
+            tmp_path=tmp_path,
+            envs=[env],
+            pipelines=[pipeline],
+        )
+        for relative, module in sorted(resolved_modules.items()):
+            pipeline_result = pipeline.validate(module, skip_reviewers=True)
+            validate_outcome = _validation_waiver_validate_outcome(pipeline_result)
+            companion_outcome = _validation_waiver_companion_outcome(
+                module,
+                root=root,
+                policy_repo_path=root,
+                binary=binary,
+                axiom_rules_path=engine_root,
+                env=env,
+                tmp_path=tmp_path,
+                compiled_cache=compiled_cache,
+            )
+            canonical_bytes = _validation_waivers.canonicalize_outcome(
+                validate_outcome,
+                companion_outcome,
+                replacements=replacements,
+            )
+            digest = _validation_waivers.fingerprint_outcome(
+                validate_outcome,
+                companion_outcome,
+                replacements=replacements,
+            )
+            fingerprints.append(
+                {
+                    "path": relative,
+                    "passed": bool(validate_outcome["passed"])
+                    and bool(companion_outcome["passed"]),
+                    "fingerprint": digest,
+                    "outcome": json.loads(canonical_bytes.decode("utf-8")),
+                }
+            )
+    return fingerprints
+
+
+def _validation_waiver_repo_relative_path(raw: str, *, label: str) -> str:
+    """Validate and normalize an opinionated POSIX repository-relative path."""
+    value = str(raw).strip()
+    if not value:
+        raise ValueError(f"{label} must not be empty")
+    if any(ord(character) < 0x20 or ord(character) == 0x7F for character in value):
+        raise ValueError(f"{label} must not contain control characters: {raw!r}")
+    if "\\" in value:
+        raise ValueError(f"{label} must use POSIX separators: {raw}")
+    if value.startswith("/") or value.endswith("/"):
+        raise ValueError(f"{label} must be a canonical repository-relative path: {raw}")
+    parts = value.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise ValueError(f"{label} must be a canonical repository-relative path: {raw}")
+    return "/".join(parts)
+
+
+def _validation_waiver_changed_paths(path: Path) -> set[str]:
+    """Read the strict one-repository-relative-path-per-line transition input."""
+    changed: set[str] = set()
+    for line_number, raw in enumerate(Path(path).read_text().splitlines(), 1):
+        if not raw.strip():
+            continue
+        if raw != raw.strip():
+            raise ValueError(
+                f"changed path line {line_number} has surrounding whitespace"
+            )
+        changed.add(
+            _validation_waiver_repo_relative_path(
+                raw,
+                label=f"changed path line {line_number}",
+            )
+        )
+    return changed
+
+
+def _validation_waiver_file(args, *, root: Path) -> Path:
+    configured = getattr(args, "waivers", None)
+    if configured is None:
+        return root / "known-validation-gaps.yaml"
+    path = Path(configured)
+    return path if path.is_absolute() else root / path
+
+
+def _emit_validation_waiver_error(args, error: Exception | str) -> None:
+    message = str(error)
+    if getattr(args, "json", False):
+        print(json.dumps({"success": False, "errors": [message]}, indent=2))
+    else:
+        print(f"validation-waivers: {message}", file=sys.stderr)
+
+
+def _cmd_validation_waivers_fingerprint(args) -> int:
+    root = Path(args.root).resolve()
+    results = _fingerprint_validation_waiver_modules(
+        list(args.modules),
+        root=root,
+        axiom_rules_path=getattr(args, "axiom_rules_path", None),
+    )
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "success": True,
+                    "root": str(root),
+                    "modules": results,
+                },
+                indent=2,
+            )
+        )
+    else:
+        for result in results:
+            state = "passes" if result["passed"] else "fails"
+            print(f"{result['path']}: {result['fingerprint']} ({state})")
+    return 0
+
+
+def _cmd_validation_waivers_active_paths(args) -> int:
+    root = Path(args.root).resolve()
+    waiver_file = _validation_waiver_file(args, root=root)
+    waivers = _validation_waivers.load_validation_waivers(
+        waiver_file,
+        repo_root=root,
+    )
+    paths = sorted(waivers.active_paths)
+    if args.json:
+        print(json.dumps(paths, indent=2))
+    else:
+        for path in paths:
+            print(path)
+    return 0
+
+
+def _cmd_validation_waivers_audit(args) -> int:
+    root = Path(args.root).resolve()
+    if not root.is_dir():
+        raise ValueError(f"RuleSpec repository root does not exist: {root}")
+    waiver_file = _validation_waiver_file(args, root=root).resolve()
+    try:
+        waiver_path = waiver_file.relative_to(root).as_posix()
+    except ValueError as error:
+        raise ValueError(
+            "head waiver YAML must be inside the repository root"
+        ) from error
+
+    protected_base_path = getattr(args, "protected_base", None)
+    changed_paths_file = getattr(args, "changed_paths", None)
+    if (protected_base_path is None) != (changed_paths_file is None):
+        raise ValueError(
+            "--protected-base and --changed-paths must be supplied together"
+        )
+
+    head = _validation_waivers.load_validation_waivers(
+        waiver_file,
+        repo_root=root,
+    )
+    base = None
+    transition_issues: tuple[str, ...] = ()
+    if protected_base_path is not None:
+        base = _validation_waivers.load_validation_waivers(
+            Path(protected_base_path),
+            repo_root=root,
+            allow_expired=True,
+            require_paths=False,
+        )
+        changed_paths = _validation_waiver_changed_paths(Path(changed_paths_file))
+        transition_issues = _validation_waivers.protected_base_transition_issues(
+            base,
+            head,
+            changed_paths=changed_paths,
+            waiver_path=waiver_path,
+        )
+
+    if transition_issues:
+        report = {
+            "success": False,
+            "root": str(root),
+            "waivers": waiver_path,
+            "checked": 0,
+            "results": [],
+            "errors": list(transition_issues),
+        }
+        _print_validation_waiver_audit_report(report, as_json=args.json)
+        return 1
+
+    active_paths = set(head.active_paths)
+    pending_only_paths = set(head.pending_paths) - active_paths
+    removed_active_paths = (
+        set(base.active_paths) - active_paths if base is not None else set()
+    )
+    classified: dict[str, str] = {path: "active" for path in active_paths}
+    classified.update({path: "pending" for path in pending_only_paths})
+    for path in removed_active_paths:
+        classified.setdefault(path, "removed")
+    classified = dict(sorted(classified.items()))
+
+    deleted_removed: set[str] = set()
+    missing_required: set[str] = set()
+    executable_paths: list[Path] = []
+    for path, kind in classified.items():
+        module = root / path
+        if module.is_file():
+            executable_paths.append(Path(path))
+        elif kind == "removed" and not module.exists() and not module.is_symlink():
+            deleted_removed.add(path)
+        else:
+            missing_required.add(path)
+
+    executed = (
+        _fingerprint_validation_waiver_modules(
+            executable_paths,
+            root=root,
+            axiom_rules_path=getattr(args, "axiom_rules_path", None),
+        )
+        if executable_paths
+        else []
+    )
+    executed_by_path = {result["path"]: result for result in executed}
+    results: list[dict[str, Any]] = []
+    errors: list[str] = []
+
+    for path, kind in classified.items():
+        if path in deleted_removed:
+            results.append(
+                {
+                    "path": path,
+                    "kind": kind,
+                    "success": True,
+                    "module_deleted": True,
+                }
+            )
+            continue
+        if path in missing_required:
+            message = f"{path}: declared {kind} waiver module does not exist"
+            errors.append(message)
+            results.append(
+                {
+                    "path": path,
+                    "kind": kind,
+                    "success": False,
+                    "error": message,
+                }
+            )
+            continue
+
+        actual = executed_by_path[path]
+        result_record = {
+            "path": path,
+            "kind": kind,
+            "passed": actual["passed"],
+            "fingerprint": actual["fingerprint"],
+            "outcome": actual["outcome"],
+        }
+        error: str | None = None
+        if kind == "active":
+            expected = head.entries[path].active.fingerprint
+            result_record["expected_fingerprint"] = expected
+            if actual["passed"]:
+                error = f"{path}: active validation waiver is stale; module now passes"
+            elif actual["fingerprint"] != expected:
+                error = (
+                    f"{path}: validation failure fingerprint drifted; expected "
+                    f"{expected}, got {actual['fingerprint']}"
+                )
+        elif kind == "pending" and not actual["passed"]:
+            error = f"{path}: pending waiver requires the current module to pass"
+        elif kind == "removed" and not actual["passed"]:
+            error = f"{path}: removed active waiver still has a failing module"
+        result_record["success"] = error is None
+        if error is not None:
+            result_record["error"] = error
+            errors.append(error)
+        results.append(result_record)
+
+    report = {
+        "success": not errors,
+        "root": str(root),
+        "waivers": waiver_path,
+        "checked": len(results),
+        "results": results,
+        "errors": errors,
+    }
+    _print_validation_waiver_audit_report(report, as_json=args.json)
+    return 0 if report["success"] else 1
+
+
+def _print_validation_waiver_audit_report(
+    report: dict[str, Any],
+    *,
+    as_json: bool,
+) -> None:
+    if as_json:
+        print(json.dumps(report, indent=2))
+        return
+    if report["success"]:
+        print(f"Validation waiver audit passed ({report['checked']} path(s) checked)")
+        return
+    print(
+        f"Validation waiver audit failed ({len(report['errors'])} error(s))",
+        file=sys.stderr,
+    )
+    for error in report["errors"]:
+        print(f"- {error}", file=sys.stderr)
+
+
+def cmd_validation_waivers(args) -> None:
+    """Dispatch strict validation waiver maintenance and audit commands."""
+    try:
+        command = args.validation_waivers_command
+        if command == "fingerprint":
+            exit_code = _cmd_validation_waivers_fingerprint(args)
+        elif command == "audit":
+            exit_code = _cmd_validation_waivers_audit(args)
+        elif command == "active-paths":
+            exit_code = _cmd_validation_waivers_active_paths(args)
+        else:
+            raise ValueError(f"unknown validation-waivers command: {command}")
+    except Exception as error:
+        _emit_validation_waiver_error(args, error)
+        exit_code = 2
+    sys.exit(exit_code)
+
+
 def _money_atom_display_path(file: Path, root: Path | None) -> str:
     """Return a stable, ratchet-matchable path for a file."""
     resolved = file.resolve()
@@ -3747,6 +4386,15 @@ def cmd_test(args):
         else:
             print(message)
         sys.exit(1)
+
+    for test_file in test_files:
+        canonical_root = _canonical_validation_checkout_root(
+            _rulespec_program_for_test_file(test_file)
+        ).resolve()
+        if canonical_root != root:
+            raise ValueError(
+                f"--root must be the canonical country checkout: {canonical_root}"
+            )
 
     axiom_rules_path = getattr(
         args, "axiom_rules_path", None

--- a/src/axiom_encode/validation_waivers.py
+++ b/src/axiom_encode/validation_waivers.py
@@ -198,7 +198,8 @@ def _load_strict_yaml(path: Path) -> object:
 
 def _contains_control_or_format(value: str) -> bool:
     return any(
-        unicodedata.category(character) in {"Cc", "Cf", "Cs"} for character in value
+        unicodedata.category(character) in {"Cc", "Cf", "Cs", "Zl", "Zp"}
+        for character in value
     )
 
 

--- a/src/axiom_encode/validation_waivers.py
+++ b/src/axiom_encode/validation_waivers.py
@@ -1,0 +1,593 @@
+"""Strict, expiring expected-failure waivers for RuleSpec validation.
+
+The waiver file is deliberately a small state machine rather than an
+allowlist.  An ``active`` record tolerates one exact combined validation and
+companion-test failure.  A ``pending`` record preapproves the exact record that
+may replace it in a later pull request; pending records never waive failures.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import stat
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path, PurePosixPath
+from types import MappingProxyType
+from typing import Any
+
+import yaml
+from yaml.constructor import ConstructorError
+from yaml.events import (
+    AliasEvent,
+    CollectionEndEvent,
+    CollectionStartEvent,
+    NodeEvent,
+    ScalarEvent,
+)
+
+MAX_WAIVER_DAYS = 90
+MAX_WAIVER_FILE_BYTES = 2_000_000
+MAX_WAIVER_ENTRIES = 10_000
+MAX_YAML_EVENTS = 250_000
+MAX_YAML_DEPTH = 32
+MAX_YAML_SCALAR_LENGTH = 65_536
+
+FINGERPRINT_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+OWNER_RE = re.compile(r"^@[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$")
+ISSUE_RE = re.compile(
+    r"^https://github\.com/TheAxiomFoundation/"
+    r"[A-Za-z0-9_.-]+/issues/[1-9][0-9]*$"
+)
+EXPIRY_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}$")
+JURISDICTION_RE = re.compile(r"^[a-z]{2}(?:-[a-z0-9]+)*$")
+CONTENT_ROOTS = frozenset({"statutes", "regulations", "policies", "legislation"})
+ENTRY_KEYS = frozenset({"active", "pending"})
+METADATA_KEYS = frozenset({"fingerprint", "owner", "issue", "expires"})
+WAIVER_SECTION = "validate_failures"
+DEFAULT_WAIVER_PATH = "known-validation-gaps.yaml"
+OUTCOME_SCHEMA = "rulespec-validation-failure/v1"
+
+
+class ValidationWaiverError(ValueError):
+    """Base error for invalid waiver files, transitions, and outcomes."""
+
+
+class WaiverSchemaError(ValidationWaiverError):
+    """Raised when the strict waiver YAML is malformed."""
+
+
+class WaiverTransitionError(ValidationWaiverError):
+    """Raised when a head waiver set bypasses protected-base approval."""
+
+
+@dataclass(frozen=True, slots=True)
+class WaiverMetadata:
+    fingerprint: str
+    owner: str
+    issue: str
+    expires: str
+
+    @property
+    def expiry_date(self) -> date:
+        return date.fromisoformat(self.expires)
+
+
+@dataclass(frozen=True, slots=True)
+class WaiverEntry:
+    path: str
+    active: WaiverMetadata | None = None
+    pending: WaiverMetadata | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationWaiverSet:
+    entries: Mapping[str, WaiverEntry]
+
+    @property
+    def active_paths(self) -> frozenset[str]:
+        return frozenset(path for path, entry in self.entries.items() if entry.active)
+
+    @property
+    def pending_paths(self) -> frozenset[str]:
+        return frozenset(path for path, entry in self.entries.items() if entry.pending)
+
+
+class _UniqueKeyLoader(yaml.SafeLoader):
+    """Safe loader that refuses duplicate and merged mapping keys."""
+
+
+def _construct_unique_mapping(
+    loader: _UniqueKeyLoader,
+    node: yaml.MappingNode,
+    deep: bool = False,
+) -> dict[Any, Any]:
+    mapping: dict[Any, Any] = {}
+    for key_node, value_node in node.value:
+        if isinstance(key_node, yaml.ScalarNode) and key_node.value == "<<":
+            raise ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                "YAML merge keys are not allowed",
+                key_node.start_mark,
+            )
+        key = loader.construct_object(key_node, deep=deep)
+        try:
+            duplicate = key in mapping
+        except TypeError as error:
+            raise ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                "found an unhashable mapping key",
+                key_node.start_mark,
+            ) from error
+        if duplicate:
+            raise ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                f"found duplicate key {key!r}",
+                key_node.start_mark,
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+_UniqueKeyLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_unique_mapping,
+)
+
+
+def _scan_bounded_yaml(text: str, *, source: Path) -> None:
+    depth = 0
+    events = 0
+    try:
+        stream = yaml.parse(text, Loader=yaml.SafeLoader)
+        for event in stream:
+            events += 1
+            if events > MAX_YAML_EVENTS:
+                raise WaiverSchemaError(
+                    f"{source}: YAML exceeds {MAX_YAML_EVENTS} parser events"
+                )
+            if isinstance(event, AliasEvent):
+                raise WaiverSchemaError(f"{source}: YAML aliases are not allowed")
+            if isinstance(event, NodeEvent) and event.anchor is not None:
+                raise WaiverSchemaError(f"{source}: YAML anchors are not allowed")
+            if (
+                isinstance(event, ScalarEvent)
+                and len(event.value) > MAX_YAML_SCALAR_LENGTH
+            ):
+                raise WaiverSchemaError(
+                    f"{source}: YAML scalar exceeds {MAX_YAML_SCALAR_LENGTH} characters"
+                )
+            if isinstance(event, CollectionStartEvent):
+                depth += 1
+                if depth > MAX_YAML_DEPTH:
+                    raise WaiverSchemaError(
+                        f"{source}: YAML nesting exceeds {MAX_YAML_DEPTH} levels"
+                    )
+            elif isinstance(event, CollectionEndEvent):
+                depth -= 1
+    except yaml.YAMLError as error:
+        raise WaiverSchemaError(f"cannot parse {source}: {error}") from error
+
+
+def _load_strict_yaml(path: Path) -> object:
+    try:
+        size = path.stat().st_size
+        if size > MAX_WAIVER_FILE_BYTES:
+            raise WaiverSchemaError(
+                f"{path}: file exceeds {MAX_WAIVER_FILE_BYTES} bytes"
+            )
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as error:
+        raise WaiverSchemaError(f"cannot read {path}: {error}") from error
+    _scan_bounded_yaml(text, source=path)
+    try:
+        return yaml.load(text, Loader=_UniqueKeyLoader)
+    except yaml.YAMLError as error:
+        raise WaiverSchemaError(f"cannot parse {path}: {error}") from error
+
+
+def _module_path(raw_path: object) -> str:
+    if not isinstance(raw_path, str) or not raw_path:
+        raise WaiverSchemaError(f"{WAIVER_SECTION} keys must be non-empty strings")
+    if (
+        raw_path != raw_path.strip()
+        or "\\" in raw_path
+        or any(
+            ord(character) < 0x20 or ord(character) == 0x7F for character in raw_path
+        )
+    ):
+        raise WaiverSchemaError(f"unsafe {WAIVER_SECTION} path: {raw_path!r}")
+    pure = PurePosixPath(raw_path)
+    if (
+        pure.is_absolute()
+        or pure.as_posix() != raw_path
+        or any(part in {"", ".", ".."} for part in pure.parts)
+        or len(pure.parts) < 3
+        or JURISDICTION_RE.fullmatch(pure.parts[0]) is None
+        or pure.parts[1] not in CONTENT_ROOTS
+        or pure.suffix != ".yaml"
+        or pure.name.endswith(".test.yaml")
+    ):
+        raise WaiverSchemaError(f"unsafe {WAIVER_SECTION} path: {raw_path!r}")
+    return raw_path
+
+
+def _require_regular_module(repo_root: Path, module_path: str) -> None:
+    module = repo_root.joinpath(*PurePosixPath(module_path).parts)
+    try:
+        metadata = module.lstat()
+    except OSError as error:
+        raise WaiverSchemaError(
+            f"{WAIVER_SECTION} path does not exist: {module_path}"
+        ) from error
+    if module.is_symlink() or not stat.S_ISREG(metadata.st_mode):
+        raise WaiverSchemaError(
+            f"{WAIVER_SECTION} path is not a regular file: {module_path}"
+        )
+    root = repo_root.resolve()
+    resolved = module.resolve()
+    if root not in resolved.parents:
+        raise WaiverSchemaError(
+            f"{WAIVER_SECTION} path escapes the repo: {module_path}"
+        )
+
+
+def resolve_validation_waiver_module(
+    repo_root: Path,
+    raw_path: str,
+) -> tuple[Path, str]:
+    """Resolve a module using exactly the path rules accepted by the schema."""
+    root = Path(repo_root).resolve()
+    module_path = _module_path(raw_path)
+    _require_regular_module(root, module_path)
+    return root.joinpath(*PurePosixPath(module_path).parts).resolve(), module_path
+
+
+def _metadata(
+    raw: object,
+    *,
+    path: str,
+    state: str,
+    today: date,
+    allow_expired: bool,
+) -> WaiverMetadata:
+    label = f"{WAIVER_SECTION}[{path!r}].{state}"
+    if not isinstance(raw, Mapping):
+        raise WaiverSchemaError(f"{label} must be a mapping")
+    keys = frozenset(raw)
+    if keys != METADATA_KEYS:
+        raise WaiverSchemaError(
+            f"{label} must contain exactly {sorted(METADATA_KEYS)} "
+            f"(missing={sorted(METADATA_KEYS - keys)}, "
+            f"extra={sorted(keys - METADATA_KEYS)})"
+        )
+
+    fingerprint = raw["fingerprint"]
+    owner = raw["owner"]
+    issue = raw["issue"]
+    expires = raw["expires"]
+    if (
+        not isinstance(fingerprint, str)
+        or FINGERPRINT_RE.fullmatch(fingerprint) is None
+    ):
+        raise WaiverSchemaError(
+            f"{label}.fingerprint must be sha256:<64 lowercase hex>"
+        )
+    if not isinstance(owner, str) or OWNER_RE.fullmatch(owner) is None:
+        raise WaiverSchemaError(f"{label}.owner must be an @GitHub-login")
+    if not isinstance(issue, str) or ISSUE_RE.fullmatch(issue) is None:
+        raise WaiverSchemaError(
+            f"{label}.issue must be an Axiom Foundation GitHub issue URL"
+        )
+    if not isinstance(expires, str) or EXPIRY_RE.fullmatch(expires) is None:
+        raise WaiverSchemaError(f"{label}.expires must be a quoted YYYY-MM-DD string")
+    try:
+        expiry = date.fromisoformat(expires)
+    except ValueError as error:
+        raise WaiverSchemaError(f"{label}.expires is not a valid date") from error
+    if expiry > today + timedelta(days=MAX_WAIVER_DAYS):
+        raise WaiverSchemaError(
+            f"{label}.expires must be within {MAX_WAIVER_DAYS} days"
+        )
+    if not allow_expired and expiry <= today:
+        raise WaiverSchemaError(f"{label} expired on {expires}")
+    return WaiverMetadata(
+        fingerprint=fingerprint,
+        owner=owner,
+        issue=issue,
+        expires=expires,
+    )
+
+
+def load_validation_waivers(
+    path: str | Path,
+    *,
+    repo_root: str | Path | None = None,
+    today: date | None = None,
+    allow_expired: bool = False,
+    require_paths: bool = True,
+) -> ValidationWaiverSet:
+    """Load the mandatory, canonical validation-waiver schema."""
+    source = Path(path)
+    if not source.exists():
+        raise WaiverSchemaError(f"required validation waiver file is missing: {source}")
+    payload = _load_strict_yaml(source)
+    if not isinstance(payload, Mapping):
+        raise WaiverSchemaError(f"{source}: document root must be a mapping")
+    if WAIVER_SECTION not in payload:
+        raise WaiverSchemaError(
+            f"{source}: required {WAIVER_SECTION} section is missing"
+        )
+    raw_entries = payload[WAIVER_SECTION]
+    if not isinstance(raw_entries, Mapping):
+        raise WaiverSchemaError(
+            f"{source}: {WAIVER_SECTION} must be a mapping keyed by module path"
+        )
+    if len(raw_entries) > MAX_WAIVER_ENTRIES:
+        raise WaiverSchemaError(
+            f"{source}: {WAIVER_SECTION} exceeds {MAX_WAIVER_ENTRIES} entries"
+        )
+
+    current_date = today or date.today()
+    root = Path(repo_root).resolve() if repo_root is not None else None
+    entries: dict[str, WaiverEntry] = {}
+    for raw_path, raw_entry in raw_entries.items():
+        module_path = _module_path(raw_path)
+        if root is not None and require_paths:
+            _require_regular_module(root, module_path)
+        label = f"{WAIVER_SECTION}[{module_path!r}]"
+        if not isinstance(raw_entry, Mapping):
+            raise WaiverSchemaError(f"{label} must be a mapping")
+        state_keys = frozenset(raw_entry)
+        if not state_keys or not state_keys <= ENTRY_KEYS:
+            raise WaiverSchemaError(
+                f"{label} must contain only active and/or pending states"
+            )
+        active = (
+            _metadata(
+                raw_entry["active"],
+                path=module_path,
+                state="active",
+                today=current_date,
+                allow_expired=allow_expired,
+            )
+            if "active" in raw_entry
+            else None
+        )
+        pending = (
+            _metadata(
+                raw_entry["pending"],
+                path=module_path,
+                state="pending",
+                today=current_date,
+                allow_expired=allow_expired,
+            )
+            if "pending" in raw_entry
+            else None
+        )
+        entries[module_path] = WaiverEntry(
+            path=module_path,
+            active=active,
+            pending=pending,
+        )
+    return ValidationWaiverSet(MappingProxyType(dict(sorted(entries.items()))))
+
+
+def protected_base_transition_issues(
+    base: ValidationWaiverSet,
+    head: ValidationWaiverSet,
+    *,
+    changed_paths: set[str] | frozenset[str],
+    waiver_path: str = DEFAULT_WAIVER_PATH,
+    today: date | None = None,
+) -> tuple[str, ...]:
+    """Return attempts to activate a waiver without protected-base approval."""
+    issues: list[str] = []
+    current_date = today or date.today()
+    changed = frozenset(changed_paths)
+    for path in sorted(set(base.entries) | set(head.entries)):
+        base_entry = base.entries.get(path)
+        head_entry = head.entries.get(path)
+        base_active = base_entry.active if base_entry else None
+        base_pending = base_entry.pending if base_entry else None
+        head_active = head_entry.active if head_entry else None
+        head_pending = head_entry.pending if head_entry else None
+
+        if head_active is not None and head_active != base_active:
+            if base_pending is None or head_active != base_pending:
+                issues.append(
+                    f"{path}: new or changed active waiver must exactly consume "
+                    "the protected base's pending record"
+                )
+            else:
+                if base_pending.expiry_date <= current_date:
+                    issues.append(
+                        f"{path}: protected-base pending approval expired on "
+                        f"{base_pending.expires}"
+                    )
+                if head_pending is not None:
+                    issues.append(
+                        f"{path}: activating a pending waiver must consume it"
+                    )
+
+        pending_added_or_changed = (
+            head_pending is not None and head_pending != base_pending
+        )
+        if pending_added_or_changed and changed != frozenset({waiver_path}):
+            issues.append(
+                f"{path}: new or changed pending approval requires a waiver-only "
+                f"pull request (only {waiver_path} may change)"
+            )
+    return tuple(issues)
+
+
+def validate_protected_base_transition(
+    base: ValidationWaiverSet,
+    head: ValidationWaiverSet,
+    *,
+    changed_paths: set[str] | frozenset[str],
+    waiver_path: str = DEFAULT_WAIVER_PATH,
+    today: date | None = None,
+) -> None:
+    issues = protected_base_transition_issues(
+        base,
+        head,
+        changed_paths=changed_paths,
+        waiver_path=waiver_path,
+        today=today,
+    )
+    if issues:
+        raise WaiverTransitionError("; ".join(issues))
+
+
+_ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_RULESPEC_ALIAS_TEMP_RE = re.compile(
+    r"<system-tmp>[/\\]axiom-rulespec-repo-aliases[/\\][0-9a-f]{16}"
+)
+_RANDOM_TEMP_RE = re.compile(r"<system-tmp>[/\\](?:tmp|\.tmp)[A-Za-z0-9._-]+")
+
+
+def _normalize_text(value: object, replacements: Mapping[str, str]) -> str:
+    text = str(value).replace("\r\n", "\n").replace("\r", "\n")
+    text = _ANSI_RE.sub("", text)
+    for raw, replacement in sorted(
+        ((str(raw), str(replacement)) for raw, replacement in replacements.items()),
+        key=lambda item: (-len(item[0]), item[0]),
+    ):
+        if not raw:
+            continue
+        text = re.sub(
+            rf"(?<![A-Za-z0-9_.-]){re.escape(raw)}(?=$|[^A-Za-z0-9_.-])",
+            lambda _match: replacement,
+            text,
+        )
+        slash_raw = raw.replace("\\", "/")
+        if slash_raw != raw:
+            text = re.sub(
+                rf"(?<![A-Za-z0-9_.-]){re.escape(slash_raw)}"
+                r"(?=$|[^A-Za-z0-9_.-])",
+                lambda _match: replacement,
+                text,
+            )
+    text = _RULESPEC_ALIAS_TEMP_RE.sub("<rulespec-alias>", text)
+    text = _RANDOM_TEMP_RE.sub("<tmp>", text)
+    return text
+
+
+def _normalized_optional_text(
+    value: object,
+    replacements: Mapping[str, str],
+) -> str | None:
+    return None if value is None else _normalize_text(value, replacements)
+
+
+def _canonical_validate(
+    outcome: object,
+    replacements: Mapping[str, str],
+) -> dict[str, object]:
+    raw = outcome if isinstance(outcome, Mapping) else {}
+    raw_validators = raw.get("validators", {})
+    validators: dict[str, dict[str, object]] = {}
+    if isinstance(raw_validators, Mapping):
+        for raw_name, raw_result in sorted(
+            raw_validators.items(), key=lambda item: str(item[0])
+        ):
+            if not isinstance(raw_result, Mapping) or raw_result.get("passed") is True:
+                continue
+            issues = raw_result.get("issues", [])
+            normalized_issues = (
+                sorted(_normalize_text(issue, replacements) for issue in issues)
+                if isinstance(issues, list)
+                else []
+            )
+            validators[str(raw_name)] = {
+                "error": _normalized_optional_text(
+                    raw_result.get("error"), replacements
+                ),
+                "issues": normalized_issues,
+            }
+    return {"passed": bool(raw.get("passed", False)), "validators": validators}
+
+
+def _canonical_companion(
+    outcome: object,
+    replacements: Mapping[str, str],
+) -> dict[str, object]:
+    raw = outcome if isinstance(outcome, Mapping) else {}
+    raw_failures = raw.get("failures", [])
+    failures: list[dict[str, object]] = []
+    if isinstance(raw_failures, list):
+        for failure in raw_failures:
+            if not isinstance(failure, Mapping):
+                continue
+            failures.append(
+                {
+                    "case": _normalized_optional_text(
+                        failure.get("case"), replacements
+                    ),
+                    "file": _normalized_optional_text(
+                        failure.get("file"), replacements
+                    ),
+                    "message": _normalize_text(
+                        failure.get("message", "companion test failed"),
+                        replacements,
+                    ),
+                }
+            )
+    failures.sort(
+        key=lambda failure: json.dumps(
+            failure, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+        )
+    )
+    cases = raw.get("cases", 0)
+    if isinstance(cases, bool) or not isinstance(cases, int) or cases < 0:
+        raise ValidationWaiverError("companion cases must be a non-negative integer")
+    return {
+        "present": bool(raw.get("present", False)),
+        "passed": bool(raw.get("passed", False)),
+        "path": _normalized_optional_text(raw.get("path"), replacements),
+        "cases": cases,
+        "failures": failures,
+    }
+
+
+def canonicalize_outcome(
+    validate: object,
+    companion: object,
+    *,
+    replacements: Mapping[str, str] | None = None,
+) -> bytes:
+    """Return deterministic semantic failure bytes, excluding volatile fields."""
+    normalized_replacements = replacements or {}
+    payload = {
+        "schema": OUTCOME_SCHEMA,
+        "validate": _canonical_validate(validate, normalized_replacements),
+        "companion": _canonical_companion(companion, normalized_replacements),
+    }
+    return (
+        json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def fingerprint_outcome(
+    validate: object,
+    companion: object,
+    *,
+    replacements: Mapping[str, str] | None = None,
+) -> str:
+    digest = hashlib.sha256(
+        canonicalize_outcome(validate, companion, replacements=replacements)
+    ).hexdigest()
+    return f"sha256:{digest}"

--- a/src/axiom_encode/validation_waivers.py
+++ b/src/axiom_encode/validation_waivers.py
@@ -12,6 +12,7 @@ import hashlib
 import json
 import re
 import stat
+import unicodedata
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import date, timedelta
@@ -177,7 +178,10 @@ def _scan_bounded_yaml(text: str, *, source: Path) -> None:
 
 def _load_strict_yaml(path: Path) -> object:
     try:
-        size = path.stat().st_size
+        metadata = path.lstat()
+        if path.is_symlink() or not stat.S_ISREG(metadata.st_mode):
+            raise WaiverSchemaError(f"{path}: waiver file must be a regular file")
+        size = metadata.st_size
         if size > MAX_WAIVER_FILE_BYTES:
             raise WaiverSchemaError(
                 f"{path}: file exceeds {MAX_WAIVER_FILE_BYTES} bytes"
@@ -192,15 +196,19 @@ def _load_strict_yaml(path: Path) -> object:
         raise WaiverSchemaError(f"cannot parse {path}: {error}") from error
 
 
+def _contains_control_or_format(value: str) -> bool:
+    return any(
+        unicodedata.category(character) in {"Cc", "Cf", "Cs"} for character in value
+    )
+
+
 def _module_path(raw_path: object) -> str:
     if not isinstance(raw_path, str) or not raw_path:
         raise WaiverSchemaError(f"{WAIVER_SECTION} keys must be non-empty strings")
     if (
         raw_path != raw_path.strip()
         or "\\" in raw_path
-        or any(
-            ord(character) < 0x20 or ord(character) == 0x7F for character in raw_path
-        )
+        or _contains_control_or_format(raw_path)
     ):
         raise WaiverSchemaError(f"unsafe {WAIVER_SECTION} path: {raw_path!r}")
     pure = PurePosixPath(raw_path)
@@ -219,17 +227,26 @@ def _module_path(raw_path: object) -> str:
 
 
 def _require_regular_module(repo_root: Path, module_path: str) -> None:
-    module = repo_root.joinpath(*PurePosixPath(module_path).parts)
-    try:
-        metadata = module.lstat()
-    except OSError as error:
-        raise WaiverSchemaError(
-            f"{WAIVER_SECTION} path does not exist: {module_path}"
-        ) from error
-    if module.is_symlink() or not stat.S_ISREG(metadata.st_mode):
-        raise WaiverSchemaError(
-            f"{WAIVER_SECTION} path is not a regular file: {module_path}"
-        )
+    parts = PurePosixPath(module_path).parts
+    current = repo_root
+    for index, part in enumerate(parts):
+        current /= part
+        try:
+            metadata = current.lstat()
+        except OSError as error:
+            raise WaiverSchemaError(
+                f"{WAIVER_SECTION} path does not exist: {module_path}"
+            ) from error
+        if current.is_symlink():
+            raise WaiverSchemaError(
+                f"{WAIVER_SECTION} path contains a symlink alias: {module_path}"
+            )
+        expected_type = stat.S_ISREG if index == len(parts) - 1 else stat.S_ISDIR
+        if not expected_type(metadata.st_mode):
+            raise WaiverSchemaError(
+                f"{WAIVER_SECTION} path is not a regular module path: {module_path}"
+            )
+    module = current
     root = repo_root.resolve()
     resolved = module.resolve()
     if root not in resolved.parents:
@@ -320,9 +337,12 @@ def load_validation_waivers(
     payload = _load_strict_yaml(source)
     if not isinstance(payload, Mapping):
         raise WaiverSchemaError(f"{source}: document root must be a mapping")
-    if WAIVER_SECTION not in payload:
+    root_keys = frozenset(payload)
+    if root_keys != frozenset({WAIVER_SECTION}):
+        extras = sorted(repr(key) for key in root_keys if key != WAIVER_SECTION)
         raise WaiverSchemaError(
-            f"{source}: required {WAIVER_SECTION} section is missing"
+            f"{source}: document root must contain exactly {WAIVER_SECTION} "
+            f"(extra={extras})"
         )
     raw_entries = payload[WAIVER_SECTION]
     if not isinstance(raw_entries, Mapping):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1764,6 +1764,12 @@ class TestCmdEvalSuiteArchive:
 
 
 class TestCmdValidate:
+    @staticmethod
+    def _module(tmp_path: Path, name: str) -> Path:
+        module = tmp_path / "rulespec-us" / "us" / "statutes" / name
+        module.parent.mkdir(parents=True, exist_ok=True)
+        return module
+
     def test_file_not_found(self, capsys):
         args = MagicMock()
         args.files = [Path("/nonexistent/file.yaml")]
@@ -1774,7 +1780,7 @@ class TestCmdValidate:
         assert "File not found" in captured.out
 
     def test_validate_pass_text_output(self, capsys, tmp_path):
-        rulespec_file = tmp_path / "test.yaml"
+        rulespec_file = self._module(tmp_path, "test.yaml")
         rulespec_file.write_text("# test")
         args = MagicMock()
         args.files = [rulespec_file]
@@ -1806,7 +1812,7 @@ class TestCmdValidate:
         assert "PASSED" in captured.out
 
     def test_validate_fail_json_output(self, capsys, tmp_path):
-        rulespec_file = tmp_path / "test.yaml"
+        rulespec_file = self._module(tmp_path, "test.yaml")
         rulespec_file.write_text("# test")
         args = MagicMock()
         args.files = [rulespec_file]
@@ -1842,8 +1848,8 @@ class TestCmdValidate:
         assert output["all_passed"] is False
 
     def test_validate_multiple_files_reuses_pipeline(self, capsys, tmp_path):
-        first = tmp_path / "first.yaml"
-        second = tmp_path / "second.yaml"
+        first = self._module(tmp_path, "first.yaml")
+        second = self._module(tmp_path, "second.yaml")
         first.write_text("# test")
         second.write_text("# test")
         args = MagicMock()
@@ -1874,7 +1880,7 @@ class TestCmdValidate:
         ]
 
     def test_validate_with_oracle_policyengine_pass(self, capsys, tmp_path):
-        rulespec_file = tmp_path / "test.yaml"
+        rulespec_file = self._module(tmp_path, "test.yaml")
         rulespec_file.write_text("# test")
         args = MagicMock()
         args.files = [rulespec_file]
@@ -1908,7 +1914,7 @@ class TestCmdValidate:
             )
 
     def test_validate_with_oracle_policyengine_fail(self, capsys, tmp_path):
-        rulespec_file = tmp_path / "test.yaml"
+        rulespec_file = self._module(tmp_path, "test.yaml")
         rulespec_file.write_text("# test")
         args = MagicMock()
         args.files = [rulespec_file]
@@ -1944,7 +1950,7 @@ class TestCmdValidate:
     def test_validate_with_oracle_classification_required_fails_unmapped(
         self, capsys, tmp_path
     ):
-        rulespec_file = tmp_path / "test.yaml"
+        rulespec_file = self._module(tmp_path, "test.yaml")
         rulespec_file.write_text("# test")
         args = MagicMock()
         args.files = [rulespec_file]
@@ -1992,7 +1998,7 @@ class TestCmdValidate:
     def test_validate_with_oracle_classification_required_allows_classified(
         self, capsys, tmp_path
     ):
-        rulespec_file = tmp_path / "test.yaml"
+        rulespec_file = self._module(tmp_path, "test.yaml")
         rulespec_file.write_text("# test")
         args = MagicMock()
         args.files = [rulespec_file]
@@ -2301,7 +2307,7 @@ class TestCmdValidate:
         assert "snap_new_exact_variable" in output
 
     def test_validate_with_oracle_taxsim_fail(self, capsys, tmp_path):
-        rulespec_file = tmp_path / "test.yaml"
+        rulespec_file = self._module(tmp_path, "test.yaml")
         rulespec_file.write_text("# test")
         args = MagicMock()
         args.files = [rulespec_file]
@@ -2333,7 +2339,7 @@ class TestCmdValidate:
             assert exc_info.value.code == 1
 
     def test_validate_with_oracle_all(self, capsys, tmp_path):
-        rulespec_file = tmp_path / "test.yaml"
+        rulespec_file = self._module(tmp_path, "test.yaml")
         rulespec_file.write_text("# test")
         args = MagicMock()
         args.files = [rulespec_file]
@@ -2366,7 +2372,7 @@ class TestCmdValidate:
             assert mock_pipeline_cls.call_args.kwargs["oracle_validators"] is None
 
     def test_validate_json_output_with_reviewresults_object(self, capsys, tmp_path):
-        rulespec_file = tmp_path / "test.yaml"
+        rulespec_file = self._module(tmp_path, "test.yaml")
         rulespec_file.write_text("# test")
         args = MagicMock()
         args.files = [rulespec_file]
@@ -2425,7 +2431,7 @@ class TestCmdValidate:
         assert output["oracle_scores"]["policyengine"] == 1.0
 
     def test_validate_passes_skip_reviewers_to_pipeline(self, tmp_path):
-        rulespec_file = tmp_path / "test.yaml"
+        rulespec_file = self._module(tmp_path, "test.yaml")
         rulespec_file.write_text("# test")
         args = MagicMock()
         args.files = [rulespec_file]
@@ -2460,7 +2466,7 @@ class TestCmdValidate:
     def test_validate_json_output_uses_null_scores_when_reviewers_skipped(
         self, capsys, tmp_path
     ):
-        rulespec_file = tmp_path / "test.yaml"
+        rulespec_file = self._module(tmp_path, "test.yaml")
         rulespec_file.write_text("# test")
         args = MagicMock()
         args.files = [rulespec_file]
@@ -2492,7 +2498,7 @@ class TestCmdValidate:
 
     def test_validate_rules_us_not_found_uses_defaults(self, capsys, tmp_path):
         """When rules_us can't be found by walking, use default paths."""
-        rulespec_file = tmp_path / "test.yaml"
+        rulespec_file = self._module(tmp_path, "test.yaml")
         rulespec_file.write_text("# test")
         args = MagicMock()
         args.files = [rulespec_file]
@@ -2676,7 +2682,7 @@ class TestCmdTest:
         expected_benefit: int,
     ) -> Path:
         repo = tmp_path / "rulespec-us"
-        target = repo / "statutes/1/1.yaml"
+        target = repo / "us/statutes/1/1.yaml"
         target.parent.mkdir(parents=True)
         target.write_text(
             """format: rulespec/v1
@@ -2738,7 +2744,7 @@ rules:
     def test_repairs_child_numeric_reencoding_parent_aliases(self, tmp_path):
         repo = tmp_path / "rulespec-us"
         rules_file = tmp_path / "out" / "codex-test-model" / "statutes/26/36B.yaml"
-        child_file = repo / "statutes/26/36B/b.yaml"
+        child_file = repo / "us/statutes/26/36B/b.yaml"
         child_file.parent.mkdir(parents=True)
         rules_file.parent.mkdir(parents=True)
         child_file.write_text(
@@ -2859,8 +2865,8 @@ rules:
     def test_repairs_child_fragment_reencoding_parent_aliases(self, tmp_path):
         repo = tmp_path / "rulespec-us"
         rules_file = tmp_path / "out" / "codex-test-model" / "statutes/42/426.yaml"
-        child_a2 = repo / "statutes/42/426/a/2.yaml"
-        child_d = repo / "statutes/42/426/d.yaml"
+        child_a2 = repo / "us/statutes/42/426/a/2.yaml"
+        child_d = repo / "us/statutes/42/426/d.yaml"
         rules_file.parent.mkdir(parents=True)
         child_a2.parent.mkdir(parents=True)
         child_d.parent.mkdir(parents=True, exist_ok=True)
@@ -2981,7 +2987,7 @@ rules:
 
     def test_executes_companion_tests_with_custom_period_name(self, capsys, tmp_path):
         repo = tmp_path / "rulespec-us"
-        target = repo / "policies/ssa/base.yaml"
+        target = repo / "us/policies/ssa/base.yaml"
         target.parent.mkdir(parents=True)
         target.write_text(
             """format: rulespec/v1
@@ -3016,7 +3022,7 @@ rules:
 
     def test_executes_companion_tests_with_table_rows(self, capsys, tmp_path):
         repo = tmp_path / "rulespec-us"
-        target = repo / "statutes/1/payment.yaml"
+        target = repo / "us/statutes/1/payment.yaml"
         target.parent.mkdir(parents=True)
         target.write_text(
             """format: rulespec/v1
@@ -3061,7 +3067,7 @@ rules:
         self, capsys, tmp_path
     ):
         repo = tmp_path / "rulespec-us"
-        target = repo / "statutes/1/relation.yaml"
+        target = repo / "us/statutes/1/relation.yaml"
         target.parent.mkdir(parents=True)
         target.write_text(
             """format: rulespec/v1
@@ -3114,7 +3120,7 @@ rules:
         self, capsys, monkeypatch, tmp_path
     ):
         stale_repo = tmp_path / "canonical" / "rulespec-us"
-        stale_child = stale_repo / "statutes/1/child.yaml"
+        stale_child = stale_repo / "us/statutes/1/child.yaml"
         stale_child.parent.mkdir(parents=True)
         stale_child.write_text(
             """format: rulespec/v1
@@ -3132,7 +3138,7 @@ rules:
         )
 
         repo = tmp_path / "workspace" / "rulespec-us"
-        child = repo / "statutes/1/child.yaml"
+        child = repo / "us/statutes/1/child.yaml"
         child.parent.mkdir(parents=True)
         child.write_text(
             """format: rulespec/v1
@@ -3148,7 +3154,7 @@ rules:
         formula: current_income + 1
 """
         )
-        parent = repo / "statutes/1/parent.yaml"
+        parent = repo / "us/statutes/1/parent.yaml"
         parent.write_text(
             """format: rulespec/v1
 imports:
@@ -3187,7 +3193,7 @@ rules:
         self, capsys, monkeypatch, tmp_path
     ):
         repo = tmp_path / "workspace" / "rulespec-us"
-        rules_file = repo / "statutes/1/1.yaml"
+        rules_file = repo / "us/statutes/1/1.yaml"
         rules_file.parent.mkdir(parents=True)
         rules_file.write_text(
             """format: rulespec/v1
@@ -3303,233 +3309,6 @@ rules:
             assert roots.index(str(stale_repo)) < roots.index(
                 str(repo.resolve().parent)
             )
-
-    def test_executes_companion_tests_from_canonical_alias_checkout(
-        self, capsys, monkeypatch, tmp_path
-    ):
-        repo = tmp_path / "rulespec-us-clean.abcd"
-        rules_file = repo / "statutes/1/alias.yaml"
-        rules_file.parent.mkdir(parents=True)
-        rules_file.write_text(
-            """format: rulespec/v1
-rules:
-  - name: benefit
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    versions:
-      - effective_from: '2024-01-01'
-        formula: income + 1
-"""
-        )
-        rules_file.with_name("alias.test.yaml").write_text(
-            """- name: canonical_temp_checkout_output
-  period: 2026-01
-  input:
-    us:statutes/1/alias#input.income: 5
-  output:
-    us:statutes/1/alias#benefit: 6
-"""
-        )
-
-        engine_root = tmp_path / "axiom-rules-engine"
-        binary = engine_root / "target/debug/axiom-rules-engine"
-        compiled_ids: list[str] = []
-        compile_programs: list[Path] = []
-
-        def fake_binary(self):
-            return binary
-
-        def fake_run(cmd, **kwargs):
-            if len(cmd) >= 6 and cmd[:3] == ["git", "-C", str(repo)]:
-                return subprocess.CompletedProcess(
-                    cmd,
-                    0,
-                    stdout="https://github.com/TheAxiomFoundation/rulespec-us.git\n",
-                    stderr="",
-                )
-            if "compile" in cmd:
-                program_path = Path(cmd[cmd.index("--program") + 1])
-                compile_programs.append(program_path)
-                item_id = "us:statutes/1/alias#benefit"
-                compiled_ids.append(item_id)
-                output_path = Path(cmd[cmd.index("--output") + 1])
-                output_path.write_text(
-                    json.dumps(
-                        {
-                            "program": {
-                                "parameters": [],
-                                "derived": [
-                                    {
-                                        "id": item_id,
-                                        "name": "benefit",
-                                        "entity": "Household",
-                                    }
-                                ],
-                            }
-                        }
-                    )
-                )
-                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
-            if "run-compiled" in cmd:
-                return subprocess.CompletedProcess(
-                    cmd,
-                    0,
-                    stdout=json.dumps(
-                        {
-                            "results": [
-                                {
-                                    "outputs": {
-                                        "us:statutes/1/alias#benefit": {
-                                            "kind": "scalar",
-                                            "value": {"kind": "integer", "value": 6},
-                                        }
-                                    }
-                                }
-                            ]
-                        }
-                    ),
-                    stderr="",
-                )
-            raise AssertionError(f"unexpected command: {cmd}")
-
-        args = MagicMock()
-        args.root = repo
-        args.paths = []
-        args.json = True
-        args.axiom_rules_path = engine_root
-
-        monkeypatch.setattr(
-            "axiom_encode.harness.validator_pipeline.ValidatorPipeline._axiom_rules_binary",
-            fake_binary,
-        )
-        monkeypatch.setattr("axiom_encode.cli.subprocess.run", fake_run)
-
-        with pytest.raises(SystemExit) as exc_info:
-            cmd_test(args)
-
-        assert exc_info.value.code == 0
-        assert json.loads(capsys.readouterr().out)["success"] is True
-        assert compiled_ids == ["us:statutes/1/alias#benefit"]
-        assert len(compile_programs) == 1
-        assert "rulespec-us" in compile_programs[0].parts
-        assert "rulespec-us-clean.abcd" not in str(compile_programs[0])
-
-    def test_executes_relation_tests_from_canonical_alias_checkout(
-        self, capsys, monkeypatch, tmp_path
-    ):
-        repo = tmp_path / "rulespec-us-clean.abcd"
-        rules_file = repo / "statutes/1/relation.yaml"
-        rules_file.parent.mkdir(parents=True)
-        rules_file.write_text(
-            """format: rulespec/v1
-rules:
-  - name: members
-    kind: data_relation
-    data_relation:
-      arity: 2
-  - name: benefit
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    versions:
-      - effective_from: '2024-01-01'
-        formula: sum(members.income)
-"""
-        )
-        rules_file.with_name("relation.test.yaml").write_text(
-            """- name: canonical_temp_checkout_relation_input
-  period: 2026-01
-  input:
-    us:statutes/1/relation#relation.members:
-      - us:statutes/1/relation#input.income: 5
-  output:
-    us:statutes/1/relation#benefit: 5
-"""
-        )
-
-        engine_root = tmp_path / "axiom-rules-engine"
-        binary = engine_root / "target/debug/axiom-rules-engine"
-        relation_names: list[str] = []
-
-        def fake_binary(self):
-            return binary
-
-        def fake_run(cmd, **kwargs):
-            if len(cmd) >= 6 and cmd[:3] == ["git", "-C", str(repo)]:
-                return subprocess.CompletedProcess(
-                    cmd,
-                    0,
-                    stdout="https://github.com/TheAxiomFoundation/rulespec-us.git\n",
-                    stderr="",
-                )
-            if "compile" in cmd:
-                output_path = Path(cmd[cmd.index("--output") + 1])
-                output_path.write_text(
-                    json.dumps(
-                        {
-                            "program": {
-                                "parameters": [],
-                                "derived": [
-                                    {
-                                        "id": "us-clean.abcd:statutes/1/relation#benefit",
-                                        "name": "benefit",
-                                        "entity": "Household",
-                                    }
-                                ],
-                            }
-                        }
-                    )
-                )
-                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
-            if "run-compiled" in cmd:
-                request = json.loads(kwargs["input"])
-                relation_names.extend(
-                    relation["name"] for relation in request["dataset"]["relations"]
-                )
-                return subprocess.CompletedProcess(
-                    cmd,
-                    0,
-                    stdout=json.dumps(
-                        {
-                            "results": [
-                                {
-                                    "outputs": {
-                                        "us:statutes/1/relation#benefit": {
-                                            "kind": "scalar",
-                                            "value": {"kind": "integer", "value": 5},
-                                        }
-                                    }
-                                }
-                            ]
-                        }
-                    ),
-                    stderr="",
-                )
-            raise AssertionError(f"unexpected command: {cmd}")
-
-        args = MagicMock()
-        args.root = repo
-        args.paths = []
-        args.json = True
-        args.axiom_rules_path = engine_root
-
-        monkeypatch.setattr(
-            "axiom_encode.harness.validator_pipeline.ValidatorPipeline._axiom_rules_binary",
-            fake_binary,
-        )
-        monkeypatch.setattr("axiom_encode.cli.subprocess.run", fake_run)
-
-        with pytest.raises(SystemExit) as exc_info:
-            cmd_test(args)
-
-        assert exc_info.value.code == 0
-        assert json.loads(capsys.readouterr().out)["success"] is True
-        assert relation_names == ["us:statutes/1/relation#relation.members"]
 
     def test_discovery_skips_axiom_dependency_tree(self, tmp_path):
         root = tmp_path / "workspace"
@@ -36041,8 +35820,8 @@ class TestTranscriptSyncCommands:
 
 class TestCmdValidateEdgeCases:
     def test_validate_rules_us_found_in_path(self, capsys, tmp_path):
-        """Test validate when file is inside a rulespec-us directory (line 350)."""
-        rules_us = tmp_path / "rulespec-us" / "statutes" / "26" / "1"
+        """Validation uses the country checkout, never a jurisdiction subroot."""
+        rules_us = tmp_path / "rulespec-us" / "us" / "statutes" / "26" / "1"
         rules_us.mkdir(parents=True)
         rulespec_file = rules_us / "test.yaml"
         rulespec_file.write_text("# test")
@@ -36075,9 +35854,8 @@ class TestCmdValidateEdgeCases:
             with pytest.raises(SystemExit) as exc_info:
                 cmd_validate(args)
             assert exc_info.value.code == 0
-            # Verify axiom_rules_path was resolved via rules_us.parent / "axiom-rules-engine"
             call_kwargs = mock_pipeline_cls.call_args[1]
-            assert "rulespec-us" in str(call_kwargs["policy_repo_path"])
+            assert call_kwargs["policy_repo_path"] == tmp_path / "rulespec-us"
 
     def test_validate_uses_enclosing_non_federal_policy_repo(self, tmp_path):
         policy_repo = tmp_path / "rulespec-us-tn" / "sources"
@@ -36107,14 +35885,9 @@ class TestCmdValidateEdgeCases:
         )
 
         with patch("axiom_encode.cli.ValidatorPipeline") as mock_pipeline_cls:
-            mock_pipeline_cls.return_value.validate.return_value = mock_result
-            with pytest.raises(SystemExit) as exc_info:
+            with pytest.raises(ValueError, match="country-monorepo layout"):
                 cmd_validate(args)
-            assert exc_info.value.code == 0
-
-        call_kwargs = mock_pipeline_cls.call_args[1]
-        assert call_kwargs["policy_repo_path"] == tmp_path / "rulespec-us-tn"
-        assert call_kwargs["axiom_rules_path"] == tmp_path / "axiom-rules-engine"
+            mock_pipeline_cls.assert_not_called()
 
     def test_validate_fallback_prefers_workspace_repo_roots(
         self, monkeypatch, tmp_path
@@ -36149,22 +35922,10 @@ class TestCmdValidateEdgeCases:
             taxsim_match=None,
         )
 
-        with (
-            patch(
-                "axiom_encode.cli._resolve_policy_repo_for_prefix",
-                return_value=rules_us_path,
-            ),
-            patch("axiom_encode.cli.ValidatorPipeline") as mock_pipeline_cls,
-        ):
-            mock_pipeline = mock_pipeline_cls.return_value
-            mock_pipeline.validate.return_value = mock_result
-            with pytest.raises(SystemExit) as exc_info:
+        with patch("axiom_encode.cli.ValidatorPipeline") as mock_pipeline_cls:
+            with pytest.raises(ValueError, match="not inside a canonical country"):
                 cmd_validate(args)
-            assert exc_info.value.code == 0
-
-        call_kwargs = mock_pipeline_cls.call_args[1]
-        assert call_kwargs["policy_repo_path"] == rules_us_path
-        assert call_kwargs["axiom_rules_path"] == axiom_rules_path
+            mock_pipeline_cls.assert_not_called()
 
 
 class TestCmdCalibrationEdgeCases:

--- a/tests/test_validation_waiver_audit_cli.py
+++ b/tests/test_validation_waiver_audit_cli.py
@@ -215,6 +215,26 @@ def test_independent_companion_matches_shared_test_command_root(tmp_path: Path):
     assert companion_policy_roots == [root]
 
 
+def test_fingerprint_rejects_symlinked_companion(tmp_path: Path):
+    root = tmp_path / "rulespec-us"
+    module = root / "us/statutes/module.yaml"
+    module.parent.mkdir(parents=True)
+    module.write_text("format: rulespec/v1\n")
+    target = module.with_name("target.test.yaml")
+    target.write_text("cases: []\n")
+    module.with_name("module.test.yaml").symlink_to(target.name)
+
+    with (
+        patch.object(cli, "ValidatorPipeline", _FakePipeline),
+        pytest.raises(ValueError, match="must not be a symlink"),
+    ):
+        cli._fingerprint_validation_waiver_modules(
+            [Path("us/statutes/module.yaml")],
+            root=root,
+            axiom_rules_path=_engine(tmp_path),
+        )
+
+
 def test_companion_parse_failure_is_deterministic_and_paths_are_normalized(
     tmp_path: Path,
 ):
@@ -326,7 +346,12 @@ def _audit_args(root: Path, protected_base: Path, changed_paths: Path):
 
 
 @pytest.mark.parametrize(
-    "value", ["us/statutes/a.yaml\nsecond", "us/statutes/\x7fa.yaml"]
+    "value",
+    [
+        "us/statutes/a.yaml\nsecond",
+        "us/statutes/\x7fa.yaml",
+        "us/statutes/\u202ea.yaml",
+    ],
 )
 def test_transition_paths_reject_control_characters(value: str):
     with pytest.raises(ValueError, match="control characters"):
@@ -563,14 +588,50 @@ def test_active_paths_emits_active_entries_only(tmp_path: Path, capsys):
         cli._validation_waivers,
         "load_validation_waivers",
         return_value=waivers,
-    ):
+    ) as loader:
         exit_code = cli._cmd_validation_waivers_active_paths(args)
 
     assert exit_code == 0
+    assert loader.call_args.args[0] == tmp_path / "known-validation-gaps.yaml"
     assert capsys.readouterr().out.splitlines() == [
         "us/statutes/26/1.yaml",
         "us/statutes/26/2.yaml",
     ]
+
+
+def test_audit_requires_protected_base_and_changed_paths(tmp_path: Path):
+    root = tmp_path / "rulespec-us"
+    root.mkdir()
+    (root / "known-validation-gaps.yaml").write_text("validate_failures: {}\n")
+    args = SimpleNamespace(
+        root=root,
+        protected_base=None,
+        changed_paths=None,
+        axiom_rules_path=None,
+        json=True,
+    )
+
+    with pytest.raises(ValueError, match="are required"):
+        cli._cmd_validation_waivers_audit(args)
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["validation-waivers", "audit"],
+        ["validation-waivers", "active-paths", "--waivers", "alternate.yaml"],
+    ],
+)
+def test_cli_rejects_missing_transition_inputs_and_alternate_waiver_files(
+    argv: list[str],
+):
+    with (
+        patch("sys.argv", ["axiom-encode", *argv]),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        cli.main()
+
+    assert exc_info.value.code == 2
 
 
 def test_main_registers_validation_waiver_subcommands(tmp_path: Path):

--- a/tests/test_validation_waiver_audit_cli.py
+++ b/tests/test_validation_waiver_audit_cli.py
@@ -351,11 +351,24 @@ def _audit_args(root: Path, protected_base: Path, changed_paths: Path):
         "us/statutes/a.yaml\nsecond",
         "us/statutes/\x7fa.yaml",
         "us/statutes/\u202ea.yaml",
+        "us/statutes/\u2028a.yaml",
     ],
 )
 def test_transition_paths_reject_control_characters(value: str):
     with pytest.raises(ValueError, match="control characters"):
         cli._validation_waiver_repo_relative_path(value, label="changed path")
+
+
+def test_changed_paths_rejects_unicode_separator_before_deduplication(
+    tmp_path: Path,
+):
+    changed_paths = tmp_path / "changed.txt"
+    changed_paths.write_text(
+        "known-validation-gaps.yaml\nknown-validation-gaps.yaml\u2028\n"
+    )
+
+    with pytest.raises(ValueError, match="control characters"):
+        cli._validation_waiver_changed_paths(changed_paths)
 
 
 def test_audit_checks_active_pending_and_removed_waivers(tmp_path: Path, capsys):

--- a/tests/test_validation_waiver_audit_cli.py
+++ b/tests/test_validation_waiver_audit_cli.py
@@ -1,0 +1,598 @@
+"""Focused tests for the strict validation-waiver CLI."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from axiom_encode import cli
+
+
+def _validator(*, passed: bool, issues=(), error=None):
+    return SimpleNamespace(
+        passed=passed,
+        issues=list(issues),
+        error=error,
+        duration_ms=999,
+        raw_output="volatile raw output",
+        score=0.123,
+    )
+
+
+def _pipeline_result(*, passed: bool, issues=("broken",), error="broken"):
+    return SimpleNamespace(
+        all_passed=passed,
+        results={
+            "compile": _validator(
+                passed=passed,
+                issues=() if passed else issues,
+                error=None if passed else error,
+            ),
+            "ci": _validator(passed=True),
+        },
+    )
+
+
+class _FakePipeline:
+    instances = []
+    result = _pipeline_result(passed=False)
+    validate_error = None
+
+    def __init__(self, *, policy_repo_path, axiom_rules_path, enable_oracles):
+        self.policy_repo_path = Path(policy_repo_path)
+        self.axiom_rules_path = Path(axiom_rules_path)
+        self.enable_oracles = enable_oracles
+        self.local_corpus_root = None
+        self.validated = []
+        type(self).instances.append(self)
+
+    def _axiom_rules_binary(self):
+        return self.axiom_rules_path / "axiom-rules-engine"
+
+    def _rulespec_compile_env(self):
+        return {
+            "AXIOM_RULESPEC_REPO_ROOTS": str(self.policy_repo_path),
+            "AXIOM_CORPUS_REPO": str(self.policy_repo_path.parent / "axiom-corpus"),
+        }
+
+    def validate(self, module, *, skip_reviewers):
+        self.validated.append((Path(module), skip_reviewers))
+        if self.validate_error is not None:
+            raise self.validate_error
+        return self.result
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_pipeline():
+    _FakePipeline.instances = []
+    _FakePipeline.result = _pipeline_result(passed=False)
+    _FakePipeline.validate_error = None
+
+
+def _engine(tmp_path: Path) -> Path:
+    engine = tmp_path / "engine"
+    engine.mkdir()
+    (engine / "axiom-rules-engine").write_text("")
+    return engine
+
+
+def test_validate_outcome_keeps_all_failed_issues_and_excludes_volatile_fields():
+    result = SimpleNamespace(
+        all_passed=False,
+        results={
+            "compile": _validator(
+                passed=False,
+                issues=("first", "second"),
+                error="compile error",
+            ),
+            "ci": _validator(passed=True),
+        },
+    )
+
+    outcome = cli._validation_waiver_validate_outcome(result)
+
+    assert outcome == {
+        "passed": False,
+        "validators": {
+            "compile": {
+                "passed": False,
+                "issues": ["first", "second"],
+                "error": "compile error",
+            }
+        },
+    }
+    assert "duration_ms" not in json.dumps(outcome)
+    assert "raw_output" not in json.dumps(outcome)
+    assert "score" not in json.dumps(outcome)
+
+
+def test_inconsistent_pipeline_aggregate_is_fatal_infrastructure_error():
+    result = SimpleNamespace(
+        all_passed=False,
+        results={"ci": _validator(passed=True)},
+    )
+
+    with pytest.raises(RuntimeError, match="inconsistent aggregate"):
+        cli._validation_waiver_validate_outcome(result)
+
+
+def test_fingerprint_reuses_pipeline_and_marks_missing_companion_explicit(
+    tmp_path: Path,
+):
+    root = tmp_path / "rulespec-us"
+    content_root = root / "us/statutes"
+    content_root.mkdir(parents=True)
+    for name in ("b.yaml", "a.yaml"):
+        (content_root / name).write_text("format: rulespec/v1\n")
+    engine = _engine(tmp_path)
+
+    with patch.object(cli, "ValidatorPipeline", _FakePipeline):
+        results = cli._fingerprint_validation_waiver_modules(
+            [Path("us/statutes/b.yaml"), Path("us/statutes/a.yaml")],
+            root=root,
+            axiom_rules_path=engine,
+        )
+
+    assert len(_FakePipeline.instances) == 1
+    assert [result["path"] for result in results] == [
+        "us/statutes/a.yaml",
+        "us/statutes/b.yaml",
+    ]
+    validation_pipelines = [
+        pipeline for pipeline in _FakePipeline.instances if pipeline.validated
+    ]
+    assert len(validation_pipelines) == 1
+    assert [path.name for path, skip in validation_pipelines[0].validated] == [
+        "a.yaml",
+        "b.yaml",
+    ]
+    assert all(skip is True for _, skip in validation_pipelines[0].validated)
+    assert all(result["outcome"]["companion"]["present"] is False for result in results)
+    assert all(result["outcome"]["companion"]["passed"] is True for result in results)
+    assert all(result["fingerprint"].startswith("sha256:") for result in results)
+
+
+def test_validation_and_fingerprint_use_canonical_checkout_root(tmp_path: Path):
+    root = tmp_path / "rulespec-us"
+    modules = []
+    for relative in ("us/statutes/1.yaml", "us-ca/regulations/1.yaml"):
+        module = root / relative
+        module.parent.mkdir(parents=True, exist_ok=True)
+        module.write_text("format: rulespec/v1\n")
+        modules.append(Path(relative))
+    engine = _engine(tmp_path)
+
+    with patch.object(cli, "ValidatorPipeline", _FakePipeline):
+        cli._fingerprint_validation_waiver_modules(
+            modules,
+            root=root,
+            axiom_rules_path=engine,
+        )
+
+    assert cli._resolve_validation_repo_roots(root / modules[0])[0] == root
+    assert cli._resolve_validation_repo_roots(root / modules[1])[0] == root
+    assert {pipeline.policy_repo_path for pipeline in _FakePipeline.instances} == {root}
+
+
+def test_validation_rejects_legacy_flat_checkout_layout(tmp_path: Path):
+    module = tmp_path / "rulespec-us-ca/regulations/1.yaml"
+    module.parent.mkdir(parents=True)
+    module.write_text("format: rulespec/v1\n")
+
+    with pytest.raises(ValueError, match="country-monorepo layout"):
+        cli._canonical_validation_checkout_root(module)
+
+
+def test_independent_companion_matches_shared_test_command_root(tmp_path: Path):
+    root = tmp_path / "rulespec-us"
+    module = root / "us-ca/regulations/1.yaml"
+    module.parent.mkdir(parents=True)
+    module.write_text("format: rulespec/v1\n")
+    module.with_name("1.test.yaml").write_text("cases: []\n")
+    engine = _engine(tmp_path)
+    companion_policy_roots = []
+
+    def execute(*args, **kwargs):
+        companion_policy_roots.append(kwargs["policy_repo_path"])
+        return {"cases": 0, "compiled": 1, "failures": []}
+
+    with (
+        patch.object(cli, "ValidatorPipeline", _FakePipeline),
+        patch.object(cli, "_execute_rulespec_test_file", side_effect=execute),
+    ):
+        cli._fingerprint_validation_waiver_modules(
+            [Path("us-ca/regulations/1.yaml")],
+            root=root,
+            axiom_rules_path=engine,
+        )
+
+    # Validation, the ordinary companion command, and the independent audit
+    # share the country checkout as their only policy root.
+    assert companion_policy_roots == [root]
+
+
+def test_companion_parse_failure_is_deterministic_and_paths_are_normalized(
+    tmp_path: Path,
+):
+    root = tmp_path / "rulespec-us"
+    module = root / "us/statutes/module.yaml"
+    module.parent.mkdir(parents=True)
+    module.write_text("format: rulespec/v1\n")
+    module.with_name("module.test.yaml").write_text("not: valid cases\n")
+    engine = _engine(tmp_path)
+    _FakePipeline.result = _pipeline_result(passed=True)
+
+    def fail_parse(*args, **kwargs):
+        raise ValueError(
+            f"bad test under {root}; engine={engine}; tmp={kwargs['tmp_path']}"
+        )
+
+    with (
+        patch.object(cli, "ValidatorPipeline", _FakePipeline),
+        patch.object(cli, "_execute_rulespec_test_file", side_effect=fail_parse),
+    ):
+        result = cli._fingerprint_validation_waiver_modules(
+            [Path("us/statutes/module.yaml")],
+            root=root,
+            axiom_rules_path=engine,
+        )[0]
+
+    serialized = json.dumps(result["outcome"])
+    assert result["passed"] is False
+    assert "ValueError: bad test" in serialized
+    assert str(root) not in serialized
+    assert str(engine) not in serialized
+    assert "<repo>" in serialized
+    assert "<engine>" in serialized
+    assert "<tmp>" in serialized
+
+
+def test_unexpected_pipeline_exception_is_not_fingerprintable(tmp_path: Path):
+    root = tmp_path / "rulespec-us"
+    module = root / "us/statutes/module.yaml"
+    module.parent.mkdir(parents=True)
+    module.write_text("format: rulespec/v1\n")
+    engine = _engine(tmp_path)
+    _FakePipeline.validate_error = RuntimeError("validator infrastructure broke")
+
+    with (
+        patch.object(cli, "ValidatorPipeline", _FakePipeline),
+        pytest.raises(RuntimeError, match="infrastructure broke"),
+    ):
+        cli._fingerprint_validation_waiver_modules(
+            [Path("us/statutes/module.yaml")],
+            root=root,
+            axiom_rules_path=engine,
+        )
+
+
+@pytest.mark.parametrize(
+    "module_path",
+    [
+        "module.yaml",
+        "us/statutes/module.yml",
+        "us/statutes/module.test.yaml",
+    ],
+)
+def test_fingerprint_rejects_paths_the_waiver_schema_cannot_store(
+    tmp_path: Path,
+    module_path: str,
+):
+    root = tmp_path / "rulespec-us"
+    module = root / module_path
+    module.parent.mkdir(parents=True, exist_ok=True)
+    module.write_text("format: rulespec/v1\n")
+
+    with pytest.raises(
+        cli._validation_waivers.WaiverSchemaError,
+        match="unsafe validate_failures path",
+    ):
+        cli._fingerprint_validation_waiver_modules(
+            [Path(module_path)],
+            root=root,
+            axiom_rules_path=_engine(tmp_path),
+        )
+
+
+def _metadata(fingerprint: str):
+    return SimpleNamespace(fingerprint=fingerprint)
+
+
+def _entry(path: str, *, active=None, pending=None):
+    return SimpleNamespace(path=path, active=active, pending=pending)
+
+
+def _waiver_set(entries):
+    return SimpleNamespace(
+        entries=entries,
+        active_paths={path for path, entry in entries.items() if entry.active},
+        pending_paths={path for path, entry in entries.items() if entry.pending},
+    )
+
+
+def _audit_args(root: Path, protected_base: Path, changed_paths: Path):
+    return SimpleNamespace(
+        root=root,
+        waivers=None,
+        protected_base=protected_base,
+        changed_paths=changed_paths,
+        axiom_rules_path=None,
+        json=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "value", ["us/statutes/a.yaml\nsecond", "us/statutes/\x7fa.yaml"]
+)
+def test_transition_paths_reject_control_characters(value: str):
+    with pytest.raises(ValueError, match="control characters"):
+        cli._validation_waiver_repo_relative_path(value, label="changed path")
+
+
+def test_audit_checks_active_pending_and_removed_waivers(tmp_path: Path, capsys):
+    root = tmp_path / "rulespec-us"
+    root.mkdir()
+    (root / "known-validation-gaps.yaml").write_text("validate_failures: {}\n")
+    for path in ("active.yaml", "both.yaml", "pending.yaml", "removed.yaml"):
+        (root / path).write_text("format: rulespec/v1\n")
+    base_file = tmp_path / "base.yaml"
+    base_file.write_text("validate_failures: {}\n")
+    changed_file = tmp_path / "changed.txt"
+    changed_file.write_text("known-validation-gaps.yaml\n")
+
+    head = _waiver_set(
+        {
+            "active.yaml": _entry("active.yaml", active=_metadata("sha256:active")),
+            "both.yaml": _entry(
+                "both.yaml",
+                active=_metadata("sha256:both"),
+                pending=_metadata("sha256:future"),
+            ),
+            "pending.yaml": _entry("pending.yaml", pending=_metadata("sha256:pending")),
+        }
+    )
+    base = _waiver_set(
+        {
+            "active.yaml": _entry("active.yaml", active=_metadata("sha256:active")),
+            "both.yaml": _entry("both.yaml", active=_metadata("sha256:both")),
+            "removed.yaml": _entry("removed.yaml", active=_metadata("sha256:removed")),
+        }
+    )
+    executed = [
+        {
+            "path": "active.yaml",
+            "passed": False,
+            "fingerprint": "sha256:active",
+            "outcome": {},
+        },
+        {
+            "path": "both.yaml",
+            "passed": False,
+            "fingerprint": "sha256:both",
+            "outcome": {},
+        },
+        {
+            "path": "pending.yaml",
+            "passed": True,
+            "fingerprint": "sha256:passing",
+            "outcome": {},
+        },
+        {
+            "path": "removed.yaml",
+            "passed": True,
+            "fingerprint": "sha256:passing",
+            "outcome": {},
+        },
+    ]
+
+    with (
+        patch.object(
+            cli._validation_waivers,
+            "load_validation_waivers",
+            side_effect=[head, base],
+        ),
+        patch.object(
+            cli._validation_waivers,
+            "protected_base_transition_issues",
+            return_value=(),
+        ),
+        patch.object(
+            cli,
+            "_fingerprint_validation_waiver_modules",
+            return_value=executed,
+        ),
+    ):
+        exit_code = cli._cmd_validation_waivers_audit(
+            _audit_args(root, base_file, changed_file)
+        )
+
+    report = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert report["success"] is True
+    assert {item["kind"] for item in report["results"]} == {
+        "active",
+        "pending",
+        "removed",
+    }
+    both = next(item for item in report["results"] if item["path"] == "both.yaml")
+    assert both["expected_fingerprint"] == "sha256:both"
+
+
+@pytest.mark.parametrize(
+    ("kind", "passed", "actual_fingerprint", "expected_error"),
+    [
+        ("active", True, "sha256:passing", "active validation waiver is stale"),
+        ("active", False, "sha256:changed", "failure fingerprint drifted"),
+        ("pending", False, "sha256:failing", "pending waiver requires"),
+    ],
+)
+def test_audit_rejects_invalid_runtime_waiver_state(
+    tmp_path: Path,
+    capsys,
+    kind: str,
+    passed: bool,
+    actual_fingerprint: str,
+    expected_error: str,
+):
+    root = tmp_path / "rulespec-us"
+    module_path = "us/statutes/module.yaml"
+    module = root / module_path
+    module.parent.mkdir(parents=True)
+    module.write_text("format: rulespec/v1\n")
+    (root / "known-validation-gaps.yaml").write_text("validate_failures: {}\n")
+    base_file = tmp_path / "base.yaml"
+    base_file.write_text("validate_failures: {}\n")
+    changed_file = tmp_path / "changed.txt"
+    changed_file.write_text("")
+
+    expected_fingerprint = "sha256:expected"
+    entry = _entry(
+        module_path,
+        active=_metadata(expected_fingerprint) if kind == "active" else None,
+        pending=_metadata(expected_fingerprint) if kind == "pending" else None,
+    )
+    waivers = _waiver_set({module_path: entry})
+    executed = [
+        {
+            "path": module_path,
+            "passed": passed,
+            "fingerprint": actual_fingerprint,
+            "outcome": {},
+        }
+    ]
+
+    with (
+        patch.object(
+            cli._validation_waivers,
+            "load_validation_waivers",
+            side_effect=[waivers, waivers],
+        ),
+        patch.object(
+            cli._validation_waivers,
+            "protected_base_transition_issues",
+            return_value=(),
+        ),
+        patch.object(
+            cli,
+            "_fingerprint_validation_waiver_modules",
+            return_value=executed,
+        ),
+    ):
+        exit_code = cli._cmd_validation_waivers_audit(
+            _audit_args(root, base_file, changed_file)
+        )
+
+    report = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert report["success"] is False
+    assert len(report["errors"]) == 1
+    assert expected_error in report["errors"][0]
+
+
+def test_removed_waiver_must_pass_unless_module_was_deleted(tmp_path: Path, capsys):
+    root = tmp_path / "rulespec-us"
+    root.mkdir()
+    (root / "known-validation-gaps.yaml").write_text("validate_failures: {}\n")
+    (root / "still-broken.yaml").write_text("format: rulespec/v1\n")
+    base_file = tmp_path / "base.yaml"
+    base_file.write_text("validate_failures: {}\n")
+    changed_file = tmp_path / "changed.txt"
+    changed_file.write_text("known-validation-gaps.yaml\n")
+    head = _waiver_set({})
+    base = _waiver_set(
+        {
+            "still-broken.yaml": _entry(
+                "still-broken.yaml", active=_metadata("sha256:old")
+            ),
+            "deleted.yaml": _entry("deleted.yaml", active=_metadata("sha256:deleted")),
+        }
+    )
+    executed = [
+        {
+            "path": "still-broken.yaml",
+            "passed": False,
+            "fingerprint": "sha256:old",
+            "outcome": {},
+        }
+    ]
+    with (
+        patch.object(
+            cli._validation_waivers,
+            "load_validation_waivers",
+            side_effect=[head, base],
+        ),
+        patch.object(
+            cli._validation_waivers,
+            "protected_base_transition_issues",
+            return_value=(),
+        ),
+        patch.object(
+            cli,
+            "_fingerprint_validation_waiver_modules",
+            return_value=executed,
+        ),
+    ):
+        exit_code = cli._cmd_validation_waivers_audit(
+            _audit_args(root, base_file, changed_file)
+        )
+
+    report = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert any("still-broken.yaml" in error for error in report["errors"])
+    deleted = next(item for item in report["results"] if item["path"] == "deleted.yaml")
+    assert deleted == {
+        "path": "deleted.yaml",
+        "kind": "removed",
+        "success": True,
+        "module_deleted": True,
+    }
+
+
+def test_active_paths_emits_active_entries_only(tmp_path: Path, capsys):
+    waivers = SimpleNamespace(
+        active_paths=frozenset({"us/statutes/26/1.yaml", "us/statutes/26/2.yaml"}),
+        pending_paths=frozenset({"us/statutes/26/3.yaml"}),
+    )
+    args = SimpleNamespace(root=tmp_path, waivers=None, json=False)
+
+    with patch.object(
+        cli._validation_waivers,
+        "load_validation_waivers",
+        return_value=waivers,
+    ):
+        exit_code = cli._cmd_validation_waivers_active_paths(args)
+
+    assert exit_code == 0
+    assert capsys.readouterr().out.splitlines() == [
+        "us/statutes/26/1.yaml",
+        "us/statutes/26/2.yaml",
+    ]
+
+
+def test_main_registers_validation_waiver_subcommands(tmp_path: Path):
+    with (
+        patch(
+            "sys.argv",
+            [
+                "axiom-encode",
+                "validation-waivers",
+                "fingerprint",
+                "module.yaml",
+                "--root",
+                str(tmp_path),
+                "--json",
+            ],
+        ),
+        patch.object(cli, "cmd_validation_waivers") as command,
+    ):
+        cli.main()
+
+    args = command.call_args.args[0]
+    assert args.validation_waivers_command == "fingerprint"
+    assert args.modules == [Path("module.yaml")]
+    assert args.root == tmp_path
+    assert args.json is True

--- a/tests/test_validation_waivers.py
+++ b/tests/test_validation_waivers.py
@@ -1,0 +1,453 @@
+"""Tests for strict, protected-base validation failure waivers."""
+
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from pathlib import Path
+from types import MappingProxyType
+
+import pytest
+
+from axiom_encode.validation_waivers import (
+    MAX_WAIVER_DAYS,
+    ValidationWaiverSet,
+    WaiverEntry,
+    WaiverMetadata,
+    WaiverSchemaError,
+    canonicalize_outcome,
+    fingerprint_outcome,
+    load_validation_waivers,
+    protected_base_transition_issues,
+)
+
+TODAY = date(2026, 7, 10)
+EXPIRY = (TODAY + timedelta(days=MAX_WAIVER_DAYS)).isoformat()
+PATH = "us/statutes/26/1.yaml"
+OTHER_PATH = "us-ca/regulations/mpp/1.yaml"
+
+
+def _metadata(
+    marker: str = "a",
+    *,
+    expires: str = EXPIRY,
+    owner: str = "@MaxGhenis",
+    issue: str = "https://github.com/TheAxiomFoundation/rulespec-us/issues/782",
+) -> WaiverMetadata:
+    return WaiverMetadata(
+        fingerprint=f"sha256:{marker * 64}",
+        owner=owner,
+        issue=issue,
+        expires=expires,
+    )
+
+
+def _entry(path: str, *, active=None, pending=None) -> WaiverEntry:
+    return WaiverEntry(path=path, active=active, pending=pending)
+
+
+def _set(*entries: WaiverEntry) -> ValidationWaiverSet:
+    return ValidationWaiverSet(
+        MappingProxyType({entry.path: entry for entry in entries})
+    )
+
+
+def _repo(tmp_path: Path, *paths: str) -> Path:
+    root = tmp_path / "rulespec-us"
+    root.mkdir()
+    for path in paths:
+        module = root / path
+        module.parent.mkdir(parents=True, exist_ok=True)
+        module.write_text("format: rulespec/v1\n")
+    return root
+
+
+def _metadata_yaml(
+    marker: str = "a",
+    *,
+    expires: str = EXPIRY,
+    issue: str = "https://github.com/TheAxiomFoundation/rulespec-us/issues/782",
+) -> str:
+    return (
+        f'fingerprint: "sha256:{marker * 64}"\n'
+        '      owner: "@MaxGhenis"\n'
+        f'      issue: "{issue}"\n'
+        f'      expires: "{expires}"\n'
+    )
+
+
+def _valid_yaml(*, active: bool = True, pending: bool = False) -> str:
+    states = ""
+    if active:
+        states += "    active:\n      " + _metadata_yaml("a")
+    if pending:
+        states += "    pending:\n      " + _metadata_yaml("b")
+    return f"validate_failures:\n  {PATH}:\n{states}"
+
+
+def test_requires_file_and_section_but_accepts_empty_mapping(tmp_path: Path):
+    root = _repo(tmp_path)
+    with pytest.raises(WaiverSchemaError, match="required.*file.*missing"):
+        load_validation_waivers(root / "missing.yaml", repo_root=root, today=TODAY)
+
+    waiver_file = root / "known-validation-gaps.yaml"
+    waiver_file.write_text("shape_issues: []\n")
+    with pytest.raises(WaiverSchemaError, match="required validate_failures"):
+        load_validation_waivers(waiver_file, repo_root=root, today=TODAY)
+
+    waiver_file.write_text("validate_failures: {}\n")
+    loaded = load_validation_waivers(waiver_file, repo_root=root, today=TODAY)
+    assert loaded.active_paths == frozenset()
+    assert loaded.pending_paths == frozenset()
+
+
+@pytest.mark.parametrize("content", ["[]\n", "false\n", "0\n", "''\n"])
+def test_rejects_falsy_non_mapping_document_roots(tmp_path: Path, content: str):
+    root = _repo(tmp_path)
+    waiver_file = root / "known-validation-gaps.yaml"
+    waiver_file.write_text(content)
+
+    with pytest.raises(WaiverSchemaError, match="document root must be a mapping"):
+        load_validation_waivers(waiver_file, repo_root=root, today=TODAY)
+
+
+def test_loads_nested_active_and_pending_with_cross_repo_issue(tmp_path: Path):
+    root = _repo(tmp_path, PATH)
+    content = _valid_yaml(active=True, pending=False)
+    content += "    pending:\n      " + _metadata_yaml(
+        "b",
+        issue="https://github.com/TheAxiomFoundation/axiom-encode/issues/1036",
+    )
+    waiver_file = root / "known-validation-gaps.yaml"
+    waiver_file.write_text(content)
+
+    loaded = load_validation_waivers(waiver_file, repo_root=root, today=TODAY)
+
+    assert loaded.active_paths == {PATH}
+    assert loaded.pending_paths == {PATH}
+    assert loaded.entries[PATH].pending.issue.endswith("axiom-encode/issues/1036")
+
+
+@pytest.mark.parametrize(
+    ("content", "message"),
+    [
+        (f"validate_failures:\n  - {PATH}\n", "must be a mapping"),
+        (
+            f"validate_failures:\n  {PATH}:\n    fingerprint: sha256:{'a' * 64}\n",
+            "active and/or pending",
+        ),
+        (
+            f"validate_failures:\n  {PATH}:\n    active:\n"
+            f"      fingerprint: sha256:{'a' * 64}\n"
+            '      owner: "@MaxGhenis"\n'
+            '      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"\n',
+            "must contain exactly",
+        ),
+        (
+            _valid_yaml().replace('fingerprint: "sha256:', 'fingerprint: "sha512:', 1),
+            "fingerprint must be",
+        ),
+        (
+            _valid_yaml().replace('owner: "@MaxGhenis"', 'owner: "MaxGhenis"'),
+            "@GitHub-login",
+        ),
+        (
+            _valid_yaml().replace(
+                "https://github.com/TheAxiomFoundation/rulespec-us/issues/782",
+                "https://github.com/OtherOrg/repo/issues/1",
+            ),
+            "Axiom Foundation GitHub issue URL",
+        ),
+        (
+            _valid_yaml().replace(f'expires: "{EXPIRY}"', f"expires: {EXPIRY}"),
+            "quoted YYYY-MM-DD",
+        ),
+    ],
+)
+def test_rejects_legacy_flat_or_malformed_records(
+    tmp_path: Path, content: str, message: str
+):
+    root = _repo(tmp_path, PATH)
+    waiver_file = root / "known-validation-gaps.yaml"
+    waiver_file.write_text(content)
+
+    with pytest.raises(WaiverSchemaError, match=message):
+        load_validation_waivers(waiver_file, repo_root=root, today=TODAY)
+
+
+def test_expiry_is_strictly_future_and_at_most_ninety_days(tmp_path: Path):
+    root = _repo(tmp_path, PATH)
+    waiver_file = root / "known-validation-gaps.yaml"
+
+    waiver_file.write_text(_valid_yaml())
+    assert (
+        load_validation_waivers(waiver_file, repo_root=root, today=TODAY)
+        .entries[PATH]
+        .active.expires
+        == EXPIRY
+    )
+
+    waiver_file.write_text(_valid_yaml().replace(EXPIRY, TODAY.isoformat()))
+    with pytest.raises(WaiverSchemaError, match="expired"):
+        load_validation_waivers(waiver_file, repo_root=root, today=TODAY)
+
+    too_far = (TODAY + timedelta(days=MAX_WAIVER_DAYS + 1)).isoformat()
+    waiver_file.write_text(_valid_yaml().replace(EXPIRY, too_far))
+    with pytest.raises(WaiverSchemaError, match="within 90 days"):
+        load_validation_waivers(waiver_file, repo_root=root, today=TODAY)
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        f"validate_failures:\n  {PATH}: {{}}\n  {PATH}: {{}}\n",
+        "validate_failures: &waivers {}\ncopy: *waivers\n",
+        f"validate_failures:\n  {PATH}:\n    <<: {{}}\n    active:\n"
+        f"      {_metadata_yaml()}",
+    ],
+)
+def test_rejects_duplicate_keys_aliases_anchors_and_merges(
+    tmp_path: Path, content: str
+):
+    root = _repo(tmp_path, PATH)
+    waiver_file = root / "known-validation-gaps.yaml"
+    waiver_file.write_text(content)
+
+    with pytest.raises(WaiverSchemaError):
+        load_validation_waivers(waiver_file, repo_root=root, today=TODAY)
+
+
+@pytest.mark.parametrize(
+    "unsafe_path",
+    [
+        "/us/statutes/26/1.yaml",
+        "us/statutes/../1.yaml",
+        "us\\statutes\\26\\1.yaml",
+        "US/statutes/26/1.yaml",
+        "us/sources/26/1.yaml",
+        "us/statutes/26/1.test.yaml",
+    ],
+)
+def test_rejects_noncanonical_module_paths(tmp_path: Path, unsafe_path: str):
+    root = _repo(tmp_path, PATH)
+    waiver_file = root / "known-validation-gaps.yaml"
+    waiver_file.write_text(_valid_yaml().replace(PATH, unsafe_path))
+
+    with pytest.raises(WaiverSchemaError, match="unsafe"):
+        load_validation_waivers(
+            waiver_file, repo_root=root, today=TODAY, require_paths=False
+        )
+
+
+def test_rejects_control_characters_that_could_inject_active_path_lines(
+    tmp_path: Path,
+):
+    root = _repo(tmp_path, PATH)
+    waiver_file = root / "known-validation-gaps.yaml"
+    injected = '"us/statutes/inject\\nus/statutes/victim.yaml"'
+    waiver_file.write_text(_valid_yaml().replace(PATH, injected))
+
+    with pytest.raises(WaiverSchemaError, match="unsafe"):
+        load_validation_waivers(
+            waiver_file,
+            repo_root=root,
+            today=TODAY,
+            require_paths=False,
+        )
+
+
+def test_requires_existing_regular_head_paths_but_not_base_paths(tmp_path: Path):
+    root = _repo(tmp_path)
+    waiver_file = root / "known-validation-gaps.yaml"
+    waiver_file.write_text(_valid_yaml())
+
+    with pytest.raises(WaiverSchemaError, match="does not exist"):
+        load_validation_waivers(waiver_file, repo_root=root, today=TODAY)
+    assert load_validation_waivers(
+        waiver_file,
+        repo_root=root,
+        today=TODAY,
+        require_paths=False,
+    ).active_paths == {PATH}
+
+
+def test_new_or_changed_pending_is_waiver_only():
+    base = _set(_entry(PATH, active=_metadata("a")))
+    head = _set(_entry(PATH, active=_metadata("a"), pending=_metadata("b")))
+
+    assert (
+        protected_base_transition_issues(
+            base,
+            head,
+            changed_paths={"known-validation-gaps.yaml"},
+            today=TODAY,
+        )
+        == ()
+    )
+    issues = protected_base_transition_issues(
+        base,
+        head,
+        changed_paths={"known-validation-gaps.yaml", PATH},
+        today=TODAY,
+    )
+    assert any("waiver-only" in issue for issue in issues)
+
+
+def test_active_can_only_change_by_consuming_exact_base_pending():
+    active = _metadata("a")
+    pending = _metadata("b")
+    base = _set(_entry(PATH, active=active, pending=pending))
+
+    assert (
+        protected_base_transition_issues(
+            base,
+            _set(_entry(PATH, active=pending)),
+            changed_paths={PATH, "known-validation-gaps.yaml"},
+            today=TODAY,
+        )
+        == ()
+    )
+    direct_change = protected_base_transition_issues(
+        _set(_entry(PATH, active=active)),
+        _set(_entry(PATH, active=pending)),
+        changed_paths={PATH, "known-validation-gaps.yaml"},
+        today=TODAY,
+    )
+    assert any("must exactly consume" in issue for issue in direct_change)
+    unconsumed = protected_base_transition_issues(
+        base,
+        _set(_entry(PATH, active=pending, pending=pending)),
+        changed_paths={"known-validation-gaps.yaml"},
+        today=TODAY,
+    )
+    assert any("must consume it" in issue for issue in unconsumed)
+
+
+def test_new_active_without_base_pending_is_rejected_and_removals_are_safe():
+    empty = _set()
+    new_active = _set(_entry(PATH, active=_metadata("a")))
+    assert protected_base_transition_issues(
+        empty,
+        new_active,
+        changed_paths={"known-validation-gaps.yaml"},
+        today=TODAY,
+    )
+    assert (
+        protected_base_transition_issues(
+            new_active,
+            empty,
+            changed_paths={"known-validation-gaps.yaml", PATH},
+            today=TODAY,
+        )
+        == ()
+    )
+
+
+def test_expired_base_pending_cannot_be_consumed():
+    expired = _metadata("b", expires=(TODAY - timedelta(days=1)).isoformat())
+    base = _set(_entry(PATH, active=_metadata("a"), pending=expired))
+    head = _set(_entry(PATH, active=expired))
+
+    issues = protected_base_transition_issues(
+        base,
+        head,
+        changed_paths={PATH, "known-validation-gaps.yaml"},
+        today=TODAY,
+    )
+
+    assert any("pending approval expired" in issue for issue in issues)
+
+
+def test_fingerprint_is_semantic_deterministic_and_retains_duplicates():
+    validate = {
+        "passed": False,
+        "duration_ms": 123,
+        "validators": {
+            "ci": {
+                "passed": False,
+                "issues": ["second /tmp/work", "first", "first"],
+                "error": "first",
+                "raw_output": "ignored",
+            },
+            "compile": {"passed": True, "issues": ["ignored"]},
+        },
+    }
+    companion = {
+        "present": True,
+        "passed": False,
+        "path": "/tmp/work/us/statutes/26/1.test.yaml",
+        "cases": 2,
+        "failures": [
+            {"file": "/tmp/work/test", "case": "b", "message": "later"},
+            {"file": "/tmp/work/test", "case": "a", "message": "earlier"},
+        ],
+        "compiled_programs": 999,
+    }
+    replacements = {"/tmp/work": "<repo>"}
+
+    canonical = json.loads(
+        canonicalize_outcome(validate, companion, replacements=replacements).decode(
+            "utf-8"
+        )
+    )
+    digest = fingerprint_outcome(validate, companion, replacements=replacements)
+
+    assert canonical["schema"] == "rulespec-validation-failure/v1"
+    assert canonical["validate"]["validators"] == {
+        "ci": {
+            "error": "first",
+            "issues": ["first", "first", "second <repo>"],
+        }
+    }
+    assert [failure["case"] for failure in canonical["companion"]["failures"]] == [
+        "a",
+        "b",
+    ]
+    assert "/tmp/work" not in json.dumps(canonical)
+    assert digest == fingerprint_outcome(
+        {**validate, "duration_ms": 999999},
+        {**companion, "compiled_programs": 0},
+        replacements=replacements,
+    )
+    assert digest != fingerprint_outcome(
+        validate,
+        {**companion, "cases": 3},
+        replacements=replacements,
+    )
+
+
+def test_fingerprint_normalizes_validator_owned_alias_and_temp_directories():
+    def validate(alias: str, temporary: str) -> dict:
+        return {
+            "passed": False,
+            "validators": {
+                "ci": {
+                    "passed": False,
+                    "error": (
+                        f"compile {alias}/rulespec-us/us/statutes/1.yaml "
+                        f"via {temporary}/compiled.json"
+                    ),
+                    "issues": [],
+                }
+            },
+        }
+
+    companion = {
+        "present": False,
+        "passed": True,
+        "path": "us/statutes/1.test.yaml",
+        "cases": 0,
+        "failures": [],
+    }
+    first = validate(
+        "/tmp/axiom-rulespec-repo-aliases/aaaaaaaaaaaaaaaa",
+        "/tmp/tmpFirst123",
+    )
+    second = validate(
+        "/tmp/axiom-rulespec-repo-aliases/bbbbbbbbbbbbbbbb",
+        "/tmp/tmpSecond456",
+    )
+
+    assert fingerprint_outcome(
+        first, companion, replacements={"/tmp": "<system-tmp>"}
+    ) == fingerprint_outcome(second, companion, replacements={"/tmp": "<system-tmp>"})

--- a/tests/test_validation_waivers.py
+++ b/tests/test_validation_waivers.py
@@ -92,7 +92,11 @@ def test_requires_file_and_section_but_accepts_empty_mapping(tmp_path: Path):
 
     waiver_file = root / "known-validation-gaps.yaml"
     waiver_file.write_text("shape_issues: []\n")
-    with pytest.raises(WaiverSchemaError, match="required validate_failures"):
+    with pytest.raises(WaiverSchemaError, match="exactly validate_failures"):
+        load_validation_waivers(waiver_file, repo_root=root, today=TODAY)
+
+    waiver_file.write_text("validate_failures: {}\nschema_typo: true\n")
+    with pytest.raises(WaiverSchemaError, match="exactly validate_failures"):
         load_validation_waivers(waiver_file, repo_root=root, today=TODAY)
 
     waiver_file.write_text("validate_failures: {}\n")
@@ -226,6 +230,7 @@ def test_rejects_duplicate_keys_aliases_anchors_and_merges(
         "US/statutes/26/1.yaml",
         "us/sources/26/1.yaml",
         "us/statutes/26/1.test.yaml",
+        "us/statutes/26/\u202e1.yaml",
     ],
 )
 def test_rejects_noncanonical_module_paths(tmp_path: Path, unsafe_path: str):
@@ -269,6 +274,30 @@ def test_requires_existing_regular_head_paths_but_not_base_paths(tmp_path: Path)
         today=TODAY,
         require_paths=False,
     ).active_paths == {PATH}
+
+
+def test_rejects_symlinked_waiver_file(tmp_path: Path):
+    root = _repo(tmp_path, PATH)
+    target = root / "waiver-target.yaml"
+    target.write_text(_valid_yaml())
+    waiver_file = root / "known-validation-gaps.yaml"
+    waiver_file.symlink_to(target.name)
+
+    with pytest.raises(WaiverSchemaError, match="regular file"):
+        load_validation_waivers(waiver_file, repo_root=root, today=TODAY)
+
+
+def test_rejects_symlinked_module_path_components(tmp_path: Path):
+    root = _repo(tmp_path)
+    target_directory = root / "us/statutes/actual"
+    target_directory.mkdir(parents=True)
+    (target_directory / "1.yaml").write_text("format: rulespec/v1\n")
+    (root / "us/statutes/alias").symlink_to(target_directory.name)
+    waiver_file = root / "known-validation-gaps.yaml"
+    waiver_file.write_text(_valid_yaml().replace(PATH, "us/statutes/alias/1.yaml"))
+
+    with pytest.raises(WaiverSchemaError, match="symlink alias"):
+        load_validation_waivers(waiver_file, repo_root=root, today=TODAY)
 
 
 def test_new_or_changed_pending_is_waiver_only():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1211"
+version = "0.2.1212"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1212"
+version = "0.2.1213"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary\n\n- add one canonical strict parser and model for validation-failure waivers\n- require exact module paths and exact SHA-256 fingerprints of the current failure set\n- separate active waivers from pending activation requests\n- enforce protected-base pending-to-active transitions\n- reject duplicate keys, aliases, anchors, unknown fields, unsafe paths, symlinked inputs, stale passes, changed failures, and legacy list layouts\n- require protected-base and changed-path evidence for every transition audit\n- expose the same core to encoder CLI and downstream artifact builders\n- bump axiom-encode to 0.2.1213\n\n## Why\n\nRuleSpec repositories need a temporary validation-gap mechanism while they migrate, but the waiver itself must not become a compatibility layer. This core makes every exception exact, owned, expiring, and auditable; a passing or differently failing module immediately invalidates its active waiver.\n\nThe schema is intentionally breaking because Axiom has not launched. There is no legacy parser, alias, fallback layout, whole-program allowlist, alternate waiver path, or permissive default.\n\n## Impact\n\nCallers can use one implementation for admission, CI, and artifact isolation. New active waivers must first exist as an exact pending entry on the protected base. Pending entries never suppress validation failures.\n\nThis replaces closed stacked PR #1106 after its base branch was merged and deleted.\n\n## Validation\n\n- 737 focused waiver and CLI tests passed through escape-hatch hardening\n- final Unicode and release-guard delta: 62 focused tests passed\n- final-head GitHub CI: 3,399 passed, 70 skipped\n- Ruff and formatting checks pass across the source and test trees\n- version metadata is consistently 0.2.1213\n- independent hard-cut review: SHIP\n