### PR TITLE
Add trusted targeted RuleSpec re-encode workflow

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -1,0 +1,229 @@
+name: Targeted signed RuleSpec re-encode
+
+on:
+  workflow_dispatch:
+    inputs:
+      citation:
+        description: Canonical corpus citation path
+        required: true
+        type: string
+      rulespec_ref:
+        description: Immutable rulespec-us commit SHA to re-encode
+        required: true
+        type: string
+      corpus_ref:
+        description: Immutable axiom-corpus commit SHA
+        required: true
+        type: string
+      rules_engine_ref:
+        description: Immutable axiom-rules-engine commit SHA
+        required: true
+        type: string
+      review_finding:
+        description: Validator or independent-review finding to address
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: targeted-signed-reencode
+  cancel-in-progress: false
+
+jobs:
+  encode:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout axiom-encode
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: axiom-encode
+          persist-credentials: false
+
+      - name: Checkout rulespec-us
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: TheAxiomFoundation/rulespec-us
+          ref: ${{ inputs.rulespec_ref }}
+          path: rulespec-us
+          token: ${{ secrets.AXIOM_REPO_TOKEN || secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+
+      - name: Checkout axiom-corpus
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: TheAxiomFoundation/axiom-corpus
+          ref: ${{ inputs.corpus_ref }}
+          path: axiom-corpus
+          token: ${{ secrets.AXIOM_REPO_TOKEN || secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+
+      - name: Checkout axiom-rules-engine
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: TheAxiomFoundation/axiom-rules-engine
+          ref: ${{ inputs.rules_engine_ref }}
+          path: axiom-rules-engine
+          token: ${{ secrets.AXIOM_REPO_TOKEN || secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.11.7"
+
+      - name: Set up Go 1.26.1
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: 1.26.1
+          cache: false
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30
+
+      - name: Build Axiom rules engine
+        working-directory: axiom-rules-engine
+        run: |
+          cargo build --release --locked
+          test -x target/release/axiom-rules-engine
+
+      - name: Install encoder
+        working-directory: axiom-encode
+        run: |
+          uv sync --locked --python 3.13 --extra api
+          rm -rf "$RUNNER_TEMP/axiom-verification-site-packages"
+          uv pip install --python .venv/bin/python \
+            --target "$RUNNER_TEMP/axiom-verification-site-packages" ".[api]"
+
+      - name: Provision protected signing supervisor
+        working-directory: axiom-encode
+        env:
+          TRUST_APPLY_ROOT: ${{ vars.AXIOM_ENCODE_APPLY_SIGNING_PUBLIC_KEY }}
+          TRUST_EVAL_ROOT: ${{ vars.AXIOM_ENCODE_EVAL_SIGNING_PUBLIC_KEY }}
+          TRUST_CORPUS_RELEASE_ROOT: ${{ vars.AXIOM_CORPUS_RELEASE_PUBLIC_KEY }}
+        run: |
+          CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags='-buildid=' \
+            -o "$RUNNER_TEMP/axiom-encode-signing-supervisor" \
+            ./cmd/axiom-encode-signing-supervisor
+          CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags='-buildid=' \
+            -o "$RUNNER_TEMP/axiom-encode-apply-signer" \
+            ./cmd/axiom-encode-apply-signer
+          sudo rm -rf /opt/axiom-verification
+          sudo .venv/bin/python scripts/provision_verification_supervisor.py \
+            --destination /opt/axiom-verification \
+            --supervisor "$RUNNER_TEMP/axiom-encode-signing-supervisor" \
+            --site-packages "$RUNNER_TEMP/axiom-verification-site-packages" \
+            --apply-root "$TRUST_APPLY_ROOT" \
+            --eval-root "$TRUST_EVAL_ROOT" \
+            --corpus-release-root "$TRUST_CORPUS_RELEASE_ROOT"
+          sudo install -o root -g root -m 0755 \
+            "$RUNNER_TEMP/axiom-encode-apply-signer" \
+            /opt/axiom-verification/axiom-encode-apply-signer
+          sudo chown -R 0:0 /opt/axiom-verification
+          sudo chmod -R go-w /opt/axiom-verification
+
+      - name: Encode, review, validate, and apply
+        env:
+          AXIOM_ENCODE_APPLY_SIGNING_KEY: ${{ secrets.AXIOM_ENCODE_APPLY_SIGNING_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          CITATION: ${{ inputs.citation }}
+          REVIEW_FINDING: ${{ inputs.review_finding }}
+        run: |
+          args=(
+            /opt/axiom-verification/axiom-encode encode
+            --backend openai
+            --corpus-path "$GITHUB_WORKSPACE/axiom-corpus"
+            --axiom-rules-engine-path "$GITHUB_WORKSPACE/axiom-rules-engine"
+            --policy-repo-path "$GITHUB_WORKSPACE/rulespec-us"
+            --output "$RUNNER_TEMP/generated"
+            --mode repo-augmented
+            --db "$RUNNER_TEMP/encodings.db"
+            --no-sync
+            --apply
+          )
+          if [ -n "$REVIEW_FINDING" ]; then
+            args+=(--review-findings "$REVIEW_FINDING")
+          fi
+          args+=("$CITATION")
+
+          /opt/axiom-verification/axiom-encode-apply-signer run \
+            --scope apply_ed25519 \
+            --key-env AXIOM_ENCODE_APPLY_SIGNING_KEY \
+            --supervisor /opt/axiom-verification/axiom-encode-signing-supervisor \
+            --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
+            --trusted-python-runtime-root /opt/axiom-verification/python \
+            --trusted-python-import-root /opt/axiom-verification/python/lib/python3.13/site-packages \
+            --trusted-python-package-root /opt/axiom-verification/python/lib/python3.13/site-packages/axiom_encode \
+            --expected-github-repository TheAxiomFoundation/axiom-encode \
+            --allowed-workflow-ref TheAxiomFoundation/axiom-encode/.github/workflows/targeted-signed-reencode.yml@refs/heads/main \
+            --allowed-event-name workflow_dispatch \
+            -- "${args[@]}"
+
+      - name: Verify generated provenance
+        env:
+          RULESPEC_REF: ${{ inputs.rulespec_ref }}
+        run: |
+          /opt/axiom-verification/axiom-encode-signing-supervisor \
+            --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
+            --trusted-python-runtime-root /opt/axiom-verification/python \
+            --trusted-python-import-root /opt/axiom-verification/python/lib/python3.13/site-packages \
+            --trusted-python-package-root /opt/axiom-verification/python/lib/python3.13/site-packages/axiom_encode \
+            -- /opt/axiom-verification/axiom-encode guard-generated \
+            --repo "$GITHUB_WORKSPACE/rulespec-us" \
+            --base-ref "$RULESPEC_REF" \
+            --corpus-path "$GITHUB_WORKSPACE/axiom-corpus" \
+            --expected-encoder-checkout "$GITHUB_WORKSPACE/axiom-encode" \
+            --json > "$RUNNER_TEMP/guard-generated.json"
+          git -C rulespec-us diff --check
+
+      - name: Package exact generated changes
+        env:
+          CITATION: ${{ inputs.citation }}
+          RULESPEC_REF: ${{ inputs.rulespec_ref }}
+        run: |
+          artifact="$RUNNER_TEMP/targeted-reencode"
+          mkdir -p "$artifact"
+          git -C rulespec-us diff --binary --full-index HEAD > "$artifact/tracked.patch"
+          git -C rulespec-us ls-files --others --exclude-standard -z \
+            | tar -C rulespec-us --null -czf "$artifact/untracked.tar.gz" --files-from -
+          git -C rulespec-us status --short > "$artifact/status.txt"
+          cp "$RUNNER_TEMP/guard-generated.json" "$artifact/guard-generated.json"
+          python - "$artifact/metadata.json" <<'PY'
+          import json
+          import os
+          import subprocess
+          import sys
+
+          def rev(path):
+              return subprocess.check_output(
+                  ["git", "-C", path, "rev-parse", "HEAD"], text=True
+              ).strip()
+
+          payload = {
+              "schema": "axiom-encode/targeted-reencode-artifact/v1",
+              "citation": os.environ["CITATION"],
+              "rulespec_base": os.environ["RULESPEC_REF"],
+              "encoder_commit": rev("axiom-encode"),
+              "corpus_commit": rev("axiom-corpus"),
+              "rules_engine_commit": rev("axiom-rules-engine"),
+              "workflow_run_id": os.environ["GITHUB_RUN_ID"],
+          }
+          with open(sys.argv[1], "w", encoding="utf-8") as stream:
+              json.dump(payload, stream, indent=2, sort_keys=True)
+              stream.write("\n")
+          PY
+          sha256sum "$artifact"/* > "$artifact/SHA256SUMS"
+          test -s "$artifact/status.txt"
+
+      - name: Upload signed re-encode artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: targeted-reencode-${{ github.run_id }}
+          path: ${{ runner.temp }}/targeted-reencode
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -33,6 +33,8 @@ concurrency:
 
 jobs:
   encode:
+    if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
+    environment: production-signing
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
@@ -40,6 +42,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: axiom-encode
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Checkout rulespec-us
@@ -48,6 +51,7 @@ jobs:
           repository: TheAxiomFoundation/rulespec-us
           ref: ${{ inputs.rulespec_ref }}
           path: rulespec-us
+          fetch-depth: 0
           token: ${{ secrets.AXIOM_REPO_TOKEN || secrets.GITHUB_TOKEN }}
           persist-credentials: false
 
@@ -57,6 +61,7 @@ jobs:
           repository: TheAxiomFoundation/axiom-corpus
           ref: ${{ inputs.corpus_ref }}
           path: axiom-corpus
+          fetch-depth: 0
           token: ${{ secrets.AXIOM_REPO_TOKEN || secrets.GITHUB_TOKEN }}
           persist-credentials: false
 
@@ -66,8 +71,42 @@ jobs:
           repository: TheAxiomFoundation/axiom-rules-engine
           ref: ${{ inputs.rules_engine_ref }}
           path: axiom-rules-engine
+          fetch-depth: 0
           token: ${{ secrets.AXIOM_REPO_TOKEN || secrets.GITHUB_TOKEN }}
           persist-credentials: false
+
+      - name: Verify immutable checkout identities
+        env:
+          RULESPEC_REF: ${{ inputs.rulespec_ref }}
+          CORPUS_REF: ${{ inputs.corpus_ref }}
+          RULES_ENGINE_REF: ${{ inputs.rules_engine_ref }}
+        run: |
+          set -euo pipefail
+          sha_pattern='^[0-9a-f]{40}$'
+          verify_checkout() {
+            local label="$1"
+            local requested="$2"
+            local checkout="$3"
+            if [[ ! "$requested" =~ $sha_pattern ]]; then
+              echo "$label ref must be a full lowercase commit SHA" >&2
+              exit 1
+            fi
+            actual="$(git -C "$checkout" rev-parse HEAD)"
+            if [ "$actual" != "$requested" ]; then
+              echo "$label checkout resolved to $actual, expected $requested" >&2
+              exit 1
+            fi
+          }
+          if [[ ! "$GITHUB_SHA" =~ $sha_pattern ]]; then
+            echo "GITHUB_SHA must be a full lowercase commit SHA" >&2
+            exit 1
+          fi
+          test "$(git -C axiom-encode rev-parse HEAD)" = "$GITHUB_SHA"
+          verify_checkout rulespec-us "$RULESPEC_REF" rulespec-us
+          verify_checkout axiom-corpus "$CORPUS_REF" axiom-corpus
+          verify_checkout axiom-rules-engine "$RULES_ENGINE_REF" axiom-rules-engine
+          git -C axiom-corpus merge-base --is-ancestor HEAD refs/remotes/origin/main
+          git -C axiom-rules-engine merge-base --is-ancestor HEAD refs/remotes/origin/main
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
@@ -147,11 +186,17 @@ jobs:
             --apply
           )
           if [ -n "$REVIEW_FINDING" ]; then
-            args+=(--review-findings "$REVIEW_FINDING")
+            review_finding_path="$GITHUB_WORKSPACE/axiom-rules-engine/.axiom-targeted-review-finding.txt"
+            if [ -e "$review_finding_path" ] || [ -L "$review_finding_path" ]; then
+              echo "reserved review finding path already exists" >&2
+              exit 1
+            fi
+            printf '%s\n' "$REVIEW_FINDING" > "$review_finding_path"
+            args+=(--review-findings "$review_finding_path")
           fi
           args+=("$CITATION")
 
-          /opt/axiom-verification/axiom-encode-apply-signer run \
+          exec /opt/axiom-verification/axiom-encode-apply-signer run \
             --scope apply_ed25519 \
             --key-env AXIOM_ENCODE_APPLY_SIGNING_KEY \
             --supervisor /opt/axiom-verification/axiom-encode-signing-supervisor \
@@ -165,8 +210,6 @@ jobs:
             -- "${args[@]}"
 
       - name: Verify generated provenance
-        env:
-          RULESPEC_REF: ${{ inputs.rulespec_ref }}
         run: |
           /opt/axiom-verification/axiom-encode-signing-supervisor \
             --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
@@ -175,7 +218,6 @@ jobs:
             --trusted-python-package-root /opt/axiom-verification/python/lib/python3.13/site-packages/axiom_encode \
             -- /opt/axiom-verification/axiom-encode guard-generated \
             --repo "$GITHUB_WORKSPACE/rulespec-us" \
-            --base-ref "$RULESPEC_REF" \
             --corpus-path "$GITHUB_WORKSPACE/axiom-corpus" \
             --expected-encoder-checkout "$GITHUB_WORKSPACE/axiom-encode" \
             --json > "$RUNNER_TEMP/guard-generated.json"
@@ -184,7 +226,6 @@ jobs:
       - name: Package exact generated changes
         env:
           CITATION: ${{ inputs.citation }}
-          RULESPEC_REF: ${{ inputs.rulespec_ref }}
         run: |
           artifact="$RUNNER_TEMP/targeted-reencode"
           mkdir -p "$artifact"
@@ -207,7 +248,7 @@ jobs:
           payload = {
               "schema": "axiom-encode/targeted-reencode-artifact/v1",
               "citation": os.environ["CITATION"],
-              "rulespec_base": os.environ["RULESPEC_REF"],
+              "rulespec_base": rev("rulespec-us"),
               "encoder_commit": rev("axiom-encode"),
               "corpus_commit": rev("axiom-corpus"),
               "rules_engine_commit": rev("axiom-rules-engine"),

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1469,7 +1469,9 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert all(step["with"]["fetch-depth"] == 0 for step in checkout_steps)
 
     identity_step = next(
-        step for step in steps if step.get("name") == "Verify immutable checkout identities"
+        step
+        for step in steps
+        if step.get("name") == "Verify immutable checkout identities"
     )
     identity_command = identity_step["run"]
     assert "^[0-9a-f]{40}$" in identity_command

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1457,12 +1457,24 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert set(trigger) == {"workflow_dispatch"}
     assert workflow["permissions"] == {"contents": "read"}
 
-    steps = workflow["jobs"]["encode"]["steps"]
+    job = workflow["jobs"]["encode"]
+    assert job["environment"] == "production-signing"
+    assert "github.ref == 'refs/heads/main'" in job["if"]
+    steps = job["steps"]
     checkout_steps = [
         step for step in steps if step.get("uses", "").startswith("actions/checkout@")
     ]
     assert checkout_steps
     assert all(step["with"]["persist-credentials"] is False for step in checkout_steps)
+    assert all(step["with"]["fetch-depth"] == 0 for step in checkout_steps)
+
+    identity_step = next(
+        step for step in steps if step.get("name") == "Verify immutable checkout identities"
+    )
+    identity_command = identity_step["run"]
+    assert "^[0-9a-f]{40}$" in identity_command
+    assert "rev-parse HEAD" in identity_command
+    assert "merge-base --is-ancestor" in identity_command
 
     apply_step = next(
         step
@@ -1473,7 +1485,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         "${{ secrets.AXIOM_ENCODE_APPLY_SIGNING_KEY }}"
     )
     command = apply_step["run"]
-    assert "axiom-encode-apply-signer run" in command
+    assert "exec /opt/axiom-verification/axiom-encode-apply-signer run" in command
     assert "--key-env AXIOM_ENCODE_APPLY_SIGNING_KEY" in command
     assert (
         "TheAxiomFoundation/axiom-encode/.github/workflows/"
@@ -1482,6 +1494,14 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "--allowed-event-name workflow_dispatch" in command
     assert "--apply" in command
     assert "--skip-reviewers" not in command
+    assert "printf '%s\\n' \"$REVIEW_FINDING\"" in command
+    assert 'args+=(--review-findings "$review_finding_path")' in command
+
+    guard_step = next(
+        step for step in steps if step.get("name") == "Verify generated provenance"
+    )
+    assert "guard-generated" in guard_step["run"]
+    assert "--base-ref" not in guard_step["run"]
 
     secret_steps = [
         step

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import _cffi_backend
 import cryptography
 import pytest
+import yaml
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
@@ -1446,3 +1447,45 @@ def test_production_apply_signer_binary_rejects_wrong_ci_context(
         os.close(key_read)
     assert completed.returncode == 2
     assert "does not match the expected repository" in completed.stderr
+
+
+def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
+    )
+    trigger = workflow.get("on", workflow.get(True))
+    assert set(trigger) == {"workflow_dispatch"}
+    assert workflow["permissions"] == {"contents": "read"}
+
+    steps = workflow["jobs"]["encode"]["steps"]
+    checkout_steps = [
+        step for step in steps if step.get("uses", "").startswith("actions/checkout@")
+    ]
+    assert checkout_steps
+    assert all(step["with"]["persist-credentials"] is False for step in checkout_steps)
+
+    apply_step = next(
+        step
+        for step in steps
+        if step.get("name") == "Encode, review, validate, and apply"
+    )
+    assert apply_step["env"]["AXIOM_ENCODE_APPLY_SIGNING_KEY"] == (
+        "${{ secrets.AXIOM_ENCODE_APPLY_SIGNING_KEY }}"
+    )
+    command = apply_step["run"]
+    assert "axiom-encode-apply-signer run" in command
+    assert "--key-env AXIOM_ENCODE_APPLY_SIGNING_KEY" in command
+    assert (
+        "TheAxiomFoundation/axiom-encode/.github/workflows/"
+        "targeted-signed-reencode.yml@refs/heads/main" in command
+    )
+    assert "--allowed-event-name workflow_dispatch" in command
+    assert "--apply" in command
+    assert "--skip-reviewers" not in command
+
+    secret_steps = [
+        step
+        for step in steps
+        if "AXIOM_ENCODE_APPLY_SIGNING_KEY" in (step.get("env") or {})
+    ]
+    assert secret_steps == [apply_step]


### PR DESCRIPTION
## Summary
- add a main-only `workflow_dispatch` lane for one corpus-backed RuleSpec re-encode
- protect the apply key in a `production-signing` Environment restricted to the `main` branch
- require exact immutable checkout SHAs before provisioning or signing
- run `encode --apply` through the protected external signer with full reviewers
- verify the complete tracked and untracked worktree through `guard-generated`
- publish an exact binary patch, signed untracked artifacts, provenance metadata, and checksums for mechanical integration

## Validation
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run ruff format --check src tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest`: 4,064 passed, 106 skipped
- focused workflow security test: 1 passed
- all workflow shell blocks pass `bash -n`
- hosted lint, Python 3.13, macOS signer, and Ubuntu signer checks pass at `0b27313055539c9f2ff5825cebc3d4b1d0610e5a`

## Review cycle
- [x] independent security review requested
- [x] five actionable findings fixed: branch secret exposure, incomplete worktree guard, parent-shell key lifetime, mutable refs, and review-finding input handling
- [x] focused and broad checks rerun
- [x] independent re-review found no actionable findings
- [x] hosted CI passes