### PR TITLE
Preserve legacy pending declarations during sync

### DIFF
--- a/changelog.d/pending-sync-legacy-root.fixed.md
+++ b/changelog.d/pending-sync-legacy-root.fixed.md
@@ -1,0 +1,1 @@
+Preserve existing unmapped legacy-root declarations during oracle coverage pending sync.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1250"
+version = "0.2.1251"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1252"
+version = "0.2.1253"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1251"
+version = "0.2.1252"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1250"
+__version__ = "0.2.1251"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1252"
+__version__ = "0.2.1253"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1251"
+__version__ = "0.2.1252"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5283,6 +5283,11 @@ def cmd_oracle_coverage_pending(args):
     if args.pending_command == "sync":
         report = build_policyengine_coverage_report(root)
         authorized_prefixes = _pending_sync_authorized_prefixes(root)
+        try:
+            existing_pending_ids = set(load_pending_declarations(root))
+        except PendingDeclarationError as error:
+            print(f"oracle-coverage-pending error: {error}", file=sys.stderr)
+            sys.exit(2)
 
         unmapped = [
             item["legal_id"]
@@ -5290,7 +5295,10 @@ def cmd_oracle_coverage_pending(args):
             if item.get("status") == "unmapped"
             and str(item.get("legal_id") or "").partition(":")[0].split("-", 1)[0]
             == root.name.removeprefix("rulespec-")
-            and str(item.get("file") or "").startswith(authorized_prefixes)
+            and (
+                str(item.get("file") or "").startswith(authorized_prefixes)
+                or item.get("legal_id") in existing_pending_ids
+            )
         ]
         try:
             result = sync_repo_pending(

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5222,8 +5222,10 @@ def cmd_cloud_queue(args):
     sys.exit(0)
 
 
-def _pending_sync_authorized_prefixes(root: Path) -> tuple[str, ...]:
-    """Return report path prefixes authorized to enter one pending ledger."""
+def _pending_sync_authorized_prefixes(
+    root: Path,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Return new-entry and existing legacy report path prefixes."""
 
     nested_checkout = root / root.name
     if nested_checkout.is_dir() and not nested_checkout.is_symlink():
@@ -5250,6 +5252,10 @@ def _pending_sync_authorized_prefixes(root: Path) -> tuple[str, ...]:
         for jurisdiction in jurisdictions
         for module_root in sorted(RULESPEC_ATOMIC_MODULE_ROOTS)
     ]
+    legacy_prefixes = [
+        f"{display_prefix}{jurisdiction}/manual/"
+        for jurisdiction in jurisdictions
+    ]
     programs_dir = content_checkout / RULESPEC_COMPOSITION_SPEC_ROOT
     if programs_dir.is_dir() and not programs_dir.is_symlink():
         prefixes.extend(
@@ -5259,7 +5265,7 @@ def _pending_sync_authorized_prefixes(root: Path) -> tuple[str, ...]:
             and not child.is_symlink()
             and re.fullmatch(rf"{re.escape(country)}(?:-[a-z0-9]+)*", child.name)
         )
-    return tuple(prefixes)
+    return tuple(prefixes), tuple(legacy_prefixes)
 
 
 def _resolve_composition_rulespec_checkout(raw_path: Path) -> Path:
@@ -5282,7 +5288,9 @@ def cmd_oracle_coverage_pending(args):
     root = _resolve_composition_rulespec_checkout(args.root)
     if args.pending_command == "sync":
         report = build_policyengine_coverage_report(root)
-        authorized_prefixes = _pending_sync_authorized_prefixes(root)
+        authorized_prefixes, existing_legacy_prefixes = (
+            _pending_sync_authorized_prefixes(root)
+        )
         try:
             existing_pending_ids = set(load_pending_declarations(root))
         except PendingDeclarationError as error:
@@ -5297,7 +5305,12 @@ def cmd_oracle_coverage_pending(args):
             == root.name.removeprefix("rulespec-")
             and (
                 str(item.get("file") or "").startswith(authorized_prefixes)
-                or item.get("legal_id") in existing_pending_ids
+                or (
+                    item.get("legal_id") in existing_pending_ids
+                    and str(item.get("file") or "").startswith(
+                        existing_legacy_prefixes
+                    )
+                )
             )
         ]
         try:

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5253,8 +5253,7 @@ def _pending_sync_authorized_prefixes(
         for module_root in sorted(RULESPEC_ATOMIC_MODULE_ROOTS)
     ]
     legacy_prefixes = [
-        f"{display_prefix}{jurisdiction}/manual/"
-        for jurisdiction in jurisdictions
+        f"{display_prefix}{jurisdiction}/manual/" for jurisdiction in jurisdictions
     ]
     programs_dir = content_checkout / RULESPEC_COMPOSITION_SPEC_ROOT
     if programs_dir.is_dir() and not programs_dir.is_symlink():
@@ -5307,9 +5306,7 @@ def cmd_oracle_coverage_pending(args):
                 str(item.get("file") or "").startswith(authorized_prefixes)
                 or (
                     item.get("legal_id") in existing_pending_ids
-                    and str(item.get("file") or "").startswith(
-                        existing_legacy_prefixes
-                    )
+                    and str(item.get("file") or "").startswith(existing_legacy_prefixes)
                 )
             )
         ]

--- a/tests/test_oracle_coverage_pending.py
+++ b/tests/test_oracle_coverage_pending.py
@@ -505,6 +505,53 @@ entries:
     )
 
 
+def test_cli_pending_sync_drops_declared_nested_same_country_checkout(
+    tmp_path, monkeypatch
+):
+    checkout = tmp_path / "rulespec-us"
+    legal_id = "us-mo:policies/demo/x#nested_checkout_output"
+    _write(
+        checkout / "us/statutes/placeholder.yaml",
+        """format: rulespec/v1
+rules: []
+""",
+    )
+    _write(
+        checkout / "rulespec-us-mo/policies/demo/x.yaml",
+        """format: rulespec/v1
+rules:
+  - name: nested_checkout_output
+    kind: derived
+    versions:
+      - effective_from: '2025-01-01'
+        formula: some_input
+""",
+    )
+    _write(
+        checkout / "oracle-coverage-pending.yaml",
+        f"""version: 1
+ceiling: 1
+entries:
+  - legal_id: {legal_id}
+    source: manual
+    since: 2026-07-07
+""",
+    )
+
+    code = _run_cli(
+        monkeypatch,
+        "oracle-coverage-pending",
+        "sync",
+        "--root",
+        str(checkout),
+        "--source",
+        "bulk",
+    )
+
+    assert code == 0
+    assert load_pending_files(checkout)[0].entries == ()
+
+
 def test_cli_pending_sync_includes_country_monorepo_state_output(tmp_path, monkeypatch):
     checkout = tmp_path / "rulespec-us"
     legal_id = "us-hi:statutes/235-54#individual_personal_exemption_deduction"

--- a/tests/test_oracle_coverage_pending.py
+++ b/tests/test_oracle_coverage_pending.py
@@ -452,6 +452,59 @@ rules:
     assert foreign_id not in declared
 
 
+def test_cli_pending_sync_preserves_declared_legacy_root_output(
+    tmp_path, monkeypatch
+):
+    checkout = tmp_path / "rulespec-us"
+    legal_id = "us-mo:manual/dss/snap/example#legacy_manual_output"
+    _write(
+        checkout / "us-mo/manual/dss/snap/example.yaml",
+        """format: rulespec/v1
+rules:
+  - name: legacy_manual_output
+    kind: derived
+    versions:
+      - effective_from: '2025-01-01'
+        formula: some_input
+""",
+    )
+    _write(
+        checkout / "oracle-coverage-pending.yaml",
+        f"""version: 1
+ceiling: 1
+entries:
+  - legal_id: {legal_id}
+    source: manual
+    since: 2026-07-07
+""",
+    )
+
+    code = _run_cli(
+        monkeypatch,
+        "oracle-coverage-pending",
+        "sync",
+        "--root",
+        str(checkout),
+        "--source",
+        "bulk",
+    )
+
+    assert code == 0
+    assert [entry.legal_id for entry in load_pending_files(checkout)[0].entries] == [
+        legal_id
+    ]
+    assert (
+        _run_cli(
+            monkeypatch,
+            "oracle-coverage-pending",
+            "check",
+            "--root",
+            str(checkout),
+        )
+        == 0
+    )
+
+
 def test_cli_pending_sync_includes_country_monorepo_state_output(tmp_path, monkeypatch):
     checkout = tmp_path / "rulespec-us"
     legal_id = "us-hi:statutes/235-54#individual_personal_exemption_deduction"

--- a/tests/test_oracle_coverage_pending.py
+++ b/tests/test_oracle_coverage_pending.py
@@ -452,9 +452,7 @@ rules:
     assert foreign_id not in declared
 
 
-def test_cli_pending_sync_preserves_declared_legacy_root_output(
-    tmp_path, monkeypatch
-):
+def test_cli_pending_sync_preserves_declared_legacy_root_output(tmp_path, monkeypatch):
     checkout = tmp_path / "rulespec-us"
     legal_id = "us-mo:manual/dss/snap/example#legacy_manual_output"
     _write(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1252"
+version = "0.2.1253"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1251"
+version = "0.2.1252"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1250"
+version = "0.2.1251"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- preserve an existing pending declaration when its exact output remains unmapped under a legacy noncanonical module root
- continue rejecting new out-of-bound outputs from pending sync
- add a CLI regression proving sync followed by check remains green for a declared legacy `manual/` output
- bump encoder to 0.2.1251

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest tests/test_oracle_coverage_pending.py -q` (34 passed)
- `uv run pytest` (3922 passed, 106 skipped)
- live rulespec-us smoke: sync retained 742 declarations; immediate check applied 742 with zero stale and passed