### PR TITLE
Parse C.R.S. section labels as three atomic hyphen segments (fixes #1143)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1259"
+version = "0.2.1260"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1259"
+__version__ = "0.2.1260"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -7541,8 +7541,7 @@ def _preserve_state_statute_dotted_leaf(
         # segments, never subsection separators.
         crs_segments = tail[-1].split("-")
         return len(crs_segments) == 3 and all(
-            re.fullmatch(r"\d+(?:\.\d+)*", segment)
-            for segment in crs_segments
+            re.fullmatch(r"\d+(?:\.\d+)*", segment) for segment in crs_segments
         )
     if not re.fullmatch(r"\d+(?:\.\d+)+", tail[-1]):
         return False

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -7536,7 +7536,14 @@ def _preserve_state_statute_dotted_leaf(
     if jurisdiction != "us-co" or root != "statutes" or len(tail) < 2:
         return False
     if len(tail) == 2 and tail[0].isdigit():
-        return bool(re.fullmatch(r"\d+(?:-\d+)+(?:\.\d+)+", tail[-1]))
+        # C.R.S. section labels are structured by hyphens as
+        # title-article-section. Dots are part of any one of those three
+        # segments, never subsection separators.
+        crs_segments = tail[-1].split("-")
+        return len(crs_segments) == 3 and all(
+            re.fullmatch(r"\d+(?:\.\d+)*", segment)
+            for segment in crs_segments
+        )
     if not re.fullmatch(r"\d+(?:\.\d+)+", tail[-1]):
         return False
     return bool(re.fullmatch(r"\d+(?:-\d+)+(?:\.\d+)?", tail[-2]))

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -1749,7 +1749,11 @@ def _preserve_state_statute_dotted_leaf_for_normalization(
     if jurisdiction != "us-co" or root != "statutes" or len(tail) < 2:
         return False
     if len(tail) == 2 and tail[0].isdigit():
-        return bool(re.fullmatch(r"\d+(?:-\d+)+(?:\.\d+)+", tail[-1]))
+        crs_segments = tail[-1].split("-")
+        return len(crs_segments) == 3 and all(
+            re.fullmatch(r"\d+(?:\.\d+)*", segment)
+            for segment in crs_segments
+        )
     if not re.fullmatch(r"\d+(?:\.\d+)+", tail[-1]):
         return False
     return bool(re.fullmatch(r"\d+(?:-\d+)+(?:\.\d+)?", tail[-2]))

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -1751,8 +1751,7 @@ def _preserve_state_statute_dotted_leaf_for_normalization(
     if len(tail) == 2 and tail[0].isdigit():
         crs_segments = tail[-1].split("-")
         return len(crs_segments) == 3 and all(
-            re.fullmatch(r"\d+(?:\.\d+)*", segment)
-            for segment in crs_segments
+            re.fullmatch(r"\d+(?:\.\d+)*", segment) for segment in crs_segments
         )
     if not re.fullmatch(r"\d+(?:\.\d+)+", tail[-1]):
         return False

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -1964,9 +1964,7 @@ def test_source_identifier_handles_dotted_leaf_segments(citation, expected):
         "39-26-702",
     ],
 )
-def test_colorado_statute_paths_are_hyphen_structured_and_dot_atomic(
-    tmp_path, section
-):
+def test_colorado_statute_paths_are_hyphen_structured_and_dot_atomic(tmp_path, section):
     citation = f"us-co/statute/39/{section}"
     module = _source_identifier_to_relative_rulespec_path(citation)
     companion = module.with_name(f"{module.stem}.test.yaml")

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -1954,6 +1954,46 @@ def test_source_identifier_handles_dotted_leaf_segments(citation, expected):
     assert str(_source_identifier_to_relative_rulespec_path(citation)) == expected
 
 
+@pytest.mark.parametrize(
+    "section",
+    [
+        "39-28.5-107",
+        "39-30.5-104",
+        "39-22-123.5",
+        "39-1-104.5",
+        "39-26-702",
+    ],
+)
+def test_colorado_statute_paths_are_hyphen_structured_and_dot_atomic(
+    tmp_path, section
+):
+    citation = f"us-co/statute/39/{section}"
+    module = _source_identifier_to_relative_rulespec_path(citation)
+    companion = module.with_name(f"{module.stem}.test.yaml")
+
+    assert module == Path(f"statutes/39/{section}.yaml")
+    assert companion == Path(f"statutes/39/{section}.test.yaml")
+
+    # Applied manifests mirror the complete module path. Exercise the same
+    # transformation here so a dotted article cannot diverge at apply time.
+    from axiom_encode.cli import _applied_encoding_manifest_path
+
+    assert _applied_encoding_manifest_path(Path("us-co") / module) == Path(
+        f".axiom/encoding-manifests/us-co/statutes/39/{section}.json"
+    )
+
+    # The reverse index reconstructs the canonical target from the filename;
+    # resolving that citation again must recover the byte-identical path.
+    content_root = _canonical_rulespec_content_root(tmp_path, "us-co")
+    rules_file = content_root / module
+    rules_file.parent.mkdir(parents=True, exist_ok=True)
+    rules_file.write_text("format: rulespec/v1\nrules: []\n")
+    reversed_citation = _canonical_rulespec_target_for_path(rules_file)
+
+    assert reversed_citation == f"us-co:statutes/39/{section}"
+    assert _source_identifier_to_relative_rulespec_path(reversed_citation) == module
+
+
 def test_resolve_eval_output_path_uses_path_like_citation_directly():
     """Sanity: a citation that already looks like a corpus path is used as-is."""
     from axiom_encode.harness.evals import _resolve_eval_output_path

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -34,6 +34,7 @@ from axiom_encode.harness.proof_validator import (
 )
 from axiom_encode.harness.validator_pipeline import (
     OracleSubprocessResult,
+    _corpus_citation_to_normalized_target,
     _extract_json_object,
     _infer_us_state_code_from_rulespec_path,
     _normalize_us_tax_filing_status,
@@ -134,6 +135,22 @@ if not AXIOM_RULES_PATH.is_dir():
 AXIOM_RULES_ENGINE_BINARY = AXIOM_RULES_PATH / "target" / "debug" / "axiom-rules-engine"
 TEST_CORPUS_RELEASE_NAME = "test-release"
 TEST_CORPUS_VERSION = "test-version"
+
+
+@pytest.mark.parametrize(
+    "section",
+    [
+        "39-28.5-107",
+        "39-30.5-104",
+        "39-22-123.5",
+        "39-1-104.5",
+        "39-26-702",
+    ],
+)
+def test_colorado_corpus_citation_lookup_keeps_crs_segments_dot_atomic(section):
+    assert _corpus_citation_to_normalized_target(
+        f"us-co/statute/39/{section}"
+    ) == ("statutes", "39", section)
 
 
 def test_claude_reviewer_disables_tools_and_scrubs_signing_capabilities(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -148,9 +148,11 @@ TEST_CORPUS_VERSION = "test-version"
     ],
 )
 def test_colorado_corpus_citation_lookup_keeps_crs_segments_dot_atomic(section):
-    assert _corpus_citation_to_normalized_target(
-        f"us-co/statute/39/{section}"
-    ) == ("statutes", "39", section)
+    assert _corpus_citation_to_normalized_target(f"us-co/statute/39/{section}") == (
+        "statutes",
+        "39",
+        section,
+    )
 
 
 def test_claude_reviewer_disables_tools_and_scrubs_signing_capabilities(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1259"
+version = "0.2.1260"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
Dotted ARTICLE numbers nested as subsection paths: encoding `us-co/statute/39/39-28.5-107` installed `39/39-28/5-107.yaml`, which reads as §39-28(5)(107) under filepath-=-citation. Root cause in two places (`evals.py` dot-preservation only honored dots in the final hyphen segment; `validator_pipeline.py` duplicated it). Both now parse C.R.S. labels as exactly three hyphen-separated segments with dots atomic inside each. Regressions pin dotted SECTIONS (`39-22-123.5`, `39-1-104.5`) and plain sections unchanged, plus path↔citation roundtrip identity. Unblocks the CO lane's 115 parked dotted-article modules. Authored by a gpt-5.6-sol worker; reviewed by Fable (cross-model dual approval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)