### PR TITLE
Guard applied-manifest shrinkage and preflight apply signing (0.2.1219)

### DIFF
--- a/changelog.d/apply-path-hardening.changed.md
+++ b/changelog.d/apply-path-hardening.changed.md
@@ -1,0 +1,1 @@
+Prevent `encode --apply` from silently shrinking existing applied-file manifest coverage unless `--allow-shrink` is explicit, and fail signing-broker preflight before model generation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1218"
+version = "0.2.1219"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1218"
+__version__ = "0.2.1219"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -1716,6 +1716,14 @@ def main():
         ),
     )
     encode_parser.add_argument(
+        "--allow-shrink",
+        action="store_true",
+        help=(
+            "With --apply, explicitly allow replacing an existing apply manifest "
+            "with one that covers fewer files."
+        ),
+    )
+    encode_parser.add_argument(
         "--apply-target-only",
         action="store_true",
         help=(
@@ -17616,10 +17624,16 @@ def _require_applied_encoding_manifest_signer() -> SigningBroker:
 
 
 @contextlib.contextmanager
-def _isolated_apply_manifest_signer():
+def _isolated_apply_manifest_signer(*, preflight: bool = False):
     """Yield the dedicated signer process; no private bytes enter this process."""
 
-    yield _require_applied_encoding_manifest_signer()
+    try:
+        signer = _require_applied_encoding_manifest_signer()
+    except RuntimeError as exc:
+        if preflight:
+            raise RuntimeError(f"{exc} (preflight)") from exc
+        raise
+    yield signer
 
 
 def _unsigned_applied_encoding_manifest_bytes(payload: dict) -> bytes:
@@ -18058,7 +18072,7 @@ def cmd_encode(args):
             # Recovery needs no signing capability and must happen before any
             # model, corpus, or live-checkout preflight consumes partial state.
             _recover_apply_transaction(policy_checkout_path)
-            with _isolated_apply_manifest_signer() as signing_broker:
+            with _isolated_apply_manifest_signer(preflight=True) as signing_broker:
                 return _cmd_encode_with_authoritative_rulespec_roots(
                     args,
                     apply_signing_broker=signing_broker,
@@ -20826,6 +20840,7 @@ def _cmd_encode_with_authoritative_rulespec_roots(
                             run_id=logged_run.id,
                             supplemental_files=supplemental_files,
                             signing_broker=apply_signing_broker,
+                            allow_shrink=(getattr(args, "allow_shrink", False) is True),
                         )
                     except (RuntimeError, ValueError) as exc:
                         outcome["status"] = "apply_blocked_manifest"
@@ -36374,6 +36389,7 @@ def _stage_signed_apply_manifest(
     run_id: str | None,
     signing_broker: SigningBroker,
     axiom_encode_git: dict[str, object],
+    allow_shrink: bool = False,
 ) -> tuple[Path, bytes]:
     """Build and sign the complete manifest in an isolated canonical checkout."""
 
@@ -36421,6 +36437,13 @@ def _stage_signed_apply_manifest(
             run_id=run_id,
             signing_broker=signing_broker,
             axiom_encode_git=axiom_encode_git,
+            existing_manifest_path=(
+                checkout_root
+                / _applied_encoding_manifest_path(
+                    Path(content_root.name) / relative_output
+                )
+            ),
+            allow_shrink=allow_shrink,
         )
         manifest_relative = staged_manifest.relative_to(staged_checkout)
         return manifest_relative, staged_manifest.read_bytes()
@@ -37591,6 +37614,7 @@ def _apply_generated_encoding_result(
     run_id: str | None = None,
     supplemental_files: dict[Path, str] | None = None,
     signing_broker: SigningBroker | None = None,
+    allow_shrink: bool = False,
 ) -> list[Path]:
     """Validate, pre-sign, and transactionally install one generated encoding."""
     output_file = Path(str(getattr(result, "output_file", "") or ""))
@@ -37660,6 +37684,7 @@ def _apply_generated_encoding_result(
         run_id=run_id,
         signing_broker=signing_broker,
         axiom_encode_git=axiom_encode_git,
+        allow_shrink=allow_shrink,
     )
     # Re-open the live toolchain and every evidence artifact after manifest
     # construction so a concurrent mutation cannot be smuggled into install.
@@ -37717,8 +37742,19 @@ def _apply_generated_encoding_result(
         for relative_path in planned
     }
     expected_originals[manifest_path] = _apply_transaction_file_digest(manifest_path)
+    new_manifest_applied_files = {
+        (Path(content_root.name) / relative_path).as_posix()
+        for relative_path in planned
+    }
 
     def pre_install_check() -> None:
+        # The transaction lock is now held. Recheck the live destination so a
+        # concurrent manifest expansion after staging cannot be overwritten.
+        _require_applied_manifest_not_shrunk(
+            manifest_path,
+            new_applied_files=new_manifest_applied_files,
+            allow_shrink=allow_shrink,
+        )
         locked_release = load_rulespec_local_corpus_release(
             content_root,
             corpus_path,
@@ -37982,6 +38018,8 @@ def _write_applied_encoding_manifest(
     axiom_encode_git: dict[str, object],
     signing_broker: SigningBroker,
     run_id: str | None = None,
+    existing_manifest_path: Path | None = None,
+    allow_shrink: bool = False,
 ) -> Path:
     """Record that live RuleSpec files were installed by the encoder."""
     content_root = _rulespec_apply_content_root(policy_repo_path, relative_output)
@@ -38025,6 +38063,11 @@ def _write_applied_encoding_manifest(
             continue
         seen_applied_paths.add(relative_path)
         unique_applied_files.append(path)
+    _require_applied_manifest_not_shrunk(
+        existing_manifest_path or manifest_path,
+        new_applied_files=seen_applied_paths,
+        allow_shrink=allow_shrink,
+    )
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
     local_corpus_release = load_rulespec_local_corpus_release(
         policy_repo_path,
@@ -38098,6 +38141,73 @@ def _write_applied_encoding_manifest(
     _sign_applied_encoding_manifest(payload, signing_broker)
     manifest_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
     return manifest_path
+
+
+def _require_applied_manifest_not_shrunk(
+    manifest_path: Path,
+    *,
+    new_applied_files: set[str],
+    allow_shrink: bool = False,
+) -> None:
+    """Refuse to silently drop files from an existing manifest's coverage."""
+
+    manifest_path = Path(manifest_path)
+    if allow_shrink or not manifest_path.is_file():
+        return
+    try:
+        raw = manifest_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        problem = f"is unreadable ({exc})"
+        raise RuntimeError(
+            f"Cannot determine prior apply-manifest coverage because {manifest_path} "
+            f"{problem}. Refusing to replace it; pass --allow-shrink to acknowledge "
+            "deliberate recovery."
+        ) from exc
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"Cannot determine prior apply-manifest coverage because {manifest_path} "
+            f"contains invalid JSON ({exc}). Refusing to replace it; pass "
+            "--allow-shrink to acknowledge deliberate recovery."
+        ) from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(
+            f"Cannot determine prior apply-manifest coverage because {manifest_path} "
+            "does not contain a JSON object. Refusing to replace it; pass "
+            "--allow-shrink to acknowledge deliberate recovery."
+        )
+    entries = payload.get("applied_files")
+    if not isinstance(entries, list):
+        raise RuntimeError(
+            f"Cannot determine prior apply-manifest coverage because {manifest_path} "
+            "has malformed applied_files (expected a list). Refusing to replace it; "
+            "pass --allow-shrink to acknowledge deliberate recovery."
+        )
+    existing_applied_files: set[str] = set()
+    for index, entry in enumerate(entries):
+        if (
+            not isinstance(entry, dict)
+            or not isinstance(entry.get("path"), str)
+            or not entry["path"].strip()
+        ):
+            raise RuntimeError(
+                f"Cannot determine prior apply-manifest coverage because {manifest_path} "
+                f"has malformed applied_files[{index}] (expected an object with a "
+                "non-empty string path). Refusing to replace it; pass --allow-shrink "
+                "to acknowledge deliberate recovery."
+            )
+        if entry.get("deleted") is not True:
+            existing_applied_files.add(entry["path"])
+    dropped = sorted(existing_applied_files - new_applied_files)
+    if not dropped:
+        return
+    raise RuntimeError(
+        "Refusing to shrink existing apply manifest coverage; dropped files: "
+        + ", ".join(dropped)
+        + ". Re-run the signing workflow against the full branch diff using "
+        "base ref origin/main, or pass --allow-shrink to confirm this removal."
+    )
 
 
 def _applied_encoding_manifest_path(relative_output: Path) -> Path:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6865,6 +6865,7 @@ class TestCmdEncode:
         args.skip_reviewers = overrides.get("skip_reviewers", False)
         args.apply = overrides.get("apply", False)
         args.apply_target_only = overrides.get("apply_target_only", False)
+        args.allow_shrink = overrides.get("allow_shrink", False)
         return args
 
     def _make_eval_result(self, success=True):
@@ -7037,6 +7038,63 @@ class TestCmdEncode:
         out = capsys.readouterr().out
         assert "Codex backend requires authentication" in out
         assert "auth.json" in out
+
+    def test_encode_apply_without_signer_fails_preflight_before_backend(self, tmp_path):
+        args = self._make_args(tmp_path, apply=True)
+        signing_error = (
+            "Apply-manifest signing must be provisioned through an externally "
+            "attached trusted signing broker"
+        )
+        with (
+            patch("axiom_encode.cli.run_model_eval") as mock_run,
+            patch(
+                "axiom_encode.cli._require_applied_encoding_manifest_signer",
+                side_effect=RuntimeError(signing_error),
+            ),
+            pytest.raises(RuntimeError, match=r"trusted signing broker.*\(preflight\)"),
+        ):
+            cmd_encode(args)
+
+        mock_run.assert_not_called()
+
+    @pytest.mark.parametrize("allow_shrink", [False, True])
+    def test_encode_apply_propagates_allow_shrink_to_apply_guard(
+        self, tmp_path, allow_shrink
+    ):
+        args = self._make_args(
+            tmp_path,
+            apply=True,
+            sync=False,
+            allow_shrink=allow_shrink,
+        )
+        result = self._make_eval_result(True)
+        output_file = args.output / "codex-test-model/statutes/26/1.yaml"
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text("format: rulespec/v1\nrules: []\n")
+        result.output_file = str(output_file)
+
+        def apply_guard(_result, **kwargs):
+            if not kwargs["allow_shrink"]:
+                raise RuntimeError("Refusing synthetic manifest shrink")
+            return [args.policy_repo_path / "us/statutes/26/1.yaml"]
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                return_value=(True, [], {}),
+            ),
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                side_effect=apply_guard,
+            ) as mock_apply,
+            patch.dict(os.environ, TEST_APPLY_SIGNING_ENV, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == (0 if allow_shrink else 1)
+        assert mock_apply.call_args.kwargs["allow_shrink"] is allow_shrink
 
     def test_encode_codex_backend_with_auth_runs(self, capsys, tmp_path):
         """Positive: a passing preflight lets the codex-default encode proceed."""
@@ -32217,6 +32275,294 @@ class TestManifestCurrentState:
             )
             is None
         )
+
+
+class TestAppliedManifestShrinkGuard:
+    def _write_manifest(self, path: Path, applied_files: list[str]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "applied_files": [
+                        {"path": item, "sha256": "a" * 64} for item in applied_files
+                    ]
+                }
+            )
+        )
+
+    def test_shrink_is_refused_and_names_dropped_files(self, tmp_path):
+        from axiom_encode.cli import _require_applied_manifest_not_shrunk
+
+        manifest = tmp_path / "manifest.json"
+        self._write_manifest(manifest, ["be/rule.yaml", "be/rule.test.yaml"])
+
+        with pytest.raises(RuntimeError) as exc_info:
+            _require_applied_manifest_not_shrunk(
+                manifest,
+                new_applied_files={"be/rule.yaml"},
+            )
+
+        assert "be/rule.test.yaml" in str(exc_info.value)
+        assert "--allow-shrink" in str(exc_info.value)
+        assert "origin/main" in str(exc_info.value)
+
+    def test_partial_overlap_is_refused_and_names_dropped_files(self, tmp_path):
+        from axiom_encode.cli import _require_applied_manifest_not_shrunk
+
+        manifest = tmp_path / "manifest.json"
+        self._write_manifest(manifest, ["a.yaml", "b.yaml"])
+
+        with pytest.raises(RuntimeError) as exc_info:
+            _require_applied_manifest_not_shrunk(
+                manifest,
+                new_applied_files={"a.yaml", "x.yaml"},
+            )
+
+        message = str(exc_info.value)
+        assert "b.yaml" in message
+        assert "a.yaml" not in message
+        assert "x.yaml" not in message
+
+    def test_shrink_is_permitted_with_flag(self, tmp_path):
+        from axiom_encode.cli import _require_applied_manifest_not_shrunk
+
+        manifest = tmp_path / "manifest.json"
+        self._write_manifest(manifest, ["be/rule.yaml", "be/rule.test.yaml"])
+
+        _require_applied_manifest_not_shrunk(
+            manifest,
+            new_applied_files={"be/rule.yaml"},
+            allow_shrink=True,
+        )
+
+    def test_equal_set_passes(self, tmp_path):
+        from axiom_encode.cli import _require_applied_manifest_not_shrunk
+
+        manifest = tmp_path / "manifest.json"
+        files = {"be/rule.yaml", "be/rule.test.yaml"}
+        self._write_manifest(manifest, sorted(files))
+
+        _require_applied_manifest_not_shrunk(manifest, new_applied_files=files)
+
+    def test_pure_extension_passes(self, tmp_path):
+        from axiom_encode.cli import _require_applied_manifest_not_shrunk
+
+        manifest = tmp_path / "manifest.json"
+        self._write_manifest(manifest, ["be/rule.yaml"])
+
+        _require_applied_manifest_not_shrunk(
+            manifest,
+            new_applied_files={"be/rule.yaml", "be/rule.test.yaml"},
+        )
+
+    def test_fresh_manifest_path_passes(self, tmp_path):
+        from axiom_encode.cli import _require_applied_manifest_not_shrunk
+
+        _require_applied_manifest_not_shrunk(
+            tmp_path / "new.json",
+            new_applied_files={"be/rule.yaml"},
+        )
+
+    @pytest.mark.parametrize(
+        ("raw", "problem"),
+        [
+            ("not json\n", "invalid JSON"),
+            (json.dumps([]), "JSON object"),
+            (json.dumps({"applied_files": [{"sha256": "a" * 64}]}), "applied_files[0]"),
+        ],
+    )
+    def test_malformed_existing_manifest_requires_allow_shrink(
+        self, tmp_path, raw, problem
+    ):
+        from axiom_encode.cli import _require_applied_manifest_not_shrunk
+
+        manifest = tmp_path / "broken-manifest.json"
+        manifest.write_text(raw)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            _require_applied_manifest_not_shrunk(
+                manifest,
+                new_applied_files={"dk/statutes/composed/x.yaml"},
+            )
+
+        message = str(exc_info.value)
+        assert str(manifest) in message
+        assert problem in message
+        assert "prior apply-manifest coverage" in message
+        assert "--allow-shrink" in message
+        _require_applied_manifest_not_shrunk(
+            manifest,
+            new_applied_files={"dk/statutes/composed/x.yaml"},
+            allow_shrink=True,
+        )
+
+    def test_unreadable_existing_manifest_requires_allow_shrink(self, tmp_path):
+        from axiom_encode.cli import _require_applied_manifest_not_shrunk
+
+        manifest = tmp_path / "unreadable-manifest.json"
+        manifest.write_text("{}\n")
+        with (
+            patch.object(Path, "read_text", side_effect=OSError("permission denied")),
+            pytest.raises(RuntimeError) as exc_info,
+        ):
+            _require_applied_manifest_not_shrunk(
+                manifest,
+                new_applied_files={"dk/statutes/composed/x.yaml"},
+            )
+
+        message = str(exc_info.value)
+        assert str(manifest) in message
+        assert "unreadable" in message
+        assert "permission denied" in message
+        assert "--allow-shrink" in message
+
+    def test_stage_normalizes_content_relative_files_to_checkout_manifest_paths(
+        self, tmp_path
+    ):
+        from axiom_encode.cli import _stage_signed_apply_manifest
+
+        checkout = tmp_path / "rulespec-dk"
+        content_root = checkout / "dk"
+        (checkout / ".axiom").mkdir(parents=True)
+        (checkout / ".axiom/toolchain.toml").write_text("[toolchain]\n")
+        (checkout / "known-validation-gaps.yaml").write_text("[]\n")
+        manifest = checkout / ".axiom/encoding-manifests/dk/statutes/composed/x.json"
+        self._write_manifest(
+            manifest,
+            [
+                "dk/statutes/composed/x.yaml",
+                "dk/statutes/composed/x.test.yaml",
+            ],
+        )
+        planned = {
+            Path("statutes/composed/x.yaml"): b"format: rulespec/v1\nrules: []\n",
+            Path("statutes/composed/x.test.yaml"): b"[]\n",
+        }
+
+        def write_staged(_result, **kwargs):
+            staged_root = kwargs["policy_repo_path"].parent
+            applied = {
+                path.relative_to(staged_root).as_posix()
+                for path in kwargs["applied_files"]
+            }
+            from axiom_encode.cli import _require_applied_manifest_not_shrunk
+
+            _require_applied_manifest_not_shrunk(
+                kwargs["existing_manifest_path"],
+                new_applied_files=applied,
+                allow_shrink=kwargs["allow_shrink"],
+            )
+            staged_manifest = (
+                staged_root / ".axiom/encoding-manifests/dk/statutes/composed/x.json"
+            )
+            staged_manifest.parent.mkdir(parents=True)
+            staged_manifest.write_text("{}\n")
+            return staged_manifest
+
+        with (
+            patch(
+                "axiom_encode.cli._rulespec_checkout_root",
+                return_value=checkout,
+            ),
+            patch(
+                "axiom_encode.cli.load_rulespec_toolchain",
+                return_value=SimpleNamespace(root=checkout),
+            ),
+            patch(
+                "axiom_encode.cli._write_applied_encoding_manifest",
+                side_effect=write_staged,
+            ),
+        ):
+            relative, _raw = _stage_signed_apply_manifest(
+                object(),
+                output_root=tmp_path / "out",
+                content_root=content_root,
+                corpus_path=tmp_path / "corpus",
+                relative_output=Path("statutes/composed/x.yaml"),
+                planned=planned,
+                run_id=None,
+                signing_broker=TEST_APPLY_SIGNING_BROKER,
+                axiom_encode_git={},
+            )
+
+        assert relative == Path(".axiom/encoding-manifests/dk/statutes/composed/x.json")
+
+    def test_locked_recheck_refuses_manifest_expanded_after_staging(self, tmp_path):
+        output_root = tmp_path / "out"
+        checkout = tmp_path / "rulespec-dk"
+        content_root = checkout / "dk"
+        generated = output_root / "codex-test-model/statutes/composed/x.yaml"
+        generated.parent.mkdir(parents=True)
+        generated.write_text("format: rulespec/v1\nrules: []\n")
+        content_root.mkdir(parents=True)
+        manifest = checkout / ".axiom/encoding-manifests/dk/statutes/composed/x.json"
+        manifest.parent.mkdir(parents=True)
+        self._write_manifest(manifest, ["dk/statutes/composed/x.yaml"])
+        result = SimpleNamespace(output_file=str(generated), backend="codex")
+        setattr(
+            result,
+            _APPLY_VALIDATION_SNAPSHOT_ATTR,
+            {"validation_execution": {"policy_content_files": {}}},
+        )
+
+        def install_after_expansion(_files, *, pre_install_check, **_kwargs):
+            self._write_manifest(
+                manifest,
+                [
+                    "dk/statutes/composed/x.yaml",
+                    "dk/statutes/composed/x.test.yaml",
+                ],
+            )
+            pre_install_check()
+
+        with (
+            patch("axiom_encode.cli._recover_apply_transaction"),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={},
+            ),
+            patch("axiom_encode.cli._stamp_generated_source_attestation_for_apply"),
+            patch("axiom_encode.cli._enforce_canonical_concept_registry"),
+            patch(
+                "axiom_encode.cli.load_rulespec_local_corpus_release",
+                return_value=object(),
+            ),
+            patch("axiom_encode.cli._require_unchanged_successful_apply_validation"),
+            patch("axiom_encode.cli._enforce_no_apply_collision"),
+            patch(
+                "axiom_encode.cli._planned_apply_file_bytes",
+                return_value=(
+                    {Path("statutes/composed/x.yaml"): generated.read_bytes()},
+                    False,
+                ),
+            ),
+            patch(
+                "axiom_encode.cli._require_planned_apply_bytes_match_validation_snapshot"
+            ),
+            patch(
+                "axiom_encode.cli._stage_signed_apply_manifest",
+                return_value=(
+                    Path(".axiom/encoding-manifests/dk/statutes/composed/x.json"),
+                    b"{}\n",
+                ),
+            ),
+            patch(
+                "axiom_encode.cli._require_staged_manifest_matches_validation_snapshot"
+            ),
+            patch("axiom_encode.cli._ensure_safe_apply_target"),
+            patch(
+                "axiom_encode.cli._install_apply_transaction",
+                side_effect=install_after_expansion,
+            ),
+            pytest.raises(RuntimeError, match="x.test.yaml"),
+        ):
+            _apply_generated_encoding_result(
+                result,
+                output_root=output_root,
+                policy_repo_path=content_root,
+                corpus_path=tmp_path / "corpus",
+                signing_broker=TEST_APPLY_SIGNING_BROKER,
+            )
 
 
 class TestManifestCensus:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1218"
+version = "0.2.1219"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
Closes #1117, closes #1118.

**Shrink guard (#1117):** every path that rewrites an existing applied-encoding manifest now refuses a new `applied_files` set that is a strict subset of the one already attested at the destination, naming the dropped files; `encode --apply --allow-shrink` overrides deliberately. The guard fires both pre-stage and again under the transaction lock, so a concurrent manifest expansion cannot be overwritten either. Equal sets, supersets, and fresh manifests are unaffected. (Live failure: rulespec-dk#6 — a single-file follow-up re-sign silently dropped the companion test from attestation; caught only by the pre-merge audit. Note: the issue named `sign-applied-files`, which no longer exists on main — manual attestation was absorbed into the broker-only flow — so the guard lands on the surviving internal rewrite paths and the `encode` surface.)

**Apply preflight (#1118):** `encode --apply` constructs the isolated apply-manifest signer BEFORE the generation backend is dispatched, failing fast with the same message plus a "(preflight)" marker; the late check remains as a backstop. Run-DB evidence: 8 runs since 2026-06-28 burned a complete generation before dying on the missing signing prerequisite (`apply_blocked_manifest`).

Encoder 0.2.1218 → 0.2.1219, changelog fragment included, single-commit version-ratchet pattern.

Checks: ruff + compileall clean; focused suite 902 passed; 14 new shrink/preflight test cases on the branch (helper + integration level: allow-shrink propagation through encode --apply, staging path normalization for the dk#6-shaped case, malformed/unreadable-manifest refusal, and a locked-recheck concurrent-expansion case via the transaction installer seam); version-ratchet tests 3/3 (verified failing-then-passing across the squash — the ratchet itself caught the interim two-commit state).

Implementation: gpt-5.6-sol (codex) worker from the filed issues; reviewed by Fable; independent clean-context Sol audit before merge per the session review standing and the repo /cycle discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


**Audit round 1** (clean-context Sol): DO-NOT-SHIP — malformed/unreadable existing manifests silently bypassed the guard, and tests were helper-level only. **Remediated**: such manifests now refuse replacement naming the file and problem (prior coverage indeterminate) and require --allow-shrink as the deliberate-recovery acknowledgement; integration tests added per the audit list. Delta re-audit verdict posted below before merge.