### PR TITLE
Handle repealed corpus tombstones fail closed

### DIFF
--- a/changelog.d/repealed-corpus-tombstones.fixed.md
+++ b/changelog.d/repealed-corpus-tombstones.fixed.md
@@ -1,0 +1,1 @@
+Ignore explicit bodyless repealed leaf tombstones when composing current-law parent corpus text.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1255"
+version = "0.2.1256"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1255"
+__version__ = "0.2.1256"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/corpus_resolver.py
+++ b/src/axiom_encode/corpus_resolver.py
@@ -454,6 +454,7 @@ class _StoredRecord:
     row: CorpusRowIdentity
     body: str | None
     heading: str | None
+    status: str | None
     level: int | None
     ordinal: int | None
     file_path: Path
@@ -588,6 +589,10 @@ def resolve_local_corpus_source(
             )
         selected = records[0]
         candidate = by_path[selected.row.citation_path]
+        if selected.status == "repealed":
+            raise InvalidActiveCorpusSourceError(
+                f"Active corpus source {selected.row.citation_path!r} is repealed"
+            )
         component_rows: tuple[CorpusRowIdentity, ...] = ()
         stored_body = selected.body
         if stored_body is None:
@@ -1088,6 +1093,7 @@ def _read_matching_records(
                 row=row,
                 body=body,
                 heading=_optional_string(record.get("heading")),
+                status=_record_status(record),
                 level=_optional_int(record.get("level")),
                 ordinal=_optional_int(record.get("ordinal")),
                 file_path=path,
@@ -1168,6 +1174,7 @@ def _read_descendant_records(
                 row=row,
                 body=body,
                 heading=_optional_string(record.get("heading")),
+                status=_record_status(record),
                 level=level,
                 ordinal=ordinal,
                 file_path=path,
@@ -1239,17 +1246,56 @@ def _compose_descendant_text(
                 child_paths.add(child)
             parent = child
 
+    for record in records:
+        if record.status != "repealed":
+            continue
+        if record.body is not None or children.get(record.row.citation_path):
+            raise CorpusDescendantStructureError(
+                f"Active corpus source {citation_path!r} has malformed "
+                f"repealed descendant {record.row.citation_path!r}"
+            )
+
     ordered: list[_StoredRecord] = []
+    contributes_cache: dict[str, bool] = {}
+
+    def contributes_current_text(path: str) -> bool:
+        cached = contributes_cache.get(path)
+        if cached is not None:
+            return cached
+        record = unique_by_path.get(path)
+        if record is not None and record.status == "repealed":
+            contributes_cache[path] = False
+            return False
+        if record is not None and record.body is not None:
+            contributes_cache[path] = True
+            return True
+        child_paths = children.get(path, set())
+        if not child_paths:
+            # Preserve the existing fail-closed visit for ordinary bodyless leaves.
+            contributes_cache[path] = True
+            return True
+        contributes = any(contributes_current_text(child) for child in child_paths)
+        contributes_cache[path] = contributes
+        return contributes
 
     def visit(path: str) -> None:
         record = unique_by_path.get(path)
+        if record is not None and record.status == "repealed":
+            # A repealed bodyless leaf is an explicit current-law tombstone,
+            # not a missing branch of the parent source. It contributes no text.
+            return
         if record is not None and record.body is not None:
             # A body-bearing provision is the shallowest complete source for
             # its subtree. Including represented children as well would
             # duplicate legal text and alter the attested hash.
             ordered.append(record)
             return
-        child_paths = children.get(path, set())
+        raw_child_paths = children.get(path, set())
+        child_paths = {
+            child for child in raw_child_paths if contributes_current_text(child)
+        }
+        if raw_child_paths and not child_paths:
+            return
         if not child_paths:
             raise CorpusDescendantStructureError(
                 f"Active corpus source {citation_path!r} has uncovered "
@@ -3771,6 +3817,14 @@ def _record_body(
     if isinstance(value, str) and value.strip():
         return value
     return None
+
+
+def _record_status(record: dict[str, Any]) -> str | None:
+    metadata = record.get("metadata")
+    if not isinstance(metadata, Mapping):
+        return None
+    status = metadata.get("status")
+    return status if status == "repealed" else None
 
 
 def _clean_string_value(value: Any, *, label: str) -> str:

--- a/tests/test_corpus_resolver.py
+++ b/tests/test_corpus_resolver.py
@@ -2940,6 +2940,160 @@ def test_metadata_parent_rejects_uncovered_bodyless_branch(tmp_path: Path):
         resolve_local_corpus_source(CITATION, _release(tmp_path))
 
 
+def test_metadata_parent_omits_explicit_repealed_bodyless_leaf(tmp_path: Path):
+    version = "2026-01-01-repealed-leaf"
+    _write_selector(tmp_path, [_scope(version)])
+    _write_rows(
+        tmp_path,
+        version,
+        [
+            {"citation_path": CITATION, "body": None},
+            {"citation_path": f"{CITATION}/1", "body": "operative text"},
+            {
+                "citation_path": f"{CITATION}/2",
+                "body": None,
+                "heading": "Repealed provision. (Repealed)",
+                "metadata": {"status": "repealed"},
+            },
+        ],
+    )
+
+    resolved = resolve_local_corpus_source(CITATION, _release(tmp_path))
+
+    assert resolved.body == "operative text"
+    assert [row.citation_path for row in resolved.component_rows] == [f"{CITATION}/1"]
+
+
+def test_metadata_parent_rejects_top_level_repealed_status_field(tmp_path: Path):
+    version = "2026-01-01-top-level-repealed"
+    _write_selector(tmp_path, [_scope(version)])
+    _write_rows(
+        tmp_path,
+        version,
+        [
+            {"citation_path": CITATION, "body": None},
+            {"citation_path": f"{CITATION}/1", "body": "operative text"},
+            {
+                "citation_path": f"{CITATION}/2",
+                "body": None,
+                "status": "repealed",
+            },
+        ],
+    )
+
+    with pytest.raises(InvalidActiveCorpusSourceError, match="uncovered bodyless"):
+        resolve_local_corpus_source(CITATION, _release(tmp_path))
+
+
+def test_metadata_parent_rejects_repealed_bodyless_nonleaf(tmp_path: Path):
+    version = "2026-01-01-repealed-nonleaf"
+    _write_selector(tmp_path, [_scope(version)])
+    _write_rows(
+        tmp_path,
+        version,
+        [
+            {"citation_path": CITATION, "body": None},
+            {"citation_path": f"{CITATION}/1", "body": "operative text"},
+            {
+                "citation_path": f"{CITATION}/2",
+                "body": None,
+                "metadata": {"status": "repealed"},
+            },
+            {"citation_path": f"{CITATION}/2/A", "body": "stale repealed text"},
+        ],
+    )
+
+    with pytest.raises(InvalidActiveCorpusSourceError, match="malformed repealed"):
+        resolve_local_corpus_source(CITATION, _release(tmp_path))
+
+
+def test_rejects_directly_selected_repealed_bodyless_parent(tmp_path: Path):
+    version = "2026-01-01-repealed-parent"
+    _write_selector(tmp_path, [_scope(version)])
+    _write_rows(
+        tmp_path,
+        version,
+        [
+            {
+                "citation_path": CITATION,
+                "body": None,
+                "metadata": {"status": "repealed"},
+            },
+            {"citation_path": f"{CITATION}/1", "body": "stale repealed text"},
+        ],
+    )
+
+    with pytest.raises(InvalidActiveCorpusSourceError, match="is repealed"):
+        resolve_local_corpus_source(CITATION, _release(tmp_path))
+
+
+def test_metadata_parent_rejects_repealed_body_bearing_leaf(tmp_path: Path):
+    version = "2026-01-01-repealed-body"
+    _write_selector(tmp_path, [_scope(version)])
+    _write_rows(
+        tmp_path,
+        version,
+        [
+            {"citation_path": CITATION, "body": None},
+            {"citation_path": f"{CITATION}/1", "body": "operative text"},
+            {
+                "citation_path": f"{CITATION}/2",
+                "body": "stale repealed text",
+                "metadata": {"status": "repealed"},
+            },
+        ],
+    )
+
+    with pytest.raises(InvalidActiveCorpusSourceError, match="malformed repealed"):
+        resolve_local_corpus_source(CITATION, _release(tmp_path))
+
+
+def test_repealed_leaf_does_not_disable_operative_sibling_ordinals(tmp_path: Path):
+    version = "2026-01-01-repealed-ordering"
+    _write_selector(tmp_path, [_scope(version)])
+    _write_rows(
+        tmp_path,
+        version,
+        [
+            {"citation_path": CITATION, "body": None},
+            {"citation_path": f"{CITATION}/10", "body": "first", "ordinal": 1},
+            {"citation_path": f"{CITATION}/2", "body": "second", "ordinal": 2},
+            {
+                "citation_path": f"{CITATION}/3",
+                "body": None,
+                "metadata": {"status": "repealed"},
+            },
+        ],
+    )
+
+    resolved = resolve_local_corpus_source(CITATION, _release(tmp_path))
+
+    assert resolved.body == "first\n\nsecond"
+
+
+def test_rejects_malformed_repealed_row_below_body_bearing_ancestor(
+    tmp_path: Path,
+):
+    version = "2026-01-01-covered-repealed"
+    _write_selector(tmp_path, [_scope(version)])
+    _write_rows(
+        tmp_path,
+        version,
+        [
+            {"citation_path": CITATION, "body": None},
+            {"citation_path": f"{CITATION}/1", "body": "complete subtree"},
+            {
+                "citation_path": f"{CITATION}/1/A",
+                "body": "stale repealed text",
+                "metadata": {"status": "repealed"},
+            },
+        ],
+    )
+
+    with pytest.raises(InvalidActiveCorpusSourceError, match="malformed repealed"):
+        resolve_local_corpus_source(CITATION, _release(tmp_path))
+
+
 def test_active_bodyless_row_without_descendants_is_invalid(tmp_path: Path):
     version = "2026-01-01-no-descendants"
     _write_selector(tmp_path, [_scope(version)])

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1255"
+version = "0.2.1256"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- omit explicit bodyless `metadata.status: repealed` leaves when composing current-law parent sources
- reject directly selected or malformed repealed records fail closed
- preserve operative sibling ordering when tombstones are omitted

## Cycle
- independent review round 1 found selected/nonleaf repealed gaps; fixed and added adversarial tests
- independent review round 2 found ordering and covered-subtree gaps; fixed and added regression tests
- independent review round 3: no actionable findings

## Checks
- `uv run --python 3.13 ruff check pyproject.toml src/axiom_encode scripts tests`
- `python3.13 -m compileall -q src/axiom_encode scripts`
- `uv run --python 3.13 pytest` (3935 passed, 106 skipped)
