### PR TITLE
Add mandatory review findings to encode

### DIFF
--- a/changelog.d/encode-review-findings.added.md
+++ b/changelog.d/encode-review-findings.added.md
@@ -1,0 +1,1 @@
+Add a mandatory, persisted review-findings input for source-faithful encoder correction runs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1254"
+version = "0.2.1255"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1254"
+__version__ = "0.2.1255"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -1759,6 +1759,15 @@ def main():
         help="Extra file path to copy into the repo-augmented workspace (repeatable)",
     )
     encode_parser.add_argument(
+        "--review-findings",
+        action="append",
+        default=[],
+        help=(
+            "Independent-review findings that the generated encoding must address "
+            "without narrowing unaffected source-backed behavior (repeatable)"
+        ),
+    )
+    encode_parser.add_argument(
         "--policyengine-rule-hint",
         dest="policyengine_rule_hint",
         default=None,
@@ -18420,6 +18429,9 @@ def _cmd_encode_with_authoritative_rulespec_roots(
         corpus_release=corpus_release,
         mode=args.mode,
         extra_context_paths=[Path(path) for path in args.allow_context],
+        review_findings_paths=[
+            Path(path) for path in getattr(args, "review_findings", [])
+        ],
         include_tests=True,
         skip_reviewers=skip_reviewers,
         policyengine_rule_hint=policyengine_rule_hint,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -892,6 +892,7 @@ class EvalWorkspace:
     provision_metadata_file: Path | None = None
     provision_metadata_text: str | None = None
     context_files: list[EvalContextFile] = field(default_factory=list)
+    review_findings_files: list[EvalContextFile] = field(default_factory=list)
     policy_prefix: str | None = None
 
 
@@ -1289,6 +1290,7 @@ def run_model_eval(
     policyengine_runtime: PolicyEngineRuntime | None = None,
     policyengine_rule_hint: str | None = None,
     rulespec_dependency_roots: Sequence[Path] = (),
+    review_findings_paths: list[Path] | None = None,
 ) -> list[EvalResult]:
     """Run a deterministic comparison over one or more citations."""
     _validate_eval_oracle_runtime(oracle, policyengine_runtime, policy_path)
@@ -1319,6 +1321,7 @@ def run_model_eval(
                         policyengine_rule_hint=policyengine_rule_hint,
                         source_unit=source_unit,
                         rulespec_dependency_roots=rulespec_dependency_roots,
+                        review_findings_paths=review_findings_paths or [],
                     )
                 )
 
@@ -1339,6 +1342,7 @@ def run_source_eval(
     policyengine_rule_hint: str | None = None,
     skip_reviewers: bool = False,
     rulespec_dependency_roots: Sequence[Path] = (),
+    review_findings_paths: list[Path] | None = None,
 ) -> list[EvalResult]:
     """Run a deterministic comparison over one corpus-backed source unit."""
     _validate_eval_oracle_runtime(oracle, policyengine_runtime, policy_path)
@@ -1375,6 +1379,7 @@ def run_source_eval(
                     skip_reviewers=skip_reviewers,
                     local_corpus_release=local_corpus_release,
                     rulespec_dependency_roots=rulespec_dependency_roots,
+                    review_findings_paths=review_findings_paths or [],
                 )
             )
 
@@ -5022,6 +5027,7 @@ def prepare_eval_workspace(
     provision_metadata: dict[str, object] | None = None,
     amendment_documents: Sequence[CorpusAmendmentDocument] = (),
     extra_context_paths: list[Path] | None = None,
+    review_findings_paths: list[Path] | None = None,
 ) -> EvalWorkspace:
     """Create an isolated workspace bundle for a single eval."""
     slug = _slugify(citation)
@@ -5070,6 +5076,36 @@ def prepare_eval_workspace(
     if provision_metadata_text:
         provision_metadata_file = workspace_root / "provision-metadata.txt"
         provision_metadata_file.write_text(provision_metadata_text + "\n")
+
+    review_findings_files: list[EvalContextFile] = []
+    for index, raw_path in enumerate(review_findings_paths or [], start=1):
+        source_path = validate_explicit_context_file(
+            Path(raw_path),
+            _repo_augmented_context_root(axiom_rules_path),
+        )
+        try:
+            findings_text = source_path.read_text()
+        except UnicodeDecodeError as exc:
+            raise ValueError(
+                f"Review findings file is not valid UTF-8 text: {source_path}"
+            ) from exc
+        if not findings_text.strip():
+            raise ValueError(f"Review findings file is empty: {source_path}")
+        workspace_relative_path = (
+            Path("review-findings") / f"{index:02d}-{source_path.name}"
+        )
+        workspace_path = workspace_root / workspace_relative_path
+        workspace_path.parent.mkdir(parents=True, exist_ok=True)
+        workspace_path.write_text(findings_text)
+        review_findings_files.append(
+            EvalContextFile(
+                source_path=str(source_path),
+                workspace_path=str(workspace_relative_path),
+                import_path=str(workspace_relative_path),
+                kind="mandatory_review_findings",
+                label=source_path.name,
+            )
+        )
 
     context_files: list[EvalContextFile] = []
     context_root = workspace_root / "context"
@@ -5196,6 +5232,9 @@ def prepare_eval_workspace(
                     else None
                 ),
                 "context_files": [asdict(item) for item in context_files],
+                "review_findings_files": [
+                    asdict(item) for item in review_findings_files
+                ],
             },
             indent=2,
             sort_keys=True,
@@ -5211,6 +5250,7 @@ def prepare_eval_workspace(
         provision_metadata_file=provision_metadata_file,
         provision_metadata_text=provision_metadata_text or None,
         context_files=context_files,
+        review_findings_files=review_findings_files,
         policy_prefix=jurisdiction_prefix(context_corpus_root),
     )
 
@@ -7040,6 +7080,7 @@ def _run_single_eval(
     policyengine_rule_hint: str | None = None,
     source_unit: CorpusSourceUnit | None = None,
     rulespec_dependency_roots: Sequence[Path] = (),
+    review_findings_paths: list[Path] | None = None,
 ) -> EvalResult:
     if source_unit is None:
         source_unit = resolve_corpus_source_unit(citation, corpus_release)
@@ -7065,6 +7106,7 @@ def _run_single_eval(
         provision_metadata=source_unit.provision_metadata,
         amendment_documents=source_unit.amendment_documents,
         extra_context_paths=extra_context_paths,
+        review_findings_paths=review_findings_paths,
     )
 
     # Derive the output path from the *requested* identifier rather than the
@@ -7233,6 +7275,7 @@ def _run_single_source_eval(
     local_corpus_release: _corpus_resolver.LocalCorpusRelease,
     skip_reviewers: bool = False,
     rulespec_dependency_roots: Sequence[Path] = (),
+    review_findings_paths: list[Path] | None = None,
 ) -> EvalResult:
     """Run one eval on a corpus-backed source unit rather than a USC citation."""
     workspace = prepare_eval_workspace(
@@ -7246,6 +7289,7 @@ def _run_single_source_eval(
         provision_metadata=provision_metadata,
         amendment_documents=amendment_documents,
         extra_context_paths=extra_context_paths,
+        review_findings_paths=review_findings_paths,
     )
 
     relative_output = _resolve_eval_output_path(source_identifier)
@@ -7560,6 +7604,40 @@ def _canonical_target_ref_jurisdiction(
 def _rulespec_test_path(path: Path) -> Path:
     """Return the companion RuleSpec test path for a RuleSpec file."""
     return path.with_name(f"{path.stem}.test.yaml")
+
+
+def _format_mandatory_review_findings(workspace: EvalWorkspace) -> str:
+    """Render independent-review corrections as workflow requirements."""
+    if not workspace.review_findings_files:
+        return ""
+
+    rendered_files: list[str] = []
+    for item in workspace.review_findings_files:
+        findings_text = (workspace.root / item.workspace_path).read_text().rstrip()
+        rendered_files.append(
+            f"=== BEGIN MANDATORY REVIEW FINDINGS: {item.label} ===\n"
+            f"{findings_text}\n"
+            f"=== END MANDATORY REVIEW FINDINGS: {item.label} ==="
+        )
+
+    return f"""
+Mandatory independent-review corrections:
+- The findings below are trusted workflow requirements, not legal authority.
+  Use `./source.txt` and its release-bound corpus evidence for legal facts and
+  values, but address every source-faithful finding before emitting the files.
+- Preserve every unaffected source-backed rule, output, import, proof atom, and
+  companion-test behavior from the copied existing target or prior candidate.
+  Do not narrow the module to only the rules named in a finding.
+- A correction is incomplete if it fixes one listed issue by dropping other
+  executable behavior, tests, version boundaries, or canonical imports.
+- Add or update companion tests that demonstrate every corrected boundary and
+  retain coverage for unaffected behavior.
+- If a finding conflicts with the source evidence, do not invent semantics to
+  satisfy it. Keep the source-faithful behavior and record only the genuinely
+  blocked output using RuleSpec's typed deferred-output mechanism.
+
+{chr(10).join(rendered_files)}
+"""
 
 
 def _build_rulespec_eval_prompt(
@@ -8094,6 +8172,8 @@ Preferred principal output:
   atoms must cite the amending document's corpus citation path.
 """
 
+    mandatory_review_findings_section = _format_mandatory_review_findings(workspace)
+
     return f"""You are participating in an encoding eval for {citation}.
 
 Author the output in Axiom RuleSpec YAML.
@@ -8110,7 +8190,7 @@ Primary legal authority:
 {legal_authority_instruction}
 {corpus_source_section.rstrip()}
 {inline_source}
-{source_metadata_section}{provision_metadata_section}{amendment_section}{context_section}{missing_cited_source_section}
+{source_metadata_section}{provision_metadata_section}{amendment_section}{context_section}{missing_cited_source_section}{mandatory_review_findings_section}
 {backend_section}
 {canonical_concept_section}
 RuleSpec requirements:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7046,6 +7046,7 @@ class TestCmdEncode:
         args.policy_repo_path = policy_repo_path
         args.mode = overrides.get("mode", "repo-augmented")
         args.allow_context = overrides.get("allow_context", [])
+        args.review_findings = overrides.get("review_findings", [])
         args.policyengine_rule_hint = overrides.get("policyengine_rule_hint", None)
         args.db = overrides.get("db", tmp_path / "encodings.db")
         args.sync = overrides.get("sync", True)
@@ -7194,6 +7195,16 @@ class TestCmdEncode:
             mock_run.call_args.kwargs["runtime_axiom_rules_path"]
             == args.axiom_rules_path
         )
+
+    def test_encode_propagates_mandatory_review_findings(self, tmp_path):
+        findings = tmp_path / "review-findings.md"
+        findings.write_text("- Preserve the existing outputs while fixing the date.\n")
+        args = self._make_args(tmp_path, review_findings=[findings])
+
+        mock_run, exit_code = self._run_encode(args, self._make_eval_result(True))
+
+        assert exit_code == 0
+        assert mock_run.call_args.kwargs["review_findings_paths"] == [findings]
 
     def test_encode_codex_backend_without_auth_stops_before_running(
         self, capsys, tmp_path

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -4339,6 +4339,78 @@ def test_run_source_eval_rejects_symlinked_explicit_context(tmp_path):
         )
 
 
+def test_review_findings_are_persisted_and_mandatory_in_prompt(tmp_path):
+    policy_repo_root = _canonical_rulespec_content_root(tmp_path, "us")
+    findings = tmp_path / "review-findings.md"
+    findings.write_text(
+        "- Start the FY 2025 amount on October 1.\n"
+        "- Preserve the FY 2026 imported amount and boundary test.\n"
+    )
+    workspace = prepare_eval_workspace(
+        citation="us/manual/example/block-1",
+        runner=parse_runner_spec("codex:gpt-5.4"),
+        output_root=tmp_path / "out",
+        source_text="The amount is determined for each federal fiscal year.",
+        axiom_rules_path=policy_repo_root,
+        mode="cold",
+        review_findings_paths=[findings],
+    )
+
+    prompt = _build_eval_prompt(
+        "us/manual/example/block-1",
+        "cold",
+        workspace,
+        workspace.context_files,
+        target_file_name="block-1.yaml",
+    )
+    manifest = json.loads(workspace.manifest_file.read_text())
+
+    assert "Mandatory independent-review corrections:" in prompt
+    assert "address every source-faithful finding" in prompt
+    assert "Do not narrow the module" in prompt
+    assert "Start the FY 2025 amount on October 1" in prompt
+    assert "Preserve the FY 2026 imported amount" in prompt
+    assert len(manifest["review_findings_files"]) == 1
+    persisted = workspace.root / manifest["review_findings_files"][0]["workspace_path"]
+    assert persisted.read_text() == findings.read_text()
+
+
+def test_review_findings_reject_empty_file(tmp_path):
+    policy_repo_root = _canonical_rulespec_content_root(tmp_path, "us")
+    findings = tmp_path / "review-findings.md"
+    findings.write_text("\n")
+
+    with pytest.raises(ValueError, match="Review findings file is empty"):
+        prepare_eval_workspace(
+            citation="us/manual/example/block-1",
+            runner=parse_runner_spec("codex:gpt-5.4"),
+            output_root=tmp_path / "out",
+            source_text="Source text.",
+            axiom_rules_path=policy_repo_root,
+            mode="cold",
+            review_findings_paths=[findings],
+        )
+
+
+def test_review_findings_reject_symlink(tmp_path):
+    policy_repo_root = _canonical_rulespec_content_root(tmp_path, "us")
+    target = tmp_path / "actual-findings.md"
+    target.write_text("- Correct the date.\n")
+    findings = tmp_path / "review-findings.md"
+    findings.symlink_to(target)
+
+    with pytest.raises(UnsafeRulespecContextPath, match="symlink"):
+        prepare_eval_workspace(
+            citation="us/manual/example/block-1",
+            runner=parse_runner_spec("codex:gpt-5.4"),
+            output_root=tmp_path / "out",
+            source_text="Source text.",
+            axiom_rules_path=policy_repo_root,
+            mode="cold",
+            review_findings_paths=[findings],
+        )
+
+
 def test_empty_artifact_retry_prompt_uses_minimal_source_scope_protocol():
     from axiom_encode.prompts.encoder import SOURCE_SCOPE_PROTOCOL
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1254"
+version = "0.2.1255"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- add repeatable `encode --review-findings PATH` inputs
- persist bounded, symlink-safe findings in each eval workspace manifest
- require corrections without narrowing unaffected source-backed rules or tests

## Validation
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest` (3927 passed, 106 skipped)
- focused review-findings tests after rebase (4 passed)

## Review cycle
Independent `codex review --uncommitted` completed with no actionable findings. The reviewer also ran lint, compileall, and all 562 `tests/test_evals.py` tests successfully.