### PR TITLE
Fetch pinned corpus release for targeted re-encode

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -139,6 +139,95 @@ jobs:
           uv pip install --python .venv/bin/python \
             --target "$RUNNER_TEMP/axiom-verification-site-packages" ".[api]"
 
+      - name: Fetch pinned signed corpus release object
+        shell: bash
+        env:
+          SUPABASE_URL: https://swocpijqqahhuwtuahwc.supabase.co
+          SUPABASE_ANON_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "$SUPABASE_ANON_KEY"
+          mapfile -t release_pin < <(axiom-encode/.venv/bin/python - <<'PY'
+          import re
+          import tomllib
+          from pathlib import Path
+
+          toolchain_path = Path("rulespec-us/.axiom/toolchain.toml")
+          toolchain = tomllib.loads(toolchain_path.read_text(encoding="utf-8"))[
+              "toolchain"
+          ]
+          release_name = toolchain["axiom_corpus_release"]
+          release_sha = toolchain["axiom_corpus_release_content_sha256"]
+          if not isinstance(release_name, str) or re.fullmatch(
+              r"[a-z0-9][a-z0-9._-]*", release_name
+          ) is None:
+              raise SystemExit("RuleSpec corpus release name is invalid")
+          if not isinstance(release_sha, str) or re.fullmatch(
+              r"[0-9a-f]{64}", release_sha
+          ) is None:
+              raise SystemExit("RuleSpec corpus release digest is invalid")
+          print(release_name)
+          print(release_sha)
+          PY
+          )
+          if [ "${#release_pin[@]}" -ne 2 ]; then
+            echo "RuleSpec toolchain did not yield exactly one corpus release pin" >&2
+            exit 1
+          fi
+          release_name="${release_pin[0]}"
+          release_sha="${release_pin[1]}"
+          destination="$GITHUB_WORKSPACE/axiom-corpus/releases/$release_name/$release_sha.json"
+          mkdir -p "$(dirname "$destination")"
+          url="${SUPABASE_URL%/}/rest/v1/release_objects?select=release_object&release_name=eq.${release_name}&content_sha256=eq.${release_sha}&limit=2"
+          curl --fail --silent --show-error --location --proto '=https' --tlsv1.2 \
+            --header "apikey: $SUPABASE_ANON_KEY" \
+            --header "Authorization: Bearer $SUPABASE_ANON_KEY" \
+            --header "Accept-Profile: corpus" \
+            --output "$destination.tmp" "$url"
+          release_commit="$(axiom-encode/.venv/bin/python - \
+            "$destination.tmp" "$destination" "$release_name" "$release_sha" <<'PY'
+          import hashlib
+          import json
+          import sys
+          from pathlib import Path
+
+          source, destination = Path(sys.argv[1]), Path(sys.argv[2])
+          expected_name, expected_sha = sys.argv[3], sys.argv[4]
+          try:
+              rows = json.loads(source.read_bytes())
+          except (OSError, json.JSONDecodeError) as exc:
+              raise SystemExit(f"Corpus release acquisition returned invalid JSON: {exc}")
+          if not isinstance(rows, list) or len(rows) != 1 or not isinstance(rows[0], dict):
+              raise SystemExit("Corpus release registry did not return exactly one object")
+          payload = rows[0].get("release_object")
+          if not isinstance(payload, dict) or payload.get("release") != expected_name:
+              raise SystemExit("Corpus release registry returned the wrong object")
+          content = payload.get("content")
+          if not isinstance(content, dict):
+              raise SystemExit("Corpus release registry returned invalid content")
+          actual = hashlib.sha256(json.dumps(
+              content, sort_keys=True, separators=(",", ":"), ensure_ascii=True,
+          ).encode()).hexdigest()
+          if payload.get("content_sha256") != actual or actual != expected_sha:
+              raise SystemExit("Corpus release registry returned a content-address mismatch")
+          git = content.get("git")
+          release_commit = git.get("commit") if isinstance(git, dict) else None
+          if not isinstance(release_commit, str):
+              raise SystemExit("Corpus release registry returned invalid Git provenance")
+          source.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+          source.replace(destination)
+          print(release_commit)
+          PY
+          )"
+          if [[ ! "$release_commit" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Signed release provenance is not a full lowercase commit SHA" >&2
+            exit 1
+          fi
+          git -C axiom-corpus merge-base --is-ancestor "$release_commit" HEAD || {
+            echo "Pinned corpus checkout predates signed release provenance" >&2
+            exit 1
+          }
+
       - name: Provision protected signing supervisor
         working-directory: axiom-encode
         env:

--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -147,28 +147,10 @@ jobs:
         run: |
           set -euo pipefail
           test -n "$SUPABASE_ANON_KEY"
-          mapfile -t release_pin < <(axiom-encode/.venv/bin/python - <<'PY'
-          import re
-          import tomllib
-          from pathlib import Path
-
-          toolchain_path = Path("rulespec-us/.axiom/toolchain.toml")
-          toolchain = tomllib.loads(toolchain_path.read_text(encoding="utf-8"))[
-              "toolchain"
-          ]
-          release_name = toolchain["axiom_corpus_release"]
-          release_sha = toolchain["axiom_corpus_release_content_sha256"]
-          if not isinstance(release_name, str) or re.fullmatch(
-              r"[a-z0-9][a-z0-9._-]*", release_name
-          ) is None:
-              raise SystemExit("RuleSpec corpus release name is invalid")
-          if not isinstance(release_sha, str) or re.fullmatch(
-              r"[0-9a-f]{64}", release_sha
-          ) is None:
-              raise SystemExit("RuleSpec corpus release digest is invalid")
-          print(release_name)
-          print(release_sha)
-          PY
+          materializer=axiom-encode/scripts/materialize_corpus_release.py
+          toolchain=rulespec-us/.axiom/toolchain.toml
+          mapfile -t release_pin < <(
+            axiom-encode/.venv/bin/python "$materializer" pin --toolchain "$toolchain"
           )
           if [ "${#release_pin[@]}" -ne 2 ]; then
             echo "RuleSpec toolchain did not yield exactly one corpus release pin" >&2
@@ -176,49 +158,21 @@ jobs:
           fi
           release_name="${release_pin[0]}"
           release_sha="${release_pin[1]}"
-          destination="$GITHUB_WORKSPACE/axiom-corpus/releases/$release_name/$release_sha.json"
-          mkdir -p "$(dirname "$destination")"
+          response="$(mktemp "$RUNNER_TEMP/corpus-release-response.XXXXXX")"
+          trap 'rm -f "$response"' EXIT
           url="${SUPABASE_URL%/}/rest/v1/release_objects?select=release_object&release_name=eq.${release_name}&content_sha256=eq.${release_sha}&limit=2"
-          curl --fail --silent --show-error --location --proto '=https' --tlsv1.2 \
+          curl --fail --silent --show-error --location \
+            --proto '=https' --proto-redir '=https' --tlsv1.2 \
+            --max-filesize 16777216 \
             --header "apikey: $SUPABASE_ANON_KEY" \
             --header "Authorization: Bearer $SUPABASE_ANON_KEY" \
             --header "Accept-Profile: corpus" \
-            --output "$destination.tmp" "$url"
-          release_commit="$(axiom-encode/.venv/bin/python - \
-            "$destination.tmp" "$destination" "$release_name" "$release_sha" <<'PY'
-          import hashlib
-          import json
-          import sys
-          from pathlib import Path
-
-          source, destination = Path(sys.argv[1]), Path(sys.argv[2])
-          expected_name, expected_sha = sys.argv[3], sys.argv[4]
-          try:
-              rows = json.loads(source.read_bytes())
-          except (OSError, json.JSONDecodeError) as exc:
-              raise SystemExit(f"Corpus release acquisition returned invalid JSON: {exc}")
-          if not isinstance(rows, list) or len(rows) != 1 or not isinstance(rows[0], dict):
-              raise SystemExit("Corpus release registry did not return exactly one object")
-          payload = rows[0].get("release_object")
-          if not isinstance(payload, dict) or payload.get("release") != expected_name:
-              raise SystemExit("Corpus release registry returned the wrong object")
-          content = payload.get("content")
-          if not isinstance(content, dict):
-              raise SystemExit("Corpus release registry returned invalid content")
-          actual = hashlib.sha256(json.dumps(
-              content, sort_keys=True, separators=(",", ":"), ensure_ascii=True,
-          ).encode()).hexdigest()
-          if payload.get("content_sha256") != actual or actual != expected_sha:
-              raise SystemExit("Corpus release registry returned a content-address mismatch")
-          git = content.get("git")
-          release_commit = git.get("commit") if isinstance(git, dict) else None
-          if not isinstance(release_commit, str):
-              raise SystemExit("Corpus release registry returned invalid Git provenance")
-          source.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
-          source.replace(destination)
-          print(release_commit)
-          PY
-          )"
+            --output "$response" "$url"
+          release_commit="$(axiom-encode/.venv/bin/python "$materializer" \
+            materialize --toolchain "$toolchain" --response "$response" \
+            --corpus-root axiom-corpus)"
+          rm -f "$response"
+          trap - EXIT
           if [[ ! "$release_commit" =~ ^[0-9a-f]{40}$ ]]; then
             echo "Signed release provenance is not a full lowercase commit SHA" >&2
             exit 1

--- a/scripts/materialize_corpus_release.py
+++ b/scripts/materialize_corpus_release.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Validate and materialize a registry-backed corpus release object."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import stat
+import tomllib
+from pathlib import Path
+from typing import Any
+
+MAX_REGISTRY_RESPONSE_BYTES = 16 * 1024 * 1024
+_RELEASE_NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+class ReleaseAcquisitionError(ValueError):
+    """The release pin, registry response, or destination is unsafe."""
+
+
+def load_release_pin(toolchain_path: Path) -> tuple[str, str]:
+    """Read and validate the corpus release pin from a RuleSpec toolchain file."""
+
+    try:
+        document = tomllib.loads(toolchain_path.read_text(encoding="utf-8"))
+        toolchain = document["toolchain"]
+        release_name = toolchain["axiom_corpus_release"]
+        release_sha = toolchain["axiom_corpus_release_content_sha256"]
+    except (OSError, KeyError, TypeError, tomllib.TOMLDecodeError) as exc:
+        raise ReleaseAcquisitionError(f"invalid RuleSpec toolchain: {exc}") from exc
+    if (
+        not isinstance(release_name, str)
+        or _RELEASE_NAME_RE.fullmatch(release_name) is None
+    ):
+        raise ReleaseAcquisitionError("RuleSpec corpus release name is invalid")
+    if not isinstance(release_sha, str) or _SHA256_RE.fullmatch(release_sha) is None:
+        raise ReleaseAcquisitionError("RuleSpec corpus release digest is invalid")
+    return release_name, release_sha
+
+
+def _read_bounded_regular_file(path: Path) -> bytes:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    nofollow = getattr(os, "O_NOFOLLOW", None)
+    if nofollow is None:
+        raise ReleaseAcquisitionError("this platform cannot reject response symlinks")
+    try:
+        descriptor = os.open(path, flags | nofollow)
+    except OSError as exc:
+        raise ReleaseAcquisitionError(
+            f"could not open registry response: {exc}"
+        ) from exc
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise ReleaseAcquisitionError("registry response is not a regular file")
+        if metadata.st_size > MAX_REGISTRY_RESPONSE_BYTES:
+            raise ReleaseAcquisitionError("registry response exceeds the 16 MiB limit")
+        chunks: list[bytes] = []
+        remaining = MAX_REGISTRY_RESPONSE_BYTES + 1
+        while remaining:
+            chunk = os.read(descriptor, min(1024 * 1024, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        payload = b"".join(chunks)
+        if len(payload) > MAX_REGISTRY_RESPONSE_BYTES:
+            raise ReleaseAcquisitionError("registry response exceeds the 16 MiB limit")
+        return payload
+    finally:
+        os.close(descriptor)
+
+
+def _validate_registry_response(
+    raw_response: bytes,
+    *,
+    expected_name: str,
+    expected_sha: str,
+) -> tuple[dict[str, Any], str]:
+    try:
+        rows = json.loads(raw_response)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ReleaseAcquisitionError(f"registry returned invalid JSON: {exc}") from exc
+    if not isinstance(rows, list) or len(rows) != 1 or not isinstance(rows[0], dict):
+        raise ReleaseAcquisitionError(
+            "registry did not return exactly one release object"
+        )
+    payload = rows[0].get("release_object")
+    if not isinstance(payload, dict) or payload.get("release") != expected_name:
+        raise ReleaseAcquisitionError("registry returned the wrong release object")
+    content = payload.get("content")
+    if not isinstance(content, dict):
+        raise ReleaseAcquisitionError("registry returned invalid release content")
+    canonical_content = json.dumps(
+        content,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    actual_sha = hashlib.sha256(canonical_content).hexdigest()
+    if payload.get("content_sha256") != actual_sha or actual_sha != expected_sha:
+        raise ReleaseAcquisitionError("registry returned a content-address mismatch")
+    git = content.get("git")
+    release_commit = git.get("commit") if isinstance(git, dict) else None
+    if (
+        not isinstance(release_commit, str)
+        or _COMMIT_RE.fullmatch(release_commit) is None
+    ):
+        raise ReleaseAcquisitionError("registry returned invalid Git provenance")
+    return payload, release_commit
+
+
+def _write_contained_release(
+    corpus_root: Path,
+    *,
+    release_name: str,
+    release_sha: str,
+    payload: dict[str, Any],
+) -> Path:
+    nofollow = getattr(os, "O_NOFOLLOW", None)
+    directory = getattr(os, "O_DIRECTORY", None)
+    if nofollow is None or directory is None:
+        raise ReleaseAcquisitionError("this platform cannot enforce safe corpus paths")
+    directory_flags = os.O_RDONLY | directory | nofollow | getattr(os, "O_CLOEXEC", 0)
+    try:
+        root_descriptor = os.open(corpus_root, directory_flags)
+    except OSError as exc:
+        raise ReleaseAcquisitionError(
+            f"corpus root is not a safe directory: {exc}"
+        ) from exc
+    descriptor = root_descriptor
+    try:
+        for segment in ("releases", release_name):
+            try:
+                os.mkdir(segment, mode=0o755, dir_fd=descriptor)
+            except FileExistsError:
+                pass
+            try:
+                child = os.open(segment, directory_flags, dir_fd=descriptor)
+            except OSError as exc:
+                raise ReleaseAcquisitionError(
+                    f"corpus release destination is not a safe directory: {exc}"
+                ) from exc
+            if descriptor != root_descriptor:
+                os.close(descriptor)
+            descriptor = child
+
+        filename = f"{release_sha}.json"
+        file_flags = (
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | nofollow
+            | getattr(os, "O_CLOEXEC", 0)
+        )
+        try:
+            output = os.open(filename, file_flags, 0o600, dir_fd=descriptor)
+        except OSError as exc:
+            raise ReleaseAcquisitionError(
+                f"could not exclusively create corpus release object: {exc}"
+            ) from exc
+        try:
+            materialized = (
+                json.dumps(payload, indent=2, sort_keys=True) + "\n"
+            ).encode("utf-8")
+            with os.fdopen(output, "wb", closefd=True) as stream:
+                stream.write(materialized)
+                stream.flush()
+                os.fsync(stream.fileno())
+        except BaseException:
+            try:
+                os.unlink(filename, dir_fd=descriptor)
+            except OSError:
+                pass
+            raise
+    finally:
+        if descriptor != root_descriptor:
+            os.close(descriptor)
+        os.close(root_descriptor)
+    return corpus_root / "releases" / release_name / f"{release_sha}.json"
+
+
+def materialize_registry_response(
+    response_path: Path,
+    corpus_root: Path,
+    *,
+    release_name: str,
+    release_sha: str,
+) -> tuple[Path, str]:
+    """Validate one registry response and write its object inside the corpus root."""
+
+    if _RELEASE_NAME_RE.fullmatch(release_name) is None:
+        raise ReleaseAcquisitionError("corpus release name is invalid")
+    if _SHA256_RE.fullmatch(release_sha) is None:
+        raise ReleaseAcquisitionError("corpus release digest is invalid")
+    payload, release_commit = _validate_registry_response(
+        _read_bounded_regular_file(response_path),
+        expected_name=release_name,
+        expected_sha=release_sha,
+    )
+    destination = _write_contained_release(
+        corpus_root,
+        release_name=release_name,
+        release_sha=release_sha,
+        payload=payload,
+    )
+    return destination, release_commit
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    pin = subparsers.add_parser("pin", help="print a validated RuleSpec release pin")
+    pin.add_argument("--toolchain", type=Path, required=True)
+    materialize = subparsers.add_parser(
+        "materialize", help="validate and materialize a registry response"
+    )
+    materialize.add_argument("--toolchain", type=Path, required=True)
+    materialize.add_argument("--response", type=Path, required=True)
+    materialize.add_argument("--corpus-root", type=Path, required=True)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    release_name, release_sha = load_release_pin(args.toolchain)
+    if args.command == "pin":
+        print(release_name)
+        print(release_sha)
+        return 0
+    _, release_commit = materialize_registry_response(
+        args.response,
+        args.corpus_root,
+        release_name=release_name,
+        release_sha=release_sha,
+    )
+    print(release_commit)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ReleaseAcquisitionError as exc:
+        raise SystemExit(f"Corpus release acquisition error: {exc}") from exc

--- a/tests/test_materialize_corpus_release.py
+++ b/tests/test_materialize_corpus_release.py
@@ -1,0 +1,166 @@
+"""Tests for safe registry-backed corpus release materialization."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[1]
+_SPEC = importlib.util.spec_from_file_location(
+    "materialize_corpus_release",
+    ROOT / "scripts" / "materialize_corpus_release.py",
+)
+assert _SPEC is not None and _SPEC.loader is not None
+release_acquisition = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(release_acquisition)
+
+
+def _response(
+    release_name: str = "test-release",
+    commit: str = "a" * 40,
+) -> tuple[bytes, str, str]:
+    content = {"git": {"commit": commit}}
+    digest = hashlib.sha256(
+        json.dumps(
+            content,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode()
+    ).hexdigest()
+    payload = {
+        "release": release_name,
+        "content_sha256": digest,
+        "content": content,
+        "signature": {"value": "verified by the protected signer"},
+    }
+    return json.dumps([{"release_object": payload}]).encode(), digest, commit
+
+
+def _write_toolchain(path: Path, release_name: str, digest: str) -> None:
+    path.write_text(
+        "[toolchain]\n"
+        f'axiom_corpus_release = "{release_name}"\n'
+        f'axiom_corpus_release_content_sha256 = "{digest}"\n'
+    )
+
+
+def test_materializes_valid_registry_response(tmp_path: Path) -> None:
+    raw, digest, commit = _response()
+    response = tmp_path / "response.json"
+    response.write_bytes(raw)
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+
+    destination, actual_commit = release_acquisition.materialize_registry_response(
+        response,
+        corpus,
+        release_name="test-release",
+        release_sha=digest,
+    )
+
+    assert actual_commit == commit
+    assert destination == corpus / "releases" / "test-release" / f"{digest}.json"
+    assert json.loads(destination.read_text())["content_sha256"] == digest
+
+
+@pytest.mark.parametrize(
+    ("response_factory", "message"),
+    [
+        (lambda raw, _digest: b"not-json", "invalid JSON"),
+        (lambda raw, _digest: json.dumps([]).encode(), "exactly one"),
+        (
+            lambda raw, _digest: json.dumps(json.loads(raw) * 2).encode(),
+            "exactly one",
+        ),
+        (
+            lambda raw, _digest: raw.replace(
+                b'"content_sha256": "', b'"content_sha256": "0'
+            ),
+            "content-address mismatch",
+        ),
+    ],
+)
+def test_rejects_invalid_registry_responses(
+    tmp_path: Path,
+    response_factory,
+    message: str,
+) -> None:
+    raw, digest, _ = _response()
+    response = tmp_path / "response.json"
+    response.write_bytes(response_factory(raw, digest))
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+
+    with pytest.raises(release_acquisition.ReleaseAcquisitionError, match=message):
+        release_acquisition.materialize_registry_response(
+            response,
+            corpus,
+            release_name="test-release",
+            release_sha=digest,
+        )
+
+
+def test_rejects_invalid_git_provenance(tmp_path: Path) -> None:
+    raw, digest, _ = _response(commit="invalid-commit")
+    response = tmp_path / "response.json"
+    response.write_bytes(raw)
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+
+    with pytest.raises(
+        release_acquisition.ReleaseAcquisitionError, match="Git provenance"
+    ):
+        release_acquisition.materialize_registry_response(
+            response,
+            corpus,
+            release_name="test-release",
+            release_sha=digest,
+        )
+
+
+def test_rejects_oversized_registry_response(tmp_path: Path) -> None:
+    response = tmp_path / "response.json"
+    response.write_bytes(b"x" * (release_acquisition.MAX_REGISTRY_RESPONSE_BYTES + 1))
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+
+    with pytest.raises(release_acquisition.ReleaseAcquisitionError, match="16 MiB"):
+        release_acquisition.materialize_registry_response(
+            response,
+            corpus,
+            release_name="test-release",
+            release_sha="0" * 64,
+        )
+
+
+def test_rejects_symlinked_release_directory(tmp_path: Path) -> None:
+    raw, digest, _ = _response()
+    response = tmp_path / "response.json"
+    response.write_bytes(raw)
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    (corpus / "releases").symlink_to(tmp_path / "outside", target_is_directory=True)
+
+    with pytest.raises(
+        release_acquisition.ReleaseAcquisitionError, match="safe directory"
+    ):
+        release_acquisition.materialize_registry_response(
+            response,
+            corpus,
+            release_name="test-release",
+            release_sha=digest,
+        )
+    assert not (tmp_path / "outside").exists()
+
+
+def test_load_release_pin_rejects_unsafe_name(tmp_path: Path) -> None:
+    toolchain = tmp_path / "toolchain.toml"
+    _write_toolchain(toolchain, "../escape", "0" * 64)
+
+    with pytest.raises(release_acquisition.ReleaseAcquisitionError, match="name"):
+        release_acquisition.load_release_pin(toolchain)

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1489,17 +1489,19 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         "SUPABASE_ANON_KEY": "${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY }}",
     }
     release_command = release_step["run"]
-    assert "tomllib" in release_command
+    assert "materialize_corpus_release.py" in release_command
     assert "rulespec-us/.axiom/toolchain.toml" in release_command
-    assert 'r"[a-z0-9][a-z0-9._-]*"' in release_command
-    assert 'r"[0-9a-f]{64}"' in release_command
-    assert "/axiom-corpus/releases/$release_name/$release_sha.json" in release_command
+    assert 'pin --toolchain "$toolchain"' in release_command
+    assert 'mktemp "$RUNNER_TEMP/' in release_command
     assert "/rest/v1/release_objects?select=release_object" in release_command
     assert "content_sha256=eq.${release_sha}&limit=2" in release_command
-    assert "--proto '=https' --tlsv1.2" in release_command
+    assert "--proto '=https' --proto-redir '=https' --tlsv1.2" in release_command
+    assert "--max-filesize 16777216" in release_command
     assert "Accept-Profile: corpus" in release_command
-    assert 'payload.get("content_sha256") != actual' in release_command
-    assert 'content.get("git")' in release_command
+    assert (
+        'materialize --toolchain "$toolchain" --response "$response"' in release_command
+    )
+    assert "--corpus-root axiom-corpus" in release_command
     assert 'merge-base --is-ancestor "$release_commit" HEAD' in release_command
 
     provision_step = next(

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1479,6 +1479,29 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "rev-parse HEAD" in identity_command
     assert "merge-base --is-ancestor" in identity_command
 
+    release_step = next(
+        step
+        for step in steps
+        if step.get("name") == "Fetch pinned signed corpus release object"
+    )
+    assert release_step["env"] == {
+        "SUPABASE_URL": "https://swocpijqqahhuwtuahwc.supabase.co",
+        "SUPABASE_ANON_KEY": "${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY }}",
+    }
+    release_command = release_step["run"]
+    assert "tomllib" in release_command
+    assert "rulespec-us/.axiom/toolchain.toml" in release_command
+    assert 'r"[a-z0-9][a-z0-9._-]*"' in release_command
+    assert 'r"[0-9a-f]{64}"' in release_command
+    assert "/axiom-corpus/releases/$release_name/$release_sha.json" in release_command
+    assert "/rest/v1/release_objects?select=release_object" in release_command
+    assert "content_sha256=eq.${release_sha}&limit=2" in release_command
+    assert "--proto '=https' --tlsv1.2" in release_command
+    assert "Accept-Profile: corpus" in release_command
+    assert 'payload.get("content_sha256") != actual' in release_command
+    assert 'content.get("git")' in release_command
+    assert 'merge-base --is-ancestor "$release_commit" HEAD' in release_command
+
     provision_step = next(
         step
         for step in steps


### PR DESCRIPTION
## Summary
- materialize the RuleSpec-pinned signed corpus release from the public registry before targeted encoding
- validate release pins, canonical content SHA-256, and signed corpus Git provenance
- bound registry responses at 16 MiB and materialize through descriptor-relative no-follow paths
- cover malformed, duplicate, mismatched, oversized, invalid-provenance, and symlinked responses

## Checks
- `uv run --python 3.13 ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run --python 3.13 pytest` (4,090 passed, 106 skipped)
- hosted lint, Python 3.13, Ubuntu signing, and macOS signing checks

## Cycle
- First independent review found an unbounded response, corpus-local symlink risk, and insufficient behavioral coverage.
- Fixed all findings in `a521118f` with a bounded materializer and negative tests.
- Second independent review of exact commit `a521118fc0a96e55718ad335f4b4f453d8ce770a`: no actionable findings.
- All focused, full, and hosted checks passed after the substantive fixes.