### PR TITLE
Restore pending ledger sync on latest oracle classifier

### DIFF
--- a/changelog.d/pending-exact-checkout-sync.added.md
+++ b/changelog.d/pending-exact-checkout-sync.added.md
@@ -1,0 +1,1 @@
+Restore atomic oracle pending-ledger synchronization for explicitly authorized canonical RuleSpec checkouts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1236"
+version = "0.2.1237"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1232"
+version = "0.2.1233"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1235"
+version = "0.2.1236"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1230"
+version = "0.2.1231"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1231"
+version = "0.2.1232"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1233"
+version = "0.2.1234"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1234"
+version = "0.2.1235"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1229"
+version = "0.2.1230"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1235"
+__version__ = "0.2.1236"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1233"
+__version__ = "0.2.1234"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1234"
+__version__ = "0.2.1235"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1231"
+__version__ = "0.2.1232"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1236"
+__version__ = "0.2.1237"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1232"
+__version__ = "0.2.1233"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1229"
+__version__ = "0.2.1230"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1230"
+__version__ = "0.2.1231"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5160,10 +5160,16 @@ def cmd_oracle_coverage_pending(args):
     root = _resolve_canonical_rulespec_checkout(args.root)
     if args.pending_command == "sync":
         report = build_policyengine_coverage_report(root)
+        authorized_prefixes = tuple(
+            f"{jurisdiction}/"
+            for jurisdiction in sorted(jurisdiction_subdir_names(root))
+        )
+
         unmapped = [
             item["legal_id"]
             for item in report.get("items") or []
-            if item.get("status") == "unmapped" and item.get("repo") == root.name
+            if item.get("status") == "unmapped"
+            and str(item.get("file") or "").startswith(authorized_prefixes)
         ]
         try:
             result = sync_repo_pending(

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5160,16 +5160,14 @@ def cmd_oracle_coverage_pending(args):
     root = _resolve_canonical_rulespec_checkout(args.root)
     if args.pending_command == "sync":
         report = build_policyengine_coverage_report(root)
-        coverage_checkout = root
-        display_prefix = ""
         nested_checkout = root / root.name
-        if nested_checkout.is_dir() and is_policy_repo_root(nested_checkout):
-            coverage_checkout = nested_checkout
-            display_prefix = f"{root.name}/"
-        authorized_prefixes = tuple(
-            f"{display_prefix}{jurisdiction}/"
-            for jurisdiction in sorted(jurisdiction_subdir_names(coverage_checkout))
-        )
+        if nested_checkout.is_dir() and not nested_checkout.is_symlink():
+            authorized_prefixes = (f"{root.name}/",)
+        else:
+            authorized_prefixes = tuple(
+                f"{jurisdiction}/"
+                for jurisdiction in sorted(jurisdiction_subdir_names(root))
+            )
 
         unmapped = [
             item["legal_id"]

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -4843,7 +4843,7 @@ def cmd_oracle_coverage(args):
         print(f"Unsupported oracle: {args.oracle}")
         sys.exit(2)
 
-    root = _resolve_canonical_rulespec_checkout(args.root)
+    root = _resolve_composition_rulespec_checkout(args.root)
     include_program_surfaces = getattr(args, "include_program_surfaces", False) is True
     fail_on_pending_program_surfaces = (
         getattr(args, "fail_on_pending_program_surfaces", False) is True
@@ -5197,7 +5197,7 @@ def _pending_sync_authorized_prefixes(root: Path) -> tuple[str, ...]:
     return tuple(prefixes)
 
 
-def _resolve_pending_checkout(raw_path: Path) -> Path:
+def _resolve_composition_rulespec_checkout(raw_path: Path) -> Path:
     """Resolve an exact country checkout while admitting top-level ProgramSpecs."""
 
     checkout = _resolve_explicit_existing_directory(
@@ -5214,7 +5214,7 @@ def _resolve_pending_checkout(raw_path: Path) -> Path:
 
 def cmd_oracle_coverage_pending(args):
     """Check or synchronize one exact checkout's declared-pending ratchet."""
-    root = _resolve_pending_checkout(args.root)
+    root = _resolve_composition_rulespec_checkout(args.root)
     if args.pending_command == "sync":
         report = build_policyengine_coverage_report(root)
         authorized_prefixes = _pending_sync_authorized_prefixes(root)

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -109,6 +109,7 @@ from .concepts.jurisdiction import jurisdiction_prefix as _repo_jurisdiction_pre
 from .constants import (
     DEFAULT_OPENAI_MODEL,
     RULESPEC_ATOMIC_MODULE_ROOTS,
+    RULESPEC_COMPOSITION_SPEC_ROOT,
     RULESPEC_FILE_SUFFIX,
     RULESPEC_FILESYSTEM_ROOTS,
     RULESPEC_TEST_FILE_SUFFIX,
@@ -5155,19 +5156,43 @@ def cmd_cloud_queue(args):
     sys.exit(0)
 
 
+def _pending_sync_authorized_prefixes(root: Path) -> tuple[str, ...]:
+    """Return report path prefixes authorized to enter one pending ledger."""
+
+    nested_checkout = root / root.name
+    if nested_checkout.is_dir() and not nested_checkout.is_symlink():
+        content_checkout = nested_checkout
+        display_prefix = f"{root.name}/"
+        country = root.name.removeprefix("rulespec-")
+        jurisdictions = sorted(
+            child.name
+            for child in content_checkout.iterdir()
+            if child.is_dir()
+            and not child.is_symlink()
+            and re.fullmatch(rf"{re.escape(country)}(?:-[a-z0-9]+)*", child.name)
+        )
+    else:
+        content_checkout = root
+        display_prefix = ""
+        jurisdictions = sorted(jurisdiction_subdir_names(root))
+
+    prefixes = [
+        f"{display_prefix}{jurisdiction}/{module_root}/"
+        for jurisdiction in jurisdictions
+        for module_root in sorted(RULESPEC_ATOMIC_MODULE_ROOTS)
+    ]
+    programs_dir = content_checkout / RULESPEC_COMPOSITION_SPEC_ROOT
+    if programs_dir.is_dir() and not programs_dir.is_symlink():
+        prefixes.append(f"{display_prefix}{RULESPEC_COMPOSITION_SPEC_ROOT}/")
+    return tuple(prefixes)
+
+
 def cmd_oracle_coverage_pending(args):
     """Check or synchronize one exact checkout's declared-pending ratchet."""
     root = _resolve_canonical_rulespec_checkout(args.root)
     if args.pending_command == "sync":
         report = build_policyengine_coverage_report(root)
-        nested_checkout = root / root.name
-        if nested_checkout.is_dir() and not nested_checkout.is_symlink():
-            authorized_prefixes = (f"{root.name}/",)
-        else:
-            authorized_prefixes = tuple(
-                f"{jurisdiction}/"
-                for jurisdiction in sorted(jurisdiction_subdir_names(root))
-            )
+        authorized_prefixes = _pending_sync_authorized_prefixes(root)
 
         unmapped = [
             item["legal_id"]

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5163,7 +5163,7 @@ def cmd_oracle_coverage_pending(args):
         unmapped = [
             item["legal_id"]
             for item in report.get("items") or []
-            if item.get("status") == "unmapped"
+            if item.get("status") == "unmapped" and item.get("repo") == root.name
         ]
         try:
             result = sync_repo_pending(

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5160,9 +5160,15 @@ def cmd_oracle_coverage_pending(args):
     root = _resolve_canonical_rulespec_checkout(args.root)
     if args.pending_command == "sync":
         report = build_policyengine_coverage_report(root)
+        coverage_checkout = root
+        display_prefix = ""
+        nested_checkout = root / root.name
+        if nested_checkout.is_dir() and is_policy_repo_root(nested_checkout):
+            coverage_checkout = nested_checkout
+            display_prefix = f"{root.name}/"
         authorized_prefixes = tuple(
-            f"{jurisdiction}/"
-            for jurisdiction in sorted(jurisdiction_subdir_names(root))
+            f"{display_prefix}{jurisdiction}/"
+            for jurisdiction in sorted(jurisdiction_subdir_names(coverage_checkout))
         )
 
         unmapped = [

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -241,6 +241,7 @@ from .repo_routing import (
     canonical_rulespec_repo_name,
     canonical_rulespec_root_identity,
     find_policy_repo_root,
+    is_composition_policy_repo_root,
     is_policy_repo_root,
     jurisdiction_content_dir,
     jurisdiction_subdir_names,
@@ -5174,7 +5175,10 @@ def _pending_sync_authorized_prefixes(root: Path) -> tuple[str, ...]:
     else:
         content_checkout = root
         display_prefix = ""
-        jurisdictions = sorted(jurisdiction_subdir_names(root))
+        country = root.name.removeprefix("rulespec-")
+        jurisdictions = sorted(
+            jurisdiction_subdir_names(root, allow_composition_specs=True)
+        )
 
     prefixes = [
         f"{display_prefix}{jurisdiction}/{module_root}/"
@@ -5183,13 +5187,34 @@ def _pending_sync_authorized_prefixes(root: Path) -> tuple[str, ...]:
     ]
     programs_dir = content_checkout / RULESPEC_COMPOSITION_SPEC_ROOT
     if programs_dir.is_dir() and not programs_dir.is_symlink():
-        prefixes.append(f"{display_prefix}{RULESPEC_COMPOSITION_SPEC_ROOT}/")
+        prefixes.extend(
+            f"{display_prefix}{RULESPEC_COMPOSITION_SPEC_ROOT}/{child.name}/"
+            for child in sorted(programs_dir.iterdir())
+            if child.is_dir()
+            and not child.is_symlink()
+            and re.fullmatch(rf"{re.escape(country)}(?:-[a-z0-9]+)*", child.name)
+        )
     return tuple(prefixes)
+
+
+def _resolve_pending_checkout(raw_path: Path) -> Path:
+    """Resolve an exact country checkout while admitting top-level ProgramSpecs."""
+
+    checkout = _resolve_explicit_existing_directory(
+        raw_path,
+        label="RuleSpec checkout",
+    )
+    if not is_composition_policy_repo_root(checkout):
+        raise ValueError(
+            "RuleSpec checkout must be the exact canonical rulespec-<country> "
+            f"checkout; got {checkout}"
+        )
+    return checkout
 
 
 def cmd_oracle_coverage_pending(args):
     """Check or synchronize one exact checkout's declared-pending ratchet."""
-    root = _resolve_canonical_rulespec_checkout(args.root)
+    root = _resolve_pending_checkout(args.root)
     if args.pending_command == "sync":
         report = build_policyengine_coverage_report(root)
         authorized_prefixes = _pending_sync_authorized_prefixes(root)
@@ -5198,6 +5223,8 @@ def cmd_oracle_coverage_pending(args):
             item["legal_id"]
             for item in report.get("items") or []
             if item.get("status") == "unmapped"
+            and str(item.get("legal_id") or "").partition(":")[0].split("-", 1)[0]
+            == root.name.removeprefix("rulespec-")
             and str(item.get("file") or "").startswith(authorized_prefixes)
         ]
         try:

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -233,6 +233,7 @@ from .oracles.policyengine.pending import (
     load_pending_declarations,
     load_pending_files,
     ratchet_problems,
+    sync_repo_pending,
 )
 from .oracles.policyengine.snap_readiness import build_snap_readiness_report
 from .repo_routing import (
@@ -1167,7 +1168,7 @@ def main():
         "--json", action="store_true", help="Output as JSON"
     )
 
-    # oracle-coverage-pending command — read-only declared-pending ratchet
+    # oracle-coverage-pending command — declared-pending ratchet
     pending_parser = subparsers.add_parser(
         "oracle-coverage-pending",
         help=(
@@ -1197,6 +1198,35 @@ def main():
     )
     pending_check.add_argument(
         "--json", action="store_true", help="Output the pending summary as JSON"
+    )
+
+    pending_sync = pending_sub.add_parser(
+        "sync",
+        help=(
+            "Atomically rewrite one exact checkout's declaration to its current "
+            "unmapped outputs."
+        ),
+    )
+    pending_sync.add_argument(
+        "--root",
+        type=Path,
+        required=True,
+        help="Exact canonical rulespec-<country> checkout",
+    )
+    pending_sync.add_argument(
+        "--source",
+        default="bulk",
+        help="Source label for newly declared outputs (default: bulk)",
+    )
+    pending_sync.add_argument(
+        "--since",
+        default=None,
+        help="ISO date for newly declared outputs (default: today)",
+    )
+    pending_sync.add_argument(
+        "--issue",
+        default=None,
+        help="Optional tracking issue URL to retain in the declaration",
     )
 
     # classify command — emit us.yaml mapping entries for a state's encoded outputs
@@ -5126,8 +5156,34 @@ def cmd_cloud_queue(args):
 
 
 def cmd_oracle_coverage_pending(args):
-    """Check one checkout's declared-pending ratchet without mutating it."""
+    """Check or synchronize one exact checkout's declared-pending ratchet."""
     root = _resolve_canonical_rulespec_checkout(args.root)
+    if args.pending_command == "sync":
+        report = build_policyengine_coverage_report(root)
+        unmapped = [
+            item["legal_id"]
+            for item in report.get("items") or []
+            if item.get("status") == "unmapped"
+        ]
+        try:
+            result = sync_repo_pending(
+                repo_root=root,
+                unmapped_legal_ids=unmapped,
+                source=args.source,
+                since=args.since or date.today().isoformat(),
+                issue=args.issue,
+            )
+        except PendingDeclarationError as error:
+            print(f"oracle-coverage-pending error: {error}", file=sys.stderr)
+            sys.exit(2)
+        verb = "Updated" if result["changed"] else "Unchanged"
+        print(
+            f"{verb} {result['path']}: {result['count']} declared "
+            f"(+{len(result['added'])} added, "
+            f"-{len(result['dropped'])} drained)."
+        )
+        sys.exit(0)
+
     report = build_policyengine_coverage_report(root, program=args.program)
     try:
         files = load_pending_files(root)

--- a/src/axiom_encode/oracles/policyengine/pending.py
+++ b/src/axiom_encode/oracles/policyengine/pending.py
@@ -27,6 +27,9 @@ bridge produced without any axiom-oracles change.
 from __future__ import annotations
 
 import datetime as _dt
+import os
+import stat
+import tempfile
 from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
@@ -359,3 +362,131 @@ def ratchet_problems(
                 f"ceiling {pending_file.ceiling}"
             )
     return problems
+
+
+def _dump_pending_file(
+    *,
+    entries: list[PendingEntry],
+    ceiling: int,
+    issue: str | None,
+) -> str:
+    header = [
+        "# Declared oracle-coverage debt: executable RuleSpec outputs awaiting",
+        "# classification in axiom-oracles PolicyEngine mappings. The",
+        "# oracle-coverage gate treats these as pending_classification (visible,",
+        "# counted, accountable) instead of silently unmapped. Ratchets both",
+        "# ways: a new unmapped output must be declared here or the gate fails;",
+        "# an entry that is no longer unmapped must be removed.",
+        "# Maintained by: axiom-encode oracle-coverage-pending sync.",
+    ]
+    payload: dict[str, Any] = {"version": 1}
+    if issue:
+        payload["issue"] = issue
+    payload["ceiling"] = ceiling
+    payload["entries"] = [
+        entry.as_dict() for entry in sorted(entries, key=lambda item: item.legal_id)
+    ]
+    body = yaml.safe_dump(payload, sort_keys=False, allow_unicode=False)
+    return "\n".join(header) + "\n" + body
+
+
+def _pending_sync_path(root: Path) -> Path:
+    """Return the one authorized declaration path beneath an exact checkout."""
+    existing = iter_pending_file_paths(root)
+    if existing:
+        return existing[0]
+    checkout = Path(root).resolve(strict=True)
+    nested_checkout = checkout / checkout.name
+    if nested_checkout.is_dir() and is_policy_repo_root(nested_checkout):
+        return nested_checkout / PENDING_FILENAME
+    return checkout / PENDING_FILENAME
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Replace ``path`` atomically so an interrupted sync keeps a valid file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    mode = stat.S_IMODE(path.stat().st_mode) if path.is_file() else 0o644
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as stream:
+            stream.write(text)
+            stream.flush()
+            os.fchmod(stream.fileno(), mode)
+            os.fsync(stream.fileno())
+        os.replace(temporary_path, path)
+        directory_descriptor = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_descriptor)
+        finally:
+            os.close(directory_descriptor)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def sync_repo_pending(
+    *,
+    repo_root: Path,
+    unmapped_legal_ids: list[str],
+    source: str,
+    since: str,
+    issue: str | None = None,
+) -> dict[str, Any]:
+    """Atomically rewrite one exact checkout's pending declaration.
+
+    Existing entries retain their provenance while still unmapped. Newly
+    unmapped outputs receive ``source`` and ``since``; classified or removed
+    outputs are drained. The ceiling is reset to the resulting entry count.
+    """
+    root = Path(repo_root)
+    if not is_policy_repo_root(root):
+        raise PendingDeclarationError(
+            "Pending sync requires the exact canonical "
+            f"rulespec-<country> checkout: {root}"
+        )
+    if source not in _ALLOWED_SOURCES:
+        raise PendingDeclarationError(
+            f"source {source!r} must be one of {sorted(_ALLOWED_SOURCES)}"
+        )
+    since = _coerce_date(since, where="sync")
+    path = _pending_sync_path(root)
+    existing_by_id: dict[str, PendingEntry] = {}
+    if path.is_file():
+        existing = load_pending_file(path, repo=path.parent.name)
+        existing_by_id = {entry.legal_id: entry for entry in existing.entries}
+        issue = issue if issue is not None else existing.issue
+
+    wanted = sorted(set(unmapped_legal_ids))
+    entries: list[PendingEntry] = []
+    added: list[str] = []
+    for legal_id in wanted:
+        prior = existing_by_id.get(legal_id)
+        if prior is not None:
+            entries.append(prior)
+            continue
+        entries.append(
+            PendingEntry(
+                legal_id=legal_id,
+                source=source,
+                since=since,
+                note=None,
+                repo=path.parent.name,
+                file=str(path),
+            )
+        )
+        added.append(legal_id)
+    dropped = sorted(set(existing_by_id) - set(wanted))
+
+    text = _dump_pending_file(entries=entries, ceiling=len(entries), issue=issue)
+    changed = not path.is_file() or path.read_text(encoding="utf-8") != text
+    if changed:
+        _atomic_write_text(path, text)
+    return {
+        "path": str(path),
+        "count": len(entries),
+        "added": added,
+        "dropped": dropped,
+        "changed": changed,
+    }

--- a/src/axiom_encode/oracles/policyengine/pending.py
+++ b/src/axiom_encode/oracles/policyengine/pending.py
@@ -397,7 +397,11 @@ def _pending_sync_path(root: Path) -> Path:
         return existing[0]
     checkout = Path(root).resolve(strict=True)
     nested_checkout = checkout / checkout.name
-    if nested_checkout.is_dir() and is_policy_repo_root(nested_checkout):
+    if nested_checkout.is_symlink():
+        raise PendingDeclarationError(
+            f"Pending sync nested checkout must not be a symlink: {nested_checkout}"
+        )
+    if nested_checkout.is_dir():
         return nested_checkout / PENDING_FILENAME
     return checkout / PENDING_FILENAME
 

--- a/src/axiom_encode/oracles/policyengine/pending.py
+++ b/src/axiom_encode/oracles/policyengine/pending.py
@@ -37,7 +37,7 @@ from typing import Any
 
 import yaml
 
-from ...repo_routing import is_policy_repo_root
+from ...repo_routing import is_composition_policy_repo_root
 
 PENDING_FILENAME = "oracle-coverage-pending.yaml"
 # Report status assigned to a declared output. Distinct from ``unmapped`` so
@@ -201,7 +201,7 @@ def iter_pending_file_paths(root: Path) -> list[Path]:
     """
 
     raw_root = Path(root).expanduser()
-    if not is_policy_repo_root(raw_root):
+    if not is_composition_policy_repo_root(raw_root):
         raise PendingDeclarationError(
             "Pending declarations require the exact canonical "
             f"rulespec-<country> checkout: {raw_root}"
@@ -445,7 +445,7 @@ def sync_repo_pending(
     outputs are drained. The ceiling is reset to the resulting entry count.
     """
     root = Path(repo_root)
-    if not is_policy_repo_root(root):
+    if not is_composition_policy_repo_root(root):
         raise PendingDeclarationError(
             "Pending sync requires the exact canonical "
             f"rulespec-<country> checkout: {root}"

--- a/src/axiom_encode/repo_routing.py
+++ b/src/axiom_encode/repo_routing.py
@@ -88,6 +88,11 @@ def _canonical_country_checkout_name(
         return None
     blocked_roots = RULESPEC_FILESYSTEM_ROOTS
     if allow_composition_specs:
+        composition_root = checkout / RULESPEC_COMPOSITION_SPEC_ROOT
+        if (composition_root.exists() or composition_root.is_symlink()) and (
+            composition_root.is_symlink() or not composition_root.is_dir()
+        ):
+            return None
         blocked_roots = blocked_roots - {RULESPEC_COMPOSITION_SPEC_ROOT}
     if any(
         (checkout / root_name).exists() or (checkout / root_name).is_symlink()

--- a/src/axiom_encode/repo_routing.py
+++ b/src/axiom_encode/repo_routing.py
@@ -21,7 +21,7 @@ import sys
 from collections.abc import Iterable
 from pathlib import Path
 
-from .constants import RULESPEC_FILESYSTEM_ROOTS
+from .constants import RULESPEC_COMPOSITION_SPEC_ROOT, RULESPEC_FILESYSTEM_ROOTS
 
 
 class _GitProbeError(RuntimeError):
@@ -67,7 +67,11 @@ def _lexical_rulespec_path(path: Path) -> Path | None:
     return raw
 
 
-def _canonical_country_checkout_name(path: Path) -> str | None:
+def _canonical_country_checkout_name(
+    path: Path,
+    *,
+    allow_composition_specs: bool = False,
+) -> str | None:
     """Return the exact canonical country-checkout name for ``path``."""
 
     lexical = _lexical_rulespec_path(path)
@@ -82,9 +86,12 @@ def _canonical_country_checkout_name(path: Path) -> str | None:
     country = name.removeprefix("rulespec-")
     if re.fullmatch(r"[a-z]{2}", country) is None:
         return None
+    blocked_roots = RULESPEC_FILESYSTEM_ROOTS
+    if allow_composition_specs:
+        blocked_roots = blocked_roots - {RULESPEC_COMPOSITION_SPEC_ROOT}
     if any(
         (checkout / root_name).exists() or (checkout / root_name).is_symlink()
-        for root_name in RULESPEC_FILESYSTEM_ROOTS
+        for root_name in blocked_roots
     ):
         return None
     try:
@@ -144,6 +151,15 @@ def is_policy_repo_root(path: Path) -> bool:
     """Return True for an exact canonical country checkout root."""
 
     return _canonical_country_checkout_name(Path(path)) is not None
+
+
+def is_composition_policy_repo_root(path: Path) -> bool:
+    """Return True for an exact country checkout that may contain ProgramSpecs."""
+
+    return (
+        _canonical_country_checkout_name(Path(path), allow_composition_specs=True)
+        is not None
+    )
 
 
 def is_jurisdiction_content_root(path: Path) -> bool:
@@ -227,14 +243,21 @@ def resolve_jurisdiction_content_dir(
     return None
 
 
-def jurisdiction_subdir_names(checkout: Path) -> set[str]:
+def jurisdiction_subdir_names(
+    checkout: Path,
+    *,
+    allow_composition_specs: bool = False,
+) -> set[str]:
     """Return direct jurisdiction children of one canonical country checkout."""
 
     lexical = _lexical_rulespec_path(checkout)
     if lexical is None:
         return set()
     checkout = lexical.resolve()
-    checkout_name = _canonical_country_checkout_name(checkout)
+    checkout_name = _canonical_country_checkout_name(
+        checkout,
+        allow_composition_specs=allow_composition_specs,
+    )
     if checkout_name is None or not checkout.is_dir():
         return set()
     country = checkout_name.removeprefix("rulespec-")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4524,7 +4524,7 @@ class TestCmdValidate:
 
     def test_oracle_coverage_fail_on_unmapped_exits_nonzero(self, capsys, tmp_path):
         checkout = tmp_path / "rulespec-us"
-        checkout.mkdir(exist_ok=True)
+        (checkout / "programs/us/snap").mkdir(parents=True)
         args = MagicMock()
         args.root = checkout
         args.oracle = "policyengine"

--- a/tests/test_oracle_coverage_pending.py
+++ b/tests/test_oracle_coverage_pending.py
@@ -483,8 +483,29 @@ rules:
 
 
 def test_cli_pending_sync_targets_nested_actions_checkout(tmp_path, monkeypatch):
-    outer_checkout = tmp_path / "rulespec-uk"
-    nested_checkout, legal_id = _checkout_with_unmapped_output(outer_checkout)
+    outer_checkout = tmp_path / "rulespec-us"
+    nested_checkout = outer_checkout / "rulespec-us"
+    state_legal_id = "us-hi:statutes/235-54#individual_personal_exemption_deduction"
+    program_legal_id = "us-zz:programs/example/fy-2099#brand_new_program_output_xyz"
+    _write(
+        nested_checkout / "us-hi" / "statutes/235-54.yaml",
+        """format: rulespec/v1
+rules:
+  - name: individual_personal_exemption_deduction
+    kind: derived
+    versions:
+      - effective_from: '2025-01-01'
+        formula: some_input
+""",
+    )
+    _write(
+        nested_checkout / "programs/us-zz/example/fy-2099.yaml",
+        """program: us-zz/example
+period: 2099
+outputs:
+  - brand_new_program_output_xyz
+""",
+    )
 
     code = _run_cli(
         monkeypatch,
@@ -499,7 +520,10 @@ def test_cli_pending_sync_targets_nested_actions_checkout(tmp_path, monkeypatch)
     assert code == 0
     pending = load_pending_files(outer_checkout)[0]
     assert pending.path.parent == nested_checkout
-    assert [entry.legal_id for entry in pending.entries] == [legal_id]
+    assert [entry.legal_id for entry in pending.entries] == [
+        state_legal_id,
+        program_legal_id,
+    ]
 
 
 def test_pending_sync_preserves_provenance_and_drains_fixed_entries(tmp_path):

--- a/tests/test_oracle_coverage_pending.py
+++ b/tests/test_oracle_coverage_pending.py
@@ -452,6 +452,36 @@ rules:
     assert foreign_id not in declared
 
 
+def test_cli_pending_sync_includes_country_monorepo_state_output(tmp_path, monkeypatch):
+    checkout = tmp_path / "rulespec-us"
+    legal_id = "us-hi:statutes/235-54#individual_personal_exemption_deduction"
+    _write(
+        checkout / "us-hi" / "statutes/235-54.yaml",
+        """format: rulespec/v1
+rules:
+  - name: individual_personal_exemption_deduction
+    kind: derived
+    versions:
+      - effective_from: '2025-01-01'
+        formula: some_input
+""",
+    )
+
+    code = _run_cli(
+        monkeypatch,
+        "oracle-coverage-pending",
+        "sync",
+        "--root",
+        str(checkout),
+        "--source",
+        "bulk",
+    )
+
+    assert code == 0
+    declared = [entry.legal_id for entry in load_pending_files(checkout)[0].entries]
+    assert declared == [legal_id]
+
+
 def test_pending_sync_preserves_provenance_and_drains_fixed_entries(tmp_path):
     checkout = tmp_path / "rulespec-uk"
     checkout.mkdir()

--- a/tests/test_oracle_coverage_pending.py
+++ b/tests/test_oracle_coverage_pending.py
@@ -487,6 +487,7 @@ def test_cli_pending_sync_targets_nested_actions_checkout(tmp_path, monkeypatch)
     nested_checkout = outer_checkout / "rulespec-us"
     state_legal_id = "us-hi:statutes/235-54#individual_personal_exemption_deduction"
     program_legal_id = "us-zz:programs/example/fy-2099#brand_new_program_output_xyz"
+    foreign_legal_id = "us:foreign/statutes/y#foreign_output_xyz"
     _write(
         nested_checkout / "us-hi" / "statutes/235-54.yaml",
         """format: rulespec/v1
@@ -504,6 +505,17 @@ rules:
 period: 2099
 outputs:
   - brand_new_program_output_xyz
+""",
+    )
+    _write(
+        nested_checkout / "foreign/statutes/y.yaml",
+        """format: rulespec/v1
+rules:
+  - name: foreign_output_xyz
+    kind: derived
+    versions:
+      - effective_from: '2025-01-01'
+        formula: some_input
 """,
     )
 
@@ -524,6 +536,7 @@ outputs:
         state_legal_id,
         program_legal_id,
     ]
+    assert foreign_legal_id not in {entry.legal_id for entry in pending.entries}
 
 
 def test_pending_sync_preserves_provenance_and_drains_fixed_entries(tmp_path):

--- a/tests/test_oracle_coverage_pending.py
+++ b/tests/test_oracle_coverage_pending.py
@@ -487,6 +487,7 @@ def test_cli_pending_sync_targets_nested_actions_checkout(tmp_path, monkeypatch)
     nested_checkout = outer_checkout / "rulespec-us"
     state_legal_id = "us-hi:statutes/235-54#individual_personal_exemption_deduction"
     program_legal_id = "us-zz:programs/example/fy-2099#brand_new_program_output_xyz"
+    cross_country_program_id = "uk-zz:programs/example/fy-2099#cross_country_output_xyz"
     foreign_legal_id = "us:foreign/statutes/y#foreign_output_xyz"
     _write(
         nested_checkout / "us-hi" / "statutes/235-54.yaml",
@@ -518,6 +519,14 @@ rules:
         formula: some_input
 """,
     )
+    _write(
+        nested_checkout / "programs/uk-zz/example/fy-2099.yaml",
+        """program: uk-zz/example
+period: 2099
+outputs:
+  - cross_country_output_xyz
+""",
+    )
 
     code = _run_cli(
         monkeypatch,
@@ -537,6 +546,48 @@ rules:
         program_legal_id,
     ]
     assert foreign_legal_id not in {entry.legal_id for entry in pending.entries}
+    assert cross_country_program_id not in {entry.legal_id for entry in pending.entries}
+
+
+def test_cli_pending_sync_supports_direct_checkout_programs(tmp_path, monkeypatch):
+    checkout = tmp_path / "rulespec-us"
+    state_legal_id = "us-hi:statutes/235-54#direct_state_output_xyz"
+    program_legal_id = "us-hi:programs/snap/fy-2099#direct_program_output_xyz"
+    _write(
+        checkout / "us-hi/statutes/235-54.yaml",
+        """format: rulespec/v1
+rules:
+  - name: direct_state_output_xyz
+    kind: derived
+    versions:
+      - effective_from: '2025-01-01'
+        formula: some_input
+""",
+    )
+    _write(
+        checkout / "programs/us-hi/snap/fy-2099.yaml",
+        """program: us-hi/snap
+period: 2099
+outputs:
+  - direct_program_output_xyz
+""",
+    )
+
+    code = _run_cli(
+        monkeypatch,
+        "oracle-coverage-pending",
+        "sync",
+        "--root",
+        str(checkout),
+        "--source",
+        "bulk",
+    )
+
+    assert code == 0
+    assert [entry.legal_id for entry in load_pending_files(checkout)[0].entries] == [
+        program_legal_id,
+        state_legal_id,
+    ]
 
 
 def test_pending_sync_preserves_provenance_and_drains_fixed_entries(tmp_path):

--- a/tests/test_oracle_coverage_pending.py
+++ b/tests/test_oracle_coverage_pending.py
@@ -421,6 +421,37 @@ def test_cli_pending_sync_declares_unmapped_output_idempotently(tmp_path, monkey
     assert load_pending_files(checkout)[0] == pending
 
 
+def test_cli_pending_sync_excludes_nested_foreign_checkout(tmp_path, monkeypatch):
+    checkout, legal_id = _checkout_with_unmapped_output(tmp_path)
+    foreign_id = "us:statutes/9999/1#foreign_pending_output"
+    _write(
+        checkout / "rulespec-us" / "us/statutes/9999/1.yaml",
+        """format: rulespec/v1
+rules:
+  - name: foreign_pending_output
+    kind: derived
+    versions:
+      - effective_from: '2025-01-01'
+        formula: some_input
+""",
+    )
+
+    code = _run_cli(
+        monkeypatch,
+        "oracle-coverage-pending",
+        "sync",
+        "--root",
+        str(checkout),
+        "--source",
+        "bulk",
+    )
+
+    assert code == 0
+    declared = [entry.legal_id for entry in load_pending_files(checkout)[0].entries]
+    assert declared == [legal_id]
+    assert foreign_id not in declared
+
+
 def test_pending_sync_preserves_provenance_and_drains_fixed_entries(tmp_path):
     checkout = tmp_path / "rulespec-uk"
     checkout.mkdir()

--- a/tests/test_oracle_coverage_pending.py
+++ b/tests/test_oracle_coverage_pending.py
@@ -482,6 +482,26 @@ rules:
     assert declared == [legal_id]
 
 
+def test_cli_pending_sync_targets_nested_actions_checkout(tmp_path, monkeypatch):
+    outer_checkout = tmp_path / "rulespec-uk"
+    nested_checkout, legal_id = _checkout_with_unmapped_output(outer_checkout)
+
+    code = _run_cli(
+        monkeypatch,
+        "oracle-coverage-pending",
+        "sync",
+        "--root",
+        str(outer_checkout),
+        "--source",
+        "bulk",
+    )
+
+    assert code == 0
+    pending = load_pending_files(outer_checkout)[0]
+    assert pending.path.parent == nested_checkout
+    assert [entry.legal_id for entry in pending.entries] == [legal_id]
+
+
 def test_pending_sync_preserves_provenance_and_drains_fixed_entries(tmp_path):
     checkout = tmp_path / "rulespec-uk"
     checkout.mkdir()

--- a/tests/test_oracle_coverage_pending.py
+++ b/tests/test_oracle_coverage_pending.py
@@ -8,6 +8,7 @@ the oracle mappings nor the pending file still fails the gate.
 from __future__ import annotations
 
 import datetime
+import stat
 import sys
 from pathlib import Path
 
@@ -24,6 +25,7 @@ from axiom_encode.oracles.policyengine.pending import (
     load_pending_files,
     parse_pending_payload,
     ratchet_problems,
+    sync_repo_pending,
 )
 
 UNMAPPED = "uk:statutes/ukpga/9999/1/1#pending_test_only_output"
@@ -390,12 +392,102 @@ def test_cli_gate_passes_with_nested_github_actions_checkout(tmp_path, monkeypat
     assert code == 0
 
 
-def test_cli_has_no_pending_sync_mutation_command(tmp_path, monkeypatch):
+def test_cli_pending_sync_declares_unmapped_output_idempotently(tmp_path, monkeypatch):
+    checkout, legal_id = _checkout_with_unmapped_output(tmp_path)
     code = _run_cli(
         monkeypatch,
         "oracle-coverage-pending",
         "sync",
         "--root",
-        str(tmp_path / "rulespec-uk"),
+        str(checkout),
+        "--source",
+        "bulk",
     )
-    assert code == 2
+    assert code == 0
+    pending = load_pending_files(checkout)[0]
+    assert [entry.legal_id for entry in pending.entries] == [legal_id]
+    assert pending.ceiling == 1
+
+    code = _run_cli(
+        monkeypatch,
+        "oracle-coverage-pending",
+        "sync",
+        "--root",
+        str(checkout),
+        "--source",
+        "bulk",
+    )
+    assert code == 0
+    assert load_pending_files(checkout)[0] == pending
+
+
+def test_pending_sync_preserves_provenance_and_drains_fixed_entries(tmp_path):
+    checkout = tmp_path / "rulespec-uk"
+    checkout.mkdir()
+    first = sync_repo_pending(
+        repo_root=checkout,
+        unmapped_legal_ids=[UNMAPPED, OTHER_UNMAPPED],
+        source="manual",
+        since="2026-07-01",
+        issue="https://example.test/issues/1",
+    )
+    assert first["added"] == [UNMAPPED, OTHER_UNMAPPED]
+
+    second = sync_repo_pending(
+        repo_root=checkout,
+        unmapped_legal_ids=[UNMAPPED],
+        source="bulk",
+        since="2026-07-13",
+    )
+    assert second["dropped"] == [OTHER_UNMAPPED]
+    pending = load_pending_files(checkout)[0]
+    assert pending.ceiling == 1
+    assert pending.issue == "https://example.test/issues/1"
+    assert pending.entries[0].source == "manual"
+    assert pending.entries[0].since == "2026-07-01"
+
+
+def test_pending_sync_quotes_yaml_sensitive_metadata_and_preserves_mode(tmp_path):
+    checkout = tmp_path / "rulespec-uk"
+    checkout.mkdir()
+    path = checkout / "oracle-coverage-pending.yaml"
+    path.write_text(
+        "version: 1\n"
+        'issue: "tracking: issue"\n'
+        "ceiling: 1\n"
+        "entries:\n"
+        f"  - legal_id: {UNMAPPED}\n"
+        "    source: manual\n"
+        "    since: 2026-07-01\n"
+        '    note: "blocked: needs mapping #42"\n',
+        encoding="utf-8",
+    )
+    path.chmod(0o640)
+
+    sync_repo_pending(
+        repo_root=checkout,
+        unmapped_legal_ids=[UNMAPPED],
+        source="bulk",
+        since="2026-07-13",
+    )
+
+    pending = load_pending_files(checkout)[0]
+    assert pending.issue == "tracking: issue"
+    assert pending.entries[0].note == "blocked: needs mapping #42"
+    assert stat.S_IMODE(path.stat().st_mode) == 0o640
+
+
+def test_pending_sync_targets_nested_actions_checkout(tmp_path):
+    outer = tmp_path / "rulespec-uk"
+    nested = outer / "rulespec-uk"
+    nested.mkdir(parents=True)
+
+    result = sync_repo_pending(
+        repo_root=outer,
+        unmapped_legal_ids=[UNMAPPED],
+        source="bulk",
+        since="2026-07-13",
+    )
+
+    assert Path(result["path"]) == nested / "oracle-coverage-pending.yaml"
+    assert not (outer / "oracle-coverage-pending.yaml").exists()

--- a/tests/test_repo_routing.py
+++ b/tests/test_repo_routing.py
@@ -76,6 +76,16 @@ def test_composition_checkout_identity_admits_only_top_level_programs(tmp_path):
     assert is_composition_policy_repo_root(checkout) is False
 
 
+def test_composition_checkout_identity_rejects_symlinked_programs(tmp_path):
+    checkout = tmp_path / "rulespec-us"
+    _init_checkout(checkout, "https://github.com/TheAxiomFoundation/rulespec-us.git")
+    external_programs = tmp_path / "external-programs"
+    external_programs.mkdir()
+    (checkout / "programs").symlink_to(external_programs, target_is_directory=True)
+
+    assert is_composition_policy_repo_root(checkout) is False
+
+
 def test_canonical_rulespec_root_identity_is_stable_for_direct_content_root(tmp_path):
     checkout = tmp_path / "rulespec-us"
     _init_checkout(checkout, "https://github.com/TheAxiomFoundation/rulespec-us.git")

--- a/tests/test_repo_routing.py
+++ b/tests/test_repo_routing.py
@@ -25,6 +25,7 @@ from axiom_encode.repo_routing import (
     canonical_rulespec_repo_name,
     canonical_rulespec_root_identity,
     find_policy_repo_root,
+    is_composition_policy_repo_root,
     is_policy_repo_root,
     jurisdiction_subdir_names,
 )
@@ -60,6 +61,19 @@ def test_rulespec_filesystem_and_atomic_root_contracts_are_distinct():
     assert RULESPEC_FILESYSTEM_ROOTS == (
         RULESPEC_ATOMIC_MODULE_ROOTS | {RULESPEC_COMPOSITION_SPEC_ROOT}
     )
+
+
+def test_composition_checkout_identity_admits_only_top_level_programs(tmp_path):
+    checkout = tmp_path / "rulespec-us"
+    _init_checkout(checkout, "https://github.com/TheAxiomFoundation/rulespec-us.git")
+    (checkout / "programs/us/snap").mkdir(parents=True)
+
+    assert is_policy_repo_root(checkout) is False
+    assert is_composition_policy_repo_root(checkout) is True
+    assert jurisdiction_subdir_names(checkout, allow_composition_specs=True) == set()
+
+    (checkout / "statutes").mkdir()
+    assert is_composition_policy_repo_root(checkout) is False
 
 
 def test_canonical_rulespec_root_identity_is_stable_for_direct_content_root(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1232"
+version = "0.2.1233"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1231"
+version = "0.2.1232"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1233"
+version = "0.2.1234"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1230"
+version = "0.2.1231"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1236"
+version = "0.2.1237"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1234"
+version = "0.2.1235"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1235"
+version = "0.2.1236"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1229"
+version = "0.2.1230"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- restore atomic `oracle-coverage-pending sync` on the latest encoder/oracle classifier
- preserve existing pending-entry provenance while adding current unmapped outputs and draining resolved outputs
- support direct and nested country-monorepo checkouts with top-level ProgramSpecs
- restrict synchronization to canonical in-country atomic and ProgramSpec paths
- reject symlinked composition roots and use the same composition-aware resolver for the normal oracle-coverage release gate
- bump axiom-encode to `0.2.1237`

## Why
Bulk encoder runs need one immutable encoder build that classifies outputs and atomically persists the pending ledger against the same pinned oracle registry. The restored writer fails closed at the exact authorized checkout boundary and leaves pending debt visible to normal oracle-coverage gates.

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests` (pass)
- `uv run ruff format --check pyproject.toml src/axiom_encode scripts tests` (pass)
- `python -m compileall -q src/axiom_encode scripts` (pass)
- focused committed-head suite (64 passed)
- `uv run pytest` (3,863 passed, 106 skipped)
- GitHub CI: lint, Python 3.13, Ubuntu signing supervisor, and macOS signing supervisor all pass

## Review cycle
Independent review findings were fixed iteratively:
- excluded nested foreign RuleSpec checkouts and noncanonical module roots
- supported nested Actions checkouts without draining their ledgers
- limited ProgramSpecs by canonical directory and legal-ID country
- admitted direct ProgramSpec checkouts only in composition-aware reporting paths
- rejected symlinked `programs/` roots
- aligned normal `oracle-coverage` with the composition-aware pending resolver

A fresh independent review of `8a3ace0f` found no actionable defects. Its focused tests, lint, and compile checks passed. Two failures in its sandboxed full run were unrelated environment-sensitive setuid and macOS `/tmp` alias tests; both pass in the unrestricted local full suite and GitHub macOS CI.