### PR TITLE
Restore drift regeneration through verification-only supervisor delegation

### DIFF
--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -60,19 +60,52 @@ jobs:
         with:
           version: "0.11.7"
 
+      - name: Set up Go 1.26.1
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: 1.26.1
+          cache: false
+
       - name: Set up Python
         run: uv python install 3.13
 
       - name: Install
-        run: uv sync --locked --python 3.13 --extra api
+        run: |
+          uv sync --locked --python 3.13 --extra api
+          rm -rf "$RUNNER_TEMP/axiom-verification-site-packages"
+          uv pip install --python .venv/bin/python \
+            --target "$RUNNER_TEMP/axiom-verification-site-packages" ".[api]"
+
+      - name: Provision protected verification supervisor
+        env:
+          TRUST_APPLY_ROOT: ${{ vars.AXIOM_ENCODE_APPLY_SIGNING_PUBLIC_KEY }}
+          TRUST_EVAL_ROOT: ${{ vars.AXIOM_ENCODE_EVAL_SIGNING_PUBLIC_KEY }}
+          TRUST_CORPUS_RELEASE_ROOT: ${{ vars.AXIOM_CORPUS_RELEASE_PUBLIC_KEY }}
+        run: |
+          CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags='-buildid=' \
+            -o "$RUNNER_TEMP/axiom-encode-signing-supervisor" \
+            ./cmd/axiom-encode-signing-supervisor
+          sudo rm -rf /opt/axiom-verification
+          sudo .venv/bin/python scripts/provision_verification_supervisor.py \
+            --destination /opt/axiom-verification \
+            --supervisor "$RUNNER_TEMP/axiom-encode-signing-supervisor" \
+            --site-packages "$RUNNER_TEMP/axiom-verification-site-packages" \
+            --apply-root "$TRUST_APPLY_ROOT" --eval-root "$TRUST_EVAL_ROOT" \
+            --corpus-release-root "$TRUST_CORPUS_RELEASE_ROOT"
+          sudo chown -R 0:0 /opt/axiom-verification
+          sudo chmod -R go-w /opt/axiom-verification
 
       - name: Pre-classify the worklist (cheap pre-step, before generation)
         env:
           # Judges (and the ambiguous-entry arbiter) run cross-family on Claude.
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          AXIOM_CORPUS_RELEASE_PUBLIC_KEY: ${{ secrets.AXIOM_CORPUS_RELEASE_PUBLIC_KEY }}
         run: |
-          .venv/bin/axiom-encode preclassify \
+          /opt/axiom-verification/axiom-encode-signing-supervisor \
+            --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
+            --trusted-python-runtime-root /opt/axiom-verification/python \
+            --trusted-python-import-root /opt/axiom-verification/python/lib/python3.13/site-packages \
+            --trusted-python-package-root /opt/axiom-verification/python/lib/python3.13/site-packages/axiom_encode \
+            -- /opt/axiom-verification/axiom-encode preclassify \
             --worklist "${{ inputs.worklist }}" \
             --root external/rulespec \
             --corpus-path external/axiom-corpus \

--- a/.github/workflows/golden-regeneration.yml
+++ b/.github/workflows/golden-regeneration.yml
@@ -75,6 +75,12 @@ jobs:
         with:
           version: "0.11.7"
 
+      - name: Set up Go 1.26.1
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: 1.26.1
+          cache: false
+
       - name: Set up Python
         run: uv python install 3.13
 
@@ -91,13 +97,36 @@ jobs:
 
       - name: Install encoder
         working-directory: axiom-encode
-        run: uv sync --locked --python 3.13 --extra api
+        run: |
+          uv sync --locked --python 3.13 --extra api
+          rm -rf "$RUNNER_TEMP/axiom-verification-site-packages"
+          uv pip install --python .venv/bin/python \
+            --target "$RUNNER_TEMP/axiom-verification-site-packages" ".[api]"
+
+      - name: Provision protected verification supervisor
+        working-directory: axiom-encode
+        env:
+          TRUST_APPLY_ROOT: ${{ vars.AXIOM_ENCODE_APPLY_SIGNING_PUBLIC_KEY }}
+          TRUST_EVAL_ROOT: ${{ vars.AXIOM_ENCODE_EVAL_SIGNING_PUBLIC_KEY }}
+          TRUST_CORPUS_RELEASE_ROOT: ${{ vars.AXIOM_CORPUS_RELEASE_PUBLIC_KEY }}
+        run: |
+          CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags='-buildid=' \
+            -o "$RUNNER_TEMP/axiom-encode-signing-supervisor" \
+            ./cmd/axiom-encode-signing-supervisor
+          sudo rm -rf /opt/axiom-verification
+          sudo .venv/bin/python scripts/provision_verification_supervisor.py \
+            --destination /opt/axiom-verification \
+            --supervisor "$RUNNER_TEMP/axiom-encode-signing-supervisor" \
+            --site-packages "$RUNNER_TEMP/axiom-verification-site-packages" \
+            --apply-root "$TRUST_APPLY_ROOT" --eval-root "$TRUST_EVAL_ROOT" \
+            --corpus-release-root "$TRUST_CORPUS_RELEASE_ROOT"
+          sudo chown -R 0:0 /opt/axiom-verification
+          sudo chmod -R go-w /opt/axiom-verification
 
       - name: Validate dry-run wiring
         if: ${{ inputs.dry_run }}
         working-directory: axiom-encode
         env:
-          AXIOM_CORPUS_RELEASE_PUBLIC_KEY: ${{ vars.AXIOM_CORPUS_RELEASE_PUBLIC_KEY }}
           AXIOM_CORPUS_ROOT: ${{ github.workspace }}/axiom-corpus
           AXIOM_DRIFT_ROOT: ${{ github.workspace }}/rulespec-us
           DRIFT_SAMPLE_SIZE: ${{ inputs.k || '5' }}
@@ -106,7 +135,12 @@ jobs:
             3|4|5) ;;
             *) echo "k must be an integer from 3 through 5" >&2; exit 2 ;;
           esac
-          .venv/bin/axiom-encode drift-check \
+          /opt/axiom-verification/axiom-encode-signing-supervisor \
+            --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
+            --trusted-python-runtime-root /opt/axiom-verification/python \
+            --trusted-python-import-root /opt/axiom-verification/python/lib/python3.13/site-packages \
+            --trusted-python-package-root /opt/axiom-verification/python/lib/python3.13/site-packages/axiom_encode \
+            -- /opt/axiom-verification/axiom-encode drift-check \
             --root "$AXIOM_DRIFT_ROOT" --corpus-path "$AXIOM_CORPUS_ROOT" \
             --k "$DRIFT_SAMPLE_SIZE" --dry-run --json
 
@@ -115,7 +149,6 @@ jobs:
         working-directory: axiom-encode
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          AXIOM_CORPUS_RELEASE_PUBLIC_KEY: ${{ vars.AXIOM_CORPUS_RELEASE_PUBLIC_KEY }}
           AXIOM_CORPUS_ROOT: ${{ github.workspace }}/axiom-corpus
           AXIOM_DRIFT_ROOT: ${{ github.workspace }}/rulespec-us
           AXIOM_RULES_ENGINE_ROOT: ${{ github.workspace }}/axiom-rules-engine
@@ -127,11 +160,22 @@ jobs:
             *) echo "k must be an integer from 3 through 5" >&2; exit 2 ;;
           esac
           set +e
-          .venv/bin/axiom-encode drift-check \
+          /opt/axiom-verification/axiom-encode-signing-supervisor \
+            --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
+            --trusted-python-runtime-root /opt/axiom-verification/python \
+            --trusted-python-import-root /opt/axiom-verification/python/lib/python3.13/site-packages \
+            --trusted-python-package-root /opt/axiom-verification/python/lib/python3.13/site-packages/axiom_encode \
+            -- /opt/axiom-verification/axiom-encode drift-check \
             --root "$AXIOM_DRIFT_ROOT" --corpus-path "$AXIOM_CORPUS_ROOT" \
             --axiom-rules-engine-path "$AXIOM_RULES_ENGINE_ROOT" \
             --k "$DRIFT_SAMPLE_SIZE" \
             --regenerate --regenerate-backend openai \
+            --verification-supervisor /opt/axiom-verification/axiom-encode-signing-supervisor \
+            --verification-trusted-roots /opt/axiom-verification/signing-trust-roots.json \
+            --verification-runtime-root /opt/axiom-verification/python \
+            --verification-import-root /opt/axiom-verification/python/lib/python3.13/site-packages \
+            --verification-package-root /opt/axiom-verification/python/lib/python3.13/site-packages/axiom_encode \
+            --verification-launcher /opt/axiom-verification/axiom-encode \
             --report-file "$DRIFT_REPORT" --json
           drift_status=$?
           set -e

--- a/changelog.d/regen-verification-delegation.fixed.md
+++ b/changelog.d/regen-verification-delegation.fixed.md
@@ -1,0 +1,1 @@
+Restore golden-drift regeneration and bulk preclassification through explicit, protected verification-supervisor delegation without environment-based corpus trust.

--- a/cmd/axiom-encode-signing-supervisor/main.go
+++ b/cmd/axiom-encode-signing-supervisor/main.go
@@ -68,6 +68,8 @@ var publicEnvironmentNames = map[string]struct{}{
 }
 
 var parentOnlyEnvironmentNames = []string{
+	"OPENAI_API_KEY",
+	"ANTHROPIC_API_KEY",
 	"AXIOM_ENCODE_SUPABASE_URL",
 	"AXIOM_ENCODE_SUPABASE_SECRET_KEY",
 	"AXIOM_ENCODE_SUPABASE_ANON_KEY",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1215"
+version = "0.2.1216"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/provision_verification_supervisor.py
+++ b/scripts/provision_verification_supervisor.py
@@ -1,0 +1,79 @@
+"""Build a protected, self-contained verification-supervisor execution tree."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+
+
+def provision(
+    destination: Path,
+    supervisor: Path,
+    site_packages: Path,
+    apply_root: str,
+    eval_root: str,
+    corpus_release_root: str,
+) -> None:
+    source_runtime = Path(sys.base_prefix).resolve(strict=True)
+    source_interpreter = Path(sys.executable).resolve(strict=True)
+    runtime = destination / "python"
+    shutil.copytree(source_runtime, runtime, symlinks=False)
+    for forbidden in (
+        *runtime.rglob("*.pth"),
+        *runtime.rglob("*.egg-link"),
+        *runtime.rglob("sitecustomize.py"),
+        *runtime.rglob("usercustomize.py"),
+        *runtime.rglob("pyvenv.cfg"),
+        *runtime.rglob("__editable__*"),
+    ):
+        if forbidden.is_file():
+            forbidden.unlink()
+    target_site_packages = (
+        runtime
+        / "lib"
+        / f"python{sys.version_info.major}.{sys.version_info.minor}"
+        / "site-packages"
+    )
+    shutil.copytree(site_packages.resolve(strict=True), target_site_packages)
+    interpreter = runtime / source_interpreter.relative_to(source_runtime)
+    launcher = destination / "axiom-encode"
+    launcher.write_text(f"#!{interpreter} -I\nraise SystemExit('launcher executed')\n")
+    launcher.chmod(0o755)
+    trust = destination / "signing-trust-roots.json"
+    trust.write_text(
+        json.dumps(
+            {
+                "schema": "axiom-encode/signing-trust-roots/v2",
+                "apply_ed25519_public_key": apply_root,
+                "eval_ed25519_public_key": eval_root,
+                "corpus_release_ed25519_public_key": corpus_release_root,
+            },
+            sort_keys=True,
+        )
+        + "\n"
+    )
+    trust.chmod(0o644)
+    shutil.copy2(supervisor, destination / "axiom-encode-signing-supervisor")
+    (destination / "axiom-encode-signing-supervisor").chmod(0o755)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--destination", type=Path, required=True)
+    parser.add_argument("--supervisor", type=Path, required=True)
+    parser.add_argument("--site-packages", type=Path, required=True)
+    parser.add_argument("--apply-root", required=True)
+    parser.add_argument("--eval-root", required=True)
+    parser.add_argument("--corpus-release-root", required=True)
+    args = parser.parse_args()
+    provision(
+        args.destination.resolve(),
+        args.supervisor.resolve(),
+        args.site_packages.resolve(),
+        args.apply_root,
+        args.eval_root,
+        args.corpus_release_root,
+    )

--- a/scripts/provision_verification_supervisor.py
+++ b/scripts/provision_verification_supervisor.py
@@ -37,6 +37,7 @@ def provision(
         / f"python{sys.version_info.major}.{sys.version_info.minor}"
         / "site-packages"
     )
+    shutil.rmtree(target_site_packages)
     shutil.copytree(site_packages.resolve(strict=True), target_site_packages)
     interpreter = runtime / source_interpreter.relative_to(source_runtime)
     launcher = destination / "axiom-encode"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1215"
+__version__ = "0.2.1216"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/_trusted_signing_bootstrap.py
+++ b/src/axiom_encode/_trusted_signing_bootstrap.py
@@ -9,6 +9,19 @@ from __future__ import annotations
 import os
 import sys
 
+_FORBIDDEN_PUBLIC_ROOT_ENVIRONMENT = (
+    "AXIOM_ENCODE_APPLY_SIGNING_PUBLIC_KEY",
+    "AXIOM_ENCODE_EVAL_SIGNING_PUBLIC_KEY",
+    "AXIOM_CORPUS_RELEASE_PUBLIC_KEY",
+)
+
+for _name in _FORBIDDEN_PUBLIC_ROOT_ENVIRONMENT:
+    if _name in os.environ:
+        raise RuntimeError(
+            "public signing roots must come from the authenticated broker, "
+            f"not environment variable {_name}"
+        )
+
 if os.__spec__ is None or os.__spec__.origin != "frozen":
     raise RuntimeError("trusted bootstrap requires CPython's frozen os module")
 if sys.__spec__ is None or sys.__spec__.origin != "built-in":

--- a/src/axiom_encode/judges/cli_commands.py
+++ b/src/axiom_encode/judges/cli_commands.py
@@ -41,11 +41,13 @@ from .regeneration import (
     NoReplayableManifestError,
     RegenerationInputError,
     UnsafeRegenerationPath,
+    VerificationSupervisorConfig,
     read_citation,
     read_resolvable_citation,
     redact_sensitive_text,
     require_citation_derived_output_path,
     validate_module_path,
+    verification_supervisor_command,
 )
 
 _MAX_DRIFT_REPORT_BYTES = 20 * 1024 * 1024
@@ -163,6 +165,16 @@ def register_judge_subparsers(subparsers: argparse._SubParsersAction) -> None:
         type=Path,
         help="exact canonical rulespec-<country> checkout to sample modules from",
     )
+    drift.add_argument("--verification-supervisor", type=Path)
+    drift.add_argument("--verification-trusted-roots", type=Path)
+    drift.add_argument(
+        "--verification-runtime-root", type=Path, action="append", default=[]
+    )
+    drift.add_argument(
+        "--verification-import-root", type=Path, action="append", default=[]
+    )
+    drift.add_argument("--verification-package-root", type=Path)
+    drift.add_argument("--verification-launcher", type=Path)
     drift.add_argument(
         "--corpus-path",
         type=Path,
@@ -346,18 +358,43 @@ def cmd_judge_disposition(args: argparse.Namespace) -> int:
 def cmd_drift_check(args: argparse.Namespace) -> int:
     from . import drift
 
+    delegation_values = (
+        getattr(args, "verification_supervisor", None),
+        getattr(args, "verification_trusted_roots", None),
+        tuple(getattr(args, "verification_runtime_root", ())),
+        tuple(getattr(args, "verification_import_root", ())),
+        getattr(args, "verification_package_root", None),
+        getattr(args, "verification_launcher", None),
+    )
     if args.regenerate and (
         args.root is None
         or args.modules_file is not None
         or args.corpus_path is None
         or getattr(args, "axiom_rules_path", None) is None
+        or not all(delegation_values)
     ):
         print(
             "live drift regeneration requires --root, --corpus-path, and "
-            "--axiom-rules-engine-path and does not accept --modules-file",
+            "--axiom-rules-engine-path, and complete verification-supervisor "
+            "delegation paths and does not accept --modules-file",
             file=sys.stderr,
         )
         return 2
+    verification_supervisor = None
+    if args.regenerate:
+        verification_supervisor = VerificationSupervisorConfig(
+            executable=args.verification_supervisor,
+            trusted_roots=args.verification_trusted_roots,
+            runtime_roots=tuple(args.verification_runtime_root),
+            import_roots=tuple(args.verification_import_root),
+            package_root=args.verification_package_root,
+            launcher=args.verification_launcher,
+        )
+        try:
+            verification_supervisor_command(verification_supervisor, [])
+        except RegenerationInputError as exc:
+            print(f"invalid verification-supervisor delegation: {exc}", file=sys.stderr)
+            return 2
     modules = _load_drift_modules(args)
     if modules is None:
         return 2
@@ -381,6 +418,7 @@ def cmd_drift_check(args: argparse.Namespace) -> int:
                 root=args.root,
                 corpus_path=args.corpus_path,
                 axiom_rules_path=args.axiom_rules_path,
+                verification_supervisor=verification_supervisor,
                 backend=args.regenerate_backend,
             )
 

--- a/src/axiom_encode/judges/regeneration.py
+++ b/src/axiom_encode/judges/regeneration.py
@@ -14,13 +14,12 @@ import json
 import os
 import re
 import subprocess
-import sys
 import tempfile
 from collections.abc import Mapping
+from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 
 from axiom_encode.constants import RULESPEC_ATOMIC_MODULE_ROOTS
-from axiom_encode.corpus_release import RELEASE_OBJECT_PUBLIC_KEY_ENV
 from axiom_encode.corpus_resolver import LocalCorpusRelease
 from axiom_encode.repo_routing import (
     canonical_rulespec_root_identity,
@@ -410,6 +409,87 @@ def read_resolvable_citation(
     return citation
 
 
+@dataclass(frozen=True, slots=True)
+class VerificationSupervisorConfig:
+    """Explicit protected execution chain for a nested verification broker."""
+
+    executable: Path
+    trusted_roots: Path
+    runtime_roots: tuple[Path, ...]
+    import_roots: tuple[Path, ...]
+    package_root: Path
+    launcher: Path
+
+
+def _canonical_existing_path(path: Path, *, label: str, directory: bool) -> Path:
+    candidate = Path(path)
+    if not candidate.is_absolute():
+        raise RegenerationInputError(f"{label} must be absolute")
+    try:
+        resolved = candidate.resolve(strict=True)
+    except OSError as exc:
+        raise RegenerationInputError(f"invalid {label}: {exc}") from exc
+    if resolved != candidate:
+        raise RegenerationInputError(
+            f"{label} must be canonical and contain no symlink"
+        )
+    if directory != resolved.is_dir():
+        kind = "directory" if directory else "file"
+        raise RegenerationInputError(f"{label} must be a {kind}: {resolved}")
+    return resolved
+
+
+def verification_supervisor_command(
+    config: VerificationSupervisorConfig,
+    encode_arguments: list[str],
+) -> list[str]:
+    """Validate explicit delegation paths and build one fixed supervisor argv."""
+
+    executable = _canonical_existing_path(
+        config.executable, label="verification supervisor executable", directory=False
+    )
+    if not os.access(executable, os.X_OK):
+        raise RegenerationInputError(
+            f"verification supervisor executable is not executable: {executable}"
+        )
+    trusted_roots = _canonical_existing_path(
+        config.trusted_roots, label="verification trusted-roots file", directory=False
+    )
+    runtime_roots = tuple(
+        _canonical_existing_path(
+            path, label="verification runtime root", directory=True
+        )
+        for path in config.runtime_roots
+    )
+    import_roots = tuple(
+        _canonical_existing_path(path, label="verification import root", directory=True)
+        for path in config.import_roots
+    )
+    if not runtime_roots or not import_roots:
+        raise RegenerationInputError(
+            "verification supervisor requires explicit runtime and import roots"
+        )
+    package_root = _canonical_existing_path(
+        config.package_root, label="verification package root", directory=True
+    )
+    launcher = _canonical_existing_path(
+        config.launcher, label="verification launcher", directory=False
+    )
+    if launcher.name != "axiom-encode" or not os.access(launcher, os.X_OK):
+        raise RegenerationInputError(
+            "verification launcher must be an executable named axiom-encode"
+        )
+    command = [str(executable), "--trusted-signing-roots", str(trusted_roots)]
+    for root in runtime_roots:
+        command.extend(("--trusted-python-runtime-root", str(root)))
+    for root in import_roots:
+        command.extend(("--trusted-python-import-root", str(root)))
+    command.extend(
+        ("--trusted-python-package-root", str(package_root), "--", str(launcher))
+    )
+    return [*command, *encode_arguments]
+
+
 def child_environment(backend: str) -> dict[str, str]:
     """Build a secret-minimized environment for the encoder child process."""
 
@@ -418,16 +498,9 @@ def child_environment(backend: str) -> dict[str, str]:
     credential = os.environ.get("OPENAI_API_KEY")
     if not credential:
         raise RuntimeError("OPENAI_API_KEY is required for drift regeneration")
-    release_public_key = os.environ.get(RELEASE_OBJECT_PUBLIC_KEY_ENV)
-    if not release_public_key:
-        raise RuntimeError(
-            f"{RELEASE_OBJECT_PUBLIC_KEY_ENV} is required for drift regeneration"
-        )
-
     env = {name: os.environ[name] for name in _SAFE_CHILD_ENV if name in os.environ}
     env.setdefault("PATH", os.defpath)
     env["OPENAI_API_KEY"] = credential
-    env[RELEASE_OBJECT_PUBLIC_KEY_ENV] = release_public_key
     return env
 
 
@@ -460,10 +533,16 @@ def regenerate_module(
     root: Path,
     corpus_path: Path,
     axiom_rules_path: Path,
+    verification_supervisor: VerificationSupervisorConfig | None = None,
     backend: str = "openai",
 ) -> str:
     """Regenerate one merged module with a fixed argv and isolated secrets."""
 
+    if verification_supervisor is None:
+        raise RegenerationInputError(
+            "verification-supervisor delegation configuration is required"
+        )
+    supervisor_command = verification_supervisor_command(verification_supervisor, [])
     resolved_root = Path(root).resolve(strict=True)
     relative = validate_module_path(resolved_root, module)
     corpus_release = load_rulespec_local_corpus_release(
@@ -483,10 +562,7 @@ def regenerate_module(
             f"axiom-rules-engine path is not a directory: {resolved_axiom_rules_path}"
         )
     with tempfile.TemporaryDirectory() as tmp:
-        command = [
-            sys.executable,
-            "-m",
-            "axiom_encode.cli",
+        encode_arguments = [
             "encode",
             "--output",
             tmp,
@@ -503,6 +579,7 @@ def regenerate_module(
             "--",
             citation,
         ]
+        command = [*supervisor_command, *encode_arguments]
         process = subprocess.run(
             command,
             capture_output=True,

--- a/tests/test_judges.py
+++ b/tests/test_judges.py
@@ -648,6 +648,32 @@ def test_fidelity_command_binds_named_release_attestation(
 # -- drift ----------------------------------------------------------------
 
 
+def _verification_supervisor_fixture(
+    tmp_path: Path,
+) -> regeneration.VerificationSupervisorConfig:
+    protected = tmp_path / "verification"
+    runtime = protected / "runtime"
+    imports = runtime / "site-packages"
+    package = imports / "axiom_encode"
+    package.mkdir(parents=True, exist_ok=True)
+    supervisor = protected / "axiom-encode-signing-supervisor"
+    supervisor.write_bytes(b"fixture")
+    supervisor.chmod(0o700)
+    roots = protected / "roots.json"
+    roots.write_text("{}\n")
+    launcher = protected / "axiom-encode"
+    launcher.write_text("#!/bin/sh\nexit 1\n")
+    launcher.chmod(0o700)
+    return regeneration.VerificationSupervisorConfig(
+        executable=supervisor.resolve(),
+        trusted_roots=roots.resolve(),
+        runtime_roots=(runtime.resolve(),),
+        import_roots=(imports.resolve(),),
+        package_root=package.resolve(),
+        launcher=launcher.resolve(),
+    )
+
+
 def _regeneration_fixture(
     tmp_path: Path,
     *,
@@ -956,17 +982,15 @@ def test_drift_regenerator_uses_fixed_argv_and_minimal_environment(
         root=root,
         corpus_path=corpus,
         axiom_rules_path=_engine_fixture(tmp_path),
+        verification_supervisor=_verification_supervisor_fixture(tmp_path),
         backend="openai",
     )
 
     command = captured["command"]
     kwargs = captured["kwargs"]
-    assert command[:4] == [
-        sys.executable,
-        "-m",
-        "axiom_encode.cli",
-        "encode",
-    ]
+    assert command[0].endswith("axiom-encode-signing-supervisor")
+    assert command[command.index("--") + 1].endswith("axiom-encode")
+    assert command[command.index("--") + 2] == "encode"
     assert "--source-id" not in command
     assert Path(command[command.index("--corpus-path") + 1]) == corpus
     assert Path(command[command.index("--axiom-rules-engine-path") + 1]) == (
@@ -977,7 +1001,7 @@ def test_drift_regenerator_uses_fixed_argv_and_minimal_environment(
     assert kwargs["shell"] is False
     assert kwargs["timeout"] == regeneration.REGENERATION_TIMEOUT_SECONDS
     assert kwargs["env"]["OPENAI_API_KEY"] == "openai-test-key"
-    assert kwargs["env"]["AXIOM_CORPUS_RELEASE_PUBLIC_KEY"] == TEST_RELEASE_PUBLIC_KEY
+    assert "AXIOM_CORPUS_RELEASE_PUBLIC_KEY" not in kwargs["env"]
     assert "ANTHROPIC_API_KEY" not in kwargs["env"]
     assert "GH_TOKEN" not in kwargs["env"]
     assert "GITHUB_TOKEN" not in kwargs["env"]
@@ -1001,7 +1025,8 @@ def test_drift_regenerator_uses_fixed_argv_and_minimal_environment(
         )
 
     monkeypatch.setattr(encode_cli, "cmd_encode", resolve_only)
-    monkeypatch.setattr(sys, "argv", ["axiom-encode", *command[3:]])
+    encode_start = command.index("--") + 2
+    monkeypatch.setattr(sys, "argv", ["axiom-encode", *command[encode_start:]])
     encode_cli.main()
 
     assert parsed == {"checkout": root, "content_root": root / "us"}
@@ -1038,6 +1063,7 @@ def test_drift_regenerator_rejects_module_at_noncanonical_citation_path(
             root=root,
             corpus_path=corpus,
             axiom_rules_path=_engine_fixture(tmp_path),
+            verification_supervisor=_verification_supervisor_fixture(tmp_path),
         )
 
     assert called is False
@@ -1066,6 +1092,7 @@ def test_drift_error_report_and_published_issue_redact_model_key(tmp_path, monke
             root=root,
             corpus_path=corpus,
             axiom_rules_path=_engine_fixture(tmp_path),
+            verification_supervisor=_verification_supervisor_fixture(tmp_path),
         ),
     )
     report = drift.DriftReport(checked=[result])
@@ -1263,6 +1290,7 @@ def test_drift_regenerator_rejects_unsafe_module_paths(tmp_path, monkeypatch, mo
             root=root,
             corpus_path=corpus,
             axiom_rules_path=_engine_fixture(tmp_path),
+            verification_supervisor=_verification_supervisor_fixture(tmp_path),
         )
 
     assert called is False
@@ -1341,6 +1369,7 @@ def test_drift_regenerator_rejects_manifest_citation_traversal(tmp_path, monkeyp
             root=root,
             corpus_path=corpus,
             axiom_rules_path=_engine_fixture(tmp_path),
+            verification_supervisor=_verification_supervisor_fixture(tmp_path),
         )
 
     assert called is False
@@ -1519,12 +1548,13 @@ def test_drift_regeneration_is_openai_only(monkeypatch):
         regeneration.child_environment("codex")
 
 
-def test_drift_child_environment_requires_release_public_key(monkeypatch):
+def test_drift_child_environment_rejects_release_public_key_forwarding(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "openai-test-key")
-    monkeypatch.delenv("AXIOM_CORPUS_RELEASE_PUBLIC_KEY")
+    monkeypatch.setenv("AXIOM_CORPUS_RELEASE_PUBLIC_KEY", "counterfeit")
 
-    with pytest.raises(RuntimeError, match="AXIOM_CORPUS_RELEASE_PUBLIC_KEY"):
-        regeneration.child_environment("openai")
+    env = regeneration.child_environment("openai")
+
+    assert "AXIOM_CORPUS_RELEASE_PUBLIC_KEY" not in env
 
 
 def test_drift_child_environment_excludes_apply_manifest_signer(monkeypatch):
@@ -1652,6 +1682,39 @@ def test_live_drift_cli_requires_explicit_engine_root(capsys):
     assert "--axiom-rules-engine-path" in capsys.readouterr().err
 
 
+def test_live_drift_cli_requires_verification_delegation_before_loading(
+    tmp_path, monkeypatch, capsys
+):
+    called = False
+
+    def fail_if_loaded(_args):
+        nonlocal called
+        called = True
+        raise AssertionError("module loading must not precede delegation validation")
+
+    monkeypatch.setattr(cli_commands, "_load_drift_modules", fail_if_loaded)
+    status = cli_commands.cmd_drift_check(
+        argparse.Namespace(
+            regenerate=True,
+            dry_run=False,
+            root=tmp_path,
+            corpus_path=tmp_path,
+            axiom_rules_path=tmp_path,
+            modules_file=None,
+            verification_supervisor=None,
+            verification_trusted_roots=None,
+            verification_runtime_root=[],
+            verification_import_root=[],
+            verification_package_root=None,
+            verification_launcher=None,
+        )
+    )
+
+    assert status == 2
+    assert called is False
+    assert "verification-supervisor" in capsys.readouterr().err
+
+
 def test_drift_workflow_isolates_model_and_github_credentials_by_job():
     workflow_path = (
         Path(__file__).parents[1] / ".github" / "workflows" / "golden-regeneration.yml"
@@ -1713,8 +1776,10 @@ def test_drift_workflow_isolates_model_and_github_credentials_by_job():
     assert "OPENAI_API_KEY" in live_step["env"]
     assert "AXIOM_ENCODE_APPLY_SIGNING_PRIVATE_KEY" not in live_step["env"]
     assert "AXIOM_ENCODE_APPLY_SIGNING_PRIVATE_KEY" not in dry_run_step["env"]
-    assert "AXIOM_CORPUS_RELEASE_PUBLIC_KEY" in live_step["env"]
-    assert "AXIOM_CORPUS_RELEASE_PUBLIC_KEY" in dry_run_step["env"]
+    assert "AXIOM_CORPUS_RELEASE_PUBLIC_KEY" not in live_step["env"]
+    assert "AXIOM_CORPUS_RELEASE_PUBLIC_KEY" not in dry_run_step["env"]
+    assert "axiom-encode-signing-supervisor" in live_step["run"]
+    assert "--verification-trusted-roots" in live_step["run"]
     assert "--axiom-rules-engine-path" in live_step["run"]
     assert "AXIOM_RULES_ENGINE_ROOT" in live_step["run"]
     assert "GH_TOKEN" not in live_step["env"]
@@ -1725,7 +1790,7 @@ def test_drift_workflow_isolates_model_and_github_credentials_by_job():
         "38b5f646165f18f64307f1eef226c7a6f2d4936e"
     )
     assert all(
-        step["run"] == "uv sync --locked --python 3.13 --extra api"
+        "uv sync --locked --python 3.13 --extra api" in step["run"]
         for step in install_steps
     )
     assert all(
@@ -1748,7 +1813,9 @@ def test_bulk_worklist_workflow_has_no_legacy_generation_lane():
     assert "source_text" not in raw
     assert "--root external/rulespec" in raw
     assert "--corpus-path external/axiom-corpus" in raw
-    assert "AXIOM_CORPUS_RELEASE_PUBLIC_KEY" in raw
+    assert "AXIOM_CORPUS_RELEASE_PUBLIC_KEY:" not in raw
+    assert "axiom-encode-signing-supervisor" in raw
+    assert "sudo chown -R 0:0 /opt/axiom-verification" in raw
     checkout_steps = [
         step
         for step in workflow["jobs"]["preclassify"]["steps"]

--- a/tests/test_provision_verification_supervisor.py
+++ b/tests/test_provision_verification_supervisor.py
@@ -1,0 +1,85 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_provision_replaces_base_runtime_site_packages(tmp_path: Path) -> None:
+    source_site_packages = (
+        Path(sys.base_prefix)
+        / "lib"
+        / f"python{sys.version_info.major}.{sys.version_info.minor}"
+        / "site-packages"
+    )
+    assert (source_site_packages / "pip").is_dir()
+    assert (source_site_packages / "README.txt").is_file()
+
+    trusted_packages = tmp_path / "trusted-packages"
+    intended_package = trusted_packages / "intended_package"
+    intended_package.mkdir(parents=True)
+    (intended_package / "__init__.py").write_text("TRUSTED = True\n")
+    supervisor = tmp_path / "supervisor"
+    supervisor.write_text("supervisor\n")
+    destination = tmp_path / "provisioned"
+
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/provision_verification_supervisor.py",
+            "--destination",
+            str(destination),
+            "--supervisor",
+            str(supervisor),
+            "--site-packages",
+            str(trusted_packages),
+            "--apply-root",
+            "apply-root",
+            "--eval-root",
+            "eval-root",
+            "--corpus-release-root",
+            "corpus-release-root",
+        ],
+        check=True,
+    )
+
+    runtime = destination / "python"
+    interpreter = runtime / Path(sys.executable).resolve().relative_to(
+        Path(sys.base_prefix).resolve()
+    )
+    assert (destination / "axiom-encode").read_text().splitlines()[0] == (
+        f"#!{interpreter} -I"
+    )
+    assert json.loads((destination / "signing-trust-roots.json").read_text()) == {
+        "schema": "axiom-encode/signing-trust-roots/v2",
+        "apply_ed25519_public_key": "apply-root",
+        "eval_ed25519_public_key": "eval-root",
+        "corpus_release_ed25519_public_key": "corpus-release-root",
+    }
+
+    provisioned_site_packages = (
+        runtime
+        / "lib"
+        / f"python{sys.version_info.major}.{sys.version_info.minor}"
+        / "site-packages"
+    )
+    assert sorted(
+        path.relative_to(provisioned_site_packages)
+        for path in provisioned_site_packages.rglob("*")
+    ) == [
+        Path("intended_package"),
+        Path("intended_package/__init__.py"),
+    ]
+    assert not any(path.is_symlink() for path in destination.rglob("*"))
+    forbidden_patterns = (
+        "*.pth",
+        "*.egg-link",
+        "sitecustomize.py",
+        "usercustomize.py",
+        "pyvenv.cfg",
+        "__editable__*",
+    )
+    assert not any(
+        path.is_file()
+        for pattern in forbidden_patterns
+        for path in destination.rglob(pattern)
+    )

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -865,6 +865,8 @@ def test_compiled_supervisor_uses_isolated_direct_runtime_and_domain_signatures(
     launcher = _launcher(tmp_path, trusted_python_runtime)
     trust_config = _trust_config(tmp_path, apply_public, eval_public)
     sentinels = {
+        "OPENAI_API_KEY": "openai-sentinel",
+        "ANTHROPIC_API_KEY": "anthropic-sentinel",
         "PATH": "/hostile/bin",
         "PYTHONPATH": "/hostile/python",
         "GIT_CONFIG_GLOBAL": "/hostile/gitconfig",
@@ -902,6 +904,8 @@ def test_compiled_supervisor_uses_isolated_direct_runtime_and_domain_signatures(
         for path in result["sys_path"]
     )
     parent_only = {
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
         "AXIOM_ENCODE_SUPABASE_SECRET_KEY",
         "OTEL_EXPORTER_OTLP_HEADERS",
     }
@@ -935,6 +939,19 @@ def test_compiled_supervisor_uses_isolated_direct_runtime_and_domain_signatures(
             b64decode(result["apply_signature"]),
             SIGNATURE_DOMAIN + b"eval_ed25519\0compiled-apply-boundary",
         )
+
+
+def test_python_startup_rejects_corpus_public_root_environment() -> None:
+    completed = subprocess.run(
+        [sys.executable, str(ROOT / "src/axiom_encode/_trusted_signing_bootstrap.py")],
+        env={"AXIOM_CORPUS_RELEASE_PUBLIC_KEY": "counterfeit"},
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert "authenticated broker" in completed.stderr
+    assert "AXIOM_CORPUS_RELEASE_PUBLIC_KEY" in completed.stderr
 
 
 def test_verification_only_invocation_exposes_roots_without_signing_capability(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1215"
+version = "0.2.1216"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
Closes #1109.

## What

Restores drift-regeneration capability after the #1108 hard cut by running the regeneration parent and its nested `encode` child under **verification-only signing supervisors** — never an environment key.

- **Typed delegation config** on the drift-regeneration command surface (supervisor executable, trusted-roots file, runtime/import/package roots, launcher) — explicit and path-validated before module loading; fixed argv for the nested launch.
- **Nested verification-only supervisor** for the child `encode`: fresh broker, three protected roots reread from disk, zero signing capabilities, no descriptor inheritance (broker fds are deliberately non-inheritable; inheritance was investigated and rejected — see #1109).
- **Parent-only model-credential allowlist** in the supervisor (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`) so the nested encode keeps its backend credentials, with adversarial environment-scrubbing tests; the corpus-release env var remains rejected (including empty values).
- **Workflow provisioning**: `golden-regeneration.yml` and `bulk-encode.yml` provision a root-owned, caller-nonwritable supervisor binary, Python runtime, package tree, and three-root config (`scripts/provision_verification_supervisor.py`), and launch the outer commands under the supervisor.
- **Hard cut completed**: `AXIOM_CORPUS_RELEASE_PUBLIC_KEY` requirement/forwarding deleted from `regeneration.py` and both workflows; the name is now rejected at Python startup (`_trusted_signing_bootstrap.py`) mirroring the Go supervisor scan.

## Review cycle

Implemented and gate-fixed by gpt-5.6-sol; independently gated by a clean-context Fable audit (trust-path integrity, verification-only capability, allowlist tightness, hard-cut grep, workflow provisioning, test vacuity probes) with one hard finding — a `FileExistsError` in `provision()` under the real CI runtime layout (python-build-standalone ships `site-packages`) — fixed in the final commit with an executed no-root regression test that fails on the pre-fix code (revert-probe verified). Orchestrator runtime verification: full suite green, ratchet green, ruff clean, Go fmt/vet/build/tests clean.

## Follow-ups (tracked, not in this PR)

- #1110 — CI provisions the rules engine so the supervised validate E2E cannot silently skip; a fully-executed nested live-regeneration integration rides with it.
- Lock-pinned `uv pip install --target` in the provisioning step.
- Unit tests for `verification_supervisor_command` rejection branches and the other two bootstrap-forbidden names (gate probed all branches read-only; Go re-validates at launch).
- Provision-test hardening nits: anchor the script path via `Path(__file__)` instead of a relative path, and note the pip/README preconditions pin the python-build-standalone layout (fails loud if uv changes distributions).
- Inert fixture setenv cleanup; worklist-input env indirection.

## Test plan

- New: `tests/test_provision_verification_supervisor.py` (no-root provision regression, fails pre-fix), fixed-argv/minimal-env and fail-closed-before-loading coverage in `tests/test_judges.py`, credential-scrub + corpus-root-rejection in `tests/test_signing_supervisor.py`.
- Full suite: 3848 passed / 28 skipped / 0 failed locally (CI-equivalent venv).
- `go test ./cmd/axiom-encode-signing-supervisor/...` ok; gofmt/vet/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
