### PR TITLE
Support canonical ProgramSpec scope sync

### DIFF
--- a/changelog.d/canonical-program-scope-sync.fixed.md
+++ b/changelog.d/canonical-program-scope-sync.fixed.md
@@ -1,0 +1,1 @@
+Allow program-scope-sync to update canonical jurisdiction-local ProgramSpecs while retaining legacy top-level layout compatibility.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1257"
+version = "0.2.1258"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1257"
+__version__ = "0.2.1258"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/program_scope.py
+++ b/src/axiom_encode/program_scope.py
@@ -71,6 +71,7 @@ def _normalize_scope_path(value: str) -> str:
     path = PurePosixPath(raw)
     if (
         not raw
+        or not path.parts
         or ":" in raw
         or path.is_absolute()
         or any(part in {"", ".", ".."} for part in path.parts)
@@ -227,10 +228,20 @@ def sync_program_scope(
     if not isinstance(program, str) or not program.strip():
         raise ProgramScopeError("ProgramSpec must declare a non-empty `program`")
     program_path = _normalize_scope_path(program.strip())
-    expected_parent = Path("programs") / program_path
-    if not spec_rel.is_relative_to(expected_parent):
+    program_parts = PurePosixPath(program_path).parts
+    country = repo.name.removeprefix("rulespec-")
+    if re.fullmatch(rf"{re.escape(country)}(?:-[a-z0-9]+)*", program_parts[0]) is None:
         raise ProgramScopeError(
-            f"program spec path must be nested under {expected_parent.as_posix()}/"
+            f"program jurisdiction {program_parts[0]!r} does not belong to "
+            f"rulespec-{country}"
+        )
+    legacy_parent = Path("programs", *program_parts)
+    canonical_parent = Path(program_parts[0], "programs", *program_parts[1:])
+    expected_parents = (legacy_parent, canonical_parent)
+    if not any(spec_rel.is_relative_to(parent) for parent in expected_parents):
+        raise ProgramScopeError(
+            "program spec path must be nested under one of "
+            + ", ".join(f"{parent.as_posix()}/" for parent in expected_parents)
         )
 
     scope_node = _mapping_value(root, "scope")

--- a/tests/test_program_scope.py
+++ b/tests/test_program_scope.py
@@ -57,6 +57,89 @@ def test_sync_program_scope_changes_only_selected_sequence(tmp_path: Path) -> No
     ]
 
 
+def test_sync_program_scope_supports_jurisdiction_program_root(tmp_path: Path) -> None:
+    repo, spec = _repo(tmp_path)
+    canonical_spec = repo / "us-sc/programs/snap/fy-2026.yaml"
+    canonical_spec.parent.mkdir(parents=True)
+    spec.rename(canonical_spec)
+
+    result = sync_program_scope(
+        repo=repo,
+        program_spec=canonical_spec.relative_to(repo),
+        scope="state",
+        add=["policies/dss/snap/page-159"],
+        remove=["policies/dss/snap/page-369"],
+    )
+
+    assert result.changed is True
+    assert result.program_spec == "us-sc/programs/snap/fy-2026.yaml"
+    assert yaml.safe_load(canonical_spec.read_text())["scope"]["state"] == [
+        "policies/dss/snap/page-159",
+        "policies/dss/snap/page-163",
+    ]
+
+
+def test_sync_program_scope_rejects_wrong_jurisdiction_program_root(
+    tmp_path: Path,
+) -> None:
+    repo, spec = _repo(tmp_path)
+    wrong_spec = repo / "us-ny/programs/snap/fy-2026.yaml"
+    wrong_spec.parent.mkdir(parents=True)
+    spec.rename(wrong_spec)
+
+    with pytest.raises(ProgramScopeError, match="must be nested under one of"):
+        sync_program_scope(
+            repo=repo,
+            program_spec=wrong_spec.relative_to(repo),
+            scope="state",
+            add=["policies/dss/snap/page-159"],
+        )
+
+
+@pytest.mark.parametrize("program", [".", "./", "./."])
+def test_sync_program_scope_rejects_dot_only_program(
+    tmp_path: Path, program: str
+) -> None:
+    repo, spec = _repo(tmp_path)
+    spec.write_text(
+        spec.read_text().replace("program: us-sc/snap", f"program: {program}")
+    )
+
+    with pytest.raises(ProgramScopeError, match="safe repo-relative"):
+        sync_program_scope(
+            repo=repo,
+            program_spec=spec.relative_to(repo),
+            scope="state",
+            add=["policies/dss/snap/page-159"],
+        )
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    ["programs/uk/snap/fy-2026.yaml", "uk/programs/snap/fy-2026.yaml"],
+)
+def test_sync_program_scope_rejects_cross_country_program_root(
+    tmp_path: Path, relative_path: str
+) -> None:
+    repo, spec = _repo(tmp_path)
+    cross_country_spec = repo / relative_path
+    cross_country_spec.parent.mkdir(parents=True)
+    spec.rename(cross_country_spec)
+    cross_country_spec.write_text(
+        cross_country_spec.read_text().replace(
+            "program: us-sc/snap", "program: uk/snap"
+        )
+    )
+
+    with pytest.raises(ProgramScopeError, match="does not belong to rulespec-us"):
+        sync_program_scope(
+            repo=repo,
+            program_spec=cross_country_spec.relative_to(repo),
+            scope="state",
+            add=["policies/dss/snap/page-159"],
+        )
+
+
 def test_sync_program_scope_check_mode_does_not_write(tmp_path: Path) -> None:
     repo, spec = _repo(tmp_path)
     before = spec.read_text()

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1257"
+version = "0.2.1258"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- support canonical jurisdiction-local ProgramSpec paths such as `us-sc/programs/snap/fy-2026.yaml`
- retain compatibility with the legacy `programs/us-sc/snap/fy-2026.yaml` layout
- bind declared program jurisdictions to the country checkout and reject empty or cross-country scope paths
- release as `axiom-encode` 0.2.1258

## Review cycle
- independent review round 1 found an unhandled dot-only program path; added a normalization guard and regression coverage
- independent review round 2 found canonical paths could name a different country; bound both canonical and legacy paths to the checkout country and added regression coverage
- independent review round 3 found no actionable issues

## Checks
- `PYTHONPATH=src /private/tmp/axiom-encode-repealed-tombstones/.venv/bin/pytest -q --no-cov` (3951 passed, 106 skipped)
- `ruff check pyproject.toml src/axiom_encode scripts tests`
- `python3.13 -m compileall -q src/axiom_encode scripts`
- `git diff --check HEAD^ HEAD`
