### PR TITLE
Protect targeted signing root ancestor

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -152,6 +152,8 @@ jobs:
           CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags='-buildid=' \
             -o "$RUNNER_TEMP/axiom-encode-apply-signer" \
             ./cmd/axiom-encode-apply-signer
+          sudo chown 0:0 /opt
+          sudo chmod go-w /opt
           sudo rm -rf /opt/axiom-verification
           sudo .venv/bin/python scripts/provision_verification_supervisor.py \
             --destination /opt/axiom-verification \

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1478,6 +1478,14 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "rev-parse HEAD" in identity_command
     assert "merge-base --is-ancestor" in identity_command
 
+    provision_step = next(
+        step
+        for step in steps
+        if step.get("name") == "Provision protected signing supervisor"
+    )
+    assert "sudo chown 0:0 /opt" in provision_step["run"]
+    assert "sudo chmod go-w /opt" in provision_step["run"]
+
     apply_step = next(
         step
         for step in steps


### PR DESCRIPTION
## Summary
- protect the hosted runner's `/opt` ancestor before provisioning the root-owned verification tree
- align the targeted production workflow with the existing signing-supervisor production fixture
- assert the ancestor hardening in the workflow security test

## Validation
- Ruff check and format check
- Python bytecode compilation
- focused workflow security test: 1 passed
- `git diff --check`
- production run #29631029170 reproduced the fail-closed ancestor rejection before this fix
- hosted CI: lint, Python 3.13, Ubuntu, and macOS all passed

## Review cycle
- [x] independent review complete: no actionable findings
- [x] actionable findings resolved
- [x] focused checks rerun
- [x] hosted checks green
