### PR TITLE
Restore Danish amendment-discovery recall (spelled-out act types, short titles, document-root target rows)

### DIFF
--- a/changelog.d/dk-amendment-discovery-recall.fixed.md
+++ b/changelog.d/dk-amendment-discovery-recall.fixed.md
@@ -1,0 +1,2 @@
+Restore Danish amendment discovery for document-root targets and canonical
+Retsinformation consolidation citations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1245"
+version = "0.2.1246"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1245"
+__version__ = "0.2.1246"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -1512,11 +1512,13 @@ _AMENDMENT_NAME_STOPWORDS = frozenset(
         "amendment",
         "and",
         "article",
+        "bek",
         "bekendtgoerelse",
         "chapter",
         "code",
         "decree",
         "law",
+        "lbk",
         "lov",
         "loven",
         "of",
@@ -1543,7 +1545,11 @@ def _normalized_relation_text(value: object) -> str:
     text = "".join(
         character for character in text if not unicodedata.combining(character)
     )
-    return " ".join(re.findall(r"[a-z0-9]+", text))
+    tokens = re.findall(r"[a-z0-9]+", text)
+    # Retsinformation's Danish act-type register uses these abbreviations in
+    # ELI/citation metadata; canonicalize spelled-out citation forms likewise.
+    act_types = {"lovbekendtgoerelse": "lbk", "bekendtgoerelse": "bek"}
+    return " ".join(act_types.get(token, token) for token in tokens)
 
 
 def _metadata_scalar_values(value: object) -> Iterator[str]:
@@ -1609,7 +1615,7 @@ def _target_document_identifiers(
         segment_tokens = _normalized_tokens(segment)
         is_numbered_legal_locator = segment_tokens and segment_tokens[
             0
-        ] in _AMENDMENT_NAME_STOPWORDS - {"act"}
+        ] in _AMENDMENT_NAME_STOPWORDS - {"act", "bek", "lbk"}
         has_letters = any(character.isalpha() for character in segment)
         if (
             has_letters
@@ -1629,6 +1635,13 @@ def _target_document_identifiers(
         for key in ("title", "title_short", "title_alternative"):
             for value in _metadata_scalar_values(row.metadata.get(key)):
                 add_name(value)
+                if key == "title":
+                    title_without_parenthetical = re.sub(
+                        r"\s+\([^()]*\)\s*$", "", value
+                    )
+                    short_title_tokens = _normalized_tokens(title_without_parenthetical)
+                    if short_title_tokens[:2] == ("bek", "af"):
+                        add_name(" ".join(short_title_tokens[2:]))
         for key, value in row.metadata.items():
             normalized_key = key.casefold().replace("-", "_")
             is_eli_identifier = _is_eli_key(normalized_key)
@@ -5236,6 +5249,21 @@ def resolve_corpus_source_unit(
             ),
             None,
         )
+        if target_row is None and resolved.row.source_path:
+            source_path_matches = (
+                item
+                for item in active_rows
+                if item.row.source_path == resolved.row.source_path
+                and item.row.version == resolved.row.version
+            )
+            target_row = min(
+                source_path_matches,
+                key=lambda item: (
+                    len(item.row.citation_path.split("/")),
+                    item.row.citation_path,
+                ),
+                default=None,
+            )
         return CorpusSourceUnit(
             requested=resolved.requested,
             citation_path=resolved.citation_path,

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -907,6 +907,69 @@ def test_unrelated_newer_amendment_is_excluded_from_target_context(tmp_path):
             True,
         ),
         (
+            "dk/statute/lbk-603-2025/section-1",
+            {},
+            "lov om en boerne og ungeydelse jf lovbekendtgoerelse nr 603 af "
+            "12 maj 2025 its 1 plus ligningsloven and other acts",
+            True,
+        ),
+        (
+            "dk/statute/lbk-603-2025/section-1",
+            {
+                "title": (
+                    "Bekendtgørelse af lov om en børne- og ungeydelse "
+                    "(LBK nr 603 af 12/05/2025)"
+                )
+            },
+            "lov om social pension lov om hoejeste mellemste forhoejet almindelig "
+            "og almindelig foertidspension m v and various other acts including "
+            "lov om en boerne og ungeydelse its 4 e",
+            True,
+        ),
+        (
+            "dk/statute/lbk-603-2025/section-1",
+            {
+                "title": (
+                    "Bekendtgoerelse af lov om en boerne- og ungeydelse "
+                    "(LBK nr 603 af 12/05/2025)"
+                )
+            },
+            "various acts including lov om en boerne og ungeydelse its 4 e",
+            True,
+        ),
+        ("dk/statute/lbk-603-2025/section-1", {}, "LBK nr 604", False),
+        (
+            "dk/statute/lbk-603-2025/section-1",
+            {},
+            "lovbekendtgørelse nr. 604 af 12. maj 2025",
+            False,
+        ),
+        ("dk/statute/lbk-603-2025/section-1", {}, "LBK nr 6030", False),
+        ("uk/statute/act-766/section-1", {}, "Act 1766", False),
+        (
+            "eu/regulation/benefit/section-1",
+            {"act_number": "979/2016"},
+            "1979/2016",
+            False,
+        ),
+        (
+            "dk/statute/lbk-603-2025/section-1",
+            {
+                "title": (
+                    "Bekendtgørelse af lov om en børne- og ungeydelse "
+                    "(LBK nr 603 af 12/05/2025)"
+                )
+            },
+            "lov om en boerne under andre regler og ungeydelse",
+            False,
+        ),
+        (
+            "dk/statute/lbk-999-2025/section-1",
+            {"title": "Bekendtgørelse af lov om skat (LBK nr 999 af 01/01/2025)"},
+            "lov om skat",
+            False,
+        ),
+        (
             "dk/statute/boerne-og-ungeydelsesloven/section-1",
             {},
             "Lov om ændring af børne- og ungeydelsesloven",
@@ -1277,6 +1340,46 @@ def test_resolve_corpus_source_unit_concatenates_descendant_text_rows(tmp_path):
     assert source_unit.body == (
         "Need standards\n\nFirst extracted block.\n\nSecond extracted block."
     )
+
+
+def test_resolve_corpus_source_unit_matches_root_to_active_source_path(tmp_path):
+    target_path = "dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven"
+    target_source_path = "sources/dk/target.pdf"
+    release = _write_test_corpus_release(
+        tmp_path,
+        [
+            {"citation_path": target_path, "source_path": target_source_path},
+            {
+                "citation_path": f"{target_path}/document-1",
+                "body": "Consolidated target text.",
+                "source_path": target_source_path,
+                "metadata": {
+                    "title": (
+                        "Bekendtgørelse af lov om en børne- og ungeydelse "
+                        "(LBK nr 603 af 12/05/2025)"
+                    ),
+                    "source_note": "Curated target note.",
+                },
+            },
+            {
+                "citation_path": "dk/statute/lov-1642-2025/amendment/document-1",
+                "body": "Amendment text.",
+                "source_path": "sources/dk/amendment.pdf",
+                "metadata": {
+                    "document_type": "amendment act",
+                    "amends": target_path,
+                    "title": "LOV nr 1642 af 16/12/2025",
+                },
+            },
+        ],
+    )
+
+    source_unit = resolve_corpus_source_unit(target_path, release)
+
+    assert source_unit.provision_metadata["source_note"] == "Curated target note."
+    assert [item.citation_path for item in source_unit.amendment_documents] == [
+        "dk/statute/lov-1642-2025/amendment/document-1"
+    ]
 
 
 def test_source_identifier_maps_state_manual_to_policies_repo_path():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1245"
+version = "0.2.1246"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
Closes #1139.

The deferred #1125 live eval (unblocked by `dk-rulespec-2026-07-12`) found amendment discovery returning **zero documents on the exact corpus that motivated the feature**. Two defects, both fixed here; the live acceptance probe on the real signed release now returns curated provision metadata (21 keys) and exactly two amendment documents, newest-first (LOV 303/2026, LOV 1642/2025).

## Fixes

1. **Target-row lookup** (`resolve_corpus_source_unit`): exact citation-path/version match is still preferred; when resolution returns a document-ROOT row but active rows carry only `…/document-1` leaves, a same-`source_path`/version fallback (fewest citation segments, then lexicographic) now finds the row instead of silently dropping all curated metadata and weakening discovery identifiers.
2. **Relation-matcher recall, staying fail-closed**:
   - Act-type canonicalization after diacritic folding, from the retsinformation register: `lovbekendtgoerelse → lbk`, `bekendtgoerelse → bek`. The real convention spells out the act-type word (`…jf lovbekendtgørelse nr. 603 af 12. maj 2025…`), which the existing Nordic `(type, 'nr', number)` branch could never see. `lbk`/`bek` are added to the name stopwords so canonicalization cannot mint new distinctive name evidence (they stay eligible as structured prefixes).
   - Danish consolidation short-title derivation: titles shaped `Bekendtgørelse af <short title> (…)` also yield `<short title>` as a name identifier under the existing ≥2-distinctive-token guard — LOV 303 cites the target by short name only and was unreachable by any tier.

## Verification

- Live probe against the signed `dk-rulespec-2026-07-12` release: before = `{}` metadata / 0 amendments; after = 21 metadata keys / 2 amendments `['dk/statute/lov-303-2026/…', 'dk/statute/lov-1642-2025/…']`, expression dates `2026-02-24, 2025-12-16`.
- False-positive set re-probed and held: `lovbekendtgørelse nr. 604`, `LBK nr 6030`, generic prose, scattered/interrupted name tokens all rejected; `Act 1766`/`1979/2016` exact-token distinctions unchanged.
- New tests pin the REAL LOV 1642/303 relation strings, the short-title guard (<2 distinctive tokens ⇒ no identifier), and the document-root→leaf fallback with sibling discovery.
- Full `tests/test_evals.py`: 559 passed. Ratchet 3/3 at 0.2.1246. `ruff check` + `ruff format --check` clean. No goldens changed — the no-context byte-identity guarantee holds for targets without qualifying amendments.

Found and specified by the #1125 deferred-eval dry probe; implementation gpt-5.6-sol worker, Fable review + gate.
