### PR TITLE
Accept district-plan corpus citation paths (council instruments)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1261"
+version = "0.2.1262"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1261"
+__version__ = "0.2.1262"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/corpus_release.py
+++ b/src/axiom_encode/corpus_release.py
@@ -23,6 +23,7 @@ RELEASE_OBJECT_PUBLIC_KEY_ENV = "AXIOM_CORPUS_RELEASE_PUBLIC_KEY"
 
 _ARTIFACT_CLASSES = ("inventory", "provisions", "coverage", "sources")
 _DOCUMENT_CLASSES = {
+    "district-plan",
     "statute",
     "regulation",
     "guidance",

--- a/src/axiom_encode/corpus_resolver.py
+++ b/src/axiom_encode/corpus_resolver.py
@@ -44,9 +44,7 @@ _MAX_INTERNAL_MARK_EVIDENCE_CHARS = 64
 _MAX_DELIMITER_REPLAY_TOKENS = 1_000_000
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 _CITATION_JURISDICTION_RE = re.compile(r"^[a-z]{2,3}(?:-[a-z]{2,32})*$")
-_CITATION_HIERARCHY_SEGMENT_RE = re.compile(
-    r"^[A-Za-z0-9][A-Za-z0-9 .:\-–]*$"
-)
+_CITATION_HIERARCHY_SEGMENT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9 .:\-–]*$")
 
 _DOCUMENT_CLASSES = frozenset(
     {

--- a/src/axiom_encode/corpus_resolver.py
+++ b/src/axiom_encode/corpus_resolver.py
@@ -43,11 +43,16 @@ MAX_GENERIC_PARENT_SLICE_CHARACTER_WORK = 64 * 1024 * 1024
 _MAX_INTERNAL_MARK_EVIDENCE_CHARS = 64
 _MAX_DELIMITER_REPLAY_TOKENS = 1_000_000
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_CITATION_JURISDICTION_RE = re.compile(r"^[a-z]{2,3}(?:-[a-z]{2,32})*$")
+_CITATION_HIERARCHY_SEGMENT_RE = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9 .:\-–]*$"
+)
 
 _DOCUMENT_CLASSES = frozenset(
     {
         "form",
         "guidance",
+        "district-plan",
         "legislation",
         "manual",
         "other",
@@ -156,7 +161,7 @@ def normalize_corpus_identifier(identifier: str) -> str:
             return _normalize_citation_path(
                 "/".join((jurisdiction, document_class, *parts[1:]))
             )
-    if len(parts) >= 3 and parts[1] in _DOCUMENT_CLASSES:
+    if len(parts) >= 2 and parts[1] in _DOCUMENT_CLASSES:
         return _normalize_citation_path(value)
     cfr = _CFR_IDENTIFIER_RE.fullmatch(value)
     if cfr is not None:
@@ -3604,9 +3609,9 @@ def _normalize_citation_path(identifier: str) -> str:
             "Corpus citation path exceeds the maximum segment count of "
             f"{MAX_CORPUS_CITATION_SEGMENTS}"
         )
-    if len(parts) < 3:
+    if len(parts) < 2:
         raise InvalidCorpusCitationError(
-            f"Corpus citation path must have at least three segments: {identifier!r}"
+            f"Corpus citation path must have at least two segments: {identifier!r}"
         )
     try:
         for part in parts:
@@ -3617,6 +3622,15 @@ def _normalize_citation_path(identifier: str) -> str:
         raise InvalidCorpusCitationError(
             f"Unsupported corpus document class {parts[1]!r} in {identifier!r}"
         )
+    if _CITATION_JURISDICTION_RE.fullmatch(parts[0]) is None:
+        raise InvalidCorpusCitationError(
+            f"Invalid corpus jurisdiction {parts[0]!r} in {identifier!r}"
+        )
+    for part in parts[2:]:
+        if _CITATION_HIERARCHY_SEGMENT_RE.fullmatch(part) is None:
+            raise InvalidCorpusCitationError(
+                f"Invalid corpus citation path segment {part!r} in {identifier!r}"
+            )
     return "/".join(parts)
 
 

--- a/tests/test_corpus_resolver.py
+++ b/tests/test_corpus_resolver.py
@@ -109,6 +109,23 @@ def test_machine_identity_requires_exact_canonical_corpus_path():
             require_canonical_corpus_citation_path(alias)
 
 
+@pytest.mark.parametrize(
+    "citation_path",
+    (
+        "nz/district-plan",
+        "nz/district-plan/wellington-city/2024/muz/r13",
+    ),
+)
+def test_machine_identity_accepts_district_plan_paths(citation_path: str):
+    assert require_canonical_corpus_citation_path(citation_path) == citation_path
+    assert normalize_corpus_identifier(citation_path) == citation_path
+
+
+def test_machine_identity_still_rejects_unknown_document_classes():
+    with pytest.raises(InvalidCorpusCitationError, match="document-class"):
+        require_canonical_corpus_citation_path("nz/zoning-code/wellington-city/2024")
+
+
 def test_human_citation_normalization_remains_available():
     assert normalize_corpus_identifier("7 USC 2014(e)") == CITATION
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -18148,14 +18148,7 @@ def test_validator_pipeline_resolves_direct_proof_sources_from_authoritative_cor
 def test_district_plan_proof_source_grounds_anchored_numeric_from_corpus(tmp_path):
     citation_path = "nz/district-plan/wellington-city/2024/muz/r13"
     corpus_root = tmp_path / "axiom-corpus"
-    provisions = (
-        corpus_root
-        / "data"
-        / "corpus"
-        / "provisions"
-        / "nz"
-        / "district-plan"
-    )
+    provisions = corpus_root / "data" / "corpus" / "provisions" / "nz" / "district-plan"
     provisions.mkdir(parents=True)
     (provisions / "wellington-city-2024.jsonl").write_text(
         json.dumps(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -109,6 +109,7 @@ from axiom_encode.harness.validator_pipeline import (
     find_test_input_assignment_issues,
     find_unconsumed_local_exception_output_issues,
     find_ungrounded_numeric_issues,
+    find_ungrounded_numeric_issues_scoped,
     find_unused_import_issues,
     find_unused_modifier_parameter_issues,
     find_upstream_placement_issues,
@@ -18142,6 +18143,83 @@ def test_validator_pipeline_resolves_direct_proof_sources_from_authoritative_cor
 
     assert source_texts == {citation_path: "The official amount is $298."}
     assert find_rulespec_proof_issues(content, source_texts=source_texts) == []
+
+
+def test_district_plan_proof_source_grounds_anchored_numeric_from_corpus(tmp_path):
+    citation_path = "nz/district-plan/wellington-city/2024/muz/r13"
+    corpus_root = tmp_path / "axiom-corpus"
+    provisions = (
+        corpus_root
+        / "data"
+        / "corpus"
+        / "provisions"
+        / "nz"
+        / "district-plan"
+    )
+    provisions.mkdir(parents=True)
+    (provisions / "wellington-city-2024.jsonl").write_text(
+        json.dumps(
+            _active_corpus_record(
+                citation_path,
+                "The total gross floor area does not exceed 1,500 square metres.",
+                version="wellington-city-2024",
+                document_class="district-plan",
+                jurisdiction="nz",
+            )
+        )
+        + "\n"
+    )
+    release = _test_corpus_release(
+        corpus_root,
+        ("nz", "district-plan", "wellington-city-2024"),
+    )
+    content = textwrap.dedent(
+        f"""
+        format: rulespec/v1
+        module:
+          source_verification:
+            corpus_citation_path: {citation_path}
+        rules:
+          - name: supermarket_floor_area_limit
+            kind: parameter
+            dtype: Number
+            metadata:
+              proof:
+                atoms:
+                  - path: versions[0].formula
+                    kind: parameter
+                    source:
+                      corpus_citation_path: {citation_path}
+            versions:
+              - effective_from: '2024-01-01'
+                formula: '1500'
+        """
+    ).strip()
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path / "rulespec-nz",
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+        local_corpus_release=release,
+    )
+
+    with validator_pipeline._authoritative_corpus_scope(release):
+        source_texts = pipeline._proof_source_texts_for_rulespec_content(
+            content,
+            source_texts=None,
+        )
+
+    assert source_texts == {
+        citation_path: "The total gross floor area does not exceed 1,500 square metres."
+    }
+    assert find_rulespec_proof_issues(content, source_texts=source_texts) == []
+    assert (
+        find_ungrounded_numeric_issues_scoped(
+            content,
+            module_source_text=None,
+            proof_source_texts=source_texts,
+        )
+        == []
+    )
 
 
 def test_validator_pipeline_does_not_treat_in_memory_text_as_legal_authority(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1261"
+version = "0.2.1262"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
Closes #1144. Companion to the merged corpus-side change (TheAxiomFoundation/axiom-corpus#346): accepts the `district-plan` document class across every citation-path enforcement point, so council instruments (NZ district plans first) can ground end to end. Unblocks TheAxiomFoundation/rulespec-nz#90 (Wellington supermarket-zoning slice, currently draft on a `nz/guidance/...` placeholder).

## Enforcement points covered

- Canonical citation shape + document-class validation (`corpus_resolver.py`)
- Bare collection-root handling (`nz/district-plan`), consistent with the corpus schema's collection-root rule
- Resolver document-class filtering and local corpus lookup
- Signed release-object scope validation (`corpus_release.py`)
- Module and proof-atom `corpus_citation_path` validation via the shared canonical gate
- Authoritative proof-source resolution
- Path-anchored numeric grounding against a cited district-plan provision (fixture: `nz/district-plan/wellington-city/2024/muz/r13`)

## Reviewer notes

- **Grammar is mirrored from the canonical schema** (axiom-corpus `schema/citation-path.v1.json`): same class token, same jurisdiction shape, same hierarchy-segment charset (letters/digits/space/dot/colon/hyphen/en-dash). Two new validations are net-stricter than before (jurisdiction + segment charset were previously unchecked here).
- **Minimum segment count 3 → 2**: bare `<jurisdiction>/<document_class>` paths now normalize, matching the corpus schema's "valid only for collection-root records" semantics. Grounding a proof atom against a bare root still fails at resolution (no provision), so proofs can't exploit it. Flagging since it loosens one historical check for all classes.
- Unknown classes remain rejected; existing suites untouched.

## Tests

- Full suite (Sol run, pre-rebase): 1170 passed, 2 deselected (sandbox-env-dependent, unrelated)
- Focused resolver/release/grounding: 344 passed
- Post-rebase onto main incl. #1156 (terra default): resolver + validation files re-run, 1151 passed
- Ruff clean

## Provenance

Implemented by a gpt-5.6-sol worker (lane-dispatched), reviewed by Claude (Fable) before push; rebased onto main after #1156. If the pending fixes for #1143/#1130 land before merge, this should be rebased again — surfaces are adjacent (resolver) though no conflicts materialized with #1156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
