### PR TITLE
Add deterministic ProgramSpec scope sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,12 +225,14 @@ That guard protects atomic RuleSpec YAML under `legislation/`, `policies/`,
 manifest whose signature, signed local release source identity, waiver-set
 identity, and applied-file hashes are valid. The fifth canonical filesystem
 root, `programs/`, contains declarative `axiom-compose` ProgramSpecs and is
-deliberately outside every encoder mutation, manifest, signing, validation,
-proof, waiver, import, concept, judge, and source-hash surface. ProgramSpecs are
-admitted only by their compose-and-Rust build gate. All YAML filenames use the
-canonical `.yaml` extension; `.yml` is rejected. Running the whole-repository
-guard also makes a toolchain-only release migration fail until every existing
-atomic manifest is regenerated against the new immutable release.
+deliberately outside every atomic RuleSpec encoding, manifest, signing,
+validation, proof, waiver, import, concept, judge, and source-hash surface.
+Program scope changes can be applied or checked deterministically with
+`program-scope-sync`; they are admitted only by their compose-and-Rust build
+gate. All YAML filenames use the canonical `.yaml` extension; `.yml` is
+rejected. Running the whole-repository guard also makes a toolchain-only release
+migration fail until every existing atomic manifest is regenerated against the
+new immutable release.
 
 ## Source pinning and staleness
 

--- a/changelog.d/program-scope-sync.added.md
+++ b/changelog.d/program-scope-sync.added.md
@@ -1,0 +1,1 @@
+Add `program-scope-sync` for deterministic, validated ProgramSpec scope updates.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1237"
+version = "0.2.1238"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1243"
+version = "0.2.1244"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1239"
+version = "0.2.1240"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1241"
+version = "0.2.1242"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1238"
+version = "0.2.1239"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1242"
+version = "0.2.1243"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1244"
+version = "0.2.1245"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1240"
+version = "0.2.1241"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1242"
+__version__ = "0.2.1243"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1240"
+__version__ = "0.2.1241"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1239"
+__version__ = "0.2.1240"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1241"
+__version__ = "0.2.1242"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1244"
+__version__ = "0.2.1245"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1237"
+__version__ = "0.2.1238"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1238"
+__version__ = "0.2.1239"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1243"
+__version__ = "0.2.1244"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -237,6 +237,7 @@ from .oracles.policyengine.pending import (
     sync_repo_pending,
 )
 from .oracles.policyengine.snap_readiness import build_snap_readiness_report
+from .program_scope import ProgramScopeError, sync_program_scope
 from .repo_routing import (
     canonical_rulespec_repo_name,
     canonical_rulespec_root_identity,
@@ -1565,6 +1566,48 @@ def main():
         help="Print the machine-readable pipeline stage DAG (renderer input)",
     )
 
+    program_scope_parser = subparsers.add_parser(
+        "program-scope-sync",
+        help="Deterministically update one axiom-compose ProgramSpec scope",
+    )
+    program_scope_parser.add_argument(
+        "--repo",
+        type=Path,
+        required=True,
+        help="Exact canonical rulespec-<country> checkout",
+    )
+    program_scope_parser.add_argument(
+        "--program-spec",
+        type=Path,
+        required=True,
+        help="ProgramSpec path, relative to --repo",
+    )
+    program_scope_parser.add_argument(
+        "--scope",
+        required=True,
+        help="Scope key to update, such as federal or state",
+    )
+    program_scope_parser.add_argument(
+        "--add",
+        action="append",
+        default=[],
+        help="Module path to add without jurisdiction prefix or .yaml (repeatable)",
+    )
+    program_scope_parser.add_argument(
+        "--remove",
+        action="append",
+        default=[],
+        help="Module path to remove without jurisdiction prefix or .yaml (repeatable)",
+    )
+    program_scope_parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Do not write; exit nonzero when the requested scope state differs",
+    )
+    program_scope_parser.add_argument(
+        "--json", action="store_true", help="Output the sync result as JSON"
+    )
+
     retire_parser = subparsers.add_parser(
         "retire",
         help=(
@@ -2264,6 +2307,8 @@ def main():
         cmd_runs(args)
     elif args.command == "concepts-audit":
         cmd_concepts_audit(args)
+    elif args.command == "program-scope-sync":
+        cmd_program_scope_sync(args)
     elif args.command == "retire":
         cmd_retire(args)
     elif args.command == "guard-generated":
@@ -4201,6 +4246,33 @@ def _rulespec_output_matches(actual: dict, expected) -> bool:
     if actual.get("kind") == "judgment":
         return actual.get("outcome") == expected
     return _rulespec_scalar_matches(actual.get("value") or {}, expected)
+
+
+def cmd_program_scope_sync(args):
+    """Apply or check one deterministic ProgramSpec scope update."""
+    if not args.add and not args.remove:
+        raise SystemExit("program-scope-sync requires at least one --add or --remove")
+    try:
+        result = sync_program_scope(
+            repo=args.repo,
+            program_spec=args.program_spec,
+            scope=args.scope,
+            add=args.add,
+            remove=args.remove,
+            write=not args.check,
+        )
+    except (OSError, ProgramScopeError) as exc:
+        raise SystemExit(f"program-scope-sync failed: {exc}") from exc
+    payload = asdict(result)
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        action = "would update" if args.check and result.changed else (
+            "updated" if result.changed else "unchanged"
+        )
+        print(f"{action}: {result.program_spec} scope={result.scope}")
+    if args.check and result.changed:
+        raise SystemExit(1)
 
 
 def cmd_compile(args):

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -4267,8 +4267,10 @@ def cmd_program_scope_sync(args):
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
-        action = "would update" if args.check and result.changed else (
-            "updated" if result.changed else "unchanged"
+        action = (
+            "would update"
+            if args.check and result.changed
+            else ("updated" if result.changed else "unchanged")
         )
         print(f"{action}: {result.program_spec} scope={result.scope}")
     if args.check and result.changed:

--- a/src/axiom_encode/program_scope.py
+++ b/src/axiom_encode/program_scope.py
@@ -138,9 +138,7 @@ def _updated_scope_text(
         item_lines[value] = node.start_mark.line
 
     first_item_line = min(item_lines.values())
-    removed_lines = {
-        line for value, line in item_lines.items() if value not in desired
-    }
+    removed_lines = {line for value, line in item_lines.items() if value not in desired}
     insertions: dict[int, list[str]] = {}
 
     if not desired:
@@ -270,13 +268,17 @@ def sync_program_scope(
             f"non-empty ProgramSpec scope {scope!r} must use a block-style sequence"
         )
     payload_scope = payload.get("scope")
-    payload_target = payload_scope.get(scope) if isinstance(payload_scope, dict) else None
+    payload_target = (
+        payload_scope.get(scope) if isinstance(payload_scope, dict) else None
+    )
     if not (
         isinstance(payload_target, list)
         and all(isinstance(item, str) for item in payload_target)
         and all(isinstance(item, ScalarNode) for item in target_node.value)
     ):
-        raise ProgramScopeError(f"ProgramSpec scope {scope!r} must contain only strings")
+        raise ProgramScopeError(
+            f"ProgramSpec scope {scope!r} must contain only strings"
+        )
 
     existing = tuple(_normalize_scope_path(item.value) for item in target_node.value)
     if len(set(existing)) != len(existing):
@@ -295,7 +297,9 @@ def sync_program_scope(
     try:
         scope_root.relative_to(repo)
     except ValueError as exc:
-        raise ProgramScopeError(f"scope prefix resolves outside --repo: {prefix}") from exc
+        raise ProgramScopeError(
+            f"scope prefix resolves outside --repo: {prefix}"
+        ) from exc
     if lexical_scope_root.is_symlink() or scope_root != lexical_scope_root.absolute():
         raise ProgramScopeError("scope root path must not contain symlinks")
     missing_modules: list[str] = []

--- a/src/axiom_encode/program_scope.py
+++ b/src/axiom_encode/program_scope.py
@@ -89,7 +89,7 @@ def _scope_prefix(program: str, scope: str) -> str:
     program_path = _normalize_scope_path(program)
     jurisdiction = program_path.split("/", 1)[0]
     if scope == "federal":
-        return "us"
+        return jurisdiction.split("-", 1)[0]
     if scope == "state":
         return jurisdiction
     return scope
@@ -252,6 +252,18 @@ def sync_program_scope(
     if any(_node_reference_count(root, node) > 1 for node in target_node.value):
         raise ProgramScopeError(
             f"ProgramSpec scope {scope!r} entries must not use YAML aliases"
+        )
+    if target_node.value and (
+        target_node.start_mark.line != target_node.value[0].start_mark.line
+    ):
+        raise ProgramScopeError(
+            f"ProgramSpec scope {scope!r} must not use an anchor or explicit tag"
+        )
+    if not target_node.value and text[
+        target_node.start_mark.index : target_node.end_mark.index
+    ].lstrip().startswith(("&", "!")):
+        raise ProgramScopeError(
+            f"ProgramSpec scope {scope!r} must not use an anchor or explicit tag"
         )
     if target_node.flow_style and target_node.value:
         raise ProgramScopeError(

--- a/src/axiom_encode/program_scope.py
+++ b/src/axiom_encode/program_scope.py
@@ -12,7 +12,7 @@ from pathlib import Path, PurePosixPath
 import yaml
 from yaml.nodes import MappingNode, ScalarNode, SequenceNode
 
-from .constants import RULESPEC_ATOMIC_MODULE_ROOTS
+from .constants import RULESPEC_ATOMIC_MODULE_ROOTS, RULESPEC_TEST_FILE_SUFFIX
 from .repo_routing import is_composition_policy_repo_root
 
 
@@ -74,6 +74,7 @@ def _normalize_scope_path(value: str) -> str:
         or path.is_absolute()
         or any(part in {"", ".", ".."} for part in path.parts)
         or path.suffix in {".yaml", ".yml"}
+        or f"{path.as_posix()}.yaml".endswith(RULESPEC_TEST_FILE_SUFFIX)
     ):
         raise ProgramScopeError(
             f"scope paths must be safe repo-relative module paths without a YAML suffix: {value!r}"

--- a/src/axiom_encode/program_scope.py
+++ b/src/axiom_encode/program_scope.py
@@ -71,6 +71,7 @@ def _normalize_scope_path(value: str) -> str:
     path = PurePosixPath(raw)
     if (
         not raw
+        or ":" in raw
         or path.is_absolute()
         or any(part in {"", ".", ".."} for part in path.parts)
         or path.suffix in {".yaml", ".yml"}

--- a/src/axiom_encode/program_scope.py
+++ b/src/axiom_encode/program_scope.py
@@ -142,7 +142,7 @@ def _updated_scope_text(
     insertions: dict[int, list[str]] = {}
 
     if not desired:
-        insertions[first_item_line] = [f"{indent}[]{newline}"]
+        insertions[first_item_line] = [f"{indent}  []{newline}"]
     else:
         survivors = [
             (value, item_lines[value]) for value in existing if value in desired
@@ -247,6 +247,10 @@ def sync_program_scope(
         raise ProgramScopeError(
             f"ProgramSpec scope {scope!r} must not use a YAML alias"
         )
+    if any(_node_reference_count(root, node) > 1 for node in target_node.value):
+        raise ProgramScopeError(
+            f"ProgramSpec scope {scope!r} entries must not use YAML aliases"
+        )
     if target_node.flow_style and target_node.value:
         raise ProgramScopeError(
             f"non-empty ProgramSpec scope {scope!r} must use a block-style sequence"
@@ -334,6 +338,7 @@ def sync_program_scope(
             with tempfile.NamedTemporaryFile(
                 mode="w",
                 encoding="utf-8",
+                newline="",
                 dir=absolute_spec.parent,
                 prefix=f".{absolute_spec.name}.",
                 delete=False,

--- a/src/axiom_encode/program_scope.py
+++ b/src/axiom_encode/program_scope.py
@@ -12,12 +12,15 @@ from pathlib import Path, PurePosixPath
 import yaml
 from yaml.nodes import MappingNode, ScalarNode, SequenceNode
 
+from .repo_routing import is_composition_policy_repo_root
+
 
 class ProgramScopeError(ValueError):
     """Raised when a requested ProgramSpec scope update is unsafe or invalid."""
 
 
 _SCOPE_KEY_PATTERN = re.compile(r"^[a-z][a-z0-9_-]*$")
+_NON_IMPORT_SCOPE_KEYS = frozenset({"exclude", "include", "jurisdictions"})
 
 
 @dataclass(frozen=True)
@@ -61,8 +64,73 @@ def _scope_prefix(program: str, scope: str) -> str:
     program_path = _normalize_scope_path(program)
     jurisdiction = program_path.split("/", 1)[0]
     if scope == "federal":
-        return jurisdiction.split("-", 1)[0]
-    return jurisdiction
+        return "us"
+    if scope == "state":
+        return jurisdiction
+    return scope
+
+
+def _updated_scope_text(
+    *,
+    text: str,
+    target_node: SequenceNode,
+    existing: tuple[str, ...],
+    desired: tuple[str, ...],
+) -> str:
+    """Update item lines while retaining comments and unrelated formatting."""
+
+    indent = " " * target_node.start_mark.column
+    lines = text.splitlines(keepends=True)
+    sample_line = lines[target_node.start_mark.line]
+    newline = "\r\n" if sample_line.endswith("\r\n") else "\n"
+    if target_node.flow_style:
+        if target_node.value:
+            raise ProgramScopeError("non-empty scope sequences must use block style")
+        replacement = f"- {desired[0]}" + "".join(
+            f"{newline}{indent}- {item}" for item in desired[1:]
+        )
+        return (
+            text[: target_node.start_mark.index]
+            + replacement
+            + text[target_node.end_mark.index :]
+        )
+
+    item_lines: dict[str, int] = {}
+    for value, node in zip(existing, target_node.value, strict=True):
+        if node.start_mark.line != node.end_mark.line:
+            raise ProgramScopeError("scope entries must occupy one line each")
+        item_lines[value] = node.start_mark.line
+
+    first_item_line = min(item_lines.values())
+    removed_lines = {
+        line for value, line in item_lines.items() if value not in desired
+    }
+    insertions: dict[int, list[str]] = {}
+
+    if not desired:
+        insertions[first_item_line] = [f"{indent}[]{newline}"]
+    else:
+        survivors = [
+            (value, item_lines[value]) for value in existing if value in desired
+        ]
+        new_items = [value for value in desired if value not in existing]
+        for value in new_items:
+            if survivors and list(existing) == sorted(existing):
+                following = [line for item, line in survivors if item > value]
+                anchor = following[0] if following else survivors[-1][1] + 1
+            elif survivors:
+                anchor = survivors[-1][1] + 1
+            else:
+                anchor = first_item_line
+            insertions.setdefault(anchor, []).append(f"{indent}- {value}{newline}")
+
+    updated_lines: list[str] = []
+    for index, line in enumerate(lines):
+        updated_lines.extend(insertions.get(index, ()))
+        if index not in removed_lines:
+            updated_lines.append(line)
+    updated_lines.extend(insertions.get(len(lines), ()))
+    return "".join(updated_lines)
 
 
 def sync_program_scope(
@@ -76,17 +144,19 @@ def sync_program_scope(
 ) -> ProgramScopeSyncResult:
     """Apply one scope update while preserving all unrelated ProgramSpec text."""
 
-    repo = Path(repo).resolve()
-    if not repo.is_dir():
-        raise ProgramScopeError(f"repository does not exist: {repo}")
+    raw_repo = Path(repo)
+    if not is_composition_policy_repo_root(raw_repo):
+        raise ProgramScopeError(
+            f"repository must be an exact canonical rulespec-<country> checkout: {raw_repo}"
+        )
+    repo = raw_repo.resolve()
     if not _SCOPE_KEY_PATTERN.fullmatch(scope):
         raise ProgramScopeError(f"scope must be a lowercase identifier: {scope!r}")
+    if scope in _NON_IMPORT_SCOPE_KEYS:
+        raise ProgramScopeError(f"scope {scope!r} does not contain RuleSpec imports")
     spec_path = Path(program_spec)
     if spec_path.is_absolute():
-        try:
-            spec_path = spec_path.absolute().relative_to(repo)
-        except ValueError as exc:
-            raise ProgramScopeError("program spec must be inside --repo") from exc
+        raise ProgramScopeError("program spec must be relative to --repo")
     if spec_path.suffix != ".yaml":
         raise ProgramScopeError("program spec must be a repo-relative .yaml file")
     spec_path = Path(_normalize_scope_path(spec_path.as_posix()[:-5]))
@@ -126,9 +196,9 @@ def sync_program_scope(
     target_node = _mapping_value(scope_node, scope)
     if not isinstance(target_node, SequenceNode):
         raise ProgramScopeError(f"ProgramSpec scope {scope!r} must be a sequence")
-    if target_node.flow_style:
+    if target_node.flow_style and target_node.value:
         raise ProgramScopeError(
-            f"ProgramSpec scope {scope!r} must use a block-style sequence"
+            f"non-empty ProgramSpec scope {scope!r} must use a block-style sequence"
         )
     payload_scope = payload.get("scope")
     payload_target = payload_scope.get(scope) if isinstance(payload_scope, dict) else None
@@ -184,16 +254,11 @@ def sync_program_scope(
     desired = tuple(desired_list)
     changed = desired != existing
     if changed and write:
-        indent = " " * target_node.start_mark.column
-        replacement = "\n".join(f"{indent}- {item}" for item in desired)
-        if not replacement:
-            replacement = f"{indent}[]"
-        start_index = target_node.start_mark.index - target_node.start_mark.column
-        end_index = target_node.value[-1].end_mark.index
-        updated = (
-            text[:start_index]
-            + replacement
-            + text[end_index:]
+        updated = _updated_scope_text(
+            text=text,
+            target_node=target_node,
+            existing=existing,
+            desired=desired,
         )
         try:
             updated_payload = yaml.safe_load(updated)

--- a/src/axiom_encode/program_scope.py
+++ b/src/axiom_encode/program_scope.py
@@ -44,6 +44,28 @@ def _mapping_value(node: MappingNode, key: str):
     return matches[0] if matches else None
 
 
+def _node_reference_count(root, target) -> int:
+    """Count graph references to a composed node without following cycles twice."""
+
+    references = 0
+    expanded: set[int] = set()
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        if node is target:
+            references += 1
+        identity = id(node)
+        if identity in expanded:
+            continue
+        expanded.add(identity)
+        if isinstance(node, MappingNode):
+            for key_node, value_node in node.value:
+                stack.extend((key_node, value_node))
+        elif isinstance(node, SequenceNode):
+            stack.extend(node.value)
+    return references
+
+
 def _normalize_scope_path(value: str) -> str:
     raw = str(value).strip()
     path = PurePosixPath(raw)
@@ -130,6 +152,8 @@ def _updated_scope_text(
             if survivors and list(existing) == sorted(existing):
                 following = [line for item, line in survivors if item > value]
                 anchor = following[0] if following else survivors[-1][1] + 1
+                while anchor > 0 and lines[anchor - 1].lstrip().startswith("#"):
+                    anchor -= 1
             elif survivors:
                 anchor = survivors[-1][1] + 1
             else:
@@ -215,6 +239,10 @@ def sync_program_scope(
     target_node = _mapping_value(scope_node, scope)
     if not isinstance(target_node, SequenceNode):
         raise ProgramScopeError(f"ProgramSpec scope {scope!r} must be a sequence")
+    if _node_reference_count(root, target_node) > 1:
+        raise ProgramScopeError(
+            f"ProgramSpec scope {scope!r} must not use a YAML alias"
+        )
     if target_node.flow_style and target_node.value:
         raise ProgramScopeError(
             f"non-empty ProgramSpec scope {scope!r} must use a block-style sequence"
@@ -240,11 +268,14 @@ def sync_program_scope(
         )
 
     prefix = _scope_prefix(program.strip(), scope)
-    scope_root = (repo / prefix).resolve()
+    lexical_scope_root = repo / prefix
+    scope_root = lexical_scope_root.resolve()
     try:
         scope_root.relative_to(repo)
     except ValueError as exc:
         raise ProgramScopeError(f"scope prefix resolves outside --repo: {prefix}") from exc
+    if lexical_scope_root.is_symlink() or scope_root != lexical_scope_root.absolute():
+        raise ProgramScopeError("scope root path must not contain symlinks")
     missing_modules: list[str] = []
     for item in additions:
         if PurePosixPath(item).parts[0] not in RULESPEC_ATOMIC_MODULE_ROOTS:

--- a/src/axiom_encode/program_scope.py
+++ b/src/axiom_encode/program_scope.py
@@ -1,0 +1,235 @@
+"""Deterministic, minimal-diff updates for axiom-compose ProgramSpec scopes."""
+
+from __future__ import annotations
+
+import bisect
+import os
+import re
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+import yaml
+from yaml.nodes import MappingNode, ScalarNode, SequenceNode
+
+
+class ProgramScopeError(ValueError):
+    """Raised when a requested ProgramSpec scope update is unsafe or invalid."""
+
+
+_SCOPE_KEY_PATTERN = re.compile(r"^[a-z][a-z0-9_-]*$")
+
+
+@dataclass(frozen=True)
+class ProgramScopeSyncResult:
+    program_spec: str
+    scope: str
+    added: tuple[str, ...]
+    removed: tuple[str, ...]
+    changed: bool
+
+
+def _mapping_value(node: MappingNode, key: str):
+    matches = [
+        value_node
+        for key_node, value_node in node.value
+        if isinstance(key_node, ScalarNode) and key_node.value == key
+    ]
+    if len(matches) > 1:
+        raise ProgramScopeError(f"ProgramSpec contains duplicate {key!r} keys")
+    return matches[0] if matches else None
+
+
+def _normalize_scope_path(value: str) -> str:
+    raw = str(value).strip()
+    path = PurePosixPath(raw)
+    if (
+        not raw
+        or path.is_absolute()
+        or any(part in {"", ".", ".."} for part in path.parts)
+        or path.suffix in {".yaml", ".yml"}
+    ):
+        raise ProgramScopeError(
+            f"scope paths must be safe repo-relative module paths without a YAML suffix: {value!r}"
+        )
+    return path.as_posix()
+
+
+def _scope_prefix(program: str, scope: str) -> str:
+    if not _SCOPE_KEY_PATTERN.fullmatch(scope):
+        raise ProgramScopeError(f"scope must be a lowercase identifier: {scope!r}")
+    program_path = _normalize_scope_path(program)
+    jurisdiction = program_path.split("/", 1)[0]
+    if scope == "federal":
+        return jurisdiction.split("-", 1)[0]
+    return jurisdiction
+
+
+def sync_program_scope(
+    *,
+    repo: Path,
+    program_spec: Path,
+    scope: str,
+    add: list[str] | tuple[str, ...] = (),
+    remove: list[str] | tuple[str, ...] = (),
+    write: bool = True,
+) -> ProgramScopeSyncResult:
+    """Apply one scope update while preserving all unrelated ProgramSpec text."""
+
+    repo = Path(repo).resolve()
+    if not repo.is_dir():
+        raise ProgramScopeError(f"repository does not exist: {repo}")
+    if not _SCOPE_KEY_PATTERN.fullmatch(scope):
+        raise ProgramScopeError(f"scope must be a lowercase identifier: {scope!r}")
+    spec_path = Path(program_spec)
+    if spec_path.is_absolute():
+        try:
+            spec_path = spec_path.absolute().relative_to(repo)
+        except ValueError as exc:
+            raise ProgramScopeError("program spec must be inside --repo") from exc
+    if spec_path.suffix != ".yaml":
+        raise ProgramScopeError("program spec must be a repo-relative .yaml file")
+    spec_path = Path(_normalize_scope_path(spec_path.as_posix()[:-5]))
+    spec_rel = Path(f"{spec_path.as_posix()}.yaml")
+    lexical_spec = repo / spec_rel
+    absolute_spec = lexical_spec.resolve()
+    try:
+        absolute_spec.relative_to(repo)
+    except ValueError as exc:
+        raise ProgramScopeError("program spec must resolve inside --repo") from exc
+    if not absolute_spec.is_file():
+        raise ProgramScopeError(f"program spec does not exist: {absolute_spec}")
+    if absolute_spec != lexical_spec.absolute():
+        raise ProgramScopeError("program spec path must not contain symlinks")
+
+    text = absolute_spec.read_text(encoding="utf-8")
+    try:
+        payload = yaml.safe_load(text)
+        root = yaml.compose(text)
+    except yaml.YAMLError as exc:
+        raise ProgramScopeError(f"invalid ProgramSpec YAML: {exc}") from exc
+    if not isinstance(payload, dict) or not isinstance(root, MappingNode):
+        raise ProgramScopeError("ProgramSpec root must be a mapping")
+    program = payload.get("program")
+    if not isinstance(program, str) or not program.strip():
+        raise ProgramScopeError("ProgramSpec must declare a non-empty `program`")
+    program_path = _normalize_scope_path(program.strip())
+    expected_parent = Path("programs") / program_path
+    if not spec_rel.is_relative_to(expected_parent):
+        raise ProgramScopeError(
+            f"program spec path must be nested under {expected_parent.as_posix()}/"
+        )
+
+    scope_node = _mapping_value(root, "scope")
+    if not isinstance(scope_node, MappingNode):
+        raise ProgramScopeError("ProgramSpec must declare a `scope` mapping")
+    target_node = _mapping_value(scope_node, scope)
+    if not isinstance(target_node, SequenceNode):
+        raise ProgramScopeError(f"ProgramSpec scope {scope!r} must be a sequence")
+    if target_node.flow_style:
+        raise ProgramScopeError(
+            f"ProgramSpec scope {scope!r} must use a block-style sequence"
+        )
+    payload_scope = payload.get("scope")
+    payload_target = payload_scope.get(scope) if isinstance(payload_scope, dict) else None
+    if not (
+        isinstance(payload_target, list)
+        and all(isinstance(item, str) for item in payload_target)
+        and all(isinstance(item, ScalarNode) for item in target_node.value)
+    ):
+        raise ProgramScopeError(f"ProgramSpec scope {scope!r} must contain only strings")
+
+    existing = tuple(_normalize_scope_path(item.value) for item in target_node.value)
+    if len(set(existing)) != len(existing):
+        raise ProgramScopeError(f"ProgramSpec scope {scope!r} contains duplicate paths")
+    additions = tuple(dict.fromkeys(_normalize_scope_path(item) for item in add))
+    removals = tuple(dict.fromkeys(_normalize_scope_path(item) for item in remove))
+    overlap = set(additions) & set(removals)
+    if overlap:
+        raise ProgramScopeError(
+            f"scope paths cannot be both added and removed: {sorted(overlap)}"
+        )
+
+    prefix = _scope_prefix(program.strip(), scope)
+    scope_root = (repo / prefix).resolve()
+    try:
+        scope_root.relative_to(repo)
+    except ValueError as exc:
+        raise ProgramScopeError(f"scope prefix resolves outside --repo: {prefix}") from exc
+    missing_modules: list[str] = []
+    for item in additions:
+        lexical_module = scope_root / f"{item}.yaml"
+        module = lexical_module.resolve()
+        try:
+            module.relative_to(scope_root)
+        except ValueError:
+            missing_modules.append(item)
+            continue
+        if not module.is_file() or module != lexical_module.absolute():
+            missing_modules.append(item)
+    missing_modules.sort()
+    if missing_modules:
+        raise ProgramScopeError(
+            f"scope additions do not resolve under {prefix}/: {missing_modules}"
+        )
+
+    desired_list = [item for item in existing if item not in set(removals)]
+    for item in additions:
+        if item in desired_list:
+            continue
+        if desired_list == sorted(desired_list):
+            bisect.insort(desired_list, item)
+        else:
+            desired_list.append(item)
+    desired = tuple(desired_list)
+    changed = desired != existing
+    if changed and write:
+        indent = " " * target_node.start_mark.column
+        replacement = "\n".join(f"{indent}- {item}" for item in desired)
+        if not replacement:
+            replacement = f"{indent}[]"
+        start_index = target_node.start_mark.index - target_node.start_mark.column
+        end_index = target_node.value[-1].end_mark.index
+        updated = (
+            text[:start_index]
+            + replacement
+            + text[end_index:]
+        )
+        try:
+            updated_payload = yaml.safe_load(updated)
+        except yaml.YAMLError as exc:
+            raise ProgramScopeError(
+                f"refusing to write invalid updated ProgramSpec YAML: {exc}"
+            ) from exc
+        if updated_payload.get("scope", {}).get(scope) != list(desired):
+            raise ProgramScopeError(
+                "refusing to write a ProgramSpec whose updated scope does not match"
+            )
+
+        temporary_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=absolute_spec.parent,
+                prefix=f".{absolute_spec.name}.",
+                delete=False,
+            ) as temporary:
+                temporary_path = Path(temporary.name)
+                temporary.write(updated)
+                temporary.flush()
+                os.fsync(temporary.fileno())
+            temporary_path.chmod(absolute_spec.stat().st_mode)
+            os.replace(temporary_path, absolute_spec)
+            temporary_path = None
+        finally:
+            if temporary_path is not None:
+                temporary_path.unlink(missing_ok=True)
+
+    return ProgramScopeSyncResult(
+        program_spec=spec_rel.as_posix(),
+        scope=scope,
+        added=tuple(item for item in additions if item not in existing),
+        removed=tuple(item for item in removals if item in existing),
+        changed=changed,
+    )

--- a/src/axiom_encode/program_scope.py
+++ b/src/axiom_encode/program_scope.py
@@ -12,6 +12,7 @@ from pathlib import Path, PurePosixPath
 import yaml
 from yaml.nodes import MappingNode, ScalarNode, SequenceNode
 
+from .constants import RULESPEC_ATOMIC_MODULE_ROOTS
 from .repo_routing import is_composition_policy_repo_root
 
 
@@ -86,6 +87,17 @@ def _updated_scope_text(
     if target_node.flow_style:
         if target_node.value:
             raise ProgramScopeError("non-empty scope sequences must use block style")
+        line_prefix = sample_line[: target_node.start_mark.column]
+        if line_prefix.strip():
+            line_start = target_node.start_mark.index - target_node.start_mark.column
+            line_body = sample_line.removesuffix(newline)
+            line_end = line_start + len(line_body)
+            key_indent = len(sample_line) - len(sample_line.lstrip(" \t"))
+            item_indent = " " * (key_indent + 2)
+            suffix = text[target_node.end_mark.index : line_end]
+            prefix = text[: target_node.start_mark.index].rstrip(" \t")
+            entries = newline.join(f"{item_indent}- {item}" for item in desired)
+            return prefix + suffix + newline + entries + text[line_end:]
         replacement = f"- {desired[0]}" + "".join(
             f"{newline}{indent}- {item}" for item in desired[1:]
         )
@@ -126,10 +138,16 @@ def _updated_scope_text(
 
     updated_lines: list[str] = []
     for index, line in enumerate(lines):
-        updated_lines.extend(insertions.get(index, ()))
+        pending = insertions.get(index, ())
+        if pending and updated_lines and not updated_lines[-1].endswith(("\n", "\r")):
+            updated_lines[-1] += newline
+        updated_lines.extend(pending)
         if index not in removed_lines:
             updated_lines.append(line)
-    updated_lines.extend(insertions.get(len(lines), ()))
+    pending = insertions.get(len(lines), ())
+    if pending and updated_lines and not updated_lines[-1].endswith(("\n", "\r")):
+        updated_lines[-1] += newline
+    updated_lines.extend(pending)
     return "".join(updated_lines)
 
 
@@ -172,7 +190,8 @@ def sync_program_scope(
     if absolute_spec != lexical_spec.absolute():
         raise ProgramScopeError("program spec path must not contain symlinks")
 
-    text = absolute_spec.read_text(encoding="utf-8")
+    with absolute_spec.open(encoding="utf-8", newline="") as source:
+        text = source.read()
     try:
         payload = yaml.safe_load(text)
         root = yaml.compose(text)
@@ -228,6 +247,9 @@ def sync_program_scope(
         raise ProgramScopeError(f"scope prefix resolves outside --repo: {prefix}") from exc
     missing_modules: list[str] = []
     for item in additions:
+        if PurePosixPath(item).parts[0] not in RULESPEC_ATOMIC_MODULE_ROOTS:
+            missing_modules.append(item)
+            continue
         lexical_module = scope_root / f"{item}.yaml"
         module = lexical_module.resolve()
         try:

--- a/src/axiom_encode/program_scope.py
+++ b/src/axiom_encode/program_scope.py
@@ -236,6 +236,10 @@ def sync_program_scope(
     scope_node = _mapping_value(root, "scope")
     if not isinstance(scope_node, MappingNode):
         raise ProgramScopeError("ProgramSpec must declare a `scope` mapping")
+    if scope_node.flow_style:
+        raise ProgramScopeError("ProgramSpec `scope` mapping must use block style")
+    if _node_reference_count(root, scope_node) > 1:
+        raise ProgramScopeError("ProgramSpec `scope` mapping must not use a YAML alias")
     target_node = _mapping_value(scope_node, scope)
     if not isinstance(target_node, SequenceNode):
         raise ProgramScopeError(f"ProgramSpec scope {scope!r} must be a sequence")
@@ -296,11 +300,12 @@ def sync_program_scope(
             f"scope additions do not resolve under {prefix}/: {missing_modules}"
         )
 
+    preserve_sorted_order = list(existing) == sorted(existing)
     desired_list = [item for item in existing if item not in set(removals)]
     for item in additions:
         if item in desired_list:
             continue
-        if desired_list == sorted(desired_list):
+        if preserve_sorted_order:
             bisect.insort(desired_list, item)
         else:
             desired_list.append(item)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1572,6 +1572,32 @@ class TestMain:
                     main()
                     mock_cmd.assert_called_once()
 
+    def test_program_scope_sync_command_dispatches(self, tmp_path):
+        with patch(
+            "sys.argv",
+            [
+                "axiom_encode",
+                "program-scope-sync",
+                "--repo",
+                str(tmp_path),
+                "--program-spec",
+                "programs/us-sc/snap/fy-2026.yaml",
+                "--scope",
+                "state",
+                "--add",
+                "policies/dss/snap/page-159",
+                "--check",
+            ],
+        ):
+            with patch("axiom_encode.cli.cmd_program_scope_sync") as mock_cmd:
+                main()
+
+        args = mock_cmd.call_args.args[0]
+        assert args.repo == tmp_path
+        assert args.scope == "state"
+        assert args.add == ["policies/dss/snap/page-159"]
+        assert args.check is True
+
     @pytest.mark.parametrize("removed_oracle", ["taxsim", "all"])
     def test_validate_parser_rejects_removed_oracles(self, removed_oracle, capsys):
         with (

--- a/tests/test_program_scope.py
+++ b/tests/test_program_scope.py
@@ -104,7 +104,9 @@ def test_sync_program_scope_rejects_missing_module(tmp_path: Path) -> None:
         )
 
 
-def test_sync_program_scope_rejects_module_symlink_outside_scope(tmp_path: Path) -> None:
+def test_sync_program_scope_rejects_module_symlink_outside_scope(
+    tmp_path: Path,
+) -> None:
     repo, spec = _repo(tmp_path)
     outside = tmp_path / "outside.yaml"
     outside.write_text("format: rulespec/v1\n")
@@ -206,10 +208,8 @@ def test_sync_program_scope_uses_original_order_after_removal(tmp_path: Path) ->
     repo, spec = _repo(tmp_path)
     spec.write_text(
         spec.read_text().replace(
-            "    - policies/dss/snap/page-163\n"
-            "    - policies/dss/snap/page-369\n",
-            "    - policies/dss/snap/page-369\n"
-            "    - policies/dss/snap/page-163\n",
+            "    - policies/dss/snap/page-163\n    - policies/dss/snap/page-369\n",
+            "    - policies/dss/snap/page-369\n    - policies/dss/snap/page-163\n",
         )
     )
 
@@ -449,7 +449,9 @@ def test_sync_program_scope_rejects_scope_root_symlink(tmp_path: Path) -> None:
     state_root.rename(other_root)
     state_root.symlink_to(other_root, target_is_directory=True)
 
-    with pytest.raises(ProgramScopeError, match="scope root path must not contain symlinks"):
+    with pytest.raises(
+        ProgramScopeError, match="scope root path must not contain symlinks"
+    ):
         sync_program_scope(
             repo=repo,
             program_spec=spec.relative_to(repo),

--- a/tests/test_program_scope.py
+++ b/tests/test_program_scope.py
@@ -62,7 +62,7 @@ def test_sync_program_scope_check_mode_does_not_write(tmp_path: Path) -> None:
 
     result = sync_program_scope(
         repo=repo,
-        program_spec=spec,
+        program_spec=spec.relative_to(repo),
         scope="state",
         add=["policies/dss/snap/page-159"],
         write=False,
@@ -76,14 +76,14 @@ def test_sync_program_scope_is_idempotent(tmp_path: Path) -> None:
     repo, spec = _repo(tmp_path)
     sync_program_scope(
         repo=repo,
-        program_spec=spec,
+        program_spec=spec.relative_to(repo),
         scope="state",
         add=["policies/dss/snap/page-159"],
     )
 
     result = sync_program_scope(
         repo=repo,
-        program_spec=spec,
+        program_spec=spec.relative_to(repo),
         scope="state",
         add=["policies/dss/snap/page-159"],
     )
@@ -97,7 +97,7 @@ def test_sync_program_scope_rejects_missing_module(tmp_path: Path) -> None:
     with pytest.raises(ProgramScopeError, match="do not resolve"):
         sync_program_scope(
             repo=repo,
-            program_spec=spec,
+            program_spec=spec.relative_to(repo),
             scope="state",
             add=["policies/dss/snap/page-999"],
         )
@@ -113,7 +113,7 @@ def test_sync_program_scope_rejects_module_symlink_outside_scope(tmp_path: Path)
     with pytest.raises(ProgramScopeError, match="do not resolve"):
         sync_program_scope(
             repo=repo,
-            program_spec=spec,
+            program_spec=spec.relative_to(repo),
             scope="state",
             add=["policies/dss/snap/page-999"],
         )
@@ -128,7 +128,7 @@ def test_sync_program_scope_rejects_program_spec_symlink(tmp_path: Path) -> None
     with pytest.raises(ProgramScopeError, match="must not contain symlinks"):
         sync_program_scope(
             repo=repo,
-            program_spec=spec,
+            program_spec=spec.relative_to(repo),
             scope="state",
             add=["policies/dss/snap/page-159"],
         )
@@ -141,7 +141,7 @@ def test_sync_program_scope_rejects_unsafe_paths(tmp_path: Path, path: str) -> N
     with pytest.raises(ProgramScopeError, match="safe repo-relative"):
         sync_program_scope(
             repo=repo,
-            program_spec=spec,
+            program_spec=spec.relative_to(repo),
             scope="state",
             add=[path],
         )
@@ -152,7 +152,7 @@ def test_sync_program_scope_allows_already_absent_removal(tmp_path: Path) -> Non
 
     result = sync_program_scope(
         repo=repo,
-        program_spec=spec,
+        program_spec=spec.relative_to(repo),
         scope="state",
         remove=["policies/dss/snap/page-999"],
     )
@@ -174,7 +174,7 @@ def test_sync_program_scope_preserves_unsorted_existing_order(tmp_path: Path) ->
 
     sync_program_scope(
         repo=repo,
-        program_spec=spec,
+        program_spec=spec.relative_to(repo),
         scope="federal",
         add=["regulations/7-cfr/273/10"],
     )
@@ -186,24 +186,48 @@ def test_sync_program_scope_preserves_unsorted_existing_order(tmp_path: Path) ->
     ]
 
 
-def test_sync_program_scope_resolves_non_federal_scope_to_program_jurisdiction(
+def test_sync_program_scope_resolves_explicit_scope_to_named_jurisdiction(
     tmp_path: Path,
 ) -> None:
     repo, spec = _repo(tmp_path)
-    text = spec.read_text().replace("  state:\n", "  province:\n")
+    text = spec.read_text().replace("  state:\n", "  us-ny:\n")
     spec.write_text(text)
+    module = repo / "us-ny/policies/dss/snap/page-159.yaml"
+    module.parent.mkdir(parents=True)
+    module.write_text("format: rulespec/v1\n")
 
     result = sync_program_scope(
         repo=repo,
-        program_spec=spec,
-        scope="province",
+        program_spec=spec.relative_to(repo),
+        scope="us-ny",
         add=["policies/dss/snap/page-159"],
     )
 
     assert result.changed is True
-    assert yaml.safe_load(spec.read_text())["scope"]["province"][0] == (
+    assert yaml.safe_load(spec.read_text())["scope"]["us-ny"][0] == (
         "policies/dss/snap/page-159"
     )
+
+
+def test_sync_program_scope_preserves_scope_comments(tmp_path: Path) -> None:
+    repo, spec = _repo(tmp_path)
+    comment = "    # Page 369 remains documented for later composition.\n"
+    spec.write_text(
+        spec.read_text().replace(
+            "    - policies/dss/snap/page-369\n",
+            comment + "    - policies/dss/snap/page-369\n",
+        )
+    )
+
+    sync_program_scope(
+        repo=repo,
+        program_spec=spec.relative_to(repo),
+        scope="state",
+        add=["policies/dss/snap/page-159"],
+        remove=["policies/dss/snap/page-369"],
+    )
+
+    assert comment in spec.read_text()
 
 
 def test_sync_program_scope_rejects_unsafe_scope_key(tmp_path: Path) -> None:
@@ -212,7 +236,7 @@ def test_sync_program_scope_rejects_unsafe_scope_key(tmp_path: Path) -> None:
     with pytest.raises(ProgramScopeError, match="lowercase identifier"):
         sync_program_scope(
             repo=repo,
-            program_spec=spec,
+            program_spec=spec.relative_to(repo),
             scope="../state",
             add=["policies/dss/snap/page-159"],
         )
@@ -223,7 +247,7 @@ def test_sync_program_scope_supports_empty_block_sequence(tmp_path: Path) -> Non
 
     result = sync_program_scope(
         repo=repo,
-        program_spec=spec,
+        program_spec=spec.relative_to(repo),
         scope="state",
         remove=[
             "policies/dss/snap/page-163",
@@ -233,3 +257,59 @@ def test_sync_program_scope_supports_empty_block_sequence(tmp_path: Path) -> Non
 
     assert result.changed is True
     assert yaml.safe_load(spec.read_text())["scope"]["state"] == []
+
+    repopulated = sync_program_scope(
+        repo=repo,
+        program_spec=spec.relative_to(repo),
+        scope="state",
+        add=["policies/dss/snap/page-159"],
+    )
+
+    assert repopulated.changed is True
+    assert yaml.safe_load(spec.read_text())["scope"]["state"] == [
+        "policies/dss/snap/page-159"
+    ]
+
+
+def test_sync_program_scope_rejects_absolute_program_spec(tmp_path: Path) -> None:
+    repo, spec = _repo(tmp_path)
+
+    with pytest.raises(ProgramScopeError, match="relative to --repo"):
+        sync_program_scope(
+            repo=repo,
+            program_spec=spec,
+            scope="state",
+            add=["policies/dss/snap/page-159"],
+        )
+
+
+def test_sync_program_scope_rejects_noncanonical_checkout(tmp_path: Path) -> None:
+    repo, spec = _repo(tmp_path)
+    unrelated = tmp_path / "workspace"
+    repo.rename(unrelated)
+
+    with pytest.raises(ProgramScopeError, match="exact canonical"):
+        sync_program_scope(
+            repo=unrelated,
+            program_spec=spec.relative_to(repo),
+            scope="state",
+            add=["policies/dss/snap/page-159"],
+        )
+
+
+def test_sync_program_scope_rejects_discovery_scope(tmp_path: Path) -> None:
+    repo, spec = _repo(tmp_path)
+    spec.write_text(
+        spec.read_text().replace(
+            "  state:\n",
+            "  jurisdictions:\n",
+        )
+    )
+
+    with pytest.raises(ProgramScopeError, match="does not contain RuleSpec imports"):
+        sync_program_scope(
+            repo=repo,
+            program_spec=spec.relative_to(repo),
+            scope="jurisdictions",
+            add=["us-sc"],
+        )

--- a/tests/test_program_scope.py
+++ b/tests/test_program_scope.py
@@ -230,6 +230,76 @@ def test_sync_program_scope_preserves_scope_comments(tmp_path: Path) -> None:
     assert comment in spec.read_text()
 
 
+def test_sync_program_scope_inserts_before_following_item_comments(
+    tmp_path: Path,
+) -> None:
+    repo, spec = _repo(tmp_path)
+    module = repo / "us-sc/policies/dss/snap/page-200.yaml"
+    module.write_text("format: rulespec/v1\n")
+    comment = "    # Page 369 has separate composition requirements.\n"
+    spec.write_text(
+        spec.read_text().replace(
+            "    - policies/dss/snap/page-369\n",
+            comment + "    - policies/dss/snap/page-369\n",
+        )
+    )
+
+    sync_program_scope(
+        repo=repo,
+        program_spec=spec.relative_to(repo),
+        scope="state",
+        add=["policies/dss/snap/page-200"],
+    )
+
+    updated = spec.read_text()
+    assert updated.index("page-200") < updated.index(comment.strip())
+    assert updated.index(comment.strip()) < updated.index("page-369")
+
+
+def test_sync_program_scope_rejects_aliased_sequence(tmp_path: Path) -> None:
+    repo, spec = _repo(tmp_path)
+    spec.write_text(
+        spec.read_text()
+        .replace(
+            "scope:\n",
+            "state_imports: &state_imports\n"
+            "  - policies/dss/snap/page-163\n"
+            "  - policies/dss/snap/page-369\n\n"
+            "scope:\n",
+        )
+        .replace(
+            "  state:\n"
+            "    - policies/dss/snap/page-163\n"
+            "    - policies/dss/snap/page-369\n",
+            "  state: *state_imports\n",
+        )
+    )
+
+    with pytest.raises(ProgramScopeError, match="must not use a YAML alias"):
+        sync_program_scope(
+            repo=repo,
+            program_spec=spec.relative_to(repo),
+            scope="state",
+            add=["policies/dss/snap/page-159"],
+        )
+
+
+def test_sync_program_scope_rejects_scope_root_symlink(tmp_path: Path) -> None:
+    repo, spec = _repo(tmp_path)
+    state_root = repo / "us-sc"
+    other_root = repo / "us-ny"
+    state_root.rename(other_root)
+    state_root.symlink_to(other_root, target_is_directory=True)
+
+    with pytest.raises(ProgramScopeError, match="scope root path must not contain symlinks"):
+        sync_program_scope(
+            repo=repo,
+            program_spec=spec.relative_to(repo),
+            scope="state",
+            add=["policies/dss/snap/page-159"],
+        )
+
+
 def test_sync_program_scope_rejects_unsafe_scope_key(tmp_path: Path) -> None:
     repo, spec = _repo(tmp_path)
 

--- a/tests/test_program_scope.py
+++ b/tests/test_program_scope.py
@@ -1,0 +1,235 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+from axiom_encode.program_scope import ProgramScopeError, sync_program_scope
+
+
+def _repo(tmp_path: Path) -> tuple[Path, Path]:
+    repo = tmp_path / "rulespec-us"
+    spec = repo / "programs/us-sc/snap/fy-2026.yaml"
+    spec.parent.mkdir(parents=True)
+    spec.write_text(
+        "# preserved header\n\n"
+        "program: us-sc/snap\n"
+        "period: 2026-01\n\n"
+        "scope:\n"
+        "  federal:\n"
+        "    - regulations/7-cfr/273/9\n\n"
+        "  state:\n"
+        "    - policies/dss/snap/page-163\n"
+        "    - policies/dss/snap/page-369\n\n"
+        "outputs:\n"
+        "  - snap_benefit\n"
+    )
+    for path in ("page-159", "page-163", "page-369"):
+        module = repo / f"us-sc/policies/dss/snap/{path}.yaml"
+        module.parent.mkdir(parents=True, exist_ok=True)
+        module.write_text("format: rulespec/v1\n")
+    return repo, spec
+
+
+def test_sync_program_scope_changes_only_selected_sequence(tmp_path: Path) -> None:
+    repo, spec = _repo(tmp_path)
+    before = spec.read_text()
+
+    result = sync_program_scope(
+        repo=repo,
+        program_spec=Path("programs/us-sc/snap/fy-2026.yaml"),
+        scope="state",
+        add=["policies/dss/snap/page-159"],
+        remove=["policies/dss/snap/page-369"],
+    )
+
+    assert result.changed is True
+    assert result.added == ("policies/dss/snap/page-159",)
+    assert result.removed == ("policies/dss/snap/page-369",)
+    after = spec.read_text()
+    assert after.startswith("# preserved header\n\n")
+    assert after.split("scope:\n", 1)[0] == before.split("scope:\n", 1)[0]
+    assert after.split("outputs:\n", 1)[1] == before.split("outputs:\n", 1)[1]
+    assert "page-163\n\noutputs:" in after
+    assert yaml.safe_load(after)["scope"]["state"] == [
+        "policies/dss/snap/page-159",
+        "policies/dss/snap/page-163",
+    ]
+
+
+def test_sync_program_scope_check_mode_does_not_write(tmp_path: Path) -> None:
+    repo, spec = _repo(tmp_path)
+    before = spec.read_text()
+
+    result = sync_program_scope(
+        repo=repo,
+        program_spec=spec,
+        scope="state",
+        add=["policies/dss/snap/page-159"],
+        write=False,
+    )
+
+    assert result.changed is True
+    assert spec.read_text() == before
+
+
+def test_sync_program_scope_is_idempotent(tmp_path: Path) -> None:
+    repo, spec = _repo(tmp_path)
+    sync_program_scope(
+        repo=repo,
+        program_spec=spec,
+        scope="state",
+        add=["policies/dss/snap/page-159"],
+    )
+
+    result = sync_program_scope(
+        repo=repo,
+        program_spec=spec,
+        scope="state",
+        add=["policies/dss/snap/page-159"],
+    )
+
+    assert result.changed is False
+
+
+def test_sync_program_scope_rejects_missing_module(tmp_path: Path) -> None:
+    repo, spec = _repo(tmp_path)
+
+    with pytest.raises(ProgramScopeError, match="do not resolve"):
+        sync_program_scope(
+            repo=repo,
+            program_spec=spec,
+            scope="state",
+            add=["policies/dss/snap/page-999"],
+        )
+
+
+def test_sync_program_scope_rejects_module_symlink_outside_scope(tmp_path: Path) -> None:
+    repo, spec = _repo(tmp_path)
+    outside = tmp_path / "outside.yaml"
+    outside.write_text("format: rulespec/v1\n")
+    module = repo / "us-sc/policies/dss/snap/page-999.yaml"
+    module.symlink_to(outside)
+
+    with pytest.raises(ProgramScopeError, match="do not resolve"):
+        sync_program_scope(
+            repo=repo,
+            program_spec=spec,
+            scope="state",
+            add=["policies/dss/snap/page-999"],
+        )
+
+
+def test_sync_program_scope_rejects_program_spec_symlink(tmp_path: Path) -> None:
+    repo, spec = _repo(tmp_path)
+    real_spec = spec.with_name("real.yaml")
+    spec.rename(real_spec)
+    spec.symlink_to(real_spec)
+
+    with pytest.raises(ProgramScopeError, match="must not contain symlinks"):
+        sync_program_scope(
+            repo=repo,
+            program_spec=spec,
+            scope="state",
+            add=["policies/dss/snap/page-159"],
+        )
+
+
+@pytest.mark.parametrize("path", ["../outside", "/absolute", "page.yaml"])
+def test_sync_program_scope_rejects_unsafe_paths(tmp_path: Path, path: str) -> None:
+    repo, spec = _repo(tmp_path)
+
+    with pytest.raises(ProgramScopeError, match="safe repo-relative"):
+        sync_program_scope(
+            repo=repo,
+            program_spec=spec,
+            scope="state",
+            add=[path],
+        )
+
+
+def test_sync_program_scope_allows_already_absent_removal(tmp_path: Path) -> None:
+    repo, spec = _repo(tmp_path)
+
+    result = sync_program_scope(
+        repo=repo,
+        program_spec=spec,
+        scope="state",
+        remove=["policies/dss/snap/page-999"],
+    )
+
+    assert result.changed is False
+    assert result.removed == ()
+
+
+def test_sync_program_scope_preserves_unsorted_existing_order(tmp_path: Path) -> None:
+    repo, spec = _repo(tmp_path)
+    text = spec.read_text().replace(
+        "    - regulations/7-cfr/273/9\n",
+        "    - statutes/7/2014/a\n    - regulations/7-cfr/273/9\n",
+    )
+    spec.write_text(text)
+    module = repo / "us/regulations/7-cfr/273/10.yaml"
+    module.parent.mkdir(parents=True)
+    module.write_text("format: rulespec/v1\n")
+
+    sync_program_scope(
+        repo=repo,
+        program_spec=spec,
+        scope="federal",
+        add=["regulations/7-cfr/273/10"],
+    )
+
+    assert yaml.safe_load(spec.read_text())["scope"]["federal"] == [
+        "statutes/7/2014/a",
+        "regulations/7-cfr/273/9",
+        "regulations/7-cfr/273/10",
+    ]
+
+
+def test_sync_program_scope_resolves_non_federal_scope_to_program_jurisdiction(
+    tmp_path: Path,
+) -> None:
+    repo, spec = _repo(tmp_path)
+    text = spec.read_text().replace("  state:\n", "  province:\n")
+    spec.write_text(text)
+
+    result = sync_program_scope(
+        repo=repo,
+        program_spec=spec,
+        scope="province",
+        add=["policies/dss/snap/page-159"],
+    )
+
+    assert result.changed is True
+    assert yaml.safe_load(spec.read_text())["scope"]["province"][0] == (
+        "policies/dss/snap/page-159"
+    )
+
+
+def test_sync_program_scope_rejects_unsafe_scope_key(tmp_path: Path) -> None:
+    repo, spec = _repo(tmp_path)
+
+    with pytest.raises(ProgramScopeError, match="lowercase identifier"):
+        sync_program_scope(
+            repo=repo,
+            program_spec=spec,
+            scope="../state",
+            add=["policies/dss/snap/page-159"],
+        )
+
+
+def test_sync_program_scope_supports_empty_block_sequence(tmp_path: Path) -> None:
+    repo, spec = _repo(tmp_path)
+
+    result = sync_program_scope(
+        repo=repo,
+        program_spec=spec,
+        scope="state",
+        remove=[
+            "policies/dss/snap/page-163",
+            "policies/dss/snap/page-369",
+        ],
+    )
+
+    assert result.changed is True
+    assert yaml.safe_load(spec.read_text())["scope"]["state"] == []

--- a/tests/test_program_scope.py
+++ b/tests/test_program_scope.py
@@ -271,6 +271,82 @@ def test_sync_program_scope_supports_empty_block_sequence(tmp_path: Path) -> Non
     ]
 
 
+def test_sync_program_scope_supports_inline_empty_sequence(tmp_path: Path) -> None:
+    repo, spec = _repo(tmp_path)
+    spec.write_text(
+        spec.read_text().replace(
+            "  state:\n"
+            "    - policies/dss/snap/page-163\n"
+            "    - policies/dss/snap/page-369\n",
+            "  state: []\n",
+        )
+    )
+
+    result = sync_program_scope(
+        repo=repo,
+        program_spec=spec.relative_to(repo),
+        scope="state",
+        add=["policies/dss/snap/page-159"],
+    )
+
+    assert result.changed is True
+    assert yaml.safe_load(spec.read_text())["scope"]["state"] == [
+        "policies/dss/snap/page-159"
+    ]
+
+
+def test_sync_program_scope_preserves_crlf(tmp_path: Path) -> None:
+    repo, spec = _repo(tmp_path)
+    original = spec.read_text().replace("\n", "\r\n")
+    spec.write_bytes(original.encode())
+
+    sync_program_scope(
+        repo=repo,
+        program_spec=spec.relative_to(repo),
+        scope="state",
+        add=["policies/dss/snap/page-159"],
+    )
+
+    updated = spec.read_bytes()
+    assert updated.count(b"\r\n") == updated.count(b"\n")
+    assert updated.count(b"\r\n") > 0
+
+
+def test_sync_program_scope_rejects_non_atomic_addition(tmp_path: Path) -> None:
+    repo, spec = _repo(tmp_path)
+    module = repo / "us-sc/programs/other.yaml"
+    module.parent.mkdir(parents=True, exist_ok=True)
+    module.write_text("program: us-sc/other\n")
+
+    with pytest.raises(ProgramScopeError, match="do not resolve"):
+        sync_program_scope(
+            repo=repo,
+            program_spec=spec.relative_to(repo),
+            scope="state",
+            add=["programs/other"],
+        )
+
+
+def test_sync_program_scope_appends_after_unterminated_final_line(
+    tmp_path: Path,
+) -> None:
+    repo, spec = _repo(tmp_path)
+    spec.write_text(spec.read_text().split("\n\noutputs:", 1)[0].rstrip("\n"))
+
+    sync_program_scope(
+        repo=repo,
+        program_spec=spec.relative_to(repo),
+        scope="state",
+        add=["policies/dss/snap/page-159"],
+    )
+
+    assert yaml.safe_load(spec.read_text())["scope"]["state"] == [
+        "policies/dss/snap/page-159",
+        "policies/dss/snap/page-163",
+        "policies/dss/snap/page-369",
+    ]
+
+
 def test_sync_program_scope_rejects_absolute_program_spec(tmp_path: Path) -> None:
     repo, spec = _repo(tmp_path)
 

--- a/tests/test_program_scope.py
+++ b/tests/test_program_scope.py
@@ -251,6 +251,33 @@ def test_sync_program_scope_resolves_explicit_scope_to_named_jurisdiction(
     )
 
 
+def test_sync_program_scope_derives_non_us_federal_prefix(tmp_path: Path) -> None:
+    repo = tmp_path / "rulespec-ca"
+    spec = repo / "programs/ca-on/snap/fy-2026.yaml"
+    spec.parent.mkdir(parents=True)
+    spec.write_text(
+        "program: ca-on/snap\n"
+        "period: 2026-01\n"
+        "scope:\n"
+        "  federal: []\n"
+        "outputs: [snap_benefit]\n"
+    )
+    module = repo / "ca/statutes/example/1.yaml"
+    module.parent.mkdir(parents=True)
+    module.write_text("format: rulespec/v1\n")
+
+    sync_program_scope(
+        repo=repo,
+        program_spec=spec.relative_to(repo),
+        scope="federal",
+        add=["statutes/example/1"],
+    )
+
+    assert yaml.safe_load(spec.read_text())["scope"]["federal"] == [
+        "statutes/example/1"
+    ]
+
+
 def test_sync_program_scope_preserves_scope_comments(tmp_path: Path) -> None:
     repo, spec = _repo(tmp_path)
     comment = "    # Page 369 remains documented for later composition.\n"
@@ -345,6 +372,29 @@ def test_sync_program_scope_rejects_aliased_sequence_entry(tmp_path: Path) -> No
             program_spec=spec.relative_to(repo),
             scope="state",
             add=["policies/dss/snap/page-159"],
+        )
+
+
+@pytest.mark.parametrize("decoration", ["&state_imports", "!!seq"])
+def test_sync_program_scope_rejects_decorated_sequence(
+    tmp_path: Path,
+    decoration: str,
+) -> None:
+    repo, spec = _repo(tmp_path)
+    spec.write_text(
+        spec.read_text().replace(
+            "  state:\n",
+            f"  state: {decoration}\n",
+        )
+    )
+
+    with pytest.raises(ProgramScopeError, match="anchor or explicit tag"):
+        sync_program_scope(
+            repo=repo,
+            program_spec=spec.relative_to(repo),
+            scope="state",
+            add=["policies/dss/snap/page-159"],
+            write=False,
         )
 
 

--- a/tests/test_program_scope.py
+++ b/tests/test_program_scope.py
@@ -544,6 +544,20 @@ def test_sync_program_scope_rejects_non_atomic_addition(tmp_path: Path) -> None:
         )
 
 
+def test_sync_program_scope_rejects_companion_test_addition(tmp_path: Path) -> None:
+    repo, spec = _repo(tmp_path)
+    companion = repo / "us-sc/policies/dss/snap/page-999.test.yaml"
+    companion.write_text("format: rulespec-test/v1\n")
+
+    with pytest.raises(ProgramScopeError, match="safe repo-relative"):
+        sync_program_scope(
+            repo=repo,
+            program_spec=spec.relative_to(repo),
+            scope="state",
+            add=["policies/dss/snap/page-999.test"],
+        )
+
+
 def test_sync_program_scope_appends_after_unterminated_final_line(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_program_scope.py
+++ b/tests/test_program_scope.py
@@ -186,6 +186,32 @@ def test_sync_program_scope_preserves_unsorted_existing_order(tmp_path: Path) ->
     ]
 
 
+def test_sync_program_scope_uses_original_order_after_removal(tmp_path: Path) -> None:
+    repo, spec = _repo(tmp_path)
+    spec.write_text(
+        spec.read_text().replace(
+            "    - policies/dss/snap/page-163\n"
+            "    - policies/dss/snap/page-369\n",
+            "    - policies/dss/snap/page-369\n"
+            "    - policies/dss/snap/page-163\n",
+        )
+    )
+
+    result = sync_program_scope(
+        repo=repo,
+        program_spec=spec.relative_to(repo),
+        scope="state",
+        add=["policies/dss/snap/page-159"],
+        remove=["policies/dss/snap/page-369"],
+    )
+
+    assert result.changed is True
+    assert yaml.safe_load(spec.read_text())["scope"]["state"] == [
+        "policies/dss/snap/page-163",
+        "policies/dss/snap/page-159",
+    ]
+
+
 def test_sync_program_scope_resolves_explicit_scope_to_named_jurisdiction(
     tmp_path: Path,
 ) -> None:
@@ -281,6 +307,50 @@ def test_sync_program_scope_rejects_aliased_sequence(tmp_path: Path) -> None:
             program_spec=spec.relative_to(repo),
             scope="state",
             add=["policies/dss/snap/page-159"],
+        )
+
+
+def test_sync_program_scope_rejects_aliased_scope_mapping(tmp_path: Path) -> None:
+    repo, spec = _repo(tmp_path)
+    spec.write_text(
+        "program: us-sc/snap\n"
+        "period: 2026-01\n"
+        "scope_defaults: &scope_defaults\n"
+        "  federal:\n"
+        "    - regulations/7-cfr/273/9\n"
+        "  state:\n"
+        "    - policies/dss/snap/page-163\n"
+        "    - policies/dss/snap/page-369\n"
+        "scope: *scope_defaults\n"
+        "unused_scope: *scope_defaults\n"
+        "outputs: [snap_benefit]\n"
+    )
+
+    with pytest.raises(ProgramScopeError, match="mapping must not use a YAML alias"):
+        sync_program_scope(
+            repo=repo,
+            program_spec=spec.relative_to(repo),
+            scope="state",
+            add=["policies/dss/snap/page-159"],
+        )
+
+
+def test_sync_program_scope_rejects_flow_style_scope_mapping(tmp_path: Path) -> None:
+    repo, spec = _repo(tmp_path)
+    spec.write_text(
+        "program: us-sc/snap\n"
+        "period: 2026-01\n"
+        "scope: {state: []}\n"
+        "outputs: [snap_benefit]\n"
+    )
+
+    with pytest.raises(ProgramScopeError, match="mapping must use block style"):
+        sync_program_scope(
+            repo=repo,
+            program_spec=spec.relative_to(repo),
+            scope="state",
+            add=["policies/dss/snap/page-159"],
+            write=False,
         )
 
 

--- a/tests/test_program_scope.py
+++ b/tests/test_program_scope.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 import yaml
 
+import axiom_encode.program_scope as program_scope
 from axiom_encode.program_scope import ProgramScopeError, sync_program_scope
 
 
@@ -310,6 +311,28 @@ def test_sync_program_scope_rejects_aliased_sequence(tmp_path: Path) -> None:
         )
 
 
+def test_sync_program_scope_rejects_aliased_sequence_entry(tmp_path: Path) -> None:
+    repo, spec = _repo(tmp_path)
+    spec.write_text(
+        "program: us-sc/snap\n"
+        "period: 2026-01\n"
+        "shared_import: &shared_import policies/dss/snap/page-163\n"
+        "scope:\n"
+        "  state:\n"
+        "    - *shared_import\n"
+        "    - policies/dss/snap/page-369\n"
+        "outputs: [snap_benefit]\n"
+    )
+
+    with pytest.raises(ProgramScopeError, match="entries must not use YAML aliases"):
+        sync_program_scope(
+            repo=repo,
+            program_spec=spec.relative_to(repo),
+            scope="state",
+            add=["policies/dss/snap/page-159"],
+        )
+
+
 def test_sync_program_scope_rejects_aliased_scope_mapping(tmp_path: Path) -> None:
     repo, spec = _repo(tmp_path)
     spec.write_text(
@@ -450,6 +473,60 @@ def test_sync_program_scope_preserves_crlf(tmp_path: Path) -> None:
     updated = spec.read_bytes()
     assert updated.count(b"\r\n") == updated.count(b"\n")
     assert updated.count(b"\r\n") > 0
+
+
+def test_sync_program_scope_disables_write_newline_translation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, spec = _repo(tmp_path)
+    calls: list[dict[str, object]] = []
+    original = program_scope.tempfile.NamedTemporaryFile
+
+    def tracked_temporary_file(*args, **kwargs):
+        calls.append(kwargs)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        program_scope.tempfile,
+        "NamedTemporaryFile",
+        tracked_temporary_file,
+    )
+
+    sync_program_scope(
+        repo=repo,
+        program_spec=spec.relative_to(repo),
+        scope="state",
+        add=["policies/dss/snap/page-159"],
+    )
+
+    assert calls[0]["newline"] == ""
+
+
+def test_sync_program_scope_empties_indentationless_sequence(tmp_path: Path) -> None:
+    repo, spec = _repo(tmp_path)
+    spec.write_text(
+        spec.read_text().replace(
+            "  state:\n"
+            "    - policies/dss/snap/page-163\n"
+            "    - policies/dss/snap/page-369\n",
+            "  state:\n"
+            "  - policies/dss/snap/page-163\n"
+            "  - policies/dss/snap/page-369\n",
+        )
+    )
+
+    sync_program_scope(
+        repo=repo,
+        program_spec=spec.relative_to(repo),
+        scope="state",
+        remove=[
+            "policies/dss/snap/page-163",
+            "policies/dss/snap/page-369",
+        ],
+    )
+
+    assert yaml.safe_load(spec.read_text())["scope"]["state"] == []
 
 
 def test_sync_program_scope_rejects_non_atomic_addition(tmp_path: Path) -> None:

--- a/tests/test_program_scope.py
+++ b/tests/test_program_scope.py
@@ -148,6 +148,21 @@ def test_sync_program_scope_rejects_unsafe_paths(tmp_path: Path, path: str) -> N
         )
 
 
+def test_sync_program_scope_rejects_colon_bearing_module_path(tmp_path: Path) -> None:
+    repo, spec = _repo(tmp_path)
+    module = repo / "us-sc/statutes/47:294.yaml"
+    module.parent.mkdir(parents=True)
+    module.write_text("format: rulespec/v1\n")
+
+    with pytest.raises(ProgramScopeError, match="safe repo-relative"):
+        sync_program_scope(
+            repo=repo,
+            program_spec=spec.relative_to(repo),
+            scope="state",
+            add=["statutes/47:294"],
+        )
+
+
 def test_sync_program_scope_allows_already_absent_removal(tmp_path: Path) -> None:
     repo, spec = _repo(tmp_path)
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1238"
+version = "0.2.1239"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1240"
+version = "0.2.1241"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1243"
+version = "0.2.1244"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1239"
+version = "0.2.1240"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1241"
+version = "0.2.1242"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1237"
+version = "0.2.1238"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1242"
+version = "0.2.1243"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1244"
+version = "0.2.1245"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- add a deterministic `program-scope-sync` CLI for validated ProgramSpec scope updates
- preserve unrelated ProgramSpec text and write updates atomically
- validate canonical primary RuleSpec module paths and reject unsafe YAML, symlinks, test companions, and ambiguous imports
- document the separation between atomic RuleSpec encoding and deterministic composition updates

## Checks
- `uv run ruff format --check src tests` (109 files already formatted)
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest` (3900 passed, 106 skipped)
- focused post-format suite: 37 passed
- exhaustive add/remove ordering exercise: 0 failures across 4,548 cases

## Review cycle
- Independent review found and fixed formatting, ordering, comment-preservation, alias, symlink, newline, module-kind, and compose-path edge cases.
- Relevant focused checks were rerun after every repair.
- Final independent review on the substantive tree reported no actionable findings.
- Ruff formatting was applied mechanically afterward; format, lint, compile, and focused tests remain clean.
