### PR TITLE
Ground source-backed half-up rounding helpers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1300"
+version = "0.2.1301"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1300"
+__version__ = "0.2.1301"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -103,16 +103,16 @@ from .validator_pipeline import (
     _parse_rulespec_target,
     _resolve_rulespec_target_file,
     _source_text_looks_like_table,
+    evaluate_numeric_grounding_values,
     extract_embedded_source_text,
-    extract_grounding_values,
     extract_named_scalar_occurrences,
-    extract_numbers_from_text,
     extract_numeric_grounding_source_text,
     extract_numeric_occurrences_from_text,
     find_deferred_output_issues,
     find_ungrounded_numeric_issues,
     find_unused_import_issues,
     find_unused_modifier_parameter_issues,
+    normalize_source_backed_half_up_rounding_occurrence_text,
     numeric_value_is_grounded,
     repair_copied_cross_reference_summary,
     repair_formula_let_bindings,
@@ -121,6 +121,7 @@ from .validator_pipeline import (
     repair_source_table_interval_tests,
     repair_source_table_open_ended_bound_sentinels,
     repair_unsupported_chained_conditionals,
+    source_backed_half_up_rounding_helper_count,
 )
 
 EvalMode = Literal["cold", "repo-augmented"]
@@ -424,10 +425,22 @@ _SECTION_CROSS_REFERENCE_PATTERN = re.compile(
 _LEADING_ZERO_MANUAL_SECTION_PATTERN = re.compile(r"\b0\d{3}\.\d{2}(?:\.\d{2})?\b")
 
 
-def _numeric_occurrence_source_text(source_text: str) -> str:
+def _numeric_occurrence_source_text(
+    source_text: str,
+    *,
+    suppress_source_backed_half_up_increment: bool = False,
+) -> str:
     """Drop citation-like cross-references before source numeric coverage checks."""
     without_cross_references = _SECTION_CROSS_REFERENCE_PATTERN.sub("", source_text)
-    return _LEADING_ZERO_MANUAL_SECTION_PATTERN.sub("", without_cross_references)
+    cleaned = _LEADING_ZERO_MANUAL_SECTION_PATTERN.sub("", without_cross_references)
+    if suppress_source_backed_half_up_increment:
+        cleaned = normalize_source_backed_half_up_rounding_occurrence_text(cleaned)
+    return re.sub(
+        r"\b(?:2nd|3rd)\s+digit\b",
+        "digit",
+        cleaned,
+        flags=re.IGNORECASE,
+    )
 
 
 _UNREFERENCED_PROOF_IMPORT_RE = re.compile(
@@ -6374,11 +6387,18 @@ def _evaluate_artifact_in_scope(
         for part in (numeric_grounding_validation_source_text, proof_excerpt_text)
         if part
     )
-    source_numbers = extract_numbers_from_text(numeric_grounding_source_text or "")
+    half_up_helper_count = min(
+        source_backed_half_up_rounding_helper_count(content, source_text),
+        source_backed_half_up_rounding_helper_count(
+            content, numeric_validation_source_text or ""
+        ),
+    )
+    counted_numeric_source_text = _numeric_occurrence_source_text(
+        numeric_validation_source_text or "",
+        suppress_source_backed_half_up_increment=bool(half_up_helper_count),
+    )
     source_numeric_occurrences = Counter(
-        extract_numeric_occurrences_from_text(
-            _numeric_occurrence_source_text(numeric_validation_source_text or "")
-        )
+        extract_numeric_occurrences_from_text(counted_numeric_source_text)
     )
     if _is_empty_nonassertable_artifact(content):
         source_numeric_occurrences = Counter()
@@ -6391,6 +6411,9 @@ def _evaluate_artifact_in_scope(
     named_scalar_occurrences.update(
         _imported_named_scalar_occurrences(content, policy_repo_root)
     )
+    semantic_source_occurrence_coverage = Counter[float]()
+    if half_up_helper_count:
+        semantic_source_occurrence_coverage[5.0] = half_up_helper_count
     source_is_table = _source_text_looks_like_table(
         numeric_grounding_validation_source_text or ""
     )
@@ -6401,13 +6424,17 @@ def _evaluate_artifact_in_scope(
     )
 
     grounding_metrics: list[GroundingMetric] = []
-    for line, raw, value in extract_grounding_values(content):
+    for line, raw, value, grounded in evaluate_numeric_grounding_values(
+        content,
+        numeric_grounding_source_text,
+        authoritative_source_text=source_text,
+    ):
         grounding_metrics.append(
             GroundingMetric(
                 line=line,
                 raw=raw,
                 value=value,
-                grounded=numeric_value_is_grounded(value, source_numbers),
+                grounded=grounded,
             )
         )
 
@@ -6419,6 +6446,10 @@ def _evaluate_artifact_in_scope(
             expected_count
             if _matching_numeric_occurrence_count(named_scalar_occurrences, value)
             else 0
+        )
+        covered_count = max(
+            covered_count,
+            min(expected_count, semantic_source_occurrence_coverage[value]),
         )
         if inline_table_formula_occurrences.get(value):
             covered_count = max(covered_count, expected_count)
@@ -6434,6 +6465,7 @@ def _evaluate_artifact_in_scope(
     ungrounded_numeric_issues = find_ungrounded_numeric_issues(
         content,
         numeric_grounding_source_text,
+        authoritative_source_text=source_text,
     )
     admin_agency_aggregate_issues = find_admin_agency_aggregate_entity_issues(
         content,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -2613,6 +2613,54 @@ def _rule_atom_evidence_by_path(
     return evidence
 
 
+def _rule_verified_source_excerpt_pairs_by_path(
+    rule: Any,
+    proof_source_texts: Mapping[str, str | None] | None,
+) -> dict[str, tuple[tuple[str | None, str], ...]]:
+    """Map proof anchors to citation-only or verified excerpt/source evidence."""
+    if not isinstance(rule, dict) or proof_source_texts is None:
+        return {}
+    metadata = rule.get("metadata")
+    proof = metadata.get("proof") if isinstance(metadata, dict) else None
+    if not isinstance(proof, dict):
+        proof = rule.get("proof")
+    atoms = proof.get("atoms") if isinstance(proof, dict) else None
+    if not isinstance(atoms, list):
+        return {}
+
+    by_path: dict[str, list[tuple[str | None, str]]] = {}
+    for atom in atoms:
+        if not isinstance(atom, dict):
+            continue
+        path = str(atom.get("path") or "").strip()
+        source = atom.get("source")
+        if not path or not isinstance(source, dict):
+            continue
+        citation_path = str(source.get("corpus_citation_path") or "").strip()
+        resolved_text = proof_source_texts.get(citation_path) if citation_path else None
+        excerpts = [
+            str(source.get(field) or "").strip() for field in ("excerpt", "quote")
+        ]
+        if not resolved_text:
+            continue
+        normalized_source = _collapse_source_sentence_text(resolved_text).lower()
+        selected_excerpts = [excerpt for excerpt in excerpts if excerpt]
+        if not selected_excerpts:
+            table = source.get("table")
+            if isinstance(table, dict) and table:
+                # Structured table coordinates are the atom's selected evidence.
+                # Do not widen them to the entire cited provision for semantic
+                # exemptions such as source-described rounding operations.
+                continue
+            by_path.setdefault(path, []).append((None, resolved_text))
+            continue
+        for excerpt in selected_excerpts:
+            normalized_excerpt = _collapse_source_sentence_text(excerpt).lower()
+            if normalized_excerpt and normalized_excerpt in normalized_source:
+                by_path.setdefault(path, []).append((excerpt, resolved_text))
+    return {path: tuple(pairs) for path, pairs in by_path.items()}
+
+
 def extract_grounding_values(content: str) -> list[tuple[int, str, float]]:
     """Extract grounded numeric values from RuleSpec definitions."""
     with contextlib.suppress(yaml.YAMLError, TypeError, ValueError):
@@ -2754,10 +2802,419 @@ def _is_half_up_rounding_helper_scalar(symbol_name: str, value: float) -> bool:
     if value != 0.5:
         return False
     normalized = symbol_name.lower()
-    if "half_increment" in normalized:
+    if "rounding" in normalized and (
+        "half_increment" in normalized or "half_unit" in normalized
+    ):
         return True
     return "half_up" in normalized and (
         "rounding" in normalized or "offset" in normalized
+    )
+
+
+def _half_up_rounding_source_matchers() -> tuple[
+    tuple[re.Pattern[str], ...],
+    re.Pattern[str],
+    re.Pattern[str],
+]:
+    """Build the narrow instruction, invalidation, and prohibition matchers."""
+    threshold_value = r"(?:five|5)"
+    threshold = (
+        r"(?:"
+        + threshold_value
+        + r"\s+or\s+(?:more|greater)|at\s+least\s+"
+        + threshold_value
+        + r"|equal\s+to\s+or\s+greater\s+than\s+"
+        + threshold_value
+        + r"|greater\s+than\s+or\s+equal\s+to\s+"
+        + threshold_value
+        + r")\b"
+        r"(?=\s*(?:[,.;:]|$|\bthen\b))"
+    )
+    second_digit = r"(?:the\s+)?(?:second|2nd)\s+digit"
+    third_digit = r"(?:the\s+)?(?:third|3rd)\s+digit"
+    decimal_position = r"(?:\s+after\s+the\s+decimal\s+point)?"
+    third_digit_position = third_digit + decimal_position
+    unit = r"(?:one|1)"
+    active_instruction = (
+        r"\b(?:increas\w*|round\w*\s+up)\s+"
+        + second_digit
+        + decimal_position
+        + r"\s+by\s+"
+        + unit
+        + r"\s+(?:if|when)\s+"
+        + third_digit_position
+        + r"\s+(?:(?:is|equals?)\s+)?"
+        + threshold
+    )
+    reverse_action = (
+        r"(?:increas\w*|round\w*\s+up)\s+"
+        + second_digit
+        + decimal_position
+        + r"\s+by\s+"
+        + unit
+    )
+    passive_action = (
+        second_digit
+        + decimal_position
+        + r"\s+(?:(?:shall|must|should|will)\s+be|is)\s+"
+        r"(?:increas\w*|round\w*\s+up)\s+by\s+" + unit
+    )
+    passive_then_condition = (
+        passive_action
+        + r"\s+(?:if|when)\s+"
+        + third_digit_position
+        + r"\s+(?:(?:is|equals?)\s+)?"
+        + threshold
+    )
+    reverse_instruction = (
+        r"\b(?:if|when)\s+"
+        + third_digit_position
+        + r"\s+(?:(?:is|equals?)\s+)?"
+        + threshold
+        + r"\s*[:,]?\s*(?:then\s+)?(?:"
+        + reverse_action
+        + "|"
+        + passive_action
+        + ")"
+    )
+    invalidation = re.compile(
+        r"(?:\b(?:(?:this|that)\s+(?:rounding\s+)?"
+        r"(?:rule|procedure|method|instruction)|the\s+rounding\s+"
+        r"(?:rule|procedure|method|instruction))\b"
+        r".{0,80}\b(?:do(?:es|ne)?\s+not\s+apply|"
+        r"(?:shall|should|must)\s+not\s+(?:apply|be\s+(?:applied|used))|"
+        r"may\s+not\s+(?:apply|be\s+(?:applied|used))|"
+        r"cannot\s+be\s+(?:applied|used)|is\s+not\s+applicable|"
+        r"is\s+inapplicable|is\s+(?:prohibit\w*|disallow\w*|forbid\w*))\b|"
+        r"\b(?:do\s+not|never|(?:shall|should|must|may)\s+not|cannot)\s+"
+        r"do\s+so\b|"
+        r"\bdoing\s+so\s+is\s+"
+        r"(?:prohibit\w*|forbid\w*|disallow\w*|not\s+(?:allowed|permitted))\b|"
+        r"\bwhich\s+is\s+"
+        r"(?:prohibit\w*|forbid\w*|disallow\w*|not\s+(?:allowed|permitted))\b|"
+        r"\b(?:this|that|it)\s+is\s+"
+        r"(?:prohibit\w*|forbid\w*|disallow\w*|not\s+(?:allowed|permitted))\b|"
+        r"\b(?:this|that|it)\s+is\s+(?:illustrative|an?\s+example)"
+        r"(?:\s+only)?\b|"
+        r"\bonly\s+as\s+an?\s+illustration\b|"
+        r"\b(?:it|this)\s+is\s+not\s+(?:allowed|permitted|authorized)\b)"
+    )
+    negated_or_excepted = re.compile(
+        r"\b(?:do\s+not|never|avoid(?:s|ed|ing)?)\b"
+        r"(?:(?![.;:]|,\s*(?:but|and)\b)[\s\S])*?"
+        r"\b(?:increas\w*|round\w*\s+up)\b|"
+        r"\b(?:not\s+to|rather\s+than)\s+"
+        r"(?:increas\w*|round\w*\s+up)\b|"
+        r"\b(?:cannot|can\s+not|does\s+not|did\s+not|"
+        r"won['\N{RIGHT SINGLE QUOTATION MARK}]t|"
+        r"shan['\N{RIGHT SINGLE QUOTATION MARK}]t|"
+        r"may\s+not|must\s+not|shall\s+not|should\s+not|"
+        r"(?:do|does|did|will|would|could|must|shall|should|is|are)"
+        r"n['\N{RIGHT SINGLE QUOTATION MARK}]t"
+        r"(?:\s+to)?|can['\N{RIGHT SINGLE QUOTATION MARK}]t)\b"
+        r"(?:(?![,;:])[\s\S]){0,80}\b(?:increas\w*|round\w*\s+up)\b|"
+        r"\b(?:is\s+)?(?:prohibit\w*|forbid\w*|"
+        r"not\s+(?:permitted|allowed|authorized))\s+to\s+"
+        r"(?:increas\w*|round\w*\s+up)\b|"
+        r"\bno\s+need\s+to\s+(?:increas\w*|round\w*\s+up)\b|"
+        r"\b(?:except(?:ion)?|excluding|unless|subject\s+to)\b|"
+        r"\bfor\s+example\b|"
+        r"\b(?:for|only\s+as\s+an?)\s+illustration\b|"
+        r"\b(?:but|although)\b.{0,80}"
+        r"(?:\b(?:(?:may|shall|should|must|will|would|could)\s+not\s+|cannot\s+)"
+        r"(?:apply|be\s+(?:applied|used)|do\s+so)\b|"
+        r"\bonly\s+(?:an?\s+)?example\b|"
+        r"\bnot\s+(?:calculations?|computations?)\b)"
+    )
+    return (
+        tuple(
+            re.compile(pattern)
+            for pattern in (
+                active_instruction,
+                reverse_instruction,
+                passive_then_condition,
+            )
+        ),
+        invalidation,
+        negated_or_excepted,
+    )
+
+
+def _normalized_half_up_rounding_source_text(source_text: str) -> str:
+    normalized = re.sub(r"[^\S\n]+", " ", source_text.strip()).lower()
+    normalized = re.sub(r",\s*\n\s*", ", ", normalized)
+    return re.sub(r"(?<=[a-z0-9)])\n\s*(?=[a-z0-9])", " ", normalized)
+
+
+def _half_up_rounding_clause_instruction_spans(
+    source_text: str,
+    instruction_patterns: tuple[re.Pattern[str], ...],
+    negated_or_excepted: re.Pattern[str],
+) -> tuple[tuple[int, int], ...]:
+    """Return structurally affirmative instructions in one source clause."""
+    normalized = source_text.lower()
+    if negated_or_excepted.search(normalized):
+        return ()
+    candidate_spans = sorted(
+        {
+            match.span()
+            for pattern in instruction_patterns
+            for match in pattern.finditer(normalized)
+        }
+    )
+    accepted: list[tuple[int, int]] = []
+    for span in candidate_spans:
+        start, _end = span
+        prefix_start = accepted[-1][1] if accepted else 0
+        prefix = normalized[prefix_start:start]
+        if accepted:
+            if not re.fullmatch(r"\s*,?\s*(?:and|or)\s+", prefix):
+                continue
+        elif prefix.strip(" \t\r\n,:"):
+            structural_prefix = _STRUCTURAL_SOURCE_PREFIX_PATTERN.fullmatch(prefix)
+            official_context = re.fullmatch(
+                r"\s*(?:if|when)\s+.{1,240}\b(?:has|have)\s+"
+                r"(?:three|3)\s+or\s+more\s+digits?\s+after\s+the\s+"
+                r"decimal\s+point\s*,\s*",
+                prefix,
+            )
+            unrelated_contrast = re.fullmatch(r".+,\s*but\s+", prefix)
+            if (
+                not structural_prefix
+                and not official_context
+                and not unrelated_contrast
+            ):
+                continue
+        accepted.append(span)
+    return tuple(accepted)
+
+
+def _half_up_rounding_clause_instruction_count(
+    source_text: str,
+    instruction_patterns: tuple[re.Pattern[str], ...],
+    negated_or_excepted: re.Pattern[str],
+) -> int:
+    """Count exact instructions in one clause after clause-level exclusions."""
+    return len(
+        _half_up_rounding_clause_instruction_spans(
+            source_text, instruction_patterns, negated_or_excepted
+        )
+    )
+
+
+def _half_up_rounding_supported_line_flags(
+    lines: list[str],
+    instruction_patterns: tuple[re.Pattern[str], ...],
+    negated_or_excepted: re.Pattern[str],
+) -> tuple[bool, ...]:
+    """Mark complete instruction lines not negated by the preceding line."""
+    flags: list[bool] = []
+    for index, line in enumerate(lines):
+        supported = bool(
+            _half_up_rounding_clause_instruction_count(
+                line, instruction_patterns, negated_or_excepted
+            )
+        )
+        if supported and index:
+            preceding_line = lines[index - 1].strip().lower()
+            dangling_negation = bool(
+                re.search(
+                    r"\b(?:do\s+not|never|avoid|cannot|can\s+not|"
+                    r"may\s+not|must\s+not|shall\s+not|should\s+not|"
+                    r"will\s+not|would\s+not|could\s+not|not\s+to)\s*$",
+                    preceding_line,
+                )
+                or re.fullmatch(
+                    r"\s*(?:do\s+not|never|avoid)\s*,\s*[^,]+,?\s*",
+                    preceding_line,
+                )
+            )
+            supported = not dangling_negation
+        flags.append(supported)
+    return tuple(flags)
+
+
+def normalize_source_backed_half_up_rounding_occurrence_text(
+    source_text: str,
+) -> str:
+    """Spell out increments only inside recognized affirmative instructions."""
+    instruction_patterns, invalidation, negated_or_excepted = (
+        _half_up_rounding_source_matchers()
+    )
+    case_insensitive_patterns = tuple(
+        re.compile(pattern.pattern, re.IGNORECASE) for pattern in instruction_patterns
+    )
+
+    def normalize_instruction_units(text: str) -> str:
+        spans = _half_up_rounding_clause_instruction_spans(
+            text, case_insensitive_patterns, negated_or_excepted
+        )
+        if not spans:
+            return text
+        for start, end in sorted(spans, reverse=True):
+            instruction = re.sub(
+                r"(\bby\s+)1\b",
+                r"\g<1>one",
+                text[start:end],
+                flags=re.IGNORECASE,
+            )
+            text = text[:start] + instruction + text[end:]
+        return text
+
+    parts = re.split(r"([.!?;]+)", source_text)
+    clause_indexes = [
+        index for index in range(0, len(parts), 2) if parts[index].strip()
+    ]
+    for position, part_index in enumerate(clause_indexes):
+        clause = parts[part_index]
+        context_indexes = clause_indexes[max(0, position - 1) : position + 2]
+        context = _normalized_half_up_rounding_source_text(
+            ". ".join(parts[index] for index in context_indexes)
+        )
+        if invalidation.search(context):
+            continue
+        lines = clause.splitlines(keepends=True)
+        supported_line_flags = _half_up_rounding_supported_line_flags(
+            lines, instruction_patterns, negated_or_excepted
+        )
+        if any(supported_line_flags):
+            parts[part_index] = "".join(
+                normalize_instruction_units(line)
+                if supported_line_flags[index]
+                else line
+                for index, line in enumerate(lines)
+            )
+        else:
+            parts[part_index] = normalize_instruction_units(clause)
+    return "".join(parts)
+
+
+def _is_source_backed_half_up_rounding_helper(
+    symbol_name: str,
+    value: float,
+    source_text: str,
+) -> bool:
+    """Return True for an explicit source-backed half-up digit instruction."""
+    return bool(
+        _source_backed_half_up_rounding_instruction_count(
+            symbol_name, value, source_text
+        )
+    )
+
+
+def _source_backed_half_up_rounding_instruction_count(
+    symbol_name: str,
+    value: float,
+    source_text: str,
+) -> int:
+    """Count supported instructions while retaining adjacent invalidations."""
+    if not _is_half_up_rounding_helper_scalar(symbol_name, value):
+        return 0
+    instruction_patterns, invalidation, negated_or_excepted = (
+        _half_up_rounding_source_matchers()
+    )
+    punctuation_clauses = [
+        clause.strip() for clause in re.split(r"[.!?;]+", source_text) if clause.strip()
+    ]
+    clauses: list[str] = []
+    for clause in punctuation_clauses:
+        lines = [line.strip() for line in clause.splitlines() if line.strip()]
+        supported_line_flags = _half_up_rounding_supported_line_flags(
+            lines, instruction_patterns, negated_or_excepted
+        )
+        if not any(supported_line_flags):
+            clauses.append(clause)
+            continue
+        for index, line in enumerate(lines):
+            raw_supported = bool(
+                _half_up_rounding_clause_instruction_count(
+                    line, instruction_patterns, negated_or_excepted
+                )
+            )
+            if raw_supported and not supported_line_flags[index] and index:
+                clauses.append(f"{lines[index - 1]}\n{line}")
+            else:
+                clauses.append(line)
+    count = 0
+    for index, clause in enumerate(clauses):
+        instruction_count = _half_up_rounding_clause_instruction_count(
+            clause, instruction_patterns, negated_or_excepted
+        )
+        if not instruction_count:
+            continue
+        context = _normalized_half_up_rounding_source_text(
+            ". ".join(clauses[max(0, index - 1) : index + 2])
+        )
+        if not invalidation.search(context):
+            count += instruction_count
+    return count
+
+
+def source_backed_half_up_rounding_helper_count(
+    content: str,
+    authoritative_source_text: str,
+) -> int:
+    """Count source instructions supported by at least one direct helper."""
+    with contextlib.suppress(yaml.YAMLError, TypeError, ValueError):
+        payload = yaml.safe_load(content)
+        rules = payload.get("rules") if isinstance(payload, dict) else None
+        if isinstance(rules, list):
+            selector_table_keys = _rulespec_index_selector_keys(rules)
+            for rule in rules:
+                rule_name = (
+                    str(rule.get("name") or "").strip()
+                    if isinstance(rule, dict)
+                    else ""
+                )
+                for anchor_path, _raw, value in _rule_grounding_values_by_path(
+                    rule,
+                    selector_table_keys=selector_table_keys,
+                ):
+                    if not _is_direct_half_up_rounding_helper_value(
+                        rule, anchor_path, value
+                    ):
+                        continue
+                    instruction_count = (
+                        _source_backed_half_up_rounding_instruction_count(
+                            rule_name,
+                            value,
+                            authoritative_source_text,
+                        )
+                    )
+                    if instruction_count:
+                        return instruction_count
+    return 0
+
+
+def _is_direct_half_up_rounding_helper_value(
+    rule: Any,
+    anchor_path: str,
+    value: float,
+) -> bool:
+    """Return True only for a helper version whose whole formula is ``0.5``."""
+    if not isinstance(rule, dict):
+        return False
+    rule_name = str(rule.get("name") or "").strip()
+    if not _is_half_up_rounding_helper_scalar(rule_name, value):
+        return False
+    match = re.fullmatch(r"versions\[(\d+)\]\.formula", anchor_path)
+    versions = rule.get("versions")
+    if match is None or not isinstance(versions, list):
+        return False
+    index = int(match.group(1))
+    if index >= len(versions) or not isinstance(versions[index], dict):
+        return False
+    direct_value = _numeric_rule_value(versions[index].get("formula"))
+    return direct_value is not None and direct_value[1] == value
+
+
+def _strip_ambiguous_half_up_terms(text: str) -> str:
+    """Remove ``half-up`` prose while retaining substantive word-form halves."""
+    return re.sub(
+        r"\bhalf[- ]up\b",
+        " ",
+        text,
+        flags=re.IGNORECASE,
     )
 
 
@@ -4528,10 +4985,15 @@ def _numeric_value_grounded_in_source(
 def _ungrounded_from_values(
     grounding_values: Sequence[tuple[int, str, float]],
     source: str,
+    *,
+    source_numbers: set[float] | None = None,
+    decimal_place_scale_values: set[float] | None = None,
 ) -> list[str]:
     """Report values not grounded in ``source`` (which must be pre-stripped)."""
-    source_numbers = extract_numbers_from_text(source)
-    decimal_place_scale_values = _decimal_place_scale_values_from_source(source)
+    if source_numbers is None:
+        source_numbers = extract_numbers_from_text(source)
+    if decimal_place_scale_values is None:
+        decimal_place_scale_values = _decimal_place_scale_values_from_source(source)
     issues: list[str] = []
     for _, raw, value in grounding_values:
         if _numeric_value_grounded_in_source(
@@ -4546,9 +5008,100 @@ def _ungrounded_from_values(
     return issues
 
 
+def evaluate_numeric_grounding_values(
+    content: str,
+    source_text: str,
+    *,
+    authoritative_source_text: str | None = None,
+) -> list[tuple[int, str, float, bool]]:
+    """Return a grounding decision for every generated numeric literal.
+
+    ``source_text`` may include excerpt-verified proof evidence used for ordinary
+    literal matching. Semantic rounding support is intentionally restricted to
+    ``authoritative_source_text`` when supplied, so inline excerpts cannot grant
+    the half-up helper exemption.
+    """
+    grounding_values = extract_grounding_values(content)
+    if not grounding_values:
+        return []
+
+    authoritative_source = (
+        source_text
+        if authoritative_source_text is None
+        else authoritative_source_text.strip()
+    )
+    with contextlib.suppress(yaml.YAMLError, TypeError, ValueError):
+        payload = yaml.safe_load(content)
+        rules = payload.get("rules") if isinstance(payload, dict) else None
+        if isinstance(rules, list):
+            selector_table_keys = _rulespec_index_selector_keys(rules)
+            decisions: list[tuple[int, str, float, bool]] = []
+            source_indexes: dict[str, tuple[set[float], set[float]]] = {}
+            for rule in rules:
+                anchored_values = _rule_grounding_values_by_path(
+                    rule, selector_table_keys=selector_table_keys
+                )
+                rule_name = (
+                    str(rule.get("name") or "").strip()
+                    if isinstance(rule, dict)
+                    else ""
+                )
+                for anchor_path, raw, value in anchored_values:
+                    direct_half_up_helper = _is_direct_half_up_rounding_helper_value(
+                        rule, anchor_path, value
+                    )
+                    if direct_half_up_helper and (
+                        _is_source_backed_half_up_rounding_helper(
+                            rule_name, value, authoritative_source
+                        )
+                    ):
+                        decisions.append((1, raw, value, True))
+                        continue
+                    grounding_source = (
+                        _strip_ambiguous_half_up_terms(source_text)
+                        if _is_half_up_rounding_helper_scalar(rule_name, value)
+                        else source_text
+                    )
+                    source_index = source_indexes.get(grounding_source)
+                    if source_index is None:
+                        source_index = (
+                            extract_numbers_from_text(grounding_source),
+                            _decimal_place_scale_values_from_source(grounding_source),
+                        )
+                        source_indexes[grounding_source] = source_index
+                    decisions.append(
+                        (
+                            1,
+                            raw,
+                            value,
+                            _numeric_value_grounded_in_source(
+                                value, source_index[0], source_index[1]
+                            ),
+                        )
+                    )
+            if len(decisions) == len(grounding_values):
+                return decisions
+
+    source_numbers = extract_numbers_from_text(source_text)
+    decimal_place_scale_values = _decimal_place_scale_values_from_source(source_text)
+    return [
+        (
+            line,
+            raw,
+            value,
+            _numeric_value_grounded_in_source(
+                value, source_numbers, decimal_place_scale_values
+            ),
+        )
+        for line, raw, value in grounding_values
+    ]
+
+
 def find_ungrounded_numeric_issues(
     content: str,
     source_text: str | None = None,
+    *,
+    authoritative_source_text: str | None = None,
 ) -> list[str]:
     """Return issues for generated numeric literals absent from source text."""
     grounding_values = extract_grounding_values(content)
@@ -4566,7 +5119,20 @@ def find_ungrounded_numeric_issues(
             "`module.summary` is not accepted as source text for numeric grounding."
         ]
 
-    return _ungrounded_from_values(grounding_values, source)
+    issues: list[str] = []
+    for _line, raw, value, grounded in evaluate_numeric_grounding_values(
+        content,
+        source,
+        authoritative_source_text=authoritative_source_text,
+    ):
+        if grounded:
+            continue
+        display = raw if raw == f"{value:g}" else f"{raw} ({value:g})"
+        issues.append(
+            "Ungrounded generated numeric literal: "
+            f"{display} does not appear as a substantive numeric value in the source text."
+        )
+    return issues
 
 
 def find_ungrounded_numeric_issues_scoped(
@@ -4629,10 +5195,46 @@ def find_ungrounded_numeric_issues_scoped(
         # fabricated value that merely appears in its own excerpt. Module-source
         # retention matches the pre-existing single-source check (no regression).
         evidence_by_path = _rule_atom_evidence_by_path(rule, proof_source_texts)
+        verified_source_pairs_by_path = _rule_verified_source_excerpt_pairs_by_path(
+            rule, proof_source_texts
+        )
+        rule_name = (
+            str(rule.get("name") or "").strip() if isinstance(rule, dict) else ""
+        )
         for anchor_path, raw, value in anchored_values:
+            direct_half_up_helper = _is_direct_half_up_rounding_helper_value(
+                rule, anchor_path, value
+            )
             texts = [module_source, evidence_by_path.get(anchor_path, "")]
             combined = "\n".join(text for text in texts if text).strip()
-            for issue in _ungrounded_from_values([(1, raw, value)], combined):
+            source_evidence = verified_source_pairs_by_path.get(anchor_path, ())
+            module_supports_rounding = bool(module_source) and (
+                _is_source_backed_half_up_rounding_helper(
+                    rule_name, value, module_source
+                )
+            )
+            atom_supports_rounding = any(
+                (
+                    excerpt is None
+                    or _is_source_backed_half_up_rounding_helper(
+                        rule_name, value, excerpt
+                    )
+                )
+                and _is_source_backed_half_up_rounding_helper(
+                    rule_name, value, resolved_source
+                )
+                for excerpt, resolved_source in source_evidence
+            )
+            if direct_half_up_helper and (
+                module_supports_rounding or atom_supports_rounding
+            ):
+                continue
+            grounding_source = (
+                _strip_ambiguous_half_up_terms(combined)
+                if _is_half_up_rounding_helper_scalar(rule_name, value)
+                else combined
+            )
+            for issue in _ungrounded_from_values([(1, raw, value)], grounding_source):
                 if issue not in seen:
                     seen.add(issue)
                     issues.append(issue)

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -68,6 +68,7 @@ from axiom_encode.harness.evals import (
     _normalize_nonannual_test_period_value,
     _normalize_test_case_value,
     _normalize_test_periods_to_effective_dates,
+    _numeric_occurrence_source_text,
     _policyengine_hint_upstream_composition_issues,
     _post_openai_eval_request,
     _prepare_codex_eval_home,
@@ -6333,6 +6334,204 @@ rules:
         assert metrics.grounded_numeric_count == 1
         assert metrics.ungrounded_numeric_count == 0
         assert metrics.source_numeric_occurrence_count == 0
+
+    def test_rounding_occurrence_cleanup_does_not_cross_source_clause(self):
+        source_text = (
+            "Increase the allowance by 1 dollar. Round up the second digit if "
+            "the third digit is 5 or more."
+        )
+
+        cleaned = _numeric_occurrence_source_text(source_text)
+
+        assert validator_pipeline.extract_numeric_occurrences_from_text(cleaned) == [
+            1.0,
+            5.0,
+        ]
+        same_clause = _numeric_occurrence_source_text(
+            "Increase the second digit and decrease the allowance by 1 if needed."
+        )
+        assert validator_pipeline.extract_numeric_occurrences_from_text(
+            same_clause
+        ) == [1.0]
+        preceding_amount = _numeric_occurrence_source_text(
+            "Reduce the allowance by 1, increase the second digit by 1 if the "
+            "third digit is 5 or more."
+        )
+        assert validator_pipeline.extract_numeric_occurrences_from_text(
+            preceding_amount
+        ) == [1.0, 1.0, 5.0]
+        normalized_preceding_amount = _numeric_occurrence_source_text(
+            "Reduce the allowance by 1, increase the second digit by 1 if the "
+            "third digit is 5 or more.",
+            suppress_source_backed_half_up_increment=True,
+        )
+        assert validator_pipeline.extract_numeric_occurrences_from_text(
+            normalized_preceding_amount
+        ) == [1.0, 1.0, 5.0]
+
+        unrecognized_threshold = _numeric_occurrence_source_text(
+            "Increase the second digit by 1 if the third digit is 4 or more."
+        )
+        assert validator_pipeline.extract_numeric_occurrences_from_text(
+            unrecognized_threshold
+        ) == [1.0, 4.0]
+
+        negated_instruction = _numeric_occurrence_source_text(
+            "Do not, under any circumstances, increase the second digit by 1 "
+            "if the third digit is 5 or more."
+        )
+        assert validator_pipeline.extract_numeric_occurrences_from_text(
+            negated_instruction
+        ) == [1.0, 5.0]
+
+        recognized_instruction = (
+            "Increase the second digit by 1 if the third digit is 5 or more."
+        )
+        assert validator_pipeline.extract_numeric_occurrences_from_text(
+            _numeric_occurrence_source_text(recognized_instruction)
+        ) == [1.0, 5.0]
+        assert validator_pipeline.extract_numeric_occurrences_from_text(
+            _numeric_occurrence_source_text(
+                recognized_instruction,
+                suppress_source_backed_half_up_increment=True,
+            )
+        ) == [5.0]
+
+    def test_half_up_helper_eval_metric_uses_authoritative_rounding_instruction(
+        self, tmp_path
+    ):
+        active_instruction = (
+            "If the 3rd digit is 5 or more, increase the 2nd digit by 1"
+        )
+        passive_instruction = (
+            "If the 3rd digit is 5 or more, the 2nd digit shall be increased by 1."
+        )
+        source_text = f"{active_instruction}\n{passive_instruction}"
+        corpus_release = _write_test_corpus_provision(
+            tmp_path,
+            citation_path="ca/policy/cra/example/rounding",
+            body=source_text,
+        )
+        rulespec_file = tmp_path / "policies" / "cra" / "example" / "rounding.yaml"
+        rulespec_file.parent.mkdir(parents=True)
+        rulespec_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: ca/policy/cra/example/rounding
+rules:
+  - name: rounding_half_unit
+    kind: parameter
+    dtype: Decimal
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: ca/policy/cra/example/rounding
+              excerpt: if the 3rd digit is 5 or more, increase the 2nd digit by 1
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 0.5
+      - effective_from: '2026-01-01'
+        formula: 0.5
+"""
+        )
+
+        with (
+            patch.object(
+                ValidatorPipeline,
+                "_run_compile_check",
+                return_value=ValidationResult("compile", True, issues=[]),
+            ),
+            patch.object(
+                ValidatorPipeline,
+                "_run_ci",
+                return_value=ValidationResult("ci", True, issues=[]),
+            ),
+        ):
+            metrics = evaluate_artifact(
+                rulespec_file=rulespec_file,
+                policy_repo_root=_canonical_rulespec_content_root(tmp_path, "ca"),
+                axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+                source_text=source_text,
+                local_corpus_release=corpus_release,
+                skip_reviewers=True,
+            )
+
+        assert metrics.ci_pass
+        assert metrics.grounded_numeric_count == 2
+        assert metrics.ungrounded_numeric_count == 0
+        assert metrics.grounding[0].grounded
+        assert metrics.source_numeric_occurrence_count == 2
+        assert metrics.covered_source_numeric_occurrence_count == 2
+        assert metrics.missing_source_numeric_occurrence_count == 0
+        assert not any(
+            "Ungrounded generated numeric literal" in issue
+            for issue in metrics.ci_issues
+        )
+
+    def test_half_up_helper_does_not_cover_independent_source_value(self, tmp_path):
+        source_text = (
+            "Increase the second digit after the decimal point by one if the "
+            "third digit is five or more. Charge a fee of $5."
+        )
+        corpus_release = _write_test_corpus_provision(
+            tmp_path,
+            citation_path="ca/policy/cra/example/rounding-and-fee",
+            body=source_text,
+        )
+        rulespec_file = (
+            tmp_path / "policies" / "cra" / "example" / "rounding-and-fee.yaml"
+        )
+        rulespec_file.parent.mkdir(parents=True)
+        rulespec_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: ca/policy/cra/example/rounding-and-fee
+  summary: Charge a fee of $5.
+rules:
+  - name: rounding_half_unit
+    kind: parameter
+    dtype: Decimal
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 0.5
+      - effective_from: '2026-01-01'
+        formula: 0.5
+"""
+        )
+
+        with (
+            patch.object(
+                ValidatorPipeline,
+                "_run_compile_check",
+                return_value=ValidationResult("compile", True, issues=[]),
+            ),
+            patch.object(
+                ValidatorPipeline,
+                "_run_ci",
+                return_value=ValidationResult("ci", True, issues=[]),
+            ),
+        ):
+            metrics = evaluate_artifact(
+                rulespec_file=rulespec_file,
+                policy_repo_root=_canonical_rulespec_content_root(tmp_path, "ca"),
+                axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+                source_text=source_text,
+                local_corpus_release=corpus_release,
+                skip_reviewers=True,
+            )
+
+        assert not metrics.ci_pass
+        assert metrics.grounded_numeric_count == 2
+        assert metrics.ungrounded_numeric_count == 0
+        assert metrics.source_numeric_occurrence_count == 1
+        assert metrics.covered_source_numeric_occurrence_count == 0
+        assert metrics.missing_source_numeric_occurrence_count == 1
+        assert any("Source numeric value 5" in issue for issue in metrics.ci_issues)
 
     def test_parameter_table_grounding_uses_corpus_source_with_compact_summary(
         self, tmp_path

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -7616,6 +7616,540 @@ rules:
     assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
 
 
+@pytest.mark.parametrize(
+    ("helper_name", "source_text"),
+    (
+        (
+            "rounding_half_increment",
+            "Increase the second digit by one if the third digit is five or more.",
+        ),
+        (
+            "rounding_half_unit",
+            "If the third digit is five or more, increase the second digit by one.",
+        ),
+        (
+            "rounding_half_unit",
+            "If the third digit is five or more, increase the second digit by one. "
+            "The rule for filing deadlines does not apply to non-residents.",
+        ),
+        (
+            "rounding_half_unit",
+            "Increase the second digit by one if the third digit is five or more. "
+            "Unless stated otherwise, applications close in June.",
+        ),
+        (
+            "rounding_half_unit",
+            "If the third digit is five or more, then increase the second digit by one.",
+        ),
+        (
+            "rounding_half_unit",
+            "If the third digit is 5 or more: increase the second digit by 1.",
+        ),
+        (
+            "rounding_half_unit",
+            "If the third digit after the decimal point is five or more, increase "
+            "the second digit after the decimal point by one.",
+        ),
+        (
+            "rounding_half_unit",
+            "If the third digit is equal to or greater than 5, increase the second "
+            "digit by one.",
+        ),
+        (
+            "rounding_half_unit",
+            "Increase the second digit by one if the third digit is at least 5.",
+        ),
+        (
+            "rounding_half_unit",
+            "If the figure calculated for a pay period has three or more digits "
+            "after the decimal point, increase the second digit after the decimal "
+            "point by one if the third digit is five or more, and drop the third digit.",
+        ),
+        (
+            "rounding_half_unit",
+            "Do not change the sign, but increase the second digit by one if the "
+            "third digit is five or more.",
+        ),
+        (
+            "rounding_half_unit",
+            "Do not change the sign\nIncrease the second digit by one if the third "
+            "digit is five or more.",
+        ),
+        (
+            "rounding_half_unit",
+            "(a) Increase the second digit by one if the third digit is five or more.",
+        ),
+    ),
+)
+def test_rulespec_grounding_accepts_named_half_up_rounding_helper(
+    helper_name, source_text
+):
+    content = f"""format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: ca/policy/example/rounding
+rules:
+  - name: {helper_name}
+    kind: parameter
+    dtype: Decimal
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: ca/policy/example/rounding
+              excerpt: increase the second digit by one if the third digit is five or more
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '0.5'
+"""
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    assert extract_grounding_values(content) == [(1, "0.5", 0.5)]
+
+
+@pytest.mark.parametrize(
+    "source_text",
+    (
+        "If the third digit is five or more, the second digit shall be increased by one.",
+        "The second digit is increased by one if the third digit is five or more.",
+        "The second digit after the decimal point shall be increased by one if the third digit is five or more.",
+    ),
+)
+def test_rulespec_grounding_accepts_passive_half_up_instruction(source_text):
+    content = """format: rulespec/v1
+rules:
+  - name: rounding_half_unit
+    kind: parameter
+    dtype: Decimal
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.5
+"""
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+
+
+def test_rulespec_grounding_rejects_half_up_helper_backed_only_by_inline_excerpt():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: ca/policy/example/rounding
+rules:
+  - name: rounding_half_unit
+    kind: parameter
+    dtype: Decimal
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: ca/policy/example/rounding
+              excerpt: round half-up
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '0.5'
+"""
+
+    issues = find_ungrounded_numeric_issues(
+        content,
+        source_text="The authoritative source says only to round to the nearest cent.",
+    )
+
+    assert issues == [
+        "Ungrounded generated numeric literal: 0.5 does not appear as a "
+        "substantive numeric value in the source text."
+    ]
+
+
+def test_rulespec_grounding_rejects_unrelated_terms_and_non_scalar_helper_value():
+    content = """format: rulespec/v1
+rules:
+  - name: rounding_half_unit
+    kind: derived
+    dtype: Decimal
+    versions:
+      - effective_from: '2026-01-01'
+        formula: taxable_income * 0.5
+"""
+    source_text = (
+        "Increase support for five or more children. Round the digit count "
+        "under the separate reporting procedure."
+    )
+
+    issues = find_ungrounded_numeric_issues(content, source_text=source_text)
+
+    assert any("0.5" in issue for issue in issues), issues
+
+
+@pytest.mark.parametrize(
+    "source_text",
+    (
+        "Round down the second digit when the third digit is five or more.",
+        "Do not use half-up; always round down.",
+        "Half-up rounding is prohibited; always round down.",
+        "Avoid half-up rounding; truncate instead.",
+        "Avoid increasing the second digit by one if the third digit is five or more.",
+        "Don't increase the second digit by one if the third digit is five or more.",
+        "You won't increase the second digit by one if the third digit is five or more.",
+        "You aren't permitted to increase the second digit by one if the third digit is five or more.",
+        "The instructions say not to increase the second digit by one if the third digit is five or more.",
+        "Rather than increase the second digit by one if the third digit is five or more, truncate it.",
+        "Do not increase the second digit if the third digit is five or more.",
+        "You cannot increase the second digit by one if the third digit is five or more.",
+        "You may not increase the second digit by one if the third digit is five or more.",
+        "It doesn't increase the second digit by one if the third digit is five or more.",
+        "It is prohibited to increase the second digit by one if the third digit is five or more.",
+        "Never increase the second digit when the third digit is five or more.",
+        "It doesn't increase the second digit if the third digit is five or more.",
+        "It didn't increase the second digit if the third digit was five or more.",
+        "You shouldn't increase the second digit if the third digit is five or more.",
+        "You mustn't increase the second digit if the third digit is five or more.",
+        "There is no increase to the second digit if the third digit is five or more.",
+        "Increase the second digit except when the third digit is five or more.",
+        "Increase the second digit if the third digit is five or more, except where required by law.",
+        "The rule to increase the second digit when the third digit is five or more does not apply.",
+        "Increasing the second digit when the third digit is five or more is prohibited.",
+        "Increasing the second digit when the third digit is five or more is not permitted.",
+        "Increasing the second digit when the third digit is five or more is not authorized.",
+        "Increasing the second digit when the third digit is five or more is not allowed.",
+        "Increase the second digit if the third digit is five or more; however, this rounding rule does not apply.",
+        "Increase the second digit if the third digit is five or more. Nevertheless, this rounding procedure must not be used.",
+        "Increase the second digit if the third digit is five or more. This rounding rule does not apply.",
+        "Increase the second digit if the third digit is five or more. The rounding procedure must not be used.",
+        "Increase the second digit if the third digit is five or more. This rounding rule shall not be applied.",
+        "Increase the second digit if the third digit is five or more. This rounding rule cannot be used.",
+        "Increase the second digit if the third digit is five or more, but do not do so.",
+        "Increase the second digit by one if the third digit is five or more, but do not do so.",
+        "Increase the second digit by one if the third digit is five or more, but never do so.",
+        "Increase the second digit by one if the third digit is five or more, but it will not be applied.",
+        "Increase the second digit by one if the third digit is five or more, although it is not allowed.",
+        "Increase the second digit by one if the third digit is five or more, but this is only an example.",
+        "Increase the second digit by one if the third digit is five or more, for example.",
+        "Increase the second digit by one if the third digit is five or more. Do not do so.",
+        "Increase the second digit by one if the third digit is five or more. That rule does not apply.",
+        "Increase the second digit by one if the third digit is five or more. Doing so is prohibited.",
+        "Increase the second digit by one if the third digit is five or more. This is illustrative only.",
+        "Increase the second digit by one if the third digit is five or more. This is prohibited.",
+        "Increase the second digit by one if the third digit is five or more, but only as an illustration.",
+        "Increase the second digit if the third digit is five or more, but this is only an example.",
+        "Increase the second digit when the third digit is five or more only in examples, not calculations.",
+        "Do not under any circumstances described elsewhere in this very long provision increase the second digit if the third digit is five or more.",
+        "Rounding must not, under any circumstances described elsewhere in this provision, increase the second digit if the third digit is five or more.",
+        "Do not, under any circumstances, increase the second digit if the third digit is five or more.",
+        "Do not, under any circumstances, increase the second digit by one if the third digit is five or more.",
+        "Do not, under the exceptional circumstances described in subsection 4 and all related administrative guidance, increase the second digit by one if the third digit is five or more.",
+        "Do not\nincrease the second digit by one if the third digit is five or more.",
+        "You must not\nincrease the second digit by one if the third digit is five or more.",
+        "Never, when calculating tax, increase the second digit if the third digit is five or more.",
+        "This rounding rule is not applicable: increase the second digit if the third digit is five or more.",
+        "Increase the number of digits from two digits to five or more digits.",
+        "Increase the third digit if the second digit is five or more.",
+        "Unless the third digit is five or more, increase the second digit.",
+        "The second digit is increased only if the third digit is five or more.",
+        "The second digit is increased only when the third digit is five or more.",
+    ),
+)
+def test_rulespec_grounding_rejects_non_half_up_rounding_instructions(source_text):
+    content = """format: rulespec/v1
+rules:
+  - name: rounding_half_unit
+    kind: parameter
+    dtype: Decimal
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.5
+"""
+
+    issues = find_ungrounded_numeric_issues(content, source_text=source_text)
+
+    assert any("0.5" in issue for issue in issues), issues
+
+
+def test_rulespec_grounding_accepts_substantive_word_form_half_for_helper():
+    content = """format: rulespec/v1
+rules:
+  - name: rounding_half_unit
+    kind: parameter
+    dtype: Decimal
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.5
+"""
+
+    assert (
+        find_ungrounded_numeric_issues(
+            content,
+            source_text="The rounding increment is one half of a unit.",
+        )
+        == []
+    )
+
+
+def test_rulespec_grounding_keeps_line_oriented_rounding_instructions_separate():
+    content = """format: rulespec/v1
+rules:
+  - name: rounding_half_unit
+    kind: parameter
+    dtype: Decimal
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.5
+"""
+    source_text = (
+        "If the third digit is five or more, increase the second digit by one\n"
+        "If it is not, leave the digit unchanged"
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+
+
+@pytest.mark.parametrize(
+    "source_text",
+    (
+        "Increase the second digit after the decimal point by one if\n"
+        "the third digit is five or more.",
+        "If the third digit is five or more,\nincrease the second digit by one.",
+    ),
+)
+def test_rulespec_grounding_accepts_soft_wrapped_rounding_instruction(source_text):
+    content = """format: rulespec/v1
+rules:
+  - name: rounding_half_unit
+    kind: parameter
+    dtype: Decimal
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.5
+"""
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+
+
+@pytest.mark.parametrize(
+    "source_text",
+    (
+        "Increase the second digit by one if the third digit is\n5 or more.",
+        "Increase the second digit by one if the third digit is\nFive or more.",
+        "Increase the second digit by one if the third digit is five or\nMORE.",
+    ),
+)
+def test_rulespec_grounding_accepts_digit_and_uppercase_soft_wraps(source_text):
+    content = """format: rulespec/v1
+rules:
+  - name: rounding_half_unit
+    kind: parameter
+    dtype: Decimal
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.5
+"""
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+
+
+@pytest.mark.parametrize(
+    "source_text",
+    (
+        "Increase the second digit by the third digit when there are five or more records.",
+        "Increase the second digit if the third digit has five or more characters.",
+        "Increase the second digit if the third digit is five or more characters long.",
+        "Increase the second digit if the third digit is five or more than the fourth digit.",
+        "Increase the second digit by zero if the third digit is five or more.",
+        "Increase the second digit by two if the third digit is five or more.",
+        "If the third digit is five or more, increase the second digit by ten.",
+        "Increase the second digit by eleven if the third digit is five or more.",
+        "Increase the second digit by one hundred if the third digit is five or more.",
+        "Increase the second digit by 1,000 if the third digit is five or more.",
+        "If the third digit is five or more, increase by two the second digit.",
+        "Increase, by zero, the second digit if the third digit is five or more.",
+        "By two, increase the second digit if the third digit is five or more.",
+    ),
+)
+def test_rulespec_grounding_rejects_unrelated_five_or_more_threshold(source_text):
+    content = """format: rulespec/v1
+rules:
+  - name: rounding_half_unit
+    kind: parameter
+    dtype: Decimal
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.5
+"""
+
+    issues = find_ungrounded_numeric_issues(content, source_text=source_text)
+
+    assert any("0.5" in issue for issue in issues), issues
+
+
+@pytest.mark.parametrize(
+    "amount",
+    ("eleven", "one-half", "one half", "one hundred", "one and a half", "1,000"),
+)
+def test_half_up_source_matcher_rejects_unrecognized_increment_amount(amount):
+    source_text = (
+        f"Increase the second digit by {amount} if the third digit is five or more."
+    )
+
+    assert not validator_pipeline._is_source_backed_half_up_rounding_helper(
+        "rounding_half_unit", 0.5, source_text
+    )
+
+
+def test_half_up_source_matcher_counts_each_instruction_in_one_clause():
+    source_text = (
+        "Increase the second digit by one if the third digit is five or more, and "
+        "increase the second digit by one when the third digit is five or more."
+    )
+
+    assert (
+        validator_pipeline._source_backed_half_up_rounding_instruction_count(
+            "rounding_half_unit", 0.5, source_text
+        )
+        == 2
+    )
+
+
+def test_rulespec_grounding_ignores_negation_after_rounding_instruction():
+    content = """format: rulespec/v1
+rules:
+  - name: rounding_half_unit
+    kind: parameter
+    dtype: Decimal
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.5
+"""
+    source_text = (
+        "Increase the second digit by one if the third digit is five or more, and make "
+        "no change to later digits."
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+
+
+@pytest.mark.parametrize(
+    "source_text",
+    (
+        "Increase the second digit by one if the third digit is five or more, but do not alter the sign.",
+        "Increase the second digit by one if the third digit is five or more, and do not change later digits.",
+    ),
+)
+def test_rulespec_grounding_ignores_unrelated_trailing_prohibition(source_text):
+    content = """format: rulespec/v1
+rules:
+  - name: rounding_half_unit
+    kind: parameter
+    dtype: Decimal
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.5
+"""
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+
+
+def test_rulespec_grounding_parses_large_source_once(monkeypatch):
+    values = "\n".join(f"          row_{value}: {value}" for value in range(100, 200))
+    content = f"""format: rulespec/v1
+rules:
+  - name: schedule
+    kind: parameter
+    dtype: Decimal
+    versions:
+      - effective_from: '2026-01-01'
+        values:
+{values}
+"""
+    source_text = " ".join(f"The value is {value}." for value in range(100, 200))
+    calls = 0
+    original = validator_pipeline.extract_numbers_from_text
+
+    def counting_extract_numbers(text):
+        nonlocal calls
+        calls += 1
+        return original(text)
+
+    monkeypatch.setattr(
+        validator_pipeline, "extract_numbers_from_text", counting_extract_numbers
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    assert calls == 1
+
+
+def test_rulespec_grounding_rejects_half_up_exemption_for_helper_value_table():
+    content = """format: rulespec/v1
+rules:
+  - name: rounding_half_unit
+    kind: parameter
+    dtype: Decimal
+    versions:
+      - effective_from: '2026-01-01'
+        values:
+          default: 0.5
+"""
+
+    issues = find_ungrounded_numeric_issues(
+        content,
+        source_text="Round the result half-up to the nearest cent.",
+    )
+
+    assert any("0.5" in issue for issue in issues), issues
+
+
+def test_rulespec_grounding_rejects_unnamed_half_scalar_without_source_support():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: ca/policy/example/rounding
+rules:
+  - name: household_share
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '0.5'
+"""
+
+    issues = find_ungrounded_numeric_issues(
+        content,
+        source_text="Round monetary results to the nearest cent.",
+    )
+
+    assert issues == [
+        "Ungrounded generated numeric literal: 0.5 does not appear as a "
+        "substantive numeric value in the source text."
+    ]
+
+
+def test_rulespec_grounding_rejects_named_half_up_helper_without_source_support():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: ca/policy/example/rounding
+rules:
+  - name: rounding_half_unit
+    kind: parameter
+    dtype: Decimal
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '0.5'
+"""
+
+    issues = find_ungrounded_numeric_issues(
+        content,
+        source_text="Round monetary results to the nearest cent.",
+    )
+
+    assert issues == [
+        "Ungrounded generated numeric literal: 0.5 does not appear as a "
+        "substantive numeric value in the source text."
+    ]
+
+
 def test_rulespec_grounding_accepts_european_thousands_separator_money():
     content = """format: rulespec/v1
 module:
@@ -28744,3 +29278,228 @@ def test_grounding_binds_each_literal_to_its_own_anchored_atom():
         },
     )
     assert any("450" in issue for issue in issues), issues
+
+
+def test_scoped_grounding_uses_resolved_source_for_half_up_helper():
+    content = textwrap.dedent(
+        """
+        format: rulespec/v1
+        module:
+          source_verification:
+            corpus_citation_path: xx/policy/rounding/module
+        rules:
+          - name: rounding_half_unit
+            kind: parameter
+            dtype: Decimal
+            metadata:
+              proof:
+                atoms:
+                  - path: versions[0].formula
+                    kind: parameter
+                    source:
+                      corpus_citation_path: xx/policy/rounding/procedure
+                      excerpt: Increase the second digit after the decimal point by one if the third digit is five or more.
+            versions:
+              - effective_from: '2026-01-01'
+                formula: '0.5'
+        """
+    ).strip()
+
+    assert (
+        find_ungrounded_numeric_issues_scoped(
+            content,
+            module_source_text="The module delegates rounding to the procedure.",
+            proof_source_texts={
+                "xx/policy/rounding/procedure": (
+                    "Increase the second digit after the decimal point by one if "
+                    "the third digit is five or more."
+                )
+            },
+        )
+        == []
+    )
+
+    inline_only = content.replace(
+        "Increase the second digit after the decimal point by one if the third digit is five or more.",
+        "round half-up",
+    )
+    issues = find_ungrounded_numeric_issues_scoped(
+        inline_only,
+        module_source_text="The module delegates rounding to the procedure.",
+        proof_source_texts={
+            "xx/policy/rounding/procedure": "Round to the nearest cent."
+        },
+    )
+    assert any("0.5" in issue for issue in issues), issues
+
+    unrelated_excerpt = content.replace(
+        "Increase the second digit after the decimal point by one if the third digit is five or more.",
+        "The tax rate is one percent.",
+    )
+    issues = find_ungrounded_numeric_issues_scoped(
+        unrelated_excerpt,
+        module_source_text="",
+        proof_source_texts={
+            "xx/policy/rounding/procedure": (
+                "The tax rate is one percent. Elsewhere, increase the second "
+                "digit if the third digit is five or more."
+            )
+        },
+    )
+    assert any("0.5" in issue for issue in issues), issues
+
+    explicit_literal = content.replace(
+        "Increase the second digit after the decimal point by one if the third digit is five or more.",
+        "the rounding increment is 0.5",
+    )
+    assert (
+        find_ungrounded_numeric_issues_scoped(
+            explicit_literal,
+            module_source_text="The module delegates rounding to the procedure.",
+            proof_source_texts={
+                "xx/policy/rounding/procedure": "Round to the nearest cent."
+            },
+        )
+        == []
+    )
+
+
+def test_scoped_grounding_does_not_widen_table_evidence_for_half_up_helper():
+    content = textwrap.dedent(
+        """
+        format: rulespec/v1
+        module:
+          source_verification:
+            corpus_citation_path: xx/policy/rounding/module
+        rules:
+          - name: rounding_half_unit
+            kind: parameter
+            dtype: Decimal
+            metadata:
+              proof:
+                atoms:
+                  - path: versions[0].formula
+                    kind: table_cell
+                    source:
+                      corpus_citation_path: xx/policy/rounding/procedure
+                      table:
+                        header: administrative values
+                        row: standard calculation
+                        column: adjustment
+            versions:
+              - effective_from: '2026-01-01'
+                formula: '0.5'
+        """
+    ).strip()
+
+    issues = find_ungrounded_numeric_issues_scoped(
+        content,
+        module_source_text="The module delegates calculations to the procedure.",
+        proof_source_texts={
+            "xx/policy/rounding/procedure": (
+                "Administrative values. Standard calculation. Adjustment. "
+                "Elsewhere, increase the second digit by one if the third digit "
+                "is five or more."
+            )
+        },
+    )
+
+    assert any("0.5" in issue for issue in issues), issues
+
+
+def test_scoped_grounding_does_not_join_distinct_sources_into_rounding_rule():
+    content = textwrap.dedent(
+        """
+        format: rulespec/v1
+        rules:
+          - name: rounding_half_unit
+            kind: parameter
+            dtype: Decimal
+            metadata:
+              proof:
+                atoms:
+                  - path: versions[0].formula
+                    kind: parameter
+                    source:
+                      corpus_citation_path: xx/policy/rounding/procedure
+            versions:
+              - effective_from: '2026-01-01'
+                formula: 0.5
+        """
+    ).strip()
+
+    issues = find_ungrounded_numeric_issues_scoped(
+        content,
+        module_source_text="Increase the second digit",
+        proof_source_texts={
+            "xx/policy/rounding/procedure": ("if the third digit is five or more.")
+        },
+    )
+
+    assert any("0.5" in issue for issue in issues), issues
+
+
+def test_scoped_grounding_accepts_authoritative_source_without_excerpt():
+    content = textwrap.dedent(
+        """
+        format: rulespec/v1
+        rules:
+          - name: rounding_half_unit
+            kind: parameter
+            dtype: Decimal
+            metadata:
+              proof:
+                atoms:
+                  - path: versions[0].formula
+                    kind: parameter
+                    source:
+                      corpus_citation_path: xx/policy/rounding/procedure
+            versions:
+              - effective_from: '2026-01-01'
+                formula: 0.5
+        """
+    ).strip()
+    source_text = "Increase the second digit by one if the third digit is five or more."
+
+    assert (
+        find_ungrounded_numeric_issues_scoped(
+            content,
+            module_source_text=source_text,
+            proof_source_texts={},
+        )
+        == []
+    )
+    assert (
+        find_ungrounded_numeric_issues_scoped(
+            content,
+            module_source_text="",
+            proof_source_texts={
+                "xx/policy/rounding/procedure": source_text,
+            },
+        )
+        == []
+    )
+
+    proof_atom = """                  - path: versions[0].formula
+                    kind: parameter
+                    source:
+                      corpus_citation_path: xx/policy/rounding/procedure"""
+    two_proof_sources = content.replace(
+        proof_atom,
+        proof_atom
+        + """
+                  - path: versions[0].formula
+                    kind: parameter
+                    source:
+                      corpus_citation_path: xx/policy/rounding/threshold""",
+    )
+    issues = find_ungrounded_numeric_issues_scoped(
+        two_proof_sources,
+        module_source_text="",
+        proof_source_texts={
+            "xx/policy/rounding/procedure": "Increase the second digit",
+            "xx/policy/rounding/threshold": ("if the third digit is five or more."),
+        },
+    )
+
+    assert any("0.5" in issue for issue in issues), issues

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1300"
+version = "0.2.1301"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- recognize exact half-up rounding instructions in authoritative corpus text
- allow generated named `0.5` rounding helpers only when that source evidence is present
- keep numeric-grounding and eval occurrence accounting aligned without treating proof excerpts as self-authorizing
- add adversarial regressions for affirmative, negated, scoped, wrapped, and multi-instruction source forms

## Review cycle
- independent `codex review --uncommitted`: no actionable correctness findings
- one reviewer-sandbox-only `/var/tmp` permission failure was rerun successfully in the normal local environment

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest` (4337 passed, 117 skipped)
- focused changed-file suite (1555 passed, 31 skipped)