### PR TITLE
Map fixture schema errors to period fields (0.2.1220)

### DIFF
--- a/changelog.d/fixture-schema-errors.fixed.md
+++ b/changelog.d/fixture-schema-errors.fixed.md
@@ -1,0 +1,2 @@
+Map companion fixture period schema errors back to `period.period_kind` before
+engine dispatch, and clean generated-envelope coordinates from fallback serde errors.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1219"
+version = "0.2.1220"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1219"
+__version__ = "0.2.1220"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3895,11 +3895,12 @@ def _execute_rulespec_test_case(
         env=env,
     )
     if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip()
         failures.append(
             {
                 "file": str(test_file),
                 "case": case_name,
-                "message": result.stderr.strip() or result.stdout.strip(),
+                "message": _translate_rulespec_engine_envelope_error(message),
             }
         )
         return failures
@@ -3996,34 +3997,91 @@ def _rulespec_period_spec(value) -> dict[str, str]:
         }
         if period["period_kind"] == "custom" and value.get("name") is not None:
             period["name"] = str(value["name"])
-        return period
+        return _validate_rulespec_period_spec(period)
     if isinstance(value, int) or (
         isinstance(value, str) and len(value) == 4 and value.isdigit()
     ):
         year = int(value)
-        return {
-            "period_kind": "tax_year",
-            "start": f"{year:04d}-01-01",
-            "end": f"{year:04d}-12-31",
-        }
+        return _validate_rulespec_period_spec(
+            {
+                "period_kind": "tax_year",
+                "start": f"{year:04d}-01-01",
+                "end": f"{year:04d}-12-31",
+            }
+        )
     if isinstance(value, str) and re.fullmatch(r"\d{4}-\d{2}", value):
         year = int(value[:4])
         month = int(value[5:])
         next_year, next_month = (year + 1, 1) if month == 12 else (year, month + 1)
         next_start = date(next_year, next_month, 1)
         end = date.fromordinal(next_start.toordinal() - 1)
-        return {
-            "period_kind": "month",
-            "start": f"{year:04d}-{month:02d}-01",
-            "end": end.isoformat(),
-        }
+        return _validate_rulespec_period_spec(
+            {
+                "period_kind": "month",
+                "start": f"{year:04d}-{month:02d}-01",
+                "end": end.isoformat(),
+            }
+        )
     if isinstance(value, date):
-        return {
-            "period_kind": "day",
-            "start": value.isoformat(),
-            "end": value.isoformat(),
-        }
+        return _validate_rulespec_period_spec(
+            {
+                "period_kind": "day",
+                "start": value.isoformat(),
+                "end": value.isoformat(),
+            }
+        )
     raise ValueError(f"unsupported period shorthand: {value!r}")
+
+
+# Axiom rules engine `PeriodKind` variants, as exposed by serde during the
+# rulespec-dk#2 fixture failure. The engine is an external checkout, not vendored here.
+_RULESPEC_ENGINE_PERIOD_KINDS = (
+    "month",
+    "benefit_week",
+    "tax_year",
+    "custom",
+)
+
+
+def _validate_rulespec_period_spec(period: dict[str, str]) -> dict[str, str]:
+    period_kind = period["period_kind"]
+    if period_kind not in _RULESPEC_ENGINE_PERIOD_KINDS:
+        accepted = "|".join(_RULESPEC_ENGINE_PERIOD_KINDS)
+        raise ValueError(
+            f"period.period_kind: {period_kind!r} is not one of {accepted}"
+        )
+    return period
+
+
+_SERDE_ENVELOPE_SCHEMA_ERROR_SIGNATURES = (
+    r"unknown variant `[^`]+`, expected [^\r\n]+",
+    r"unknown field `[^`]+`, expected [^\r\n]+",
+    r"missing field `[^`]+`",
+    r"duplicate field `[^`]+`",
+    r"invalid type: [^\r\n]+, expected [^\r\n]+",
+    r"invalid value: [^\r\n]+, expected [^\r\n]+",
+    r"invalid length \d+, expected [^\r\n]+",
+)
+_SERDE_ENVELOPE_SCHEMA_ERROR = re.compile(
+    "|".join(
+        f"(?:{signature})" for signature in _SERDE_ENVELOPE_SCHEMA_ERROR_SIGNATURES
+    ),
+    re.IGNORECASE,
+)
+_SERDE_JSON_COORDINATES = re.compile(r"[ \t]+at line \d+ column \d+")
+
+
+def _translate_rulespec_engine_envelope_error(message: str) -> str:
+    """Replace internal-JSON coordinates on recognized serde envelope errors."""
+    if not _SERDE_ENVELOPE_SCHEMA_ERROR.search(message):
+        return message
+    cleaned = _SERDE_JSON_COORDINATES.sub("", message)
+    if cleaned == message:
+        return message
+    return (
+        f"{cleaned} (the engine envelope is generated; check the companion "
+        "fixture fields)"
+    )
 
 
 def _rulespec_scalar_value(value) -> dict:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -160,6 +160,7 @@ from axiom_encode.cli import (
     _stage_apply_overlay_dependency_roots,
     _stamp_generated_source_attestation_for_apply,
     _suppress_rulespec_ancestor_targets_for_subsection_overlay,
+    _translate_rulespec_engine_envelope_error,
     _try_repair_generated_aca_36b_b_premium_assistance_compat_for_apply,
     _try_repair_generated_admin_agency_aggregate_entities_for_apply,
     _try_repair_generated_bare_snapunit_entity_for_apply,
@@ -5290,6 +5291,163 @@ rules:
             {"kind": "decimal", "value": Decimal("19.99")},
             20,
         )
+
+    def _execute_period_fixture(self, tmp_path, monkeypatch, *, period_kind):
+        content_root = tmp_path / "rulespec-us/us"
+        program = content_root / "statutes/1/example.yaml"
+        program.parent.mkdir(parents=True)
+        program.write_text("format: rulespec/v1\nrules: []\n")
+        companion = program.with_name("example.test.yaml")
+        companion.write_text(
+            f"""- name: {period_kind}_period
+  period:
+    period_kind: {period_kind}
+    start: '2026-01-01'
+    end: '2026-12-31'
+  output:
+    us:statutes/1/example#benefit: 6
+"""
+        )
+        compiled_path = tmp_path / "compiled.json"
+        artifact = {
+            "program": {
+                "derived": [
+                    {
+                        "id": "us:statutes/1/example#benefit",
+                        "entity": "Case",
+                    }
+                ]
+            }
+        }
+        run = MagicMock(
+            return_value=subprocess.CompletedProcess(
+                ["axiom-rules-engine", "run-compiled"],
+                0,
+                stdout=json.dumps(
+                    {
+                        "results": [
+                            {
+                                "outputs": {
+                                    "us:statutes/1/example#benefit": {
+                                        "kind": "scalar",
+                                        "value": {"kind": "integer", "value": 6},
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ),
+                stderr="",
+            )
+        )
+        monkeypatch.setattr("axiom_encode.cli.subprocess.run", run)
+
+        result = _execute_rulespec_test_file(
+            companion,
+            binary=tmp_path / "axiom-rules-engine",
+            axiom_rules_path=tmp_path,
+            env={},
+            rulespec_roots=(tmp_path / "rulespec-us",),
+            tmp_path=tmp_path,
+            compiled_cache={program: (compiled_path, artifact)},
+            policy_repo_path=content_root,
+        )
+        return result, run
+
+    def test_invalid_period_kind_names_fixture_field_before_engine_dispatch(
+        self, monkeypatch, tmp_path
+    ):
+        result, run = self._execute_period_fixture(
+            tmp_path, monkeypatch, period_kind="year"
+        )
+
+        assert result == {
+            "cases": 1,
+            "compiled": 0,
+            "failures": [
+                {
+                    "file": str(
+                        tmp_path / "rulespec-us/us/statutes/1/example.test.yaml"
+                    ),
+                    "case": "year_period",
+                    "message": (
+                        "period.period_kind: 'year' is not one of "
+                        "month|benefit_week|tax_year|custom"
+                    ),
+                }
+            ],
+        }
+        run.assert_not_called()
+
+    def test_tax_year_period_fixture_is_unaffected(self, monkeypatch, tmp_path):
+        result, run = self._execute_period_fixture(
+            tmp_path, monkeypatch, period_kind="tax_year"
+        )
+
+        assert result == {"cases": 1, "compiled": 0, "failures": []}
+        run.assert_called_once()
+
+    def test_translates_serde_envelope_error_coordinates(self):
+        message = (
+            "unknown variant `fortnight`, expected one of `month`, `benefit_week`, "
+            "`tax_year`, `custom` at line 1 column 987"
+        )
+
+        assert _translate_rulespec_engine_envelope_error(message) == (
+            "unknown variant `fortnight`, expected one of `month`, `benefit_week`, "
+            "`tax_year`, `custom` (the engine envelope is generated; check the "
+            "companion fixture fields)"
+        )
+
+    def test_preserves_runtime_invalid_value_error_without_serde_signature(self):
+        message = "missing field data in output table at line 3 column 7"
+
+        assert _translate_rulespec_engine_envelope_error(message) == message
+
+    def test_translates_serde_invalid_value_error_coordinates(self):
+        message = "invalid value: integer `3`, expected a string at line 1 column 42"
+
+        translated = _translate_rulespec_engine_envelope_error(message)
+
+        assert translated == (
+            "invalid value: integer `3`, expected a string (the engine envelope is "
+            "generated; check the companion fixture fields)"
+        )
+        assert "at line" not in translated
+        assert translated.count("check the companion fixture fields") == 1
+
+    def test_translates_serde_duplicate_field_error_coordinates(self):
+        message = "duplicate field `foo` at line 1 column 7"
+
+        translated = _translate_rulespec_engine_envelope_error(message)
+
+        assert translated == (
+            "duplicate field `foo` (the engine envelope is generated; check the "
+            "companion fixture fields)"
+        )
+        assert "at line" not in translated
+        assert translated.count("check the companion fixture fields") == 1
+
+    def test_strips_all_serde_coordinates_and_appends_fixture_hint_once(self):
+        message = (
+            "missing field `period_kind` at line 2 column 17\n"
+            "unknown variant `fortnight` at line 5 column 29"
+        )
+
+        translated = _translate_rulespec_engine_envelope_error(message)
+
+        assert translated == (
+            "missing field `period_kind`\n"
+            "unknown variant `fortnight` (the engine envelope is generated; "
+            "check the companion fixture fields)"
+        )
+        assert "at line" not in translated
+        assert translated.count("check the companion fixture fields") == 1
+
+    def test_preserves_unknown_engine_error_shape(self):
+        message = "engine terminated while evaluating the compiled program"
+
+        assert _translate_rulespec_engine_envelope_error(message) == message
 
     def test_rejects_country_checkout_as_test_root(self, tmp_path):
         checkout = self._write_rulespec_with_test(tmp_path, expected_benefit=15)

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1219"
+version = "0.2.1220"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
Closes #1119.

Two layers so companion-fixture schema problems surface as fixture fields, not internal-JSON serde coordinates (live evidence: rulespec-dk#2's eleven `unknown variant \`year\`... at line 1 column 987` failures):

1. **Pre-dispatch validation**: the constructed test envelope's `period_kind` is validated against the engine's accepted set (month | benefit_week | tax_year | custom) before the engine is invoked, producing `period.period_kind: 'year' is not one of month|benefit_week|tax_year|custom` per case — covering the invalid `year`, the internal `period` default, and the `day` shorthand branch, none of which the engine accepts.
2. **Serde-error translation fallback**: engine parse errors matching serde schema shapes get internal-JSON coordinates stripped and a generated-envelope hint appended; unknown error shapes pass through unchanged.

Encoder 0.2.1220, changelog fragment, single-commit ratchet. Checks: ruff check + format-check clean; focused suite green (902 unsandboxed); 8 period/fixture/schema tests incl. 4 new; ratchet green.

Related: #1112 tracks the underlying encoder-accepts/engine-rejects divergence class; this PR fixes the reporting layer and blocks the known-invalid kinds pre-dispatch.

Implementation: gpt-5.6-sol (codex) worker; reviewed by Fable; clean-context Sol audit posted before merge per the session standing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)