### PR TITLE
Bump oracles pin for Denmark dk: coverage classification; release 0.2.1217

### DIFF
--- a/changelog.d/dk-oracles-pin.changed.md
+++ b/changelog.d/dk-oracles-pin.changed.md
@@ -1,0 +1,1 @@
+Bump the axiom-oracles pin to carry the Denmark `dk:` not_comparable prefix classification (axiom-oracles#270), so the changed-file oracle-coverage gate classifies rulespec-dk pilot outputs instead of failing them as unmapped.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1216"
+version = "0.2.1217"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@4356d73d61339abe92b39c7ace3a0869f401d9c5",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@fe0878a2dd566139cb690a01e0c48e268d045e46",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1216"
+__version__ = "0.2.1217"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1216"
+version = "0.2.1217"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -100,7 +100,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=4356d73d61339abe92b39c7ace3a0869f401d9c5" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=fe0878a2dd566139cb690a01e0c48e268d045e46" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -123,7 +123,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=4356d73d61339abe92b39c7ace3a0869f401d9c5#4356d73d61339abe92b39c7ace3a0869f401d9c5" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=fe0878a2dd566139cb690a01e0c48e268d045e46#fe0878a2dd566139cb690a01e0c48e268d045e46" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
Carries axiom-oracles#270 (`dk:` prefix `not_comparable` pending EUROMOD-DK wiring, merged as `fe0878a2`) so the changed-file oracle-coverage gate classifies the rulespec-dk pilot outputs (TheAxiomFoundation/rulespec-dk#2) instead of failing them as unmapped. Same four-file shape as the prior pin bumps (#1083, #1084, #1095, #1097): pyproject pin + version 0.2.1217, `__init__` version, regenerated `uv.lock`, changelog fragment.

Review cycle: focused checks green locally (version-ratchet 3 passed incl. `test_current_encoder_affecting_changes_are_behind_version_bump`; focused rulespec/EncoderPrompt suite 902 passed; ruff + compileall + towncrier clean). Independent Sol (gpt-5.6-sol) pre-merge audit: **SHIP**, no findings above NIT (one INFO: the oracles delta between pins isn't locally comparable — it is exactly the dk.yaml addition per the merged axiom-oracles#270).

Part of the Denmark pilot merge chain (rulespec-dk#1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)