### PR TITLE
Fix atomic routing in composition checkouts

### DIFF
--- a/changelog.d/composition-checkout-atomic-routing.fixed.md
+++ b/changelog.d/composition-checkout-atomic-routing.fixed.md
@@ -1,0 +1,1 @@
+Preserve atomic RuleSpec validation, source scanning, toolchain loading, and signed apply routing when a canonical country checkout also contains top-level ProgramSpecs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1247"
+version = "0.2.1248"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1247"
+__version__ = "0.2.1248"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -243,7 +243,6 @@ from .repo_routing import (
     canonical_rulespec_root_identity,
     find_policy_repo_root,
     is_composition_policy_repo_root,
-    is_policy_repo_root,
     jurisdiction_content_dir,
     jurisdiction_subdir_names,
     monorepo_checkout_name,
@@ -374,7 +373,7 @@ def _resolve_canonical_rulespec_checkout(
     """Resolve one explicitly authorized canonical country checkout."""
 
     checkout = _resolve_explicit_existing_directory(raw_path, label=label)
-    if not is_policy_repo_root(checkout):
+    if not is_composition_policy_repo_root(checkout):
         raise ValueError(
             f"{label} must be the exact canonical rulespec-<country> checkout; "
             f"got {checkout}"
@@ -437,7 +436,10 @@ def _canonical_validation_checkout_root(rulespec_file: Path) -> Path:
             "rulespec-<country>/<jurisdiction>: "
             f"{rulespec_file}"
         )
-    if content_root.name not in jurisdiction_subdir_names(content_root.parent):
+    if content_root.name not in jurisdiction_subdir_names(
+        content_root.parent,
+        allow_composition_specs=True,
+    ):
         raise ValueError(
             "validation requires the country-monorepo layout "
             f"(<rulespec-country>/<jurisdiction>/...): {rulespec_file}"
@@ -4512,13 +4514,13 @@ def _rulespec_module_paths(checkout: Path) -> list[Path]:
     """Return only atomic modules from one explicit country checkout."""
 
     checkout = _resolve_canonical_rulespec_checkout(checkout)
-    flat_roots = [checkout / root for root in sorted(RULESPEC_FILESYSTEM_ROOTS)]
+    flat_roots = [checkout / root for root in sorted(RULESPEC_ATOMIC_MODULE_ROOTS)]
     invalid_flat_roots = [
         path for path in flat_roots if path.exists() or path.is_symlink()
     ]
     if invalid_flat_roots:
         raise ValueError(
-            "RuleSpec checkout contains repository-root content; all five roots must "
+            "RuleSpec checkout contains repository-root atomic content; atomic roots must "
             "live under rulespec-<country>/<jurisdiction>/<content-root>: "
             + ", ".join(str(path) for path in invalid_flat_roots)
         )
@@ -35976,7 +35978,10 @@ def _apply_dependency_checkout_identity(root: Path) -> dict[str, object]:
     """Bind one explicit dependency checkout exactly as the overlay stages it."""
 
     checkout = Path(root).resolve()
-    jurisdictions = jurisdiction_subdir_names(checkout)
+    jurisdictions = jurisdiction_subdir_names(
+        checkout,
+        allow_composition_specs=True,
+    )
     return {
         "path": str(checkout),
         "checkout_identity": _git_checkout_execution_identity(checkout),

--- a/src/axiom_encode/concepts/audit.py
+++ b/src/axiom_encode/concepts/audit.py
@@ -19,7 +19,7 @@ import yaml
 from axiom_encode.constants import RULESPEC_ATOMIC_MODULE_ROOTS
 from axiom_encode.repo_routing import (
     canonical_rulespec_root_identity,
-    is_policy_repo_root,
+    is_composition_policy_repo_root,
     iter_jurisdiction_content_dirs,
 )
 
@@ -152,7 +152,7 @@ def _canonical_jurisdiction_roots(roots: Iterable[Path]) -> tuple[Path, ...]:
             ) from exc
         if canonical_rulespec_root_identity(root) is not None:
             candidates = (root,)
-        elif is_policy_repo_root(root):
+        elif is_composition_policy_repo_root(root):
             candidates = tuple(
                 content_root
                 for _jurisdiction, content_root in iter_jurisdiction_content_dirs(root)

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -4392,7 +4392,10 @@ def _eval_suite_rulespec_roots(
     exposed_roots = {
         checkout / jurisdiction
         for checkout in checkouts
-        for jurisdiction in jurisdiction_subdir_names(checkout)
+        for jurisdiction in jurisdiction_subdir_names(
+            checkout,
+            allow_composition_specs=True,
+        )
     }
     if not active_roots.issubset(exposed_roots):
         raise ValueError("Eval suite could not identify every active RuleSpec root")

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -19117,7 +19117,10 @@ def _normalize_rulespec_dependency_roots(
             root,
             label="RuleSpec dependency root",
         )
-        jurisdiction_children = jurisdiction_subdir_names(root)
+        jurisdiction_children = jurisdiction_subdir_names(
+            root,
+            allow_composition_specs=True,
+        )
         if not jurisdiction_children:
             raise UnsafeRulespecContextPath(
                 "RuleSpec dependency roots must be exact canonical checkout roots "

--- a/src/axiom_encode/judges/cli_commands.py
+++ b/src/axiom_encode/judges/cli_commands.py
@@ -33,7 +33,7 @@ from axiom_encode.corpus_resolver import (
     require_canonical_corpus_citation_path,
     resolve_local_corpus_source,
 )
-from axiom_encode.repo_routing import is_policy_repo_root
+from axiom_encode.repo_routing import is_composition_policy_repo_root
 from axiom_encode.toolchain import load_rulespec_local_corpus_release
 
 from .regeneration import (
@@ -539,7 +539,7 @@ def _emit_event(event, as_json: bool, args: argparse.Namespace | None = None) ->
 def _load_bound_corpus_release(args: argparse.Namespace) -> LocalCorpusRelease | None:
     try:
         root = Path(args.root).resolve(strict=True)
-        if not is_policy_repo_root(root):
+        if not is_composition_policy_repo_root(root):
             raise ValueError(
                 "root must be an exact canonical rulespec-<country> checkout"
             )
@@ -626,7 +626,7 @@ def _load_drift_modules(args: argparse.Namespace) -> dict[str, str] | None:
         except OSError as exc:
             print(f"invalid drift root {args.root}: {exc}", file=sys.stderr)
             return None
-        if not is_policy_repo_root(root):
+        if not is_composition_policy_repo_root(root):
             print(
                 "drift root must be an exact canonical "
                 f"rulespec-<country> checkout: {root}",

--- a/src/axiom_encode/judges/regeneration.py
+++ b/src/axiom_encode/judges/regeneration.py
@@ -23,7 +23,7 @@ from axiom_encode.constants import RULESPEC_ATOMIC_MODULE_ROOTS
 from axiom_encode.corpus_resolver import LocalCorpusRelease
 from axiom_encode.repo_routing import (
     canonical_rulespec_root_identity,
-    is_policy_repo_root,
+    is_composition_policy_repo_root,
 )
 from axiom_encode.toolchain import load_rulespec_local_corpus_release
 
@@ -158,7 +158,7 @@ def validate_module_path(root: Path, module: str) -> PurePosixPath:
         raise UnsafeRegenerationPath(f"module path is not normalized: {module!r}")
 
     resolved_root = Path(root).resolve(strict=True)
-    if not is_policy_repo_root(resolved_root):
+    if not is_composition_policy_repo_root(resolved_root):
         raise RegenerationInputError(
             "regeneration root must be the exact canonical "
             f"rulespec-<country> checkout: {resolved_root}"

--- a/src/axiom_encode/oracles/policyengine/snap_readiness.py
+++ b/src/axiom_encode/oracles/policyengine/snap_readiness.py
@@ -24,7 +24,7 @@ from axiom_encode.corpus_resolver import (
 )
 from axiom_encode.repo_routing import (
     canonical_rulespec_root_identity,
-    is_policy_repo_root,
+    is_composition_policy_repo_root,
 )
 from axiom_encode.toolchain import load_rulespec_local_corpus_release
 
@@ -178,7 +178,7 @@ def count_snap_corpus_provisions(
 
 
 def _resolve_rulespec_us_repo(root: Path) -> Path:
-    if root.name != "rulespec-us" or not is_policy_repo_root(root):
+    if root.name != "rulespec-us" or not is_composition_policy_repo_root(root):
         raise SnapReadinessConfigurationError(
             f"SNAP readiness requires the exact canonical rulespec-us checkout: {root}"
         )

--- a/src/axiom_encode/repo_routing.py
+++ b/src/axiom_encode/repo_routing.py
@@ -144,7 +144,10 @@ def canonical_rulespec_root_identity(path: Path) -> str | None:
     expected_checkout = monorepo_checkout_name(jurisdiction)
     if checkout.name != expected_checkout:
         return None
-    if _canonical_country_checkout_name(checkout) != expected_checkout:
+    if (
+        _canonical_country_checkout_name(checkout, allow_composition_specs=True)
+        != expected_checkout
+    ):
         return None
     country = jurisdiction_country(jurisdiction)
     if not _is_jurisdiction_dir_name(jurisdiction, country):
@@ -199,7 +202,7 @@ def canonical_rulespec_repo_name(path: Path) -> str | None:
     content_root = find_policy_repo_root(current)
     if content_root is not None:
         return f"rulespec-{content_root.name}"
-    return _canonical_country_checkout_name(current)
+    return _canonical_country_checkout_name(current, allow_composition_specs=True)
 
 
 def jurisdiction_content_dir(checkout: Path, prefix: str) -> Path:
@@ -228,7 +231,8 @@ def candidate_jurisdiction_content_dirs(base: Path, prefix: str) -> list[Path]:
     expected_checkout = monorepo_checkout_name(prefix)
     if (
         base.name == expected_checkout
-        and _canonical_country_checkout_name(base) == expected_checkout
+        and _canonical_country_checkout_name(base, allow_composition_specs=True)
+        == expected_checkout
     ):
         return [base / prefix]
     if canonical_rulespec_root_identity(base) == f"{expected_checkout}/{prefix}":
@@ -283,7 +287,10 @@ def iter_jurisdiction_content_dirs(workspace_root: Path) -> list[tuple[str, Path
         return []
     checkout = lexical.resolve()
     return [
-        (name, checkout / name) for name in sorted(jurisdiction_subdir_names(checkout))
+        (name, checkout / name)
+        for name in sorted(
+            jurisdiction_subdir_names(checkout, allow_composition_specs=True)
+        )
     ]
 
 

--- a/src/axiom_encode/run_log_export.py
+++ b/src/axiom_encode/run_log_export.py
@@ -30,7 +30,7 @@ from typing import Any, Iterable, Optional
 
 from pydantic import ValidationError
 
-from .repo_routing import is_policy_repo_root
+from .repo_routing import is_composition_policy_repo_root
 from .run_log import (
     FUNNEL_STEPS,
     SCHEMA_VERSION,
@@ -283,7 +283,7 @@ def build_manifest_index(repo_paths: Iterable[Path]) -> dict[str, dict[str, Any]
     seen_repos: set[Path] = set()
     for raw_repo_path in repo_paths:
         raw_repo_path = Path(raw_repo_path).expanduser()
-        if not is_policy_repo_root(raw_repo_path):
+        if not is_composition_policy_repo_root(raw_repo_path):
             raise ValueError(
                 "Run-log manifest indexing requires an explicit exact canonical "
                 f"rulespec-<country> checkout: {raw_repo_path}"

--- a/src/axiom_encode/source_hash.py
+++ b/src/axiom_encode/source_hash.py
@@ -43,7 +43,7 @@ from axiom_encode.corpus_resolver import (
 )
 from axiom_encode.repo_routing import (
     canonical_rulespec_root_identity,
-    is_policy_repo_root,
+    is_composition_policy_repo_root,
 )
 from axiom_encode.toolchain import load_rulespec_local_corpus_release
 
@@ -436,7 +436,7 @@ def _rulespec_scan_root_layout(root: Path) -> str:
 
     if canonical_rulespec_root_identity(root) is not None:
         return "jurisdiction"
-    if is_policy_repo_root(root):
+    if is_composition_policy_repo_root(root):
         return "country"
     raise RuleSpecScanError(
         root,
@@ -485,7 +485,11 @@ def _is_canonical_composition_spec_directory(
         return False
     if layout == "jurisdiction":
         return relative.parts == (RULESPEC_COMPOSITION_SPEC_ROOT,)
-    if layout != "country" or len(relative.parts) != 2:
+    if layout != "country":
+        return False
+    if relative.parts == (RULESPEC_COMPOSITION_SPEC_ROOT,):
+        return True
+    if len(relative.parts) != 2:
         return False
     country = root.name.removeprefix("rulespec-")
     jurisdiction, source_root = relative.parts

--- a/src/axiom_encode/toolchain.py
+++ b/src/axiom_encode/toolchain.py
@@ -17,7 +17,7 @@ from .corpus_resolver import (
     read_bounded_regular_file,
     validate_corpus_release_name,
 )
-from .repo_routing import is_policy_repo_root
+from .repo_routing import is_composition_policy_repo_root
 from .signing_broker import SigningBrokerError, get_signing_broker
 
 MAX_RULESPEC_TOOLCHAIN_BYTES = 64 * 1024
@@ -36,7 +36,7 @@ class RuleSpecToolchainError(ValueError):
 def _require_canonical_country_checkout(root: Path) -> Path:
     """Reject flat, aliased, workspace, and otherwise noncanonical roots."""
 
-    if not is_policy_repo_root(root):
+    if not is_composition_policy_repo_root(root):
         raise RuleSpecToolchainError(
             "RuleSpec toolchain root must be the exact canonical "
             f"rulespec-<country> checkout: {root}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6479,7 +6479,7 @@ rules:
         with pytest.raises(ValueError, match="exact canonical rulespec-<country>"):
             cmd_inventory(SimpleNamespace(root=tmp_path / "rulespec-us", json=True))
 
-    def test_inventory_rejects_repository_root_programs(self, tmp_path):
+    def test_inventory_ignores_repository_root_programs(self, capsys, tmp_path):
         checkout = tmp_path / "rulespec-us"
         atomic = checkout / "us/statutes/26/1.yaml"
         atomic.parent.mkdir(parents=True)
@@ -6488,8 +6488,11 @@ rules:
         program.parent.mkdir(parents=True)
         program.write_text("program: us/snap\nperiod: '2026-01'\noutputs: [benefit]\n")
 
-        with pytest.raises(ValueError, match="exact canonical rulespec-<country>"):
-            cmd_inventory(SimpleNamespace(root=checkout, json=True))
+        cmd_inventory(SimpleNamespace(root=checkout, json=True))
+
+        output = json.loads(capsys.readouterr().out)
+        assert output["total_files"] == 1
+        assert output["repos"][0]["roots"] == {"statutes": 1}
 
 
 class TestCmdIntervalTableAudit:
@@ -32287,23 +32290,38 @@ class TestProgramsRootExcludedFromAtomicGuard:
 
         assert issues == []
 
-    def test_guard_command_rejects_repository_root_programs(self, tmp_path):
+    def test_guard_command_ignores_repository_root_programs(self, capsys, tmp_path):
         checkout = tmp_path / "rulespec-us"
+        release = _bind_test_corpus_release(
+            checkout,
+            tmp_path / "axiom-corpus",
+        )
         program = checkout / "programs/us/snap/fy-2026.yaml"
         program.parent.mkdir(parents=True)
         program.write_text("program: us/snap\nperiod: 2026-01\noutputs: [benefit]\n")
 
-        with pytest.raises(ValueError, match="exact canonical rulespec-<country>"):
+        with (
+            patch(
+                "axiom_encode.cli._git_changed_files",
+                return_value=["programs/us/snap/fy-2026.yaml"],
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
             cmd_guard_generated(
                 SimpleNamespace(
                     repo=checkout,
-                    corpus_path=tmp_path / "axiom-corpus",
+                    corpus_path=release.root,
                     base_ref=None,
                     head_ref="HEAD",
                     json=False,
                     all=False,
                 )
             )
+
+        assert exc_info.value.code == 0
+        assert "All changed RuleSpec files have encoder apply manifests." in (
+            capsys.readouterr().out
+        )
 
 
 class TestManifestCurrentState:

--- a/tests/test_repo_routing.py
+++ b/tests/test_repo_routing.py
@@ -94,15 +94,13 @@ def test_composition_checkout_preserves_atomic_jurisdiction_identity(tmp_path):
     module.parent.mkdir(parents=True)
     module.write_text("format: rulespec/v1\n", encoding="utf-8")
 
-    assert canonical_rulespec_root_identity(checkout / "us-co") == (
-        "rulespec-us/us-co"
-    )
+    assert canonical_rulespec_root_identity(checkout / "us-co") == ("rulespec-us/us-co")
     assert find_policy_repo_root(module) == checkout / "us-co"
     assert canonical_rulespec_repo_name(checkout) == "rulespec-us"
     assert canonical_rulespec_repo_name(module) == "rulespec-us-co"
-    assert jurisdiction_subdir_names(
-        checkout, allow_composition_specs=True
-    ) == {"us-co"}
+    assert jurisdiction_subdir_names(checkout, allow_composition_specs=True) == {
+        "us-co"
+    }
     assert candidate_jurisdiction_content_dirs(checkout, "us-co") == [
         checkout / "us-co"
     ]

--- a/tests/test_repo_routing.py
+++ b/tests/test_repo_routing.py
@@ -86,6 +86,28 @@ def test_composition_checkout_identity_rejects_symlinked_programs(tmp_path):
     assert is_composition_policy_repo_root(checkout) is False
 
 
+def test_composition_checkout_preserves_atomic_jurisdiction_identity(tmp_path):
+    checkout = tmp_path / "rulespec-us"
+    _init_checkout(checkout, "https://github.com/TheAxiomFoundation/rulespec-us.git")
+    (checkout / "programs/us/snap").mkdir(parents=True)
+    module = checkout / "us-co/policies/snap/example.yaml"
+    module.parent.mkdir(parents=True)
+    module.write_text("format: rulespec/v1\n", encoding="utf-8")
+
+    assert canonical_rulespec_root_identity(checkout / "us-co") == (
+        "rulespec-us/us-co"
+    )
+    assert find_policy_repo_root(module) == checkout / "us-co"
+    assert canonical_rulespec_repo_name(checkout) == "rulespec-us"
+    assert canonical_rulespec_repo_name(module) == "rulespec-us-co"
+    assert jurisdiction_subdir_names(
+        checkout, allow_composition_specs=True
+    ) == {"us-co"}
+    assert candidate_jurisdiction_content_dirs(checkout, "us-co") == [
+        checkout / "us-co"
+    ]
+
+
 def test_canonical_rulespec_root_identity_is_stable_for_direct_content_root(tmp_path):
     checkout = tmp_path / "rulespec-us"
     _init_checkout(checkout, "https://github.com/TheAxiomFoundation/rulespec-us.git")
@@ -123,7 +145,7 @@ def test_country_checkout_identity_requires_existing_directory(tmp_path):
 
 @pytest.mark.parametrize(
     "root_name",
-    ["legislation", "policies", "programs", "regulations", "statutes"],
+    ["legislation", "policies", "regulations", "statutes"],
 )
 def test_country_checkout_rejects_flat_root_level_content(tmp_path, root_name):
     checkout = tmp_path / "rulespec-us"

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -538,6 +538,27 @@ def test_rulespec_compile_roots_use_only_explicit_checkouts(monkeypatch, tmp_pat
     ]
 
 
+def test_rulespec_compile_roots_accept_composition_checkouts(tmp_path):
+    policy_repo = _canonical_rulespec_content_root(tmp_path / "active", "us")
+    dependency_root = _canonical_rulespec_content_root(
+        tmp_path / "dependencies", "uk"
+    ).parent
+    (policy_repo.parent / "programs/us/snap").mkdir(parents=True)
+    (dependency_root / "programs/uk/universal-credit").mkdir(parents=True)
+
+    pipeline = ValidatorPipeline(
+        policy_repo_path=policy_repo,
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+        rulespec_dependency_roots=(dependency_root,),
+    )
+
+    assert pipeline._rulespec_compile_roots() == (
+        policy_repo.parent.resolve(),
+        dependency_root.resolve(),
+    )
+
+
 def test_rulespec_engine_env_excludes_model_and_repository_credentials(
     monkeypatch, tmp_path
 ):

--- a/tests/test_source_hash.py
+++ b/tests/test_source_hash.py
@@ -238,6 +238,21 @@ def test_iter_pinned_modules_ignores_composition_specs(tmp_path):
     assert list(iter_pinned_modules(content_root.parent)) == expected
 
 
+def test_iter_pinned_modules_ignores_checkout_program_specs(tmp_path):
+    pinned_sha = source_text_sha256(SOURCE_TEXT)
+    module_path = _write_module(tmp_path, pinned_sha)
+    checkout = tmp_path / "rulespec-us"
+    program_spec = checkout / "programs" / "us" / "snap" / "fy-2026.yaml"
+    program_spec.parent.mkdir(parents=True)
+    outside = tmp_path / "outside.yaml"
+    outside.write_text("secret: do-not-read\n", encoding="utf-8")
+    program_spec.symlink_to(outside)
+
+    assert list(iter_pinned_modules(checkout)) == [
+        PinnedModule(module_path, CITATION_PATH, pinned_sha)
+    ]
+
+
 @pytest.mark.parametrize(
     ("relative_path", "message"),
     [

--- a/tests/test_toolchain.py
+++ b/tests/test_toolchain.py
@@ -96,6 +96,14 @@ def test_load_rulespec_local_corpus_release_binds_exact_named_selector(tmp_path)
     )
 
 
+def test_toolchain_accepts_checkout_with_canonical_program_specs(tmp_path):
+    rulespec = tmp_path / "rulespec-us"
+    (rulespec / "programs/us/snap").mkdir(parents=True)
+    _write_toolchain(rulespec)
+
+    assert load_rulespec_corpus_release_pin(rulespec) == (RELEASE_NAME, "a" * 64)
+
+
 def test_environment_corpus_key_cannot_replace_protected_broker(
     tmp_path,
     monkeypatch,

--- a/tests/test_validation_waiver_audit_cli.py
+++ b/tests/test_validation_waiver_audit_cli.py
@@ -296,6 +296,16 @@ def test_validation_rejects_legacy_flat_checkout_layout(tmp_path: Path):
         cli._canonical_validation_checkout_root(module)
 
 
+def test_validation_accepts_jurisdiction_in_composition_checkout(tmp_path: Path):
+    checkout = tmp_path / "rulespec-us"
+    module = checkout / "us/statutes/1.yaml"
+    module.parent.mkdir(parents=True)
+    module.write_text("format: rulespec/v1\n")
+    (checkout / "programs/us/snap").mkdir(parents=True)
+
+    assert cli._canonical_validation_checkout_root(module) == checkout
+
+
 def test_validation_rejects_missing_explicit_engine_checkout(tmp_path: Path):
     module = tmp_path / "rulespec-us/us/statutes/1.yaml"
     module.parent.mkdir(parents=True)

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1247"
+version = "0.2.1248"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- accept canonical country checkouts that contain top-level ProgramSpecs across atomic routing, toolchain, validation, source scanning, eval, audit, and oracle command paths
- keep inventory, generated-file guards, source hashes, and apply behavior restricted to jurisdiction atomic roots
- release the fix as `axiom-encode` 0.2.1248

## Validation
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest` (3915 passed, 106 skipped)
- focused composition-routing regression suite (959 passed, 31 skipped)
- canonical RuleSpec checkout command-plane smoke

## Review Cycle
- Independent `codex review --base origin/main`
- Result: no actionable findings; reviewer confirmed ProgramSpec composition checkouts remain restricted to the four atomic module roots for atomic operations
