### PR TITLE
Repair proof excerpts from cited corpus sources

### DIFF
--- a/changelog.d/cited-proof-excerpt-repair.fixed.md
+++ b/changelog.d/cited-proof-excerpt-repair.fixed.md
@@ -1,0 +1,1 @@
+Align generated proof excerpts against each atom's cited corpus source, including child citations, before falling back to the parent module's embedded source.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1309"
+version = "0.2.1310"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1309"
+__version__ = "0.2.1310"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -20871,6 +20871,7 @@ def _run_encode_attempt(
                     _try_repair_generated_nonexact_proof_excerpts_for_apply(
                         result,
                         output_root=args.output,
+                        corpus_release=corpus_release,
                         issues=apply_issues,
                     )
                 )
@@ -27569,9 +27570,10 @@ def _try_repair_generated_nonexact_proof_excerpts_for_apply(
     result,
     *,
     output_root: Path,
+    corpus_release: LocalCorpusRelease | None = None,
     issues: list[str],
 ) -> list[str]:
-    """Align near-match generated proof excerpts to exact embedded source text."""
+    """Align near-match generated proof excerpts to their exact cited source text."""
     targets = {
         (match.group("rule"), int(match.group("atom")))
         for issue in issues
@@ -27596,13 +27598,14 @@ def _try_repair_generated_nonexact_proof_excerpts_for_apply(
         return []
     if not isinstance(payload, dict):
         return []
-    source_text = extract_embedded_source_text(
+    embedded_source_text = extract_embedded_source_text(
         content
     ) or _extract_source_verification_text(content)
-    if not source_text:
+    if not embedded_source_text and corpus_release is None:
         return []
 
     repaired: list[str] = []
+    cited_source_texts: dict[str, str | None] = {}
     for rule in payload.get("rules") or []:
         if not isinstance(rule, dict):
             continue
@@ -27618,6 +27621,19 @@ def _try_repair_generated_nonexact_proof_excerpts_for_apply(
                 continue
             excerpt = source.get("excerpt")
             if not isinstance(excerpt, str) or not excerpt.strip():
+                continue
+            source_text = embedded_source_text
+            corpus_citation_path = str(source.get("corpus_citation_path") or "").strip()
+            if corpus_release is not None and corpus_citation_path:
+                if corpus_citation_path not in cited_source_texts:
+                    cited_source_texts[corpus_citation_path] = (
+                        _local_source_text_for_corpus_path(
+                            corpus_citation_path,
+                            corpus_release=corpus_release,
+                        )
+                    )
+                source_text = cited_source_texts[corpus_citation_path] or source_text
+            if not source_text:
                 continue
             exact_excerpt = _closest_exact_source_excerpt(
                 source_text=source_text,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7197,6 +7197,63 @@ rules:
     }
 
 
+def test_repair_generated_nonexact_proof_excerpt_uses_child_citation(
+    tmp_path, monkeypatch
+):
+    output_root = tmp_path / "out"
+    rules_file = output_root / "model" / "policies" / "benefit.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+module:
+  summary: Parent source does not contain the Alberta amount.
+rules:
+- name: alberta_age_amount
+  kind: parameter
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: ca/policy/example/alberta
+          excerpt: maximum age amount of $6,100
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 6100
+"""
+    )
+    requested_paths = []
+
+    def source_text(citation_path, *, corpus_release):
+        requested_paths.append((citation_path, corpus_release))
+        return "The maximum amount for age is $6,100."
+
+    monkeypatch.setattr(
+        "axiom_encode.cli._local_source_text_for_corpus_path",
+        source_text,
+    )
+    corpus_release = SimpleNamespace(name="test-release")
+
+    repaired = _try_repair_generated_nonexact_proof_excerpts_for_apply(
+        SimpleNamespace(output_file=str(rules_file)),
+        output_root=output_root,
+        corpus_release=corpus_release,
+        issues=[
+            "Proof source evidence not found: rule `alberta_age_amount` proof atom "
+            "0 `source.excerpt` does not appear in `ca/policy/example/alberta`."
+        ],
+    )
+
+    assert repaired == ["alberta_age_amount[0]"]
+    assert requested_paths == [("ca/policy/example/alberta", corpus_release)]
+    payload = yaml.safe_load(rules_file.read_text())
+    assert (
+        payload["rules"][0]["metadata"]["proof"]["atoms"][0]["source"]["excerpt"]
+        == "The maximum amount for age is $6,100."
+    )
+
+
 class TestCmdInventory:
     def test_inventory_counts_rulespec_files_and_kinds(self, capsys, tmp_path):
         statute_file = (

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1309"
+version = "0.2.1310"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- resolve each generated proof atom's exact source text from its `corpus_citation_path` during apply repair
- cache cited source lookups and retain embedded parent source as a fallback
- cover child-citation evidence that is absent from the parent module source
- release as `axiom-encode` 0.2.1310

## Checks
- `uv run --python 3.13 ruff format --check src/axiom_encode/cli.py tests/test_cli.py`
- `uv run --python 3.13 ruff check pyproject.toml src/axiom_encode scripts tests`
- `.venv/bin/python -m compileall -q src/axiom_encode scripts`
- `uv run --python 3.13 pytest -q tests/test_cli.py` (751 passed, 10 skipped)
- `uv run --python 3.13 pytest -q` (4379 passed, 117 skipped)

## Review cycle
- Pending independent review.