### PR TITLE
Add encrypted apply signing key migration lane

### DIFF
--- a/.github/workflows/migrate-apply-signing-key.yml
+++ b/.github/workflows/migrate-apply-signing-key.yml
@@ -1,0 +1,64 @@
+name: Migrate inherited apply signing key
+
+on:
+  workflow_dispatch:
+    inputs:
+      recipient_public_key_pem_base64:
+        description: Base64-encoded RSA public key for one-time OAEP encryption
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  migrate:
+    if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
+    environment: signing-key-migration
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Encrypt inherited signing key
+        env:
+          APPLY_SIGNING_KEY: ${{ secrets.AXIOM_ENCODE_APPLY_SIGNING_KEY }}
+          APPLY_PUBLIC_KEY: ${{ vars.AXIOM_ENCODE_APPLY_SIGNING_PUBLIC_KEY }}
+          RECIPIENT_PUBLIC_KEY: ${{ inputs.recipient_public_key_pem_base64 }}
+        run: |
+          set -euo pipefail
+          umask 077
+          artifact="$RUNNER_TEMP/apply-signing-key-migration"
+          recipient="$RUNNER_TEMP/recipient-public.pem"
+          plaintext="$RUNNER_TEMP/apply-signing-key.material"
+          trap 'rm -f "$recipient" "$plaintext"' EXIT
+          mkdir -p "$artifact"
+
+          test -n "$APPLY_SIGNING_KEY"
+          test -n "$APPLY_PUBLIC_KEY"
+          printf '%s' "$RECIPIENT_PUBLIC_KEY" | base64 --decode > "$recipient"
+          openssl pkey -pubin -in "$recipient" -noout
+
+          printf '%s' "$APPLY_SIGNING_KEY" > "$plaintext"
+          key_bytes="$(wc -c < "$plaintext" | tr -d ' ')"
+          if [ "$key_bytes" -lt 40 ] || [ "$key_bytes" -gt 512 ]; then
+            echo "inherited signing key has an unsupported serialized length" >&2
+            exit 1
+          fi
+          openssl pkeyutl -encrypt \
+            -pubin \
+            -inkey "$recipient" \
+            -pkeyopt rsa_padding_mode:oaep \
+            -pkeyopt rsa_oaep_md:sha256 \
+            -in "$plaintext" \
+            -out "$artifact/apply-signing-key.oaep-sha256.bin"
+          rm -f "$plaintext"
+
+          printf '%s\n' "$APPLY_PUBLIC_KEY" > "$artifact/apply-public-key.txt"
+          sha256sum "$artifact"/* > "$artifact/SHA256SUMS"
+
+      - name: Upload encrypted migration artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: apply-signing-key-migration-${{ github.run_id }}
+          path: ${{ runner.temp }}/apply-signing-key-migration
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/migrate-apply-signing-key.yml
+++ b/.github/workflows/migrate-apply-signing-key.yml
@@ -1,3 +1,4 @@
+# One-time lane: remove this workflow and its Environment after verified migration.
 name: Migrate inherited apply signing key
 
 on:
@@ -29,31 +30,135 @@ jobs:
           artifact="$RUNNER_TEMP/apply-signing-key-migration"
           recipient="$RUNNER_TEMP/recipient-public.pem"
           plaintext="$RUNNER_TEMP/apply-signing-key.material"
-          trap 'rm -f "$recipient" "$plaintext"' EXIT
-          mkdir -p "$artifact"
+          private_der="$RUNNER_TEMP/apply-signing-key.pkcs8.der"
+          trusted_public_pem="$RUNNER_TEMP/apply-public-key.pem"
+          trap 'rm -f "$recipient" "$plaintext" "$private_der" "$trusted_public_pem"' EXIT
+          mkdir -m 700 -p "$artifact"
 
           test -n "$APPLY_SIGNING_KEY"
           test -n "$APPLY_PUBLIC_KEY"
-          printf '%s' "$RECIPIENT_PUBLIC_KEY" | base64 --decode > "$recipient"
-          openssl pkey -pubin -in "$recipient" -noout
-
           printf '%s' "$APPLY_SIGNING_KEY" > "$plaintext"
+          unset APPLY_SIGNING_KEY
           key_bytes="$(wc -c < "$plaintext" | tr -d ' ')"
-          if [ "$key_bytes" -lt 40 ] || [ "$key_bytes" -gt 512 ]; then
+          if [ "$key_bytes" -lt 40 ] || [ "$key_bytes" -gt 256 ]; then
             echo "inherited signing key has an unsupported serialized length" >&2
             exit 1
           fi
+
+          python3 - "$plaintext" "$private_der" "$trusted_public_pem" <<'PY'
+          import base64
+          import hmac
+          import os
+          import subprocess
+          import sys
+          from pathlib import Path
+
+          plaintext = Path(sys.argv[1])
+          private_der = Path(sys.argv[2])
+          trusted_public_pem = Path(sys.argv[3])
+          private_prefix = bytes.fromhex("302e020100300506032b657004220420")
+          public_prefix = bytes.fromhex("302a300506032b6570032100")
+
+          def openssl(*args: str) -> bytes:
+              completed = subprocess.run(
+                  ["openssl", *args],
+                  check=False,
+                  capture_output=True,
+                  env={"PATH": os.environ["PATH"]},
+              )
+              if completed.returncode:
+                  raise SystemExit("inherited signing material is not valid Ed25519 key material")
+              return completed.stdout
+
+          material = plaintext.read_bytes()
+          if material.startswith(b"-----BEGIN PRIVATE KEY-----"):
+              derived_public = openssl(
+                  "pkey", "-in", str(plaintext), "-pubout", "-outform", "DER"
+              )
+          else:
+              try:
+                  seed = base64.b64decode(material, validate=True)
+              except (ValueError, base64.binascii.Error):
+                  raise SystemExit("inherited signing key is not strict base64 or PKCS8 PEM") from None
+              if len(seed) != 32:
+                  raise SystemExit("inherited signing key is not a 32-byte Ed25519 seed")
+              private_der.write_bytes(private_prefix + seed)
+              derived_public = openssl(
+                  "pkey",
+                  "-inform", "DER",
+                  "-in", str(private_der),
+                  "-pubout",
+                  "-outform", "DER",
+              )
+
+          if len(derived_public) != 44 or not derived_public.startswith(public_prefix):
+              raise SystemExit("inherited signing key is not Ed25519")
+
+          trusted_serialized = os.environ["APPLY_PUBLIC_KEY"].strip()
+          if trusted_serialized.startswith("-----BEGIN PUBLIC KEY-----"):
+              trusted_public_pem.write_text(trusted_serialized + "\n", encoding="ascii")
+              trusted_public = openssl(
+                  "pkey",
+                  "-pubin",
+                  "-in", str(trusted_public_pem),
+                  "-outform", "DER",
+              )
+          else:
+              try:
+                  trusted_raw = base64.b64decode(trusted_serialized, validate=True)
+              except (ValueError, base64.binascii.Error):
+                  raise SystemExit("trusted apply public key is malformed") from None
+              if len(trusted_raw) != 32:
+                  raise SystemExit("trusted apply public key is not 32 bytes")
+              trusted_public = public_prefix + trusted_raw
+
+          if not hmac.compare_digest(derived_public, trusted_public):
+              raise SystemExit("inherited signing key does not match the trusted apply public key")
+          PY
+
+          python3 - "$recipient" <<'PY'
+          import base64
+          import os
+          import sys
+          from pathlib import Path
+
+          try:
+              recipient = base64.b64decode(
+                  os.environ["RECIPIENT_PUBLIC_KEY"], validate=True
+              )
+          except (ValueError, base64.binascii.Error):
+              raise SystemExit("recipient public key is not strict base64") from None
+          Path(sys.argv[1]).write_bytes(recipient)
+          PY
+          unset RECIPIENT_PUBLIC_KEY
+          rsa_bits="$(
+            openssl rsa -pubin -in "$recipient" -text -noout 2>/dev/null \
+              | sed -n '1s/.*(\([0-9][0-9]*\) bit).*/\1/p'
+          )"
+          if ! [[ "$rsa_bits" =~ ^[0-9]+$ ]] || [ "$rsa_bits" -lt 3072 ]; then
+            echo "recipient public key must be RSA with at least 3072 bits" >&2
+            exit 1
+          fi
+
           openssl pkeyutl -encrypt \
             -pubin \
             -inkey "$recipient" \
             -pkeyopt rsa_padding_mode:oaep \
             -pkeyopt rsa_oaep_md:sha256 \
+            -pkeyopt rsa_mgf1_md:sha256 \
             -in "$plaintext" \
             -out "$artifact/apply-signing-key.oaep-sha256.bin"
           rm -f "$plaintext"
 
           printf '%s\n' "$APPLY_PUBLIC_KEY" > "$artifact/apply-public-key.txt"
-          sha256sum "$artifact"/* > "$artifact/SHA256SUMS"
+          unset APPLY_PUBLIC_KEY
+          sha256sum \
+            "$artifact/apply-signing-key.oaep-sha256.bin" \
+            "$artifact/apply-public-key.txt" \
+            > "$artifact/SHA256SUMS"
+          actual_files="$(find "$artifact" -type f -exec basename {} \; | LC_ALL=C sort)"
+          expected_files="$(printf '%s\n' SHA256SUMS apply-public-key.txt apply-signing-key.oaep-sha256.bin)"
+          test "$actual_files" = "$expected_files"
 
       - name: Upload encrypted migration artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/migrate-apply-signing-key.yml
+++ b/.github/workflows/migrate-apply-signing-key.yml
@@ -107,6 +107,7 @@ jobs:
 
           func parsePublic(material []byte) ed25519.PublicKey {
             normalized := bytes.TrimSpace(material)
+            normalized = bytes.ReplaceAll(normalized, []byte(`\n`), []byte("\n"))
             if bytes.HasPrefix(normalized, []byte("-----BEGIN")) {
               block, rest := pem.Decode(normalized)
               if block == nil || len(bytes.TrimSpace(rest)) != 0 {

--- a/.github/workflows/migrate-apply-signing-key.yml
+++ b/.github/workflows/migrate-apply-signing-key.yml
@@ -20,6 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Install pinned Go toolchain
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: "1.26.1"
+          cache: false
+
       - name: Encrypt inherited signing key
         env:
           APPLY_SIGNING_KEY: ${{ secrets.AXIOM_ENCODE_APPLY_SIGNING_KEY }}
@@ -31,9 +37,8 @@ jobs:
           artifact="$RUNNER_TEMP/apply-signing-key-migration"
           recipient="$RUNNER_TEMP/recipient-public.pem"
           plaintext="$RUNNER_TEMP/apply-signing-key.material"
-          private_der="$RUNNER_TEMP/apply-signing-key.pkcs8.der"
-          trusted_public_pem="$RUNNER_TEMP/apply-public-key.pem"
-          trap 'rm -f "$recipient" "$plaintext" "$private_der" "$trusted_public_pem"' EXIT
+          validator_source="$RUNNER_TEMP/validate-apply-signing-key.go"
+          trap 'rm -f "$recipient" "$plaintext" "$validator_source"' EXIT
           mkdir -m 700 -p "$artifact"
 
           test -n "$APPLY_SIGNING_KEY"
@@ -46,90 +51,109 @@ jobs:
             exit 1
           fi
 
-          python3 - "$plaintext" "$private_der" "$trusted_public_pem" <<'PY'
-          import base64
-          import binascii
-          import hmac
-          import os
-          import subprocess
-          import sys
-          from pathlib import Path
+          cat > "$validator_source" <<'GO'
+          package main
 
-          plaintext = Path(sys.argv[1])
-          private_der = Path(sys.argv[2])
-          trusted_public_pem = Path(sys.argv[3])
-          private_prefix = bytes.fromhex("302e020100300506032b657004220420")
-          public_prefix = bytes.fromhex("302a300506032b6570032100")
+          import (
+            "bytes"
+            "crypto/ed25519"
+            "crypto/x509"
+            "encoding/asn1"
+            "encoding/base64"
+            "encoding/pem"
+            "fmt"
+            "os"
+          )
 
-          def openssl(*args: str, input_bytes: bytes | None = None) -> bytes:
-              completed = subprocess.run(
-                  ["openssl", *args],
-                  check=False,
-                  capture_output=True,
-                  env={"PATH": os.environ["PATH"]},
-                  input=input_bytes,
-              )
-              if completed.returncode:
-                  raise SystemExit("inherited signing material is not valid Ed25519 key material")
-              return completed.stdout
+          func fail(message string) {
+            fmt.Fprintln(os.Stderr, message)
+            os.Exit(1)
+          }
 
-          material = plaintext.read_bytes().strip()
-          if material.startswith(b"-----BEGIN"):
-              begin_marker = b"-----BEGIN PRIVATE KEY-----"
-              end_marker = b"-----END PRIVATE KEY-----"
-              if not material.startswith(begin_marker):
-                  raise SystemExit("inherited signing key PEM is not an unencrypted PKCS8 key")
-              end_offset = material.find(end_marker, len(begin_marker))
-              if end_offset < 0:
-                  raise SystemExit("inherited signing key PEM is malformed")
-              end_offset += len(end_marker)
-              if material[end_offset:].strip():
-                  raise SystemExit("inherited signing key PEM contains trailing data")
-              material = material[:end_offset]
-              derived_public = openssl(
-                  "pkey", "-pubout", "-outform", "DER", input_bytes=material
-              )
-          else:
-              try:
-                  seed = base64.b64decode(material, validate=True)
-              except (ValueError, binascii.Error):
-                  raise SystemExit("inherited signing key is not strict base64 or PKCS8 PEM") from None
-              if len(seed) != 32:
-                  raise SystemExit("inherited signing key is not a 32-byte Ed25519 seed")
-              private_der.write_bytes(private_prefix + seed)
-              derived_public = openssl(
-                  "pkey",
-                  "-inform", "DER",
-                  "-in", str(private_der),
-                  "-pubout",
-                  "-outform", "DER",
-              )
+          func parsePrivate(material []byte) (ed25519.PrivateKey, []byte) {
+            normalized := bytes.TrimSpace(material)
+            if bytes.HasPrefix(normalized, []byte("-----BEGIN")) {
+              block, rest := pem.Decode(normalized)
+              if block == nil {
+                fail("inherited signing key PEM is malformed")
+              }
+              if len(bytes.TrimSpace(rest)) != 0 {
+                fail("inherited signing key PEM contains trailing data")
+              }
+              var raw asn1.RawValue
+              trailing, err := asn1.Unmarshal(block.Bytes, &raw)
+              if err != nil || len(trailing) != 0 {
+                fail("inherited signing key PEM contains trailing ASN.1 data")
+              }
+              parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+              if err != nil {
+                fail("inherited signing key PEM must contain one PKCS8 key")
+              }
+              privateKey, ok := parsed.(ed25519.PrivateKey)
+              if !ok {
+                fail("inherited signing key must be Ed25519")
+              }
+              return privateKey, normalized
+            }
+            seed, err := base64.StdEncoding.Strict().DecodeString(string(normalized))
+            if err != nil {
+              fail("inherited signing key is not strict base64 or PKCS8 PEM")
+            }
+            if len(seed) != ed25519.SeedSize {
+              fail("inherited signing key is not a 32-byte Ed25519 seed")
+            }
+            return ed25519.NewKeyFromSeed(seed), normalized
+          }
 
-          if len(derived_public) != 44 or not derived_public.startswith(public_prefix):
-              raise SystemExit("inherited signing key is not Ed25519")
+          func parsePublic(material []byte) ed25519.PublicKey {
+            normalized := bytes.TrimSpace(material)
+            if bytes.HasPrefix(normalized, []byte("-----BEGIN")) {
+              block, rest := pem.Decode(normalized)
+              if block == nil || len(bytes.TrimSpace(rest)) != 0 {
+                fail("trusted apply public key PEM is malformed")
+              }
+              var raw asn1.RawValue
+              trailing, err := asn1.Unmarshal(block.Bytes, &raw)
+              if err != nil || len(trailing) != 0 {
+                fail("trusted apply public key PEM contains trailing ASN.1 data")
+              }
+              parsed, err := x509.ParsePKIXPublicKey(block.Bytes)
+              if err != nil {
+                fail("trusted apply public key PEM is malformed")
+              }
+              publicKey, ok := parsed.(ed25519.PublicKey)
+              if !ok {
+                fail("trusted apply public key must be Ed25519")
+              }
+              return publicKey
+            }
+            publicKey, err := base64.StdEncoding.Strict().DecodeString(string(normalized))
+            if err != nil || len(publicKey) != ed25519.PublicKeySize {
+              fail("trusted apply public key is not strict base64 Ed25519 material")
+            }
+            return ed25519.PublicKey(publicKey)
+          }
 
-          trusted_serialized = os.environ["APPLY_PUBLIC_KEY"].strip()
-          if trusted_serialized.startswith("-----BEGIN PUBLIC KEY-----"):
-              trusted_public_pem.write_text(trusted_serialized + "\n", encoding="ascii")
-              trusted_public = openssl(
-                  "pkey",
-                  "-pubin",
-                  "-in", str(trusted_public_pem),
-                  "-outform", "DER",
-              )
-          else:
-              try:
-                  trusted_raw = base64.b64decode(trusted_serialized, validate=True)
-              except (ValueError, binascii.Error):
-                  raise SystemExit("trusted apply public key is malformed") from None
-              if len(trusted_raw) != 32:
-                  raise SystemExit("trusted apply public key is not 32 bytes")
-              trusted_public = public_prefix + trusted_raw
-
-          if not hmac.compare_digest(derived_public, trusted_public):
-              raise SystemExit("inherited signing key does not match the trusted apply public key")
-          plaintext.write_bytes(material)
-          PY
+          func main() {
+            if len(os.Args) != 2 {
+              fail("expected one private-key path")
+            }
+            material, err := os.ReadFile(os.Args[1])
+            if err != nil {
+              fail("could not read inherited signing key")
+            }
+            privateKey, normalized := parsePrivate(material)
+            trustedPublic := parsePublic([]byte(os.Getenv("APPLY_PUBLIC_KEY")))
+            derivedPublic := privateKey.Public().(ed25519.PublicKey)
+            if !bytes.Equal(derivedPublic, trustedPublic) {
+              fail("inherited signing key does not match the trusted apply public key")
+            }
+            if err := os.WriteFile(os.Args[1], normalized, 0600); err != nil {
+              fail("could not normalize inherited signing key")
+            }
+          }
+          GO
+          go run "$validator_source" "$plaintext"
 
           key_bytes="$(wc -c < "$plaintext" | tr -d ' ')"
           if [ "$key_bytes" -lt 40 ] || [ "$key_bytes" -gt 256 ]; then
@@ -174,10 +198,12 @@ jobs:
 
           printf '%s\n' "$APPLY_PUBLIC_KEY" > "$artifact/apply-public-key.txt"
           unset APPLY_PUBLIC_KEY
-          sha256sum \
-            "$artifact/apply-signing-key.oaep-sha256.bin" \
-            "$artifact/apply-public-key.txt" \
-            > "$artifact/SHA256SUMS"
+          (
+            cd "$artifact"
+            sha256sum apply-signing-key.oaep-sha256.bin apply-public-key.txt \
+              > SHA256SUMS
+            sha256sum --check SHA256SUMS
+          )
           actual_files="$(find "$artifact" -type f -exec basename {} \; | LC_ALL=C sort)"
           expected_files="$(printf '%s\n' SHA256SUMS apply-public-key.txt apply-signing-key.oaep-sha256.bin)"
           test "$actual_files" = "$expected_files"

--- a/.github/workflows/migrate-apply-signing-key.yml
+++ b/.github/workflows/migrate-apply-signing-key.yml
@@ -1,4 +1,5 @@
-# One-time lane: remove this workflow and its Environment after verified migration.
+# One-time lane: after verified migration, delete the inherited organization secret,
+# this workflow, and its Environment.
 name: Migrate inherited apply signing key
 
 on:
@@ -40,13 +41,14 @@ jobs:
           printf '%s' "$APPLY_SIGNING_KEY" > "$plaintext"
           unset APPLY_SIGNING_KEY
           key_bytes="$(wc -c < "$plaintext" | tr -d ' ')"
-          if [ "$key_bytes" -lt 40 ] || [ "$key_bytes" -gt 256 ]; then
+          if [ "$key_bytes" -lt 1 ] || [ "$key_bytes" -gt 16384 ]; then
             echo "inherited signing key has an unsupported serialized length" >&2
             exit 1
           fi
 
           python3 - "$plaintext" "$private_der" "$trusted_public_pem" <<'PY'
           import base64
+          import binascii
           import hmac
           import os
           import subprocess
@@ -59,26 +61,38 @@ jobs:
           private_prefix = bytes.fromhex("302e020100300506032b657004220420")
           public_prefix = bytes.fromhex("302a300506032b6570032100")
 
-          def openssl(*args: str) -> bytes:
+          def openssl(*args: str, input_bytes: bytes | None = None) -> bytes:
               completed = subprocess.run(
                   ["openssl", *args],
                   check=False,
                   capture_output=True,
                   env={"PATH": os.environ["PATH"]},
+                  input=input_bytes,
               )
               if completed.returncode:
                   raise SystemExit("inherited signing material is not valid Ed25519 key material")
               return completed.stdout
 
-          material = plaintext.read_bytes()
-          if material.startswith(b"-----BEGIN PRIVATE KEY-----"):
+          material = plaintext.read_bytes().strip()
+          if material.startswith(b"-----BEGIN"):
+              begin_marker = b"-----BEGIN PRIVATE KEY-----"
+              end_marker = b"-----END PRIVATE KEY-----"
+              if not material.startswith(begin_marker):
+                  raise SystemExit("inherited signing key PEM is not an unencrypted PKCS8 key")
+              end_offset = material.find(end_marker, len(begin_marker))
+              if end_offset < 0:
+                  raise SystemExit("inherited signing key PEM is malformed")
+              end_offset += len(end_marker)
+              if material[end_offset:].strip():
+                  raise SystemExit("inherited signing key PEM contains trailing data")
+              material = material[:end_offset]
               derived_public = openssl(
-                  "pkey", "-in", str(plaintext), "-pubout", "-outform", "DER"
+                  "pkey", "-pubout", "-outform", "DER", input_bytes=material
               )
           else:
               try:
                   seed = base64.b64decode(material, validate=True)
-              except (ValueError, base64.binascii.Error):
+              except (ValueError, binascii.Error):
                   raise SystemExit("inherited signing key is not strict base64 or PKCS8 PEM") from None
               if len(seed) != 32:
                   raise SystemExit("inherited signing key is not a 32-byte Ed25519 seed")
@@ -106,7 +120,7 @@ jobs:
           else:
               try:
                   trusted_raw = base64.b64decode(trusted_serialized, validate=True)
-              except (ValueError, base64.binascii.Error):
+              except (ValueError, binascii.Error):
                   raise SystemExit("trusted apply public key is malformed") from None
               if len(trusted_raw) != 32:
                   raise SystemExit("trusted apply public key is not 32 bytes")
@@ -114,10 +128,18 @@ jobs:
 
           if not hmac.compare_digest(derived_public, trusted_public):
               raise SystemExit("inherited signing key does not match the trusted apply public key")
+          plaintext.write_bytes(material)
           PY
+
+          key_bytes="$(wc -c < "$plaintext" | tr -d ' ')"
+          if [ "$key_bytes" -lt 40 ] || [ "$key_bytes" -gt 256 ]; then
+            echo "normalized signing key has an unsupported serialized length" >&2
+            exit 1
+          fi
 
           python3 - "$recipient" <<'PY'
           import base64
+          import binascii
           import os
           import sys
           from pathlib import Path
@@ -126,7 +148,7 @@ jobs:
               recipient = base64.b64decode(
                   os.environ["RECIPIENT_PUBLIC_KEY"], validate=True
               )
-          except (ValueError, base64.binascii.Error):
+          except (ValueError, binascii.Error):
               raise SystemExit("recipient public key is not strict base64") from None
           Path(sys.argv[1]).write_bytes(recipient)
           PY

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1511,3 +1511,37 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         if "AXIOM_ENCODE_APPLY_SIGNING_KEY" in (step.get("env") or {})
     ]
     assert secret_steps == [apply_step]
+
+
+def test_apply_signing_key_migration_workflow_is_main_only() -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/migrate-apply-signing-key.yml").read_text()
+    )
+    trigger = workflow.get("on", workflow.get(True))
+    assert set(trigger) == {"workflow_dispatch"}
+    assert workflow["permissions"] == {"contents": "read"}
+
+    job = workflow["jobs"]["migrate"]
+    assert job["environment"] == "signing-key-migration"
+    assert "github.ref == 'refs/heads/main'" in job["if"]
+    steps = job["steps"]
+    assert not any(
+        step.get("uses", "").startswith("actions/checkout@") for step in steps
+    )
+
+    encrypt_step = next(
+        step for step in steps if step.get("name") == "Encrypt inherited signing key"
+    )
+    assert encrypt_step["env"]["APPLY_SIGNING_KEY"] == (
+        "${{ secrets.AXIOM_ENCODE_APPLY_SIGNING_KEY }}"
+    )
+    command = encrypt_step["run"]
+    assert "rsa_padding_mode:oaep" in command
+    assert "rsa_oaep_md:sha256" in command
+    assert 'rm -f "$plaintext"' in command
+    assert 'echo "$APPLY_SIGNING_KEY"' not in command
+
+    secret_steps = [
+        step for step in steps if "APPLY_SIGNING_KEY" in (step.get("env") or {})
+    ]
+    assert secret_steps == [encrypt_step]

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1710,6 +1710,33 @@ def test_apply_signing_key_migration_round_trip_and_artifact_allowlist(
         )
         assert decrypted.decode("ascii") == expected_private_key
 
+    escaped_public_pem = (
+        private_key.public_key()
+        .public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("ascii")
+        .replace("\n", "\\n")
+    )
+    escaped_public, artifact = _run_apply_key_migration(
+        tmp_path,
+        run_name="escaped-public-pem",
+        signing_key=raw_seed,
+        apply_public_key=escaped_public_pem,
+        recipient_public_key=recipient_public_key,
+    )
+    assert escaped_public.returncode == 0, escaped_public.stderr
+    decrypted = recipient_private_key.decrypt(
+        (artifact / "apply-signing-key.oaep-sha256.bin").read_bytes(),
+        padding.OAEP(
+            mgf=padding.MGF1(algorithm=hashes.SHA256()),
+            algorithm=hashes.SHA256(),
+            label=None,
+        ),
+    )
+    assert decrypted.decode("ascii") == raw_seed
+
 
 def test_apply_signing_key_migration_rejects_mismatched_or_malformed_key(
     tmp_path: Path,

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1631,16 +1631,22 @@ def test_apply_signing_key_migration_round_trip_and_artifact_allowlist(
         serialization.Encoding.PEM,
         serialization.PublicFormat.SubjectPublicKeyInfo,
     )
+    raw_seed = b64encode(seed).decode("ascii")
+    pkcs8_pem = private_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode("ascii")
     serializations = {
-        "raw-seed": b64encode(seed).decode("ascii"),
-        "pkcs8-pem": private_key.private_bytes(
-            serialization.Encoding.PEM,
-            serialization.PrivateFormat.PKCS8,
-            serialization.NoEncryption(),
-        ).decode("ascii"),
+        "raw-seed": (raw_seed, raw_seed),
+        "raw-seed-whitespace": (f" \n{raw_seed}\n ", raw_seed),
+        "pkcs8-pem": (pkcs8_pem, pkcs8_pem.strip()),
     }
 
-    for run_name, serialized_private_key in serializations.items():
+    for run_name, (
+        serialized_private_key,
+        expected_private_key,
+    ) in serializations.items():
         completed, artifact = _run_apply_key_migration(
             tmp_path,
             run_name=run_name,
@@ -1663,7 +1669,7 @@ def test_apply_signing_key_migration_round_trip_and_artifact_allowlist(
                 label=None,
             ),
         )
-        assert decrypted.decode("ascii") == serialized_private_key
+        assert decrypted.decode("ascii") == expected_private_key
 
 
 def test_apply_signing_key_migration_rejects_mismatched_or_malformed_key(
@@ -1694,11 +1700,25 @@ def test_apply_signing_key_migration_rejects_mismatched_or_malformed_key(
         apply_public_key=apply_public_key,
         recipient_public_key=recipient_public_key,
     )
+    pkcs8_pem = _private_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode("ascii")
+    trailing_data, _artifact = _run_apply_key_migration(
+        tmp_path,
+        run_name="trailing-data",
+        signing_key=f"{pkcs8_pem}not-part-of-the-pem",
+        apply_public_key=apply_public_key,
+        recipient_public_key=recipient_public_key,
+    )
 
     assert mismatched.returncode != 0
     assert "does not match the trusted apply public key" in mismatched.stderr
     assert malformed.returncode != 0
     assert "not strict base64 or PKCS8 PEM" in malformed.stderr
+    assert trailing_data.returncode != 0
+    assert "PEM contains trailing data" in trailing_data.stderr
 
 
 def test_apply_signing_key_migration_rejects_weak_recipient_rsa(

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1529,6 +1529,13 @@ def test_apply_signing_key_migration_workflow_is_main_only() -> None:
     assert not any(
         step.get("uses", "").startswith("actions/checkout@") for step in steps
     )
+    setup_go = next(
+        step for step in steps if step.get("name") == "Install pinned Go toolchain"
+    )
+    assert setup_go["uses"] == (
+        "actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16"
+    )
+    assert setup_go["with"] == {"go-version": "1.26.1", "cache": False}
 
     encrypt_step = next(
         step for step in steps if step.get("name") == "Encrypt inherited signing key"
@@ -1542,13 +1549,21 @@ def test_apply_signing_key_migration_workflow_is_main_only() -> None:
     assert "rsa_mgf1_md:sha256" in command
     assert "unset APPLY_SIGNING_KEY" in command
     assert '"$rsa_bits" -lt 3072' in command
-    assert "hmac.compare_digest(derived_public, trusted_public)" in command
+    assert "base64.StdEncoding.Strict().DecodeString" in command
+    assert "x509.ParsePKCS8PrivateKey" in command
+    assert "bytes.Equal(derivedPublic, trustedPublic)" in command
+    assert "sha256sum --check SHA256SUMS" in command
     assert 'rm -f "$plaintext"' in command
     assert 'echo "$APPLY_SIGNING_KEY"' not in command
-    assert workflow["jobs"]["migrate"]["steps"][1]["with"]["path"] == (
+    upload_step = next(
+        step
+        for step in steps
+        if step.get("name") == "Upload encrypted migration artifact"
+    )
+    assert upload_step["with"]["path"] == (
         "${{ runner.temp }}/apply-signing-key-migration"
     )
-    assert workflow["jobs"]["migrate"]["steps"][1]["with"]["retention-days"] == 1
+    assert upload_step["with"]["retention-days"] == 1
 
     secret_steps = [
         step for step in steps if "APPLY_SIGNING_KEY" in (step.get("env") or {})
@@ -1584,22 +1599,38 @@ def _run_apply_key_migration(
     apply_public_key: str,
     recipient_public_key: bytes,
 ) -> tuple[subprocess.CompletedProcess[str], Path]:
+    go = Path(shutil.which("go") or "/opt/homebrew/bin/go")
+    if not go.is_file():
+        pytest.skip("Go is required for the executable migration workflow test")
     workflow = yaml.safe_load(
         (ROOT / ".github/workflows/migrate-apply-signing-key.yml").read_text()
     )
-    command = workflow["jobs"]["migrate"]["steps"][0]["run"]
+    command = next(
+        step["run"]
+        for step in workflow["jobs"]["migrate"]["steps"]
+        if step.get("name") == "Encrypt inherited signing key"
+    )
     runner_temp = tmp_path / run_name
     runner_temp.mkdir()
     shim_dir = runner_temp / "bin"
     shim_dir.mkdir()
+    (shim_dir / "go").symlink_to(go)
     (shim_dir / "openssl").symlink_to(_migration_openssl())
     sha256sum = shim_dir / "sha256sum"
     sha256sum.write_text(
         "#!/usr/bin/env python3\n"
         "import hashlib, pathlib, sys\n"
-        "for name in sys.argv[1:]:\n"
-        "    digest = hashlib.sha256(pathlib.Path(name).read_bytes()).hexdigest()\n"
-        "    print(f'{digest}  {name}')\n"
+        "if sys.argv[1:2] == ['--check']:\n"
+        "    for line in pathlib.Path(sys.argv[2]).read_text().splitlines():\n"
+        "        expected, name = line.split('  ', 1)\n"
+        "        actual = hashlib.sha256(pathlib.Path(name).read_bytes()).hexdigest()\n"
+        "        if actual != expected:\n"
+        "            raise SystemExit(f'{name}: FAILED')\n"
+        "        print(f'{name}: OK')\n"
+        "else:\n"
+        "    for name in sys.argv[1:]:\n"
+        "        digest = hashlib.sha256(pathlib.Path(name).read_bytes()).hexdigest()\n"
+        "        print(f'{digest}  {name}')\n"
     )
     sha256sum.chmod(0o700)
     completed = subprocess.run(
@@ -1661,6 +1692,14 @@ def test_apply_signing_key_migration_round_trip_and_artifact_allowlist(
             "apply-public-key.txt",
             "apply-signing-key.oaep-sha256.bin",
         ]
+        checksum_manifest = (artifact / "SHA256SUMS").read_text()
+        assert str(tmp_path) not in checksum_manifest
+        for line in checksum_manifest.splitlines():
+            expected_digest, relative_name = line.split("  ", 1)
+            assert (
+                hashlib.sha256((artifact / relative_name).read_bytes()).hexdigest()
+                == expected_digest
+            )
         decrypted = recipient_private_key.decrypt(
             (artifact / "apply-signing-key.oaep-sha256.bin").read_bytes(),
             padding.OAEP(
@@ -1712,6 +1751,54 @@ def test_apply_signing_key_migration_rejects_mismatched_or_malformed_key(
         apply_public_key=apply_public_key,
         recipient_public_key=recipient_public_key,
     )
+    private_der = _private_key.private_bytes(
+        serialization.Encoding.DER,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    internal_trailing_der = b64encode(private_der + b"X").decode("ascii")
+    internal_trailing_pem = "\n".join(
+        [
+            "-----BEGIN PRIVATE KEY-----",
+            *(
+                internal_trailing_der[index : index + 64]
+                for index in range(0, len(internal_trailing_der), 64)
+            ),
+            "-----END PRIVATE KEY-----",
+        ]
+    )
+    trailing_der, _artifact = _run_apply_key_migration(
+        tmp_path,
+        run_name="trailing-der",
+        signing_key=internal_trailing_pem,
+        apply_public_key=apply_public_key,
+        recipient_public_key=recipient_public_key,
+    )
+
+    canonical_seed = b64encode(seed).decode("ascii")
+    alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+    padding_index = alphabet.index(canonical_seed[-2])
+    assert padding_index % 4 == 0
+    noncanonical_seed = f"{canonical_seed[:-2]}{alphabet[padding_index + 1]}="
+    noncanonical_private, _artifact = _run_apply_key_migration(
+        tmp_path,
+        run_name="noncanonical-private-base64",
+        signing_key=noncanonical_seed,
+        apply_public_key=apply_public_key,
+        recipient_public_key=recipient_public_key,
+    )
+    public_padding_index = alphabet.index(apply_public_key[-2])
+    assert public_padding_index % 4 == 0
+    noncanonical_apply_public = (
+        f"{apply_public_key[:-2]}{alphabet[public_padding_index + 1]}="
+    )
+    noncanonical_public, _artifact = _run_apply_key_migration(
+        tmp_path,
+        run_name="noncanonical-public-base64",
+        signing_key=canonical_seed,
+        apply_public_key=noncanonical_apply_public,
+        recipient_public_key=recipient_public_key,
+    )
 
     assert mismatched.returncode != 0
     assert "does not match the trusted apply public key" in mismatched.stderr
@@ -1719,6 +1806,12 @@ def test_apply_signing_key_migration_rejects_mismatched_or_malformed_key(
     assert "not strict base64 or PKCS8 PEM" in malformed.stderr
     assert trailing_data.returncode != 0
     assert "PEM contains trailing data" in trailing_data.stderr
+    assert trailing_der.returncode != 0
+    assert "contains trailing ASN.1 data" in trailing_der.stderr
+    assert noncanonical_private.returncode != 0
+    assert "not strict base64 or PKCS8 PEM" in noncanonical_private.stderr
+    assert noncanonical_public.returncode != 0
+    assert "not strict base64 Ed25519 material" in noncanonical_public.stderr
 
 
 def test_apply_signing_key_migration_rejects_weak_recipient_rsa(

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -19,7 +19,8 @@ import _cffi_backend
 import cryptography
 import pytest
 import yaml
-from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 from axiom_encode import __version__
@@ -1538,10 +1539,186 @@ def test_apply_signing_key_migration_workflow_is_main_only() -> None:
     command = encrypt_step["run"]
     assert "rsa_padding_mode:oaep" in command
     assert "rsa_oaep_md:sha256" in command
+    assert "rsa_mgf1_md:sha256" in command
+    assert "unset APPLY_SIGNING_KEY" in command
+    assert '"$rsa_bits" -lt 3072' in command
+    assert "hmac.compare_digest(derived_public, trusted_public)" in command
     assert 'rm -f "$plaintext"' in command
     assert 'echo "$APPLY_SIGNING_KEY"' not in command
+    assert workflow["jobs"]["migrate"]["steps"][1]["with"]["path"] == (
+        "${{ runner.temp }}/apply-signing-key-migration"
+    )
+    assert workflow["jobs"]["migrate"]["steps"][1]["with"]["retention-days"] == 1
 
     secret_steps = [
         step for step in steps if "APPLY_SIGNING_KEY" in (step.get("env") or {})
     ]
     assert secret_steps == [encrypt_step]
+
+
+def _migration_openssl() -> Path:
+    candidates = (
+        Path("/opt/homebrew/opt/openssl@3/bin/openssl"),
+        Path("/usr/local/opt/openssl@3/bin/openssl"),
+        Path(shutil.which("openssl") or "/missing"),
+    )
+    for candidate in candidates:
+        if not candidate.is_file():
+            continue
+        version = subprocess.run(
+            [candidate, "version"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if version.returncode == 0 and version.stdout.startswith("OpenSSL 3."):
+            return candidate
+    pytest.skip("OpenSSL 3 is required for the executable migration workflow test")
+
+
+def _run_apply_key_migration(
+    tmp_path: Path,
+    *,
+    run_name: str,
+    signing_key: str,
+    apply_public_key: str,
+    recipient_public_key: bytes,
+) -> tuple[subprocess.CompletedProcess[str], Path]:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/migrate-apply-signing-key.yml").read_text()
+    )
+    command = workflow["jobs"]["migrate"]["steps"][0]["run"]
+    runner_temp = tmp_path / run_name
+    runner_temp.mkdir()
+    shim_dir = runner_temp / "bin"
+    shim_dir.mkdir()
+    (shim_dir / "openssl").symlink_to(_migration_openssl())
+    sha256sum = shim_dir / "sha256sum"
+    sha256sum.write_text(
+        "#!/usr/bin/env python3\n"
+        "import hashlib, pathlib, sys\n"
+        "for name in sys.argv[1:]:\n"
+        "    digest = hashlib.sha256(pathlib.Path(name).read_bytes()).hexdigest()\n"
+        "    print(f'{digest}  {name}')\n"
+    )
+    sha256sum.chmod(0o700)
+    completed = subprocess.run(
+        ["bash", "-c", command],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "RUNNER_TEMP": str(runner_temp),
+            "APPLY_SIGNING_KEY": signing_key,
+            "APPLY_PUBLIC_KEY": apply_public_key,
+            "RECIPIENT_PUBLIC_KEY": b64encode(recipient_public_key).decode("ascii"),
+            "PATH": f"{shim_dir}{os.pathsep}{os.environ['PATH']}",
+        },
+    )
+    return completed, runner_temp / "apply-signing-key-migration"
+
+
+def test_apply_signing_key_migration_round_trip_and_artifact_allowlist(
+    tmp_path: Path,
+) -> None:
+    seed = bytes(range(32))
+    apply_public_key, private_key = _keypair(seed)
+    recipient_private_key = rsa.generate_private_key(
+        public_exponent=65537, key_size=3072
+    )
+    recipient_public_key = recipient_private_key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    serializations = {
+        "raw-seed": b64encode(seed).decode("ascii"),
+        "pkcs8-pem": private_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ).decode("ascii"),
+    }
+
+    for run_name, serialized_private_key in serializations.items():
+        completed, artifact = _run_apply_key_migration(
+            tmp_path,
+            run_name=run_name,
+            signing_key=serialized_private_key,
+            apply_public_key=apply_public_key,
+            recipient_public_key=recipient_public_key,
+        )
+
+        assert completed.returncode == 0, completed.stderr
+        assert sorted(path.name for path in artifact.iterdir()) == [
+            "SHA256SUMS",
+            "apply-public-key.txt",
+            "apply-signing-key.oaep-sha256.bin",
+        ]
+        decrypted = recipient_private_key.decrypt(
+            (artifact / "apply-signing-key.oaep-sha256.bin").read_bytes(),
+            padding.OAEP(
+                mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                algorithm=hashes.SHA256(),
+                label=None,
+            ),
+        )
+        assert decrypted.decode("ascii") == serialized_private_key
+
+
+def test_apply_signing_key_migration_rejects_mismatched_or_malformed_key(
+    tmp_path: Path,
+) -> None:
+    seed = bytes(range(32))
+    apply_public_key, _private_key = _keypair(seed)
+    wrong_public_key, _wrong_private_key = _keypair(bytes(reversed(range(32))))
+    recipient_private_key = rsa.generate_private_key(
+        public_exponent=65537, key_size=3072
+    )
+    recipient_public_key = recipient_private_key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    mismatched, _artifact = _run_apply_key_migration(
+        tmp_path,
+        run_name="mismatched",
+        signing_key=b64encode(seed).decode("ascii"),
+        apply_public_key=wrong_public_key,
+        recipient_public_key=recipient_public_key,
+    )
+    malformed, _artifact = _run_apply_key_migration(
+        tmp_path,
+        run_name="malformed",
+        signing_key="!" * 44,
+        apply_public_key=apply_public_key,
+        recipient_public_key=recipient_public_key,
+    )
+
+    assert mismatched.returncode != 0
+    assert "does not match the trusted apply public key" in mismatched.stderr
+    assert malformed.returncode != 0
+    assert "not strict base64 or PKCS8 PEM" in malformed.stderr
+
+
+def test_apply_signing_key_migration_rejects_weak_recipient_rsa(
+    tmp_path: Path,
+) -> None:
+    seed = bytes(range(32))
+    apply_public_key, _private_key = _keypair(seed)
+    weak_recipient = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    weak_public_key = weak_recipient.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    completed, _artifact = _run_apply_key_migration(
+        tmp_path,
+        run_name="weak-rsa",
+        signing_key=b64encode(seed).decode("ascii"),
+        apply_public_key=apply_public_key,
+        recipient_public_key=weak_public_key,
+    )
+
+    assert completed.returncode != 0
+    assert "must be RSA with at least 3072 bits" in completed.stderr


### PR DESCRIPTION
## Summary
- add a one-time main-only workflow that encrypts the inherited organization apply-signing secret directly to a caller-supplied RSA public key using OAEP-SHA256
- bind execution to the externally protected `signing-key-migration` Environment
- upload only ciphertext, the public trust root, and checksums with one-day retention
- keep repository permissions read-only and avoid checkout or repository writes

## External protection
- custom deployment branch policy: `main` only
- required reviewer: repository owner
- self-review allowed for this one-time migration
- admin bypass disabled
- no Environment secret with the same name, so the inherited organization secret is the migration source

## Validation
- Ruff check and format check
- Python bytecode compilation
- 4 focused executable migration/security tests
- workflow YAML and shell parsing
- `git diff --check`
- hosted CI: Python, lint, Ubuntu signer, and macOS signer all green

## Review cycle
- [x] independent security review complete at `722c12b55aad60c17d544885fe3da42810a954f4`
- [x] all actionable findings resolved; final review found none
- [x] focused checks rerun after the final merge from `main`
- [x] hosted checks green on the exact reviewed head