### PR TITLE
Isolate current eval artifacts during hydration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1279"
+version = "0.2.1280"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1282"
+version = "0.2.1283"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1280"
+version = "0.2.1281"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1281"
+version = "0.2.1282"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1279"
+__version__ = "0.2.1280"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1280"
+__version__ = "0.2.1281"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1282"
+__version__ = "0.2.1283"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1281"
+__version__ = "0.2.1282"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -7162,6 +7162,7 @@ def _run_single_eval(
             artifact_root=Path(output_root).resolve(),
         )
     )
+    wrote_artifact = wrote_artifact and output_file in materialized_paths
     if wrote_artifact:
         eval_root = Path(output_root) / runner.name
         protected_paths = [relative_output]
@@ -7178,7 +7179,7 @@ def _run_single_eval(
     )
 
     metrics = None
-    if output_file.exists():
+    if wrote_artifact:
         metrics = _evaluate_generated_artifact_with_repairs(
             rulespec_file=output_file,
             policy_repo_root=policy_path,
@@ -7208,7 +7209,7 @@ def _run_single_eval(
             label="generated eval RuleSpec",
             max_bytes=32 * 1024 * 1024,
         )
-        if output_file.exists() or output_file.is_symlink()
+        if wrote_artifact
         else None
     )
     result = EvalResult(
@@ -7340,6 +7341,7 @@ def _run_single_source_eval(
             artifact_root=Path(output_root).resolve(),
         )
     )
+    wrote_artifact = wrote_artifact and output_file in materialized_paths
     if wrote_artifact:
         eval_root = Path(output_root) / runner.name
         protected_paths = [relative_output]
@@ -7358,7 +7360,7 @@ def _run_single_source_eval(
     )
 
     metrics = None
-    if output_file.exists():
+    if wrote_artifact:
         metrics = _evaluate_generated_artifact_with_repairs(
             rulespec_file=output_file,
             policy_repo_root=policy_path,
@@ -7388,7 +7390,7 @@ def _run_single_source_eval(
             label="generated eval RuleSpec",
             max_bytes=32 * 1024 * 1024,
         )
-        if output_file.exists() or output_file.is_symlink()
+        if wrote_artifact
         else None
     )
     result = EvalResult(
@@ -7661,15 +7663,6 @@ def _write_eval_artifact_text(
 ) -> None:
     root, relative = _eval_artifact_write_location(target_path, artifact_root)
     _secure_atomic_eval_write(root, relative, content.encode("utf-8"))
-
-
-def _eval_artifact_exists(target_path: Path, artifact_root: Path | None) -> bool:
-    root, relative = _eval_artifact_write_location(target_path, artifact_root)
-    try:
-        _secure_eval_read(root, relative)
-    except FileNotFoundError:
-        return False
-    return True
 
 
 def _prompt_corpus_citation_path(source_unit: CorpusSourceUnit) -> str:
@@ -13795,7 +13788,7 @@ def _materialize_eval_artifact(
                 materialized_paths.add(target_path)
             if target_path == expected_path:
                 wrote_main = True
-        if wrote_main or _eval_artifact_exists(expected_path, artifact_root):
+        if wrote_main:
             return True
 
     rulespec_content = _extract_rulespec_content(llm_response)

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -7149,6 +7149,8 @@ def _run_single_eval(
     )
     generation_prompt_sha256 = _sha256_text(prompt)
     output_file = _contained_eval_output_file(output_root, runner.name, relative_output)
+    artifact_root = Path(output_root).resolve()
+    _clear_eval_target_artifacts(output_file, artifact_root)
     response, wrote_artifact, retry_count, materialized_paths = (
         _run_prompt_eval_with_empty_artifact_retry(
             runner=runner,
@@ -7159,7 +7161,7 @@ def _run_single_eval(
             target_file_name=relative_output.name,
             include_tests=include_tests,
             policyengine_rule_hint=policyengine_rule_hint,
-            artifact_root=Path(output_root).resolve(),
+            artifact_root=artifact_root,
         )
     )
     wrote_artifact = wrote_artifact and output_file in materialized_paths
@@ -7328,6 +7330,8 @@ def _run_single_source_eval(
     )
     generation_prompt_sha256 = _sha256_text(prompt)
     output_file = _contained_eval_output_file(output_root, runner.name, relative_output)
+    artifact_root = Path(output_root).resolve()
+    _clear_eval_target_artifacts(output_file, artifact_root)
     response, wrote_artifact, retry_count, materialized_paths = (
         _run_prompt_eval_with_empty_artifact_retry(
             runner=runner,
@@ -7338,7 +7342,7 @@ def _run_single_source_eval(
             target_file_name=relative_output.name,
             include_tests=True,
             policyengine_rule_hint=policyengine_rule_hint,
-            artifact_root=Path(output_root).resolve(),
+            artifact_root=artifact_root,
         )
     )
     wrote_artifact = wrote_artifact and output_file in materialized_paths
@@ -7663,6 +7667,26 @@ def _write_eval_artifact_text(
 ) -> None:
     root, relative = _eval_artifact_write_location(target_path, artifact_root)
     _secure_atomic_eval_write(root, relative, content.encode("utf-8"))
+
+
+def _clear_eval_target_artifacts(expected_path: Path, artifact_root: Path) -> None:
+    """Remove stale main and companion artifacts without following symlinks."""
+
+    for target_path in (expected_path, _rulespec_test_path(expected_path)):
+        root, relative = _eval_artifact_write_location(target_path, artifact_root)
+        _ensure_secure_eval_root(root)
+        try:
+            with _open_secure_eval_parent(root, relative, create=False) as (
+                parent_fd,
+                target_name,
+            ):
+                try:
+                    os.unlink(target_name, dir_fd=parent_fd)
+                except FileNotFoundError:
+                    continue
+                os.fsync(parent_fd)
+        except FileNotFoundError:
+            continue
 
 
 def _prompt_corpus_citation_path(source_unit: CorpusSourceUnit) -> str:

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -7035,8 +7035,9 @@ def _run_prompt_eval_with_empty_artifact_retry(
     include_tests: bool,
     policyengine_rule_hint: str | None = None,
     artifact_root: Path | None = None,
-) -> tuple[EvalPromptResponse, bool, int]:
+) -> tuple[EvalPromptResponse, bool, int, frozenset[Path]]:
     """Run an eval and retry once if no RuleSpec artifact can be materialized."""
+    materialized_paths: set[Path] = set()
     response = _run_prompt_eval(runner, workspace, prompt)
     wrote_artifact = _materialize_eval_artifact(
         response.text,
@@ -7045,9 +7046,10 @@ def _run_prompt_eval_with_empty_artifact_retry(
         workspace_root=workspace.root,
         policyengine_rule_hint=policyengine_rule_hint,
         artifact_root=artifact_root,
+        materialized_paths=materialized_paths,
     )
     if wrote_artifact or not _response_allows_empty_artifact_retry(response):
-        return response, wrote_artifact, 0
+        return response, wrote_artifact, 0, frozenset(materialized_paths)
 
     retry_prompt = _build_empty_artifact_retry_prompt(
         prompt,
@@ -7062,11 +7064,13 @@ def _run_prompt_eval_with_empty_artifact_retry(
         workspace_root=workspace.root,
         policyengine_rule_hint=policyengine_rule_hint,
         artifact_root=artifact_root,
+        materialized_paths=materialized_paths,
     )
     return (
         _combine_retry_response(response, retry_response, retry_prompt),
         retry_wrote_artifact,
         1,
+        frozenset(materialized_paths),
     )
 
 
@@ -7145,20 +7149,25 @@ def _run_single_eval(
     )
     generation_prompt_sha256 = _sha256_text(prompt)
     output_file = _contained_eval_output_file(output_root, runner.name, relative_output)
-    response, wrote_artifact, retry_count = _run_prompt_eval_with_empty_artifact_retry(
-        runner=runner,
-        workspace=workspace,
-        prompt=prompt,
-        output_file=output_file,
-        source_text=source_text,
-        target_file_name=relative_output.name,
-        include_tests=include_tests,
-        policyengine_rule_hint=policyengine_rule_hint,
-        artifact_root=Path(output_root).resolve(),
+    response, wrote_artifact, retry_count, materialized_paths = (
+        _run_prompt_eval_with_empty_artifact_retry(
+            runner=runner,
+            workspace=workspace,
+            prompt=prompt,
+            output_file=output_file,
+            source_text=source_text,
+            target_file_name=relative_output.name,
+            include_tests=include_tests,
+            policyengine_rule_hint=policyengine_rule_hint,
+            artifact_root=Path(output_root).resolve(),
+        )
     )
     if wrote_artifact:
         eval_root = Path(output_root) / runner.name
-        _hydrate_eval_root(eval_root, workspace, protected_paths=(relative_output,))
+        protected_paths = [relative_output]
+        if _rulespec_test_path(output_file) in materialized_paths:
+            protected_paths.append(_rulespec_test_path(relative_output))
+        _hydrate_eval_root(eval_root, workspace, protected_paths=protected_paths)
 
     trace_relative = Path("traces") / runner.name / f"{_slugify(citation)}.json"
     trace_file = Path(output_root).resolve() / trace_relative
@@ -7318,20 +7327,25 @@ def _run_single_source_eval(
     )
     generation_prompt_sha256 = _sha256_text(prompt)
     output_file = _contained_eval_output_file(output_root, runner.name, relative_output)
-    response, wrote_artifact, retry_count = _run_prompt_eval_with_empty_artifact_retry(
-        runner=runner,
-        workspace=workspace,
-        prompt=prompt,
-        output_file=output_file,
-        source_text=source_text,
-        target_file_name=relative_output.name,
-        include_tests=True,
-        policyengine_rule_hint=policyengine_rule_hint,
-        artifact_root=Path(output_root).resolve(),
+    response, wrote_artifact, retry_count, materialized_paths = (
+        _run_prompt_eval_with_empty_artifact_retry(
+            runner=runner,
+            workspace=workspace,
+            prompt=prompt,
+            output_file=output_file,
+            source_text=source_text,
+            target_file_name=relative_output.name,
+            include_tests=True,
+            policyengine_rule_hint=policyengine_rule_hint,
+            artifact_root=Path(output_root).resolve(),
+        )
     )
     if wrote_artifact:
         eval_root = Path(output_root) / runner.name
-        _hydrate_eval_root(eval_root, workspace, protected_paths=(relative_output,))
+        protected_paths = [relative_output]
+        if _rulespec_test_path(output_file) in materialized_paths:
+            protected_paths.append(_rulespec_test_path(relative_output))
+        _hydrate_eval_root(eval_root, workspace, protected_paths=protected_paths)
 
     trace_relative = (
         Path("traces") / runner.name / f"{_slugify(source_identifier)}.json"
@@ -13660,6 +13674,7 @@ def _materialize_eval_artifact(
     workspace_root: Path | None = None,
     policyengine_rule_hint: str | None = None,
     artifact_root: Path | None = None,
+    materialized_paths: set[Path] | None = None,
 ) -> bool:
     """Write an eval artifact and optional companion test file from model output."""
     single_amount_table_slice = bool(
@@ -13676,6 +13691,7 @@ def _materialize_eval_artifact(
             source_text=source_text,
             policyengine_rule_hint=policyengine_rule_hint,
             artifact_root=artifact_root,
+            materialized_paths=materialized_paths,
         )
         if wrote_from_workspace:
             return True
@@ -13775,6 +13791,8 @@ def _materialize_eval_artifact(
                     rule_names=stripped_test_output_names,
                 )
             _write_eval_artifact_text(target_path, content, artifact_root)
+            if materialized_paths is not None:
+                materialized_paths.add(target_path)
             if target_path == expected_path:
                 wrote_main = True
         if wrote_main or _eval_artifact_exists(expected_path, artifact_root):
@@ -13794,6 +13812,8 @@ def _materialize_eval_artifact(
         return False
 
     _write_eval_artifact_text(expected_path, rulespec_content, artifact_root)
+    if materialized_paths is not None:
+        materialized_paths.add(expected_path)
     return True
 
 
@@ -13805,6 +13825,7 @@ def _materialize_workspace_artifacts(
     source_text: str | None,
     policyengine_rule_hint: str | None = None,
     artifact_root: Path | None = None,
+    materialized_paths: set[Path] | None = None,
 ) -> bool:
     """Salvage eval artifacts that a model wrote directly into the workspace."""
     workspace_main = workspace_root / expected_path.name
@@ -13829,6 +13850,8 @@ def _materialize_workspace_artifacts(
     stripped_test_output_names.update(_indexed_parameter_rule_names(main_content))
 
     _write_eval_artifact_text(expected_path, main_content, artifact_root)
+    if materialized_paths is not None:
+        materialized_paths.add(expected_path)
 
     if workspace_test.exists():
         test_content = workspace_test.read_text()
@@ -13860,6 +13883,8 @@ def _materialize_workspace_artifacts(
             rule_names=stripped_test_output_names,
         )
         _write_eval_artifact_text(expected_test_path, test_content, artifact_root)
+        if materialized_paths is not None:
+            materialized_paths.add(expected_test_path)
 
     return True
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -7158,7 +7158,7 @@ def _run_single_eval(
     )
     if wrote_artifact:
         eval_root = Path(output_root) / runner.name
-        _hydrate_eval_root(eval_root, workspace)
+        _hydrate_eval_root(eval_root, workspace, protected_paths=(relative_output,))
 
     trace_relative = Path("traces") / runner.name / f"{_slugify(citation)}.json"
     trace_file = Path(output_root).resolve() / trace_relative
@@ -7331,7 +7331,7 @@ def _run_single_source_eval(
     )
     if wrote_artifact:
         eval_root = Path(output_root) / runner.name
-        _hydrate_eval_root(eval_root, workspace)
+        _hydrate_eval_root(eval_root, workspace, protected_paths=(relative_output,))
 
     trace_relative = (
         Path("traces") / runner.name / f"{_slugify(source_identifier)}.json"
@@ -11802,8 +11802,22 @@ def _relative_to_root(path: Path, root: Path) -> Path | None:
         return None
 
 
-def _hydrate_eval_root(eval_root: Path, workspace: EvalWorkspace) -> None:
+def _hydrate_eval_root(
+    eval_root: Path,
+    workspace: EvalWorkspace,
+    *,
+    protected_paths: Sequence[Path] = (),
+) -> None:
     """Copy allowed precedent files into the eval root so imports resolve."""
+
+    protected = {Path(path) for path in protected_paths}
+    if any(
+        path.is_absolute()
+        or not path.parts
+        or any(part in {"", ".", ".."} for part in path.parts)
+        for path in protected
+    ):
+        raise ValueError("Protected eval artifact paths must be canonical and relative")
 
     def copy_context(source: Path, target_relative: Path) -> None:
         source_raw = source.read_bytes()
@@ -11826,6 +11840,8 @@ def _hydrate_eval_root(eval_root: Path, workspace: EvalWorkspace) -> None:
             continue
 
         target_relative = _import_target_to_path(item.import_path)
+        if target_relative in protected:
+            continue
         source = workspace.root / workspace_path
         prefix = _import_target_prefix(item.import_path)
         if prefix and prefix != workspace.policy_prefix:

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -3490,6 +3490,25 @@ rules:
     }
 
 
+def test_materialize_eval_artifact_rejects_test_only_bundle_with_stale_main(
+    tmp_path,
+):
+    output_file = tmp_path / "runner" / "statutes" / "47" / "294.yaml"
+    output_file.parent.mkdir(parents=True)
+    output_file.write_text("stale prior-run main\n", encoding="utf-8")
+    materialized_paths: set[Path] = set()
+
+    wrote = _materialize_eval_artifact(
+        "=== FILE: 294.test.yaml ===\n- name: current test only\n",
+        output_file,
+        materialized_paths=materialized_paths,
+    )
+
+    assert wrote is False
+    assert output_file.read_text(encoding="utf-8") == "stale prior-run main\n"
+    assert materialized_paths == {output_file.with_name("294.test.yaml")}
+
+
 def test_materialize_eval_artifact_replaces_target_symlink_without_following_it(
     tmp_path,
 ):

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -48,6 +48,7 @@ from axiom_encode.harness.evals import (
     _canonical_rulespec_target_for_path,
     _canonical_target_ref_prefix,
     _clean_generated_file_content,
+    _clear_eval_target_artifacts,
     _codex_prompt_timeouts,
     _command_looks_out_of_bounds,
     _command_uses_policyengine_skill,
@@ -3507,6 +3508,49 @@ def test_materialize_eval_artifact_rejects_test_only_bundle_with_stale_main(
     assert wrote is False
     assert output_file.read_text(encoding="utf-8") == "stale prior-run main\n"
     assert materialized_paths == {output_file.with_name("294.test.yaml")}
+
+
+def test_clear_eval_target_artifacts_prevents_reused_companion_test(
+    tmp_path,
+):
+    output_root = tmp_path / "output"
+    output_file = output_root / "runner" / "statutes" / "47" / "294.yaml"
+    companion_test = output_file.with_name("294.test.yaml")
+    output_file.parent.mkdir(parents=True)
+    output_file.write_text("stale prior-run main\n", encoding="utf-8")
+    companion_test.write_text("- name: stale prior-run test\n", encoding="utf-8")
+
+    _clear_eval_target_artifacts(output_file, output_root)
+    wrote = _materialize_eval_artifact(
+        "format: rulespec/v1\nrules: []\n",
+        output_file,
+        artifact_root=output_root,
+    )
+
+    assert wrote is True
+    assert output_file.read_text(encoding="utf-8") == (
+        "format: rulespec/v1\nrules: []\n"
+    )
+    assert not companion_test.exists()
+
+
+def test_clear_eval_target_artifacts_rejects_symlinked_ancestor(tmp_path):
+    output_root = tmp_path / "output"
+    outside = tmp_path / "outside"
+    output_root.mkdir()
+    outside.mkdir()
+    (output_root / "runner").symlink_to(outside, target_is_directory=True)
+    outside_target = outside / "statutes" / "47" / "294.yaml"
+    outside_target.parent.mkdir(parents=True)
+    outside_target.write_text("outside sentinel\n", encoding="utf-8")
+
+    with pytest.raises(OSError):
+        _clear_eval_target_artifacts(
+            output_root / "runner" / "statutes" / "47" / "294.yaml",
+            output_root,
+        )
+
+    assert outside_target.read_text(encoding="utf-8") == "outside sentinel\n"
 
 
 def test_materialize_eval_artifact_replaces_target_symlink_without_following_it(

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -15368,6 +15368,52 @@ rules:
             "format: rulespec/v1\nmodule:\n  status: stub\nrules: []\n"
         )
 
+    def test_hydrate_eval_root_preserves_generated_target_and_copies_sibling(
+        self, tmp_path
+    ):
+        workspace_root = tmp_path / "workspace"
+        context_root = workspace_root / "context" / "statutes" / "47"
+        context_root.mkdir(parents=True)
+        old_target = context_root / "294.yaml"
+        sibling = context_root / "295.yaml"
+        old_target.write_text("old target\n", encoding="utf-8")
+        sibling.write_text("sibling context\n", encoding="utf-8")
+        workspace = EvalWorkspace(
+            root=workspace_root,
+            source_text_file=workspace_root / "source.txt",
+            manifest_file=workspace_root / "context-manifest.json",
+            context_files=[
+                EvalContextFile(
+                    source_path=old_target,
+                    workspace_path=Path("context/statutes/47/294.yaml"),
+                    import_path="us-la:statutes/47/294",
+                    kind="implementation_precedent",
+                ),
+                EvalContextFile(
+                    source_path=sibling,
+                    workspace_path=Path("context/statutes/47/295.yaml"),
+                    import_path="us-la:statutes/47/295",
+                    kind="implementation_precedent",
+                ),
+            ],
+            policy_prefix="us-la",
+        )
+        eval_root = tmp_path / "eval-root"
+        generated_target = eval_root / "statutes" / "47" / "294.yaml"
+        generated_target.parent.mkdir(parents=True)
+        generated_target.write_text("generated target\n", encoding="utf-8")
+
+        _hydrate_eval_root(
+            eval_root,
+            workspace,
+            protected_paths=(Path("statutes/47/294.yaml"),),
+        )
+
+        assert generated_target.read_text(encoding="utf-8") == "generated target\n"
+        assert (eval_root / "statutes/47/295.yaml").read_text(
+            encoding="utf-8"
+        ) == "sibling context\n"
+
     def test_prepare_eval_workspace_expands_transitive_context_imports(self, tmp_path):
         repo_root = tmp_path / "repos"
         policy_repo_root = _canonical_rulespec_content_root(repo_root, "us")

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -3450,6 +3450,7 @@ rules:
 
 def test_materialize_eval_artifact_writes_rulespec_bundle(tmp_path):
     output_file = tmp_path / "runner" / "source" / "tn-snap.yaml"
+    materialized_paths: set[Path] = set()
     llm_response = """=== FILE: tn-snap.yaml ===
 format: rulespec/v1
 module:
@@ -3476,12 +3477,17 @@ rules:
         llm_response,
         output_file,
         source_text="The standard utility allowance is $451.",
+        materialized_paths=materialized_paths,
     )
 
     assert wrote is True
     assert output_file.exists()
     assert output_file.with_name("tn-snap.test.yaml").exists()
     assert output_file.read_text().startswith("format: rulespec/v1")
+    assert materialized_paths == {
+        output_file,
+        output_file.with_name("tn-snap.test.yaml"),
+    }
 
 
 def test_materialize_eval_artifact_replaces_target_symlink_without_following_it(
@@ -15375,8 +15381,10 @@ rules:
         context_root = workspace_root / "context" / "statutes" / "47"
         context_root.mkdir(parents=True)
         old_target = context_root / "294.yaml"
+        old_target_test = context_root / "294.test.yaml"
         sibling = context_root / "295.yaml"
         old_target.write_text("old target\n", encoding="utf-8")
+        old_target_test.write_text("old target test\n", encoding="utf-8")
         sibling.write_text("sibling context\n", encoding="utf-8")
         workspace = EvalWorkspace(
             root=workspace_root,
@@ -15388,6 +15396,12 @@ rules:
                     workspace_path=Path("context/statutes/47/294.yaml"),
                     import_path="us-la:statutes/47/294",
                     kind="implementation_precedent",
+                ),
+                EvalContextFile(
+                    source_path=old_target_test,
+                    workspace_path=Path("context/statutes/47/294.test.yaml"),
+                    import_path="us-la:statutes/47/294.test",
+                    kind="existing_target_test_context",
                 ),
                 EvalContextFile(
                     source_path=sibling,
@@ -15402,14 +15416,23 @@ rules:
         generated_target = eval_root / "statutes" / "47" / "294.yaml"
         generated_target.parent.mkdir(parents=True)
         generated_target.write_text("generated target\n", encoding="utf-8")
+        generated_target_test = eval_root / "statutes" / "47" / "294.test.yaml"
+        generated_target_test.write_text("generated target test\n", encoding="utf-8")
 
         _hydrate_eval_root(
             eval_root,
             workspace,
-            protected_paths=(Path("statutes/47/294.yaml"),),
+            protected_paths=(
+                Path("statutes/47/294.yaml"),
+                Path("statutes/47/294.test.yaml"),
+            ),
         )
 
         assert generated_target.read_text(encoding="utf-8") == "generated target\n"
+        assert (
+            generated_target_test.read_text(encoding="utf-8")
+            == "generated target test\n"
+        )
         assert (eval_root / "statutes/47/295.yaml").read_text(
             encoding="utf-8"
         ) == "sibling context\n"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1279"
+version = "0.2.1280"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1280"
+version = "0.2.1281"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1281"
+version = "0.2.1282"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1282"
+version = "0.2.1283"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- preserve freshly generated RuleSpec main and companion-test artifacts during repo-context hydration
- clear stale target artifacts before each generation attempt through symlink-safe descriptor-relative deletion
- require current-attempt main materialization before hydration, metrics, hashing, or result attribution
- continue hydrating sibling and imported context with existing conflict checks
- bump axiom-encode to 0.2.1283

## Trigger
Signed run 29639805200 generated `statutes/47/294.yaml` but hydration attempted to copy the old target context onto the same path. Review then identified equivalent companion-test collisions and stale reused-output risks.

## Checks
- full local: 4,120 passed, 106 skipped
- focused hydration, retry, materialization, stale-output, and symlink tests: 8 passed
- Ruff, compileall, and diff checks passed
- hosted CI and signing-supervisor checks passed on macOS and Ubuntu

## Cycle
Independent review-fix cycle completed through four iterations. Final review of exact head `942d04626fb7cca1f3a59b24f0133dabf11036af` found no actionable issues; reviewer also ran all 608 `tests/test_evals.py` tests and a 12-test focused selection.