### PR TITLE
Bump the axiom-oracles pin for the Texas SNAP QC registry entries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1227"
+version = "0.2.1228"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@f2d2df36deb9c96b9fac4af15eab69c11d899e51",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@a1a22f1feb063517497f9c3910021f17aa5e5606",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1227"
+__version__ = "0.2.1228"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1227"
+version = "0.2.1228"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -100,7 +100,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=f2d2df36deb9c96b9fac4af15eab69c11d899e51" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=a1a22f1feb063517497f9c3910021f17aa5e5606" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -123,7 +123,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=f2d2df36deb9c96b9fac4af15eab69c11d899e51#f2d2df36deb9c96b9fac4af15eab69c11d899e51" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=a1a22f1feb063517497f9c3910021f17aa5e5606#a1a22f1feb063517497f9c3910021f17aa5e5606" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
Pulls TheAxiomFoundation/axiom-oracles#279 — the PolicyEngine coverage registry entries for the thirteen Texas SNAP surfaces, which the changed-file oracle-coverage classifier needs to classify TheAxiomFoundation/rulespec-us#891 (the Texas encodings, gate-approved by Sol + Fable on frozen refs; verdict table on that PR).

Fast-forward pin f2d2df36 → a1a22f1f (37 commits: the TX suite, the us-pe conformance scoreboard regen #280, routine affected-rerun data refreshes, and two previously-merged suite additions). Version triple bumped in the same commit (0.2.1227 → 0.2.1228: pyproject, __init__, uv.lock) per the apply gate — same shape as #1128/#1129.

No fixture syncs needed: the TX registry entries are additive (no moved ids); `grep -rln us-tx tests/` hits only pre-existing TANF/Medicaid references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)