### PR TITLE
Fix apply-path Judgment positive-test repair root (#1198)

### DIFF
--- a/changelog.d/judgment-positive-apply-root.fixed.md
+++ b/changelog.d/judgment-positive-apply-root.fixed.md
@@ -1,0 +1,1 @@
+Run generated Judgment positive companion-test repairs in a canonical apply overlay instead of compiling output-root files against the policy root.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1301"
+version = "0.2.1302"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1301"
+__version__ = "0.2.1302"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -32829,14 +32829,58 @@ def _try_repair_generated_judgment_positive_tests_for_apply(
 
     rules_file = Path(str(getattr(result, "output_file", "") or ""))
     test_file = _rulespec_test_path(rules_file)
-    return _append_generated_judgment_positive_tests_if_missing(
-        rules_file=rules_file,
-        test_file=test_file,
-        repo_path=policy_repo_path,
-        axiom_rules_path=axiom_rules_path,
-        relative_output=relative_output,
-        issues=issues,
+    policy_content_root = _rulespec_apply_content_root(
+        policy_repo_path,
+        relative_output,
     )
+    policy_checkout_path = _rulespec_apply_checkout_root(
+        policy_repo_path,
+        relative_output,
+    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        overlay_parent = Path(tmpdir).resolve(strict=True)
+        overlay_checkout = overlay_parent / policy_checkout_path.name
+        _stage_apply_overlay_dependency_root(
+            source=policy_checkout_path,
+            target=overlay_checkout,
+        )
+        overlay_content_root = overlay_checkout / policy_content_root.name
+        if canonical_rulespec_root_identity(overlay_content_root) is None:
+            raise ValueError(
+                "Judgment test repair overlay did not preserve the canonical "
+                f"RuleSpec jurisdiction root: {overlay_content_root}"
+            )
+        overlay_rules_file = overlay_content_root / relative_output
+        overlay_rules_file.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(rules_file, overlay_rules_file)
+        overlay_test_file = _rulespec_test_path(overlay_rules_file)
+
+        def check_generated_test(
+            generated_test_file: Path,
+            *,
+            root: Path,
+            axiom_rules_path: Path,
+        ) -> list[dict[str, str | None]]:
+            if Path(root).resolve() != Path(policy_repo_path).resolve():
+                raise ValueError(
+                    "Judgment test repair checker received an unexpected policy root"
+                )
+            shutil.copy2(generated_test_file, overlay_test_file)
+            return _rulespec_companion_test_failures(
+                overlay_test_file,
+                root=overlay_content_root,
+                axiom_rules_path=axiom_rules_path,
+            )
+
+        return _append_generated_judgment_positive_tests_if_missing(
+            rules_file=rules_file,
+            test_file=test_file,
+            repo_path=policy_repo_path,
+            axiom_rules_path=axiom_rules_path,
+            relative_output=relative_output,
+            issues=issues,
+            test_failure_checker=check_generated_test,
+        )
 
 
 def _only_pending_judgment_positive_output_coverage_issues(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,6 +49,7 @@ from axiom_encode.cli import (
     _apply_generated_encoding_result,
     _build_eval_suite_payload,
     _build_eval_suite_report,
+    _canonical_rulespec_compile_path,
     _changed_manifest_group_files,
     _collapse_additive_versioned_derived_formulas,
     _complete_missing_dependent_test_inputs,
@@ -183,6 +184,7 @@ from axiom_encode.cli import (
     _try_repair_generated_invalid_source_relation_types_for_apply,
     _try_repair_generated_judgment_conditionals_for_apply,
     _try_repair_generated_judgment_numeric_comparisons_for_apply,
+    _try_repair_generated_judgment_positive_tests_for_apply,
     _try_repair_generated_missing_data_relations_for_apply,
     _try_repair_generated_missing_deferred_outputs_for_apply,
     _try_repair_generated_missing_same_section_subsection_imports_for_apply,
@@ -7666,6 +7668,10 @@ class TestCmdEncode:
             patch(
                 "axiom_encode.cli._git_checkout_execution_identity",
                 side_effect=test_git_checkout_identity,
+            ),
+            patch(
+                "axiom_encode.cli._rulespec_companion_test_failures",
+                return_value=[],
             ),
         ):
             from axiom_encode.toolchain import (
@@ -20082,6 +20088,87 @@ rules:
         ]
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
+
+    def test_apply_judgment_positive_repair_checks_generated_pair_in_overlay(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        runner = "openai-gpt-5.6-terra"
+        relative_output = Path(
+            "regulations/dir-1021-2024/vat-electricity-water-exemption-directive.yaml"
+        )
+        rules_file = output_root / runner / relative_output
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: electricity_and_water_supply_is_exempt
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '2026-01-01'
+        formula: receives_electricity and receives_water
+"""
+        )
+        test_file = rules_file.with_name(
+            "vat-electricity-water-exemption-directive.test.yaml"
+        )
+        test_file.write_text("[]\n")
+        policy_repo = _canonical_rulespec_content_root(tmp_path, "et")
+        result = SimpleNamespace(runner=runner, output_file=str(rules_file))
+        target = (
+            "et:regulations/dir-1021-2024/"
+            "vat-electricity-water-exemption-directive"
+            "#electricity_and_water_supply_is_exempt"
+        )
+        checked: dict[str, Path] = {}
+
+        with pytest.raises(UnsafeRulespecContextPath):
+            _canonical_rulespec_compile_path(rules_file, policy_repo)
+
+        def check_companion(staged_test_file, *, root, axiom_rules_path):
+            staged_rules_file = staged_test_file.with_name(
+                "vat-electricity-water-exemption-directive.yaml"
+            )
+            checked["rules"] = _canonical_rulespec_compile_path(
+                staged_rules_file,
+                root,
+            )
+            checked["test"] = staged_test_file.resolve()
+            checked["root"] = root.resolve()
+            [case] = yaml.safe_load(staged_test_file.read_text())
+            assert case["output"] == {target: "holds"}
+            return []
+
+        with patch(
+            "axiom_encode.cli._rulespec_companion_test_failures",
+            side_effect=check_companion,
+        ):
+            repaired = _try_repair_generated_judgment_positive_tests_for_apply(
+                result,
+                output_root=output_root,
+                policy_repo_path=policy_repo,
+                axiom_rules_path=tmp_path / "axiom-rules-engine",
+                issues=[
+                    "Judgment rule missing positive companion output coverage: "
+                    f"`{target}` is not asserted as `holds` by the companion "
+                    "`.test.yaml` file."
+                ],
+            )
+
+        assert repaired == ["auto_positive_electricity_and_water_supply_is_exempt"]
+        assert checked["rules"].is_relative_to(checked["root"])
+        assert checked["test"].is_relative_to(checked["root"])
+        assert checked["root"] != policy_repo.resolve()
+        assert not (policy_repo / relative_output).exists()
+        [case] = yaml.safe_load(test_file.read_text())
+        assert case["input"] == {
+            "et:regulations/dir-1021-2024/"
+            "vat-electricity-water-exemption-directive#input.receives_electricity": True,
+            "et:regulations/dir-1021-2024/"
+            "vat-electricity-water-exemption-directive#input.receives_water": True,
+        }
+        assert case["output"] == {target: "holds"}
 
     def test_imported_output_repair_satisfies_positive_judgment_composition(
         self, tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1301"
+version = "0.2.1302"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
Fixes #1198 — `encode --apply` crashed with `UnsafeRulespecContextPath` whenever the judgment-positive-test repair fired (first hit: rulespec-et run [29831260020](https://github.com/TheAxiomFoundation/rulespec-et/actions/runs/29831260020) under the Path R leg; blocks a large share of the SOUTHMOD zm/ug/et backlog since eligibility/exemption predicates are exactly `derived`/`Judgment` outputs).

**Root cause**: the repair validated the generated pair (output root) against `policy_repo_path` — the guard was right, the caller's root was wrong.

**Fix**: stage the policy checkout into a temp canonical overlay (existing `_stage_apply_overlay_dependency_root` idiom), copy the generated pair in, run companion checks against the overlay via an injected `test_failure_checker`. Anchor ids still derive from the original policy repo path; the canonical-path guard is untouched; the checker fail-closes on an unexpected root.

**Verification**
- Regression test reproduces the crash under the old pairing, then asserts the repaired flow completes, appends the positive case, uses an overlay root distinct from the policy repo, and leaves the policy checkout unmodified.
- sol (implementer): `ruff format --check` + `ruff check` clean; `tests/test_cli.py` full: **754 passed, 1 skipped**.
- Claude (cross-family verifier): independent re-run of the focused subset (**11 passed**); confirmed all overlay helpers pre-exist on main (no new privileged surface).

**Deploy note**: after merge, the four `signed-apply.yml` legs (tz/zm/ug/et) need their encoder ref bumped to this SHA before the et retry — the leg pins axiom-encode.

Per Max's cross-family protocol: implemented by gpt-5.6-sol, reviewed Claude-side; flagging for Max sign-off per the encoder-repo convention (cf. #1135).

🤖 Generated with [Claude Code](https://claude.com/claude-code)