### PR TITLE
Ground numeric literals against spelled-out numbers (fixes #1130)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1260"
+version = "0.2.1261"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1260"
+__version__ = "0.2.1261"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -952,6 +952,14 @@ _STANDALONE_FRACTION_WORD_PATTERN = re.compile(
 # ("five and half per centum", "eighteen and a half per centum"); outside
 # one they would over-extract ordinary prose such as "half of the year".
 _PERCENT_FRACTION_WORD_PATTERN = rf"(?:{_FRACTION_WORD_PATTERN}|a[-\s]+half|half)"
+_DECIMAL_FRACTION_DENOMINATORS = {
+    "tenth": 10.0,
+    "hundredth": 100.0,
+    "thousandth": 1_000.0,
+}
+_DECIMAL_FRACTION_DENOMINATOR_PATTERN = (
+    r"(?P<denominator>tenths?|hundredths?|thousandths?)"
+)
 IMPORT_ITEM_PATTERN = re.compile(r"^\s*-\s*(['\"]?)([^'\"]+?)\1\s*$")
 IMPORT_MAPPING_PATTERN = re.compile(r"^\s*[A-Za-z_]\w*:\s*(['\"]?)([^'\"]+?)\1\s*$")
 _EMBEDDED_SCALAR_DIRECT_VALUE = re.compile(r"-?[\d,]+(?:\.\d+)?")
@@ -3261,6 +3269,40 @@ def _iter_normalized_special_numeric_matches(
     fraction_chars = "".join(re.escape(glyph) for glyph in _UNICODE_FRACTION_VALUES)
 
     for match in re.finditer(
+        rf"\b(?P<whole>{_CARDINAL_NUMBER_WORD_PATTERN.pattern})\s+and\s+"
+        rf"(?P<numerator>{_CARDINAL_NUMBER_WORD_PATTERN.pattern})\s+"
+        rf"one[-\s]+{_DECIMAL_FRACTION_DENOMINATOR_PATTERN}\s+"
+        r"(?:percent|per\s*cent(?:um)?)\b",
+        text,
+        re.IGNORECASE,
+    ):
+        whole = _parse_strict_cardinal_number_words(match.group("whole"))
+        numerator = _parse_strict_cardinal_number_words(match.group("numerator"))
+        denominator = _DECIMAL_FRACTION_DENOMINATORS.get(
+            match.group("denominator").lower().removesuffix("s")
+        )
+        if whole is None or numerator is None or denominator is None:
+            continue
+        matches.append((match.span(), (whole + numerator / denominator) / 100))
+
+    for match in re.finditer(
+        rf"\b(?P<numerator>{_CARDINAL_NUMBER_WORD_PATTERN.pattern})[-\s]+"
+        rf"{_DECIMAL_FRACTION_DENOMINATOR_PATTERN}\s+of\s+"
+        rf"(?P<percent>{_CARDINAL_NUMBER_WORD_PATTERN.pattern})\s+"
+        r"(?:percent|per\s*cent(?:um)?)\b",
+        text,
+        re.IGNORECASE,
+    ):
+        numerator = _parse_strict_cardinal_number_words(match.group("numerator"))
+        percent = _parse_strict_cardinal_number_words(match.group("percent"))
+        denominator = _DECIMAL_FRACTION_DENOMINATORS.get(
+            match.group("denominator").lower().removesuffix("s")
+        )
+        if numerator is None or percent is None or denominator is None:
+            continue
+        matches.append((match.span(), numerator / denominator * percent / 100))
+
+    for match in re.finditer(
         rf"\b(?P<number>{_CARDINAL_NUMBER_WORD_PATTERN.pattern})\s+"
         r"(?:percent|per\s*cent(?:um)?)\b",
         text,
@@ -3685,6 +3727,61 @@ def _parse_cardinal_number_words(text: str) -> float | None:
     if not seen_scale and len(tokens) == 1:
         return _CARDINAL_WORD_VALUES.get(tokens[0])
     return value
+
+
+def _parse_strict_cardinal_number_words(text: str) -> float | None:
+    """Parse a conventionally ordered English cardinal phrase, or fail closed."""
+    tokens = [token for token in re.split(r"[-\s]+", text.strip().lower()) if token]
+    if not tokens or tokens[0] == "and" or tokens[-1] == "and":
+        return None
+    tokens = [token for token in tokens if token != "and"]
+
+    def parse_under_thousand(group: list[str]) -> float | None:
+        if not group:
+            return None
+        total = 0.0
+        if len(group) >= 2 and group[1] == "hundred":
+            hundreds = _CARDINAL_WORD_VALUES.get(group[0])
+            if hundreds is None or not 1 <= hundreds <= 9:
+                return None
+            total = hundreds * 100
+            group = group[2:]
+            if not group:
+                return total
+        if len(group) == 1:
+            remainder = _CARDINAL_WORD_VALUES.get(group[0])
+            return total + remainder if remainder is not None else None
+        if len(group) == 2:
+            tens = _CARDINAL_WORD_VALUES.get(group[0])
+            units = _CARDINAL_WORD_VALUES.get(group[1])
+            if tens in {20, 30, 40, 50, 60, 70, 80, 90} and units is not None:
+                if 1 <= units <= 9:
+                    return total + tens + units
+        return None
+
+    total = 0.0
+    group: list[str] = []
+    previous_scale = math.inf
+    for token in tokens:
+        scale = _CARDINAL_SCALE_WORD_VALUES.get(token)
+        if scale is None or scale == 100:
+            group.append(token)
+            continue
+        if scale >= previous_scale:
+            return None
+        parsed_group = parse_under_thousand(group)
+        if parsed_group is None:
+            return None
+        total += parsed_group * scale
+        previous_scale = scale
+        group = []
+
+    if group:
+        parsed_group = parse_under_thousand(group)
+        if parsed_group is None:
+            return None
+        total += parsed_group
+    return total or None
 
 
 def _parse_fraction_word(text: str) -> float | None:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -7060,9 +7060,7 @@ rules:
         "six and eight hundred seventy-five one thousandths percent"
     )
     assert 0.065 in extract_numbers_from_text("six and five one-tenths percent")
-    assert 0.0605 in extract_numbers_from_text(
-        "SIX AND FIVE ONE-HUNDREDTHS PERCENT"
-    )
+    assert 0.0605 in extract_numbers_from_text("SIX AND FIVE ONE-HUNDREDTHS PERCENT")
     assert 5_000_000.0 in extract_numbers_from_text("five million dollars")
 
 
@@ -7089,9 +7087,7 @@ rules:
       - effective_from: '2026-01-01'
         formula: 0.0685
 """,
-        source_text=(
-            "SIX AND EIGHT HUNDRED SEVENTY-FIVE ONE-THOUSANDTHS PERCENT"
-        ),
+        source_text=("SIX AND EIGHT HUNDRED SEVENTY-FIVE ONE-THOUSANDTHS PERCENT"),
     )
 
     assert any("0.002" in issue for issue in fraction_issues)

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -7006,6 +7006,82 @@ rules:
     assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
 
 
+def test_rulespec_grounding_accepts_colorado_word_number_rates_and_dollars():
+    content = """format: rulespec/v1
+rules:
+  - name: rounded_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.001
+  - name: assessment_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.06875
+  - name: assessment_increment
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 5000
+"""
+    source_text = (
+        "rounded to the nearest one-tenth of one percent. "
+        "SIX AND EIGHT HUNDRED SEVENTY-FIVE ONE-THOUSANDTHS PERCENT "
+        "FOR EACH FIVE THOUSAND DOLLARS"
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    assert {0.001, 0.06875, 5000.0} <= extract_numbers_from_text(source_text)
+    assert 0.06875 in extract_numbers_from_text(
+        "six and eight hundred seventy-five one thousandths percent"
+    )
+    assert 0.065 in extract_numbers_from_text("six and five one-tenths percent")
+    assert 0.0605 in extract_numbers_from_text(
+        "SIX AND FIVE ONE-HUNDREDTHS PERCENT"
+    )
+    assert 5_000_000.0 in extract_numbers_from_text("five million dollars")
+
+
+def test_rulespec_grounding_rejects_nearby_colorado_word_number_values():
+    fraction_issues = find_ungrounded_numeric_issues(
+        """format: rulespec/v1
+rules:
+  - name: wrong_rounded_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.002
+""",
+        source_text="rounded to the nearest one-tenth of one percent",
+    )
+    mixed_issues = find_ungrounded_numeric_issues(
+        """format: rulespec/v1
+rules:
+  - name: wrong_assessment_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.0685
+""",
+        source_text=(
+            "SIX AND EIGHT HUNDRED SEVENTY-FIVE ONE-THOUSANDTHS PERCENT"
+        ),
+    )
+
+    assert any("0.002" in issue for issue in fraction_issues)
+    assert any("0.0685" in issue for issue in mixed_issues)
+    assert 0.0611 not in extract_numbers_from_text(
+        "six and five six one-thousandths percent"
+    )
+
+
 def test_numeric_extraction_prefers_english_compound_cardinals_over_single_words():
     assert 36.0 in extract_numbers_from_text("not longer than thirty-six months")
     assert 600.0 in extract_numbers_from_text("The amount is Six hundred dollars")

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1260"
+version = "0.2.1261"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
Colorado enrolled acts spell numbers entirely in words, so correct encodes were unpassable — the grounding gate only matched digits. Adds strict spelled-English-number → numeral equivalence: cardinals through billions, mixed tenths/hundredths/thousandths percent phrases, fraction-of-percent, dollar amounts; case/hyphenation-insensitive. Fail-closed: purely additive, exact-value only, ambiguous phrases contribute nothing, digit matching untouched. The issue's two verbatim act excerpts are test fixtures (0.001 / 0.06875 / 5000 ground; near-miss values don't). Unblocks the CO lane's 20 rate-anchor sections. Authored by a gpt-5.6-sol worker; reviewed by Fable (cross-model dual approval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)