### PR TITLE
Keep targeted review input outside pinned checkouts

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -297,11 +297,7 @@ jobs:
             --apply
           )
           if [ -n "$REVIEW_FINDING" ]; then
-            review_finding_path="$GITHUB_WORKSPACE/axiom-rules-engine/.axiom-targeted-review-finding.txt"
-            if [ -e "$review_finding_path" ] || [ -L "$review_finding_path" ]; then
-              echo "reserved review finding path already exists" >&2
-              exit 1
-            fi
+            review_finding_path="$(mktemp "$RUNNER_TEMP/axiom-targeted-review-finding.XXXXXX")"
             printf '%s\n' "$REVIEW_FINDING" > "$review_finding_path"
             args+=(--review-findings "$review_finding_path")
           fi

--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -297,7 +297,7 @@ jobs:
             --apply
           )
           if [ -n "$REVIEW_FINDING" ]; then
-            review_finding_path="$(mktemp "$RUNNER_TEMP/axiom-targeted-review-finding.XXXXXX")"
+            review_finding_path="$(mktemp "$RUNNER_TEMP/axiom-targeted-review-finding.XXXXXX.txt")"
             printf '%s\n' "$REVIEW_FINDING" > "$review_finding_path"
             args+=(--review-findings "$review_finding_path")
           fi
@@ -333,6 +333,7 @@ jobs:
       - name: Package exact generated changes
         env:
           CITATION: ${{ inputs.citation }}
+          REVIEW_FINDING_PRESENT: ${{ inputs.review_finding != '' }}
         run: |
           artifact="$RUNNER_TEMP/targeted-reencode"
           mkdir -p "$artifact"
@@ -341,6 +342,82 @@ jobs:
             | tar -C rulespec-us --null -czf "$artifact/untracked.tar.gz" --files-from -
           git -C rulespec-us status --short > "$artifact/status.txt"
           cp "$RUNNER_TEMP/guard-generated.json" "$artifact/guard-generated.json"
+          python - "$artifact/context-manifest.json" <<'PY'
+          import hashlib
+          import json
+          import os
+          import subprocess
+          import sys
+          from pathlib import Path
+
+          def git_paths(*args):
+              output = subprocess.check_output(
+                  ["git", "-C", "rulespec-us", *args]
+              )
+              return {
+                  Path(value.decode("utf-8"))
+                  for value in output.split(b"\0")
+                  if value
+              }
+
+          manifest_paths = git_paths(
+              "diff", "--name-only", "-z", "HEAD", "--",
+              ".axiom/encoding-manifests",
+          )
+          manifest_paths.update(
+              git_paths(
+                  "ls-files", "--others", "--exclude-standard", "-z", "--",
+                  ".axiom/encoding-manifests",
+              )
+          )
+          matches = []
+          for relative_path in sorted(manifest_paths):
+              manifest_path = Path("rulespec-us") / relative_path
+              payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+              if (
+                  payload.get("schema_version")
+                  == "axiom-encode/applied-rulespec/v5"
+                  and payload.get("citation") == os.environ["CITATION"]
+              ):
+                  matches.append(payload)
+          if len(matches) != 1:
+              raise SystemExit(
+                  "expected exactly one changed signed apply manifest for citation; "
+                  f"found {len(matches)}"
+              )
+
+          applied_manifest = matches[0]
+          context_path = Path(applied_manifest["context_manifest_file"]).resolve()
+          generated_root = (Path(os.environ["RUNNER_TEMP"]) / "generated").resolve()
+          try:
+              context_path.relative_to(generated_root)
+          except ValueError as exc:
+              raise SystemExit("signed context manifest is outside generated root") from exc
+          context_bytes = context_path.read_bytes()
+          context_digest = hashlib.sha256(context_bytes).hexdigest()
+          if context_digest != applied_manifest.get("context_manifest_sha256"):
+              raise SystemExit("signed context manifest digest does not match")
+
+          context_payload = json.loads(context_bytes)
+          review_findings = context_payload.get("review_findings_files")
+          if not isinstance(review_findings, list):
+              raise SystemExit("context manifest review findings evidence is malformed")
+          if os.environ["REVIEW_FINDING_PRESENT"] == "true" and not review_findings:
+              raise SystemExit("context manifest omits supplied review finding")
+          for finding in review_findings:
+              if not isinstance(finding, dict):
+                  raise SystemExit("context manifest review finding is malformed")
+              content = finding.get("content")
+              digest = finding.get("sha256")
+              if not isinstance(content, str) or not content.strip():
+                  raise SystemExit("context manifest review finding content is empty")
+              if "\r" in content:
+                  raise SystemExit("context manifest review finding is not normalized")
+              if hashlib.sha256(content.encode("utf-8")).hexdigest() != digest:
+                  raise SystemExit("context manifest review finding digest does not match")
+
+          Path(sys.argv[1]).write_bytes(context_bytes)
+          PY
           python - "$artifact/metadata.json" <<'PY'
           import json
           import os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1286"
+version = "0.2.1287"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1287"
+version = "0.2.1288"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1287"
+__version__ = "0.2.1288"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1286"
+__version__ = "0.2.1287"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -5082,6 +5082,7 @@ def prepare_eval_workspace(
         provision_metadata_file.write_text(provision_metadata_text + "\n")
 
     review_findings_files: list[EvalContextFile] = []
+    review_findings_evidence: list[dict[str, object]] = []
     for index, raw_path in enumerate(review_findings_paths or [], start=1):
         source_path = validate_explicit_context_file(
             Path(raw_path),
@@ -5093,22 +5094,37 @@ def prepare_eval_workspace(
             raise ValueError(
                 f"Review findings file is not valid UTF-8 text: {source_path}"
             ) from exc
-        if not findings_text.strip():
+        normalized_findings_text = findings_text.replace("\r\n", "\n").replace(
+            "\r", "\n"
+        )
+        if not normalized_findings_text.strip():
             raise ValueError(f"Review findings file is empty: {source_path}")
         workspace_relative_path = (
             Path("review-findings") / f"{index:02d}-{source_path.name}"
         )
         workspace_path = workspace_root / workspace_relative_path
         workspace_path.parent.mkdir(parents=True, exist_ok=True)
-        workspace_path.write_text(findings_text)
-        review_findings_files.append(
-            EvalContextFile(
-                source_path=str(source_path),
-                workspace_path=str(workspace_relative_path),
-                import_path=str(workspace_relative_path),
-                kind="mandatory_review_findings",
-                label=source_path.name,
-            )
+        workspace_path.write_text(
+            normalized_findings_text,
+            encoding="utf-8",
+            newline="",
+        )
+        context_file = EvalContextFile(
+            source_path=str(source_path),
+            workspace_path=str(workspace_relative_path),
+            import_path=str(workspace_relative_path),
+            kind="mandatory_review_findings",
+            label=source_path.name,
+        )
+        review_findings_files.append(context_file)
+        review_findings_evidence.append(
+            {
+                **asdict(context_file),
+                "content": normalized_findings_text,
+                "sha256": hashlib.sha256(
+                    normalized_findings_text.encode("utf-8")
+                ).hexdigest(),
+            }
         )
 
     context_files: list[EvalContextFile] = []
@@ -5236,9 +5252,7 @@ def prepare_eval_workspace(
                     else None
                 ),
                 "context_files": [asdict(item) for item in context_files],
-                "review_findings_files": [
-                    asdict(item) for item in review_findings_files
-                ],
+                "review_findings_files": review_findings_evidence,
             },
             indent=2,
             sort_keys=True,

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -4625,9 +4625,9 @@ def test_run_source_eval_rejects_symlinked_explicit_context(tmp_path):
 def test_review_findings_are_persisted_and_mandatory_in_prompt(tmp_path):
     policy_repo_root = _canonical_rulespec_content_root(tmp_path, "us")
     findings = tmp_path / "review-findings.md"
-    findings.write_text(
-        "- Start the FY 2025 amount on October 1.\n"
-        "- Preserve the FY 2026 imported amount and boundary test.\n"
+    findings.write_bytes(
+        b"- Start the FY 2025 amount on October 1.\r\n"
+        b"- Preserve the FY 2026 imported amount and boundary test.\r\n"
     )
     workspace = prepare_eval_workspace(
         citation="us/manual/example/block-1",
@@ -4654,8 +4654,15 @@ def test_review_findings_are_persisted_and_mandatory_in_prompt(tmp_path):
     assert "Start the FY 2025 amount on October 1" in prompt
     assert "Preserve the FY 2026 imported amount" in prompt
     assert len(manifest["review_findings_files"]) == 1
-    persisted = workspace.root / manifest["review_findings_files"][0]["workspace_path"]
-    assert persisted.read_text() == findings.read_text()
+    evidence = manifest["review_findings_files"][0]
+    persisted = workspace.root / evidence["workspace_path"]
+    expected = (
+        "- Start the FY 2025 amount on October 1.\n"
+        "- Preserve the FY 2026 imported amount and boundary test.\n"
+    )
+    assert persisted.read_text() == expected
+    assert evidence["content"] == expected
+    assert evidence["sha256"] == hashlib.sha256(expected.encode()).hexdigest()
 
 
 def test_review_findings_reject_empty_file(tmp_path):

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -29,6 +29,7 @@ from axiom_encode.cli import (
     APPLIED_ENCODING_MODEL_TOOL,
     _sign_applied_encoding_manifest,
 )
+from axiom_encode.harness.dependency_stubs import validate_explicit_context_file
 from axiom_encode.harness.evals import resolve_corpus_source_unit
 from tests.release_object_fixtures import bind_test_corpus_release
 from tests.signing_broker_fixtures import SigningBrokerFixture
@@ -1549,10 +1550,25 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "--allowed-event-name workflow_dispatch" in command
     assert "--apply" in command
     assert "--skip-reviewers" not in command
-    assert 'mktemp "$RUNNER_TEMP/axiom-targeted-review-finding.XXXXXX"' in command
+    assert 'mktemp "$RUNNER_TEMP/axiom-targeted-review-finding.XXXXXX.txt"' in command
     assert "$GITHUB_WORKSPACE/axiom-rules-engine/.axiom-targeted" not in command
     assert "printf '%s\\n' \"$REVIEW_FINDING\"" in command
     assert 'args+=(--review-findings "$review_finding_path")' in command
+
+    package_step = next(
+        step for step in steps if step.get("name") == "Package exact generated changes"
+    )
+    package_command = package_step["run"]
+    assert package_step["env"]["REVIEW_FINDING_PRESENT"] == (
+        "${{ inputs.review_finding != '' }}"
+    )
+    assert '"$artifact/context-manifest.json"' in package_command
+    assert '".axiom/encoding-manifests"' in package_command
+    assert 'payload.get("citation") == os.environ["CITATION"]' in package_command
+    assert 'applied_manifest["context_manifest_file"]' in package_command
+    assert 'applied_manifest.get("context_manifest_sha256")' in package_command
+    assert 'finding.get("content")' in package_command
+    assert 'finding.get("sha256")' in package_command
 
     guard_step = next(
         step for step in steps if step.get("name") == "Verify generated provenance"
@@ -1566,6 +1582,108 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         if "AXIOM_ENCODE_APPLY_SIGNING_KEY" in (step.get("env") or {})
     ]
     assert secret_steps == [apply_step]
+
+
+def test_targeted_review_finding_temp_file_is_valid_context(tmp_path: Path) -> None:
+    runner_temp = tmp_path / "runner-temp"
+    runner_temp.mkdir()
+    policy_root = tmp_path / "rulespec-us" / "us"
+    policy_root.mkdir(parents=True)
+    completed = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'path="$(mktemp "$RUNNER_TEMP/'
+            'axiom-targeted-review-finding.XXXXXX.txt")"; '
+            "printf '%s\\n' 'Preserve the supported provision.' > \"$path\"; "
+            "printf '%s' \"$path\"",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "RUNNER_TEMP": str(runner_temp)},
+    )
+
+    finding_path = Path(completed.stdout)
+    assert finding_path.parent == runner_temp
+    assert finding_path.suffix == ".txt"
+    assert validate_explicit_context_file(finding_path, policy_root) == finding_path
+
+
+def test_targeted_artifact_packages_signed_review_context(tmp_path: Path) -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
+    )
+    package_command = next(
+        step
+        for step in workflow["jobs"]["encode"]["steps"]
+        if step.get("name") == "Package exact generated changes"
+    )["run"]
+    marker = "python - \"$artifact/context-manifest.json\" <<'PY'\n"
+    script = package_command.split(marker, 1)[1].split(
+        '\nPY\npython - "$artifact/metadata.json"', 1
+    )[0]
+
+    rulespec = tmp_path / "rulespec-us"
+    rulespec.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=rulespec, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=rulespec,
+        check=True,
+    )
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=rulespec, check=True)
+    base = rulespec / "README.md"
+    base.write_text("fixture\n")
+    subprocess.run(["git", "add", "README.md"], cwd=rulespec, check=True)
+    subprocess.run(["git", "commit", "-qm", "fixture"], cwd=rulespec, check=True)
+
+    citation = "us-la/statute/47:294"
+    review_content = "Preserve every supported provision.\n"
+    context_payload = {
+        "citation": citation,
+        "review_findings_files": [
+            {
+                "content": review_content,
+                "sha256": hashlib.sha256(review_content.encode()).hexdigest(),
+            }
+        ],
+    }
+    context_bytes = json.dumps(context_payload, sort_keys=True).encode()
+    context_path = tmp_path / "generated" / "context-manifest.json"
+    context_path.parent.mkdir()
+    context_path.write_bytes(context_bytes)
+    applied_manifest = {
+        "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+        "citation": citation,
+        "context_manifest_file": str(context_path),
+        "context_manifest_sha256": hashlib.sha256(context_bytes).hexdigest(),
+    }
+    applied_path = (
+        rulespec / ".axiom" / "encoding-manifests" / "statutes" / "47" / "294.yaml.json"
+    )
+    applied_path.parent.mkdir(parents=True)
+    applied_path.write_text(json.dumps(applied_manifest))
+
+    packaged_context = tmp_path / "artifact" / "context-manifest.json"
+    packaged_context.parent.mkdir()
+    completed = subprocess.run(
+        [sys.executable, "-", str(packaged_context)],
+        cwd=tmp_path,
+        input=script,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "CITATION": citation,
+            "REVIEW_FINDING_PRESENT": "true",
+            "RUNNER_TEMP": str(tmp_path),
+        },
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert packaged_context.read_bytes() == context_bytes
 
 
 def test_apply_signing_key_migration_workflow_is_main_only() -> None:

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1549,6 +1549,8 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "--allowed-event-name workflow_dispatch" in command
     assert "--apply" in command
     assert "--skip-reviewers" not in command
+    assert 'mktemp "$RUNNER_TEMP/axiom-targeted-review-finding.XXXXXX"' in command
+    assert "$GITHUB_WORKSPACE/axiom-rules-engine/.axiom-targeted" not in command
     assert "printf '%s\\n' \"$REVIEW_FINDING\"" in command
     assert 'args+=(--review-findings "$review_finding_path")' in command
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1286"
+version = "0.2.1287"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1287"
+version = "0.2.1288"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- create targeted review-finding input under runner temp with a validator-approved text suffix
- keep all pinned source checkouts clean for signed provenance
- normalize mandatory review findings and bind their content plus SHA-256 into the eval context manifest
- verify and package the exact context manifest referenced by the signed apply manifest
- add executable workflow, context-validation, and artifact-packaging regression tests
- bump encoder to 0.2.1288

## Context

Signed run 29641857184 produced a Sol candidate with compile, CI, grounding, and source fidelity all passing, then rejected apply provenance because the workflow had written the transient review finding inside the pinned axiom-rules-engine checkout.

## Cycle

Initial independent review found two actionable issues: the temporary filename lacked a supported textual suffix, and the review finding was not retained as inspectable signed evidence. Both were fixed. Exact-head independent rereview of `55e0c61e185219bd70b367c9225b5db395827643` found no actionable findings and confirmed both fixes.

## Checks

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python3.13 -m compileall -q src/axiom_encode scripts`
- `uv run pytest`: 4,129 passed, 106 skipped
- focused executable tests: 7 passed
- hosted CI: all four checks green
