### PR TITLE
Accept profiled corpus release objects

### DIFF
--- a/changelog.d/corpus-release-v3.changed.md
+++ b/changelog.d/corpus-release-v3.changed.md
@@ -1,0 +1,1 @@
+Accept profiled corpus release-object/v3 signatures while preserving historical v2 verification.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1294"
+version = "0.2.1295"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1293"
+version = "0.2.1294"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1294"
+__version__ = "0.2.1295"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1293"
+__version__ = "0.2.1294"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/corpus_release.py
+++ b/src/axiom_encode/corpus_release.py
@@ -145,7 +145,7 @@ def _validate_unsigned_release_object(
             "release object has unsupported top-level fields"
         )
     schema_version = payload.get("schema_version")
-    if schema_version not in {
+    if not isinstance(schema_version, str) or schema_version not in {
         RELEASE_OBJECT_SCHEMA_V2,
         RELEASE_OBJECT_SCHEMA_VERSION,
     }:

--- a/src/axiom_encode/corpus_release.py
+++ b/src/axiom_encode/corpus_release.py
@@ -1,4 +1,4 @@
-"""Strict consumer verification for axiom-corpus release-object/v2."""
+"""Strict consumer verification for signed axiom-corpus release objects."""
 
 from __future__ import annotations
 
@@ -16,10 +16,12 @@ from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 
-RELEASE_OBJECT_SCHEMA_VERSION = "axiom-corpus/release-object/v2"
+RELEASE_OBJECT_SCHEMA_V2 = "axiom-corpus/release-object/v2"
+RELEASE_OBJECT_SCHEMA_VERSION = "axiom-corpus/release-object/v3"
 RELEASE_OBJECT_SIGNATURE_ALGORITHM = "ed25519"
 RELEASE_OBJECT_SIGNATURE_KEY_ID = "axiom-corpus-release-v2"
 RELEASE_OBJECT_PUBLIC_KEY_ENV = "AXIOM_CORPUS_RELEASE_PUBLIC_KEY"
+COMPLETE_EXPRESSION_DATES_PROFILE = "complete-expression-dates-v1"
 
 _ARTIFACT_CLASSES = ("inventory", "provisions", "coverage", "sources")
 _DOCUMENT_CLASSES = {
@@ -67,7 +69,7 @@ class VerifiedReleaseScope:
 
 @dataclass(frozen=True, slots=True)
 class VerifiedCorpusReleaseObject:
-    """The immutable identities and local inventory from release-object/v2."""
+    """The immutable identities and local inventory from a release object."""
 
     name: str
     content_sha256: str
@@ -94,7 +96,7 @@ def verify_release_object(
     *,
     public_key: str,
 ) -> VerifiedCorpusReleaseObject:
-    """Verify the canonical axiom-corpus v2 contract and Ed25519 signature."""
+    """Verify a supported canonical axiom-corpus contract and signature."""
 
     materialized = copy.deepcopy(dict(payload))
     verified = _validate_unsigned_release_object(materialized)
@@ -142,13 +144,17 @@ def _validate_unsigned_release_object(
         raise CorpusReleaseObjectError(
             "release object has unsupported top-level fields"
         )
-    if payload.get("schema_version") != RELEASE_OBJECT_SCHEMA_VERSION:
+    schema_version = payload.get("schema_version")
+    if schema_version not in {
+        RELEASE_OBJECT_SCHEMA_V2,
+        RELEASE_OBJECT_SCHEMA_VERSION,
+    }:
         raise CorpusReleaseObjectError(
             "release object uses an unsupported schema version"
         )
     release = _validate_release_name(payload.get("release"))
     content = payload.get("content")
-    if not isinstance(content, dict) or set(content) != {
+    expected_content_fields = {
         "release",
         "created_at",
         "selector_sha256",
@@ -158,9 +164,20 @@ def _validate_unsigned_release_object(
         "scopes",
         "artifacts",
         "validation",
-    }:
+    }
+    if schema_version == RELEASE_OBJECT_SCHEMA_VERSION:
+        expected_content_fields.add("quality_profile")
+    if not isinstance(content, dict) or set(content) != expected_content_fields:
         raise CorpusReleaseObjectError(
-            "release object content does not match the v2 schema"
+            f"release object content does not match the {schema_version} schema"
+        )
+    quality_profile = content.get("quality_profile")
+    if (
+        schema_version == RELEASE_OBJECT_SCHEMA_VERSION
+        and quality_profile != COMPLETE_EXPRESSION_DATES_PROFILE
+    ):
+        raise CorpusReleaseObjectError(
+            "release object has an unsupported quality profile"
         )
     if content.get("release") != release:
         raise CorpusReleaseObjectError("release object name does not match its content")
@@ -213,6 +230,8 @@ def _validate_unsigned_release_object(
             for scope in scopes
         ],
     }
+    if schema_version == RELEASE_OBJECT_SCHEMA_VERSION:
+        selector_payload["quality_profile"] = quality_profile
     selector_sha256 = content.get("selector_sha256")
     if (
         not isinstance(selector_sha256, str)
@@ -230,6 +249,11 @@ def _validate_unsigned_release_object(
         scopes=scopes,
         artifacts=artifacts,
         bucket=r2["bucket"],
+        quality_profile=(
+            str(quality_profile)
+            if schema_version == RELEASE_OBJECT_SCHEMA_VERSION
+            else None
+        ),
     )
     return VerifiedCorpusReleaseObject(
         name=release,
@@ -442,20 +466,27 @@ def _validate_validation_attestation(
     scopes: Sequence[VerifiedReleaseScope],
     artifacts: Sequence[VerifiedReleaseArtifact],
     bucket: str,
+    quality_profile: str | None = None,
 ) -> None:
+    expected_fields = {
+        "passed",
+        "deep_validation",
+        "r2_readback",
+        "supabase_projection_evidence",
+    }
+    if quality_profile is not None:
+        expected_fields.add("quality_profile")
     if (
         not isinstance(raw, dict)
-        or set(raw)
-        != {
-            "passed",
-            "deep_validation",
-            "r2_readback",
-            "supabase_projection_evidence",
-        }
+        or set(raw) != expected_fields
         or raw.get("passed") is not True
     ):
         raise CorpusReleaseObjectError(
-            "release validation does not match the v2 schema"
+            "release validation does not match its object schema"
+        )
+    if quality_profile is not None and raw.get("quality_profile") != quality_profile:
+        raise CorpusReleaseObjectError(
+            "release validation quality profile is inconsistent"
         )
     deep = raw.get("deep_validation")
     if not isinstance(deep, dict) or set(deep) != {

--- a/tests/test_corpus_release.py
+++ b/tests/test_corpus_release.py
@@ -1,4 +1,4 @@
-"""Consumer conformance tests for axiom-corpus release-object/v2."""
+"""Consumer conformance tests for signed axiom-corpus release objects."""
 
 from __future__ import annotations
 
@@ -12,6 +12,9 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 from axiom_encode.corpus_release import (
+    COMPLETE_EXPRESSION_DATES_PROFILE,
+    RELEASE_OBJECT_SCHEMA_V2,
+    RELEASE_OBJECT_SCHEMA_VERSION,
     CorpusReleaseObjectError,
     canonical_release_object_bytes,
     verify_release_object,
@@ -28,7 +31,9 @@ def _canonical_sha256(payload: dict) -> str:
     return hashlib.sha256(raw).hexdigest()
 
 
-def _signed_release_object() -> tuple[dict, str]:
+def _signed_release_object(
+    *, schema_version: str = RELEASE_OBJECT_SCHEMA_V2
+) -> tuple[dict, str]:
     private_key = Ed25519PrivateKey.generate()
     public_key = b64encode(
         private_key.public_key().public_bytes(
@@ -76,18 +81,19 @@ def _signed_release_object() -> tuple[dict, str]:
             "navigation_projection_sha256": navigation_projection_sha256,
         }
     ]
-    selector_sha256 = _canonical_sha256(
-        {
-            "name": release,
-            "scopes": [
-                {
-                    "jurisdiction": "nz",
-                    "document_class": "statute",
-                    "version": version,
-                }
-            ],
-        }
-    )
+    selector = {
+        "name": release,
+        "scopes": [
+            {
+                "jurisdiction": "nz",
+                "document_class": "statute",
+                "version": version,
+            }
+        ],
+    }
+    if schema_version == RELEASE_OBJECT_SCHEMA_VERSION:
+        selector["quality_profile"] = COMPLETE_EXPRESSION_DATES_PROFILE
+    selector_sha256 = _canonical_sha256(selector)
     content = {
         "release": release,
         "created_at": "2026-07-10T00:00:00Z",
@@ -136,8 +142,11 @@ def _signed_release_object() -> tuple[dict, str]:
             ],
         },
     }
+    if schema_version == RELEASE_OBJECT_SCHEMA_VERSION:
+        content["quality_profile"] = COMPLETE_EXPRESSION_DATES_PROFILE
+        content["validation"]["quality_profile"] = COMPLETE_EXPRESSION_DATES_PROFILE
     payload = {
-        "schema_version": "axiom-corpus/release-object/v2",
+        "schema_version": schema_version,
         "release": release,
         "content_sha256": _canonical_sha256(content),
         "content": content,
@@ -174,6 +183,80 @@ def test_verified_release_object_exposes_only_signed_inventory() -> None:
         "provisions",
         "sources",
     ]
+
+
+def test_verified_release_object_accepts_profiled_v3() -> None:
+    payload, public_key = _signed_release_object(
+        schema_version=RELEASE_OBJECT_SCHEMA_VERSION
+    )
+
+    verified = verify_release_object(payload, public_key=public_key)
+
+    assert verified.content_sha256 == payload["content_sha256"]
+    assert payload["content"]["quality_profile"] == (COMPLETE_EXPRESSION_DATES_PROFILE)
+
+
+@pytest.mark.parametrize("profile", [None, "different-profile"])
+def test_v3_release_object_requires_supported_content_profile(
+    profile: str | None,
+) -> None:
+    payload, public_key = _signed_release_object(
+        schema_version=RELEASE_OBJECT_SCHEMA_VERSION
+    )
+    if profile is None:
+        payload["content"].pop("quality_profile")
+    else:
+        payload["content"]["quality_profile"] = profile
+    payload["content_sha256"] = _canonical_sha256(payload["content"])
+
+    with pytest.raises(
+        CorpusReleaseObjectError,
+        match="content does not match|unsupported quality profile",
+    ):
+        verify_release_object(payload, public_key=public_key)
+
+
+@pytest.mark.parametrize("profile", [None, "different-profile"])
+def test_v3_release_object_requires_matching_validation_profile(
+    profile: str | None,
+) -> None:
+    payload, public_key = _signed_release_object(
+        schema_version=RELEASE_OBJECT_SCHEMA_VERSION
+    )
+    validation = payload["content"]["validation"]
+    if profile is None:
+        validation.pop("quality_profile")
+    else:
+        validation["quality_profile"] = profile
+    payload["content_sha256"] = _canonical_sha256(payload["content"])
+
+    with pytest.raises(
+        CorpusReleaseObjectError,
+        match="validation does not match|quality profile is inconsistent",
+    ):
+        verify_release_object(payload, public_key=public_key)
+
+
+def test_v3_selector_sha256_attests_quality_profile() -> None:
+    payload, public_key = _signed_release_object(
+        schema_version=RELEASE_OBJECT_SCHEMA_VERSION
+    )
+    payload["content"]["selector_sha256"] = _canonical_sha256(
+        {
+            "name": payload["release"],
+            "scopes": [
+                {
+                    key: scope[key]
+                    for key in ("jurisdiction", "document_class", "version")
+                }
+                for scope in payload["content"]["scopes"]
+            ],
+        }
+    )
+    payload["content_sha256"] = _canonical_sha256(payload["content"])
+
+    with pytest.raises(CorpusReleaseObjectError, match="selector sha256"):
+        verify_release_object(payload, public_key=public_key)
 
 
 def test_release_object_rejects_content_tamper() -> None:

--- a/tests/test_corpus_release.py
+++ b/tests/test_corpus_release.py
@@ -196,6 +196,17 @@ def test_verified_release_object_accepts_profiled_v3() -> None:
     assert payload["content"]["quality_profile"] == (COMPLETE_EXPRESSION_DATES_PROFILE)
 
 
+@pytest.mark.parametrize("schema_version", [[], {}])
+def test_release_object_rejects_non_scalar_schema_version(
+    schema_version: object,
+) -> None:
+    payload, public_key = _signed_release_object()
+    payload["schema_version"] = schema_version
+
+    with pytest.raises(CorpusReleaseObjectError, match="unsupported schema version"):
+        verify_release_object(payload, public_key=public_key)
+
+
 @pytest.mark.parametrize("profile", [None, "different-profile"])
 def test_v3_release_object_requires_supported_content_profile(
     profile: str | None,

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1294"
+version = "0.2.1295"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1293"
+version = "0.2.1294"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- accept signed `axiom-corpus/release-object/v3` objects with the required `complete-expression-dates-v1` profile
- attest the profile through the release content, selector hash, and validation evidence
- preserve strict historical v2 verification

## Validation
- `uv run --python 3.13 ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run --python 3.13 python -m compileall -q src/axiom_encode scripts`
- `uv run --python 3.13 towncrier build --draft`
- full suite before commit: 4,194 passed, 106 skipped; sole expected failure was the commit-based version-provenance guard
- committed-state focused suite: 348 passed, including the version-provenance guard, release conformance, and corpus resolver tests
- exact production `us-rulespec-2026-07-19` unsigned contract validated: 174 scopes, 2,375 artifacts, content digest `974e07f91f2dec59689034b370d4923190c0aa10eb888b487f0a6f46e47ea786`

## Review Cycle
- Independent review pending.
