### PR TITLE
Support legacy exclusive RuleSpec engine roots

### DIFF
--- a/changelog.d/legacy-exclusive-engine-roots.fixed.md
+++ b/changelog.d/legacy-exclusive-engine-roots.fixed.md
@@ -1,0 +1,1 @@
+Preserve explicit fail-closed RuleSpec validation with engines that expose the prior exclusive-root contract.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1249"
+version = "0.2.1250"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1248"
+version = "0.2.1249"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1248"
+__version__ = "0.2.1249"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1249"
+__version__ = "0.2.1250"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -247,6 +247,7 @@ from .repo_routing import (
     jurisdiction_subdir_names,
     monorepo_checkout_name,
 )
+from .rules_engine_compat import run_rulespec_compile
 from .signing_broker import (
     SigningBroker,
     SigningBrokerError,
@@ -3598,24 +3599,12 @@ def _execute_rulespec_test_file(
             else program_file
         )
         compiled_path = tmp_path / (_safe_artifact_stem(program_file) + ".json")
-        result = subprocess.run(
-            [
-                str(binary),
-                "compile",
-                "--program",
-                str(compile_file),
-                *(
-                    item
-                    for root in rulespec_roots
-                    for item in ("--rulespec-root", str(root))
-                ),
-                "--output",
-                str(compiled_path),
-            ],
-            capture_output=True,
-            text=True,
-            timeout=60,
-            cwd=str(axiom_rules_path) if axiom_rules_path.exists() else None,
+        result = run_rulespec_compile(
+            binary=binary,
+            program=compile_file,
+            rulespec_roots=rulespec_roots,
+            output=compiled_path,
+            cwd=axiom_rules_path if axiom_rules_path.exists() else None,
             env=env,
         )
         if result.returncode != 0:

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -81,6 +81,7 @@ from axiom_encode.repo_routing import (
     jurisdiction_subdir_names,
     monorepo_checkout_name,
 )
+from axiom_encode.rules_engine_compat import run_rulespec_compile
 from axiom_encode.statute import citation_to_citation_path, parse_usc_citation
 
 from .dependency_stubs import (
@@ -20405,20 +20406,12 @@ class ValidatorPipeline:
             rules_file,
             self.policy_repo_path,
         )
-        result = subprocess.run(
-            [
-                str(binary),
-                "compile",
-                "--program",
-                str(compile_file),
-                *self._rulespec_root_args(),
-                "--output",
-                str(output_path),
-            ],
-            capture_output=True,
-            text=True,
-            timeout=60,
-            cwd=str(self.axiom_rules_path) if self.axiom_rules_path.exists() else None,
+        result = run_rulespec_compile(
+            binary=binary,
+            program=compile_file,
+            rulespec_roots=self._rulespec_compile_roots(),
+            output=output_path,
+            cwd=self.axiom_rules_path if self.axiom_rules_path.exists() else None,
             env=self._rulespec_engine_env(),
         )
         if result.returncode != 0:

--- a/src/axiom_encode/rules_engine_compat.py
+++ b/src/axiom_encode/rules_engine_compat.py
@@ -57,6 +57,14 @@ def run_rulespec_compile(
     ):
         return result
 
+    unrepresentable_roots = [root for root in roots if os.pathsep in str(root)]
+    if unrepresentable_roots:
+        rendered = ", ".join(map(str, unrepresentable_roots))
+        raise ValueError(
+            "Legacy RuleSpec engine roots cannot contain the platform path "
+            f"separator {os.pathsep!r}: {rendered}"
+        )
+
     legacy_env = dict(clean_env)
     legacy_env["AXIOM_RULESPEC_REPO_ROOTS"] = os.pathsep.join(map(str, roots))
     legacy_env["AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE"] = "1"

--- a/src/axiom_encode/rules_engine_compat.py
+++ b/src/axiom_encode/rules_engine_compat.py
@@ -1,0 +1,75 @@
+"""Fail-closed compatibility for explicit RuleSpec engine root contracts."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+_UNKNOWN_EXPLICIT_ROOT_FLAG = "unknown compile argument `--rulespec-root`"
+_LEGACY_EXCLUSIVE_ROOT_FLAG = "--exclusive-rulespec-roots"
+
+
+def run_rulespec_compile(
+    *,
+    binary: Path,
+    program: Path,
+    rulespec_roots: Sequence[Path],
+    output: Path,
+    cwd: Path | None,
+    env: Mapping[str, str],
+    timeout: int = 60,
+) -> subprocess.CompletedProcess[str]:
+    """Compile with the current root contract or its prior exclusive form."""
+
+    roots = tuple(Path(root) for root in rulespec_roots)
+    if not roots:
+        raise ValueError("RuleSpec engine compilation requires an explicit root")
+    base_command = [
+        str(binary),
+        "compile",
+        "--program",
+        str(program),
+    ]
+    current_command = [
+        *base_command,
+        *(item for root in roots for item in ("--rulespec-root", str(root))),
+        "--output",
+        str(output),
+    ]
+    clean_env = dict(env)
+    clean_env.pop("AXIOM_RULESPEC_REPO_ROOTS", None)
+    clean_env.pop("AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE", None)
+    result = subprocess.run(
+        current_command,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        cwd=str(cwd) if cwd is not None else None,
+        env=clean_env,
+    )
+    output_text = result.stdout + result.stderr
+    if not (
+        result.returncode != 0
+        and _UNKNOWN_EXPLICIT_ROOT_FLAG in output_text
+        and _LEGACY_EXCLUSIVE_ROOT_FLAG in output_text
+    ):
+        return result
+
+    legacy_env = dict(clean_env)
+    legacy_env["AXIOM_RULESPEC_REPO_ROOTS"] = os.pathsep.join(map(str, roots))
+    legacy_env["AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE"] = "1"
+    return subprocess.run(
+        [
+            *base_command,
+            _LEGACY_EXCLUSIVE_ROOT_FLAG,
+            "--output",
+            str(output),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        cwd=str(cwd) if cwd is not None else None,
+        env=legacy_env,
+    )

--- a/tests/test_rules_engine_compat.py
+++ b/tests/test_rules_engine_compat.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from subprocess import CompletedProcess
 
@@ -77,6 +78,31 @@ def test_unknown_flag_without_legacy_advertisement_does_not_fallback(monkeypatch
 
     assert result is failure
     assert len(calls) == 1
+
+
+def test_legacy_contract_rejects_roots_containing_path_separator(monkeypatch):
+    unsupported = CompletedProcess(
+        [],
+        1,
+        "",
+        "unknown compile argument `--rulespec-root`\n"
+        "usage: compile [--exclusive-rulespec-roots]",
+    )
+    monkeypatch.setattr(
+        "axiom_encode.rules_engine_compat.subprocess.run",
+        lambda command, **kwargs: unsupported,
+    )
+    root = Path(f"/rulespec{os.pathsep}other/rulespec-us")
+
+    with pytest.raises(ValueError, match="platform path separator"):
+        run_rulespec_compile(
+            binary=Path("/engine/axiom-rules-engine"),
+            program=Path("/rulespec-us/us/policies/program.yaml"),
+            rulespec_roots=(root,),
+            output=Path("/tmp/program.json"),
+            cwd=Path("/engine"),
+            env={"PATH": "/bin"},
+        )
 
 
 def test_compile_requires_an_explicit_root():

--- a/tests/test_rules_engine_compat.py
+++ b/tests/test_rules_engine_compat.py
@@ -70,9 +70,7 @@ def test_other_compile_failures_do_not_fallback(monkeypatch):
 
 
 def test_unknown_flag_without_legacy_advertisement_does_not_fallback(monkeypatch):
-    failure = CompletedProcess(
-        [], 1, "", "unknown compile argument `--rulespec-root`"
-    )
+    failure = CompletedProcess([], 1, "", "unknown compile argument `--rulespec-root`")
 
     result, calls = _run(monkeypatch, [failure])
 

--- a/tests/test_rules_engine_compat.py
+++ b/tests/test_rules_engine_compat.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+from subprocess import CompletedProcess
+
+import pytest
+
+from axiom_encode.rules_engine_compat import run_rulespec_compile
+
+
+def _run(monkeypatch, responses):
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return responses.pop(0)
+
+    monkeypatch.setattr("axiom_encode.rules_engine_compat.subprocess.run", fake_run)
+    result = run_rulespec_compile(
+        binary=Path("/engine/axiom-rules-engine"),
+        program=Path("/rulespec-us/us/policies/program.yaml"),
+        rulespec_roots=(Path("/rulespec-us"),),
+        output=Path("/tmp/program.json"),
+        cwd=Path("/engine"),
+        env={"PATH": "/bin", "AXIOM_RULESPEC_REPO_ROOTS": "/ambient"},
+    )
+    return result, calls
+
+
+def test_current_explicit_root_contract_is_preferred(monkeypatch):
+    success = CompletedProcess([], 0, "ok", "")
+
+    result, calls = _run(monkeypatch, [success])
+
+    assert result is success
+    assert len(calls) == 1
+    command, kwargs = calls[0]
+    assert command[command.index("--rulespec-root") + 1] == "/rulespec-us"
+    assert "--exclusive-rulespec-roots" not in command
+    assert "AXIOM_RULESPEC_REPO_ROOTS" not in kwargs["env"]
+
+
+def test_legacy_contract_requires_exact_unknown_flag_evidence(monkeypatch):
+    unsupported = CompletedProcess(
+        [],
+        1,
+        "",
+        "unknown compile argument `--rulespec-root`\n"
+        "usage: compile [--exclusive-rulespec-roots]",
+    )
+    success = CompletedProcess([], 0, "ok", "")
+
+    result, calls = _run(monkeypatch, [unsupported, success])
+
+    assert result is success
+    assert len(calls) == 2
+    command, kwargs = calls[1]
+    assert "--rulespec-root" not in command
+    assert "--exclusive-rulespec-roots" in command
+    assert kwargs["env"]["AXIOM_RULESPEC_REPO_ROOTS"] == "/rulespec-us"
+    assert kwargs["env"]["AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE"] == "1"
+
+
+def test_other_compile_failures_do_not_fallback(monkeypatch):
+    failure = CompletedProcess([], 1, "", "invalid RuleSpec")
+
+    result, calls = _run(monkeypatch, [failure])
+
+    assert result is failure
+    assert len(calls) == 1
+
+
+def test_unknown_flag_without_legacy_advertisement_does_not_fallback(monkeypatch):
+    failure = CompletedProcess(
+        [], 1, "", "unknown compile argument `--rulespec-root`"
+    )
+
+    result, calls = _run(monkeypatch, [failure])
+
+    assert result is failure
+    assert len(calls) == 1
+
+
+def test_compile_requires_an_explicit_root():
+    with pytest.raises(
+        ValueError, match="RuleSpec engine compilation requires an explicit root"
+    ):
+        run_rulespec_compile(
+            binary=Path("/engine/axiom-rules-engine"),
+            program=Path("/rulespec-us/us/policies/program.yaml"),
+            rulespec_roots=(),
+            output=Path("/tmp/program.json"),
+            cwd=Path("/engine"),
+            env={"PATH": "/bin"},
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1248"
+version = "0.2.1249"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1249"
+version = "0.2.1250"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- compile with the current repeatable `--rulespec-root` contract by default
- fall back only when an engine explicitly rejects that flag and advertises the legacy exclusive-root contract
- preserve fail-closed root authorization, including rejection of paths that cannot be represented by the legacy environment variable
- release axiom-encode 0.2.1250

## Review cycle
- independent `codex review --base origin/main` found one P2 path-separator issue
- fixed the issue and added regression coverage
- repeated independent review; no actionable findings remained

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests` (equivalent repository Python 3.13 environment): passed
- `python -m compileall -q src/axiom_encode scripts`: passed
- `uv run pytest` (equivalent repository Python 3.13 environment): 3921 passed, 106 skipped
- real legacy-engine compile smoke against axiom-rules-engine 48797e101c093bb388be718c6f5d8fc9d9f94a7d: passed