### PR TITLE
Default to gpt-5.6-terra with validator-failure escalation to sol

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,13 @@ rows are rejected as ambiguous. If the named release or an unambiguous provision
 is unavailable, encoding stops before calling a model. Supabase run/session sync
 is a separate telemetry feature and never supplies legal source text.
 
-`encode` defaults to `--backend codex` with `gpt-5.5`; Claude/Fable capacity is
-reserved for orchestration, gating, and review rather than YAML generation. The
-Codex backend authenticates through the Codex CLI's `~/.codex/auth.json`
+`encode` defaults to `--backend codex` with `gpt-5.6-terra`. Each section gets
+up to two validator-rejected generations on that model, then one generation
+with `gpt-5.6-sol`; use
+`--escalate-after`, `--escalation-model`, or `--no-escalation` to override that
+policy. Claude/Fable capacity is reserved for orchestration, gating, and review
+rather than YAML generation. The Codex backend authenticates through the Codex
+CLI's `~/.codex/auth.json`
 (created by `codex login`, or an `OPENAI_API_KEY` recorded there); `CODEX_HOME`
 overrides the directory and `OPENAI_API_KEY` in the environment also satisfies
 the check. When neither is present `encode` stops with a clear error before

--- a/changelog.d/terra-default-validator-escalation.changed.md
+++ b/changelog.d/terra-default-validator-escalation.changed.md
@@ -1,0 +1,2 @@
+`encode` now defaults to `gpt-5.6-terra` and retries validator-rejected sections
+with bounded per-section escalation to `gpt-5.6-sol`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1258"
+version = "0.2.1259"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1258"
+__version__ = "0.2.1259"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
@@ -6,6 +6,8 @@ __version__ = "0.2.1258"
 from .constants import (
     DEFAULT_CLI_MODEL,
     DEFAULT_MODEL,
+    DEFAULT_OPENAI_ESCALATE_AFTER,
+    DEFAULT_OPENAI_ESCALATION_MODEL,
     DEFAULT_OPENAI_MODEL,
     REVIEWER_CLI_MODEL,
 )
@@ -53,6 +55,8 @@ __all__ = [
     "DEFAULT_MODEL",
     "DEFAULT_CLI_MODEL",
     "DEFAULT_OPENAI_MODEL",
+    "DEFAULT_OPENAI_ESCALATION_MODEL",
+    "DEFAULT_OPENAI_ESCALATE_AFTER",
     "REVIEWER_CLI_MODEL",
     "EncodingDB",
     "EncodingRun",

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -107,6 +107,8 @@ from .concepts import (
 )
 from .concepts.jurisdiction import jurisdiction_prefix as _repo_jurisdiction_prefix
 from .constants import (
+    DEFAULT_OPENAI_ESCALATE_AFTER,
+    DEFAULT_OPENAI_ESCALATION_MODEL,
     DEFAULT_OPENAI_MODEL,
     RULESPEC_ATOMIC_MODULE_ROOTS,
     RULESPEC_COMPOSITION_SPEC_ROOT,
@@ -503,6 +505,19 @@ def _add_gpt_backend_argument(parser: argparse.ArgumentParser) -> None:
             "Defaults to 'codex' locally, or the AXIOM_ENCODE_GPT_BACKEND env var when set."
         ),
     )
+
+
+def _positive_int(value: str) -> int:
+    """Parse one strictly positive CLI integer."""
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"expected a positive integer, got {value!r}"
+        ) from exc
+    if parsed < 1:
+        raise argparse.ArgumentTypeError(f"expected a positive integer, got {value!r}")
+    return parsed
 
 
 def _add_required_corpus_path_argument(parser: argparse.ArgumentParser) -> None:
@@ -1723,6 +1738,31 @@ def main():
         "--model",
         default=None,
         help=f"Model to use for encoding (default: {DEFAULT_OPENAI_MODEL})",
+    )
+    encode_parser.add_argument(
+        "--escalation-model",
+        default=DEFAULT_OPENAI_ESCALATION_MODEL,
+        help=(
+            "Model for the final validator-failure retry "
+            f"(default: {DEFAULT_OPENAI_ESCALATION_MODEL})"
+        ),
+    )
+    encode_parser.add_argument(
+        "--escalate-after",
+        type=_positive_int,
+        default=DEFAULT_OPENAI_ESCALATE_AFTER,
+        metavar="N",
+        help=(
+            "Escalate after N validator-rejected generations "
+            f"(default: {DEFAULT_OPENAI_ESCALATE_AFTER})"
+        ),
+    )
+    encode_parser.add_argument(
+        "--no-escalation",
+        dest="escalation_enabled",
+        action="store_false",
+        default=True,
+        help="Disable validator-failure retries and model escalation",
     )
     encode_parser.add_argument(
         "--backend",
@@ -5886,7 +5926,13 @@ def cmd_run_log_staleness(args):
         sys.exit(1)
 
 
-def _emit_run_log_events_safe(result, run_id, outcome):
+def _emit_run_log_events_safe(
+    result,
+    run_id,
+    outcome,
+    *,
+    total_duration_ms: int | None = None,
+):
     """Emit run-log events for a just-completed encode run; never fatal.
 
     Set ``AXIOM_ENCODE_DISABLE_RUN_LOG=1`` to opt out.
@@ -5896,7 +5942,12 @@ def _emit_run_log_events_safe(result, run_id, outcome):
     try:
         from .run_log_export import emit_live_encode_events
 
-        emit_live_encode_events(result, run_id, outcome or {})
+        emit_live_encode_events(
+            result,
+            run_id,
+            outcome or {},
+            total_duration_ms=total_duration_ms,
+        )
     except Exception:  # noqa: BLE001 - run-log emission must never break a run
         pass
 
@@ -18393,18 +18444,272 @@ def cmd_encode(args):
         return _cmd_encode_with_authoritative_rulespec_roots(args)
 
 
+class _EncodeEscalationConfig(NamedTuple):
+    enabled: bool
+    initial_model: str
+    escalation_model: str
+    escalate_after: int
+
+
+class _FailedEncodeAttempt(NamedTuple):
+    result: Any
+    error: str
+
+
+class _EncodeAttemptExecution(NamedTuple):
+    result: Any
+    outcome: dict[str, Any]
+    apply_passed: bool
+    logged_run: EncodingRun | None
+
+
+def _resolve_encode_escalation_config(args) -> _EncodeEscalationConfig:
+    """Resolve and validate the per-section validator retry policy."""
+    initial_model = getattr(args, "model", None) or DEFAULT_OPENAI_MODEL
+    escalation_model = getattr(
+        args,
+        "escalation_model",
+        DEFAULT_OPENAI_ESCALATION_MODEL,
+    )
+    if (
+        not isinstance(escalation_model, str)
+        or not escalation_model
+        or escalation_model != escalation_model.strip()
+    ):
+        raise ValueError("encode --escalation-model must be a non-empty model ID")
+    escalate_after = getattr(
+        args,
+        "escalate_after",
+        DEFAULT_OPENAI_ESCALATE_AFTER,
+    )
+    if (
+        isinstance(escalate_after, bool)
+        or not isinstance(escalate_after, int)
+        or escalate_after < 1
+    ):
+        raise ValueError("encode --escalate-after must be a positive integer")
+    return _EncodeEscalationConfig(
+        enabled=getattr(args, "escalation_enabled", True) is not False,
+        initial_model=str(initial_model),
+        escalation_model=escalation_model,
+        escalate_after=escalate_after,
+    )
+
+
+def _encode_attempt_was_validator_rejected(
+    result,
+    outcome: dict[str, Any],
+) -> bool:
+    """Return whether the attempt reached and failed a retryable validator gate."""
+    if outcome.get("status") == "apply_blocked_validation":
+        return True
+    if outcome.get("apply_requested") is True:
+        return False
+    return str(getattr(result, "error", "") or "") in {
+        "Generated RuleSpec failed compile validation",
+        "Generated RuleSpec failed CI validation",
+    }
+
+
+def _next_encode_attempt_model(
+    config: _EncodeEscalationConfig,
+    *,
+    current_model: str,
+    failed_attempt_count: int,
+) -> str | None:
+    """Choose the next bounded retry model after one more validator rejection."""
+    if not config.enabled:
+        return None
+    failures_after_current = failed_attempt_count + 1
+    already_escalated = (
+        current_model == config.escalation_model
+        and config.escalation_model != config.initial_model
+    )
+    if already_escalated:
+        return None
+    if failures_after_current < config.escalate_after:
+        return config.initial_model
+    if config.escalation_model == config.initial_model:
+        return None
+    return config.escalation_model
+
+
+def _require_compatible_encode_retry_model(*, backend: str, model: str) -> None:
+    """Reject a known cross-provider retry before invoking the wrong CLI."""
+    if backend == "claude" and model.startswith("gpt-"):
+        raise ValueError(
+            "encode cannot use a GPT escalation model with --backend claude; "
+            "pass a Claude-compatible --escalation-model or --no-escalation"
+        )
+
+
+def _clear_retry_destination(
+    result,
+    *,
+    output_root: Path,
+    backend: str,
+    next_model: str,
+) -> None:
+    """Remove only the next attempt's generated files to prevent stale reuse."""
+    relative_output = _relative_generated_output_path(result, output_root=output_root)
+    next_runner = parse_runner_spec(f"{backend}:{next_model}")
+    generated_root = (Path(output_root) / next_runner.name).resolve()
+    output_file = (generated_root / relative_output).resolve()
+    try:
+        output_file.relative_to(generated_root)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"Retry output {output_file} escapes generated root {generated_root}"
+        ) from exc
+    retry_files = (
+        output_file,
+        _rulespec_test_path(output_file),
+        output_file.with_suffix(".repair.json"),
+    )
+    for retry_file in retry_files:
+        if retry_file.is_dir() and not retry_file.is_symlink():
+            raise RuntimeError(f"Retry output path is a directory: {retry_file}")
+        retry_file.unlink(missing_ok=True)
+
+
 def _cmd_encode_with_authoritative_rulespec_roots(
     args,
     *,
     apply_signing_broker: SigningBroker | None = None,
     resolved_policy_checkout_path: Path | None = None,
 ):
-    """Encode a corpus-backed source unit through the RuleSpec eval pipeline."""
+    """Encode one section with bounded full-gate validator retries."""
+    config = _resolve_encode_escalation_config(args)
+    if config.enabled and config.escalation_model != config.initial_model:
+        _require_compatible_encode_retry_model(
+            backend=args.backend,
+            model=config.escalation_model,
+        )
+    failed_attempts: tuple[_FailedEncodeAttempt, ...] = ()
+    current_model = config.initial_model
+
+    while True:
+        execution = _run_encode_attempt(
+            args,
+            model=current_model,
+            prior_attempts=failed_attempts,
+            defer_logging=config.enabled,
+            apply_signing_broker=apply_signing_broker,
+            resolved_policy_checkout_path=resolved_policy_checkout_path,
+        )
+        next_model = None
+        if _encode_attempt_was_validator_rejected(
+            execution.result,
+            execution.outcome,
+        ):
+            next_model = _next_encode_attempt_model(
+                config,
+                current_model=current_model,
+                failed_attempt_count=len(failed_attempts),
+            )
+        if next_model is not None:
+            failure = _FailedEncodeAttempt(
+                result=execution.result,
+                error=_encode_outcome_issue(execution.result, execution.outcome),
+            )
+            failed_attempts = (*failed_attempts, failure)
+            action = (
+                "escalating" if next_model == config.escalation_model else "retrying"
+            )
+            print(
+                f"  generation={action} failed_attempts={len(failed_attempts)} "
+                f"from_model={current_model} to_model={next_model}"
+            )
+            _clear_retry_destination(
+                execution.result,
+                output_root=args.output,
+                backend=args.backend,
+                next_model=next_model,
+            )
+            current_model = next_model
+            continue
+
+        outcome = execution.outcome
+        escalated = (
+            current_model == config.escalation_model
+            and config.escalation_model != config.initial_model
+        )
+        if escalated:
+            outcome["generation_escalation"] = {
+                "escalated": True,
+                "failed_attempt_count": len(failed_attempts),
+                "initial_model": config.initial_model,
+                "escalation_model": config.escalation_model,
+            }
+        db_path = getattr(args, "db", DEFAULT_DB)
+        logged_run = execution.logged_run
+        if logged_run is None:
+            final_attempt_success, final_attempt_error = _encode_iteration_verdict(
+                execution.result, outcome
+            )
+            logged_run = _log_eval_result(
+                execution.result,
+                db_path=db_path,
+                end_session=False,
+                log_issue=False,
+                prior_attempts=failed_attempts,
+                final_attempt_success=final_attempt_success,
+                final_attempt_error=final_attempt_error,
+            )
+            print(f"  run_id={logged_run.id}")
+        repair_manifest = _record_encode_outcome(
+            db_path=db_path,
+            result=execution.result,
+            run=logged_run,
+            outcome=outcome,
+        )
+        _emit_run_log_events_safe(
+            execution.result,
+            logged_run.id,
+            outcome,
+            total_duration_ms=logged_run.total_duration_ms,
+        )
+        apply_requested = getattr(args, "apply", False) is True
+        if apply_requested:
+            print(
+                f"  outcome={outcome['status']} "
+                f"final_success={outcome['final_success']}"
+            )
+        if repair_manifest and repair_manifest.exists():
+            print(f"  repair_manifest={repair_manifest}")
+        if getattr(args, "sync", True) is True:
+            sync_result = _sync_run_to_supabase_if_configured(
+                logged_run,
+                db_path=db_path,
+            )
+            if not sync_result["configured"]:
+                print("  supabase_sync=skipped")
+            elif sync_result["run"] and sync_result["session"]:
+                print("  supabase_sync=run+session")
+            elif sync_result["run"]:
+                print("  supabase_sync=run")
+            else:
+                print("  supabase_sync=failed")
+
+        if apply_requested:
+            sys.exit(0 if execution.apply_passed else 1)
+        sys.exit(0 if execution.result.success else 1)
+
+
+def _run_encode_attempt(
+    args,
+    *,
+    model: str,
+    prior_attempts: Sequence[_FailedEncodeAttempt] = (),
+    defer_logging: bool = True,
+    apply_signing_broker: SigningBroker | None = None,
+    resolved_policy_checkout_path: Path | None = None,
+) -> _EncodeAttemptExecution:
+    """Run one generation through the existing standalone and apply gates."""
     if getattr(args, "apply", False) is True and not apply_signing_broker:
         raise RuntimeError(
             "encode --apply requires its signing key to be isolated before generation"
         )
-    model = args.model or DEFAULT_OPENAI_MODEL
     runner = f"{args.backend}:{model}"
     rulespec_dependency_roots = _rulespec_dependency_roots_from_args(args)
     if args.backend == "codex":
@@ -18513,15 +18818,33 @@ def _cmd_encode_with_authoritative_rulespec_roots(
     print(f"  trace={result.trace_file}")
     print(f"  manifest={result.context_manifest_file}")
     db_path = getattr(args, "db", DEFAULT_DB)
-    logged_run = _log_eval_result(
-        result,
-        db_path=db_path,
-        end_session=False,
-        log_issue=False,
-    )
-    print(f"  run_id={logged_run.id}")
+    logged_run: EncodingRun | None = None
+
+    def _ensure_logged_run(
+        *,
+        final_attempt_success: bool | None = None,
+        final_attempt_error: str | None = None,
+    ) -> EncodingRun:
+        nonlocal logged_run
+        if logged_run is None:
+            logged_run = _log_eval_result(
+                result,
+                db_path=db_path,
+                end_session=False,
+                log_issue=False,
+                prior_attempts=prior_attempts,
+                final_attempt_success=final_attempt_success,
+                final_attempt_error=final_attempt_error,
+            )
+            print(f"  run_id={logged_run.id}")
+        return logged_run
+
+    if not defer_logging:
+        # Preserve the legacy --no-escalation durability boundary: generation
+        # is recorded before the apply validator starts or can raise.
+        _ensure_logged_run()
+
     outcome = _initial_encode_outcome(result, apply_requested=apply_requested)
-    repair_manifest = None
     apply_passed = False
     if apply_requested:
         if not _can_attempt_apply(result):
@@ -21154,7 +21477,9 @@ def _cmd_encode_with_authoritative_rulespec_roots(
                             output_root=args.output,
                             policy_repo_path=policy_repo_path,
                             corpus_path=corpus_path,
-                            run_id=logged_run.id,
+                            run_id=_ensure_logged_run(
+                                final_attempt_success=True,
+                            ).id,
                             supplemental_files=supplemental_files,
                             signing_broker=apply_signing_broker,
                             allow_shrink=(getattr(args, "allow_shrink", False) is True),
@@ -21171,31 +21496,12 @@ def _cmd_encode_with_authoritative_rulespec_roots(
                         outcome["apply_success"] = True
                         outcome["final_success"] = True
                         outcome["applied_files"] = [str(path) for path in applied]
-    repair_manifest = _record_encode_outcome(
-        db_path=db_path,
+    return _EncodeAttemptExecution(
         result=result,
-        run=logged_run,
         outcome=outcome,
+        apply_passed=apply_passed,
+        logged_run=logged_run,
     )
-    _emit_run_log_events_safe(result, logged_run.id, outcome)
-    if apply_requested:
-        print(f"  outcome={outcome['status']} final_success={outcome['final_success']}")
-    if repair_manifest and repair_manifest.exists():
-        print(f"  repair_manifest={repair_manifest}")
-    if getattr(args, "sync", True) is True:
-        sync_result = _sync_run_to_supabase_if_configured(logged_run, db_path=db_path)
-        if not sync_result["configured"]:
-            print("  supabase_sync=skipped")
-        elif sync_result["run"] and sync_result["session"]:
-            print("  supabase_sync=run+session")
-        elif sync_result["run"]:
-            print("  supabase_sync=run")
-        else:
-            print("  supabase_sync=failed")
-
-    if apply_requested:
-        sys.exit(0 if apply_passed else 1)
-    sys.exit(0 if result.success else 1)
 
 
 def _can_attempt_apply(result) -> bool:
@@ -42220,33 +42526,61 @@ def _log_eval_result(
     db_path: Path,
     end_session: bool = True,
     log_issue: bool = True,
+    prior_attempts: Sequence[_FailedEncodeAttempt] = (),
+    final_attempt_success: bool | None = None,
+    final_attempt_error: str | None = None,
 ) -> EncodingRun:
     """Persist an eval-backed encode run in the local run history DB."""
     rulespec_content = _read_optional_text(getattr(result, "output_file", ""))
     source_text = _read_eval_source_text(getattr(result, "context_manifest_file", ""))
-    error = getattr(result, "error", None)
-    iteration_errors = []
-    if isinstance(error, str) and error:
-        iteration_errors.append(
-            IterationError(
-                error_type="validation",
-                message=error,
+    iterations: list[Iteration] = []
+    for attempt_number, failed_attempt in enumerate(prior_attempts, 1):
+        iterations.append(
+            Iteration(
+                attempt=attempt_number,
+                duration_ms=int(getattr(failed_attempt.result, "duration_ms", 0) or 0),
+                errors=[
+                    IterationError(
+                        error_type="validation",
+                        message=failed_attempt.error,
+                    )
+                ],
+                success=False,
             )
         )
+    if final_attempt_success is None:
+        resolved_final_success = bool(getattr(result, "success", False))
+        final_error = getattr(result, "error", None)
+    else:
+        resolved_final_success = final_attempt_success
+        final_error = final_attempt_error
+    final_errors = []
+    if isinstance(final_error, str) and final_error:
+        final_errors.append(
+            IterationError(
+                error_type="validation",
+                message=final_error,
+            )
+        )
+    iterations.append(
+        Iteration(
+            attempt=len(iterations) + 1,
+            duration_ms=int(getattr(result, "duration_ms", 0) or 0),
+            errors=final_errors,
+            success=resolved_final_success,
+        )
+    )
+    attempt_results = [
+        *(failed_attempt.result for failed_attempt in prior_attempts),
+        result,
+    ]
 
     run = EncodingRun(
         citation=result.citation,
         file_path=str(result.output_file),
         source_text=source_text,
-        iterations=[
-            Iteration(
-                attempt=1,
-                duration_ms=int(result.duration_ms or 0),
-                errors=iteration_errors,
-                success=bool(result.success),
-            )
-        ],
-        total_duration_ms=int(result.duration_ms or 0),
+        iterations=iterations,
+        total_duration_ms=sum(iteration.duration_ms for iteration in iterations),
         agent_type=f"{result.backend}:encoder",
         agent_model=str(result.model or ""),
         rulespec_content=rulespec_content,
@@ -42264,6 +42598,7 @@ def _log_eval_result(
         repair_manifest=repair_manifest,
         log_issue=log_issue,
         end_session=end_session,
+        attempt_results=attempt_results,
     )
     return run
 
@@ -42276,8 +42611,23 @@ def _log_eval_session(
     repair_manifest: Path | None = None,
     log_issue: bool = True,
     end_session: bool = True,
+    attempt_results: Sequence[Any] = (),
 ) -> None:
     """Persist a minimal SDK-style session for eval-backed encode runs."""
+    attempts = list(attempt_results) or [result]
+
+    def _sum_attempt_field(field: str) -> int:
+        return sum(int(getattr(attempt, field, 0) or 0) for attempt in attempts)
+
+    attempt_costs = [
+        float(cost)
+        for attempt in attempts
+        if isinstance(
+            (cost := getattr(attempt, "estimated_cost_usd", None)), (int, float)
+        )
+        and not isinstance(cost, bool)
+    ]
+
     session = db.start_session(
         model=str(getattr(result, "model", "") or ""),
         cwd=os.getcwd(),
@@ -42287,10 +42637,10 @@ def _log_eval_session(
     )
     db.update_session_tokens(
         session.id,
-        input_tokens=int(getattr(result, "input_tokens", 0) or 0),
-        output_tokens=int(getattr(result, "output_tokens", 0) or 0),
-        cache_read_tokens=int(getattr(result, "cache_read_tokens", 0) or 0),
-        cache_creation_tokens=int(getattr(result, "cache_creation_tokens", 0) or 0),
+        input_tokens=_sum_attempt_field("input_tokens"),
+        output_tokens=_sum_attempt_field("output_tokens"),
+        cache_read_tokens=_sum_attempt_field("cache_read_tokens"),
+        cache_creation_tokens=_sum_attempt_field("cache_creation_tokens"),
     )
     db.log_event(
         session.id,
@@ -42310,15 +42660,14 @@ def _log_eval_session(
         "citation": run.citation,
         "success": bool(getattr(result, "success", False)),
         "standalone_validation_success": bool(getattr(result, "success", False)),
-        "duration_ms": int(getattr(result, "duration_ms", 0) or 0),
-        "estimated_cost_usd": getattr(result, "estimated_cost_usd", None),
-        "input_tokens": int(getattr(result, "input_tokens", 0) or 0),
-        "output_tokens": int(getattr(result, "output_tokens", 0) or 0),
-        "cache_read_tokens": int(getattr(result, "cache_read_tokens", 0) or 0),
-        "cache_creation_tokens": int(getattr(result, "cache_creation_tokens", 0) or 0),
-        "reasoning_output_tokens": int(
-            getattr(result, "reasoning_output_tokens", 0) or 0
-        ),
+        "duration_ms": _sum_attempt_field("duration_ms"),
+        "generation_attempt_count": len(attempts),
+        "estimated_cost_usd": sum(attempt_costs) if attempt_costs else None,
+        "input_tokens": _sum_attempt_field("input_tokens"),
+        "output_tokens": _sum_attempt_field("output_tokens"),
+        "cache_read_tokens": _sum_attempt_field("cache_read_tokens"),
+        "cache_creation_tokens": _sum_attempt_field("cache_creation_tokens"),
+        "reasoning_output_tokens": _sum_attempt_field("reasoning_output_tokens"),
         "retrieved_file_count": len(getattr(result, "retrieved_files", []) or []),
         "unexpected_access_count": len(
             getattr(result, "unexpected_accesses", []) or []
@@ -42456,6 +42805,20 @@ def _record_encode_outcome(
             )
     db.end_session(run.session_id)
     return repair_manifest
+
+
+def _encode_iteration_verdict(
+    result,
+    outcome: dict[str, Any],
+) -> tuple[bool, str | None]:
+    """Map the final full-gate outcome to one generation iteration verdict."""
+    status = outcome.get("status")
+    if status in {"apply_applied", "apply_blocked_manifest"}:
+        return True, None
+    if status in {"apply_blocked_generation", "apply_blocked_validation"}:
+        return False, _encode_outcome_issue(result, outcome)
+    success = bool(getattr(result, "success", False))
+    return success, None if success else _encode_outcome_issue(result, outcome)
 
 
 def _encode_outcome_issue(result, outcome: dict) -> str:

--- a/src/axiom_encode/codex_cli.py
+++ b/src/axiom_encode/codex_cli.py
@@ -30,7 +30,7 @@ def codex_auth_json_path() -> Path:
 def codex_auth_error() -> str | None:
     """Return a clear error when the Codex CLI has no usable auth file.
 
-    ``axiom-encode encode`` defaults to the Codex backend (gpt-5.5), which
+    ``axiom-encode encode`` defaults to the Codex backend (gpt-5.6-terra), which
     authenticates through the Codex CLI's ``auth.json`` (ChatGPT sign-in or
     an ``OPENAI_API_KEY`` recorded by ``codex login``). When neither that
     file nor ``OPENAI_API_KEY`` is present, encoding fails deep inside the

--- a/src/axiom_encode/constants.py
+++ b/src/axiom_encode/constants.py
@@ -12,7 +12,9 @@ REVIEWER_CLI_MODEL = "opus"
 # This is also the *generator* family the LLM judges must never share (see
 # below): same-model self-review correlates errors (the 9/9 identical
 # hardcoded-600,000 incident is the cautionary tale).
-DEFAULT_OPENAI_MODEL = "gpt-5.5"
+DEFAULT_OPENAI_MODEL = "gpt-5.6-terra"
+DEFAULT_OPENAI_ESCALATION_MODEL = "gpt-5.6-sol"
+DEFAULT_OPENAI_ESCALATE_AFTER = 2
 
 # LLM judge models (maximum-traceability part 2). Cross-family by design: the
 # generator is a GPT model, so judges run on a Claude-family model. Volume runs

--- a/src/axiom_encode/judges/__init__.py
+++ b/src/axiom_encode/judges/__init__.py
@@ -1,7 +1,8 @@
 """LLM judge stages for the encoding pipeline (maximum-traceability part 2).
 
-Cross-family judging: the generator is ``gpt-5.5``; judges run on a Claude-family
-model. Every stage emits a structured :class:`~axiom_encode.judges.run_log.JudgeEvent`
+Cross-family judging: the generator is ``gpt-5.6-terra``; judges run on a
+Claude-family model. Every stage emits a structured
+:class:`~axiom_encode.judges.run_log.JudgeEvent`
 (``axiom_encode.run_log.v1``) and is fail-closed — a judge that cannot reach a
 verdict emits a ``judge_error`` event, never a silent pass.
 

--- a/src/axiom_encode/judges/calibration.py
+++ b/src/axiom_encode/judges/calibration.py
@@ -31,6 +31,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
 
+from ..constants import DEFAULT_OPENAI_MODEL
 from . import statutory_fidelity
 from .client import JudgeClient
 from .run_log import TokenCounts, Verdict
@@ -54,7 +55,7 @@ def load_cases(
     *,
     n: int = 30,
     seed: Optional[int] = 0,
-    generator_model: str = "gpt-5.5",
+    generator_model: str = DEFAULT_OPENAI_MODEL,
 ) -> list[CalibrationCase]:
     """Load a balanced sample of known-good and known-bad historical generations."""
 

--- a/src/axiom_encode/judges/client.py
+++ b/src/axiom_encode/judges/client.py
@@ -1,7 +1,7 @@
 """Cross-family Anthropic judge client for the LLM judge stages.
 
-The generator is ``gpt-5.5``; the judges MUST run on a Claude-family model so a
-judge's errors do not correlate with the generator's (the 9/9 identical
+The generator is ``gpt-5.6-terra``; the judges MUST run on a Claude-family
+model so a judge's errors do not correlate with the generator's (the 9/9 identical
 hardcoded-600,000 incident is the cautionary tale). This module enforces that
 guard and the fail-closed contract:
 

--- a/src/axiom_encode/run_log_export.py
+++ b/src/axiom_encode/run_log_export.py
@@ -230,6 +230,7 @@ def emit_live_encode_events(
     run_id: str,
     outcome: dict[str, Any],
     *,
+    total_duration_ms: int | None = None,
     log_dir: Optional[Path] = None,
 ) -> RunLogWriter:
     """Emit generate + gate + apply events for a just-completed encode run.
@@ -245,7 +246,11 @@ def emit_live_encode_events(
         "generate",
         StageStatus.passed if generation_ok else StageStatus.failed,
         reason=getattr(result, "error", None),
-        duration_ms=getattr(result, "duration_ms", None),
+        duration_ms=(
+            total_duration_ms
+            if total_duration_ms is not None
+            else getattr(result, "duration_ms", None)
+        ),
         attrs={
             "citation": getattr(result, "citation", None),
             "legal_id": None,
@@ -261,6 +266,7 @@ def emit_live_encode_events(
                 getattr(result, "metrics", None), "embedded_source_present", None
             ),
             "retry_count": getattr(result, "retry_count", None),
+            "generation_escalation": (outcome or {}).get("generation_escalation"),
         },
     )
     for kwargs in _gate_events_from_metrics(getattr(result, "metrics", None)):
@@ -393,6 +399,7 @@ def synthesize_backfill_events(
             "trace_sha256": (manifest or {}).get("trace_sha256"),
             "corpus_context_ref": (manifest or {}).get("context_manifest_file"),
             "corpus_context_sha256": (manifest or {}).get("context_manifest_sha256"),
+            "generation_escalation": outcome.get("generation_escalation"),
             "backfilled": True,
         },
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -235,6 +235,9 @@ from axiom_encode.cli import (
     main,
 )
 from axiom_encode.constants import (
+    DEFAULT_OPENAI_ESCALATE_AFTER,
+    DEFAULT_OPENAI_ESCALATION_MODEL,
+    DEFAULT_OPENAI_MODEL,
     RULESPEC_ATOMIC_MODULE_ROOTS,
     RULESPEC_COMPOSITION_SPEC_ROOT,
     RULESPEC_FILE_SUFFIX,
@@ -694,6 +697,12 @@ def test_package_version_metadata_matches_pyproject():
 
     assert pyproject["project"]["version"] == AXIOM_ENCODE_TEST_VERSION
     assert lock_version == AXIOM_ENCODE_TEST_VERSION
+
+
+def test_openai_encode_model_defaults():
+    assert DEFAULT_OPENAI_MODEL == "gpt-5.6-terra"
+    assert DEFAULT_OPENAI_ESCALATION_MODEL == "gpt-5.6-sol"
+    assert DEFAULT_OPENAI_ESCALATE_AFTER == 2
 
 
 def test_ensure_rulespec_import_preserves_unindented_import_list():
@@ -1813,6 +1822,11 @@ class TestMain:
             with patch("axiom_encode.cli.cmd_encode") as mock_cmd:
                 main()
                 mock_cmd.assert_called_once()
+                args = mock_cmd.call_args.args[0]
+                assert args.model is None
+                assert args.escalation_model == DEFAULT_OPENAI_ESCALATION_MODEL
+                assert args.escalate_after == DEFAULT_OPENAI_ESCALATE_AFTER
+                assert args.escalation_enabled is True
 
     def test_encode_accepts_policyengine_rule_hint(self):
         with patch(
@@ -1834,6 +1848,33 @@ class TestMain:
             with patch("axiom_encode.cli.cmd_encode") as mock_cmd:
                 main()
                 mock_cmd.assert_called_once()
+
+    def test_encode_accepts_escalation_controls(self):
+        with patch(
+            "sys.argv",
+            [
+                "axiom_encode",
+                "encode",
+                "26 USC 1",
+                "--escalation-model",
+                "gpt-test-escalation",
+                "--escalate-after",
+                "3",
+                "--no-escalation",
+                "--corpus-path",
+                "/tmp/axiom-corpus",
+                "--axiom-rules-engine-path",
+                "/tmp/axiom-rules-engine",
+                "--policy-repo-path",
+                "/tmp/rulespec-us",
+            ],
+        ):
+            with patch("axiom_encode.cli.cmd_encode") as mock_cmd:
+                main()
+                args = mock_cmd.call_args.args[0]
+                assert args.escalation_model == "gpt-test-escalation"
+                assert args.escalate_after == 3
+                assert args.escalation_enabled is False
 
     def test_eval_command_dispatches(self):
         with patch(
@@ -7039,6 +7080,17 @@ class TestCmdEncode:
         args.citation = citation
         args.output = overrides.get("output", tmp_path / "out")
         args.model = overrides.get("model", "test-model")
+        args.escalation_model = overrides.get(
+            "escalation_model",
+            DEFAULT_OPENAI_ESCALATION_MODEL,
+        )
+        args.escalate_after = overrides.get(
+            "escalate_after",
+            DEFAULT_OPENAI_ESCALATE_AFTER,
+        )
+        # Most command tests cover one pre-existing attempt path. Dedicated
+        # escalation tests opt in explicitly so their gate sequences stay clear.
+        args.escalation_enabled = overrides.get("escalation_enabled", False)
         args.backend = overrides.get("backend", "codex")
         args.corpus_path = corpus_path
         args.corpus_release = corpus_release
@@ -7068,6 +7120,7 @@ class TestCmdEncode:
         result.input_tokens = 100
         result.output_tokens = 50
         result.cache_read_tokens = 0
+        result.cache_creation_tokens = 0
         result.reasoning_output_tokens = 0
         result.retrieved_files = []
         result.unexpected_accesses = []
@@ -7179,6 +7232,62 @@ class TestCmdEncode:
                     cmd_encode(args)
             return mock_run, exc_info.value.code
 
+    def _run_validator_escalation_case(self, args, validator_outcomes):
+        generated_models = []
+        validated_models = []
+        remaining_outcomes = list(validator_outcomes)
+
+        def generate(**kwargs):
+            runner_spec = kwargs["runner_specs"][0]
+            backend, model = runner_spec.split(":", 1)
+            runner_name = f"{backend}-{model}"
+            generated_models.append(model)
+            result = self._make_eval_result(True)
+            result.backend = backend
+            result.model = model
+            result.runner = runner_name
+            result.mode = args.mode
+            result.generation_prompt_sha256 = f"prompt-{len(generated_models)}"
+            output_file = (
+                args.output / runner_name / "statutes" / "26" / "1" / "j" / "2.yaml"
+            )
+            output_file.parent.mkdir(parents=True, exist_ok=True)
+            output_file.write_text("format: rulespec/v1\nrules: []\n")
+            result.output_file = str(output_file)
+            return [result]
+
+        def validate(result, **_kwargs):
+            validated_models.append(result.model)
+            passed = remaining_outcomes.pop(0)
+            issues = [] if passed else ["validator rejected generated section"]
+            return passed, issues, {}
+
+        applied_file = args.policy_repo_path / "us/statutes/26/1/j/2.yaml"
+        with (
+            patch("axiom_encode.cli.run_model_eval", side_effect=generate) as mock_run,
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                side_effect=validate,
+            ) as mock_validate,
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, TEST_APPLY_SIGNING_ENV, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert not remaining_outcomes
+        return (
+            exc_info.value.code,
+            generated_models,
+            validated_models,
+            mock_run,
+            mock_validate,
+            mock_apply,
+        )
+
     def test_encode_success(self, capsys, tmp_path):
         args = self._make_args(tmp_path)
         mock_run, exit_code = self._run_encode(args, self._make_eval_result(True))
@@ -7194,6 +7303,197 @@ class TestCmdEncode:
         assert (
             mock_run.call_args.kwargs["runtime_axiom_rules_path"]
             == args.axiom_rules_path
+        )
+
+    def test_encode_escalates_after_n_validator_failures(self, tmp_path):
+        args = self._make_args(
+            tmp_path,
+            model=None,
+            apply=True,
+            sync=False,
+            escalation_enabled=True,
+        )
+
+        exit_code, generated, validated, mock_run, mock_validate, mock_apply = (
+            self._run_validator_escalation_case(args, [False, False, True])
+        )
+
+        assert exit_code == 0
+        assert generated == [
+            DEFAULT_OPENAI_MODEL,
+            DEFAULT_OPENAI_MODEL,
+            DEFAULT_OPENAI_ESCALATION_MODEL,
+        ]
+        assert validated == generated
+        assert mock_run.call_count == 3
+        assert mock_validate.call_count == 3
+        mock_apply.assert_called_once()
+        assert mock_apply.call_args.args[0].model == DEFAULT_OPENAI_ESCALATION_MODEL
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert len(run.iterations) == 3
+        assert [iteration.success for iteration in run.iterations] == [
+            False,
+            False,
+            True,
+        ]
+        assert run.agent_model == DEFAULT_OPENAI_ESCALATION_MODEL
+        assert run.outcome["generation_escalation"] == {
+            "escalated": True,
+            "failed_attempt_count": 2,
+            "initial_model": DEFAULT_OPENAI_MODEL,
+            "escalation_model": DEFAULT_OPENAI_ESCALATION_MODEL,
+        }
+
+    def test_encode_rejects_incompatible_escalation_model_before_generation(
+        self, tmp_path
+    ):
+        args = self._make_args(
+            tmp_path,
+            backend="claude",
+            model="claude-compatible-model",
+            escalation_enabled=True,
+        )
+
+        with (
+            patch("axiom_encode.cli.run_model_eval") as mock_run,
+            pytest.raises(
+                ValueError,
+                match="GPT escalation model with --backend claude",
+            ),
+        ):
+            cmd_encode(args)
+
+        mock_run.assert_not_called()
+
+    def test_encode_success_before_threshold_never_escalates(self, tmp_path):
+        args = self._make_args(
+            tmp_path,
+            model=None,
+            apply=True,
+            sync=False,
+            escalation_enabled=True,
+        )
+
+        exit_code, generated, validated, _run, _validate, mock_apply = (
+            self._run_validator_escalation_case(args, [False, True])
+        )
+
+        assert exit_code == 0
+        assert generated == [DEFAULT_OPENAI_MODEL, DEFAULT_OPENAI_MODEL]
+        assert validated == generated
+        mock_apply.assert_called_once()
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert len(run.iterations) == 2
+        assert "generation_escalation" not in run.outcome
+
+    def test_encode_retries_when_escalation_model_matches_initial(self, tmp_path):
+        args = self._make_args(
+            tmp_path,
+            model="same-model",
+            escalation_model="same-model",
+            apply=True,
+            sync=False,
+            escalation_enabled=True,
+        )
+
+        exit_code, generated, validated, _run, _validate, mock_apply = (
+            self._run_validator_escalation_case(args, [False, True])
+        )
+
+        assert exit_code == 0
+        assert generated == ["same-model", "same-model"]
+        assert validated == generated
+        mock_apply.assert_called_once()
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert "generation_escalation" not in run.outcome
+
+    def test_encode_no_escalation_preserves_single_attempt(self, tmp_path):
+        args = self._make_args(
+            tmp_path,
+            model=None,
+            apply=True,
+            sync=False,
+            escalation_enabled=False,
+        )
+
+        exit_code, generated, validated, mock_run, mock_validate, mock_apply = (
+            self._run_validator_escalation_case(args, [False])
+        )
+
+        assert exit_code == 1
+        assert generated == [DEFAULT_OPENAI_MODEL]
+        assert validated == generated
+        mock_run.assert_called_once()
+        mock_validate.assert_called_once()
+        mock_apply.assert_not_called()
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert len(run.iterations) == 1
+        assert "generation_escalation" not in run.outcome
+
+    def test_encode_no_escalation_logs_before_validator_exception(self, tmp_path):
+        args = self._make_args(
+            tmp_path,
+            model=None,
+            apply=True,
+            sync=False,
+            escalation_enabled=False,
+        )
+        result = self._make_eval_result(True)
+        result.model = DEFAULT_OPENAI_MODEL
+        result.runner = f"codex-{DEFAULT_OPENAI_MODEL}"
+        result.output_file = str(
+            args.output / result.runner / "statutes" / "26" / "1" / "j" / "2.yaml"
+        )
+        Path(result.output_file).parent.mkdir(parents=True, exist_ok=True)
+        Path(result.output_file).write_text("format: rulespec/v1\nrules: []\n")
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                side_effect=RuntimeError("validator interrupted"),
+            ),
+            patch.dict(os.environ, TEST_APPLY_SIGNING_ENV, clear=True),
+            pytest.raises(RuntimeError, match="validator interrupted"),
+        ):
+            cmd_encode(args)
+
+        runs = EncodingDB(args.db).get_recent_runs(limit=2)
+        assert len(runs) == 1
+        assert runs[0].agent_model == DEFAULT_OPENAI_MODEL
+
+    def test_encode_escalated_generation_runs_full_validator_gate(self, tmp_path):
+        args = self._make_args(
+            tmp_path,
+            model=None,
+            apply=True,
+            sync=False,
+            escalation_enabled=True,
+        )
+
+        exit_code, generated, validated, _run, mock_validate, mock_apply = (
+            self._run_validator_escalation_case(args, [False, False, False])
+        )
+
+        assert exit_code == 1
+        assert generated == [
+            DEFAULT_OPENAI_MODEL,
+            DEFAULT_OPENAI_MODEL,
+            DEFAULT_OPENAI_ESCALATION_MODEL,
+        ]
+        assert validated == generated
+        assert mock_validate.call_count == 3
+        assert mock_validate.call_args.args[0].model == DEFAULT_OPENAI_ESCALATION_MODEL
+        mock_apply.assert_not_called()
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert run.outcome["generation_escalation"]["failed_attempt_count"] == 2
+        assert [iteration.success for iteration in run.iterations] == [
+            False,
+            False,
+            False,
+        ]
+        assert run.iterations[-1].errors[0].message == (
+            "validator rejected generated section"
         )
 
     def test_encode_propagates_mandatory_review_findings(self, tmp_path):
@@ -7420,7 +7720,9 @@ class TestCmdEncode:
         result.context_manifest_file = str(tmp_path / "context.json")
         mock_run, exit_code = self._run_encode(args, result)
         assert exit_code == 1
-        assert mock_run.call_args.kwargs["runner_specs"] == ["codex:gpt-5.5"]
+        assert mock_run.call_args.kwargs["runner_specs"] == [
+            f"codex:{DEFAULT_OPENAI_MODEL}"
+        ]
         repair_manifest = tmp_path / "out.repair.json"
         assert repair_manifest.exists()
         assert json.loads(repair_manifest.read_text())["citation"] == "26 USC 1"

--- a/tests/test_judges.py
+++ b/tests/test_judges.py
@@ -2361,7 +2361,7 @@ def _make_db(path: Path):
 def test_calibration_load_cases_balanced(tmp_path):
     db = tmp_path / "e.db"
     _make_db(db)
-    cases = calibration.load_cases(db, n=6, seed=0)
+    cases = calibration.load_cases(db, n=6, seed=0, generator_model="gpt-5.5")
     labels = [c.label for c in cases]
     assert labels.count("good") == 3
     assert labels.count("bad") == 3

--- a/tests/test_run_log.py
+++ b/tests/test_run_log.py
@@ -226,6 +226,25 @@ def test_backfill_emits_generate_with_backfilled_flag():
     assert generate.attrs["citation"] == "us-ct/statute/17b-104"
 
 
+def test_backfill_preserves_escalation_metadata_and_aggregate_duration():
+    escalation = {
+        "escalated": True,
+        "failed_attempt_count": 2,
+        "initial_model": "gpt-5.6-terra",
+        "escalation_model": "gpt-5.6-sol",
+    }
+    events = rx.synthesize_backfill_events(
+        _fake_run(
+            total_duration_ms=12600,
+            outcome={"generation_escalation": escalation},
+        ),
+        None,
+    )
+    generate = next(event for event in events if event.stage == "generate")
+    assert generate.duration_ms == 12600
+    assert generate.attrs["generation_escalation"] == escalation
+
+
 def test_backfill_never_fabricates_downstream_or_judge_stages():
     run = _fake_run(
         outcome={
@@ -347,7 +366,17 @@ def test_live_emission_records_real_gate_verdicts(tmp_path):
     writer = rx.emit_live_encode_events(
         result,
         "liverun1",
-        {"final_success": False, "status": "apply_blocked_validation"},
+        {
+            "final_success": False,
+            "status": "apply_blocked_validation",
+            "generation_escalation": {
+                "escalated": True,
+                "failed_attempt_count": 2,
+                "initial_model": "gpt-5.6-terra",
+                "escalation_model": "gpt-5.6-sol",
+            },
+        },
+        total_duration_ms=12600,
         log_dir=tmp_path,
     )
     assert writer.last_error is None
@@ -358,6 +387,13 @@ def test_live_emission_records_real_gate_verdicts(tmp_path):
     assert by_stage["gate.ci"].reason_code == "ci_failure"
     assert by_stage["gate.grounding"].status == "passed"
     assert by_stage["apply"].status == "failed"
+    assert by_stage["generate"].duration_ms == 12600
+    assert by_stage["generate"].attrs["generation_escalation"] == {
+        "escalated": True,
+        "failed_attempt_count": 2,
+        "initial_model": "gpt-5.6-terra",
+        "escalation_model": "gpt-5.6-sol",
+    }
     # Live logs are NOT flagged as backfill.
     assert by_stage["generate"].attrs.get("backfilled") is None
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1258"
+version = "0.2.1259"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
Two coupled changes:

1. **Default model gpt-5.5 → gpt-5.6-terra** (constants, CLI docs, judges' generator default) — lanes omitting `--model` have been encoding on a generation-old model.
2. **Validator-failure model escalation, built into the encode loop**: up to N full generate→validate attempts on the selected model (`--escalate-after`, default 2), then one generation with `--escalation-model` (default gpt-5.6-sol) through the same complete gate; `--no-escalation` preserves single-model behavior. Per-section records log attempt count, both models, and aggregate accounting. Field evidence: C.R.S. 39-22-544 failed five terra generations across five different validators and passed on the first sol generation; the ladder was hand-rolled in the CO lane's runner — this ships it to every lane.

Authored by a gpt-5.6-sol worker; reviewed by Fable (cross-model dual approval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)