### PR TITLE
Bump the axiom-oracles pin for the relocated wrapper mappings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1224"
+version = "0.2.1225"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@5619297d93222c5716b585a390427204dd08cc8c",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@f2d2df36deb9c96b9fac4af15eab69c11d899e51",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1224"
+__version__ = "0.2.1225"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1224"
+version = "0.2.1225"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -100,7 +100,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=5619297d93222c5716b585a390427204dd08cc8c" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=f2d2df36deb9c96b9fac4af15eab69c11d899e51" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -123,7 +123,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=5619297d93222c5716b585a390427204dd08cc8c#5619297d93222c5716b585a390427204dd08cc8c" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=f2d2df36deb9c96b9fac4af15eab69c11d899e51#f2d2df36deb9c96b9fac4af15eab69c11d899e51" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
One-line pin bump pulling TheAxiomFoundation/axiom-oracles#276 (the five relocated federal eligibility-wrapper mappings) plus the encoder version bump the apply gate requires. Completes the classifier chain for TheAxiomFoundation/rulespec-us#879.

🤖 Generated with [Claude Code](https://claude.com/claude-code)