### PR TITLE
Canonicalize colon-structured statute filenames

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1275"
+version = "0.2.1276"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1274"
+version = "0.2.1275"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1278"
+version = "0.2.1279"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1277"
+version = "0.2.1278"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1273"
+version = "0.2.1274"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1276"
+version = "0.2.1277"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1278"
+__version__ = "0.2.1279"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1276"
+__version__ = "0.2.1277"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1275"
+__version__ = "0.2.1276"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1274"
+__version__ = "0.2.1275"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1277"
+__version__ = "0.2.1278"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1273"
+__version__ = "0.2.1274"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -7141,7 +7141,7 @@ def _run_single_eval(
         policyengine_rule_hint=policyengine_rule_hint,
     )
     generation_prompt_sha256 = _sha256_text(prompt)
-    output_file = Path(output_root) / runner.name / relative_output
+    output_file = _contained_eval_output_file(output_root, runner.name, relative_output)
     output_file.parent.mkdir(parents=True, exist_ok=True)
     response, wrote_artifact, retry_count = _run_prompt_eval_with_empty_artifact_retry(
         runner=runner,
@@ -7312,7 +7312,7 @@ def _run_single_source_eval(
         policyengine_rule_hint=policyengine_rule_hint,
     )
     generation_prompt_sha256 = _sha256_text(prompt)
-    output_file = Path(output_root) / runner.name / relative_output
+    output_file = _contained_eval_output_file(output_root, runner.name, relative_output)
     output_file.parent.mkdir(parents=True, exist_ok=True)
     response, wrote_artifact, retry_count = _run_prompt_eval_with_empty_artifact_retry(
         runner=runner,
@@ -7442,6 +7442,25 @@ def _resolve_eval_output_path(
     )
 
 
+def _contained_eval_output_file(
+    output_root: Path,
+    runner_name: str,
+    relative_output: Path,
+) -> Path:
+    """Resolve an eval artifact path and require runner-root containment."""
+
+    resolved_output_root = Path(output_root).resolve()
+    runner_root = (resolved_output_root / runner_name).resolve()
+    if not runner_root.is_relative_to(resolved_output_root):
+        raise ValueError(f"Eval runner path escapes output root: {runner_name!r}")
+    output_file = (runner_root / relative_output).resolve()
+    if not output_file.is_relative_to(runner_root):
+        raise ValueError(
+            f"Eval output path escapes runner root: {relative_output.as_posix()!r}"
+        )
+    return output_file
+
+
 def _prompt_corpus_citation_path(source_unit: CorpusSourceUnit) -> str:
     """Return the canonical requested path bound by the resolver attestation."""
 
@@ -7465,12 +7484,16 @@ def _source_identifier_to_relative_rulespec_path(source_id: str) -> Path:
         for part in source_id.strip().strip("/").split("/")
         if part
     ]
+    if any(part in {".", ".."} for part in parts):
+        raise ValueError(
+            f"Unsafe RuleSpec path component in source identifier: {source_id!r}"
+        )
     if parts and ":" in parts[0]:
         jurisdiction, source_root = parts[0].split(":", 1)
         if source_root in _RULESPEC_SOURCE_ROOT_TOKENS:
             tail = parts[1:]
             root = _RULESPEC_OUTPUT_ROOT_BY_SOURCE_TOKEN.get(source_root, source_root)
-            tail = _expand_colon_structured_statute_tail(root, tail)
+            tail = _expand_louisiana_title_section_tail(jurisdiction, root, tail)
             if (
                 tail
                 and jurisdiction == "us"
@@ -7491,7 +7514,6 @@ def _source_identifier_to_relative_rulespec_path(source_id: str) -> Path:
         tail = parts[1:]
         if tail:
             root = _RULESPEC_OUTPUT_ROOT_BY_SOURCE_TOKEN.get(parts[0], parts[0])
-            tail = _expand_colon_structured_statute_tail(root, tail)
             if tail and tail[0] == _UK_LEGISLATION_DOMAIN_TOKEN:
                 tail = _canonical_uk_legislation_tail(tail)
             return Path(root) / _dotted_leaf_to_nested_yaml_path(tail)
@@ -7499,7 +7521,7 @@ def _source_identifier_to_relative_rulespec_path(source_id: str) -> Path:
         root = _RULESPEC_OUTPUT_ROOT_BY_SOURCE_TOKEN.get(parts[1])
         if root is not None:
             tail = parts[2:]
-            tail = _expand_colon_structured_statute_tail(root, tail)
+            tail = _expand_louisiana_title_section_tail(parts[0], root, tail)
             if parts[0] == "us" and parts[1] in {"regulation", "regulations"}:
                 tail = _canonical_us_regulation_tail(tail)
             if parts[0] == "uk":
@@ -7511,18 +7533,28 @@ def _source_identifier_to_relative_rulespec_path(source_id: str) -> Path:
     raise ValueError(f"Unsupported canonical source identifier: {source_id!r}")
 
 
-def _expand_colon_structured_statute_tail(root: str, tail: list[str]) -> list[str]:
-    """Expand state statute ``title:section`` labels into path components."""
+def _expand_louisiana_title_section_tail(
+    jurisdiction: str,
+    root: str,
+    tail: list[str],
+) -> list[str]:
+    """Expand Louisiana statute ``title:section`` labels into path components."""
 
-    if root != "statutes":
+    if jurisdiction != "us-la" or root != "statutes" or not tail:
         return tail
-    expanded: list[str] = []
-    for part in tail:
-        components = part.split(":")
-        if any(not component for component in components):
-            raise ValueError(f"Invalid colon-structured statute segment: {part!r}")
-        expanded.extend(components)
-    return expanded
+    title_section = tail[0]
+    if any(":" in component for component in tail[1:]):
+        raise ValueError(f"Invalid Louisiana statute path: {tail!r}")
+    if ":" not in title_section:
+        return tail
+    components = title_section.split(":")
+    if len(components) != 2 or any(
+        component in {"", ".", ".."} for component in components
+    ):
+        raise ValueError(
+            f"Invalid Louisiana title:section statute segment: {title_section!r}"
+        )
+    return [*components, *tail[1:]]
 
 
 def _dotted_leaf_to_nested_yaml_path(tail: list[str]) -> Path:

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -7602,7 +7602,7 @@ def _secure_eval_read(root: Path, relative_path: Path) -> bytes:
         parent_fd,
         target_name,
     ):
-        flags = os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW
+        flags = os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW | os.O_NONBLOCK
         file_fd = os.open(target_name, flags, dir_fd=parent_fd)
         try:
             metadata = os.fstat(file_fd)
@@ -7739,6 +7739,14 @@ def _expand_louisiana_title_section_tail(
 
     if jurisdiction != "us-la" or root != "statutes" or not tail:
         return tail
+    if any(
+        not component
+        or component.startswith(".")
+        or component.endswith(".")
+        or ".." in component
+        for component in tail
+    ):
+        raise ValueError(f"Invalid Louisiana statute path: {tail!r}")
     title_section = tail[0]
     if any(":" in component for component in tail[1:]):
         raise ValueError(f"Invalid Louisiana statute path: {tail!r}")

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -10,6 +10,7 @@ import math
 import os
 import re
 import shutil
+import stat
 import subprocess
 import tempfile
 import time
@@ -6133,8 +6134,7 @@ def _target_rel_for_eval_identifier(citation: str) -> Path | None:
     if ":" in first_part:
         _jurisdiction, source_root = first_part.split(":", 1)
         if source_root in _RULESPEC_SOURCE_ROOT_TOKENS:
-            rest = normalized.split(":", 1)[1]
-            return _source_identifier_to_relative_rulespec_path(rest)
+            return _source_identifier_to_relative_rulespec_path(normalized)
     if _looks_like_corpus_citation_path(normalized):
         return _source_identifier_to_relative_rulespec_path(normalized)
     try:
@@ -7034,6 +7034,7 @@ def _run_prompt_eval_with_empty_artifact_retry(
     target_file_name: str,
     include_tests: bool,
     policyengine_rule_hint: str | None = None,
+    artifact_root: Path | None = None,
 ) -> tuple[EvalPromptResponse, bool, int]:
     """Run an eval and retry once if no RuleSpec artifact can be materialized."""
     response = _run_prompt_eval(runner, workspace, prompt)
@@ -7043,6 +7044,7 @@ def _run_prompt_eval_with_empty_artifact_retry(
         source_text=source_text,
         workspace_root=workspace.root,
         policyengine_rule_hint=policyengine_rule_hint,
+        artifact_root=artifact_root,
     )
     if wrote_artifact or not _response_allows_empty_artifact_retry(response):
         return response, wrote_artifact, 0
@@ -7059,6 +7061,7 @@ def _run_prompt_eval_with_empty_artifact_retry(
         source_text=source_text,
         workspace_root=workspace.root,
         policyengine_rule_hint=policyengine_rule_hint,
+        artifact_root=artifact_root,
     )
     return (
         _combine_retry_response(response, retry_response, retry_prompt),
@@ -7142,7 +7145,6 @@ def _run_single_eval(
     )
     generation_prompt_sha256 = _sha256_text(prompt)
     output_file = _contained_eval_output_file(output_root, runner.name, relative_output)
-    output_file.parent.mkdir(parents=True, exist_ok=True)
     response, wrote_artifact, retry_count = _run_prompt_eval_with_empty_artifact_retry(
         runner=runner,
         workspace=workspace,
@@ -7152,16 +7154,19 @@ def _run_single_eval(
         target_file_name=relative_output.name,
         include_tests=include_tests,
         policyengine_rule_hint=policyengine_rule_hint,
+        artifact_root=Path(output_root).resolve(),
     )
     if wrote_artifact:
         eval_root = Path(output_root) / runner.name
         _hydrate_eval_root(eval_root, workspace)
 
-    trace_file = (
-        Path(output_root) / "traces" / runner.name / f"{_slugify(citation)}.json"
+    trace_relative = Path("traces") / runner.name / f"{_slugify(citation)}.json"
+    trace_file = Path(output_root).resolve() / trace_relative
+    _secure_atomic_eval_write(
+        Path(output_root).resolve(),
+        trace_relative,
+        json.dumps(response.trace or {}, indent=2, sort_keys=True).encode("utf-8"),
     )
-    trace_file.parent.mkdir(parents=True, exist_ok=True)
-    trace_file.write_text(json.dumps(response.trace or {}, indent=2, sort_keys=True))
 
     metrics = None
     if output_file.exists():
@@ -7313,7 +7318,6 @@ def _run_single_source_eval(
     )
     generation_prompt_sha256 = _sha256_text(prompt)
     output_file = _contained_eval_output_file(output_root, runner.name, relative_output)
-    output_file.parent.mkdir(parents=True, exist_ok=True)
     response, wrote_artifact, retry_count = _run_prompt_eval_with_empty_artifact_retry(
         runner=runner,
         workspace=workspace,
@@ -7323,19 +7327,21 @@ def _run_single_source_eval(
         target_file_name=relative_output.name,
         include_tests=True,
         policyengine_rule_hint=policyengine_rule_hint,
+        artifact_root=Path(output_root).resolve(),
     )
     if wrote_artifact:
         eval_root = Path(output_root) / runner.name
         _hydrate_eval_root(eval_root, workspace)
 
-    trace_file = (
-        Path(output_root)
-        / "traces"
-        / runner.name
-        / f"{_slugify(source_identifier)}.json"
+    trace_relative = (
+        Path("traces") / runner.name / f"{_slugify(source_identifier)}.json"
     )
-    trace_file.parent.mkdir(parents=True, exist_ok=True)
-    trace_file.write_text(json.dumps(response.trace or {}, indent=2, sort_keys=True))
+    trace_file = Path(output_root).resolve() / trace_relative
+    _secure_atomic_eval_write(
+        Path(output_root).resolve(),
+        trace_relative,
+        json.dumps(response.trace or {}, indent=2, sort_keys=True).encode("utf-8"),
+    )
 
     metrics = None
     if output_file.exists():
@@ -7459,6 +7465,191 @@ def _contained_eval_output_file(
             f"Eval output path escapes runner root: {relative_output.as_posix()!r}"
         )
     return output_file
+
+
+@contextlib.contextmanager
+def _open_secure_eval_parent(
+    root: Path,
+    relative_path: Path,
+    *,
+    create: bool,
+) -> Iterator[tuple[int, str]]:
+    """Open a symlink-free parent directory beneath one trusted eval root."""
+
+    relative = Path(relative_path)
+    if (
+        relative.is_absolute()
+        or not relative.parts
+        or any(part in {"", ".", ".."} for part in relative.parts)
+    ):
+        raise ValueError(f"Unsafe eval artifact path: {relative.as_posix()!r}")
+    nofollow = getattr(os, "O_NOFOLLOW", None)
+    directory = getattr(os, "O_DIRECTORY", None)
+    if nofollow is None or directory is None:
+        raise RuntimeError(
+            "Secure eval artifact writes require O_NOFOLLOW and O_DIRECTORY"
+        )
+    directory_flags = os.O_RDONLY | os.O_CLOEXEC | nofollow | directory
+    descriptors: list[int] = []
+    try:
+        current_fd = os.open(Path(root), directory_flags)
+        descriptors.append(current_fd)
+        for component in relative.parts[:-1]:
+            try:
+                child_fd = os.open(component, directory_flags, dir_fd=current_fd)
+            except FileNotFoundError:
+                if not create:
+                    raise
+                try:
+                    os.mkdir(component, 0o755, dir_fd=current_fd)
+                except FileExistsError:
+                    pass
+                child_fd = os.open(component, directory_flags, dir_fd=current_fd)
+            descriptors.append(child_fd)
+            current_fd = child_fd
+        yield current_fd, relative.name
+    finally:
+        for descriptor in reversed(descriptors):
+            os.close(descriptor)
+
+
+def _secure_atomic_eval_write(root: Path, relative_path: Path, raw: bytes) -> None:
+    """Atomically write bytes beneath an eval root without following symlinks."""
+
+    if not isinstance(raw, bytes):
+        raise TypeError("Eval artifact payload must be bytes")
+    _ensure_secure_eval_root(root)
+    with _open_secure_eval_parent(root, relative_path, create=True) as (
+        parent_fd,
+        target_name,
+    ):
+        temporary_name: str | None = None
+        temporary_fd: int | None = None
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC | os.O_NOFOLLOW
+        try:
+            for _attempt in range(100):
+                candidate = f".{target_name}.{os.urandom(16).hex()}.tmp"
+                try:
+                    temporary_fd = os.open(candidate, flags, 0o600, dir_fd=parent_fd)
+                except FileExistsError:
+                    continue
+                temporary_name = candidate
+                break
+            if temporary_fd is None or temporary_name is None:
+                raise OSError("Could not reserve a temporary eval artifact")
+            remaining = memoryview(raw)
+            while remaining:
+                written = os.write(temporary_fd, remaining)
+                if written <= 0:
+                    raise OSError("short write while materializing eval artifact")
+                remaining = remaining[written:]
+            os.fsync(temporary_fd)
+            os.close(temporary_fd)
+            temporary_fd = None
+            os.replace(
+                temporary_name,
+                target_name,
+                src_dir_fd=parent_fd,
+                dst_dir_fd=parent_fd,
+            )
+            temporary_name = None
+            os.fsync(parent_fd)
+        finally:
+            if temporary_fd is not None:
+                os.close(temporary_fd)
+            if temporary_name is not None:
+                with contextlib.suppress(FileNotFoundError):
+                    os.unlink(temporary_name, dir_fd=parent_fd)
+
+
+def _ensure_secure_eval_root(root: Path) -> None:
+    """Create one eval root beneath its parent and reject a root symlink."""
+
+    resolved = Path(os.path.abspath(root))
+    nofollow = getattr(os, "O_NOFOLLOW", None)
+    directory = getattr(os, "O_DIRECTORY", None)
+    if nofollow is None or directory is None:
+        raise RuntimeError(
+            "Secure eval artifact writes require O_NOFOLLOW and O_DIRECTORY"
+        )
+    flags = os.O_RDONLY | os.O_CLOEXEC | nofollow | directory
+    try:
+        root_fd = os.open(resolved, flags)
+    except FileNotFoundError:
+        resolved.parent.mkdir(parents=True, exist_ok=True)
+        parent_fd = os.open(resolved.parent, flags)
+        try:
+            try:
+                os.mkdir(resolved.name, 0o755, dir_fd=parent_fd)
+            except FileExistsError:
+                pass
+            root_fd = os.open(resolved.name, flags, dir_fd=parent_fd)
+        finally:
+            os.close(parent_fd)
+    os.close(root_fd)
+
+
+def _secure_eval_read(root: Path, relative_path: Path) -> bytes:
+    """Read one regular eval artifact through a symlink-free descriptor walk."""
+
+    with _open_secure_eval_parent(root, relative_path, create=False) as (
+        parent_fd,
+        target_name,
+    ):
+        flags = os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW
+        file_fd = os.open(target_name, flags, dir_fd=parent_fd)
+        try:
+            metadata = os.fstat(file_fd)
+            if not stat.S_ISREG(metadata.st_mode):
+                raise ValueError(
+                    f"Eval artifact is not a regular file: {relative_path.as_posix()}"
+                )
+            chunks: list[bytes] = []
+            while True:
+                chunk = os.read(file_fd, 1024 * 1024)
+                if not chunk:
+                    return b"".join(chunks)
+                chunks.append(chunk)
+        finally:
+            os.close(file_fd)
+
+
+def _eval_artifact_write_location(
+    target_path: Path,
+    artifact_root: Path | None,
+) -> tuple[Path, Path]:
+    """Return the trusted root and lexical relative path for one artifact."""
+
+    target = Path(os.path.abspath(target_path))
+    if artifact_root is None:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        return target.parent, Path(target.name)
+    root = Path(os.path.abspath(artifact_root))
+    try:
+        relative = target.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(
+            f"Eval artifact target is outside output root: {target}"
+        ) from exc
+    return root, relative
+
+
+def _write_eval_artifact_text(
+    target_path: Path,
+    content: str,
+    artifact_root: Path | None,
+) -> None:
+    root, relative = _eval_artifact_write_location(target_path, artifact_root)
+    _secure_atomic_eval_write(root, relative, content.encode("utf-8"))
+
+
+def _eval_artifact_exists(target_path: Path, artifact_root: Path | None) -> bool:
+    root, relative = _eval_artifact_write_location(target_path, artifact_root)
+    try:
+        _secure_eval_read(root, relative)
+    except FileNotFoundError:
+        return False
+    return True
 
 
 def _prompt_corpus_citation_path(source_unit: CorpusSourceUnit) -> str:
@@ -11595,15 +11786,20 @@ def _relative_to_root(path: Path, root: Path) -> Path | None:
 def _hydrate_eval_root(eval_root: Path, workspace: EvalWorkspace) -> None:
     """Copy allowed precedent files into the eval root so imports resolve."""
 
-    def copy_context(source: Path, target: Path) -> None:
-        if target.exists():
-            if target.read_bytes() != source.read_bytes():
+    def copy_context(source: Path, target_relative: Path) -> None:
+        source_raw = source.read_bytes()
+        try:
+            existing_raw = _secure_eval_read(eval_root, target_relative)
+        except FileNotFoundError:
+            existing_raw = None
+        if existing_raw is not None:
+            if existing_raw != source_raw:
                 raise ValueError(
-                    f"Conflicting eval context files target the same path: {target}"
+                    "Conflicting eval context files target the same path: "
+                    f"{eval_root / target_relative}"
                 )
             return
-        target.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(source, target)
+        _secure_atomic_eval_write(eval_root, target_relative, source_raw)
 
     for item in workspace.context_files:
         workspace_path = Path(item.workspace_path)
@@ -11618,7 +11814,7 @@ def _hydrate_eval_root(eval_root: Path, workspace: EvalWorkspace) -> None:
             # canonical dependency roots. Never materialize a hidden `_axiom`
             # checkout inside generated output.
             continue
-        copy_context(source, eval_root / target_relative)
+        copy_context(source, target_relative)
 
 
 def _run_prompt_eval(
@@ -13428,6 +13624,7 @@ def _materialize_eval_artifact(
     source_text: str | None = None,
     workspace_root: Path | None = None,
     policyengine_rule_hint: str | None = None,
+    artifact_root: Path | None = None,
 ) -> bool:
     """Write an eval artifact and optional companion test file from model output."""
     single_amount_table_slice = bool(
@@ -13443,6 +13640,7 @@ def _materialize_eval_artifact(
             single_amount_table_slice=single_amount_table_slice,
             source_text=source_text,
             policyengine_rule_hint=policyengine_rule_hint,
+            artifact_root=artifact_root,
         )
         if wrote_from_workspace:
             return True
@@ -13541,11 +13739,10 @@ def _materialize_eval_artifact(
                     content,
                     rule_names=stripped_test_output_names,
                 )
-            target_path.parent.mkdir(parents=True, exist_ok=True)
-            target_path.write_text(content)
+            _write_eval_artifact_text(target_path, content, artifact_root)
             if target_path == expected_path:
                 wrote_main = True
-        if wrote_main or expected_path.exists():
+        if wrote_main or _eval_artifact_exists(expected_path, artifact_root):
             return True
 
     rulespec_content = _extract_rulespec_content(llm_response)
@@ -13561,8 +13758,7 @@ def _materialize_eval_artifact(
     except ValueError:
         return False
 
-    expected_path.parent.mkdir(parents=True, exist_ok=True)
-    expected_path.write_text(rulespec_content)
+    _write_eval_artifact_text(expected_path, rulespec_content, artifact_root)
     return True
 
 
@@ -13573,6 +13769,7 @@ def _materialize_workspace_artifacts(
     single_amount_table_slice: bool,
     source_text: str | None,
     policyengine_rule_hint: str | None = None,
+    artifact_root: Path | None = None,
 ) -> bool:
     """Salvage eval artifacts that a model wrote directly into the workspace."""
     workspace_main = workspace_root / expected_path.name
@@ -13596,8 +13793,7 @@ def _materialize_workspace_artifacts(
     )
     stripped_test_output_names.update(_indexed_parameter_rule_names(main_content))
 
-    expected_path.parent.mkdir(parents=True, exist_ok=True)
-    expected_path.write_text(main_content)
+    _write_eval_artifact_text(expected_path, main_content, artifact_root)
 
     if workspace_test.exists():
         test_content = workspace_test.read_text()
@@ -13628,7 +13824,7 @@ def _materialize_workspace_artifacts(
             test_content,
             rule_names=stripped_test_output_names,
         )
-        expected_test_path.write_text(test_content)
+        _write_eval_artifact_text(expected_test_path, test_content, artifact_root)
 
     return True
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -7456,15 +7456,21 @@ def _contained_eval_output_file(
     """Resolve an eval artifact path and require runner-root containment."""
 
     resolved_output_root = Path(output_root).resolve()
-    runner_root = (resolved_output_root / runner_name).resolve()
-    if not runner_root.is_relative_to(resolved_output_root):
+    runner_relative = Path(runner_name)
+    relative = Path(relative_output)
+    if runner_relative.is_absolute() or any(
+        part in {"", ".", ".."} for part in runner_relative.parts
+    ):
         raise ValueError(f"Eval runner path escapes output root: {runner_name!r}")
-    output_file = (runner_root / relative_output).resolve()
-    if not output_file.is_relative_to(runner_root):
+    if (
+        relative.is_absolute()
+        or not relative.parts
+        or any(part in {"", ".", ".."} for part in relative.parts)
+    ):
         raise ValueError(
             f"Eval output path escapes runner root: {relative_output.as_posix()!r}"
         )
-    return output_file
+    return resolved_output_root / runner_relative / relative
 
 
 @contextlib.contextmanager

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -7470,6 +7470,7 @@ def _source_identifier_to_relative_rulespec_path(source_id: str) -> Path:
         if source_root in _RULESPEC_SOURCE_ROOT_TOKENS:
             tail = parts[1:]
             root = _RULESPEC_OUTPUT_ROOT_BY_SOURCE_TOKEN.get(source_root, source_root)
+            tail = _expand_colon_structured_statute_tail(root, tail)
             if (
                 tail
                 and jurisdiction == "us"
@@ -7490,6 +7491,7 @@ def _source_identifier_to_relative_rulespec_path(source_id: str) -> Path:
         tail = parts[1:]
         if tail:
             root = _RULESPEC_OUTPUT_ROOT_BY_SOURCE_TOKEN.get(parts[0], parts[0])
+            tail = _expand_colon_structured_statute_tail(root, tail)
             if tail and tail[0] == _UK_LEGISLATION_DOMAIN_TOKEN:
                 tail = _canonical_uk_legislation_tail(tail)
             return Path(root) / _dotted_leaf_to_nested_yaml_path(tail)
@@ -7497,6 +7499,7 @@ def _source_identifier_to_relative_rulespec_path(source_id: str) -> Path:
         root = _RULESPEC_OUTPUT_ROOT_BY_SOURCE_TOKEN.get(parts[1])
         if root is not None:
             tail = parts[2:]
+            tail = _expand_colon_structured_statute_tail(root, tail)
             if parts[0] == "us" and parts[1] in {"regulation", "regulations"}:
                 tail = _canonical_us_regulation_tail(tail)
             if parts[0] == "uk":
@@ -7506,6 +7509,20 @@ def _source_identifier_to_relative_rulespec_path(source_id: str) -> Path:
                     return Path(root) / Path(*tail[:-1]) / f"{tail[-1]}.yaml"
                 return Path(root) / _dotted_leaf_to_nested_yaml_path(tail)
     raise ValueError(f"Unsupported canonical source identifier: {source_id!r}")
+
+
+def _expand_colon_structured_statute_tail(root: str, tail: list[str]) -> list[str]:
+    """Expand state statute ``title:section`` labels into path components."""
+
+    if root != "statutes":
+        return tail
+    expanded: list[str] = []
+    for part in tail:
+        components = part.split(":")
+        if any(not component for component in components):
+            raise ValueError(f"Invalid colon-structured statute segment: {part!r}")
+        expanded.extend(components)
+    return expanded
 
 
 def _dotted_leaf_to_nested_yaml_path(tail: list[str]) -> Path:

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -7745,13 +7745,18 @@ def _expand_louisiana_title_section_tail(
     if ":" not in title_section:
         return tail
     components = title_section.split(":")
+    expanded = [*components, *tail[1:]]
     if len(components) != 2 or any(
-        component in {"", ".", ".."} for component in components
+        not component
+        or component.startswith(".")
+        or component.endswith(".")
+        or ".." in component
+        for component in expanded
     ):
         raise ValueError(
             f"Invalid Louisiana title:section statute segment: {title_section!r}"
         )
-    return [*components, *tail[1:]]
+    return expanded
 
 
 def _dotted_leaf_to_nested_yaml_path(tail: list[str]) -> Path:

--- a/tests/test_encoder_path_collisions.py
+++ b/tests/test_encoder_path_collisions.py
@@ -43,6 +43,7 @@ from tests.release_object_fixtures import bind_test_corpus_release
     [
         ("us-la/statute/47:294", "us-la/statute/47:.294"),
         ("us-la/statute/47:294.4", "us-la/statute/47:294..4"),
+        ("us-la/statute/47:294.4", "us-la/statute/47/294..4"),
     ],
 )
 def test_louisiana_malformed_dotted_identity_cannot_alias_valid_path(
@@ -50,7 +51,7 @@ def test_louisiana_malformed_dotted_identity_cannot_alias_valid_path(
     malformed,
 ):
     assert _resolve_eval_output_path(valid).suffix == ".yaml"
-    with pytest.raises(ValueError, match="Invalid Louisiana title:section"):
+    with pytest.raises(ValueError, match="Invalid Louisiana"):
         _resolve_eval_output_path(malformed)
 
 

--- a/tests/test_encoder_path_collisions.py
+++ b/tests/test_encoder_path_collisions.py
@@ -38,6 +38,22 @@ from tests.release_object_fixtures import bind_test_corpus_release
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize(
+    "valid,malformed",
+    [
+        ("us-la/statute/47:294", "us-la/statute/47:.294"),
+        ("us-la/statute/47:294.4", "us-la/statute/47:294..4"),
+    ],
+)
+def test_louisiana_malformed_dotted_identity_cannot_alias_valid_path(
+    valid,
+    malformed,
+):
+    assert _resolve_eval_output_path(valid).suffix == ".yaml"
+    with pytest.raises(ValueError, match="Invalid Louisiana title:section"):
+        _resolve_eval_output_path(malformed)
+
+
 def _make_workspace(root: Path) -> EvalWorkspace:
     root.mkdir(parents=True, exist_ok=True)
     source_text_file = root / "source.txt"

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -2129,6 +2129,12 @@ def test_target_rel_preserves_colon_prefixed_louisiana_jurisdiction():
         "us-la/statute/47:294/../outside",
         "us-la/statute/47:294:outside",
         "us-la/statute/47:294/sub:section",
+        "us-la/statute/47:.294",
+        "us-la/statute/47:294.",
+        "us-la/statute/47:294..4",
+        "us-la/statute/47:294/.subsection",
+        "us-la/statute/47:294/subsection.",
+        "us-la/statute/47:294/sub..section",
     ],
 )
 def test_resolve_eval_output_path_rejects_unsafe_louisiana_components(citation):

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -2146,19 +2146,30 @@ def test_contained_eval_output_file_rejects_output_root_escape(tmp_path):
         _contained_eval_output_file(tmp_path, "../outside", Path("artifact.yaml"))
 
 
-def test_contained_eval_output_file_rejects_symlink_escape(tmp_path):
+def test_contained_eval_output_file_preserves_lexical_target_symlink(tmp_path):
     runner_root = tmp_path / "runner"
-    outside = tmp_path / "outside"
-    runner_root.mkdir()
-    outside.mkdir()
-    (runner_root / "linked").symlink_to(outside, target_is_directory=True)
+    canonical = runner_root / "statutes" / "26" / "1.yaml"
+    requested = runner_root / "statutes" / "47" / "294.yaml"
+    canonical.parent.mkdir(parents=True)
+    requested.parent.mkdir(parents=True)
+    canonical.write_text("canonical sentinel\n", encoding="utf-8")
+    requested.symlink_to(canonical)
 
-    with pytest.raises(ValueError, match="escapes runner root"):
-        _contained_eval_output_file(
-            tmp_path,
-            "runner",
-            Path("linked/artifact.yaml"),
-        )
+    output_file = _contained_eval_output_file(
+        tmp_path,
+        "runner",
+        Path("statutes/47/294.yaml"),
+    )
+    wrote = _materialize_eval_artifact(
+        "format: rulespec/v1\nrules: []\n",
+        output_file,
+        artifact_root=tmp_path,
+    )
+
+    assert wrote is True
+    assert output_file == requested
+    assert not requested.is_symlink()
+    assert canonical.read_text(encoding="utf-8") == "canonical sentinel\n"
 
 
 class TestCorpusSourceResolution:

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -81,6 +81,7 @@ from axiom_encode.harness.evals import (
     _slugify,
     _source_identifier_to_relative_rulespec_path,
     _source_metadata_citation_path,
+    _target_rel_for_eval_identifier,
     _target_source_scope_for_heuristics,
     _validate_eval_result_artifacts,
     _validate_eval_suite_execution_identity,
@@ -2115,6 +2116,12 @@ def test_resolve_eval_output_path_rejects_empty_colon_statute_component():
         _resolve_eval_output_path("us-la/statute/47::294")
 
 
+def test_target_rel_preserves_colon_prefixed_louisiana_jurisdiction():
+    assert _target_rel_for_eval_identifier("us-la:statute/47:294") == Path(
+        "statutes/47/294.yaml"
+    )
+
+
 @pytest.mark.parametrize(
     "citation",
     [
@@ -3450,6 +3457,45 @@ rules:
     assert output_file.exists()
     assert output_file.with_name("tn-snap.test.yaml").exists()
     assert output_file.read_text().startswith("format: rulespec/v1")
+
+
+def test_materialize_eval_artifact_replaces_target_symlink_without_following_it(
+    tmp_path,
+):
+    output_file = tmp_path / "runner" / "statutes" / "47" / "294.yaml"
+    outside = tmp_path / "outside.yaml"
+    output_file.parent.mkdir(parents=True)
+    outside.write_text("outside sentinel\n", encoding="utf-8")
+    output_file.symlink_to(outside)
+
+    wrote = _materialize_eval_artifact(
+        "format: rulespec/v1\nrules: []\n",
+        output_file,
+    )
+
+    assert wrote is True
+    assert outside.read_text(encoding="utf-8") == "outside sentinel\n"
+    assert not output_file.is_symlink()
+    assert output_file.read_text(encoding="utf-8") == (
+        "format: rulespec/v1\nrules: []\n"
+    )
+
+
+def test_materialize_eval_artifact_rejects_symlinked_output_ancestor(tmp_path):
+    output_root = tmp_path / "output"
+    outside = tmp_path / "outside"
+    output_root.mkdir()
+    outside.mkdir()
+    (output_root / "runner").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(OSError):
+        _materialize_eval_artifact(
+            "format: rulespec/v1\nrules: []\n",
+            output_root / "runner" / "statutes" / "47" / "294.yaml",
+            artifact_root=output_root,
+        )
+
+    assert list(outside.iterdir()) == []
 
 
 def test_materialize_eval_artifact_repairs_copied_cross_reference_summary(tmp_path):

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -1929,6 +1929,10 @@ def test_subparagraph_coverage_checklist_requires_exact_corpus_source_keys():
             "us-co/statute/39/39-22-104/1.5",
             "statutes/39/39-22-104/1.5.yaml",
         ),
+        # Louisiana's corpus preserves the official R.S. title:section label,
+        # while RuleSpec represents the separator as a directory boundary.
+        ("us-la/statute/47:294", "statutes/47/294.yaml"),
+        ("us-la/statute/47:297.4", "statutes/47/297/4.yaml"),
         # Slash-separated citations (USC, NYCRR, CFR) are unaffected — these
         # are regression cases for the dot-stripping fix.
         (
@@ -2087,6 +2091,24 @@ def test_resolve_eval_output_path_rejects_free_text_source_identity():
 
 def test_resolve_eval_output_path_uses_exact_canonical_path():
     assert _resolve_eval_output_path("us/statute/26/63") == Path("statutes/26/63.yaml")
+
+
+@pytest.mark.parametrize(
+    "citation,expected",
+    [
+        ("us-la/statute/47:294", "statutes/47/294.yaml"),
+        ("us-la/statute/47:297.4", "statutes/47/297/4.yaml"),
+    ],
+)
+def test_resolve_eval_output_path_expands_louisiana_title_section_separator(
+    citation, expected
+):
+    assert _resolve_eval_output_path(citation) == Path(expected)
+
+
+def test_resolve_eval_output_path_rejects_empty_colon_statute_component():
+    with pytest.raises(ValueError, match="Invalid colon-structured statute segment"):
+        _resolve_eval_output_path("us-la/statute/47::294")
 
 
 class TestCorpusSourceResolution:

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -77,6 +77,7 @@ from axiom_encode.harness.evals import (
     _rulespec_validation_target,
     _run_claude_prompt_eval,
     _run_codex_prompt_eval,
+    _secure_eval_read,
     _select_cross_section_context_files,
     _slugify,
     _source_identifier_to_relative_rulespec_path,
@@ -2150,6 +2151,13 @@ def test_contained_eval_output_file_rejects_runner_root_escape(tmp_path):
 def test_contained_eval_output_file_rejects_output_root_escape(tmp_path):
     with pytest.raises(ValueError, match="runner path escapes output root"):
         _contained_eval_output_file(tmp_path, "../outside", Path("artifact.yaml"))
+
+
+def test_secure_eval_read_rejects_fifo_without_blocking(tmp_path):
+    os.mkfifo(tmp_path / "artifact.yaml")
+
+    with pytest.raises(ValueError, match="not a regular file"):
+        _secure_eval_read(tmp_path, Path("artifact.yaml"))
 
 
 def test_contained_eval_output_file_preserves_lexical_target_symlink(tmp_path):

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -51,6 +51,7 @@ from axiom_encode.harness.evals import (
     _codex_prompt_timeouts,
     _command_looks_out_of_bounds,
     _command_uses_policyengine_skill,
+    _contained_eval_output_file,
     _context_file_executable_surfaces,
     _context_import_target,
     _eval_result_from_payload,
@@ -1933,6 +1934,9 @@ def test_subparagraph_coverage_checklist_requires_exact_corpus_source_keys():
         # while RuleSpec represents the separator as a directory boundary.
         ("us-la/statute/47:294", "statutes/47/294.yaml"),
         ("us-la/statute/47:297.4", "statutes/47/297/4.yaml"),
+        # Colon expansion is a Louisiana source convention, not a generic
+        # rewrite for every jurisdiction.
+        ("us-tx/statute/1:2", "statutes/1:2.yaml"),
         # Slash-separated citations (USC, NYCRR, CFR) are unaffected — these
         # are regression cases for the dot-stripping fix.
         (
@@ -2107,8 +2111,47 @@ def test_resolve_eval_output_path_expands_louisiana_title_section_separator(
 
 
 def test_resolve_eval_output_path_rejects_empty_colon_statute_component():
-    with pytest.raises(ValueError, match="Invalid colon-structured statute segment"):
+    with pytest.raises(ValueError, match="Invalid Louisiana title:section"):
         _resolve_eval_output_path("us-la/statute/47::294")
+
+
+@pytest.mark.parametrize(
+    "citation",
+    [
+        "us-la/statute/47:..",
+        "us-la/statute/47:294/../outside",
+        "us-la/statute/47:294:outside",
+        "us-la/statute/47:294/sub:section",
+    ],
+)
+def test_resolve_eval_output_path_rejects_unsafe_louisiana_components(citation):
+    with pytest.raises(ValueError):
+        _resolve_eval_output_path(citation)
+
+
+def test_contained_eval_output_file_rejects_runner_root_escape(tmp_path):
+    with pytest.raises(ValueError, match="escapes runner root"):
+        _contained_eval_output_file(tmp_path, "runner", Path("../../outside.yaml"))
+
+
+def test_contained_eval_output_file_rejects_output_root_escape(tmp_path):
+    with pytest.raises(ValueError, match="runner path escapes output root"):
+        _contained_eval_output_file(tmp_path, "../outside", Path("artifact.yaml"))
+
+
+def test_contained_eval_output_file_rejects_symlink_escape(tmp_path):
+    runner_root = tmp_path / "runner"
+    outside = tmp_path / "outside"
+    runner_root.mkdir()
+    outside.mkdir()
+    (runner_root / "linked").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="escapes runner root"):
+        _contained_eval_output_file(
+            tmp_path,
+            "runner",
+            Path("linked/artifact.yaml"),
+        )
 
 
 class TestCorpusSourceResolution:

--- a/tests/test_judges.py
+++ b/tests/test_judges.py
@@ -1240,7 +1240,7 @@ def test_drift_regenerator_supports_root_mirror_state_manifest(tmp_path):
     )
 
 
-def test_drift_regenerator_allows_colon_in_contained_module_path(tmp_path):
+def test_drift_regenerator_requires_canonical_path_for_colon_citation(tmp_path):
     root, module, _manifest = _regeneration_fixture(
         tmp_path,
         module="us-la/statutes/47:294.yaml",
@@ -1249,10 +1249,14 @@ def test_drift_regenerator_allows_colon_in_contained_module_path(tmp_path):
     relative = regeneration.validate_module_path(root, module)
 
     assert regeneration.generated_subpath(relative) == Path("statutes/47:294.yaml")
-    assert regeneration.require_citation_derived_output_path(
-        relative,
-        "us-la/statute/47:294",
-    ) == Path("statutes/47:294.yaml")
+    with pytest.raises(
+        regeneration.RegenerationInputError,
+        match=r"canonically encodes to statutes/47/294\.yaml",
+    ):
+        regeneration.require_citation_derived_output_path(
+            relative,
+            "us-la/statute/47:294",
+        )
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1273"
+version = "0.2.1274"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1276"
+version = "0.2.1277"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1278"
+version = "0.2.1279"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1277"
+version = "0.2.1278"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1274"
+version = "0.2.1275"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1275"
+version = "0.2.1276"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- canonicalize Louisiana `title:section` citations such as `us-la/statute/47:294`
- reject malformed dotted identities and traversal components without changing other jurisdictions
- preserve canonical lexical output identity across symlinks
- materialize YAML, tests, hydrated context, and traces with descriptor-relative no-follow atomic writes
- reject special-file reads without blocking
- bump axiom-encode to 0.2.1279

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest` -> 4,116 passed, 106 skipped
- focused eval/judge/collision tests -> 731 passed
- all hosted CI and signing-supervisor checks green

## Review-fix cycle
- Independent review found traversal and over-broad jurisdiction mapping; fixed with Louisiana-only validation and output-root containment.
- Follow-up review found TOCTOU writes and colon-prefixed target lookup divergence; fixed with descriptor-relative no-follow writes and jurisdiction-preserving lookup.
- Follow-up review found same-runner symlink aliasing; fixed by preserving lexical targets.
- Follow-up reviews found malformed dotted and slash-form identity collisions plus blocking FIFO reads; fixed with collision validation and nonblocking regular-file admission.
- Final independent review of exact commit `1f5c7d5dbe9cda3648860ddb9a976cb1cfd5d0e8`: no actionable findings.
