### PR TITLE
Bump the axiom-oracles pin for the CTR reg-layer mapping sweep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1228"
+version = "0.2.1229"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@a1a22f1feb063517497f9c3910021f17aa5e5606",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@9901e2479ac39bba865b8232e1c7d879ba447d8d",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1228"
+__version__ = "0.2.1229"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1228"
+version = "0.2.1229"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -100,7 +100,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=a1a22f1feb063517497f9c3910021f17aa5e5606" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=9901e2479ac39bba865b8232e1c7d879ba447d8d" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -123,7 +123,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=a1a22f1feb063517497f9c3910021f17aa5e5606#a1a22f1feb063517497f9c3910021f17aa5e5606" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=9901e2479ac39bba865b8232e1c7d879ba447d8d#9901e2479ac39bba865b8232e1c7d879ba447d8d" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## What

Bumps the git-pinned `axiom-oracles` dependency (`pyproject.toml` + `uv.lock`) from `a1a22f1` to `9901e24` and the axiom-encode patch version `0.2.1228 → 0.2.1229`, mirroring the pin-bump precedent (#1128 / #1129 / #1133).

The new axiom-oracles commit `9901e24` is TheAxiomFoundation/axiom-oracles#278 (the CTR mapping sweep) rebased onto the current axiom-oracles `main`, so it is a **superset**: `a1a22f1` (Texas SNAP QC replay suite, #279 — the pin currently on encode `main`) **plus** the incoming Council Tax Reduction mappings — four `not_comparable` prefixes for the CTR-ENP / CTR-SC / CTR-WA regulation-layer spines (`uk:regulations/{uksi/2012/2885, ssi/2021/249, ssi/2012/319, wsi/2013/3029}/`) plus the refreshed Kingston rationales. No Texas regression.

## Why (propagation mechanism)

The org shared workflow `TheAxiomFoundation/.github/.github/workflows/validate-rulespec.yml` runs the changed-file oracle-coverage classifier from an axiom-encode checkout and, in its install step, **force-reinstalls the `axiom-oracles @ git+...` spec declared in this `pyproject.toml`**:

> axiom-oracles is a git dependency whose version string does not change per commit, so pip treats the pinned SHA as "already satisfied" and keeps the stale copy — the classifier then reports freshly-added not_comparable mappings as unmapped. Force-reinstall the axiom-oracles pin declared by this checkout so the classifier reads its bridge mappings.

So the classifier reads the axiom-oracles mappings **at the SHA pinned here**. Without this bump it reads the pre-CTR pin (`a1a22f1`) and would classify the incoming CTR reg-layer outputs as `unmapped` instead of `not_comparable`. The `--force-reinstall --no-deps` in the shared workflow is what makes the new SHA take effect despite the unchanged `axiom-oracles==0.2.1` version string.

## Sequencing

- **Depends on axiom-oracles#278 — merge only after it lands.**
- The pin currently points at the #278 branch tip (`9901e24`, reachable via `refs/heads/fix/uk-ctr-mapping-sweep` and `refs/pull/278/head`, so the git dep resolves). Before merging this PR, **re-point the SHA (both `pyproject.toml` and the two `uv.lock` occurrences) to #278's squash-merge commit on axiom-oracles `main`**, so the pin sits on a main-reachable commit.
- If another encode PR bumps the version first, re-bump past it (currently `0.2.1229`).

## Tests

Dependency-pin bump only (no source change), matching #1129 / #1133. No towncrier fragment (pin bumps don't add one).

Left open for review — no merge.
