### PR TITLE
Reuse verified checkout for signed manifest identity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1290"
+version = "0.2.1291"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1289"
+version = "0.2.1290"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1289"
+__version__ = "0.2.1290"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1290"
+__version__ = "0.2.1291"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -37129,7 +37129,7 @@ def _apply_encoder_execution_identity() -> dict[str, object]:
     """Bind apply provenance to this checkout or the verified CI source checkout."""
 
     checkout_override = os.environ.get("AXIOM_ENCODE_APPLY_CHECKOUT")
-    checkout_root = Path(__file__).resolve().parents[2]
+    checkout_root = _axiom_encode_repo_root()
     expected_ci_sha: str | None = None
     if checkout_override:
         if os.environ.get("GITHUB_ACTIONS") != "true":

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -18577,9 +18577,8 @@ def _current_guard_encoder_execution_identity() -> dict[str, str]:
     exact encoder commit and version pinned by the consumer workflow.
     """
 
-    repo_root = _axiom_encode_repo_root()
     try:
-        checkout_identity = _git_checkout_execution_identity(repo_root)
+        checkout_identity = _apply_encoder_execution_identity()
     except (OSError, ValueError, RuntimeError) as exc:
         raise RuntimeError(
             f"running axiom-encode checkout identity is unavailable: {exc}"
@@ -18594,7 +18593,10 @@ def _current_guard_encoder_execution_identity() -> dict[str, str]:
         raise RuntimeError(
             "running axiom-encode must be a clean Git checkout at a full commit"
         )
-    versions = _axiom_encode_versions_at_ref(repo_root, "HEAD")
+    repo_root = checkout_identity.get("path")
+    if not isinstance(repo_root, str):
+        raise RuntimeError("running axiom-encode checkout identity lacks its root")
+    versions = _axiom_encode_versions_at_ref(Path(repo_root), "HEAD")
     if any(
         versions.get(field) != __version__ for field in ("pyproject", "package", "lock")
     ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1235,6 +1235,33 @@ def test_running_encoder_identity_default_preserves_non_git_error(
         _current_guard_encoder_execution_identity()
 
 
+def test_running_encoder_identity_uses_verified_workflow_checkout(
+    tmp_path, monkeypatch
+):
+    workspace = tmp_path / "workspace"
+    checkout = workspace / "axiom-encode"
+    commit = _init_encoder_identity_checkout(checkout)
+    _git(
+        checkout,
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/TheAxiomFoundation/axiom-encode.git",
+    )
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.setenv("GITHUB_WORKSPACE", str(workspace))
+    monkeypatch.setenv("GITHUB_SHA", commit)
+    monkeypatch.setenv("AXIOM_ENCODE_APPLY_CHECKOUT", str(checkout))
+
+    identity = _current_guard_encoder_execution_identity()
+
+    assert identity == {
+        "repository": APPLIED_ENCODING_OFFICIAL_REPOSITORY,
+        "commit": commit,
+        "version": AXIOM_ENCODE_TEST_VERSION,
+    }
+
+
 def test_apply_encoder_identity_uses_verified_workflow_checkout(tmp_path, monkeypatch):
     workspace = tmp_path / "workspace"
     checkout = workspace / "axiom-encode"
@@ -6978,8 +7005,7 @@ rules:
         assert exc_info.value.code != 0
         assert (
             "Proof atom kind normalization error: RuleSpec jurisdiction root "
-            "must not be a symlink:"
-            in capsys.readouterr().err
+            "must not be a symlink:" in capsys.readouterr().err
         )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1290"
+version = "0.2.1291"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1289"
+version = "0.2.1290"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- route signed-manifest writer identity through the verified workflow checkout
- retain exact Git SHA, version, cleanliness, and installed-package byte binding
- preserve the local repository-root fallback
- add a production-environment regression test
- bump encoder to 0.2.1291

## Context

Targeted signed run 29642830126 produced a first-attempt candidate with standalone generation, compile, CI, grounding, and source fidelity all passing, then blocked manifest creation because the writer inspected the installed package directory as though it were a Git checkout.

## Cycle

The initial implementation passed focused tests. The full suite exposed one fallback-test regression; the default root was restored through `_axiom_encode_repo_root()`, focused tests were rerun, and the full suite passed. Independent exact-head review of `1054aa6c5d65c530bcee14a1a35603d2ce3b00d9` found no actionable findings.

## Checks

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python3.13 -m compileall -q src/axiom_encode scripts`
- `uv run pytest`: 4,145 passed, 106 skipped
- focused identity tests: 9 passed
- focused version-provenance tests: 4 passed
- hosted CI: all four checks green
