### PR TITLE
Allow reviewed-head signed reencode artifacts

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -13,7 +13,7 @@ on:
         default: us
         type: string
       rulespec_ref:
-        description: Immutable rulespec-<country> commit SHA on main to re-encode
+        description: Immutable main SHA, or an allowlisted reviewed SHA for artifact-only runs
         required: true
         type: string
       corpus_ref:
@@ -98,6 +98,7 @@ jobs:
           COUNTRY: ${{ inputs.country }}
           RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
           RULESPEC_REF: ${{ inputs.rulespec_ref }}
+          OPEN_PR: ${{ inputs.open_pr }}
           CORPUS_REF: ${{ inputs.corpus_ref }}
           RULES_ENGINE_REF: ${{ inputs.rules_engine_ref }}
         run: |
@@ -127,8 +128,9 @@ jobs:
           verify_checkout axiom-rules-engine "$RULES_ENGINE_REF" axiom-rules-engine
           test "$(git -C "$RULESPEC_CHECKOUT" remote get-url origin)" = \
             "https://github.com/TheAxiomFoundation/rulespec-$COUNTRY"
-          git -C "$RULESPEC_CHECKOUT" merge-base --is-ancestor \
-            HEAD refs/remotes/origin/main
+          python axiom-encode/scripts/prepare_signed_backfill.py \
+            validate-rulespec-base "$RULESPEC_CHECKOUT" "$COUNTRY" \
+            "$RULESPEC_REF" "$OPEN_PR"
           git -C axiom-corpus merge-base --is-ancestor HEAD refs/remotes/origin/main
           git -C axiom-rules-engine merge-base --is-ancestor HEAD refs/remotes/origin/main
 

--- a/changelog.d/reviewed-rulespec-reencode-bridge.fixed.md
+++ b/changelog.d/reviewed-rulespec-reencode-bridge.fixed.md
@@ -1,0 +1,1 @@
+Permit artifact-only targeted signed re-encodes from the exact independently reviewed RuleSpec US migration head while continuing to require main ancestry for PR-publishing runs.

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -10,9 +10,18 @@ import subprocess
 from pathlib import Path, PurePosixPath
 
 COUNTRY_PATTERN = re.compile(r"[a-z]{2}")
+COMMIT_PATTERN = re.compile(r"[0-9a-f]{40}")
 MANIFEST_ROOT = PurePosixPath(".axiom/encoding-manifests")
 RULESPEC_ATOMIC_ROOTS = frozenset(
     {"legislation", "policies", "regulations", "statutes"}
+)
+REVIEWED_RULESPEC_REFS = frozenset(
+    {
+        (
+            "us",
+            "52467ee7d99f4aa31882dfa7ec16835db2613eb3",
+        ),
+    }
 )
 
 
@@ -27,6 +36,42 @@ def branch_name(country: str, run_id: str, run_attempt: str) -> str:
     if not run_id.isdecimal() or not run_attempt.isdecimal():
         raise ValueError("run id and attempt must be decimal integers")
     return f"axiom/signed-backfill-{country}-{run_id}-{run_attempt}"
+
+
+def validate_rulespec_base(
+    repo: Path,
+    country: str,
+    requested_ref: str,
+    *,
+    open_pr: bool,
+) -> str:
+    """Admit main ancestry or one exact independently reviewed migration head."""
+
+    validate_country(country)
+    if COMMIT_PATTERN.fullmatch(requested_ref) is None:
+        raise ValueError("rulespec ref must be a full lowercase commit SHA")
+    actual_ref = _git(repo, "rev-parse", "HEAD").decode().strip()
+    if actual_ref != requested_ref:
+        raise ValueError("rulespec checkout does not match the requested ref")
+    main_ancestor = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "merge-base",
+            "--is-ancestor",
+            "HEAD",
+            "refs/remotes/origin/main",
+        ],
+        check=False,
+    ).returncode == 0
+    if main_ancestor:
+        return "main"
+    if (country, requested_ref) not in REVIEWED_RULESPEC_REFS:
+        raise ValueError("rulespec ref is neither on main nor an approved reviewed head")
+    if open_pr:
+        raise ValueError("reviewed-head runs are artifact-only and cannot open a pull request")
+    return "reviewed-head-artifact"
 
 
 def _git(repo: Path, *args: str) -> bytes:
@@ -150,6 +195,11 @@ def main() -> None:
     branch_parser.add_argument("country")
     branch_parser.add_argument("run_id")
     branch_parser.add_argument("run_attempt")
+    base_parser = subparsers.add_parser("validate-rulespec-base")
+    base_parser.add_argument("repo", type=Path)
+    base_parser.add_argument("country")
+    base_parser.add_argument("requested_ref")
+    base_parser.add_argument("open_pr", choices=("true", "false"))
     stage_parser = subparsers.add_parser("stage")
     stage_parser.add_argument("repo", type=Path)
     args = parser.parse_args()
@@ -158,6 +208,15 @@ def main() -> None:
             print(validate_country(args.country))
         elif args.command == "branch-name":
             print(branch_name(args.country, args.run_id, args.run_attempt))
+        elif args.command == "validate-rulespec-base":
+            print(
+                validate_rulespec_base(
+                    args.repo,
+                    args.country,
+                    args.requested_ref,
+                    open_pr=args.open_pr == "true",
+                )
+            )
         else:
             stage_authorized_changes(args.repo)
     except (OSError, ValueError, json.JSONDecodeError, subprocess.CalledProcessError) as exc:

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -7,9 +7,11 @@ from pathlib import Path
 import pytest
 
 from scripts.prepare_signed_backfill import (
+    REVIEWED_RULESPEC_REFS,
     branch_name,
     stage_authorized_changes,
     validate_country,
+    validate_rulespec_base,
 )
 
 
@@ -32,6 +34,13 @@ def _repo(tmp_path: Path) -> Path:
     _git(repo, "add", "README.md")
     _git(repo, "commit", "-m", "base")
     return repo
+
+
+def _add_origin_main(repo: Path) -> str:
+    base = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "remote", "add", "origin", str(repo))
+    _git(repo, "update-ref", "refs/remotes/origin/main", base)
+    return base
 
 
 def _write_signed_change(repo: Path) -> tuple[Path, Path]:
@@ -106,3 +115,48 @@ def test_rerun_attempt_uses_recoverable_distinct_branch() -> None:
     assert first == "axiom/signed-backfill-us-12345-1"
     assert rerun == "axiom/signed-backfill-us-12345-2"
     assert rerun != first
+
+
+def test_validate_rulespec_base_accepts_main_ancestor(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    base = _add_origin_main(repo)
+
+    assert validate_rulespec_base(repo, "us", base, open_pr=True) == "main"
+
+
+def test_validate_rulespec_base_accepts_exact_reviewed_head_artifact_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "rulespec-us"
+    reviewed_ref = next(
+        ref for country, ref in REVIEWED_RULESPEC_REFS if country == "us"
+    )
+    monkeypatch.setattr(
+        "scripts.prepare_signed_backfill._git",
+        lambda _repo, *_args: f"{reviewed_ref}\n".encode(),
+    )
+    monkeypatch.setattr(
+        "scripts.prepare_signed_backfill.subprocess.run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 1),
+    )
+
+    assert (
+        validate_rulespec_base(repo, "us", reviewed_ref, open_pr=False)
+        == "reviewed-head-artifact"
+    )
+
+    with pytest.raises(ValueError, match="artifact-only"):
+        validate_rulespec_base(repo, "us", reviewed_ref, open_pr=True)
+
+
+def test_validate_rulespec_base_rejects_unreviewed_non_main_head(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    _add_origin_main(repo)
+    _git(repo, "commit", "--allow-empty", "-m", "unreviewed")
+    head = _git(repo, "rev-parse", "HEAD")
+
+    with pytest.raises(ValueError, match="neither on main nor an approved"):
+        validate_rulespec_base(repo, "us", head, open_pr=False)

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1742,6 +1742,8 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert set(trigger) == {"workflow_dispatch"}
     assert workflow["permissions"] == {"contents": "read"}
     inputs = trigger["workflow_dispatch"]["inputs"]
+    assert "allowlisted reviewed SHA" in inputs["rulespec_ref"]["description"]
+    assert "artifact-only" in inputs["rulespec_ref"]["description"]
     assert inputs["country"] == {
         "description": "Canonical RuleSpec country checkout (for rulespec-<country>)",
         "required": True,
@@ -1781,6 +1783,9 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "^[0-9a-f]{40}$" in identity_command
     assert "rev-parse HEAD" in identity_command
     assert "merge-base --is-ancestor" in identity_command
+    assert "validate-rulespec-base" in identity_command
+    assert '"$RULESPEC_REF" "$OPEN_PR"' in identity_command
+    assert identity_step["env"]["OPEN_PR"] == "${{ inputs.open_pr }}"
     assert '"https://github.com/TheAxiomFoundation/rulespec-$COUNTRY"' in (
         identity_command
     )


### PR DESCRIPTION
## Summary

- admit the exact independently reviewed RuleSpec US migration head `52467ee7d99f4aa31882dfa7ec16835db2613eb3` to the protected targeted re-encode workflow
- require reviewed-head runs to be artifact-only and reject `open_pr=true` before signing
- retain main ancestry for every PR-publishing run and exact checkout/repository verification for all runs

## Review cycle

- Cycle 1 independent security review found one P3 documentation drift in the dispatch input description; no fail-open findings.
- Updated the description and added regression assertions.
- Cycle 2 independent re-review found no actionable findings.

## Checks

- `uv run --python 3.13 ruff check pyproject.toml src/axiom_encode scripts tests`
- `python3.13 -m compileall -q src/axiom_encode scripts`
- `uv run --python 3.13 pytest`: 4385 passed, 114 skipped
- focused workflow/helper tests: 19 passed, 46 skipped
- `git diff --check`

This is a narrow migration bridge. The allowlist contains one immutable reviewed commit, and reviewed-head runs cannot push or open a pull request.