### PR TITLE
Classify protected Git probe failures

### DIFF
--- a/.github/workflows/provision-selftest.yml
+++ b/.github/workflows/provision-selftest.yml
@@ -90,11 +90,12 @@ jobs:
         run: |
           set -euo pipefail
           dest="$RUNNER_TEMP/dest"
+          trusted_path="$dest/python/bin"
           interp="$(sed -n '1s/^#!\([^ ]*\).*/\1/p' "$dest/axiom-encode")"
           echo "launcher interpreter: $interp"
           case "$interp" in "$dest"/python/*) ;; *) echo "launcher points outside the runtime"; exit 1 ;; esac
           env -i \
-            PATH="$dest" \
+            PATH="$trusted_path" \
             HOME="$dest/python" \
             GIT_CONFIG_GLOBAL=/dev/null \
             GIT_CONFIG_NOSYSTEM=1 \
@@ -118,7 +119,7 @@ jobs:
           done
           printf 'changed\n' > "$hostile_repo/a.txt"
           env -i \
-            PATH="$dest" \
+            PATH="$trusted_path" \
             HOME="$dest/python" \
             GIT_CONFIG_COUNT=1 \
             GIT_CONFIG_KEY_0=core.fsmonitor \
@@ -126,7 +127,7 @@ jobs:
             GIT_EXTERNAL_DIFF="$RUNNER_TEMP/hostile-git-helper" \
             git -C "$hostile_repo" status --porcelain >/dev/null
           env -i \
-            PATH="$dest" \
+            PATH="$trusted_path" \
             HOME="$dest/python" \
             GIT_CONFIG_COUNT=1 \
             GIT_CONFIG_KEY_0=core.fsmonitor \
@@ -145,7 +146,7 @@ jobs:
             'diff --binary HEAD -- a.txt' \
             'diff --name-only --no-renames --diff-filter=ACDMRT -z HEAD'; do
             if env -i \
-              PATH="$dest" \
+              PATH="$trusted_path" \
               HOME="$dest/python" \
               git -C "$hostile_repo" $args >/dev/null; then
               echo "trusted Git wrapper accepted worktree filter: $args" >&2
@@ -158,7 +159,7 @@ jobs:
             /usr/bin/git -C "$hostile_repo" config \
               "filter.$driver.clean" "$RUNNER_TEMP/hostile-git-helper"
             if env -i \
-              PATH="$dest" \
+              PATH="$trusted_path" \
               HOME="$dest/python" \
               git -C "$hostile_repo" diff --binary HEAD -- a.txt >/dev/null; then
               echo "trusted Git wrapper accepted sentinel filter: $driver" >&2
@@ -166,7 +167,7 @@ jobs:
             fi
           done
           if env -i \
-            PATH="$dest" \
+            PATH="$trusted_path" \
             HOME="$dest/python" \
             git -C "$hostile_repo" remote add blocked \
               https://example.invalid/repo.git; then
@@ -178,7 +179,7 @@ jobs:
             exit 1
           fi
           if env -i \
-            PATH="$dest" \
+            PATH="$trusted_path" \
             HOME="$dest/python" \
             git -C "$hostile_repo" cat-file --filters HEAD:a.txt >/dev/null; then
             echo "trusted Git wrapper accepted cat-file --filters" >&2
@@ -210,7 +211,7 @@ jobs:
             'status --porcelain --untracked-files=no' \
             'diff --binary HEAD -- sub'; do
             if env -i \
-              PATH="$dest" \
+              PATH="$trusted_path" \
               HOME="$dest/python" \
               git -C "$parent_repo" $args >/dev/null; then
               echo "trusted Git wrapper accepted gitlink: $args" >&2
@@ -241,7 +242,7 @@ jobs:
           find "$partial_clone/.git/objects/pack" -maxdepth 1 -type f \
             -printf '%f\n' | sort > "$RUNNER_TEMP/packs-before"
           if env -i \
-            PATH="$dest" \
+            PATH="$trusted_path" \
             HOME="$dest/python" \
             git -C "$partial_clone" cat-file blob "$promised_oid" >/dev/null; then
             echo "trusted Git wrapper lazily fetched a promised object" >&2
@@ -271,7 +272,7 @@ jobs:
             > "$RUNNER_TEMP/replaced-output"
           cmp "$replace_repo/replacement.txt" "$RUNNER_TEMP/replaced-output"
           env -i \
-            PATH="$dest" \
+            PATH="$trusted_path" \
             HOME="$dest/python" \
             git -C "$replace_repo" cat-file blob "$original_oid" \
             > "$RUNNER_TEMP/trusted-object-output"
@@ -317,7 +318,7 @@ jobs:
           test -e "$hostile_marker"
           rm -f "$hostile_marker"
           env -i \
-            PATH="$dest" \
+            PATH="$trusted_path" \
             HOME="$dest/python" \
             git -C "$signature_repo" log --format=%H -- \
               pyproject.toml src/axiom_encode/__init__.py uv.lock >/dev/null

--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -174,7 +174,7 @@ jobs:
           RULESPEC_CHECKOUT: ${{ github.workspace }}/rulespec-us
         run: |
           set -euo pipefail
-          trusted_path=/opt/axiom-verification
+          trusted_path=/opt/axiom-verification/python/bin
           trusted_home=/opt/axiom-verification/python
           env -i PATH="$trusted_path" HOME="$trusted_home" \
             git -C "$RULESPEC_CHECKOUT" rev-parse --show-toplevel

--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -184,16 +184,20 @@ jobs:
             /opt/axiom-verification/axiom-encode)"
           env -i PATH="$trusted_path" HOME="$trusted_home" \
             "$interpreter" -I - "$RULESPEC_CHECKOUT" <<'PY'
+          import ctypes
           import json
           import sys
           from pathlib import Path
 
           from axiom_encode.constants import RULESPEC_FILESYSTEM_ROOTS
-          from axiom_encode.repo_routing import canonical_rulespec_repo_name
+          from axiom_encode.repo_routing import (
+              canonical_rulespec_repo_name,
+              inspect_canonical_rulespec_checkout,
+          )
+          from axiom_encode.signing_broker import _harden_signing_capability_process
 
           checkout = Path(sys.argv[1])
-          payload = {
-              "canonical_repo_name": canonical_rulespec_repo_name(checkout),
+          structure = {
               "git_marker_is_symlink": (checkout / ".git").is_symlink(),
               "name": checkout.name,
               "path": str(checkout),
@@ -204,9 +208,29 @@ jobs:
                   if (checkout / name).exists() or (checkout / name).is_symlink()
               ),
           }
+
+          def route_payload():
+              inspection = inspect_canonical_rulespec_checkout(
+                  checkout, allow_composition_specs=True
+              )
+              return {
+                  "canonical_repo_name": canonical_rulespec_repo_name(checkout),
+                  "rejection": inspection.rejection,
+              }
+
+          direct = route_payload()
+          _harden_signing_capability_process(role="routing-probe")
+          if sys.platform.startswith("linux"):
+              libc = ctypes.CDLL(None, use_errno=True)
+              if libc.prctl(38, 1, 0, 0, 0) != 0:
+                  raise SystemExit("could not enable routing-probe no-new-privileges")
+          hardened = route_payload()
+          payload = {**structure, "direct": direct, "hardened": hardened}
           print(json.dumps(payload, sort_keys=True))
-          if payload["canonical_repo_name"] != checkout.name:
+          if direct["canonical_repo_name"] != checkout.name:
               raise SystemExit("protected RuleSpec routing rejected checkout")
+          if hardened["canonical_repo_name"] != checkout.name:
+              raise SystemExit("hardened RuleSpec routing rejected checkout")
           PY
 
       - name: Encode, review, validate, and apply

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1272"
+version = "0.2.1273"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1271"
+version = "0.2.1272"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/provision_verification_supervisor.py
+++ b/scripts/provision_verification_supervisor.py
@@ -469,12 +469,12 @@ def _resolve_trusted_git(raw_git: Path) -> Path:
 
 
 def _install_trusted_git_wrapper(
-    destination: Path, interpreter: Path, trusted_git: Path
+    tool_directory: Path, interpreter: Path, trusted_git: Path
 ) -> Path:
     """Install a read-only Git command broker into the isolated PATH."""
 
-    wrapper = destination / "git"
-    wrapper.write_text(
+    wrapper = tool_directory / "git"
+    content = (
         f"#!{interpreter} -I\n"
         "import os\n"
         "import re\n"
@@ -682,6 +682,15 @@ def _install_trusted_git_wrapper(
         "    args[cursor + 1:cursor + 1] = ['--no-ext-diff', '--no-textconv']\n"
         "os.execv(git, [*trusted, *args])\n"
     )
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(wrapper, flags, 0o700)
+    except FileExistsError as exc:
+        raise SystemExit("trusted Git wrapper path already exists") from exc
+    with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+        stream.write(content)
     wrapper.chmod(0o755)
     return wrapper
 
@@ -715,7 +724,7 @@ def provision(
         _relocate_elf_rpaths(runtime, patchelf)
     interpreter = runtime / source_interpreter.relative_to(source_runtime)
     _assert_self_contained(runtime, source_runtime, interpreter)
-    _install_trusted_git_wrapper(destination, interpreter, trusted_git)
+    _install_trusted_git_wrapper(interpreter.parent, interpreter, trusted_git)
     launcher = destination / "axiom-encode"
     launcher.write_text(f"#!{interpreter} -I\nraise SystemExit('launcher executed')\n")
     launcher.chmod(0o755)

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1271"
+__version__ = "0.2.1272"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1272"
+__version__ = "0.2.1273"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/repo_routing.py
+++ b/src/axiom_encode/repo_routing.py
@@ -28,6 +28,10 @@ from .constants import RULESPEC_COMPOSITION_SPEC_ROOT, RULESPEC_FILESYSTEM_ROOTS
 class _GitProbeError(RuntimeError):
     """Git identity could not be checked for an observed repository boundary."""
 
+    def __init__(self, message: str, *, category: str = "error") -> None:
+        super().__init__(message)
+        self.category = category
+
 
 class CanonicalRuleSpecCheckoutInspection(NamedTuple):
     """Canonical checkout identity and a stable rejection code."""
@@ -124,24 +128,30 @@ def inspect_canonical_rulespec_checkout(
         return CanonicalRuleSpecCheckoutInspection(None, "atomic-root-at-checkout")
     try:
         git_boundary = _nearest_git_boundary(checkout)
-    except _GitProbeError:
-        return CanonicalRuleSpecCheckoutInspection(None, "git-boundary-probe-error")
+    except _GitProbeError as exc:
+        return CanonicalRuleSpecCheckoutInspection(
+            None, f"git-boundary-probe-{exc.category}"
+        )
     if git_boundary is not None and git_boundary != checkout:
         return CanonicalRuleSpecCheckoutInspection(None, "git-boundary-mismatch")
     if git_boundary is None:
         return CanonicalRuleSpecCheckoutInspection(name, None)
     try:
         git_top_level = _git_top_level(str(checkout))
-    except _GitProbeError:
-        return CanonicalRuleSpecCheckoutInspection(None, "git-top-level-probe-error")
+    except _GitProbeError as exc:
+        return CanonicalRuleSpecCheckoutInspection(
+            None, f"git-top-level-probe-{exc.category}"
+        )
     if git_top_level is None:
         return CanonicalRuleSpecCheckoutInspection(None, "git-top-level-unavailable")
     if git_top_level is not None and git_top_level != checkout:
         return CanonicalRuleSpecCheckoutInspection(None, "git-top-level-mismatch")
     try:
         origin_name = _git_origin_repo_name(str(checkout))
-    except _GitProbeError:
-        return CanonicalRuleSpecCheckoutInspection(None, "git-origin-probe-error")
+    except _GitProbeError as exc:
+        return CanonicalRuleSpecCheckoutInspection(
+            None, f"git-origin-probe-{exc.category}"
+        )
     if origin_name is not None and origin_name != name:
         return CanonicalRuleSpecCheckoutInspection(None, "git-origin-name-mismatch")
     return CanonicalRuleSpecCheckoutInspection(name, None)
@@ -348,7 +358,10 @@ def _git_top_level(root: str) -> Path | None:
             timeout=2,
         )
     except (OSError, subprocess.SubprocessError) as exc:
-        raise _GitProbeError(f"Could not inspect Git top-level for {root}") from exc
+        raise _GitProbeError(
+            f"Could not inspect Git top-level for {root}",
+            category=_git_probe_exception_category(exc),
+        ) from exc
     if completed.returncode != 0:
         return None
     top_level = completed.stdout.strip()
@@ -368,7 +381,10 @@ def _git_origin_repo_name(root: str) -> str | None:
             timeout=2,
         )
     except (OSError, subprocess.SubprocessError) as exc:
-        raise _GitProbeError(f"Could not inspect Git origin for {root}") from exc
+        raise _GitProbeError(
+            f"Could not inspect Git origin for {root}",
+            category=_git_probe_exception_category(exc),
+        ) from exc
     if completed.returncode != 0:
         return None
     remote = completed.stdout.strip().rstrip("/")
@@ -376,3 +392,13 @@ def _git_origin_repo_name(root: str) -> str | None:
         return None
     name = remote.rsplit("/", 1)[-1]
     return name.removesuffix(".git") or None
+
+
+def _git_probe_exception_category(exc: BaseException) -> str:
+    """Return a bounded, non-secret category for a failed Git process launch."""
+
+    if isinstance(exc, subprocess.TimeoutExpired):
+        return "timeout"
+    if isinstance(exc, OSError):
+        return f"oserror-{exc.errno}" if exc.errno is not None else "oserror"
+    return "subprocess-error"

--- a/tests/test_provision_supervisor.py
+++ b/tests/test_provision_supervisor.py
@@ -310,6 +310,32 @@ class TestTrustedGit:
         with pytest.raises(SystemExit, match="contains a symlink"):
             provisioner._resolve_trusted_git(alias)
 
+    @pytest.mark.parametrize("symlink", [False, True])
+    def test_installed_wrapper_refuses_existing_path(self, tmp_path, symlink):
+        git = shutil.which("git")
+        if git is None:
+            pytest.skip("Git is required")
+        tool_directory = tmp_path / "tools"
+        tool_directory.mkdir()
+        wrapper = tool_directory / "git"
+        sentinel = tmp_path / "sentinel"
+        sentinel.write_text("unchanged\n")
+        if symlink:
+            wrapper.symlink_to(sentinel)
+        else:
+            wrapper.write_text("unchanged\n")
+
+        with pytest.raises(SystemExit, match="wrapper path already exists"):
+            provisioner._install_trusted_git_wrapper(
+                tool_directory,
+                Path(sys.executable).resolve(),
+                provisioner._resolve_trusted_git(Path(git).resolve()),
+            )
+
+        assert sentinel.read_text() == "unchanged\n"
+        if not symlink:
+            assert wrapper.read_text() == "unchanged\n"
+
     def test_installed_wrapper_blocks_local_executable_config(self, tmp_path):
         git = shutil.which("git")
         if git is None:

--- a/tests/test_provision_verification_supervisor.py
+++ b/tests/test_provision_verification_supervisor.py
@@ -55,8 +55,9 @@ def test_provision_replaces_base_runtime_site_packages(tmp_path: Path) -> None:
     assert (destination / "axiom-encode").read_text().splitlines()[0] == (
         f"#!{interpreter} -I"
     )
-    git_wrapper = destination / "git"
+    git_wrapper = interpreter.parent / "git"
     assert git_wrapper.read_text().splitlines()[0] == f"#!{interpreter} -I"
+    assert not (destination / "git").exists()
     repository = tmp_path / "rulespec-us"
     subprocess.run(
         [str(Path(git).resolve()), "init", "--quiet", str(repository)], check=True
@@ -70,7 +71,7 @@ def test_provision_replaces_base_runtime_site_packages(tmp_path: Path) -> None:
             "GIT_CONFIG_GLOBAL": "/dev/null",
             "GIT_CONFIG_NOSYSTEM": "1",
             "HOME": str(runtime),
-            "PATH": str(destination),
+            "PATH": str(interpreter.parent),
         },
     )
     assert Path(top_level.stdout.strip()) == repository

--- a/tests/test_repo_routing.py
+++ b/tests/test_repo_routing.py
@@ -266,6 +266,35 @@ def test_canonical_identity_rejects_observed_git_boundary_when_git_unavailable(
     assert canonical_rulespec_root_identity(plain_root) == "rulespec-us/us-co"
 
 
+@pytest.mark.parametrize(
+    ("error", "rejection"),
+    [
+        (FileNotFoundError(2, "git unavailable"), "git-top-level-probe-oserror-2"),
+        (
+            subprocess.TimeoutExpired(["git", "rev-parse"], 2),
+            "git-top-level-probe-timeout",
+        ),
+    ],
+)
+def test_checkout_inspection_categorizes_git_probe_launch_failures(
+    monkeypatch,
+    tmp_path,
+    error,
+    rejection,
+):
+    checkout = tmp_path / "rulespec-us"
+    _init_checkout(checkout, "https://github.com/TheAxiomFoundation/rulespec-us.git")
+
+    def failed_git(*_args, **_kwargs):
+        raise error
+
+    monkeypatch.setattr("axiom_encode.repo_routing.subprocess.run", failed_git)
+
+    assert inspect_canonical_rulespec_checkout(
+        checkout, allow_composition_specs=True
+    ) == (None, rejection)
+
+
 def test_candidate_roots_reject_noncanonical_checkout_alias(tmp_path):
     checkout = tmp_path / "rulespec-us-clean.abcd"
     _init_checkout(checkout, "https://github.com/TheAxiomFoundation/rulespec-us.git")

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1496,7 +1496,11 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     routing_command = routing_step["run"]
     assert 'env -i PATH="$trusted_path" HOME="$trusted_home"' in routing_command
     assert "canonical_rulespec_repo_name(checkout)" in routing_command
+    assert "inspect_canonical_rulespec_checkout" in routing_command
+    assert '_harden_signing_capability_process(role="routing-probe")' in routing_command
+    assert "libc.prctl(38, 1, 0, 0, 0)" in routing_command
     assert "protected RuleSpec routing rejected checkout" in routing_command
+    assert "hardened RuleSpec routing rejected checkout" in routing_command
 
     apply_step = next(
         step

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1494,6 +1494,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         if step.get("name") == "Verify protected RuleSpec routing"
     )
     routing_command = routing_step["run"]
+    assert "trusted_path=/opt/axiom-verification/python/bin" in routing_command
     assert 'env -i PATH="$trusted_path" HOME="$trusted_home"' in routing_command
     assert "canonical_rulespec_repo_name(checkout)" in routing_command
     assert "inspect_canonical_rulespec_checkout" in routing_command

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1272"
+version = "0.2.1273"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1271"
+version = "0.2.1272"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- align the trusted Git wrapper location with the supervisor child’s actual isolated `PATH`
- create the wrapper exclusively with no symlink following and refuse pre-existing paths
- classify protected Git launch failures into bounded errno, timeout, and subprocess categories
- exercise routing before and after signer-equivalent process hardening
- release the fix as axiom-encode `0.2.1273`

## Root cause
The supervisor rewrites the protected launcher to `/opt/axiom-verification/python/bin/python3.13` and sets child `PATH` to that interpreter directory. Provisioning had installed the only allowed Git wrapper at `/opt/axiom-verification/git`. The signer child therefore raised `FileNotFoundError` when routing invoked unqualified `git`, while the workflow’s direct probe succeeded because it manually used the parent directory.

## Checks
- focused provisioning/routing/workflow tests: 81 passed independently
- version provenance: passed
- Ruff check and format check
- compileall
- uv lock --check
- git diff --check
- hosted CI: lint, full Python 3.13, Ubuntu and macOS signing builds all passed
- hosted production-layout provision selftests: Python 3.13 and 3.14 both passed

## Cycle
Initial review of the diagnostic-only head found no findings. After the substantive path-alignment fix, a fresh independent review of exact head `755dcf03decb4bf4f5e382ba4343a64f7679cb11` found no actionable findings and verified the wrapper location, exclusive/no-follow creation, workflow syntax, and synchronized release metadata.