### PR TITLE
Use trusted runtime identity in targeted re-encodes

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -279,7 +279,6 @@ jobs:
       - name: Encode, review, validate, and apply
         env:
           AXIOM_ENCODE_APPLY_SIGNING_KEY: ${{ secrets.AXIOM_ENCODE_APPLY_SIGNING_KEY }}
-          AXIOM_ENCODE_APPLY_CHECKOUT: ${{ github.workspace }}/axiom-encode
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CITATION: ${{ inputs.citation }}
           REVIEW_FINDING: ${{ inputs.review_finding }}

--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -205,7 +205,10 @@ jobs:
             --apply-root "$TRUST_APPLY_ROOT" \
             --eval-root "$TRUST_EVAL_ROOT" \
             --corpus-release-root "$TRUST_CORPUS_RELEASE_ROOT" \
-            --git /usr/bin/git
+            --git /usr/bin/git \
+            --encoder-git-root "$GITHUB_WORKSPACE/axiom-encode" \
+            --encoder-commit "$GITHUB_SHA" \
+            --encoder-origin-repository github.com/TheAxiomFoundation/axiom-encode
           sudo install -o root -g root -m 0755 \
             "$RUNNER_TEMP/axiom-encode-apply-signer" \
             /opt/axiom-verification/axiom-encode-apply-signer

--- a/changelog.d/targeted-trusted-runtime-identity.fixed.md
+++ b/changelog.d/targeted-trusted-runtime-identity.fixed.md
@@ -1,0 +1,1 @@
+Remove the duplicate checkout identity from targeted signed re-encodes now that the protected runtime supplies a byte-bound encoder attestation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1292"
+version = "0.2.1293"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1292"
+__version__ = "0.2.1293"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1570,9 +1570,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert apply_step["env"]["AXIOM_ENCODE_APPLY_SIGNING_KEY"] == (
         "${{ secrets.AXIOM_ENCODE_APPLY_SIGNING_KEY }}"
     )
-    assert apply_step["env"]["AXIOM_ENCODE_APPLY_CHECKOUT"] == (
-        "${{ github.workspace }}/axiom-encode"
-    )
+    assert "AXIOM_ENCODE_APPLY_CHECKOUT" not in apply_step["env"]
     command = apply_step["run"]
     assert "exec /opt/axiom-verification/axiom-encode-apply-signer run" in command
     assert "--key-env AXIOM_ENCODE_APPLY_SIGNING_KEY" in command

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1546,7 +1546,9 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "sudo chown 0:0 /opt" in provision_step["run"]
     assert "sudo chmod go-w /opt" in provision_step["run"]
     assert "--git /usr/bin/git" in provision_step["run"]
-    assert '--encoder-git-root "$GITHUB_WORKSPACE/axiom-encode"' in provision_step["run"]
+    assert (
+        '--encoder-git-root "$GITHUB_WORKSPACE/axiom-encode"' in provision_step["run"]
+    )
     assert '--encoder-commit "$GITHUB_SHA"' in provision_step["run"]
     assert (
         "--encoder-origin-repository "

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1546,6 +1546,12 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "sudo chown 0:0 /opt" in provision_step["run"]
     assert "sudo chmod go-w /opt" in provision_step["run"]
     assert "--git /usr/bin/git" in provision_step["run"]
+    assert '--encoder-git-root "$GITHUB_WORKSPACE/axiom-encode"' in provision_step["run"]
+    assert '--encoder-commit "$GITHUB_SHA"' in provision_step["run"]
+    assert (
+        "--encoder-origin-repository "
+        "github.com/TheAxiomFoundation/axiom-encode" in provision_step["run"]
+    )
 
     routing_step = next(
         step

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1292"
+version = "0.2.1293"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- remove the obsolete `AXIOM_ENCODE_APPLY_CHECKOUT` export from targeted signed re-encodes
- provision the byte-bound trusted-runtime attestation with the encoder repository, commit, and origin
- assert the workflow cannot reactivate both apply identity sources
- bump axiom-encode to 0.2.1293

## Why
Encoder main fails closed when both the checkout override and trusted-runtime attestation are active. Production run 29657921130 reached successful generation, compilation, and CI validation, then rejected the duplicate identity sources before signing.

## Checks
- `uv run --python 3.13 ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run --python 3.13 python -m compileall -q src/axiom_encode scripts`
- focused targeted-workflow regression: passed
- exact substantive head full suite: 4,189 passed, 106 skipped, 12 warnings
- final formatting-only head focused regression: passed
- hosted CI: Linux, macOS, Python 3.13, and lint all passed

## Review cycle
- independent review identified that the workflow removed the competing identity source without supplying the trusted-attestation producer identity
- fixed by binding the attestation to the encoder git root, exact commit, and canonical origin
- independent re-review found no remaining actionable findings
