### PR TITLE
Add word-fraction numeric extraction (companion to #1181)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1299"
+version = "0.2.1300"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1299"
+__version__ = "0.2.1300"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -959,6 +959,20 @@ _STANDALONE_FRACTION_WORD_PATTERN = re.compile(
 # ("five and half per centum", "eighteen and a half per centum"); outside
 # one they would over-extract ordinary prose such as "half of the year".
 _PERCENT_FRACTION_WORD_PATTERN = rf"(?:{_FRACTION_WORD_PATTERN}|a[-\s]+half|half)"
+_WORD_QUANTITY_FRACTION_PATTERN = re.compile(
+    r"(?<!\bfirst\s)\b(?P<of_fraction>"
+    r"half|quarter|third|one[-\s]+(?:half|quarter|third)|"
+    r"a\s+(?:half|quarter|third)|two[-\s]+thirds|three[-\s]+quarters"
+    r")\b(?=\s+of\b)|"
+    r"\bequal\s+to\s+(?P<equal_fraction>half|quarter|third)\b|"
+    r"\b(?P<prefixed_fraction>"
+    r"one[-\s]+(?:half|quarter|third)|a\s+(?:half|quarter|third)|"
+    r"two[-\s]+thirds|three[-\s]+quarters"
+    r")\b|"
+    r"\breplace\s+(?P<replace_fraction>half|quarter|third)\s+with\s+"
+    r"(?P<replacement_fraction>half|quarter|third)\b",
+    re.IGNORECASE,
+)
 _DECIMAL_FRACTION_DENOMINATORS = {
     "tenth": 10.0,
     "hundredth": 100.0,
@@ -3160,6 +3174,11 @@ def extract_numbers_from_text(text: str) -> set[float]:
         occupied_spans.append(span)
     numbers.update(_iter_ascii_mixed_fraction_percentage_component_values(text))
     numbers.update(_extract_percentage_context_values(text))
+    for span, value in _iter_word_quantity_fraction_matches(text):
+        if _span_overlaps(span, occupied_spans):
+            continue
+        numbers.add(value)
+        occupied_spans.append(span)
     for span, value in _iter_standalone_fraction_word_matches(text):
         if _span_overlaps(span, occupied_spans):
             continue
@@ -3837,6 +3856,38 @@ def _iter_standalone_fraction_word_matches(
         value = _parse_fraction_word(match.group(1))
         if value is not None:
             yield match.span(1), value
+
+
+def _iter_word_quantity_fraction_matches(
+    text: str,
+) -> Iterator[tuple[tuple[int, int], float]]:
+    """Yield word fractions used as quantities, excluding ordinary prose senses."""
+    values = {
+        "half": 0.5,
+        "quarter": 0.25,
+        "third": 1 / 3,
+        "one half": 0.5,
+        "a half": 0.5,
+        "one quarter": 0.25,
+        "a quarter": 0.25,
+        "one third": 1 / 3,
+        "a third": 1 / 3,
+        "two thirds": 2 / 3,
+        "three quarters": 0.75,
+    }
+    for match in _WORD_QUANTITY_FRACTION_PATTERN.finditer(text):
+        for group_name in (
+            "of_fraction",
+            "equal_fraction",
+            "prefixed_fraction",
+            "replace_fraction",
+            "replacement_fraction",
+        ):
+            raw = match.group(group_name)
+            if raw is None:
+                continue
+            normalized = re.sub(r"[-\s]+", " ", raw.lower())
+            yield match.span(group_name), values[normalized]
 
 
 def _extract_percentage_context_values(text: str) -> set[float]:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -7176,6 +7176,39 @@ def test_numeric_extraction_word_half_requires_percentage_context():
     assert not any(math.isclose(value, 0.005) for value in prose_numbers)
 
 
+def test_numeric_extraction_reads_nz_word_fraction_quantity():
+    source_text = (
+        "The amount of the tax credit is an amount equal to quarter of a "
+        "person's total member credit contributions."
+    )
+    assert 0.25 in extract_numbers_from_text(source_text)
+
+
+def test_numeric_extraction_reads_word_fractions_in_replacement_instruction():
+    assert {0.5, 0.25} <= extract_numbers_from_text("replace half with quarter")
+
+
+def test_numeric_extraction_reads_compound_word_fraction_quantity():
+    assert 0.75 in extract_numbers_from_text("three-quarters of the amount")
+
+
+@pytest.mark.parametrize(
+    ("source_text", "expected"),
+    [
+        ("equal to half", 0.5),
+        ("a quarter", 0.25),
+        ("one-third", 1 / 3),
+        ("two-thirds", 2 / 3),
+    ],
+)
+def test_numeric_extraction_maps_word_fraction_values(source_text, expected):
+    assert expected in extract_numbers_from_text(source_text)
+
+
+def test_numeric_extraction_ignores_non_quantity_quarter():
+    assert 0.25 not in extract_numbers_from_text("the quarter ended in March")
+
+
 def test_numeric_extraction_handles_ghana_cedi_grouped_thousands():
     # The Ghana cedi symbol glued to a grouped-thousands amount ("GH¢5,880")
     # must still yield the full value, not just the trailing "880". Mirrors

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1299"
+version = "0.2.1300"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
Statutes state fractional rates as words: Income Tax Act 2007 (NZ) s MK 4 sets the KiwiSaver government contribution as "an amount equal to quarter of a person's total member credit contributions", and Taxation (Budget Measures) Act 2025 s 13 amends by instruction — "replace half with quarter". `extract_numbers_from_text` had no word-fraction handling outside percentage contexts, so rulespec parameters like `0.25` fail numeric grounding against the only official texts that state them.

This adds a context-guarded word-fraction pass: `half`/`quarter`/`third` (+ `one-`/`a` prefixed, `two-thirds`, `three-quarters`) numeralize only when used as quantities — followed by `of`, preceded by `equal to`, explicitly prefixed, or inside a `replace X with Y` amendment instruction. Ordinary prose senses ("the quarter ended in March", "first half of the year") do not fire. Money and percentage paths untouched; span-overlap bookkeeping matches the existing fraction iterators.

## Motivating blocked case
rulespec-nz `kiwisaver/contributions` — the last module holding a validation waiver in its family; every other numeric literal now grounds. This unblocks deleting the final two waiver records (22→20).

## Verification
- Full suite: 8 failed / 4296 passed locally — the 8 are the known mac-environmental TrustedGit + site-packages set, byte-identical on clean origin/main (verified for #1185 this morning). Zero regressions.
- New tests: MK 4 sentence → 0.25; `replace half with quarter` → {0.5, 0.25}; `three-quarters of` → 0.75; value map ×4; non-quantity guard ("the quarter ended in March" → no 0.25).
- ruff format + check clean; version triple-bumped 0.2.1299 → 0.2.1300 (pyproject + `__init__` + uv.lock).

## Provenance
- Author: gpt-5.6-sol via codex-run (read-write worktree from origin/main @ affbfe72), task-scoped prompt in `ops/nz-lane/sol-word-fractions-prompt.md`, report in `sol-fractions-report.md`.
- Reviewer: Claude Fable 5 (this PR) — diff review + independent full-suite run + gate verification. Cross-family per the standing regime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
