### PR TITLE
Add --expected-encoder-checkout to the read-only apply-manifest guards

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1217"
+version = "0.2.1218"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1217"
+__version__ = "0.2.1218"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -506,6 +506,20 @@ def _add_required_corpus_path_argument(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def _add_expected_encoder_checkout_argument(
+    parser: argparse.ArgumentParser,
+) -> None:
+    parser.add_argument(
+        "--expected-encoder-checkout",
+        type=Path,
+        default=None,
+        help=(
+            "Clean axiom-encode checkout whose HEAD identity must match manifests "
+            "and the running package version"
+        ),
+    )
+
+
 def _require_existing_parser_option(
     parser: argparse.ArgumentParser,
     option: str,
@@ -1421,6 +1435,7 @@ def main():
         help="Verify every existing RuleSpec YAML file, not only git changes",
     )
     _add_required_corpus_path_argument(guard_generated_parser)
+    _add_expected_encoder_checkout_argument(guard_generated_parser)
     guard_generated_parser.add_argument(
         "--json", action="store_true", help="Output guard result as JSON"
     )
@@ -1438,6 +1453,7 @@ def main():
         required=True,
         help="Exact canonical rulespec-<country> checkout",
     )
+    _add_expected_encoder_checkout_argument(manifest_census_parser)
     manifest_census_parser.add_argument(
         "--json",
         action="store_true",
@@ -5343,6 +5359,7 @@ def cmd_guard_generated(args):
         head_ref=args.head_ref,
         roots=roots,
         all_files=all_files,
+        expected_encoder_checkout=getattr(args, "expected_encoder_checkout", None),
     )
     payload = {"repo": str(repo_path), "passed": not issues, "issues": issues}
     if args.json:
@@ -5359,7 +5376,12 @@ def cmd_guard_generated(args):
     sys.exit(0 if not issues else 1)
 
 
-def _manifest_census(repo_path: Path, *, roots: tuple[str, ...]) -> dict[str, object]:
+def _manifest_census(
+    repo_path: Path,
+    *,
+    roots: tuple[str, ...],
+    expected_encoder_checkout: Path | None = None,
+) -> dict[str, object]:
     """Compute model-generated and unmanifested rule-file counts.
 
     A file is ``encoder`` when a signature-valid manifest with a genuine
@@ -5375,8 +5397,12 @@ def _manifest_census(repo_path: Path, *, roots: tuple[str, ...]) -> dict[str, ob
     manifest_paths = _all_applied_encoding_manifest_paths(repo_path, roots=roots)
     surviving = [path for path in manifest_paths if (repo_path / path).exists()]
     try:
-        expected_encoder_identity = _current_guard_encoder_execution_identity()
+        expected_encoder_identity = _read_only_guard_encoder_execution_identity(
+            expected_encoder_checkout
+        )
     except RuntimeError:
+        if expected_encoder_checkout is not None:
+            raise
         entries, coverage = {}, {}
     else:
         entries, _issues = _load_applied_encoding_manifest_entries(
@@ -5454,7 +5480,11 @@ def cmd_manifest_census(args):
         label="RuleSpec checkout",
     )
     roots = tuple(sorted(RULESPEC_ATOMIC_MODULE_ROOTS))
-    census = _manifest_census(repo_path, roots=roots)
+    census = _manifest_census(
+        repo_path,
+        roots=roots,
+        expected_encoder_checkout=getattr(args, "expected_encoder_checkout", None),
+    )
     census["captured_at"] = (
         datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
     )
@@ -16041,6 +16071,7 @@ def guard_generated_change_issues(
     roots: tuple[str, ...] = tuple(sorted(RULESPEC_ATOMIC_MODULE_ROOTS)),
     changed_files: list[str] | None = None,
     all_files: bool = False,
+    expected_encoder_checkout: Path | None = None,
 ) -> list[str]:
     """Return issues for RuleSpec changes not bound to the signed local release."""
     repo_path = Path(repo_path).resolve()
@@ -16128,7 +16159,9 @@ def guard_generated_change_issues(
         ]
 
     try:
-        expected_encoder_identity = _current_guard_encoder_execution_identity()
+        expected_encoder_identity = _read_only_guard_encoder_execution_identity(
+            expected_encoder_checkout
+        )
     except RuntimeError as exc:
         return [f"Cannot verify the running pinned encoder identity: {exc}"]
 
@@ -17950,6 +17983,52 @@ def _current_guard_encoder_execution_identity() -> dict[str, str]:
         "repository": APPLIED_ENCODING_OFFICIAL_REPOSITORY,
         "commit": commit,
         "version": __version__,
+    }
+
+
+def _read_only_guard_encoder_execution_identity(
+    expected_encoder_checkout: Path | None,
+) -> dict[str, str]:
+    """Resolve a read-only guard identity from its explicit or running checkout."""
+
+    if expected_encoder_checkout is None:
+        return _current_guard_encoder_execution_identity()
+
+    repo_root = Path(expected_encoder_checkout)
+    try:
+        checkout_identity = _git_checkout_execution_identity(repo_root)
+    except (OSError, ValueError, RuntimeError) as exc:
+        raise RuntimeError(
+            f"expected axiom-encode checkout identity is unavailable: {exc}"
+        ) from exc
+    commit = checkout_identity.get("commit")
+    if (
+        checkout_identity.get("kind") != "git"
+        or checkout_identity.get("dirty") is not False
+        or not isinstance(commit, str)
+        or re.fullmatch(r"[0-9a-f]{40}", commit) is None
+    ):
+        raise RuntimeError(
+            "running axiom-encode must be a clean Git checkout at a full commit"
+        )
+    versions = _axiom_encode_versions_at_ref(repo_root, "HEAD")
+    checkout_version = versions.get("pyproject")
+    if not checkout_version or any(
+        versions.get(field) != checkout_version for field in ("package", "lock")
+    ):
+        raise RuntimeError(
+            "expected axiom-encode checkout version does not match pyproject.toml, "
+            "src/axiom_encode/__init__.py, and uv.lock at HEAD"
+        )
+    if checkout_version != __version__:
+        raise RuntimeError(
+            f"provisioned runtime version {__version__} does not match expected "
+            f"encoder checkout version {checkout_version}"
+        )
+    return {
+        "repository": APPLIED_ENCODING_OFFICIAL_REPOSITORY,
+        "commit": commit,
+        "version": checkout_version,
     }
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -52,6 +52,7 @@ from axiom_encode.cli import (
     _complete_missing_imported_test_inputs,
     _convert_indexed_parameter_values_to_derived_formulas,
     _convert_versioned_boolean_parameters_to_indicators,
+    _current_guard_encoder_execution_identity,
     _default_generated_test_input_value,
     _discover_rulespec_test_files,
     _effective_runner_specs,
@@ -82,6 +83,7 @@ from axiom_encode.cli import (
     _person_scoped_definition_issue_names,
     _promote_boolean_comparison_predicates_to_judgment,
     _qualify_deferred_output_subsection_paths,
+    _read_only_guard_encoder_execution_identity,
     _record_successful_apply_validation,
     _recover_apply_transaction,
     _relative_generated_output_path,
@@ -1126,6 +1128,85 @@ def _init_test_git_repo(repo: Path) -> None:
     _git(repo, "init")
     _git(repo, "config", "user.email", "test@example.com")
     _git(repo, "config", "user.name", "Test User")
+
+
+def _init_encoder_identity_checkout(
+    repo: Path,
+    *,
+    version: str = AXIOM_ENCODE_TEST_VERSION,
+) -> str:
+    _init_test_git_repo(repo)
+    source_root = Path(__file__).resolve().parents[1]
+    version_files = (
+        "pyproject.toml",
+        "src/axiom_encode/__init__.py",
+        "uv.lock",
+    )
+    for relative in version_files:
+        target = repo / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        content = (source_root / relative).read_text()
+        if version != AXIOM_ENCODE_TEST_VERSION:
+            content = content.replace(AXIOM_ENCODE_TEST_VERSION, version)
+        target.write_text(content)
+    _git(repo, "add", *version_files)
+    _git(repo, "commit", "-m", "test encoder identity")
+    return _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+
+def test_expected_encoder_checkout_resolves_clean_matching_identity(tmp_path):
+    checkout = tmp_path / "axiom-encode"
+    commit = _init_encoder_identity_checkout(checkout)
+
+    identity = _read_only_guard_encoder_execution_identity(checkout)
+
+    assert identity == {
+        "repository": APPLIED_ENCODING_OFFICIAL_REPOSITORY,
+        "commit": commit,
+        "version": AXIOM_ENCODE_TEST_VERSION,
+    }
+
+
+def test_expected_encoder_checkout_rejects_dirty_checkout(tmp_path):
+    checkout = tmp_path / "axiom-encode"
+    _init_encoder_identity_checkout(checkout)
+    (checkout / "untracked.txt").write_text("dirty\n")
+
+    with pytest.raises(
+        RuntimeError,
+        match="running axiom-encode must be a clean Git checkout at a full commit",
+    ):
+        _read_only_guard_encoder_execution_identity(checkout)
+
+
+def test_expected_encoder_checkout_rejects_runtime_version_mismatch(tmp_path):
+    checkout = tmp_path / "axiom-encode"
+    _init_encoder_identity_checkout(checkout, version="999.0.0")
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            rf"provisioned runtime version {re.escape(AXIOM_ENCODE_TEST_VERSION)} "
+            r"does not match expected encoder checkout version 999\.0\.0"
+        ),
+    ):
+        _read_only_guard_encoder_execution_identity(checkout)
+
+
+def test_running_encoder_identity_default_preserves_non_git_error(
+    tmp_path, monkeypatch
+):
+    package_root = tmp_path / "frozen-runtime"
+    package_root.mkdir()
+    monkeypatch.setattr(
+        "axiom_encode.cli._axiom_encode_repo_root", lambda: package_root
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="running axiom-encode must be a clean Git checkout at a full commit",
+    ):
+        _current_guard_encoder_execution_identity()
 
 
 def _write_active_corpus_row(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1217"
+version = "0.2.1218"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
Under the protected verification supervisor the encoder executes from the frozen provisioned runtime — never a git checkout — so the read-only guards' running-checkout identity derivation cannot work in consumer CI (rulespec-nz#83, "Reject manual RuleSpec changes": `Cannot verify the running pinned encoder identity`). There was no CLI surface for the existing `expected_encoder_identity` parameter.

The read-only guards (generated-guard / manifest census) now accept `--expected-encoder-checkout PATH`: identity derives from that checkout with the same strictness (clean git, full 40-hex commit, pyproject/package/lock version agreement) and is **hard-bound to the running package version** ("provisioned runtime version X does not match expected encoder checkout version Y"). Without the flag, behavior is unchanged; an explicitly given checkout fails closed (no census fallback). The apply/write path is untouched and still requires the running checkout.

Version bumped to 0.2.1218 per the encoder-affecting-change discipline. Full suite: 3,851 passed.

The shared validate workflow will pass `--expected-encoder-checkout "$GITHUB_WORKSPACE/_axiom/axiom-encode"` (the pinned, ancestry-verified checkout).

Part of the axiom-encode#1101 canonical-provenance migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)