### PR TITLE
encode#1147: country-general signed-apply workflow

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -527,6 +527,10 @@ jobs:
             -F draft=true > "$RUNNER_TEMP/lane-pull-request.json"
           cp "$RUNNER_TEMP/lane-pull-request.json" \
             "$RUNNER_TEMP/targeted-reencode/lane-pull-request.json"
+
+      - name: Finalize signed re-encode artifact checksums
+        run: |
+          set -euo pipefail
           sha256sum "$RUNNER_TEMP/targeted-reencode"/* \
             > "$RUNNER_TEMP/targeted-reencode/SHA256SUMS"
 

--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -48,22 +48,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
-      - name: Validate country routing input
-        env:
-          COUNTRY: ${{ inputs.country }}
-        run: |
-          set -euo pipefail
-          if [[ ! "$COUNTRY" =~ ^[a-z]{2}$ ]]; then
-            echo "country must be a two-letter lowercase country code" >&2
-            exit 1
-          fi
-
       - name: Checkout axiom-encode
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: axiom-encode
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Validate country routing input
+        env:
+          COUNTRY: ${{ inputs.country }}
+        run: |
+          set -euo pipefail
+          python axiom-encode/scripts/prepare_signed_backfill.py \
+            validate-country "$COUNTRY"
 
       - name: Checkout canonical RuleSpec country
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -481,7 +481,8 @@ jobs:
           set -euo pipefail
           branch="axiom/signed-backfill-${COUNTRY}-${GITHUB_RUN_ID}"
           git -C "$RULESPEC_CHECKOUT" switch -c "$branch"
-          git -C "$RULESPEC_CHECKOUT" -c core.hooksPath=/dev/null add --all
+          python axiom-encode/scripts/prepare_signed_backfill.py stage \
+            "$RULESPEC_CHECKOUT"
           git -C "$RULESPEC_CHECKOUT" \
             -c core.hooksPath=/dev/null \
             -c user.name=axiom-encode-bot \

--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -7,8 +7,13 @@ on:
         description: Canonical corpus citation path
         required: true
         type: string
+      country:
+        description: Canonical RuleSpec country checkout (for rulespec-<country>)
+        required: true
+        default: us
+        type: string
       rulespec_ref:
-        description: Immutable rulespec-us commit SHA to re-encode
+        description: Immutable rulespec-<country> commit SHA on main to re-encode
         required: true
         type: string
       corpus_ref:
@@ -38,6 +43,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
+      - name: Validate country routing input
+        env:
+          COUNTRY: ${{ inputs.country }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$COUNTRY" =~ ^[a-z]{2}$ ]]; then
+            echo "country must be a two-letter lowercase country code" >&2
+            exit 1
+          fi
+
       - name: Checkout axiom-encode
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -45,12 +60,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Checkout rulespec-us
+      - name: Checkout canonical RuleSpec country
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: TheAxiomFoundation/rulespec-us
+          repository: TheAxiomFoundation/rulespec-${{ inputs.country }}
           ref: ${{ inputs.rulespec_ref }}
-          path: rulespec-us
+          path: rulespec-${{ inputs.country }}
           fetch-depth: 0
           token: ${{ secrets.AXIOM_REPO_TOKEN || secrets.GITHUB_TOKEN }}
           persist-credentials: false
@@ -77,6 +92,8 @@ jobs:
 
       - name: Verify immutable checkout identities
         env:
+          COUNTRY: ${{ inputs.country }}
+          RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
           RULESPEC_REF: ${{ inputs.rulespec_ref }}
           CORPUS_REF: ${{ inputs.corpus_ref }}
           RULES_ENGINE_REF: ${{ inputs.rules_engine_ref }}
@@ -102,9 +119,13 @@ jobs:
             exit 1
           fi
           test "$(git -C axiom-encode rev-parse HEAD)" = "$GITHUB_SHA"
-          verify_checkout rulespec-us "$RULESPEC_REF" rulespec-us
+          verify_checkout "rulespec-$COUNTRY" "$RULESPEC_REF" "$RULESPEC_CHECKOUT"
           verify_checkout axiom-corpus "$CORPUS_REF" axiom-corpus
           verify_checkout axiom-rules-engine "$RULES_ENGINE_REF" axiom-rules-engine
+          test "$(git -C "$RULESPEC_CHECKOUT" remote get-url origin)" = \
+            "https://github.com/TheAxiomFoundation/rulespec-$COUNTRY"
+          git -C "$RULESPEC_CHECKOUT" merge-base --is-ancestor \
+            HEAD refs/remotes/origin/main
           git -C axiom-corpus merge-base --is-ancestor HEAD refs/remotes/origin/main
           git -C axiom-rules-engine merge-base --is-ancestor HEAD refs/remotes/origin/main
 
@@ -144,11 +165,12 @@ jobs:
         env:
           SUPABASE_URL: https://swocpijqqahhuwtuahwc.supabase.co
           SUPABASE_ANON_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
         run: |
           set -euo pipefail
           test -n "$SUPABASE_ANON_KEY"
           materializer=axiom-encode/scripts/materialize_corpus_release.py
-          toolchain=rulespec-us/.axiom/toolchain.toml
+          toolchain="$RULESPEC_CHECKOUT/.axiom/toolchain.toml"
           mapfile -t release_pin < <(
             axiom-encode/.venv/bin/python "$materializer" pin --toolchain "$toolchain"
           )
@@ -217,7 +239,7 @@ jobs:
 
       - name: Verify protected RuleSpec routing
         env:
-          RULESPEC_CHECKOUT: ${{ github.workspace }}/rulespec-us
+          RULESPEC_CHECKOUT: ${{ github.workspace }}/rulespec-${{ inputs.country }}
         run: |
           set -euo pipefail
           trusted_path=/opt/axiom-verification/python/bin
@@ -285,13 +307,14 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CITATION: ${{ inputs.citation }}
           REVIEW_FINDING: ${{ inputs.review_finding }}
+          RULESPEC_CHECKOUT: ${{ github.workspace }}/rulespec-${{ inputs.country }}
         run: |
           args=(
             /opt/axiom-verification/axiom-encode encode
             --backend openai
             --corpus-path "$GITHUB_WORKSPACE/axiom-corpus"
             --axiom-rules-engine-path "$GITHUB_WORKSPACE/axiom-rules-engine"
-            --policy-repo-path "$GITHUB_WORKSPACE/rulespec-us"
+            --policy-repo-path "$RULESPEC_CHECKOUT"
             --output "$RUNNER_TEMP/generated"
             --mode repo-augmented
             --db "$RUNNER_TEMP/encodings.db"
@@ -319,6 +342,8 @@ jobs:
             -- "${args[@]}"
 
       - name: Verify generated provenance
+        env:
+          RULESPEC_CHECKOUT: ${{ github.workspace }}/rulespec-${{ inputs.country }}
         run: |
           /opt/axiom-verification/axiom-encode-signing-supervisor \
             --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
@@ -326,23 +351,24 @@ jobs:
             --trusted-python-import-root /opt/axiom-verification/python/lib/python3.13/site-packages \
             --trusted-python-package-root /opt/axiom-verification/python/lib/python3.13/site-packages/axiom_encode \
             -- /opt/axiom-verification/axiom-encode guard-generated \
-            --repo "$GITHUB_WORKSPACE/rulespec-us" \
+            --repo "$RULESPEC_CHECKOUT" \
             --corpus-path "$GITHUB_WORKSPACE/axiom-corpus" \
             --expected-encoder-checkout "$GITHUB_WORKSPACE/axiom-encode" \
             --json > "$RUNNER_TEMP/guard-generated.json"
-          git -C rulespec-us diff --check
+          git -C "$RULESPEC_CHECKOUT" diff --check
 
       - name: Package exact generated changes
         env:
           CITATION: ${{ inputs.citation }}
           REVIEW_FINDING_PRESENT: ${{ inputs.review_finding != '' }}
+          RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
         run: |
           artifact="$RUNNER_TEMP/targeted-reencode"
           mkdir -p "$artifact"
-          git -C rulespec-us diff --binary --full-index HEAD > "$artifact/tracked.patch"
-          git -C rulespec-us ls-files --others --exclude-standard -z \
-            | tar -C rulespec-us --null -czf "$artifact/untracked.tar.gz" --files-from -
-          git -C rulespec-us status --short > "$artifact/status.txt"
+          git -C "$RULESPEC_CHECKOUT" diff --binary --full-index HEAD > "$artifact/tracked.patch"
+          git -C "$RULESPEC_CHECKOUT" ls-files --others --exclude-standard -z \
+            | tar -C "$RULESPEC_CHECKOUT" --null -czf "$artifact/untracked.tar.gz" --files-from -
+          git -C "$RULESPEC_CHECKOUT" status --short > "$artifact/status.txt"
           cp "$RUNNER_TEMP/guard-generated.json" "$artifact/guard-generated.json"
           python - "$artifact/context-manifest.json" <<'PY'
           import hashlib
@@ -354,7 +380,7 @@ jobs:
 
           def git_paths(*args):
               output = subprocess.check_output(
-                  ["git", "-C", "rulespec-us", *args]
+                  ["git", "-C", os.environ["RULESPEC_CHECKOUT"], *args]
               )
               return {
                   Path(value.decode("utf-8"))
@@ -374,7 +400,7 @@ jobs:
           )
           matches = []
           for relative_path in sorted(manifest_paths):
-              manifest_path = Path("rulespec-us") / relative_path
+              manifest_path = Path(os.environ["RULESPEC_CHECKOUT"]) / relative_path
               payload = json.loads(manifest_path.read_text(encoding="utf-8"))
               if (
                   payload.get("schema_version")
@@ -434,7 +460,7 @@ jobs:
           payload = {
               "schema": "axiom-encode/targeted-reencode-artifact/v1",
               "citation": os.environ["CITATION"],
-              "rulespec_base": rev("rulespec-us"),
+              "rulespec_base": rev(os.environ["RULESPEC_CHECKOUT"]),
               "encoder_commit": rev("axiom-encode"),
               "corpus_commit": rev("axiom-corpus"),
               "rules_engine_commit": rev("axiom-rules-engine"),
@@ -444,8 +470,57 @@ jobs:
               json.dump(payload, stream, indent=2, sort_keys=True)
               stream.write("\n")
           PY
-          sha256sum "$artifact"/* > "$artifact/SHA256SUMS"
           test -s "$artifact/status.txt"
+
+      - name: Commit reviewed lane changes locally
+        env:
+          COUNTRY: ${{ inputs.country }}
+          CITATION: ${{ inputs.citation }}
+          RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
+        run: |
+          set -euo pipefail
+          branch="axiom/signed-backfill-${COUNTRY}-${GITHUB_RUN_ID}"
+          git -C "$RULESPEC_CHECKOUT" switch -c "$branch"
+          git -C "$RULESPEC_CHECKOUT" -c core.hooksPath=/dev/null add --all
+          git -C "$RULESPEC_CHECKOUT" \
+            -c core.hooksPath=/dev/null \
+            -c user.name=axiom-encode-bot \
+            -c user.email=axiom-encode-bot@users.noreply.github.com \
+            commit -m "Add signed encoding manifest for ${CITATION}"
+
+      - name: Push lane branch and open draft pull request
+        env:
+          GH_TOKEN: ${{ secrets.AXIOM_REPO_TOKEN }}
+          COUNTRY: ${{ inputs.country }}
+          CITATION: ${{ inputs.citation }}
+          RULESPEC_REF: ${{ inputs.rulespec_ref }}
+          RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
+        run: |
+          set -euo pipefail
+          test -n "$GH_TOKEN"
+          repo="TheAxiomFoundation/rulespec-${COUNTRY}"
+          branch="axiom/signed-backfill-${COUNTRY}-${GITHUB_RUN_ID}"
+          body="$(printf '%s\n' \
+            '## Signed apply manifest' \
+            '' \
+            "Citation: \`${CITATION}\`" \
+            "Base commit: \`${RULESPEC_REF}\`" \
+            "Axiom Encode run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            '' \
+            'This draft PR was produced by the protected country-general signed-apply workflow. Review all RuleSpec and manifest changes before marking it ready.')"
+          gh auth setup-git
+          git -C "$RULESPEC_CHECKOUT" -c core.hooksPath=/dev/null push \
+            "https://github.com/${repo}.git" "HEAD:refs/heads/${branch}"
+          gh api --method POST "repos/${repo}/pulls" \
+            -f title="Add signed encoding manifest for ${CITATION}" \
+            -f head="TheAxiomFoundation:${branch}" \
+            -f base=main \
+            -f body="$body" \
+            -F draft=true > "$RUNNER_TEMP/lane-pull-request.json"
+          cp "$RUNNER_TEMP/lane-pull-request.json" \
+            "$RUNNER_TEMP/targeted-reencode/lane-pull-request.json"
+          sha256sum "$RUNNER_TEMP/targeted-reencode"/* \
+            > "$RUNNER_TEMP/targeted-reencode/SHA256SUMS"
 
       - name: Upload signed re-encode artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -28,6 +28,11 @@ on:
         description: Validator or independent-review finding to address
         required: false
         type: string
+      open_pr:
+        description: Commit, push, and open a draft RuleSpec pull request
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -473,6 +478,7 @@ jobs:
           test -s "$artifact/status.txt"
 
       - name: Commit reviewed lane changes locally
+        if: ${{ inputs.open_pr }}
         env:
           COUNTRY: ${{ inputs.country }}
           CITATION: ${{ inputs.citation }}
@@ -491,6 +497,7 @@ jobs:
             commit -m "Add signed encoding manifest for ${CITATION}"
 
       - name: Push lane branch and open draft pull request
+        if: ${{ inputs.open_pr }}
         env:
           GH_TOKEN: ${{ secrets.AXIOM_REPO_TOKEN }}
           COUNTRY: ${{ inputs.country }}

--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -479,7 +479,8 @@ jobs:
           RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
         run: |
           set -euo pipefail
-          branch="axiom/signed-backfill-${COUNTRY}-${GITHUB_RUN_ID}"
+          branch="$(python axiom-encode/scripts/prepare_signed_backfill.py branch-name \
+            "$COUNTRY" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT")"
           git -C "$RULESPEC_CHECKOUT" switch -c "$branch"
           python axiom-encode/scripts/prepare_signed_backfill.py stage \
             "$RULESPEC_CHECKOUT"
@@ -500,7 +501,8 @@ jobs:
           set -euo pipefail
           test -n "$GH_TOKEN"
           repo="TheAxiomFoundation/rulespec-${COUNTRY}"
-          branch="axiom/signed-backfill-${COUNTRY}-${GITHUB_RUN_ID}"
+          branch="$(python axiom-encode/scripts/prepare_signed_backfill.py branch-name \
+            "$COUNTRY" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT")"
           body="$(printf '%s\n' \
             '## Signed apply manifest' \
             '' \

--- a/changelog.d/1147-country-signed-backfill.added.md
+++ b/changelog.d/1147-country-signed-backfill.added.md
@@ -1,0 +1,2 @@
+Generalize the protected targeted signed-apply workflow across country RuleSpec
+repositories and publish each signed result as a reviewable draft lane pull request.

--- a/changelog.d/1147-country-signed-backfill.added.md
+++ b/changelog.d/1147-country-signed-backfill.added.md
@@ -1,2 +1,2 @@
 Generalize the protected targeted signed-apply workflow across country RuleSpec
-repositories and publish each signed result as a reviewable draft lane pull request.
+repositories, with fail-closed, explicitly enabled draft pull request publication.

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -11,6 +11,9 @@ from pathlib import Path, PurePosixPath
 
 COUNTRY_PATTERN = re.compile(r"[a-z]{2}")
 MANIFEST_ROOT = PurePosixPath(".axiom/encoding-manifests")
+RULESPEC_ATOMIC_ROOTS = frozenset(
+    {"legislation", "policies", "regulations", "statutes"}
+)
 
 
 def validate_country(value: str) -> str:
@@ -54,6 +57,20 @@ def _safe_relative_path(value: object, *, label: str) -> PurePosixPath:
     return path
 
 
+def _validate_rulespec_path(repo: Path, path: PurePosixPath, *, label: str) -> None:
+    repo_prefix = "rulespec-"
+    if not repo.name.startswith(repo_prefix):
+        raise ValueError("repository directory must use the rulespec-<country> name")
+    country = validate_country(repo.name.removeprefix(repo_prefix))
+    if (
+        len(path.parts) < 3
+        or (path.parts[0] != country and not path.parts[0].startswith(f"{country}-"))
+        or path.parts[1] not in RULESPEC_ATOMIC_ROOTS
+        or path.suffix != ".yaml"
+    ):
+        raise ValueError(f"{label} is not a canonical RuleSpec YAML path")
+
+
 def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
     changed = _changed_paths(repo)
     manifests = {
@@ -78,10 +95,11 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
         for index, entry in enumerate(applied_files):
             if not isinstance(entry, dict):
                 raise ValueError(f"{relative} applied_files[{index}] is malformed")
+            label = f"{relative} applied_files[{index}].path"
+            applied_path = _safe_relative_path(entry.get("path"), label=label)
+            _validate_rulespec_path(repo, applied_path, label=label)
             authorized.add(
-                _safe_relative_path(
-                    entry.get("path"), label=f"{relative} applied_files[{index}].path"
-                )
+                applied_path
             )
 
     unexpected = changed - authorized

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Fail-closed helpers for publishing targeted signed RuleSpec backfills."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from pathlib import Path, PurePosixPath
+
+COUNTRY_PATTERN = re.compile(r"[a-z]{2}")
+MANIFEST_ROOT = PurePosixPath(".axiom/encoding-manifests")
+
+
+def validate_country(value: str) -> str:
+    if COUNTRY_PATTERN.fullmatch(value) is None:
+        raise ValueError("country must be a two-letter lowercase country code")
+    return value
+
+
+def branch_name(country: str, run_id: str, run_attempt: str) -> str:
+    validate_country(country)
+    if not run_id.isdecimal() or not run_attempt.isdecimal():
+        raise ValueError("run id and attempt must be decimal integers")
+    return f"axiom/signed-backfill-{country}-{run_id}-{run_attempt}"
+
+
+def _git(repo: Path, *args: str) -> bytes:
+    return subprocess.check_output(["git", "-C", str(repo), *args])
+
+
+def _changed_paths(repo: Path) -> set[PurePosixPath]:
+    output = _git(repo, "status", "--porcelain=v1", "-z", "--untracked-files=all")
+    paths: set[PurePosixPath] = set()
+    fields = output.split(b"\0")
+    index = 0
+    while index < len(fields) and fields[index]:
+        entry = fields[index]
+        status = entry[:2]
+        if len(entry) < 4 or status[:1] in {b"R", b"C"} or status[1:] in {b"R", b"C"}:
+            raise ValueError("renamed/copied or malformed changed paths are not publishable")
+        paths.add(PurePosixPath(entry[3:].decode("utf-8")))
+        index += 1
+    return paths
+
+
+def _safe_relative_path(value: object, *, label: str) -> PurePosixPath:
+    if not isinstance(value, str):
+        raise ValueError(f"{label} must be a string")
+    path = PurePosixPath(value)
+    if path.is_absolute() or ".." in path.parts or not path.parts:
+        raise ValueError(f"{label} is not a safe repository-relative path")
+    return path
+
+
+def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
+    changed = _changed_paths(repo)
+    manifests = {
+        path
+        for path in changed
+        if path.is_relative_to(MANIFEST_ROOT) and path.suffix == ".json"
+    }
+    if not manifests:
+        raise ValueError("no changed signed apply manifest is available to authorize publication")
+
+    authorized = set(manifests)
+    for relative in manifests:
+        manifest_path = repo / relative
+        if not manifest_path.is_file() or manifest_path.is_symlink():
+            raise ValueError(f"changed manifest is not a regular file: {relative}")
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+        if payload.get("schema_version") != "axiom-encode/applied-rulespec/v5":
+            raise ValueError(f"changed manifest has an unsupported schema: {relative}")
+        applied_files = payload.get("applied_files")
+        if not isinstance(applied_files, list) or not applied_files:
+            raise ValueError(f"changed manifest has no applied_files authorization: {relative}")
+        for index, entry in enumerate(applied_files):
+            if not isinstance(entry, dict):
+                raise ValueError(f"{relative} applied_files[{index}] is malformed")
+            authorized.add(
+                _safe_relative_path(
+                    entry.get("path"), label=f"{relative} applied_files[{index}].path"
+                )
+            )
+
+    unexpected = changed - authorized
+    missing = authorized - changed
+    if unexpected:
+        raise ValueError(
+            "publication found changed paths outside signed manifest authorization: "
+            + ", ".join(map(str, sorted(unexpected)))
+        )
+    if missing:
+        raise ValueError(
+            "signed manifest authorizes paths that are not changed: "
+            + ", ".join(map(str, sorted(missing)))
+        )
+    return authorized
+
+
+def stage_authorized_changes(repo: Path) -> None:
+    authorized = authorized_changed_paths(repo)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "-c",
+            "core.hooksPath=/dev/null",
+            "add",
+            "--",
+            *map(str, sorted(authorized)),
+        ],
+        check=True,
+    )
+    staged = {
+        PurePosixPath(value.decode("utf-8"))
+        for value in _git(repo, "diff", "--cached", "--name-only", "-z").split(b"\0")
+        if value
+    }
+    if staged != authorized:
+        raise ValueError("staged paths differ from signed manifest authorization")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    country_parser = subparsers.add_parser("validate-country")
+    country_parser.add_argument("country")
+    branch_parser = subparsers.add_parser("branch-name")
+    branch_parser.add_argument("country")
+    branch_parser.add_argument("run_id")
+    branch_parser.add_argument("run_attempt")
+    stage_parser = subparsers.add_parser("stage")
+    stage_parser.add_argument("repo", type=Path)
+    args = parser.parse_args()
+    try:
+        if args.command == "validate-country":
+            print(validate_country(args.country))
+        elif args.command == "branch-name":
+            print(branch_name(args.country, args.run_id, args.run_attempt))
+        else:
+            stage_authorized_changes(args.repo)
+    except (OSError, ValueError, json.JSONDecodeError, subprocess.CalledProcessError) as exc:
+        parser.exit(1, f"error: {exc}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.prepare_signed_backfill import (
+    branch_name,
+    stage_authorized_changes,
+    validate_country,
+)
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "rulespec-us"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "config", "user.email", "test@example.com")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "base")
+    return repo
+
+
+def _write_signed_change(repo: Path) -> tuple[Path, Path]:
+    rule = repo / "us/regulations/example.yaml"
+    rule.parent.mkdir(parents=True)
+    rule.write_text("rules: []\n", encoding="utf-8")
+    manifest = repo / ".axiom/encoding-manifests/us/regulations/example.json"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": "axiom-encode/applied-rulespec/v5",
+                "applied_files": [{"path": "us/regulations/example.yaml"}],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return rule, manifest
+
+
+@pytest.mark.parametrize("country", ["../x", "us/x", "${{ inputs.x }}", "us\n"])
+def test_validate_country_rejects_adversarial_values(country: str) -> None:
+    with pytest.raises(ValueError, match="two-letter lowercase"):
+        validate_country(country)
+
+
+def test_stage_authorized_changes_stages_only_manifest_and_applied_files(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    rule, manifest = _write_signed_change(repo)
+
+    stage_authorized_changes(repo)
+
+    assert _git(repo, "diff", "--cached", "--name-only").splitlines() == sorted(
+        [str(manifest.relative_to(repo)), str(rule.relative_to(repo))]
+    )
+
+
+def test_stage_authorized_changes_rejects_unexpected_file(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    _write_signed_change(repo)
+    (repo / "encoder-surprise.txt").write_text("must not publish\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="outside signed manifest authorization"):
+        stage_authorized_changes(repo)
+
+    assert _git(repo, "diff", "--cached", "--name-only") == ""
+
+
+def test_rerun_attempt_uses_recoverable_distinct_branch() -> None:
+    first = branch_name("us", "12345", "1")
+    rerun = branch_name("us", "12345", "2")
+
+    assert first == "axiom/signed-backfill-us-12345-1"
+    assert rerun == "axiom/signed-backfill-us-12345-2"
+    assert rerun != first

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -83,6 +83,22 @@ def test_stage_authorized_changes_rejects_unexpected_file(tmp_path: Path) -> Non
     assert _git(repo, "diff", "--cached", "--name-only") == ""
 
 
+def test_stage_rejects_manifest_authorizing_non_rulespec_path(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    _rule, manifest = _write_signed_change(repo)
+    payload = json.loads(manifest.read_text(encoding="utf-8"))
+    payload["applied_files"] = [{"path": ".github/workflows/pwn.yml"}]
+    manifest.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+    unexpected = repo / ".github/workflows/pwn.yml"
+    unexpected.parent.mkdir(parents=True)
+    unexpected.write_text("name: unexpected\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="not a canonical RuleSpec YAML path"):
+        stage_authorized_changes(repo)
+
+    assert _git(repo, "diff", "--cached", "--name-only") == ""
+
+
 def test_rerun_attempt_uses_recoverable_distinct_branch() -> None:
     first = branch_name("us", "12345", "1")
     rerun = branch_name("us", "12345", "2")

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1741,11 +1741,27 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     trigger = workflow.get("on", workflow.get(True))
     assert set(trigger) == {"workflow_dispatch"}
     assert workflow["permissions"] == {"contents": "read"}
+    inputs = trigger["workflow_dispatch"]["inputs"]
+    assert inputs["country"] == {
+        "description": "Canonical RuleSpec country checkout (for rulespec-<country>)",
+        "required": True,
+        "default": "us",
+        "type": "string",
+    }
 
     job = workflow["jobs"]["encode"]
     assert job["environment"] == "production-signing"
     assert "github.ref == 'refs/heads/main'" in job["if"]
     steps = job["steps"]
+    country_step = next(
+        step for step in steps if step.get("name") == "Validate country routing input"
+    )
+    assert "^[a-z]{2}$" in country_step["run"]
+    assert steps.index(country_step) < next(
+        index
+        for index, step in enumerate(steps)
+        if step.get("name") == "Checkout canonical RuleSpec country"
+    )
     checkout_steps = [
         step for step in steps if step.get("uses", "").startswith("actions/checkout@")
     ]
@@ -1762,6 +1778,9 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "^[0-9a-f]{40}$" in identity_command
     assert "rev-parse HEAD" in identity_command
     assert "merge-base --is-ancestor" in identity_command
+    assert '"https://github.com/TheAxiomFoundation/rulespec-$COUNTRY"' in (
+        identity_command
+    )
 
     release_step = next(
         step
@@ -1771,10 +1790,11 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert release_step["env"] == {
         "SUPABASE_URL": "https://swocpijqqahhuwtuahwc.supabase.co",
         "SUPABASE_ANON_KEY": "${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY }}",
+        "RULESPEC_CHECKOUT": "rulespec-${{ inputs.country }}",
     }
     release_command = release_step["run"]
     assert "materialize_corpus_release.py" in release_command
-    assert "rulespec-us/.axiom/toolchain.toml" in release_command
+    assert '$RULESPEC_CHECKOUT/.axiom/toolchain.toml' in release_command
     assert 'pin --toolchain "$toolchain"' in release_command
     assert 'mktemp "$RUNNER_TEMP/' in release_command
     assert "/rest/v1/release_objects?select=release_object" in release_command
@@ -1872,6 +1892,24 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     ]
     assert secret_steps == [apply_step]
 
+    publish_step = next(
+        step
+        for step in steps
+        if step.get("name") == "Push lane branch and open draft pull request"
+    )
+    assert publish_step["env"]["GH_TOKEN"] == "${{ secrets.AXIOM_REPO_TOKEN }}"
+    assert "AXIOM_ENCODE_APPLY_SIGNING_KEY" not in publish_step["env"]
+    publish_command = publish_step["run"]
+    assert 'repo="TheAxiomFoundation/rulespec-${COUNTRY}"' in publish_command
+    assert 'branch="axiom/signed-backfill-${COUNTRY}-${GITHUB_RUN_ID}"' in (
+        publish_command
+    )
+    assert "core.hooksPath=/dev/null" in publish_command
+    assert '"HEAD:refs/heads/${branch}"' in publish_command
+    assert "gh api --method POST" in publish_command
+    assert "-f base=main" in publish_command
+    assert "-F draft=true" in publish_command
+
 
 def test_targeted_review_finding_temp_file_is_valid_context(tmp_path: Path) -> None:
     runner_temp = tmp_path / "runner-temp"
@@ -1913,7 +1951,7 @@ def test_targeted_artifact_packages_signed_review_context(tmp_path: Path) -> Non
         '\nPY\npython - "$artifact/metadata.json"', 1
     )[0]
 
-    rulespec = tmp_path / "rulespec-us"
+    rulespec = tmp_path / "rulespec-nz"
     rulespec.mkdir()
     subprocess.run(["git", "init", "-q"], cwd=rulespec, check=True)
     subprocess.run(
@@ -1968,6 +2006,7 @@ def test_targeted_artifact_packages_signed_review_context(tmp_path: Path) -> Non
             "CITATION": citation,
             "REVIEW_FINDING_PRESENT": "true",
             "RUNNER_TEMP": str(tmp_path),
+            "RULESPEC_CHECKOUT": "rulespec-nz",
         },
     )
 

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1911,6 +1911,19 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "gh api --method POST" in publish_command
     assert "-f base=main" in publish_command
     assert "-F draft=true" in publish_command
+    assert "SHA256SUMS" not in publish_command
+
+    checksum_step = next(
+        step
+        for step in steps
+        if step.get("name") == "Finalize signed re-encode artifact checksums"
+    )
+    assert "if" not in checksum_step
+    assert 'sha256sum "$RUNNER_TEMP/targeted-reencode"/*' in checksum_step["run"]
+    upload_step = next(
+        step for step in steps if step.get("name") == "Upload signed re-encode artifact"
+    )
+    assert steps.index(checksum_step) + 1 == steps.index(upload_step)
 
 
 def test_targeted_review_finding_temp_file_is_valid_context(tmp_path: Path) -> None:

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1797,7 +1797,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     }
     release_command = release_step["run"]
     assert "materialize_corpus_release.py" in release_command
-    assert '$RULESPEC_CHECKOUT/.axiom/toolchain.toml' in release_command
+    assert "$RULESPEC_CHECKOUT/.axiom/toolchain.toml" in release_command
     assert 'pin --toolchain "$toolchain"' in release_command
     assert 'mktemp "$RUNNER_TEMP/' in release_command
     assert "/rest/v1/release_objects?select=release_object" in release_command

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1758,7 +1758,8 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     country_step = next(
         step for step in steps if step.get("name") == "Validate country routing input"
     )
-    assert "^[a-z]{2}$" in country_step["run"]
+    assert "prepare_signed_backfill.py" in country_step["run"]
+    assert 'validate-country "$COUNTRY"' in country_step["run"]
     assert steps.index(country_step) < next(
         index
         for index, step in enumerate(steps)

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1748,6 +1748,8 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         "default": "us",
         "type": "string",
     }
+    assert inputs["open_pr"]["type"] == "boolean"
+    assert inputs["open_pr"]["default"] is False
 
     job = workflow["jobs"]["encode"]
     assert job["environment"] == "production-signing"
@@ -1897,13 +1899,12 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         for step in steps
         if step.get("name") == "Push lane branch and open draft pull request"
     )
+    assert publish_step["if"] == "${{ inputs.open_pr }}"
     assert publish_step["env"]["GH_TOKEN"] == "${{ secrets.AXIOM_REPO_TOKEN }}"
     assert "AXIOM_ENCODE_APPLY_SIGNING_KEY" not in publish_step["env"]
     publish_command = publish_step["run"]
     assert 'repo="TheAxiomFoundation/rulespec-${COUNTRY}"' in publish_command
-    assert 'branch="axiom/signed-backfill-${COUNTRY}-${GITHUB_RUN_ID}"' in (
-        publish_command
-    )
+    assert '"$COUNTRY" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT"' in publish_command
     assert "core.hooksPath=/dev/null" in publish_command
     assert '"HEAD:refs/heads/${branch}"' in publish_command
     assert "gh api --method POST" in publish_command


### PR DESCRIPTION
# Generalize signed apply and backfill across country lanes

Closes #1147.

## Summary

- add a required `country` input (defaulting to `us`) and derive the canonical
  `TheAxiomFoundation/rulespec-<country>` checkout from it
- bind the immutable RuleSpec SHA to that exact origin and require it to be an
  ancestor of the lane repository's `origin/main`
- route corpus-release pinning, protected RuleSpec inspection, signed apply,
  provenance verification, and artifact packaging through the parameterized
  checkout
- commit the verified lane-local changes to a unique branch and open a draft PR
  in the lane repository; the workflow never pushes lane `main`

Signed manifests remain lane-local under
`.axiom/encoding-manifests/`. This matches the ownership model: each RuleSpec
lane reviews and lands its own content and provenance rather than sending
manifests to a central repository.

## Security properties preserved

- dispatch remains bound to `workflow_dispatch` from `axiom-encode` `main`
- the `production-signing` environment and read-only workflow permissions remain
- all four checkouts use immutable full lowercase SHAs, fetch full history, and
  persist no credentials
- the country input is restricted to a two-letter lowercase code; both the exact
  canonical GitHub origin and main ancestry are verified before protected work
- lane authorization remains a human decision at the protected
  `production-signing` environment approval gate; syntax validation is not an
  authorization allowlist, and an approved run can target any canonical
  two-letter `TheAxiomFoundation/rulespec-<country>` repository
- the root-owned protected supervisor is provisioned unchanged with the apply,
  eval, and corpus-release trust roots
- the apply key is still exposed to exactly one step and consumed only through
  `axiom-encode-apply-signer run --key-env`
- the signer remains bound to this workflow on `refs/heads/main` and to
  `workflow_dispatch`
- `guard-generated` and the exact one-manifest/context-evidence checks run before
  any publication token is exposed
- the cross-repository token is isolated to the final publication step; commit
  and push hooks are disabled, and publication targets only the already-bound
  canonical lane repository
- publication uses a unique run-ID branch and creates a draft PR against `main`;
  it does not force-push or directly update `main`

## Pilot and rollout

After this PR passes CI, completes `/cycle`, is reviewed, and is merged, Max or
the supervised operator should dispatch one NZ citation whose corrected content
is already on `rulespec-nz` main. Use the operator command in the final handoff;
it resolves all three current main commits and passes those immutable SHAs to
the workflow. Do not run the pilot before approval.

Success requires a green signing run, a new draft PR in `rulespec-nz`, exactly
one changed signed v5 apply manifest for the citation, a clean provenance guard,
and independent verification against `AXIOM_ENCODE_APPLY_SIGNING_PUBLIC_KEY`.
Review and merge the lane PR through its normal cycle. Roll out one reviewed
citation/repository at a time; enable generated-content enforcement only after
that lane's census is clean.

## Validation

- `actionlint .github/workflows/targeted-signed-reencode.yml`
- independent YAML parse
- focused workflow security and artifact tests
- repository lint, compile, and test checks as recorded in the final handoff

Real GitHub Actions behavior still must confirm environment approval, secret and
token scope, lane branch/ruleset permissions, Ubuntu protected-runtime behavior,
OpenAI encode behavior for the chosen NZ citation, and draft PR creation. No
production workflow was dispatched while preparing this change.

---
## ⚠️ DRAFT — do not merge yet
This is a **country-general signed-apply** workflow for encode#1147 (new-country lanes currently
cannot mint signed manifests; US path has been live since June). Authored by an agent (gpt-5.6-sol),
independently adversarially re-reviewed by a fresh gpt-5.6-sol pass **GO-for-draft** + main-loop concurrence.
**Provenance flag:** main-loop was Opus-served this session (classifier fallback) — this PR needs a
clean-provenance (Fable/human) review before merge.

### Independent review: GO for draft, with must-fix-before-pilot concerns
Security properties all verified PRESERVED (main-branch guard, immutable-checkout SHA/ancestry
verification, three trust roots, key-only-in-apply-step via `--key-env` launcher, post-apply
`guard-generated`). `country` input is injection/traversal-safe (exact `^[a-z]{2}$`, validated before any
checkout). Regime-compliant (no toolchain.toml/CODEOWNERS/pin changes; newsfragment present).

**Resolve before the pilot dispatch / merge:**
1. Publication uses `git add --all` — replace with an authenticated changed-path allowlist (the signed
   manifest + files it authorizes) so an unexpected encoder-created file can't enter the PR.
2. Branch name uses only `GITHUB_RUN_ID` — not rerun-safe (push-success→PR-fail rerun non-fast-forwards).
   Use `GITHUB_RUN_ATTEMPT` / reuse-existing-branch / idempotent push.
3. `country=us` now adds commit/push/draft-PR publication to every US run — confirm this doesn't disrupt
   the live US signed path before merge.
4. Tests inspect YAML strings only — add adversarial-`country`, publication-scope, and rerun-recovery tests.

Pilot target (post-merge, gated on human go): `rulespec-nz`. Do not dispatch until 1–4 are resolved.
