### PR TITLE
Make the sub-paragraph coverage gate satisfiable for local-authority modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1262"
+version = "0.2.1263"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1262"
+__version__ = "0.2.1263"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -10411,7 +10411,9 @@ def find_source_subparagraph_coverage_issues(
         _source_relation_covered_subparagraphs(payload, citation_path)
     )
     covered_children.update(
-        _deferred_output_covered_subparagraphs(payload, citation_path)
+        _deferred_output_covered_subparagraphs(
+            payload, citation_path, rules_file=rules_file
+        )
     )
 
     issues: list[str] = []
@@ -10600,17 +10602,34 @@ def _source_relation_subparagraph_paths(
 def _deferred_output_covered_subparagraphs(
     payload: dict[str, Any],
     citation_path: str,
+    *,
+    rules_file: Path | None = None,
 ) -> set[tuple[str, ...]]:
     return {
         _top_level_subparagraph_path(path)
-        for path in _deferred_output_subparagraph_paths(payload, citation_path)
+        for path in _deferred_output_subparagraph_paths(
+            payload, citation_path, rules_file=rules_file
+        )
         if path
     }
+
+
+def _module_self_scope_parts(rules_file: Path | None) -> tuple[str, ...]:
+    """The module's own repo-relative stem parts, from its filesystem root."""
+    if rules_file is None:
+        return ()
+    file_parts = rules_file.with_suffix("").parts
+    for index in range(len(file_parts) - 1, -1, -1):
+        if file_parts[index] in RULESPEC_ATOMIC_MODULE_ROOTS:
+            return tuple(file_parts[index:])
+    return ()
 
 
 def _deferred_output_subparagraph_paths(
     payload: dict[str, Any],
     citation_path: str,
+    *,
+    rules_file: Path | None = None,
 ) -> set[tuple[str, ...]]:
     module = payload.get("module")
     if not isinstance(module, dict):
@@ -10620,7 +10639,13 @@ def _deferred_output_subparagraph_paths(
         return set()
 
     base_parts = _rulespec_base_parts_for_corpus_path(citation_path)
-    if not base_parts:
+    # A module whose rulespec path does not mirror its corpus document (a
+    # council policy module sourced from a scheme manual, say) cannot name a
+    # corpus-mirror deferral target under an atomic root — `manuals/...` is
+    # not a module root. Such a module defers a sub-paragraph by naming its
+    # own future output: <its own stem path>/<sub-paragraph>#symbol.
+    self_parts = _module_self_scope_parts(rules_file)
+    if not base_parts and not self_parts:
         return set()
 
     paths: set[tuple[str, ...]] = set()
@@ -10633,11 +10658,18 @@ def _deferred_output_subparagraph_paths(
             continue
         target_parts = _rulespec_relative_path_parts(target_ref.relative_path)
         if (
-            len(target_parts) <= len(base_parts)
-            or target_parts[: len(base_parts)] != base_parts
+            base_parts
+            and len(target_parts) > len(base_parts)
+            and target_parts[: len(base_parts)] == base_parts
         ):
+            paths.add(tuple(part.lower() for part in target_parts[len(base_parts) :]))
             continue
-        paths.add(tuple(part.lower() for part in target_parts[len(base_parts) :]))
+        if (
+            self_parts
+            and len(target_parts) > len(self_parts)
+            and target_parts[: len(self_parts)] == self_parts
+        ):
+            paths.add(tuple(part.lower() for part in target_parts[len(self_parts) :]))
     return paths
 
 
@@ -10841,13 +10873,28 @@ def _rulespec_base_parts_for_corpus_path(citation_path: str) -> tuple[str, ...]:
         "regulation": "regulations",
         **_RULESPEC_DOCUMENT_CLASS_DIRS,
     }
-    if len(parts) >= 3 and len(parts[0]) == 2 and parts[1] in generic_class_dirs:
-        # Unitary jurisdictions (gh, ug, ng, be, uk, ...) mirror the corpus
-        # class directly under the country code; the rulespec layout uses the
-        # pluralized class dir. Without this branch the sub-paragraph
-        # coverage gate fires for these jurisdictions but deferred_outputs
-        # entries can never satisfy it (the base resolves empty), making the
-        # gate unsatisfiable outside the US.
+    if (
+        len(parts) >= 3
+        and (
+            (len(parts[0]) == 2 and parts[0].isalpha())
+            or (
+                len(parts[0]) > 3
+                and parts[0][2] == "-"
+                and parts[0][:2].isalpha()
+                and not parts[0].startswith("us-")
+            )
+        )
+        and parts[1] in generic_class_dirs
+    ):
+        # Unitary jurisdictions (gh, ug, ng, be, uk, ...) and their
+        # local-authority sub-jurisdictions (uk-kingston-upon-thames, ...)
+        # mirror the corpus class directly under the jurisdiction prefix; the
+        # rulespec layout uses the pluralized class dir. Without this branch
+        # the sub-paragraph coverage gate fires for these jurisdictions but
+        # deferred_outputs entries can never satisfy it (the base resolves
+        # empty), making the gate unsatisfiable outside the US. The us-*
+        # prefixes are excluded only because the dedicated branches above
+        # already map them.
         return (generic_class_dirs[parts[1]], *parts[2:])
     return ()
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -7233,6 +7233,61 @@ def test_deferred_outputs_cover_subparagraphs_for_unitary_jurisdictions():
     assert ("f",) in covered
 
 
+def test_deferred_outputs_cover_subparagraphs_for_local_authority_jurisdictions():
+    # Local-authority sub-jurisdictions (uk-kingston-upon-thames, ...) hit the
+    # same unsatisfiable-gate failure the unitary branch fixed: their corpus
+    # paths resolved to an empty base, so a council-scheme module could defer
+    # page-38(e) forever without the gate ever seeing it. Only us-* prefixes
+    # keep their dedicated mappings.
+    from axiom_encode.harness.validator_pipeline import (
+        _deferred_output_covered_subparagraphs,
+        _rulespec_base_parts_for_corpus_path,
+    )
+
+    assert _rulespec_base_parts_for_corpus_path(
+        "uk-kingston-upon-thames/manual/"
+        "council-tax-reduction-scheme-2026-2027/page-38"
+    ) == ("manuals", "council-tax-reduction-scheme-2026-2027", "page-38")
+    # A bare hyphen or non-alpha prefix is not a jurisdiction.
+    assert (
+        _rulespec_base_parts_for_corpus_path("x-/manual/scheme/page-1") == ()
+    )
+    assert (
+        _rulespec_base_parts_for_corpus_path("12-city/manual/scheme/page-1") == ()
+    )
+
+    # A policy module sourced from a scheme manual cannot mirror the corpus
+    # path under an atomic module root (`manuals/...` is not one), so it
+    # defers a sub-paragraph by naming its own future output.
+    payload = {
+        "module": {
+            "deferred_outputs": [
+                {
+                    "output": (
+                        "uk-kingston-upon-thames:policies/kingston-upon-thames/"
+                        "council-tax-reduction/e#applicable_premiums_amount"
+                    ),
+                    "reason": "premium schedules not yet encoded",
+                }
+            ]
+        }
+    }
+    citation = (
+        "uk-kingston-upon-thames/manual/"
+        "council-tax-reduction-scheme-2026-2027/page-38"
+    )
+    rules_file = Path(
+        "rulespec-uk/uk-kingston-upon-thames/policies/kingston-upon-thames/"
+        "council-tax-reduction.yaml"
+    )
+    covered = _deferred_output_covered_subparagraphs(
+        payload, citation, rules_file=rules_file
+    )
+    assert ("e",) in covered
+    # Without the module's own path there is nothing to scope against.
+    assert _deferred_output_covered_subparagraphs(payload, citation) == set()
+
+
 def test_numeric_extraction_handles_uganda_shilling_suffix():
     # Ugandan prints glue a "/=" (or plain "=") shilling suffix to amounts
     # ("Exceeding 100,000= but not exceeding 200,000= 5,000=" in the Local

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -7245,16 +7245,11 @@ def test_deferred_outputs_cover_subparagraphs_for_local_authority_jurisdictions(
     )
 
     assert _rulespec_base_parts_for_corpus_path(
-        "uk-kingston-upon-thames/manual/"
-        "council-tax-reduction-scheme-2026-2027/page-38"
+        "uk-kingston-upon-thames/manual/council-tax-reduction-scheme-2026-2027/page-38"
     ) == ("manuals", "council-tax-reduction-scheme-2026-2027", "page-38")
     # A bare hyphen or non-alpha prefix is not a jurisdiction.
-    assert (
-        _rulespec_base_parts_for_corpus_path("x-/manual/scheme/page-1") == ()
-    )
-    assert (
-        _rulespec_base_parts_for_corpus_path("12-city/manual/scheme/page-1") == ()
-    )
+    assert _rulespec_base_parts_for_corpus_path("x-/manual/scheme/page-1") == ()
+    assert _rulespec_base_parts_for_corpus_path("12-city/manual/scheme/page-1") == ()
 
     # A policy module sourced from a scheme manual cannot mirror the corpus
     # path under an atomic module root (`manuals/...` is not one), so it
@@ -7273,8 +7268,7 @@ def test_deferred_outputs_cover_subparagraphs_for_local_authority_jurisdictions(
         }
     }
     citation = (
-        "uk-kingston-upon-thames/manual/"
-        "council-tax-reduction-scheme-2026-2027/page-38"
+        "uk-kingston-upon-thames/manual/council-tax-reduction-scheme-2026-2027/page-38"
     )
     rules_file = Path(
         "rulespec-uk/uk-kingston-upon-thames/policies/kingston-upon-thames/"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1262"
+version = "0.2.1263"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
Closes the last mechanical blocker on rulespec-uk#46 (Kingston CTR re-emission, rulespec-uk#157/#158) and unblocks every future local-authority scheme module.

## The two coupled gaps

1. **`_rulespec_base_parts_for_corpus_path` returned `()` for hyphenated non-US jurisdictions.** The function's own comment documents this failure class ("the base resolves empty, making the gate unsatisfiable outside the US") and fixes it for two-letter unitary codes — but `uk-kingston-upon-thames/manual/…` fell through every branch. The generic branch now accepts `<cc>-<locality>` prefixes (with `us-*` excluded — its dedicated mappings above stand) and requires the two-letter form to be alphabetic (`x-`, `12` no longer read as jurisdictions).

2. **A policy module sourced from a scheme manual cannot name any corpus-mirror deferral target.** `manuals/` is not in `RULESPEC_ATOMIC_MODULE_ROOTS`, so `…:manuals/<doc>/page-38/e#…` cannot parse — with (1) fixed, the gate would still be unsatisfiable for these modules. The deferral matcher now also accepts **self-scoped** targets: the module's own stem path plus the sub-paragraph tail (`uk-kingston-upon-thames:policies/kingston-upon-thames/council-tax-reduction/e#applicable_premiums_amount` defers `page-38(e)`). `rules_file` is threaded from `find_source_subparagraph_coverage_issues` into the matcher; corpus-mirror matching is unchanged and tried first.

## Verification (canonical fingerprint harness)

Ran `_fingerprint_validation_waiver_modules` — the exact audit CI executes — with engine `05eac9d2` and corpus release `uk-rulespec-2026-07-14` (content at `592ac643`), after first proving harness fidelity by reproducing three known fingerprints byte-for-byte (Kingston old `044194c9…`, Kingston current-PR `abc925b5…`, pension-credit `80020417…`):

- **Kingston module** (re-emitted taper fix + singular `page-38` locator + self-scoped deferral): `passed=True` — validate clean, companions 7/7.
- **All 12 other active waivers in rulespec-uk's ledger**: fingerprints reproduce **byte-for-byte** under this fix — the encode-ref bump cannot drift any other waiver.

`tests/test_rulespec_validation.py`: 839/839, including two new regression tests (base-parts resolution incl. negative prefixes; self-scoped deferral matching with and without `rules_file`).

## Landing chain (for reviewers)

axiom-encode merge → rulespec-uk encode-ref bump (protected pin PR) → rulespec-uk stacked module-fix + waiver-removal PR (protected waiver PR). The audit's design makes the module fix and waiver removal atomic by construction; this PR is what makes the module actually pass.

Refs rulespec-uk#46, rulespec-uk#140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
