### PR TITLE
Prefer canonical context outputs during encoding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1246"
+version = "0.2.1247"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1246"
+__version__ = "0.2.1247"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -7943,6 +7943,7 @@ Test file rules:
   without this paired positive/negative companion.
 - Do not collapse a list of cited exceptions or cross-reference carve-outs into one aggregate fact such as `sections_..._do_not_preclude...`. Encode or import each cited exception separately, then combine them in a helper if useful.
 - If context files import this target file or reference this target file's outputs, use that as a signal to repair the dependency graph, not as a requirement to preserve old names. Keep an old output only when it remains the cleanest source-faithful RuleSpec surface.
+- When a copied context file already exports the operative legal condition that the requested source consumes, import and use that canonical output. Do not recreate it as a local factual input merely because the requested source describes a person or household as entitled, eligible, qualified, allowed, or subject to that condition. Keep a local fact only when the requested source states a distinct operative fact that the context output does not represent.
 - Do not preserve existing factual input slots referenced by copied formulas or companion tests when a cleaner source-faithful encoding removes them. For names listed under invalid copied local inputs, do not preserve, rename, or recreate them.
 - When this source text itself names the operative factual disqualification,
   exception, or eligibility condition, encode that named condition as a local

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -1109,6 +1109,13 @@ _TESTS_PROTOCOL = """- Emit only RuleSpec YAML; use `.test.yaml` companions when
   as a signal to repair the dependency graph, not as a requirement to preserve
   old names. Keep an old output only when it remains the cleanest
   source-faithful RuleSpec surface.
+- When a copied context file already exports the operative legal condition that
+  the requested source consumes, import and use that canonical output. Do not
+  recreate it as a local factual input merely because the requested source
+  describes a person or household as entitled, eligible, qualified, allowed,
+  or subject to that condition. Keep a local fact only when the requested
+  source states a distinct operative fact that the context output does not
+  represent.
 - Do not preserve existing factual input slots referenced by copied formulas or
   companion tests when a cleaner source-faithful encoding removes them. This is
   especially important for names listed under invalid copied local inputs.

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -134,6 +134,8 @@ def _assert_encoder_prompt_topics(prompt: str) -> None:
         "`clause_ii_provides_otherwise`",
         "paragraph_d_2_methodology_limit_satisfied",
         "dependency graph remains acyclic",
+        "copied context file already exports the operative legal condition",
+        "Do not\n  recreate it as a local factual input",
         "Axiom formulas have no date literal type",
         "Never use `post_YYYY`, `pre_YYYY`, `after_YYYY`, `before_YYYY`",
         "Do not write `else if` or `elif`",

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -8326,6 +8326,11 @@ class TestEvalPrompt:
         assert "sets that exception input true" in prompt
         assert "Do not collapse a list of cited exceptions" in prompt
         assert "Do not create derived `dtype: Boolean` helper rules" in prompt
+        assert (
+            "copied context file already exports the operative legal condition"
+            in prompt
+        )
+        assert "Do not recreate it as a local factual input" in prompt
 
     def test_build_eval_prompt_includes_supported_schema_enums(self, tmp_path):
         workspace = prepare_eval_workspace(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1246"
+version = "0.2.1247"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- require encoder prompt paths to import an operative legal condition already exported by copied context
- prevent entitlement and eligibility conditions from being recreated as local factual inputs
- add prompt regression coverage for generic and eval encoders

## Motivation
A South Carolina SNAP page 163 re-encode received page 164 as explicit context, but retained a duplicate local BUA-entitlement fact instead of consuming page 164's canonical output. This change fixes the reusable encoder instruction; generated RuleSpec remains encoder-owned.

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest` (3900 passed, 106 skipped)

## Cycle
- Independent review pending.