### PR TITLE
Diagnose protected RuleSpec routing

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -169,6 +169,46 @@ jobs:
           sudo chown -R 0:0 /opt/axiom-verification
           sudo chmod -R go-w /opt/axiom-verification
 
+      - name: Verify protected RuleSpec routing
+        env:
+          RULESPEC_CHECKOUT: ${{ github.workspace }}/rulespec-us
+        run: |
+          set -euo pipefail
+          trusted_path=/opt/axiom-verification
+          trusted_home=/opt/axiom-verification/python
+          env -i PATH="$trusted_path" HOME="$trusted_home" \
+            git -C "$RULESPEC_CHECKOUT" rev-parse --show-toplevel
+          env -i PATH="$trusted_path" HOME="$trusted_home" \
+            git -C "$RULESPEC_CHECKOUT" remote get-url origin
+          interpreter="$(sed -n '1s/^#!\([^ ]*\).*/\1/p' \
+            /opt/axiom-verification/axiom-encode)"
+          env -i PATH="$trusted_path" HOME="$trusted_home" \
+            "$interpreter" -I - "$RULESPEC_CHECKOUT" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          from axiom_encode.constants import RULESPEC_FILESYSTEM_ROOTS
+          from axiom_encode.repo_routing import canonical_rulespec_repo_name
+
+          checkout = Path(sys.argv[1])
+          payload = {
+              "canonical_repo_name": canonical_rulespec_repo_name(checkout),
+              "git_marker_is_symlink": (checkout / ".git").is_symlink(),
+              "name": checkout.name,
+              "path": str(checkout),
+              "resolved_path": str(checkout.resolve()),
+              "unexpected_root_entries": sorted(
+                  name
+                  for name in RULESPEC_FILESYSTEM_ROOTS - {"programs"}
+                  if (checkout / name).exists() or (checkout / name).is_symlink()
+              ),
+          }
+          print(json.dumps(payload, sort_keys=True))
+          if payload["canonical_repo_name"] != checkout.name:
+              raise SystemExit("protected RuleSpec routing rejected checkout")
+          PY
+
       - name: Encode, review, validate, and apply
         env:
           AXIOM_ENCODE_APPLY_SIGNING_KEY: ${{ secrets.AXIOM_ENCODE_APPLY_SIGNING_KEY }}

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1488,6 +1488,16 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "sudo chmod go-w /opt" in provision_step["run"]
     assert "--git /usr/bin/git" in provision_step["run"]
 
+    routing_step = next(
+        step
+        for step in steps
+        if step.get("name") == "Verify protected RuleSpec routing"
+    )
+    routing_command = routing_step["run"]
+    assert 'env -i PATH="$trusted_path" HOME="$trusted_home"' in routing_command
+    assert "canonical_rulespec_repo_name(checkout)" in routing_command
+    assert "protected RuleSpec routing rejected checkout" in routing_command
+
     apply_step = next(
         step
         for step in steps


### PR DESCRIPTION
## Summary
- reproduce protected RuleSpec routing with the provisioned launcher before signing or model execution
- report non-secret checkout structure needed to identify the hosted-only canonical-routing rejection
- enforce the diagnostic step in the workflow contract test

## Why
Production targeted re-encode run 29635407266 passed protected signer binding and challenge verification, then failed with `encode --apply requires the exact canonical rulespec-<country> checkout`. The same pinned checkout and protected wrapper route correctly locally. This step moves that check before signer/model work and captures the exact hosted boundary without exposing credentials or repository content.

## Checks
- `uv run --python 3.13 pytest -q tests/test_signing_supervisor.py::test_targeted_signed_reencode_workflow_is_main_dispatch_only --no-cov`
- `uv run --python 3.13 pytest -q tests/test_signing_supervisor.py --no-cov` (6 passed, 38 skipped)
- `uv run --python 3.13 ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run --python 3.13 python -m compileall -q src/axiom_encode scripts`
- `git diff --check`
- hosted CI: lint, Python 3.13, Ubuntu supervisor, and macOS supervisor all passed

## Cycle
Independent review of `f0a32f4939729819b32b4d7e23b111cfc0851da4` found no actionable findings. The reviewer verified YAML/heredoc behavior, Bash syntax, diagnostic ordering, credential removal, and test coverage.