### PR TITLE
Report canonical RuleSpec routing failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1269"
+version = "0.2.1270"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1270"
+version = "0.2.1271"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1270"
+__version__ = "0.2.1271"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1269"
+__version__ = "0.2.1270"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -18502,11 +18502,17 @@ def cmd_encode(args):
                 policy_checkout_path,
                 allow_composition_specs=True,
             )
-            if checkout_inspection.name != policy_checkout_path.name:
+            if (
+                canonical_rulespec_repo_name(policy_checkout_path)
+                != policy_checkout_path.name
+            ):
+                rejection = (
+                    checkout_inspection.rejection or "repository-context-mismatch"
+                )
                 raise ValueError(
                     "encode --apply requires the exact canonical "
                     "rulespec-<country> checkout "
-                    f"(rejection: {checkout_inspection.rejection or 'name-mismatch'})"
+                    f"(rejection: {rejection})"
                 )
             # Recovery needs no signing capability and must happen before any
             # model, corpus, or live-checkout preflight consumes partial state.

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -249,6 +249,7 @@ from .repo_routing import (
     canonical_rulespec_repo_name,
     canonical_rulespec_root_identity,
     find_policy_repo_root,
+    inspect_canonical_rulespec_checkout,
     is_composition_policy_repo_root,
     jurisdiction_content_dir,
     jurisdiction_subdir_names,
@@ -18497,13 +18498,15 @@ def cmd_encode(args):
                 args.policy_repo_path,
                 label="RuleSpec checkout",
             )
-            if (
-                canonical_rulespec_repo_name(policy_checkout_path)
-                != policy_checkout_path.name
-            ):
+            checkout_inspection = inspect_canonical_rulespec_checkout(
+                policy_checkout_path,
+                allow_composition_specs=True,
+            )
+            if checkout_inspection.name != policy_checkout_path.name:
                 raise ValueError(
                     "encode --apply requires the exact canonical "
-                    "rulespec-<country> checkout"
+                    "rulespec-<country> checkout "
+                    f"(rejection: {checkout_inspection.rejection or 'name-mismatch'})"
                 )
             # Recovery needs no signing capability and must happen before any
             # model, corpus, or live-checkout preflight consumes partial state.

--- a/src/axiom_encode/repo_routing.py
+++ b/src/axiom_encode/repo_routing.py
@@ -20,12 +20,20 @@ import subprocess
 import sys
 from collections.abc import Iterable
 from pathlib import Path
+from typing import NamedTuple
 
 from .constants import RULESPEC_COMPOSITION_SPEC_ROOT, RULESPEC_FILESYSTEM_ROOTS
 
 
 class _GitProbeError(RuntimeError):
     """Git identity could not be checked for an observed repository boundary."""
+
+
+class CanonicalRuleSpecCheckoutInspection(NamedTuple):
+    """Canonical checkout identity and a stable rejection code."""
+
+    name: str | None
+    rejection: str | None
 
 
 def jurisdiction_country(prefix: str) -> str:
@@ -74,54 +82,69 @@ def _canonical_country_checkout_name(
 ) -> str | None:
     """Return the exact canonical country-checkout name for ``path``."""
 
+    return inspect_canonical_rulespec_checkout(
+        path,
+        allow_composition_specs=allow_composition_specs,
+    ).name
+
+
+def inspect_canonical_rulespec_checkout(
+    path: Path,
+    *,
+    allow_composition_specs: bool = False,
+) -> CanonicalRuleSpecCheckoutInspection:
+    """Inspect one exact country checkout without weakening route acceptance."""
+
     lexical = _lexical_rulespec_path(path)
     if lexical is None:
-        return None
+        return CanonicalRuleSpecCheckoutInspection(None, "lexical-path-rejected")
     if not lexical.is_dir():
-        return None
+        return CanonicalRuleSpecCheckoutInspection(None, "checkout-not-directory")
     checkout = lexical.resolve()
     name = checkout.name
     if not name.startswith("rulespec-"):
-        return None
+        return CanonicalRuleSpecCheckoutInspection(None, "checkout-name-prefix")
     country = name.removeprefix("rulespec-")
     if re.fullmatch(r"[a-z]{2}", country) is None:
-        return None
+        return CanonicalRuleSpecCheckoutInspection(None, "checkout-country-name")
     blocked_roots = RULESPEC_FILESYSTEM_ROOTS
     if allow_composition_specs:
         composition_root = checkout / RULESPEC_COMPOSITION_SPEC_ROOT
         if (composition_root.exists() or composition_root.is_symlink()) and (
             composition_root.is_symlink() or not composition_root.is_dir()
         ):
-            return None
+            return CanonicalRuleSpecCheckoutInspection(
+                None, "composition-root-not-directory"
+            )
         blocked_roots = blocked_roots - {RULESPEC_COMPOSITION_SPEC_ROOT}
     if any(
         (checkout / root_name).exists() or (checkout / root_name).is_symlink()
         for root_name in blocked_roots
     ):
-        return None
+        return CanonicalRuleSpecCheckoutInspection(None, "atomic-root-at-checkout")
     try:
         git_boundary = _nearest_git_boundary(checkout)
     except _GitProbeError:
-        return None
+        return CanonicalRuleSpecCheckoutInspection(None, "git-boundary-probe-error")
     if git_boundary is not None and git_boundary != checkout:
-        return None
+        return CanonicalRuleSpecCheckoutInspection(None, "git-boundary-mismatch")
     if git_boundary is None:
-        return name
+        return CanonicalRuleSpecCheckoutInspection(name, None)
     try:
         git_top_level = _git_top_level(str(checkout))
     except _GitProbeError:
-        return None
+        return CanonicalRuleSpecCheckoutInspection(None, "git-top-level-probe-error")
     if git_top_level is None:
-        return None
+        return CanonicalRuleSpecCheckoutInspection(None, "git-top-level-unavailable")
     if git_top_level is not None and git_top_level != checkout:
-        return None
+        return CanonicalRuleSpecCheckoutInspection(None, "git-top-level-mismatch")
     try:
         origin_name = _git_origin_repo_name(str(checkout))
     except _GitProbeError:
-        return None
+        return CanonicalRuleSpecCheckoutInspection(None, "git-origin-probe-error")
     if origin_name is not None and origin_name != name:
-        return None
-    return name
+        return CanonicalRuleSpecCheckoutInspection(None, "git-origin-name-mismatch")
+    return CanonicalRuleSpecCheckoutInspection(name, None)
 
 
 def canonical_rulespec_root_identity(path: Path) -> str | None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7566,6 +7566,23 @@ class TestCmdEncode:
         with pytest.raises(ValueError, match=r"rejection: checkout-country-name"):
             cmd_encode(args)
 
+    def test_encode_apply_rejects_nested_checkout_name(self, tmp_path):
+        nested_checkout = (
+            tmp_path / "rulespec-us" / "us-co" / "scratch" / "rulespec-us"
+        )
+        nested_checkout.parent.mkdir(parents=True)
+        args = self._make_args(
+            tmp_path,
+            apply=True,
+            policy_repo_path=nested_checkout,
+            create_content_root=False,
+        )
+
+        with pytest.raises(
+            ValueError, match=r"rejection: repository-context-mismatch"
+        ):
+            cmd_encode(args)
+
     @pytest.mark.parametrize("allow_shrink", [False, True])
     def test_encode_apply_propagates_allow_shrink_to_apply_guard(
         self, tmp_path, allow_shrink

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7555,6 +7555,17 @@ class TestCmdEncode:
 
         mock_run.assert_not_called()
 
+    def test_encode_apply_reports_canonical_checkout_rejection(self, tmp_path):
+        args = self._make_args(
+            tmp_path,
+            apply=True,
+            policy_repo_path=tmp_path / "rulespec-usa",
+            create_content_root=False,
+        )
+
+        with pytest.raises(ValueError, match=r"rejection: checkout-country-name"):
+            cmd_encode(args)
+
     @pytest.mark.parametrize("allow_shrink", [False, True])
     def test_encode_apply_propagates_allow_shrink_to_apply_guard(
         self, tmp_path, allow_shrink

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7567,9 +7567,7 @@ class TestCmdEncode:
             cmd_encode(args)
 
     def test_encode_apply_rejects_nested_checkout_name(self, tmp_path):
-        nested_checkout = (
-            tmp_path / "rulespec-us" / "us-co" / "scratch" / "rulespec-us"
-        )
+        nested_checkout = tmp_path / "rulespec-us" / "us-co" / "scratch" / "rulespec-us"
         nested_checkout.parent.mkdir(parents=True)
         args = self._make_args(
             tmp_path,
@@ -7578,9 +7576,7 @@ class TestCmdEncode:
             create_content_root=False,
         )
 
-        with pytest.raises(
-            ValueError, match=r"rejection: repository-context-mismatch"
-        ):
+        with pytest.raises(ValueError, match=r"rejection: repository-context-mismatch"):
             cmd_encode(args)
 
     @pytest.mark.parametrize("allow_shrink", [False, True])

--- a/tests/test_repo_routing.py
+++ b/tests/test_repo_routing.py
@@ -25,6 +25,7 @@ from axiom_encode.repo_routing import (
     canonical_rulespec_repo_name,
     canonical_rulespec_root_identity,
     find_policy_repo_root,
+    inspect_canonical_rulespec_checkout,
     is_composition_policy_repo_root,
     is_policy_repo_root,
     jurisdiction_subdir_names,
@@ -70,10 +71,16 @@ def test_composition_checkout_identity_admits_only_top_level_programs(tmp_path):
 
     assert is_policy_repo_root(checkout) is False
     assert is_composition_policy_repo_root(checkout) is True
+    assert inspect_canonical_rulespec_checkout(
+        checkout, allow_composition_specs=True
+    ) == ("rulespec-us", None)
     assert jurisdiction_subdir_names(checkout, allow_composition_specs=True) == set()
 
     (checkout / "statutes").mkdir()
     assert is_composition_policy_repo_root(checkout) is False
+    assert inspect_canonical_rulespec_checkout(
+        checkout, allow_composition_specs=True
+    ) == (None, "atomic-root-at-checkout")
 
 
 def test_composition_checkout_identity_rejects_symlinked_programs(tmp_path):
@@ -233,6 +240,9 @@ def test_canonical_identity_observes_changed_git_origin(tmp_path):
     )
 
     assert canonical_rulespec_root_identity(policy_root) is None
+    assert inspect_canonical_rulespec_checkout(
+        checkout, allow_composition_specs=True
+    ) == (None, "git-origin-name-mismatch")
 
 
 def test_canonical_identity_rejects_observed_git_boundary_when_git_unavailable(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1269"
+version = "0.2.1270"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1270"
+version = "0.2.1271"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- preserve canonical RuleSpec repository-context acceptance while returning stable rejection codes
- include the rejected invariant in `encode --apply` failures
- cover valid composition checkouts, blocked atomic roots, changed origins, CLI propagation, and nested checkout rejection
- release the behavior as axiom-encode `0.2.1271`

## Why
Production run 29635855628 proved the checkout is canonical immediately before signer launch, but `encode --apply` still rejected it after the signer attached. The former boolean-style failure suppressed which invariant failed. Stable, non-secret rejection codes isolate the signer child mismatch without exposing repository content or credentials.

## Checks
- focused routing/provenance tests: 32 passed
- full independent suite: 4,077 passed, 106 skipped
- `uv run --python 3.13 ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run --python 3.13 ruff format --check src/ tests/`
- `uv run --python 3.13 python -m compileall -q src/axiom_encode scripts`
- `uv lock --check`
- `git diff --check`
- hosted CI: lint, Python 3.13, Ubuntu supervisor, and macOS supervisor all passed

## Cycle
First independent review found a nested Git-less checkout acceptance regression. The guard was restored to use `canonical_rulespec_repo_name` as the acceptance authority, a regression test was added, and the release bump was moved after the fix. Second independent review of exact head `57ec340702425069af30bddb8ba63b874a8bb712` found no actionable findings.