### PR TITLE
Fix nested oracle pending checkout discovery

### DIFF
--- a/changelog.d/nested-oracle-pending-checkout.fixed.md
+++ b/changelog.d/nested-oracle-pending-checkout.fixed.md
@@ -1,0 +1,1 @@
+Load oracle coverage pending declarations from GitHub Actions' nested canonical checkout layout.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1225"
+version = "0.2.1226"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1225"
+__version__ = "0.2.1226"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/pending.py
+++ b/src/axiom_encode/oracles/policyengine/pending.py
@@ -189,7 +189,13 @@ def load_pending_file(path: Path, *, repo: str | None = None) -> PendingFile:
 
 
 def iter_pending_file_paths(root: Path) -> list[Path]:
-    """Return the pending declaration in one explicit canonical checkout."""
+    """Return the pending declaration in one explicit canonical checkout.
+
+    GitHub Actions places the repository at ``rulespec-us/rulespec-us`` and
+    passes the outer canonical checkout root to oracle coverage. Support that
+    exact nested checkout as well as the direct layout used by local callers.
+    Never scan sibling repositories.
+    """
 
     raw_root = Path(root).expanduser()
     if not is_policy_repo_root(raw_root):
@@ -197,12 +203,32 @@ def iter_pending_file_paths(root: Path) -> list[Path]:
             "Pending declarations require the exact canonical "
             f"rulespec-<country> checkout: {raw_root}"
         )
-    own = raw_root.resolve(strict=True) / PENDING_FILENAME
-    if own.is_symlink():
+    checkout = raw_root.resolve(strict=True)
+    nested_checkout = checkout / checkout.name
+    if nested_checkout.is_symlink():
         raise PendingDeclarationError(
-            f"Pending declaration must be a regular file, not a symlink: {own}"
+            "Nested RuleSpec checkout must be a regular directory, not a symlink: "
+            f"{nested_checkout}"
         )
-    return [own] if own.is_file() else []
+
+    candidates = [checkout / PENDING_FILENAME]
+    if nested_checkout.is_dir():
+        candidates.append(nested_checkout / PENDING_FILENAME)
+
+    found: list[Path] = []
+    for path in candidates:
+        if path.is_symlink():
+            raise PendingDeclarationError(
+                f"Pending declaration must be a regular file, not a symlink: {path}"
+            )
+        if path.is_file():
+            found.append(path)
+    if len(found) > 1:
+        raise PendingDeclarationError(
+            "Pending declaration is ambiguous; keep exactly one file in the direct "
+            f"or nested canonical checkout: {', '.join(str(path) for path in found)}"
+        )
+    return found
 
 
 def load_pending_files(root: Path) -> list[PendingFile]:

--- a/tests/test_oracle_coverage_pending.py
+++ b/tests/test_oracle_coverage_pending.py
@@ -223,6 +223,58 @@ def test_pending_loader_rejects_workspace_and_does_not_scan_siblings(tmp_path):
     ]
 
 
+def test_pending_loader_reads_exact_nested_github_actions_checkout(tmp_path):
+    checkout = tmp_path / "rulespec-us"
+    nested_checkout = checkout / "rulespec-us"
+    nested_checkout.mkdir(parents=True)
+    _write(
+        nested_checkout / "oracle-coverage-pending.yaml",
+        "version: 1\nentries: []\n",
+    )
+
+    assert [pending.path for pending in load_pending_files(checkout)] == [
+        nested_checkout / "oracle-coverage-pending.yaml"
+    ]
+
+
+def test_pending_loader_rejects_ambiguous_direct_and_nested_files(tmp_path):
+    checkout = tmp_path / "rulespec-us"
+    nested_checkout = checkout / "rulespec-us"
+    nested_checkout.mkdir(parents=True)
+    for path in (
+        checkout / "oracle-coverage-pending.yaml",
+        nested_checkout / "oracle-coverage-pending.yaml",
+    ):
+        _write(path, "version: 1\nentries: []\n")
+
+    with pytest.raises(PendingDeclarationError, match="ambiguous"):
+        load_pending_files(checkout)
+
+
+def test_pending_loader_rejects_symlinked_nested_checkout(tmp_path):
+    checkout = tmp_path / "rulespec-us"
+    checkout.mkdir()
+    outside_checkout = tmp_path / "outside"
+    outside_checkout.mkdir()
+    (checkout / "rulespec-us").symlink_to(outside_checkout, target_is_directory=True)
+
+    with pytest.raises(PendingDeclarationError, match="regular directory"):
+        load_pending_files(checkout)
+
+
+@pytest.mark.parametrize("nested", [False, True])
+def test_pending_loader_rejects_symlinked_pending_file(tmp_path, nested):
+    checkout = tmp_path / "rulespec-us"
+    declaration_root = checkout / "rulespec-us" if nested else checkout
+    declaration_root.mkdir(parents=True)
+    outside_file = tmp_path / "outside-pending.yaml"
+    _write(outside_file, "version: 1\nentries: []\n")
+    (declaration_root / "oracle-coverage-pending.yaml").symlink_to(outside_file)
+
+    with pytest.raises(PendingDeclarationError, match="regular file"):
+        load_pending_files(checkout)
+
+
 # --- registry-backed integration: the real gate path ----------------------
 
 
@@ -315,6 +367,26 @@ def test_cli_gate_passes_when_declared(tmp_path, monkeypatch):
         "--fail-on-unmapped",
         "--fail-on-stale-pending",
     )
+    assert code == 0
+
+
+def test_cli_gate_passes_with_nested_github_actions_checkout(tmp_path, monkeypatch):
+    outer_checkout = tmp_path / "rulespec-uk"
+    nested_checkout, legal_id = _checkout_with_unmapped_output(outer_checkout)
+    _write(
+        nested_checkout / "oracle-coverage-pending.yaml",
+        f"version: 1\nentries:\n  - legal_id: {legal_id}\n    source: bulk\n    since: 2026-07-07\n",
+    )
+
+    code = _run_cli(
+        monkeypatch,
+        "oracle-coverage",
+        "--root",
+        str(outer_checkout),
+        "--fail-on-unmapped",
+        "--fail-on-stale-pending",
+    )
+
     assert code == 0
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1225"
+version = "0.2.1226"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- load `oracle-coverage-pending.yaml` from the exact same-name nested checkout used by GitHub Actions
- preserve the canonical-root trust boundary, reject symlinks, and reject ambiguous direct+nested declarations
- add loader, security-boundary, and real CLI gate regressions

## Bug
RuleSpec CI passes the outer Actions checkout root (for example `/home/runner/work/rulespec-us`) while the repository is nested at `/home/runner/work/rulespec-us/rulespec-us`. The coverage report found the nested RuleSpec outputs, but pending discovery only checked the outer directory, so declared pending outputs were incorrectly reported as unmapped.

## Checks
- `uv run --python 3.13 pytest -q tests/test_oracle_coverage_pending.py` (26 passed)
- `uv run --python 3.13 pytest` (3847 passed, 104 skipped; before the final three focused symlink cases, which pass above)
- `uv run --python 3.13 ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- exact nested Missouri CI-layout simulation: 27/27 outputs reclassified as `pending_classification`, 0 unmapped

## Review cycle
Independent review found missing direct coverage for the new symlink rejection branches. Added nested-checkout and direct/nested pending-file symlink tests, reran focused checks, and repeated independent review. Second review found no remaining actionable findings.