### PR TITLE
Fix numeric extraction for unit-glued numerals (#1181)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1298"
+version = "0.2.1299"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1298"
+__version__ = "0.2.1299"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -722,6 +722,13 @@ SOURCE_TEXT_NUMBER_PATTERN = re.compile(
     r"(?:^|(?<=[\s$£€(\[,+\-−*/\"'`“”‘’]))"
     r"(-?(?:[\d,]+(?:\.\d+)?|\.\d+))\b"
 )
+GLUED_UNIT_NUMBER_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9])"
+    r"(?P<number>\d{1,3}(?:,\d{3})+|\d+)"
+    r"(?P<unit>m(?:2|²)|ha|km|kw|db)"
+    r"(?![A-Za-z0-9])",
+    re.IGNORECASE,
+)
 EUROPEAN_DECIMAL_NUMBER_PATTERN = re.compile(
     r"(?:^|(?<=[\s$£€(\[,+\-−*/\"'`“”‘’]))"
     r"(-?(?:\d{1,3}(?:[.\u00a0\u202f]\d{3})+|\d+),(?:\d{1,2}|\d{4}))"
@@ -3139,6 +3146,12 @@ def extract_numbers_from_text(text: str) -> set[float]:
     numbers.update(_extract_centime_unit_values(original_text))
     numbers.update(_extract_annual_context_values(original_text))
     numbers.update(_extract_vehicle_tax_fiscal_power_table_values(original_text))
+
+    for match in GLUED_UNIT_NUMBER_PATTERN.finditer(text):
+        span = match.span()
+        with contextlib.suppress(ValueError):
+            numbers.add(float(match.group("number").replace(",", "")))
+            occupied_spans.append(span)
 
     for span, value in _iter_normalized_special_numeric_matches(text):
         if _span_overlaps(span, occupied_spans):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -7338,6 +7338,37 @@ def test_numeric_extraction_handles_uganda_shilling_suffix():
     assert 5.0 in eq and 7.0 in eq
 
 
+@pytest.mark.parametrize(
+    "source_text",
+    [
+        "... does not exceed 1,500m2.",
+        "... does not exceed 1,500m².",
+        "... does not exceed 1500m2.",
+        "... does not exceed 1,500 m2.",
+        "... does not exceed 1,500.",
+    ],
+)
+def test_numeric_extraction_handles_unit_glued_numerals(source_text):
+    assert 1500.0 in extract_numbers_from_text(source_text)
+
+
+@pytest.mark.parametrize(
+    ("source_text", "excluded_values"),
+    [
+        ("MUZ-R13", {13.0}),
+        ("R13.1", {13.1, 1.0}),
+    ],
+)
+def test_numeric_extraction_keeps_identifier_shaped_tokens_excluded(
+    source_text, excluded_values
+):
+    assert extract_numbers_from_text(source_text).isdisjoint(excluded_values)
+
+
+def test_numeric_extraction_preserves_alphanumeric_clause_handling():
+    assert extract_numbers_from_text("clause 5AB") == set()
+
+
 def test_numeric_extraction_handles_ocr_range_hyphen():
     # OCR'd band tables glue the range hyphen to the upper bound
     # ("0 -2,000 0%" in the Ethiopia Proclamation 1395/2025 scan),

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1298"
+version = "0.2.1299"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
Closes #1181. `extract_numbers_from_text` missed numerals glued to a following unit token — the idiom NZ district plans (and other council instruments) use throughout, e.g. *"The total gross floor area does not exceed 1,500m2."* extracted nothing, so a correctly-encoded `1500` parameter failed the numeric-grounding gate (first hit: rulespec-nz#90, worked around by ending the proof-atom excerpt at the digits).

New pass (allowlisted glued units, digits-first only so identifier-shaped tokens like `MUZ-R13` stay excluded):

```
(?<![A-Za-z0-9])(?P<number>\d{1,3}(?:,\d{3})+|\d+)(?P<unit>m(?:2|²)|ha|km|kw|db)(?![A-Za-z0-9])
```

The issue's six-variant repro matrix is the test set, plus identifier non-regression cases. Money and percentage extraction paths untouched.

Verification: full suite **4,288 passed** (8 pre-existing supervisor-environment failures reproduce identically on clean `origin/main` on macOS — unrelated to this change); glued-unit tests 5/5; `ruff format` + `ruff check` clean; version bump 0.2.1299 across pyproject/`__init__`/uv.lock. Implemented by gpt-5.6-sol from the issue spec; independently verified (full-suite run + main-baseline failure comparison) before this PR.

Consumption note: rulespec-nz currently pins `axiom-encode-ref` at 0e6d572d (pre-#1168) because the org validate workflow doesn't pass the newer supervisor's `--git` argument — this fix lands on main now and reaches consumers with the next coordinated workflow + encode re-pin, ahead of any further council-plan ingestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
