### PR TITLE
Add base-bound proof hash migration cascade

### DIFF
--- a/changelog.d/base-bound-proof-hash-cascade.added.md
+++ b/changelog.d/base-bound-proof-hash-cascade.added.md
@@ -1,0 +1,1 @@
+Add a deterministic, base-bound proof-import hash cascade for reviewed repository migrations. It rewrites only hashes that exactly match an ancestor target and emits a durable audit report.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1268"
+version = "0.2.1269"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1268"
+__version__ = "0.2.1269"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -4984,13 +4984,6 @@ def cmd_migration_cascade_proof_hashes(args) -> int:
             print(render_proof_hash_cascade_plan(plan, as_json=args.json))
             return 1 if plan.eligible else 0
         payload = apply_proof_hash_cascade(plan, args.report)
-        post_apply = build_proof_hash_cascade_plan(args.root, args.base_ref)
-        if post_apply.eligible:
-            print(
-                "proof hash cascade left eligible migration-induced hashes",
-                file=sys.stderr,
-            )
-            return 1
     except (OSError, ValueError, yaml.YAMLError) as exc:
         print(f"proof hash cascade failed: {exc}", file=sys.stderr)
         return 2

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -240,6 +240,11 @@ from .oracles.policyengine.pending import (
 )
 from .oracles.policyengine.snap_readiness import build_snap_readiness_report
 from .program_scope import ProgramScopeError, sync_program_scope
+from .proof_hash_migration import (
+    apply_proof_hash_cascade,
+    build_proof_hash_cascade_plan,
+    render_proof_hash_cascade_plan,
+)
 from .repo_routing import (
     canonical_rulespec_repo_name,
     canonical_rulespec_root_identity,
@@ -1062,6 +1067,45 @@ def main():
     )
     migration_inventory_parser.add_argument(
         "--json", action="store_true", help="Emit machine-readable JSON"
+    )
+
+    proof_hash_cascade_parser = subparsers.add_parser(
+        "migration-cascade-proof-hashes",
+        help=(
+            "Cascade proof-import hashes changed by a base-bound repository migration"
+        ),
+    )
+    proof_hash_cascade_parser.add_argument(
+        "--root",
+        required=True,
+        type=Path,
+        help="Clean canonical rulespec-<country> checkout",
+    )
+    proof_hash_cascade_parser.add_argument(
+        "--base-ref",
+        required=True,
+        help="Ancestor commit whose target hashes must match every rewritten hash",
+    )
+    proof_hash_cascade_mode = proof_hash_cascade_parser.add_mutually_exclusive_group(
+        required=True
+    )
+    proof_hash_cascade_mode.add_argument(
+        "--check",
+        action="store_true",
+        help="Report eligible migration-induced stale hashes without writing",
+    )
+    proof_hash_cascade_mode.add_argument(
+        "--apply",
+        action="store_true",
+        help="Rewrite only exact base-matching hashes and write an audit report",
+    )
+    proof_hash_cascade_parser.add_argument(
+        "--report",
+        type=Path,
+        help="Required with --apply; JSON path under .axiom/migrations",
+    )
+    proof_hash_cascade_parser.add_argument(
+        "--json", action="store_true", help="Emit machine-readable output"
     )
 
     interval_table_audit_parser = subparsers.add_parser(
@@ -2336,6 +2380,8 @@ def main():
         cmd_inventory(args)
     elif args.command == "migration-inventory":
         cmd_migration_inventory(args)
+    elif args.command == "migration-cascade-proof-hashes":
+        sys.exit(cmd_migration_cascade_proof_hashes(args))
     elif args.command == "interval-table-audit":
         cmd_interval_table_audit(args)
     elif args.command == "oracle-coverage":
@@ -4922,6 +4968,40 @@ def cmd_migration_inventory(args):
             )
         print(f"{len(rows)} module citation failure(s).")
     raise SystemExit(1)
+
+
+def cmd_migration_cascade_proof_hashes(args) -> int:
+    """Audit or apply proof hashes caused by an exact ancestor migration."""
+    if args.apply and args.report is None:
+        print("--report is required with --apply", file=sys.stderr)
+        return 2
+    if args.check and args.report is not None:
+        print("--report is only valid with --apply", file=sys.stderr)
+        return 2
+    try:
+        plan = build_proof_hash_cascade_plan(args.root, args.base_ref)
+        if args.check:
+            print(render_proof_hash_cascade_plan(plan, as_json=args.json))
+            return 1 if plan.eligible else 0
+        payload = apply_proof_hash_cascade(plan, args.report)
+        post_apply = build_proof_hash_cascade_plan(args.root, args.base_ref)
+        if post_apply.eligible:
+            print(
+                "proof hash cascade left eligible migration-induced hashes",
+                file=sys.stderr,
+            )
+            return 1
+    except (OSError, ValueError, yaml.YAMLError) as exc:
+        print(f"proof hash cascade failed: {exc}", file=sys.stderr)
+        return 2
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"eligible_replacements={payload['eligible_replacements']}")
+        print(f"ignored_mismatches={payload['ignored_mismatches']}")
+        print(f"applied_files={len(payload['applied_files'])}")
+        print(f"report={args.report}")
+    return 0
 
 
 def cmd_interval_table_audit(args):

--- a/src/axiom_encode/proof_hash_migration.py
+++ b/src/axiom_encode/proof_hash_migration.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
+import stat
 import subprocess
+import tempfile
 from collections import defaultdict
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -13,9 +16,11 @@ from typing import Literal
 
 import yaml
 from yaml.nodes import MappingNode, Node, ScalarNode, SequenceNode
+from yaml.tokens import AliasToken, AnchorToken, KeyToken
 
 from .constants import RULESPEC_ATOMIC_MODULE_ROOTS
 from .harness.validator_pipeline import _parse_rulespec_target
+from .repo_routing import is_composition_policy_repo_root, jurisdiction_country
 
 REPORT_SCHEMA = "axiom-encode/proof-hash-cascade/v1"
 _CHECKOUT_NAME_RE = re.compile(r"rulespec-[a-z]{2}")
@@ -30,6 +35,7 @@ class HashOccurrence:
     declared_hash: str
     base_target_hash: str | None
     current_target_hash: str | None
+    replacement_hash: str | None
     status: Literal[
         "eligible",
         "preexisting_mismatch",
@@ -48,11 +54,47 @@ class HashOccurrence:
 
 
 @dataclass(frozen=True)
+class _ProofImportScan:
+    importer_path: str
+    target: str
+    target_path: str
+    line: int
+    declared_hash: str
+    base_target_hash: str
+    current_target_hash: str
+    start_index: int
+    end_index: int
+    scalar_style: str | None
+
+    def occurrence(
+        self,
+        *,
+        status: Literal["eligible", "preexisting_mismatch"],
+        replacement: str | None,
+    ) -> HashOccurrence:
+        return HashOccurrence(
+            importer_path=self.importer_path,
+            target=self.target,
+            target_path=self.target_path,
+            line=self.line,
+            declared_hash=self.declared_hash,
+            base_target_hash=self.base_target_hash,
+            current_target_hash=self.current_target_hash,
+            replacement_hash=replacement,
+            status=status,
+            start_index=self.start_index,
+            end_index=self.end_index,
+            scalar_style=self.scalar_style,
+        )
+
+
+@dataclass(frozen=True)
 class CascadePlan:
     root: Path
     base_commit: str
     head_commit: str
     occurrences: tuple[HashOccurrence, ...]
+    importer_sha256: tuple[tuple[str, str], ...]
 
     @property
     def eligible(self) -> tuple[HashOccurrence, ...]:
@@ -63,7 +105,12 @@ class CascadePlan:
         return tuple(item for item in self.occurrences if item.status != "eligible")
 
 
-def build_proof_hash_cascade_plan(root: Path, base_ref: str) -> CascadePlan:
+def build_proof_hash_cascade_plan(
+    root: Path,
+    base_ref: str,
+    *,
+    _expected_worktree_bytes: dict[str, bytes] | None = None,
+) -> CascadePlan:
     checkout = _validate_checkout(root)
     base_commit = _git_text(checkout, "rev-parse", "--verify", f"{base_ref}^{{commit}}")
     head_commit = _git_text(checkout, "rev-parse", "--verify", "HEAD^{commit}")
@@ -84,18 +131,57 @@ def build_proof_hash_cascade_plan(root: Path, base_ref: str) -> CascadePlan:
         raise ValueError(f"base ref {base_ref!r} is not an ancestor of HEAD")
 
     tracked = _git_text(checkout, "ls-files", "-z", strip=False).split("\0")
+    country = checkout.name.removeprefix("rulespec-")
     module_paths = sorted(
         path
         for path in tracked
         if path
         and _is_atomic_module_path(Path(path))
+        and jurisdiction_country(Path(path).parts[0]) == country
         and not path.endswith(".test.yaml")
     )
-    base_hashes: dict[str, str | None] = {}
-    current_hashes: dict[str, str | None] = {}
-    occurrences: list[HashOccurrence] = []
+    head_entries = _git_tree_entries(checkout, head_commit)
+    head_blob_bytes = _git_blob_batch(
+        checkout,
+        {
+            object_id
+            for path, (mode, object_type, object_id) in head_entries.items()
+            if _is_atomic_module_path(Path(path))
+            and jurisdiction_country(Path(path).parts[0]) == country
+            and mode.startswith("100")
+            and object_type == "blob"
+        },
+    )
+    base_target_bytes: dict[str, bytes | None] = {}
+    current_target_bytes: dict[str, bytes | None] = {}
+    importer_hashes: dict[str, str] = {}
+    module_bytes: dict[str, bytes] = {}
+    candidates: list[_ProofImportScan] = []
+    current_non_base: list[_ProofImportScan] = []
+    ignored: list[HashOccurrence] = []
     for importer_path in module_paths:
-        content = (checkout / importer_path).read_text(encoding="utf-8")
+        importer_file = checkout / importer_path
+        importer_bytes = _read_regular_worktree_file(
+            checkout, importer_file, label="importer"
+        )
+        head_importer = head_entries.get(importer_path)
+        if head_importer is None:
+            raise ValueError(f"tracked importer is missing from HEAD: {importer_path}")
+        head_mode, head_type, _head_object = head_importer
+        if not head_mode.startswith("100") or head_type != "blob":
+            raise ValueError(
+                f"tracked importer is not a regular HEAD blob: {importer_path}"
+            )
+        expected_importer_bytes = (_expected_worktree_bytes or {}).get(
+            importer_path, head_blob_bytes.get(_head_object)
+        )
+        if importer_bytes != expected_importer_bytes:
+            raise ValueError(
+                f"importer worktree bytes differ from HEAD: {importer_path}"
+            )
+        importer_hashes[importer_path] = _sha256(importer_bytes)
+        module_bytes[importer_path] = importer_bytes
+        content = importer_bytes.decode("utf-8")
         for target_node, hash_node in _proof_import_scalar_nodes(content):
             target = target_node.value.strip()
             declared_hash = hash_node.value.strip()
@@ -104,36 +190,81 @@ def build_proof_hash_cascade_plan(root: Path, base_ref: str) -> CascadePlan:
             target_ref = _parse_rulespec_target(target)
             if target_ref is None:
                 continue
+            if jurisdiction_country(target_ref.prefix) != country:
+                raise ValueError(
+                    f"proof import target {target!r} does not belong to {checkout.name}"
+                )
             target_path = (
                 Path(target_ref.prefix) / target_ref.relative_path
             ).as_posix()
-            if target_path not in current_hashes:
+            if target_path not in current_target_bytes:
                 target_file = checkout / target_path
-                current_hashes[target_path] = (
-                    _sha256(target_file.read_bytes())
-                    if target_file.is_file() and not target_file.is_symlink()
-                    else None
+                current_target_bytes[target_path] = (
+                    _read_optional_regular_worktree_file(
+                        checkout, target_file, label="proof import target"
+                    )
                 )
-            if target_path not in base_hashes:
-                base_bytes = _git_file(checkout, base_commit, target_path)
-                base_hashes[target_path] = (
-                    _sha256(base_bytes) if base_bytes is not None else None
+                if current_target_bytes[target_path] is not None:
+                    head_target = head_entries.get(target_path)
+                    if head_target is None:
+                        raise ValueError(
+                            f"proof import target is missing from HEAD: {target_path}"
+                        )
+                    head_mode, head_type, _head_object = head_target
+                    if not head_mode.startswith("100") or head_type != "blob":
+                        raise ValueError(
+                            "proof import target is not a regular HEAD blob: "
+                            f"{target_path}"
+                        )
+                    expected_target_bytes = (_expected_worktree_bytes or {}).get(
+                        target_path, head_blob_bytes.get(_head_object)
+                    )
+                    if current_target_bytes[target_path] != expected_target_bytes:
+                        raise ValueError(
+                            "proof import target worktree bytes differ from HEAD: "
+                            f"{target_path}"
+                        )
+            if target_path not in base_target_bytes:
+                base_target_bytes[target_path] = _git_file(
+                    checkout, base_commit, target_path
                 )
-            base_hash = base_hashes[target_path]
-            current_hash = current_hashes[target_path]
-            expected_base = f"sha256:{base_hash}" if base_hash else None
-            expected_current = f"sha256:{current_hash}" if current_hash else None
+            base_bytes = base_target_bytes[target_path]
+            current_bytes = current_target_bytes[target_path]
+            expected_base = (
+                f"sha256:{_sha256(base_bytes)}" if base_bytes is not None else None
+            )
+            expected_current = (
+                f"sha256:{_sha256(current_bytes)}"
+                if current_bytes is not None
+                else None
+            )
             if expected_current is None:
                 status = "current_target_missing"
             elif expected_base is None:
                 status = "base_target_missing"
-            elif declared_hash == expected_base and declared_hash != expected_current:
-                status = "eligible"
-            elif declared_hash != expected_current:
-                status = "preexisting_mismatch"
             else:
+                scan = _ProofImportScan(
+                    importer_path=importer_path,
+                    target=target,
+                    target_path=target_path,
+                    line=hash_node.start_mark.line + 1,
+                    declared_hash=declared_hash,
+                    base_target_hash=expected_base,
+                    current_target_hash=expected_current,
+                    start_index=hash_node.start_mark.index,
+                    end_index=hash_node.end_mark.index,
+                    scalar_style=hash_node.style,
+                )
+                if declared_hash == expected_base:
+                    candidates.append(scan)
+                elif declared_hash == expected_current:
+                    current_non_base.append(scan)
+                else:
+                    ignored.append(
+                        scan.occurrence(status="preexisting_mismatch", replacement=None)
+                    )
                 continue
-            occurrences.append(
+            ignored.append(
                 HashOccurrence(
                     importer_path=importer_path,
                     target=target,
@@ -142,18 +273,102 @@ def build_proof_hash_cascade_plan(root: Path, base_ref: str) -> CascadePlan:
                     declared_hash=declared_hash,
                     base_target_hash=expected_base,
                     current_target_hash=expected_current,
+                    replacement_hash=None,
                     status=status,
                     start_index=hash_node.start_mark.index,
                     end_index=hash_node.end_mark.index,
                     scalar_style=hash_node.style,
                 )
             )
+
+    final_module_bytes = _resolve_base_bound_cascade(
+        module_bytes=module_bytes,
+        candidates=candidates,
+        current_target_bytes=current_target_bytes,
+    )
+    eligible: list[HashOccurrence] = []
+    for scan in candidates:
+        replacement = _target_hash_for_virtual_files(
+            scan.target_path,
+            virtual_module_bytes=final_module_bytes,
+            current_target_bytes=current_target_bytes,
+        )
+        if replacement != scan.declared_hash:
+            eligible.append(scan.occurrence(status="eligible", replacement=replacement))
+    for scan in current_non_base:
+        final_target_hash = _target_hash_for_virtual_files(
+            scan.target_path,
+            virtual_module_bytes=final_module_bytes,
+            current_target_bytes=current_target_bytes,
+        )
+        if final_target_hash != scan.current_target_hash:
+            raise ValueError(
+                "base-bound cascade would stale a non-base-authorized proof import: "
+                f"{scan.importer_path}:{scan.line} -> {scan.target_path}"
+            )
     return CascadePlan(
         root=checkout,
         base_commit=base_commit,
         head_commit=head_commit,
-        occurrences=tuple(occurrences),
+        occurrences=tuple([*eligible, *ignored]),
+        importer_sha256=tuple(sorted(importer_hashes.items())),
     )
+
+
+def _resolve_base_bound_cascade(
+    *,
+    module_bytes: dict[str, bytes],
+    candidates: list[_ProofImportScan],
+    current_target_bytes: dict[str, bytes | None],
+) -> dict[str, bytes]:
+    candidates_by_importer: dict[str, list[_ProofImportScan]] = defaultdict(list)
+    for scan in candidates:
+        candidates_by_importer[scan.importer_path].append(scan)
+    virtual = dict(module_bytes)
+    iteration_limit = len(candidates_by_importer) + 2
+    for _iteration in range(iteration_limit):
+        updated_virtual = dict(virtual)
+        for importer_path, scans in sorted(candidates_by_importer.items()):
+            original = module_bytes[importer_path].decode("utf-8")
+            updated = original
+            for scan in sorted(
+                scans, key=lambda value: value.start_index, reverse=True
+            ):
+                replacement = _target_hash_for_virtual_files(
+                    scan.target_path,
+                    virtual_module_bytes=virtual,
+                    current_target_bytes=current_target_bytes,
+                )
+                rendered = _render_scalar(replacement, scan.scalar_style)
+                updated = (
+                    updated[: scan.start_index] + rendered + updated[scan.end_index :]
+                )
+            updated_virtual[importer_path] = updated.encode("utf-8")
+        if all(
+            updated_virtual[path] == virtual[path] for path in candidates_by_importer
+        ):
+            return updated_virtual
+        virtual = updated_virtual
+    raise ValueError(
+        "base-bound proof hash cascade did not converge; candidate imports contain "
+        "a dependency cycle"
+    )
+
+
+def _target_hash_for_virtual_files(
+    target_path: str,
+    *,
+    virtual_module_bytes: dict[str, bytes],
+    current_target_bytes: dict[str, bytes | None],
+) -> str:
+    content = virtual_module_bytes.get(target_path)
+    if content is None:
+        content = current_target_bytes.get(target_path)
+    if content is None:
+        raise ValueError(
+            f"proof import target disappeared during planning: {target_path}"
+        )
+    return f"sha256:{_sha256(content)}"
 
 
 def apply_proof_hash_cascade(plan: CascadePlan, report_path: Path) -> dict[str, object]:
@@ -163,20 +378,26 @@ def apply_proof_hash_cascade(plan: CascadePlan, report_path: Path) -> dict[str, 
     if _git_text(plan.root, "status", "--porcelain"):
         raise ValueError("proof hash cascade apply requires a clean Git checkout")
     report = _validate_report_path(plan.root, report_path)
+    planned_importer_hashes = dict(plan.importer_sha256)
     grouped: dict[str, list[HashOccurrence]] = defaultdict(list)
     for item in plan.eligible:
         grouped[item.importer_path].append(item)
     updated_files: dict[str, tuple[bytes, bytes, int]] = {}
     for relative_path, items in sorted(grouped.items()):
         path = plan.root / relative_path
-        original = path.read_text(encoding="utf-8")
+        original_bytes = _read_regular_worktree_file(plan.root, path, label="importer")
+        if _sha256(original_bytes) != planned_importer_hashes.get(relative_path):
+            raise ValueError(
+                f"planned importer bytes changed before apply: {relative_path}"
+            )
+        original = original_bytes.decode("utf-8")
         updated = original
         for item in sorted(items, key=lambda value: value.start_index, reverse=True):
-            if item.current_target_hash is None:
+            if item.replacement_hash is None:
                 raise ValueError(
-                    f"eligible target unexpectedly has no current hash: {item.target_path}"
+                    f"eligible target unexpectedly has no replacement hash: {item.target_path}"
                 )
-            replacement = _render_scalar(item.current_target_hash, item.scalar_style)
+            replacement = _render_scalar(item.replacement_hash, item.scalar_style)
             updated = (
                 updated[: item.start_index] + replacement + updated[item.end_index :]
             )
@@ -185,17 +406,26 @@ def apply_proof_hash_cascade(plan: CascadePlan, report_path: Path) -> dict[str, 
                 f"eligible proof hash cascade produced no change: {relative_path}"
             )
         updated_files[relative_path] = (
-            original.encode("utf-8"),
+            original_bytes,
             updated.encode("utf-8"),
             len(items),
         )
+
+    for item in plan.eligible:
+        target_bytes = _read_regular_worktree_file(
+            plan.root,
+            plan.root / item.target_path,
+            label="proof import target",
+        )
+        if f"sha256:{_sha256(target_bytes)}" != item.current_target_hash:
+            raise ValueError(
+                f"planned target bytes changed before apply: {item.target_path}"
+            )
 
     applied_files: list[dict[str, object]] = []
     for relative_path, (original, updated, replacement_count) in sorted(
         updated_files.items()
     ):
-        path = plan.root / relative_path
-        path.write_bytes(updated)
         applied_files.append(
             {
                 "path": relative_path,
@@ -207,6 +437,7 @@ def apply_proof_hash_cascade(plan: CascadePlan, report_path: Path) -> dict[str, 
 
     payload: dict[str, object] = {
         "schema": REPORT_SCHEMA,
+        "status": "complete",
         "base_commit": plan.base_commit,
         "head_commit_before_apply": plan.head_commit,
         "eligible_replacements": len(plan.eligible),
@@ -215,10 +446,76 @@ def apply_proof_hash_cascade(plan: CascadePlan, report_path: Path) -> dict[str, 
         "replacements": [item.public_record() for item in plan.eligible],
         "ignored": [item.public_record() for item in plan.ignored],
     }
-    report.parent.mkdir(parents=True, exist_ok=True)
-    report.write_text(
-        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-    )
+    prepared_payload = {**payload, "status": "prepared"}
+    created_report_dirs = _create_report_parent(plan.root, report.parent)
+    try:
+        _write_json_exclusive(report, prepared_payload)
+    except BaseException:
+        _remove_empty_directories(created_report_dirs)
+        raise
+
+    written_paths: list[str] = []
+    try:
+        for relative_path, (original, updated, _count) in sorted(updated_files.items()):
+            path = plan.root / relative_path
+            mode = stat.S_IMODE(path.stat(follow_symlinks=False).st_mode)
+            written_paths.append(relative_path)
+            _atomic_replace_bytes(path, updated, mode=mode)
+        post_apply = build_proof_hash_cascade_plan(
+            plan.root,
+            plan.base_commit,
+            _expected_worktree_bytes={
+                path: updated
+                for path, (_original, updated, _count) in updated_files.items()
+            },
+        )
+        if post_apply.eligible:
+            raise ValueError(
+                "proof hash cascade left eligible migration-induced hashes"
+            )
+        ignored_identity = {
+            (item.importer_path, item.line, item.target_path, item.status)
+            for item in plan.ignored
+        }
+        post_ignored_identity = {
+            (item.importer_path, item.line, item.target_path, item.status)
+            for item in post_apply.ignored
+        }
+        if post_ignored_identity != ignored_identity:
+            raise ValueError("proof hash cascade changed the ignored mismatch set")
+        _atomic_replace_bytes(report, _json_bytes(payload), mode=0o644)
+    except BaseException as exc:
+        rollback_failures: list[str] = []
+        for relative_path in reversed(written_paths):
+            original, _updated, _count = updated_files[relative_path]
+            path = plan.root / relative_path
+            try:
+                mode = stat.S_IMODE(path.stat(follow_symlinks=False).st_mode)
+                _atomic_replace_bytes(path, original, mode=mode)
+            except BaseException as rollback_exc:
+                rollback_failures.append(
+                    f"{relative_path}: {type(rollback_exc).__name__}: {rollback_exc}"
+                )
+        rollback_payload = {
+            **prepared_payload,
+            "status": "rollback_failed" if rollback_failures else "rolled_back",
+            "failure": f"{type(exc).__name__}: {exc}",
+            "rollback_failures": rollback_failures,
+        }
+        report_failure: BaseException | None = None
+        try:
+            _atomic_replace_bytes(report, _json_bytes(rollback_payload), mode=0o644)
+        except BaseException as report_exc:
+            report_failure = report_exc
+        if rollback_failures or report_failure is not None:
+            detail = "; ".join(rollback_failures)
+            if report_failure is not None:
+                report_detail = (
+                    f"audit report: {type(report_failure).__name__}: {report_failure}"
+                )
+                detail = f"{detail}; {report_detail}" if detail else report_detail
+            raise RuntimeError(f"proof hash cascade rollback failed: {detail}") from exc
+        raise
     return payload
 
 
@@ -252,7 +549,10 @@ def render_proof_hash_cascade_plan(plan: CascadePlan, *, as_json: bool) -> str:
 
 
 def _validate_checkout(root: Path) -> Path:
-    checkout = Path(root).expanduser().resolve(strict=True)
+    supplied = Path(root).expanduser()
+    if not is_composition_policy_repo_root(supplied):
+        raise ValueError("root must be a canonical rulespec-<country> checkout")
+    checkout = supplied.resolve(strict=True)
     if not checkout.is_dir() or not _CHECKOUT_NAME_RE.fullmatch(checkout.name):
         raise ValueError("root must be a canonical rulespec-<country> checkout")
     inside = _git_text(checkout, "rev-parse", "--is-inside-work-tree")
@@ -271,16 +571,14 @@ def _validate_report_path(root: Path, report_path: Path) -> Path:
     resolved_parent = raw.parent.resolve(strict=False)
     report = resolved_parent / raw.name
     allowed = root / ".axiom" / "migrations"
-    try:
-        report.relative_to(allowed)
-    except ValueError as exc:
-        raise ValueError("report must be written under .axiom/migrations") from exc
+    if resolved_parent != allowed:
+        raise ValueError("report must be written directly under .axiom/migrations")
     if report.suffix != ".json":
         raise ValueError("report path must end in .json")
     if report.is_symlink():
         raise ValueError("report path must not be a symlink")
-    if report.exists() and not report.is_file():
-        raise ValueError("report path must be a regular file")
+    if report.exists():
+        raise ValueError("report path must not already exist")
     return report
 
 
@@ -295,38 +593,155 @@ def _is_atomic_module_path(path: Path) -> bool:
 
 
 def _proof_import_scalar_nodes(content: str) -> list[tuple[ScalarNode, ScalarNode]]:
+    tokens = tuple(yaml.scan(content))
+    if any(
+        isinstance(token, AliasToken)
+        and token_index > 0
+        and isinstance(tokens[token_index - 1], KeyToken)
+        for token_index, token in enumerate(tokens)
+    ):
+        raise ValueError("RuleSpec document contains a YAML alias mapping key")
+    marker_tokens = tuple(
+        token for token in tokens if isinstance(token, (AnchorToken, AliasToken))
+    )
     root = yaml.compose(content)
     if root is None:
         return []
+    if not isinstance(root, MappingNode):
+        raise ValueError("RuleSpec document root must be a mapping")
     found: list[tuple[ScalarNode, ScalarNode]] = []
-
-    def visit(node: Node) -> None:
-        if isinstance(node, MappingNode):
-            fields = {
-                key.value: value
-                for key, value in node.value
-                if isinstance(key, ScalarNode)
-            }
-            import_node = fields.get("import")
-            if isinstance(import_node, MappingNode):
-                import_fields = {
-                    key.value: value
-                    for key, value in import_node.value
-                    if isinstance(key, ScalarNode)
-                }
-                target = import_fields.get("target")
-                hash_node = import_fields.get("hash")
-                if isinstance(target, ScalarNode) and isinstance(hash_node, ScalarNode):
-                    found.append((target, hash_node))
-            for key, value in node.value:
-                visit(key)
-                visit(value)
-        elif isinstance(node, SequenceNode):
-            for value in node.value:
-                visit(value)
-
-    visit(root)
+    root_fields = _mapping_fields(root, context="document root")
+    rules = root_fields.get("rules")
+    if rules is None:
+        return []
+    _require_direct_mapping_value(root, "rules", rules, context="document root")
+    if not isinstance(rules, SequenceNode):
+        raise ValueError("RuleSpec rules must be a sequence")
+    seen_hash_spans: set[tuple[int, int]] = set()
+    previous_rule_end = rules.start_mark.index
+    for rule_index, rule in enumerate(rules.value):
+        if rule.start_mark.index < previous_rule_end:
+            raise ValueError(
+                f"rules[{rule_index}] uses a YAML alias outside its sequence item"
+            )
+        previous_rule_end = rule.end_mark.index
+        _require_node_within(rule, rules, context=f"rules[{rule_index}]")
+        if not isinstance(rule, MappingNode):
+            raise ValueError(f"RuleSpec rules[{rule_index}] must be a mapping")
+        rule_fields = _mapping_fields(rule, context=f"rules[{rule_index}]")
+        metadata = rule_fields.get("metadata")
+        if metadata is None:
+            continue
+        _require_direct_mapping_value(
+            rule, "metadata", metadata, context=f"rules[{rule_index}]"
+        )
+        if not isinstance(metadata, MappingNode):
+            raise ValueError(f"rules[{rule_index}].metadata must be a mapping")
+        metadata_fields = _mapping_fields(
+            metadata, context=f"rules[{rule_index}].metadata"
+        )
+        proof = metadata_fields.get("proof")
+        if proof is None:
+            continue
+        _require_direct_mapping_value(
+            metadata, "proof", proof, context=f"rules[{rule_index}].metadata"
+        )
+        if not isinstance(proof, MappingNode):
+            raise ValueError(f"rules[{rule_index}].metadata.proof must be a mapping")
+        proof_fields = _mapping_fields(
+            proof, context=f"rules[{rule_index}].metadata.proof"
+        )
+        atoms = proof_fields.get("atoms")
+        if atoms is None:
+            continue
+        _require_direct_mapping_value(
+            proof, "atoms", atoms, context=f"rules[{rule_index}].metadata.proof"
+        )
+        if not isinstance(atoms, SequenceNode):
+            raise ValueError(
+                f"rules[{rule_index}].metadata.proof.atoms must be a sequence"
+            )
+        for atom_index, atom in enumerate(atoms.value):
+            context = f"rules[{rule_index}].metadata.proof.atoms[{atom_index}]"
+            _require_node_within(atom, atoms, context=context)
+            if not isinstance(atom, MappingNode):
+                raise ValueError(f"{context} must be a mapping")
+            atom_fields = _mapping_fields(atom, context=context)
+            kind = atom_fields.get("kind")
+            if not isinstance(kind, ScalarNode) or kind.value != "import":
+                continue
+            _require_direct_mapping_value(atom, "kind", kind, context=context)
+            import_node = atom_fields.get("import")
+            if not isinstance(import_node, MappingNode):
+                raise ValueError(f"{context}.import must be a mapping")
+            _require_direct_mapping_value(atom, "import", import_node, context=context)
+            import_fields = _mapping_fields(import_node, context=f"{context}.import")
+            target = import_fields.get("target")
+            hash_node = import_fields.get("hash")
+            if not isinstance(target, ScalarNode) or not isinstance(
+                hash_node, ScalarNode
+            ):
+                raise ValueError(f"{context}.import requires scalar target and hash")
+            _require_direct_mapping_value(
+                import_node, "target", target, context=f"{context}.import"
+            )
+            _require_direct_mapping_value(
+                import_node, "hash", hash_node, context=f"{context}.import"
+            )
+            if hash_node.value.strip() != "sha256:local" and any(
+                proof.start_mark.index <= token.start_mark.index < proof.end_mark.index
+                for token in marker_tokens
+            ):
+                raise ValueError(
+                    f"rules[{rule_index}].metadata.proof contains YAML anchors or "
+                    "aliases and a nonlocal import proof atom"
+                )
+            span = (hash_node.start_mark.index, hash_node.end_mark.index)
+            if span in seen_hash_spans:
+                raise ValueError(
+                    f"{context}.import hash is duplicated through an alias"
+                )
+            seen_hash_spans.add(span)
+            found.append((target, hash_node))
     return found
+
+
+def _mapping_fields(node: MappingNode, *, context: str) -> dict[str, Node]:
+    fields: dict[str, Node] = {}
+    for key, value in node.value:
+        if not isinstance(key, ScalarNode):
+            raise ValueError(f"{context} contains a non-scalar key")
+        if key.tag == "tag:yaml.org,2002:merge":
+            raise ValueError(f"{context} contains a YAML merge key")
+        if key.value in fields:
+            raise ValueError(f"{context} contains duplicate key {key.value!r}")
+        fields[key.value] = value
+    return fields
+
+
+def _require_direct_mapping_value(
+    mapping: MappingNode, key_name: str, value: Node, *, context: str
+) -> None:
+    key_node = next(
+        (
+            key
+            for key, candidate in mapping.value
+            if isinstance(key, ScalarNode)
+            and key.value == key_name
+            and candidate is value
+        ),
+        None,
+    )
+    if key_node is None or value.start_mark.index < key_node.end_mark.index:
+        raise ValueError(f"{context}.{key_name} uses a YAML alias outside its field")
+
+
+def _require_node_within(node: Node, parent: Node, *, context: str) -> None:
+    if (
+        node.start_mark.index < parent.start_mark.index
+        or node.end_mark.index > parent.end_mark.index
+    ):
+        raise ValueError(f"{context} uses a YAML alias outside its container")
 
 
 def _render_scalar(value: str, style: str | None) -> str:
@@ -337,6 +752,113 @@ def _render_scalar(value: str, style: str | None) -> str:
     if style == '"':
         return json.dumps(value)
     raise ValueError(f"unsupported proof hash scalar style: {style!r}")
+
+
+def _read_optional_regular_worktree_file(
+    root: Path, path: Path, *, label: str
+) -> bytes | None:
+    relative = path.relative_to(root)
+    cursor = root
+    for part in relative.parts:
+        cursor /= part
+        if cursor.is_symlink():
+            raise ValueError(f"{label} must not contain a symlink: {relative}")
+    if not path.exists():
+        return None
+    if not path.is_file():
+        raise ValueError(f"{label} must be a regular file: {relative}")
+    return path.read_bytes()
+
+
+def _read_regular_worktree_file(root: Path, path: Path, *, label: str) -> bytes:
+    content = _read_optional_regular_worktree_file(root, path, label=label)
+    if content is None:
+        raise ValueError(f"{label} does not exist: {path.relative_to(root)}")
+    return content
+
+
+def _create_report_parent(root: Path, parent: Path) -> tuple[Path, ...]:
+    allowed = root / ".axiom" / "migrations"
+    try:
+        parent.relative_to(allowed)
+    except ValueError as exc:
+        raise ValueError("report must be written under .axiom/migrations") from exc
+    missing: list[Path] = []
+    cursor = parent
+    while cursor != root and not cursor.exists():
+        missing.append(cursor)
+        cursor = cursor.parent
+    created: list[Path] = []
+    try:
+        for directory in reversed(missing):
+            directory.mkdir()
+            created.append(directory)
+            _fsync_directory(directory.parent)
+    except BaseException:
+        _remove_empty_directories(tuple(reversed(created)))
+        raise
+    return tuple(reversed(created))
+
+
+def _remove_empty_directories(directories: tuple[Path, ...]) -> None:
+    for directory in directories:
+        try:
+            directory.rmdir()
+            _fsync_directory(directory.parent)
+        except OSError:
+            return
+
+
+def _json_bytes(payload: dict[str, object]) -> bytes:
+    return (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+
+def _write_json_exclusive(path: Path, payload: dict[str, object]) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(path, flags, 0o644)
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            descriptor = -1
+            stream.write(_json_bytes(payload))
+            stream.flush()
+            os.fsync(stream.fileno())
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    _fsync_directory(path.parent)
+
+
+def _atomic_replace_bytes(path: Path, content: bytes, *, mode: int) -> None:
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        os.fchmod(descriptor, mode)
+        with os.fdopen(descriptor, "wb") as stream:
+            descriptor = -1
+            stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        _fsync_directory(path.parent)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        temporary.unlink(missing_ok=True)
+
+
+def _fsync_directory(path: Path) -> None:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    descriptor = os.open(path, flags)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
 
 
 def _git_text(root: Path, *args: str, strip: bool = True) -> str:
@@ -381,6 +903,74 @@ def _git_file(root: Path, commit: str, path: str) -> bytes | None:
         detail = blob.stderr.decode(errors="replace").strip()
         raise ValueError(f"git cat-file failed for {commit}:{path}: {detail}")
     return blob.stdout
+
+
+def _git_tree_entries(root: Path, commit: str) -> dict[str, tuple[str, str, str]]:
+    completed = subprocess.run(
+        ["git", "-C", str(root), "ls-tree", "-r", "-z", commit],
+        check=False,
+        capture_output=True,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.decode(errors="replace").strip()
+        raise ValueError(f"git ls-tree failed for {commit}: {detail}")
+    entries: dict[str, tuple[str, str, str]] = {}
+    for raw_entry in completed.stdout.split(b"\0"):
+        if not raw_entry:
+            continue
+        metadata, separator, raw_path = raw_entry.partition(b"\t")
+        fields = metadata.split()
+        if separator != b"\t" or len(fields) != 3:
+            raise ValueError(f"unexpected git tree entry for {commit}")
+        mode, object_type, object_id = (field.decode("ascii") for field in fields)
+        path = raw_path.decode(errors="surrogateescape")
+        entries[path] = (mode, object_type, object_id)
+    return entries
+
+
+def _git_blob_batch(root: Path, object_ids: set[str]) -> dict[str, bytes]:
+    if not object_ids:
+        return {}
+    requested = sorted(object_ids)
+    completed = subprocess.run(
+        ["git", "-C", str(root), "cat-file", "--batch"],
+        input="".join(f"{object_id}\n" for object_id in requested).encode("ascii"),
+        check=False,
+        capture_output=True,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.decode(errors="replace").strip()
+        raise ValueError(f"git cat-file --batch failed: {detail}")
+    output = completed.stdout
+    offset = 0
+    blobs: dict[str, bytes] = {}
+    for expected_object_id in requested:
+        header_end = output.find(b"\n", offset)
+        if header_end < 0:
+            raise ValueError("git cat-file --batch returned a truncated header")
+        header = output[offset:header_end].split()
+        if len(header) != 3:
+            raise ValueError("git cat-file --batch returned an invalid header")
+        object_id, object_type, raw_size = header
+        if object_id.decode("ascii") != expected_object_id or object_type != b"blob":
+            raise ValueError(
+                f"git cat-file --batch returned an unexpected object for {expected_object_id}"
+            )
+        try:
+            size = int(raw_size)
+        except ValueError as exc:
+            raise ValueError(
+                "git cat-file --batch returned an invalid blob size"
+            ) from exc
+        content_start = header_end + 1
+        content_end = content_start + size
+        if content_end >= len(output) or output[content_end : content_end + 1] != b"\n":
+            raise ValueError("git cat-file --batch returned truncated blob content")
+        blobs[expected_object_id] = output[content_start:content_end]
+        offset = content_end + 1
+    if offset != len(output):
+        raise ValueError("git cat-file --batch returned unexpected trailing output")
+    return blobs
 
 
 def _sha256(content: bytes) -> str:

--- a/src/axiom_encode/proof_hash_migration.py
+++ b/src/axiom_encode/proof_hash_migration.py
@@ -1,0 +1,387 @@
+"""Base-bound proof-import hash migration for repository schema changes."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Literal
+
+import yaml
+from yaml.nodes import MappingNode, Node, ScalarNode, SequenceNode
+
+from .constants import RULESPEC_ATOMIC_MODULE_ROOTS
+from .harness.validator_pipeline import _parse_rulespec_target
+
+REPORT_SCHEMA = "axiom-encode/proof-hash-cascade/v1"
+_CHECKOUT_NAME_RE = re.compile(r"rulespec-[a-z]{2}")
+
+
+@dataclass(frozen=True)
+class HashOccurrence:
+    importer_path: str
+    target: str
+    target_path: str
+    line: int
+    declared_hash: str
+    base_target_hash: str | None
+    current_target_hash: str | None
+    status: Literal[
+        "eligible",
+        "preexisting_mismatch",
+        "base_target_missing",
+        "current_target_missing",
+    ]
+    start_index: int
+    end_index: int
+    scalar_style: str | None
+
+    def public_record(self) -> dict[str, object]:
+        record = asdict(self)
+        for key in ("start_index", "end_index", "scalar_style"):
+            record.pop(key)
+        return record
+
+
+@dataclass(frozen=True)
+class CascadePlan:
+    root: Path
+    base_commit: str
+    head_commit: str
+    occurrences: tuple[HashOccurrence, ...]
+
+    @property
+    def eligible(self) -> tuple[HashOccurrence, ...]:
+        return tuple(item for item in self.occurrences if item.status == "eligible")
+
+    @property
+    def ignored(self) -> tuple[HashOccurrence, ...]:
+        return tuple(item for item in self.occurrences if item.status != "eligible")
+
+
+def build_proof_hash_cascade_plan(root: Path, base_ref: str) -> CascadePlan:
+    checkout = _validate_checkout(root)
+    base_commit = _git_text(checkout, "rev-parse", "--verify", f"{base_ref}^{{commit}}")
+    head_commit = _git_text(checkout, "rev-parse", "--verify", "HEAD^{commit}")
+    ancestor = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(checkout),
+            "merge-base",
+            "--is-ancestor",
+            base_commit,
+            head_commit,
+        ],
+        check=False,
+        capture_output=True,
+    )
+    if ancestor.returncode != 0:
+        raise ValueError(f"base ref {base_ref!r} is not an ancestor of HEAD")
+
+    tracked = _git_text(checkout, "ls-files", "-z", strip=False).split("\0")
+    module_paths = sorted(
+        path
+        for path in tracked
+        if path
+        and _is_atomic_module_path(Path(path))
+        and not path.endswith(".test.yaml")
+    )
+    base_hashes: dict[str, str | None] = {}
+    current_hashes: dict[str, str | None] = {}
+    occurrences: list[HashOccurrence] = []
+    for importer_path in module_paths:
+        content = (checkout / importer_path).read_text(encoding="utf-8")
+        for target_node, hash_node in _proof_import_scalar_nodes(content):
+            target = target_node.value.strip()
+            declared_hash = hash_node.value.strip()
+            if declared_hash == "sha256:local":
+                continue
+            target_ref = _parse_rulespec_target(target)
+            if target_ref is None:
+                continue
+            target_path = (
+                Path(target_ref.prefix) / target_ref.relative_path
+            ).as_posix()
+            if target_path not in current_hashes:
+                target_file = checkout / target_path
+                current_hashes[target_path] = (
+                    _sha256(target_file.read_bytes())
+                    if target_file.is_file() and not target_file.is_symlink()
+                    else None
+                )
+            if target_path not in base_hashes:
+                base_bytes = _git_file(checkout, base_commit, target_path)
+                base_hashes[target_path] = (
+                    _sha256(base_bytes) if base_bytes is not None else None
+                )
+            base_hash = base_hashes[target_path]
+            current_hash = current_hashes[target_path]
+            expected_base = f"sha256:{base_hash}" if base_hash else None
+            expected_current = f"sha256:{current_hash}" if current_hash else None
+            if expected_current is None:
+                status = "current_target_missing"
+            elif expected_base is None:
+                status = "base_target_missing"
+            elif declared_hash == expected_base and declared_hash != expected_current:
+                status = "eligible"
+            elif declared_hash != expected_current:
+                status = "preexisting_mismatch"
+            else:
+                continue
+            occurrences.append(
+                HashOccurrence(
+                    importer_path=importer_path,
+                    target=target,
+                    target_path=target_path,
+                    line=hash_node.start_mark.line + 1,
+                    declared_hash=declared_hash,
+                    base_target_hash=expected_base,
+                    current_target_hash=expected_current,
+                    status=status,
+                    start_index=hash_node.start_mark.index,
+                    end_index=hash_node.end_mark.index,
+                    scalar_style=hash_node.style,
+                )
+            )
+    return CascadePlan(
+        root=checkout,
+        base_commit=base_commit,
+        head_commit=head_commit,
+        occurrences=tuple(occurrences),
+    )
+
+
+def apply_proof_hash_cascade(plan: CascadePlan, report_path: Path) -> dict[str, object]:
+    current_head = _git_text(plan.root, "rev-parse", "--verify", "HEAD^{commit}")
+    if current_head != plan.head_commit:
+        raise ValueError("proof hash cascade plan HEAD changed before apply")
+    if _git_text(plan.root, "status", "--porcelain"):
+        raise ValueError("proof hash cascade apply requires a clean Git checkout")
+    report = _validate_report_path(plan.root, report_path)
+    grouped: dict[str, list[HashOccurrence]] = defaultdict(list)
+    for item in plan.eligible:
+        grouped[item.importer_path].append(item)
+    updated_files: dict[str, tuple[bytes, bytes, int]] = {}
+    for relative_path, items in sorted(grouped.items()):
+        path = plan.root / relative_path
+        original = path.read_text(encoding="utf-8")
+        updated = original
+        for item in sorted(items, key=lambda value: value.start_index, reverse=True):
+            if item.current_target_hash is None:
+                raise ValueError(
+                    f"eligible target unexpectedly has no current hash: {item.target_path}"
+                )
+            replacement = _render_scalar(item.current_target_hash, item.scalar_style)
+            updated = (
+                updated[: item.start_index] + replacement + updated[item.end_index :]
+            )
+        if updated == original:
+            raise ValueError(
+                f"eligible proof hash cascade produced no change: {relative_path}"
+            )
+        updated_files[relative_path] = (
+            original.encode("utf-8"),
+            updated.encode("utf-8"),
+            len(items),
+        )
+
+    applied_files: list[dict[str, object]] = []
+    for relative_path, (original, updated, replacement_count) in sorted(
+        updated_files.items()
+    ):
+        path = plan.root / relative_path
+        path.write_bytes(updated)
+        applied_files.append(
+            {
+                "path": relative_path,
+                "before_sha256": _sha256(original),
+                "after_sha256": _sha256(updated),
+                "replacements": replacement_count,
+            }
+        )
+
+    payload: dict[str, object] = {
+        "schema": REPORT_SCHEMA,
+        "base_commit": plan.base_commit,
+        "head_commit_before_apply": plan.head_commit,
+        "eligible_replacements": len(plan.eligible),
+        "ignored_mismatches": len(plan.ignored),
+        "applied_files": applied_files,
+        "replacements": [item.public_record() for item in plan.eligible],
+        "ignored": [item.public_record() for item in plan.ignored],
+    }
+    report.parent.mkdir(parents=True, exist_ok=True)
+    report.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return payload
+
+
+def render_proof_hash_cascade_plan(plan: CascadePlan, *, as_json: bool) -> str:
+    payload = {
+        "schema": REPORT_SCHEMA,
+        "base_commit": plan.base_commit,
+        "head_commit": plan.head_commit,
+        "eligible_replacements": len(plan.eligible),
+        "ignored_mismatches": len(plan.ignored),
+        "eligible": [item.public_record() for item in plan.eligible],
+        "ignored": [item.public_record() for item in plan.ignored],
+    }
+    if as_json:
+        return json.dumps(payload, indent=2, sort_keys=True)
+    lines = [
+        f"base_commit={plan.base_commit}",
+        f"head_commit={plan.head_commit}",
+        f"eligible_replacements={len(plan.eligible)}",
+        f"ignored_mismatches={len(plan.ignored)}",
+    ]
+    lines.extend(
+        f"eligible {item.importer_path}:{item.line} {item.target_path}"
+        for item in plan.eligible
+    )
+    lines.extend(
+        f"ignored[{item.status}] {item.importer_path}:{item.line} {item.target_path}"
+        for item in plan.ignored
+    )
+    return "\n".join(lines)
+
+
+def _validate_checkout(root: Path) -> Path:
+    checkout = Path(root).expanduser().resolve(strict=True)
+    if not checkout.is_dir() or not _CHECKOUT_NAME_RE.fullmatch(checkout.name):
+        raise ValueError("root must be a canonical rulespec-<country> checkout")
+    inside = _git_text(checkout, "rev-parse", "--is-inside-work-tree")
+    if inside != "true":
+        raise ValueError("root must be a Git worktree")
+    top_level = Path(_git_text(checkout, "rev-parse", "--show-toplevel")).resolve(
+        strict=True
+    )
+    if top_level != checkout:
+        raise ValueError("root must be the Git worktree root")
+    return checkout
+
+
+def _validate_report_path(root: Path, report_path: Path) -> Path:
+    raw = report_path if report_path.is_absolute() else root / report_path
+    resolved_parent = raw.parent.resolve(strict=False)
+    report = resolved_parent / raw.name
+    allowed = root / ".axiom" / "migrations"
+    try:
+        report.relative_to(allowed)
+    except ValueError as exc:
+        raise ValueError("report must be written under .axiom/migrations") from exc
+    if report.suffix != ".json":
+        raise ValueError("report path must end in .json")
+    if report.is_symlink():
+        raise ValueError("report path must not be a symlink")
+    if report.exists() and not report.is_file():
+        raise ValueError("report path must be a regular file")
+    return report
+
+
+def _is_atomic_module_path(path: Path) -> bool:
+    parts = path.parts
+    return (
+        len(parts) >= 3
+        and re.fullmatch(r"[a-z]{2}(?:-[a-z0-9-]+)*", parts[0]) is not None
+        and parts[1] in RULESPEC_ATOMIC_MODULE_ROOTS
+        and path.suffix == ".yaml"
+    )
+
+
+def _proof_import_scalar_nodes(content: str) -> list[tuple[ScalarNode, ScalarNode]]:
+    root = yaml.compose(content)
+    if root is None:
+        return []
+    found: list[tuple[ScalarNode, ScalarNode]] = []
+
+    def visit(node: Node) -> None:
+        if isinstance(node, MappingNode):
+            fields = {
+                key.value: value
+                for key, value in node.value
+                if isinstance(key, ScalarNode)
+            }
+            import_node = fields.get("import")
+            if isinstance(import_node, MappingNode):
+                import_fields = {
+                    key.value: value
+                    for key, value in import_node.value
+                    if isinstance(key, ScalarNode)
+                }
+                target = import_fields.get("target")
+                hash_node = import_fields.get("hash")
+                if isinstance(target, ScalarNode) and isinstance(hash_node, ScalarNode):
+                    found.append((target, hash_node))
+            for key, value in node.value:
+                visit(key)
+                visit(value)
+        elif isinstance(node, SequenceNode):
+            for value in node.value:
+                visit(value)
+
+    visit(root)
+    return found
+
+
+def _render_scalar(value: str, style: str | None) -> str:
+    if style is None:
+        return value
+    if style == "'":
+        return "'" + value.replace("'", "''") + "'"
+    if style == '"':
+        return json.dumps(value)
+    raise ValueError(f"unsupported proof hash scalar style: {style!r}")
+
+
+def _git_text(root: Path, *args: str, strip: bool = True) -> str:
+    completed = subprocess.run(
+        ["git", "-C", str(root), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise ValueError(f"git {' '.join(args)} failed: {detail}")
+    return completed.stdout.strip() if strip else completed.stdout
+
+
+def _git_file(root: Path, commit: str, path: str) -> bytes | None:
+    tree_entry = subprocess.run(
+        ["git", "-C", str(root), "ls-tree", "-z", commit, "--", path],
+        check=False,
+        capture_output=True,
+    )
+    if tree_entry.returncode != 0:
+        detail = tree_entry.stderr.decode(errors="replace").strip()
+        raise ValueError(f"git ls-tree failed for {commit}:{path}: {detail}")
+    if not tree_entry.stdout:
+        return None
+    metadata, separator, entry_path = tree_entry.stdout.rstrip(b"\0").partition(b"\t")
+    fields = metadata.split()
+    if separator != b"\t" or len(fields) != 3:
+        raise ValueError(f"unexpected git tree entry for {commit}:{path}")
+    mode, object_type, object_id = fields
+    if entry_path.decode(errors="surrogateescape") != path:
+        raise ValueError(f"git tree entry path mismatch for {commit}:{path}")
+    if mode == b"120000" or object_type != b"blob":
+        raise ValueError(f"base target must be a regular Git blob: {commit}:{path}")
+    blob = subprocess.run(
+        ["git", "-C", str(root), "cat-file", "blob", object_id.decode("ascii")],
+        check=False,
+        capture_output=True,
+    )
+    if blob.returncode != 0:
+        detail = blob.stderr.decode(errors="replace").strip()
+        raise ValueError(f"git cat-file failed for {commit}:{path}: {detail}")
+    return blob.stdout
+
+
+def _sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()

--- a/tests/test_proof_hash_migration.py
+++ b/tests/test_proof_hash_migration.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from axiom_encode.cli import cmd_migration_cascade_proof_hashes
+from axiom_encode.proof_hash_migration import (
+    REPORT_SCHEMA,
+    apply_proof_hash_cascade,
+    build_proof_hash_cascade_plan,
+)
+
+
+def _git(root: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(root), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _commit(root: Path, message: str) -> str:
+    _git(root, "add", "-A")
+    _git(root, "commit", "-m", message)
+    return _git(root, "rev-parse", "HEAD")
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _migration_repo(tmp_path: Path) -> tuple[Path, str, Path, Path]:
+    root = tmp_path / "rulespec-us"
+    root.mkdir()
+    _git(root, "init")
+    _git(root, "config", "user.email", "test@example.com")
+    _git(root, "config", "user.name", "Test")
+    target = root / "us-ak/policies/source.yaml"
+    importer = root / "us-ak/policies/importer.yaml"
+    target.parent.mkdir(parents=True)
+    target.write_text(
+        """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ak/policy/source/block-1
+rules:
+  - name: amount
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        value: 1
+"""
+    )
+    old_hash = _sha256(target)
+    importer.write_text(
+        f"""format: rulespec/v1
+imports:
+  - us-ak:policies/source#amount
+rules:
+  - name: result
+    kind: derived
+    dtype: Money
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ak:policies/source#amount
+              output: amount
+              hash: 'sha256:{old_hash}' # preserve this comment
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ak:policies/source#amount
+              output: amount
+              hash: sha256:preexisting
+    versions:
+      - effective_from: '2026-01-01'
+        formula: amount
+"""
+    )
+    base = _commit(root, "base")
+    target.write_text(
+        target.read_text().replace("rules:\n", "  summary: migrated\nrules:\n")
+    )
+    _commit(root, "migrate source metadata")
+    return root, base, target, importer
+
+
+def test_cascade_rewrites_only_exact_base_hash_and_preserves_format(tmp_path):
+    root, base, target, importer = _migration_repo(tmp_path)
+
+    plan = build_proof_hash_cascade_plan(root, base)
+
+    assert len(plan.eligible) == 1
+    assert plan.eligible[0].importer_path == "us-ak/policies/importer.yaml"
+    assert plan.eligible[0].target_path == "us-ak/policies/source.yaml"
+    assert [item.status for item in plan.ignored] == ["preexisting_mismatch"]
+
+    report_path = Path(".axiom/migrations/proof-hashes.json")
+    payload = apply_proof_hash_cascade(plan, report_path)
+    content = importer.read_text()
+    expected = f"sha256:{_sha256(target)}"
+
+    assert f"hash: '{expected}' # preserve this comment" in content
+    assert "hash: sha256:preexisting" in content
+    assert payload["schema"] == REPORT_SCHEMA
+    assert payload["eligible_replacements"] == 1
+    assert payload["ignored_mismatches"] == 1
+    assert payload["applied_files"] == [
+        {
+            "path": "us-ak/policies/importer.yaml",
+            "before_sha256": payload["applied_files"][0]["before_sha256"],
+            "after_sha256": _sha256(importer),
+            "replacements": 1,
+        }
+    ]
+    report = json.loads((root / report_path).read_text())
+    assert report == payload
+
+    post_apply = build_proof_hash_cascade_plan(root, base)
+    assert post_apply.eligible == ()
+    assert [item.status for item in post_apply.ignored] == ["preexisting_mismatch"]
+
+
+def test_cascade_reports_target_added_after_base_without_rewriting(tmp_path):
+    root = tmp_path / "rulespec-us"
+    root.mkdir()
+    _git(root, "init")
+    _git(root, "config", "user.email", "test@example.com")
+    _git(root, "config", "user.name", "Test")
+    marker = root / "README.md"
+    marker.write_text("base\n")
+    base = _commit(root, "base")
+    target = root / "us-ny/policies/new-source.yaml"
+    importer = root / "us-ny/policies/importer.yaml"
+    target.parent.mkdir(parents=True)
+    target.write_text("format: rulespec/v1\nrules: []\n")
+    importer.write_text(
+        """format: rulespec/v1
+rules:
+  - name: result
+    metadata:
+      proof:
+        atoms:
+          - kind: import
+            import:
+              target: us-ny:policies/new-source#amount
+              hash: sha256:old
+    versions: []
+"""
+    )
+    _commit(root, "add source and importer")
+
+    plan = build_proof_hash_cascade_plan(root, base)
+
+    assert plan.eligible == ()
+    assert [item.status for item in plan.ignored] == ["base_target_missing"]
+
+
+def test_cascade_requires_ancestor_base(tmp_path):
+    root, base, _target, _importer = _migration_repo(tmp_path)
+    _git(root, "checkout", "--orphan", "unrelated")
+    _git(root, "rm", "-rf", ".")
+    (root / "README.md").write_text("unrelated\n")
+    _commit(root, "unrelated")
+
+    with pytest.raises(ValueError, match="is not an ancestor of HEAD"):
+        build_proof_hash_cascade_plan(root, base)
+
+
+def test_cascade_apply_rejects_dirty_checkout(tmp_path):
+    root, base, _target, importer = _migration_repo(tmp_path)
+    plan = build_proof_hash_cascade_plan(root, base)
+    importer.write_text(importer.read_text() + "# dirty\n")
+
+    with pytest.raises(ValueError, match="requires a clean Git checkout"):
+        apply_proof_hash_cascade(plan, Path(".axiom/migrations/proof-hashes.json"))
+
+    assert not (root / ".axiom/migrations/proof-hashes.json").exists()
+
+
+def test_cascade_apply_rejects_changed_head(tmp_path):
+    root, base, _target, _importer = _migration_repo(tmp_path)
+    plan = build_proof_hash_cascade_plan(root, base)
+    (root / "README.md").write_text("new head\n")
+    _commit(root, "advance head")
+
+    with pytest.raises(ValueError, match="plan HEAD changed before apply"):
+        apply_proof_hash_cascade(plan, Path(".axiom/migrations/proof-hashes.json"))
+
+
+def test_cascade_apply_rejects_report_path_escape_and_symlink(tmp_path):
+    root, base, _target, _importer = _migration_repo(tmp_path)
+    plan = build_proof_hash_cascade_plan(root, base)
+
+    with pytest.raises(ValueError, match="under .axiom/migrations"):
+        apply_proof_hash_cascade(plan, Path("../escaped.json"))
+
+    migrations = root / ".axiom/migrations"
+    migrations.mkdir(parents=True)
+    outside = tmp_path / "outside.json"
+    report = migrations / "proof-hashes.json"
+    report.symlink_to(outside)
+    _commit(root, "track report symlink")
+    symlink_plan = build_proof_hash_cascade_plan(root, base)
+
+    with pytest.raises(ValueError, match="must not be a symlink"):
+        apply_proof_hash_cascade(symlink_plan, report)
+
+    assert not outside.exists()
+
+
+def test_cascade_requires_exact_worktree_root(tmp_path):
+    root, base, _target, _importer = _migration_repo(tmp_path)
+    nested = root / "rulespec-us"
+    nested.mkdir()
+
+    with pytest.raises(ValueError, match="must be the Git worktree root"):
+        build_proof_hash_cascade_plan(nested, base)
+
+
+def test_cascade_command_check_apply_and_post_apply_check(tmp_path, capsys):
+    root, base, _target, _importer = _migration_repo(tmp_path)
+    args = SimpleNamespace(
+        root=root,
+        base_ref=base,
+        check=True,
+        apply=False,
+        report=None,
+        json=True,
+    )
+
+    assert cmd_migration_cascade_proof_hashes(args) == 1
+    assert json.loads(capsys.readouterr().out)["eligible_replacements"] == 1
+
+    args.check = False
+    args.apply = True
+    args.report = Path(".axiom/migrations/proof-hashes.json")
+    assert cmd_migration_cascade_proof_hashes(args) == 0
+    assert json.loads(capsys.readouterr().out)["eligible_replacements"] == 1
+
+    _commit(root, "apply proof hash cascade")
+    args.check = True
+    args.apply = False
+    args.report = None
+    assert cmd_migration_cascade_proof_hashes(args) == 0
+    assert json.loads(capsys.readouterr().out)["eligible_replacements"] == 0
+
+
+def test_cascade_command_requires_report_only_for_apply(tmp_path, capsys):
+    root, base, _target, _importer = _migration_repo(tmp_path)
+    args = SimpleNamespace(
+        root=root,
+        base_ref=base,
+        check=False,
+        apply=True,
+        report=None,
+        json=False,
+    )
+
+    assert cmd_migration_cascade_proof_hashes(args) == 2
+    assert "--report is required with --apply" in capsys.readouterr().err
+
+    args.check = True
+    args.apply = False
+    args.report = Path(".axiom/migrations/unexpected.json")
+    assert cmd_migration_cascade_proof_hashes(args) == 2
+    assert "--report is only valid with --apply" in capsys.readouterr().err

--- a/tests/test_proof_hash_migration.py
+++ b/tests/test_proof_hash_migration.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 
 import pytest
 
+import axiom_encode.proof_hash_migration as proof_hash_migration
 from axiom_encode.cli import cmd_migration_cascade_proof_hashes
 from axiom_encode.proof_hash_migration import (
     REPORT_SCHEMA,
@@ -33,6 +34,26 @@ def _commit(root: Path, message: str) -> str:
 
 def _sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _proof_import_module(target: str, target_hash: str) -> str:
+    return f"""format: rulespec/v1
+rules:
+  - name: result
+    kind: derived
+    dtype: Money
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: {target}#amount
+              hash: sha256:{target_hash}
+    versions:
+      - effective_from: '2026-01-01'
+        formula: amount
+"""
 
 
 def _migration_repo(tmp_path: Path) -> tuple[Path, str, Path, Path]:
@@ -126,6 +147,7 @@ def test_cascade_rewrites_only_exact_base_hash_and_preserves_format(tmp_path):
     report = json.loads((root / report_path).read_text())
     assert report == payload
 
+    _commit(root, "apply proof hash cascade")
     post_apply = build_proof_hash_cascade_plan(root, base)
     assert post_apply.eligible == ()
     assert [item.status for item in post_apply.ignored] == ["preexisting_mismatch"]
@@ -205,6 +227,11 @@ def test_cascade_apply_rejects_report_path_escape_and_symlink(tmp_path):
     with pytest.raises(ValueError, match="under .axiom/migrations"):
         apply_proof_hash_cascade(plan, Path("../escaped.json"))
 
+    with pytest.raises(ValueError, match="directly under .axiom/migrations"):
+        apply_proof_hash_cascade(
+            plan, Path(".axiom/migrations/nested/proof-hashes.json")
+        )
+
     migrations = root / ".axiom/migrations"
     migrations.mkdir(parents=True)
     outside = tmp_path / "outside.json"
@@ -224,8 +251,469 @@ def test_cascade_requires_exact_worktree_root(tmp_path):
     nested = root / "rulespec-us"
     nested.mkdir()
 
-    with pytest.raises(ValueError, match="must be the Git worktree root"):
+    with pytest.raises(ValueError, match="canonical rulespec-<country>"):
         build_proof_hash_cascade_plan(nested, base)
+
+
+def test_cascade_selects_only_rule_proof_import_atoms(tmp_path):
+    root, base, target, importer = _migration_repo(tmp_path)
+    content = importer.read_text()
+    base_hash = content.split("hash: 'sha256:", 1)[1].split("'", 1)[0]
+    distracting = f"""module:
+  import:
+    target: us-ak:policies/source#amount
+    hash: sha256:{base_hash}
+"""
+    importer.write_text(content.replace("imports:\n", distracting + "imports:\n"))
+    _commit(root, "add non-proof import mapping")
+    target.write_text(target.read_text() + "# another migration\n")
+    _commit(root, "migrate target again")
+
+    plan = build_proof_hash_cascade_plan(root, base)
+
+    assert len(plan.eligible) == 1
+    apply_proof_hash_cascade(plan, Path(".axiom/migrations/proof-hashes.json"))
+    updated = importer.read_text()
+    assert f"    hash: sha256:{base_hash}\n" in updated
+    assert f"hash: 'sha256:{_sha256(target)}'" in updated
+
+
+def test_cascade_resolves_transitive_importers_to_final_hashes(tmp_path):
+    root = tmp_path / "rulespec-us"
+    root.mkdir()
+    _git(root, "init")
+    _git(root, "config", "user.email", "test@example.com")
+    _git(root, "config", "user.name", "Test")
+    module_root = root / "us-ak/policies"
+    module_root.mkdir(parents=True)
+    leaf = module_root / "leaf.yaml"
+    middle = module_root / "middle.yaml"
+    top = module_root / "top.yaml"
+    leaf.write_text("format: rulespec/v1\nrules: []\n")
+    middle.write_text(_proof_import_module("us-ak:policies/leaf", _sha256(leaf)))
+    top.write_text(_proof_import_module("us-ak:policies/middle", _sha256(middle)))
+    base = _commit(root, "base import chain")
+    leaf.write_text(leaf.read_text() + "# migrated\n")
+    _commit(root, "migrate leaf")
+
+    plan = build_proof_hash_cascade_plan(root, base)
+
+    assert len(plan.eligible) == 2
+    assert {item.importer_path for item in plan.eligible} == {
+        "us-ak/policies/middle.yaml",
+        "us-ak/policies/top.yaml",
+    }
+    apply_proof_hash_cascade(plan, Path(".axiom/migrations/transitive.json"))
+    assert f"hash: sha256:{_sha256(leaf)}" in middle.read_text()
+    assert f"hash: sha256:{_sha256(middle)}" in top.read_text()
+    _commit(root, "apply transitive proof hash cascade")
+    assert build_proof_hash_cascade_plan(root, base).eligible == ()
+
+
+def test_cascade_rejects_new_staleness_for_non_base_authorized_import(tmp_path):
+    root = tmp_path / "rulespec-us"
+    root.mkdir()
+    _git(root, "init")
+    _git(root, "config", "user.email", "test@example.com")
+    _git(root, "config", "user.name", "Test")
+    module_root = root / "us-ak/policies"
+    module_root.mkdir(parents=True)
+    leaf = module_root / "leaf.yaml"
+    middle = module_root / "middle.yaml"
+    top = module_root / "top.yaml"
+    leaf.write_text("format: rulespec/v1\nrules: []\n")
+    middle.write_text(_proof_import_module("us-ak:policies/leaf", _sha256(leaf)))
+    top.write_text(_proof_import_module("us-ak:policies/middle", _sha256(middle)))
+    base = _commit(root, "base import chain")
+    leaf.write_text(leaf.read_text() + "# migrated\n")
+    middle.write_text(middle.read_text() + "# independently changed\n")
+    top.write_text(_proof_import_module("us-ak:policies/middle", _sha256(middle)))
+    _commit(root, "advance target and dependent")
+
+    with pytest.raises(ValueError, match="non-base-authorized proof import"):
+        build_proof_hash_cascade_plan(root, base)
+
+
+def test_cascade_rejects_duplicate_proof_import_keys(tmp_path):
+    root, base, _target, importer = _migration_repo(tmp_path)
+    importer.write_text(
+        importer.read_text().replace(
+            "              hash: 'sha256:",
+            "              target: us-ak:policies/source#duplicate\n"
+            "              hash: 'sha256:",
+            1,
+        )
+    )
+    _commit(root, "add duplicate proof target")
+
+    with pytest.raises(ValueError, match="contains duplicate key 'target'"):
+        build_proof_hash_cascade_plan(root, base)
+
+
+def test_cascade_rejects_tracked_symlink_importer(tmp_path):
+    root, base, _target, importer = _migration_repo(tmp_path)
+    external = tmp_path / "external-importer.yaml"
+    external.write_text(importer.read_text())
+    importer.unlink()
+    importer.symlink_to(external)
+    _commit(root, "replace importer with symlink")
+
+    with pytest.raises(ValueError, match="importer must not contain a symlink"):
+        build_proof_hash_cascade_plan(root, base)
+
+    assert "sha256:preexisting" in external.read_text()
+
+
+def test_cascade_rejects_tracked_symlink_target(tmp_path):
+    root, base, target, _importer = _migration_repo(tmp_path)
+    external = tmp_path / "external-target.yaml"
+    external.write_text(target.read_text())
+    target.unlink()
+    target.symlink_to(external)
+    _commit(root, "replace target with symlink")
+
+    with pytest.raises(
+        ValueError, match="proof import target must not contain a symlink"
+    ):
+        build_proof_hash_cascade_plan(root, base)
+
+
+def test_cascade_rejects_ignored_target_missing_from_head(tmp_path):
+    root = tmp_path / "rulespec-us"
+    root.mkdir()
+    _git(root, "init")
+    _git(root, "config", "user.email", "test@example.com")
+    _git(root, "config", "user.name", "Test")
+    module_root = root / "us-ak/policies"
+    module_root.mkdir(parents=True)
+    target = module_root / "ignored-target.yaml"
+    importer = module_root / "importer.yaml"
+    target.write_text("format: rulespec/v1\nrules: []\n")
+    importer.write_text(
+        _proof_import_module("us-ak:policies/ignored-target", _sha256(target))
+    )
+    (root / ".gitignore").write_text("us-ak/policies/ignored-target.yaml\n")
+    base = _commit(root, "track importer but ignore target")
+
+    assert _git(root, "status", "--porcelain") == ""
+    with pytest.raises(ValueError, match="proof import target is missing from HEAD"):
+        build_proof_hash_cascade_plan(root, base)
+
+
+@pytest.mark.parametrize(
+    ("hidden_file", "message"),
+    [
+        ("target", "proof import target worktree bytes differ from HEAD"),
+        ("importer", "importer worktree bytes differ from HEAD"),
+    ],
+)
+def test_cascade_rejects_assume_unchanged_worktree_bytes(
+    tmp_path, hidden_file, message
+):
+    root, base, target, importer = _migration_repo(tmp_path)
+    path = target if hidden_file == "target" else importer
+    path.write_text(path.read_text() + "# hidden worktree change\n")
+    relative = path.relative_to(root).as_posix()
+    _git(root, "update-index", "--assume-unchanged", relative)
+
+    assert _git(root, "status", "--porcelain") == ""
+    with pytest.raises(ValueError, match=message):
+        build_proof_hash_cascade_plan(root, base)
+
+
+def test_cascade_rejects_proof_hash_alias_outside_import_field(tmp_path):
+    root = tmp_path / "rulespec-us"
+    root.mkdir()
+    _git(root, "init")
+    _git(root, "config", "user.email", "test@example.com")
+    _git(root, "config", "user.name", "Test")
+    module_root = root / "us-ak/policies"
+    module_root.mkdir(parents=True)
+    target = module_root / "source.yaml"
+    importer = module_root / "importer.yaml"
+    target.write_text("format: rulespec/v1\nrules: []\n")
+    importer.write_text(
+        f"""format: rulespec/v1
+shared_hash: &shared_hash sha256:{_sha256(target)}
+rules:
+  - name: result
+    kind: derived
+    dtype: Money
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ak:policies/source#amount
+              hash: *shared_hash
+    versions:
+      - effective_from: '2026-01-01'
+        formula: amount
+"""
+    )
+    base = _commit(root, "base aliased proof hash")
+    target.write_text(target.read_text() + "# migrated\n")
+    _commit(root, "migrate source")
+
+    with pytest.raises(ValueError, match="YAML alias outside its field"):
+        build_proof_hash_cascade_plan(root, base)
+
+
+def test_cascade_rejects_directly_anchored_proof_hash(tmp_path):
+    root, base, _target, importer = _migration_repo(tmp_path)
+    importer.write_text(
+        importer.read_text().replace("hash: 'sha256:", "hash: &proof_hash 'sha256:")
+    )
+    _commit(root, "anchor proof hash")
+
+    with pytest.raises(ValueError, match="contains YAML anchors or aliases"):
+        build_proof_hash_cascade_plan(root, base)
+
+
+def test_cascade_rejects_nested_import_mapping_alias(tmp_path):
+    root = tmp_path / "rulespec-us"
+    root.mkdir()
+    _git(root, "init")
+    _git(root, "config", "user.email", "test@example.com")
+    _git(root, "config", "user.name", "Test")
+    module_root = root / "us-ak/policies"
+    module_root.mkdir(parents=True)
+    target = module_root / "source.yaml"
+    importer = module_root / "importer.yaml"
+    target.write_text("format: rulespec/v1\nrules: []\n")
+    importer.write_text(
+        f"""format: rulespec/v1
+rules:
+  - name: result
+    kind: derived
+    dtype: Money
+    metadata:
+      proof:
+        atoms:
+          - kind: custom
+            shared_import: &shared_import
+              target: us-ak:policies/source#amount
+              hash: sha256:{_sha256(target)}
+          - path: versions[0].formula
+            kind: import
+            import: *shared_import
+    versions:
+      - effective_from: '2026-01-01'
+        formula: amount
+"""
+    )
+    base = _commit(root, "base nested import alias")
+    target.write_text(target.read_text() + "# migrated\n")
+    _commit(root, "migrate source")
+
+    with pytest.raises(ValueError, match="YAML alias outside its field"):
+        build_proof_hash_cascade_plan(root, base)
+
+
+def test_cascade_rejects_ancestor_anchor_inherited_by_yaml_merge(tmp_path):
+    root, base, _target, importer = _migration_repo(tmp_path)
+    content = importer.read_text().replace(
+        "    metadata:\n      proof:",
+        "    metadata: &shared_metadata\n      proof:",
+        1,
+    )
+    importer.write_text(
+        content
+        + """  - name: inherited_result
+    kind: derived
+    dtype: Money
+    metadata:
+      <<: *shared_metadata
+    versions:
+      - effective_from: '2026-01-01'
+        formula: amount
+"""
+    )
+    _commit(root, "inherit anchored metadata with YAML merge")
+
+    with pytest.raises(ValueError, match="contains a YAML merge key"):
+        build_proof_hash_cascade_plan(root, base)
+
+
+def test_cascade_rejects_alias_used_as_mapping_key(tmp_path):
+    root, base, _target, importer = _migration_repo(tmp_path)
+    content = importer.read_text().replace(
+        "format: rulespec/v1\n",
+        "format: rulespec/v1\nshared_key: &metadata_key metadata\n",
+        1,
+    )
+    importer.write_text(content.replace("    metadata:\n", "    *metadata_key:\n", 1))
+    _commit(root, "use alias as metadata mapping key")
+
+    with pytest.raises(ValueError, match="contains a YAML alias mapping key"):
+        build_proof_hash_cascade_plan(root, base)
+
+
+def test_cascade_rejects_alias_used_as_rule_sequence_item(tmp_path):
+    root = tmp_path / "rulespec-us"
+    root.mkdir()
+    _git(root, "init")
+    _git(root, "config", "user.email", "test@example.com")
+    _git(root, "config", "user.name", "Test")
+    module_root = root / "us-ak/policies"
+    module_root.mkdir(parents=True)
+    target = module_root / "source.yaml"
+    importer = module_root / "importer.yaml"
+    target.write_text("format: rulespec/v1\nrules: []\n")
+    importer.write_text(
+        f"""format: rulespec/v1
+rules:
+  - name: anchor_holder
+    shared_rule: &shared_rule
+      name: result
+      kind: derived
+      dtype: Money
+      metadata:
+        proof:
+          atoms:
+            - path: versions[0].formula
+              kind: import
+              import:
+                target: us-ak:policies/source#amount
+                hash: sha256:{_sha256(target)}
+      versions:
+        - effective_from: '2026-01-01'
+          formula: amount
+  - *shared_rule
+"""
+    )
+    base = _commit(root, "base rule sequence alias")
+    target.write_text(target.read_text() + "# migrated\n")
+    _commit(root, "migrate source")
+
+    with pytest.raises(ValueError, match="YAML alias outside its sequence item"):
+        build_proof_hash_cascade_plan(root, base)
+
+
+def test_cascade_ignores_importers_outside_checkout_country(tmp_path):
+    root = tmp_path / "rulespec-us"
+    root.mkdir()
+    _git(root, "init")
+    _git(root, "config", "user.email", "test@example.com")
+    _git(root, "config", "user.name", "Test")
+    module_root = root / "ca/policies"
+    module_root.mkdir(parents=True)
+    target = module_root / "source.yaml"
+    importer = module_root / "importer.yaml"
+    target.write_text("format: rulespec/v1\nrules: []\n")
+    importer.write_text(_proof_import_module("ca:policies/source", _sha256(target)))
+    base = _commit(root, "base foreign-country modules")
+    target.write_text(target.read_text() + "# migrated\n")
+    _commit(root, "migrate foreign-country target")
+
+    plan = build_proof_hash_cascade_plan(root, base)
+
+    assert plan.occurrences == ()
+
+
+def test_cascade_rejects_cross_country_target(tmp_path):
+    root, base, _target, importer = _migration_repo(tmp_path)
+    importer.write_text(importer.read_text().replace("us-ak:policies", "ca:policies"))
+    _commit(root, "add cross-country target")
+
+    with pytest.raises(ValueError, match="does not belong to rulespec-us"):
+        build_proof_hash_cascade_plan(root, base)
+
+
+def test_cascade_rejects_existing_report(tmp_path):
+    root, base, _target, _importer = _migration_repo(tmp_path)
+    report = root / ".axiom/migrations/proof-hashes.json"
+    report.parent.mkdir(parents=True)
+    report.write_text("{}\n")
+    _commit(root, "reserve migration report")
+    plan = build_proof_hash_cascade_plan(root, base)
+
+    with pytest.raises(ValueError, match="must not already exist"):
+        apply_proof_hash_cascade(plan, report)
+
+    assert report.read_text() == "{}\n"
+
+
+def test_cascade_rejects_symlink_checkout_alias(tmp_path):
+    root, base, _target, _importer = _migration_repo(tmp_path)
+    alias_parent = tmp_path / "alias"
+    alias_parent.mkdir()
+    alias = alias_parent / "rulespec-us"
+    alias.symlink_to(root, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="canonical rulespec-<country>"):
+        build_proof_hash_cascade_plan(alias, base)
+
+
+def test_cascade_journals_and_rolls_back_when_importer_write_fails(
+    tmp_path, monkeypatch
+):
+    root, base, _target, importer = _migration_repo(tmp_path)
+    original = importer.read_bytes()
+    report = root / ".axiom/migrations/proof-hashes.json"
+    plan = build_proof_hash_cascade_plan(root, base)
+    real_atomic_replace = proof_hash_migration._atomic_replace_bytes
+
+    def fail_importer(path, content, *, mode):
+        if path == importer and content != original:
+            assert json.loads(report.read_text())["status"] == "prepared"
+            raise OSError("simulated importer write failure")
+        real_atomic_replace(path, content, mode=mode)
+
+    monkeypatch.setattr(proof_hash_migration, "_atomic_replace_bytes", fail_importer)
+
+    with pytest.raises(OSError, match="simulated importer write failure"):
+        apply_proof_hash_cascade(plan, report)
+
+    assert importer.read_bytes() == original
+    audit = json.loads(report.read_text())
+    assert audit["status"] == "rolled_back"
+    assert audit["failure"] == "OSError: simulated importer write failure"
+
+
+def test_cascade_fsyncs_each_created_audit_directory_parent(tmp_path, monkeypatch):
+    root, base, _target, _importer = _migration_repo(tmp_path)
+    plan = build_proof_hash_cascade_plan(root, base)
+    observed: list[Path] = []
+    real_fsync_directory = proof_hash_migration._fsync_directory
+
+    def observe_fsync(path):
+        observed.append(path)
+        real_fsync_directory(path)
+
+    monkeypatch.setattr(proof_hash_migration, "_fsync_directory", observe_fsync)
+
+    apply_proof_hash_cascade(plan, Path(".axiom/migrations/proof-hashes.json"))
+
+    assert root in observed
+    assert root / ".axiom" in observed
+    assert root / ".axiom/migrations" in observed
+
+
+def test_cascade_rolls_back_when_report_finalization_fails(tmp_path, monkeypatch):
+    root, base, _target, importer = _migration_repo(tmp_path)
+    original = importer.read_bytes()
+    report = root / ".axiom/migrations/proof-hashes.json"
+    plan = build_proof_hash_cascade_plan(root, base)
+    real_atomic_replace = proof_hash_migration._atomic_replace_bytes
+
+    def fail_complete_report(path, content, *, mode):
+        if path == report and json.loads(content)["status"] == "complete":
+            raise OSError("simulated report finalization failure")
+        real_atomic_replace(path, content, mode=mode)
+
+    monkeypatch.setattr(
+        proof_hash_migration, "_atomic_replace_bytes", fail_complete_report
+    )
+
+    with pytest.raises(OSError, match="simulated report finalization failure"):
+        apply_proof_hash_cascade(plan, report)
+
+    assert importer.read_bytes() == original
+    audit = json.loads(report.read_text())
+    assert audit["status"] == "rolled_back"
+    assert audit["failure"] == "OSError: simulated report finalization failure"
 
 
 def test_cascade_command_check_apply_and_post_apply_check(tmp_path, capsys):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1268"
+version = "0.2.1269"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- add a deterministic migration command that cascades proof-import hashes only when the declared hash exactly matches the target blob at a required ancestor commit
- require a clean canonical country RuleSpec checkout, unchanged HEAD bytes, and a durable JSON audit report under `.axiom/migrations` for apply
- report but never rewrite pre-existing or missing-target mismatches; reject aliases, symlinks, non-blob targets, and cross-country discovery

## Validation
- `uv run --python 3.13 --extra dev ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run --python 3.13 --extra dev python -m compileall -q src/axiom_encode scripts`
- `uv run --python 3.13 --extra dev pytest` (4,063 passed, 106 skipped)
- focused migration suite: 31 passed
- repository-scale check against rulespec-us PR #911: 183 eligible replacements across 81 files and 5 preserved pre-existing mismatches
- disposable transactional apply: complete; 183 hash-only replacements and durable report
- hosted CI: lint, Python 3.13, Ubuntu build, and macOS build all pass on `056b61b2bf0eb6d066db7349f898b774b197c0ca`

## Review cycle
- [x] independent review requested
- [x] prior actionable findings fixed
- [x] focused checks rerun
- [ ] no actionable findings remain on final SHA
- [x] broad local checks pass
- [x] hosted CI passes

## Residual risk
- apply assumes exclusive use of the checkout; clean-tree, HEAD-byte, and in-transaction postchecks detect drift, but there is no interprocess filesystem lock