### PR TITLE
Record validation-failure categories in outcome telemetry

### DIFF
--- a/changelog.d/outcome-failure-categories.added.md
+++ b/changelog.d/outcome-failure-categories.added.md
@@ -1,0 +1,1 @@
+Record bounded, classified validation failure telemetry for standalone and overlay-blocked encoding outcomes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1221"
+version = "0.2.1222"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1221"
+__version__ = "0.2.1222"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -174,6 +174,7 @@ from .harness.evals import (
     run_model_eval,
     run_source_eval,
     summarize_readiness,
+    summarize_validation_failures,
 )
 from .harness.policyengine_runtime import (
     PolicyEngineRuntime,
@@ -20806,6 +20807,7 @@ def _cmd_encode_with_authoritative_rulespec_roots(
                 )
                 outcome["status"] = "apply_blocked_validation"
                 outcome["apply_error"] = detail
+                _replace_overlay_validation_failures(outcome, apply_issues)
                 outcome["final_success"] = False
                 print(f"  apply=blocked_validation:{detail}")
             if can_apply:
@@ -20886,6 +20888,7 @@ def _cmd_encode_with_authoritative_rulespec_roots(
                     )
                     outcome["status"] = "apply_blocked_validation"
                     outcome["apply_error"] = detail
+                    _replace_overlay_validation_failures(outcome, apply_issues)
                     outcome["final_success"] = False
                     print(f"  apply=blocked_validation:{detail}")
                 else:
@@ -42094,7 +42097,7 @@ def _log_eval_session(
 def _initial_encode_outcome(result, *, apply_requested: bool) -> dict:
     """Build the workflow-level outcome object for an eval-backed encode run."""
     standalone_success = bool(getattr(result, "success", False))
-    return {
+    outcome = {
         "standalone_validation_success": standalone_success,
         "apply_requested": bool(apply_requested),
         "overlay_validation_success": None,
@@ -42105,6 +42108,43 @@ def _initial_encode_outcome(result, *, apply_requested: bool) -> dict:
         "apply_error": None,
         "applied_files": [],
     }
+    metrics = getattr(result, "metrics", None)
+    if metrics is not None and not standalone_success:
+        try:
+            labeled_issues = [
+                (gate, issues)
+                for gate, attribute in (
+                    ("compile", "compile_issues"),
+                    ("ci", "ci_issues"),
+                    ("numeric_occurrence", "numeric_occurrence_issues"),
+                    ("generalist_review", "generalist_review_issues"),
+                    ("policyengine", "policyengine_issues"),
+                    ("taxsim", "taxsim_issues"),
+                )
+                if (issues := getattr(metrics, attribute, None))
+            ]
+            outcome.update(summarize_validation_failures(labeled_issues))
+        except Exception:
+            outcome["validation_failure_counts"] = {"telemetry:error": 1}
+    return outcome
+
+
+def _replace_overlay_validation_failures(outcome: dict, issues: Sequence[str]) -> None:
+    """Replace any standalone failure telemetry with the overlay block reason."""
+    if not issues:
+        # The `standalone_failed:` block route arrives with no overlay issues;
+        # the standalone summary is the only telemetry that run has. Keep it.
+        return
+    for key in (
+        "validation_failures",
+        "validation_failures_truncated",
+        "validation_failure_counts",
+    ):
+        outcome.pop(key, None)
+    try:
+        outcome.update(summarize_validation_failures([("overlay", issues)]))
+    except Exception:
+        outcome["validation_failure_counts"] = {"telemetry:error": 1}
 
 
 def _record_encode_outcome(

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -735,6 +735,140 @@ class EvalArtifactMetrics:
     policyengine_runtime_identity_sha256: str | None = None
 
 
+_VALIDATION_ISSUE_CLASSIFIERS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(
+            r"(?:companion (?:output |test )?coverage|companion test asserts|"
+            r"companion `\.test\.yaml` file)",
+            re.IGNORECASE,
+        ),
+        "companion_coverage",
+    ),
+    (
+        re.compile(
+            r"\bproof (?:atom|malformed|claim|missing|source|import|table)\b",
+            re.IGNORECASE,
+        ),
+        "proof_atoms",
+    ),
+    (
+        re.compile(r"\bungrounded generated numeric literal\b", re.IGNORECASE),
+        "ungrounded_literal",
+    ),
+    (
+        re.compile(
+            r"(?:fixture|test case).*(?:failed|failure|error|expected|returned|"
+            r"missing from execution response)|"
+            r"(?:failed|failure|error).*(?:fixture|test case)",
+            re.IGNORECASE,
+        ),
+        "fixture_execution",
+    ),
+    (
+        re.compile(
+            r"(?:zero comparable oracle evidence|oracle coverage|"
+            r"No PolicyEngine-comparable tests found|"
+            r"PE=.*RuleSpec expects=)",
+            re.IGNORECASE,
+        ),
+        "oracle_coverage",
+    ),
+    (
+        re.compile(
+            r"(?:canonical concept|concept registry|Invalid concept registry)",
+            re.IGNORECASE,
+        ),
+        "concept_registry",
+    ),
+    (
+        re.compile(
+            r"(?:import (?:`[^`]*` )?(?:missing|does not resolve|resolution)|"
+            r"missing imports?|could not resolve import)",
+            re.IGNORECASE,
+        ),
+        "import_resolution",
+    ),
+    (
+        re.compile(
+            r"(?:YAML parse failed|could not be read as RuleSpec YAML|"
+            r"RuleSpec tests must be a YAML list|schema (?:is not supported|invalid)|"
+            r"unsupported (?:registry format|schema))",
+            re.IGNORECASE,
+        ),
+        "schema",
+    ),
+    (
+        re.compile(r"(?:embedded source|Numeric source required)", re.IGNORECASE),
+        "embedded_source",
+    ),
+    (
+        re.compile(
+            r"(?:compile failed|failed compile validation|"
+            r"compile did not return an artifact payload)",
+            re.IGNORECASE,
+        ),
+        "compile",
+    ),
+)
+_VALIDATION_FALLBACK_QUOTED_RE = re.compile(r"(?:`[^`]*`|'[^']*'|\"[^\"]*\")")
+_VALIDATION_FALLBACK_PATH_RE = re.compile(
+    r"(?:[A-Za-z]:)?(?:[/\\][^\s:;,]+)+|\b[^\s:;,]+[/\\][^\s:;,]+"
+)
+_VALIDATION_FALLBACK_FILENAME_RE = re.compile(r"\b[\w.-]*\.[A-Za-z]{1,6}\b")
+_VALIDATION_FALLBACK_DIGIT_RE = re.compile(r"\d+")
+_VALIDATION_FALLBACK_TOKEN_RE = re.compile(r"[a-z]+")
+
+
+def classify_validation_issue(issue: str) -> str:
+    """Return a stable, bounded class for one emitted validation issue."""
+    detail = str(issue)
+    for pattern, message_class in _VALIDATION_ISSUE_CLASSIFIERS:
+        if pattern.search(detail):
+            return message_class
+    normalized = _VALIDATION_FALLBACK_QUOTED_RE.sub(" ", detail.lower())
+    normalized = _VALIDATION_FALLBACK_PATH_RE.sub(" ", normalized)
+    normalized = _VALIDATION_FALLBACK_FILENAME_RE.sub(" ", normalized)
+    normalized = _VALIDATION_FALLBACK_DIGIT_RE.sub(" ", normalized)
+    tokens = _VALIDATION_FALLBACK_TOKEN_RE.findall(normalized)[:6]
+    return "_".join(tokens)[:60] or "unclassified"
+
+
+def summarize_validation_failures(
+    labeled_issues: Sequence[tuple[str, Sequence[str]]],
+) -> dict:
+    """Build bounded issue detail plus uncapped counts for outcome telemetry."""
+    failures: list[dict[str, str]] = []
+    counts: Counter[str] = Counter()
+    seen: set[tuple[str, str]] = set()
+    for gate, issues in labeled_issues:
+        gate_text = str(gate)
+        for issue in issues:
+            detail = str(issue)
+            identity = (gate_text, detail)
+            if identity in seen:
+                continue
+            seen.add(identity)
+            message_class = classify_validation_issue(detail)
+            counts[f"{gate_text}:{message_class}"] += 1
+            failures.append(
+                {
+                    "gate": gate_text,
+                    "message_class": message_class,
+                    "detail": detail[:240],
+                }
+            )
+    if not failures:
+        return {}
+    result: dict[str, object] = {
+        "validation_failures": failures[:40],
+        "validation_failure_counts": dict(counts),
+    }
+    dropped = len(failures) - 40
+    if dropped > 0:
+        result["validation_failures_truncated"] = dropped
+    return result
+
+
 @dataclass
 class EvalContextFile:
     """A context file copied into the eval workspace."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9776,7 +9776,14 @@ rules: []
             patch("axiom_encode.cli.run_model_eval", return_value=[result]),
             patch(
                 "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
-                return_value=(False, ["dependent failed"], {}),
+                return_value=(
+                    False,
+                    [
+                        "dependent failed",
+                        "Proof atom missing path: rule `x` proof atom 0 must declare `path`.",
+                    ],
+                    {},
+                ),
             ),
             patch("axiom_encode.cli._apply_generated_encoding_result") as mock_apply,
             patch.dict(
@@ -9794,6 +9801,10 @@ rules: []
         assert run.outcome["status"] == "apply_blocked_validation"
         assert run.outcome["final_success"] is False
         assert run.outcome["apply_error"] == "dependent failed"
+        assert run.outcome["validation_failure_counts"] == {
+            "overlay:dependent_failed": 1,
+            "overlay:proof_atoms": 1,
+        }
         events = EncodingDB(args.db).get_session_events(run.session_id)
         assert [event.event_type for event in events] == [
             "encode_request",
@@ -21865,6 +21876,23 @@ rules: []
         args.apply = True
         result = self._make_eval_result(False)
         result.error = "Generated RuleSpec failed compile validation"
+        result.metrics = SimpleNamespace(
+            compile_pass=False,
+            compile_issues=["Axiom rules engine compile failed: standalone bad"],
+            ci_pass=False,
+            ci_issues=[],
+            grounded_numeric_count=0,
+            ungrounded_numeric_count=0,
+            embedded_source_present=True,
+            grounding=[],
+            numeric_occurrence_issues=[],
+            generalist_review_pass=None,
+            generalist_review_score=None,
+            generalist_review_issues=[],
+            policyengine_pass=None,
+            policyengine_score=None,
+            policyengine_issues=[],
+        )
         output_file = tmp_path / "out" / "codex-test-model" / "regulations/example.yaml"
         output_file.parent.mkdir(parents=True)
         output_file.write_text("format: rulespec/v1\nrules: []\n")
@@ -21874,7 +21902,14 @@ rules: []
             patch("axiom_encode.cli.run_model_eval", return_value=[result]),
             patch(
                 "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
-                return_value=(False, ["overlay compile failed"], {}),
+                return_value=(
+                    False,
+                    [
+                        "overlay compile failed",
+                        "Ungrounded generated numeric literal: 0.15 does not appear as a substantive numeric value in the source text.",
+                    ],
+                    {},
+                ),
             ) as mock_overlay,
             patch("axiom_encode.cli._apply_generated_encoding_result") as mock_apply,
             patch.dict(
@@ -21893,6 +21928,13 @@ rules: []
         assert run.outcome["status"] == "apply_blocked_validation"
         assert run.outcome["overlay_validation_success"] is False
         assert run.outcome["apply_error"] == "overlay compile failed"
+        assert run.outcome["validation_failure_counts"] == {
+            "overlay:compile": 1,
+            "overlay:ungrounded_literal": 1,
+        }
+        assert all(
+            item["gate"] == "overlay" for item in run.outcome["validation_failures"]
+        )
         assert run.outcome["final_success"] is False
 
     def test_encode_apply_records_final_success_when_overlay_apply_passes(
@@ -32882,3 +32924,114 @@ rules: []
 
         census = json.loads(capsys.readouterr().out)
         assert census["captured_at"].endswith("Z")
+
+
+def test_initial_encode_outcome_records_multigate_validation_failures():
+    from axiom_encode.cli import _initial_encode_outcome
+
+    metrics = SimpleNamespace(
+        compile_issues=["Axiom rules engine compile failed: bad formula"],
+        ci_issues=[
+            "Proof atom missing path: rule `x` proof atom 0 must declare `path`."
+        ],
+        numeric_occurrence_issues=[
+            "Ungrounded generated numeric literal: 0.15 does not appear as a substantive numeric value in the source text."
+        ],
+        generalist_review_issues=[],
+        policyengine_issues=[],
+    )
+    outcome = _initial_encode_outcome(
+        SimpleNamespace(
+            success=False,
+            error="Generated RuleSpec failed CI validation",
+            metrics=metrics,
+        ),
+        apply_requested=False,
+    )
+
+    assert [item["gate"] for item in outcome["validation_failures"]] == [
+        "compile",
+        "ci",
+        "numeric_occurrence",
+    ]
+    assert outcome["validation_failure_counts"] == {
+        "compile:compile": 1,
+        "ci:proof_atoms": 1,
+        "numeric_occurrence:ungrounded_literal": 1,
+    }
+    assert "validation_failures_truncated" not in outcome
+
+
+def test_initial_encode_outcome_success_omits_validation_failure_keys():
+    from axiom_encode.cli import _initial_encode_outcome
+
+    outcome = _initial_encode_outcome(
+        SimpleNamespace(
+            success=True, error=None, metrics=SimpleNamespace(ci_issues=["ignored"])
+        ),
+        apply_requested=False,
+    )
+
+    assert not any(key.startswith("validation_failure") for key in outcome)
+
+
+def test_initial_encode_outcome_telemetry_error_never_propagates():
+    from axiom_encode.cli import _initial_encode_outcome
+
+    with patch(
+        "axiom_encode.cli.summarize_validation_failures",
+        side_effect=RuntimeError("telemetry broke"),
+    ):
+        outcome = _initial_encode_outcome(
+            SimpleNamespace(
+                success=False,
+                error="Generated RuleSpec failed CI validation",
+                metrics=SimpleNamespace(ci_issues=["No tests found."]),
+            ),
+            apply_requested=False,
+        )
+
+    assert outcome["validation_failure_counts"] == {"telemetry:error": 1}
+
+
+def test_overlay_validation_failures_replace_standalone_telemetry():
+    from axiom_encode.cli import _replace_overlay_validation_failures
+
+    outcome = {
+        "apply_error": "Axiom rules engine compile failed: overlay bad",
+        "validation_failures": [{"gate": "ci"}],
+        "validation_failures_truncated": 7,
+        "validation_failure_counts": {"ci:proof_atoms": 1},
+    }
+    issues = [
+        "Axiom rules engine compile failed: overlay bad",
+        "Proof atom missing path: rule `x` proof atom 0 must declare `path`.",
+    ]
+    _replace_overlay_validation_failures(outcome, issues)
+
+    assert outcome["apply_error"] == issues[0]
+    assert [item["gate"] for item in outcome["validation_failures"]] == [
+        "overlay",
+        "overlay",
+    ]
+    assert outcome["validation_failure_counts"] == {
+        "overlay:compile": 1,
+        "overlay:proof_atoms": 1,
+    }
+    assert "validation_failures_truncated" not in outcome
+
+
+def test_overlay_validation_failures_keep_standalone_telemetry_when_no_issues():
+    from axiom_encode.cli import _replace_overlay_validation_failures
+
+    outcome = {
+        "apply_error": "standalone_failed: Generated RuleSpec failed CI validation",
+        "validation_failures": [
+            {"gate": "ci", "message_class": "proof_atoms", "detail": "x"}
+        ],
+        "validation_failure_counts": {"ci:proof_atoms": 1},
+    }
+    _replace_overlay_validation_failures(outcome, [])
+
+    assert outcome["validation_failure_counts"] == {"ci:proof_atoms": 1}
+    assert [item["gate"] for item in outcome["validation_failures"]] == ["ci"]

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -16155,3 +16155,111 @@ def _fake_eval_result(
             ),
         ),
     )
+
+
+@pytest.mark.parametrize(
+    ("issue", "expected"),
+    [
+        (
+            "Derived rule missing companion output coverage: `us:x#amount` is not asserted by the companion `.test.yaml` file.",
+            "companion_coverage",
+        ),
+        (
+            "Proof atom missing path: rule `amount` proof atom 0 must declare `path`.",
+            "proof_atoms",
+        ),
+        (
+            "Proof import hash mismatch: rule `amount` proof atom 0 declares sha256 `abc` but resolved import has sha256 `def`.",
+            "proof_atoms",
+        ),
+        (
+            "Ungrounded generated numeric literal: 0.15 does not appear as a substantive numeric value in the source text.",
+            "ungrounded_literal",
+        ),
+        (
+            "Test case `basic` output `amount` expected decimal 10, got decimal 9.",
+            "fixture_execution",
+        ),
+        (
+            "PolicyEngine produced zero comparable oracle evidence",
+            "oracle_coverage",
+        ),
+        ("PE=10.00, RuleSpec expects=9.00", "oracle_coverage"),
+        ("No PolicyEngine-comparable tests found", "oracle_coverage"),
+        (
+            "Import `us:statutes/26/1` does not resolve to a RuleSpec file in the clean policy repository.",
+            "import_resolution",
+        ),
+        ("rules.test.yaml YAML parse failed: mapping values are not allowed", "schema"),
+        (
+            "Canonical concept import missing: `household_income` uniquely resolves nearby.",
+            "concept_registry",
+        ),
+        (
+            "Numeric source required: RuleSpec defines policy numeric literals but does not provide source text.",
+            "embedded_source",
+        ),
+        ("Axiom rules engine compile failed: unknown rule kind", "compile"),
+        (
+            "Axiom rules engine compile did not return an artifact payload.",
+            "compile",
+        ),
+    ],
+)
+def test_classify_validation_issue_known_families(issue, expected):
+    from axiom_encode.harness.evals import classify_validation_issue
+
+    assert classify_validation_issue(issue) == expected
+
+
+def test_classify_validation_issue_fallback_is_deterministic_and_bounded():
+    from axiom_encode.harness.evals import classify_validation_issue
+
+    issue = 'Unexpected 123 item at /tmp/build/thing.yaml named "private value" remains wrong'
+    assert classify_validation_issue(issue) == "unexpected_item_at_named_remains_wrong"
+    assert classify_validation_issue(issue) == classify_validation_issue(issue)
+    assert len(classify_validation_issue("word " * 100)) <= 60
+    assert classify_validation_issue("123 '/tmp/x'") == "unclassified"
+
+
+def test_classify_validation_issue_fallback_collapses_filenames_and_lines():
+    from axiom_encode.harness.evals import classify_validation_issue
+
+    first = classify_validation_issue(
+        "Unexpected validator failure at alpha.yaml line 12"
+    )
+    second = classify_validation_issue(
+        "Unexpected validator failure at beta.yaml line 98"
+    )
+
+    assert first == second == "unexpected_validator_failure_at_line"
+
+
+def test_classify_validation_issue_handles_pathological_text():
+    from axiom_encode.harness.evals import classify_validation_issue
+
+    result = classify_validation_issue(("\udcff" * 100_000) + " 123")
+    assert result == "unclassified"
+
+
+def test_summarize_validation_failures_empty():
+    from axiom_encode.harness.evals import summarize_validation_failures
+
+    assert summarize_validation_failures([]) == {}
+
+
+def test_summarize_validation_failures_deduplicates_caps_and_counts_before_cap():
+    from axiom_encode.harness.evals import summarize_validation_failures
+
+    issues = [f"Novel validator issue {index}" for index in range(41)]
+    summary = summarize_validation_failures(
+        [("ci", [issues[0], issues[0], *issues[1:]]), ("compile", ["x" * 300])]
+    )
+
+    assert len(summary["validation_failures"]) == 40
+    assert summary["validation_failures_truncated"] == 2
+    assert summary["validation_failures"][0]["detail"] == issues[0]
+    assert summary["validation_failures"][1]["detail"] == issues[1]
+    assert sum(summary["validation_failure_counts"].values()) == 42
+    assert summary["validation_failure_counts"][f"compile:{'x' * 60}"] == 1
+    assert all(len(item["detail"]) <= 240 for item in summary["validation_failures"])

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1221"
+version = "0.2.1222"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
Closes #1122.

177/205 `apply_blocked_validation` rows since 6/28 recorded only `primary_error: "Generated RuleSpec failed CI validation"` — the failure-class distribution the run had already computed was discarded, so "which CI-failure classes should the harness or auto-repair attack next" was unanswerable from `encodings.db`.

## What this adds

Blocked outcomes now carry, in `outcome_json`:

- **`validation_failures`** — `[{gate, message_class, detail}]`, detail truncated to 240 chars, list capped at 40 entries (`validation_failures_truncated` records the dropped count when the cap bites).
- **`validation_failure_counts`** — `{"<gate>:<message_class>": n}`, aggregated **before** the cap, so the distribution survives truncation and failure-mode dashboards are one SQL query.

Two recording surfaces:

- **Standalone/eval failures** (`_initial_encode_outcome`): populated from the `EvalArtifactMetrics` issue lists the run already produced — gates `compile`, `ci`, `numeric_occurrence`, `generalist_review`, `policyengine`, `taxsim` (non-empty lists only).
- **Apply-block sites** (both `apply_blocked_validation` paths): the full `apply_issues` list recorded under gate `overlay`, **replacing** any standalone summary (the block reason is the overlay result). `apply_error` stays the first issue, unchanged.

Classification is a deterministic ordered matcher over the known validator families (`companion_coverage`, `proof_atoms`, `ungrounded_literal`, `fixture_execution`, `oracle_coverage`, `concept_registry`, `import_resolution`, `schema`, `embedded_source`, `compile`), patterns derived from the actual emitting sites, with a normalized-token fallback (quoted spans/paths/digits stripped, first 6 tokens, 60-char cap) for anything unmatched. Exact `(gate, detail)` duplicates dedup before counting.

Telemetry assembly never raises — an unexpected error records `{"telemetry:error": 1}` rather than taking down the encode.

## Not changed

- No DB schema change, no backfill (forward-only per the issue).
- `status` / `primary_error` / `apply_error` semantics untouched.
- `_eval_artifact_validation_error` return strings untouched (matched elsewhere).

## Verification

- `ruff check` + `ruff format --check src/ tests/` clean.
- `tests/test_evals.py` + `tests/test_cli.py`: **1,241 passed** (26s), including 27 new/focused tests (classifier per family with real emitter strings, fallback determinism, caps + truncated count + counts-before-cap + dedup, surface A across 3 gates, surface B replace semantics, success path adds no keys, pathological-input never-raises) and the encoder version ratchet at 0.2.1222.

## Review cycle

Clean-context adversarial audit (round 1) found one HIGH and two residuals, all fixed:

- **HIGH — empty-overlay route destroyed standalone telemetry.** `_can_attempt_apply` deliberately admits standalone-validation failures, so a block with empty `apply_issues` (the `standalone_failed:` detail branch) popped the surface-A summary and recorded nothing — exactly the rows this PR exists for. Fix: the replace helper keeps the standalone summary when there are no overlay issues, with a regression test.
- **MED — fallback fragmented on bare filenames.** `alpha.yaml` vs `beta.yaml` (path regex only caught slash-containing paths) produced different distribution keys for the same failure. Fix: extension-bearing tokens are stripped before tokenization; the auditor's exact probe pair now collapses to `unexpected_validator_failure_at_line`, pinned by test.
- **LOW — dead speculative classifier alternatives.** `oracle mismatch` / `PolicyEngine mismatch` had no real emitting site; removed. Every remaining pattern alternative is backed by a real emitter.

After fixes: 1,243 passed across `test_evals.py` + `test_cli.py`; ruff check + format clean; round-2 delta audit on the final commit.
