### PR TITLE
Normalize Unicode dashes in RuleSpec output paths

### DIFF
--- a/changelog.d/unicode-dash-output-paths.fixed.md
+++ b/changelog.d/unicode-dash-output-paths.fixed.md
@@ -1,1 +1,1 @@
-Normalize Unicode dash punctuation to ASCII hyphens in generated RuleSpec filesystem paths while preserving authoritative corpus citation identifiers.
+Normalize Unicode dash punctuation to ASCII hyphens across canonical, alias, and structured RuleSpec output paths while preserving authoritative corpus citation identifiers.

--- a/changelog.d/unicode-dash-output-paths.fixed.md
+++ b/changelog.d/unicode-dash-output-paths.fixed.md
@@ -1,0 +1,1 @@
+Normalize Unicode dash punctuation to ASCII hyphens in generated RuleSpec filesystem paths while preserving authoritative corpus citation identifiers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1265"
+version = "0.2.1266"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1266"
+version = "0.2.1267"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1267"
+version = "0.2.1268"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1266"
+__version__ = "0.2.1267"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1265"
+__version__ = "0.2.1266"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1267"
+__version__ = "0.2.1268"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -229,6 +229,12 @@ _RULESPEC_OUTPUT_ROOT_BY_SOURCE_TOKEN = {
     "statute": "statutes",
     "statutes": "statutes",
 }
+_RULESPEC_PATH_DASH_TRANSLATION = str.maketrans(
+    {
+        ord(character): "-"
+        for character in "\u2010\u2011\u2012\u2013\u2014\u2015\u2212\ufe58\ufe63\uff0d"
+    }
+)
 _UK_LEGISLATION_DOMAIN_TOKEN = "legislation.gov.uk"
 _UK_LEGISLATION_SECTION_TOKENS = {"article", "regulation", "section"}
 _CODEX_DEFAULT_TIMEOUT_SECONDS = 600
@@ -7448,14 +7454,20 @@ def _prompt_corpus_citation_path(source_unit: CorpusSourceUnit) -> str:
 def _source_identifier_to_relative_rulespec_path(source_id: str) -> Path:
     """Map a canonical source identifier to its RuleSpec artifact path.
 
-    Each path segment is treated as a directory and a dot inside the leaf
-    segment is treated as a further nesting separator (CDSS-style numbering
-    like ``63-503.132`` becomes ``63-503/132``). This avoids the pathlib
+    Unicode dash punctuation is normalized only in the returned filesystem
+    path; the authoritative source identifier remains unchanged. Each path
+    segment is treated as a directory and a dot inside the leaf segment is
+    treated as a further nesting separator (CDSS-style numbering like
+    ``63-503.132`` becomes ``63-503/132``). This avoids the pathlib
     ``with_suffix`` pitfall where a dotted leaf would be silently truncated
     to a section-level path and collide with sibling subsections at apply
     time (issue #71).
     """
-    parts = [part for part in source_id.strip().strip("/").split("/") if part]
+    parts = [
+        part.translate(_RULESPEC_PATH_DASH_TRANSLATION)
+        for part in source_id.strip().strip("/").split("/")
+        if part
+    ]
     if parts and ":" in parts[0]:
         jurisdiction, source_root = parts[0].split(":", 1)
         if source_root in _RULESPEC_SOURCE_ROOT_TOKENS:

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -4966,8 +4966,10 @@ def select_context_files(
     )
     if statutes_root is None:
         return []
+    title = normalize_rulespec_path_segment(parts.title)
+    section = normalize_rulespec_path_segment(parts.section)
     section_root = validate_rulespec_context_directory(
-        statutes_root / parts.title / parts.section,
+        statutes_root / title / section,
         repo_root,
     )
     target_rel = citation_to_relative_rulespec_path(parts)
@@ -4986,7 +4988,7 @@ def select_context_files(
 
     if not candidates:
         title_root = validate_rulespec_context_directory(
-            statutes_root / parts.title,
+            statutes_root / title,
             repo_root,
         )
         if title_root is not None:

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -53,6 +53,7 @@ from axiom_encode.statute import (
     CitationParts,
     citation_to_citation_path,
     citation_to_relative_rulespec_path,
+    normalize_rulespec_path_segment,
     parse_usc_citation,
 )
 from axiom_encode.toolchain import (
@@ -229,12 +230,6 @@ _RULESPEC_OUTPUT_ROOT_BY_SOURCE_TOKEN = {
     "statute": "statutes",
     "statutes": "statutes",
 }
-_RULESPEC_PATH_DASH_TRANSLATION = str.maketrans(
-    {
-        ord(character): "-"
-        for character in "\u2010\u2011\u2012\u2013\u2014\u2015\u2212\ufe58\ufe63\uff0d"
-    }
-)
 _UK_LEGISLATION_DOMAIN_TOKEN = "legislation.gov.uk"
 _UK_LEGISLATION_SECTION_TOKENS = {"article", "regulation", "section"}
 _CODEX_DEFAULT_TIMEOUT_SECONDS = 600
@@ -7464,7 +7459,7 @@ def _source_identifier_to_relative_rulespec_path(source_id: str) -> Path:
     time (issue #71).
     """
     parts = [
-        part.translate(_RULESPEC_PATH_DASH_TRANSLATION)
+        normalize_rulespec_path_segment(part)
         for part in source_id.strip().strip("/").split("/")
         if part
     ]

--- a/src/axiom_encode/statute.py
+++ b/src/axiom_encode/statute.py
@@ -6,6 +6,19 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
+_RULESPEC_PATH_DASH_TRANSLATION = str.maketrans(
+    {
+        ord(character): "-"
+        for character in "\u2010\u2011\u2012\u2013\u2014\u2015\u2212\ufe58\ufe63\uff0d"
+    }
+)
+
+
+def normalize_rulespec_path_segment(segment: str) -> str:
+    """Return an ASCII-dash filesystem segment without changing legal IDs."""
+
+    return segment.translate(_RULESPEC_PATH_DASH_TRANSLATION)
+
 
 @dataclass(frozen=True)
 class CitationParts:
@@ -76,7 +89,10 @@ def citation_to_relative_rulespec_path(citation: str | CitationParts) -> Path:
         if isinstance(citation, CitationParts)
         else parse_usc_citation(citation)
     )
-    section_path = Path("statutes") / parts.title / parts.section
-    if not parts.fragments:
+    title = normalize_rulespec_path_segment(parts.title)
+    section = normalize_rulespec_path_segment(parts.section)
+    fragments = tuple(normalize_rulespec_path_segment(item) for item in parts.fragments)
+    section_path = Path("statutes") / title / section
+    if not fragments:
         return section_path.with_suffix(".yaml")
-    return section_path / Path(*parts.fragments).with_suffix(".yaml")
+    return section_path / Path(*fragments).with_suffix(".yaml")

--- a/tests/test_encoder_path_collisions.py
+++ b/tests/test_encoder_path_collisions.py
@@ -26,6 +26,7 @@ from axiom_encode.cli import _enforce_no_apply_collision
 from axiom_encode.harness.evals import (
     EvalPromptResponse,
     EvalWorkspace,
+    _resolve_eval_output_path,
     _run_single_eval,
     parse_runner_spec,
     resolve_corpus_source_unit,
@@ -199,6 +200,24 @@ def test_collision_guard_allows_overwrite_with_same_citation_path(tmp_path: Path
         corpus_citation_path="us-ca/regulation/mpp/63-503.132",
     )
     # Re-applying the same encode (re-run after a fix) must succeed.
+    _enforce_no_apply_collision(source_file=source, target_file=target)
+
+
+def test_unicode_dash_citation_reuses_ascii_target_path(tmp_path: Path):
+    citation_path = "us/statute/42/1437c\u20131"
+    relative_target = _resolve_eval_output_path(citation_path)
+    source = _write_rulespec(
+        tmp_path / "src.yaml",
+        corpus_citation_path=citation_path,
+    )
+    target = _write_rulespec(
+        tmp_path / relative_target,
+        corpus_citation_path=citation_path,
+    )
+
+    assert relative_target == Path("statutes/42/1437c-1.yaml")
+    assert citation_path in source.read_text()
+    assert citation_path in target.read_text()
     _enforce_no_apply_collision(source_file=source, target_file=target)
 
 

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -1955,6 +1955,29 @@ def test_source_identifier_handles_dotted_leaf_segments(citation, expected):
 
 
 @pytest.mark.parametrize(
+    "dash",
+    [
+        "\u2010",
+        "\u2011",
+        "\u2012",
+        "\u2013",
+        "\u2014",
+        "\u2015",
+        "\u2212",
+        "\ufe58",
+        "\ufe63",
+        "\uff0d",
+    ],
+)
+def test_source_identifier_normalizes_unicode_dashes_only_in_output_path(dash):
+    citation = f"us/statute/42/1437c{dash}1"
+
+    assert _source_identifier_to_relative_rulespec_path(citation) == Path(
+        "statutes/42/1437c-1.yaml"
+    )
+
+
+@pytest.mark.parametrize(
     "section",
     [
         "39-28.5-107",

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -13852,6 +13852,32 @@ class TestRepoAugmentedContext:
         assert section_dir / "b.yaml" in selected
         assert section_dir / "c.yaml" in selected
 
+    @pytest.mark.parametrize(
+        "citation",
+        [
+            "42/1437c\u20131/d",
+            CitationParts(title="42", section="1437c\u20131", fragments=("d",)),
+        ],
+        ids=["slash-alias", "structured-citation"],
+    )
+    def test_select_context_files_uses_normalized_section_path(
+        self,
+        tmp_path,
+        citation,
+    ):
+        policy_repo_root = _canonical_rulespec_content_root(tmp_path, "us")
+        title_dir = policy_repo_root / "statutes" / "42"
+        section_dir = title_dir / "1437c-1"
+        section_dir.mkdir(parents=True)
+        sibling = section_dir / "e.yaml"
+        sibling.write_text("same-section sibling")
+        for index in range(6):
+            (title_dir / f"{index}.yaml").write_text("unrelated title context")
+
+        selected = select_context_files(citation, policy_repo_root)
+
+        assert sibling in selected
+
     def test_prepare_eval_workspace_writes_manifest_and_context(self, tmp_path):
         repo_root = tmp_path / "repos"
         policy_repo_root = _canonical_rulespec_content_root(repo_root, "us")

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -110,6 +110,7 @@ from axiom_encode.harness.validator_pipeline import (
 )
 from axiom_encode.repo_routing import find_policy_repo_root, monorepo_checkout_name
 from axiom_encode.signing_broker import get_signing_broker
+from axiom_encode.statute import CitationParts, citation_to_relative_rulespec_path
 from tests.eval_evidence_fixtures import (
     install_test_eval_evidence_keys,
 )
@@ -1975,6 +1976,22 @@ def test_source_identifier_normalizes_unicode_dashes_only_in_output_path(dash):
     assert _source_identifier_to_relative_rulespec_path(citation) == Path(
         "statutes/42/1437c-1.yaml"
     )
+
+
+def test_slash_usc_alias_normalizes_unicode_dash_in_output_path():
+    assert _resolve_eval_output_path(
+        "42/1437c\u20131",
+        fallback=citation_to_relative_rulespec_path,
+    ) == Path("statutes/42/1437c-1.yaml")
+
+
+def test_structured_usc_citation_normalizes_only_output_path():
+    citation = CitationParts(title="42", section="1437c\u20131", fragments=("d",))
+
+    assert citation_to_relative_rulespec_path(citation) == Path(
+        "statutes/42/1437c-1/d.yaml"
+    )
+    assert citation.section == "1437c\u20131"
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1265"
+version = "0.2.1266"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1267"
+version = "0.2.1268"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1266"
+version = "0.2.1267"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- normalize Unicode dash variants to ASCII hyphens only when mapping authoritative corpus citation IDs to RuleSpec filesystem paths
- preserve the original corpus citation and generated RuleSpec legal IDs byte-for-byte
- cover all supported dash variants and verify re-apply targets the existing ASCII module instead of creating a Unicode-path duplicate
- bump axiom-encode to `0.2.1266`

This fixes the canonical-layout failure exposed by rulespec-us #911 for 42 USC 1437c–1.

## Review cycle

Cycle in progress. This PR remains draft until independent review findings are resolved and all hosted checks are green.

## Local checks

- focused path/collision tests: 10 passed
- Ruff formatting and lint: pass
- `python -m compileall -q src/axiom_encode scripts`: pass
- Towncrier draft: pass
- `git diff --check`: pass
- full pytest: running
