### PR TITLE
Revalidate stamped dependent source attestations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1312"
+version = "0.2.1313"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1313"
+version = "0.2.1314"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1310"
+version = "0.2.1311"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1311"
+version = "0.2.1312"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1310"
+__version__ = "0.2.1311"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1312"
+__version__ = "0.2.1313"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1311"
+__version__ = "0.2.1312"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1313"
+__version__ = "0.2.1314"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -37483,6 +37483,61 @@ def _supplemental_source_attestation_issues(
     return issues
 
 
+def _stamp_matching_supplemental_source_attestations(
+    supplemental_files: dict[Path, str],
+    *,
+    attestation: dict[str, object] | None,
+) -> dict[Path, str]:
+    """Bind modified RuleSpec dependents that cite the primary resolved source."""
+
+    if attestation is None:
+        return dict(supplemental_files)
+    source_sha256 = attestation.get("source_sha256")
+    if not isinstance(source_sha256, str) or not source_sha256:
+        return dict(supplemental_files)
+    attested_paths = {
+        str(attestation[field])
+        for field in (
+            "requested_corpus_citation_path",
+            "resolved_corpus_citation_path",
+        )
+        if isinstance(attestation.get(field), str) and attestation.get(field)
+    }
+
+    stamped = dict(supplemental_files)
+    for relative_path, content in sorted(
+        supplemental_files.items(), key=lambda item: item[0].as_posix()
+    ):
+        if relative_path.suffix != RULESPEC_FILE_SUFFIX or relative_path.name.endswith(
+            RULESPEC_TEST_FILE_SUFFIX
+        ):
+            continue
+        try:
+            payload = yaml.safe_load(content)
+        except (UnicodeError, yaml.YAMLError, ValueError):
+            continue
+        if not isinstance(payload, dict) or payload.get("format") != "rulespec/v1":
+            continue
+        module = payload.get("module")
+        verification = (
+            module.get("source_verification") if isinstance(module, dict) else None
+        )
+        if not isinstance(verification, dict):
+            continue
+        declared_paths = _source_verification_citation_paths(verification)
+        if not declared_paths or not set(declared_paths).issubset(attested_paths):
+            continue
+        if verification.get("source_sha256") == source_sha256:
+            continue
+        verification["source_sha256"] = source_sha256
+        stamped[relative_path] = yaml.safe_dump(
+            payload,
+            sort_keys=False,
+            allow_unicode=True,
+        )
+    return stamped
+
+
 _APPLY_VALIDATION_SNAPSHOT_ATTR = "_axiom_apply_validation_snapshot"
 
 
@@ -40707,6 +40762,29 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
         )
         for _ in range(_APPLY_OVERLAY_VALIDATION_REPAIR_LIMIT):
             if all(validation.all_passed for _, validation in validations):
+                stamped_supplemental_files = (
+                    _stamp_matching_supplemental_source_attestations(
+                        supplemental_files,
+                        attestation=_generated_result_source_attestation(result),
+                    )
+                )
+                if stamped_supplemental_files != supplemental_files:
+                    supplemental_files = stamped_supplemental_files
+                    for relative_path, content in supplemental_files.items():
+                        overlay_path = (
+                            overlay_content_root
+                            / _canonical_apply_relative_path(relative_path)
+                        )
+                        if overlay_path.suffix != RULESPEC_FILE_SUFFIX:
+                            continue
+                        overlay_path.write_text(content)
+                    validations = _validate_overlay_files(
+                        pipeline,
+                        dependent_pipeline=dependent_pipeline,
+                        overlay_target=overlay_target,
+                        dependents=dependents,
+                    )
+                    continue
                 _record_successful_apply_validation(
                     result,
                     output_root=output_root,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -40753,7 +40753,7 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
         for path in changed_proof_hash_files:
             supplemental_files[
                 _relative_to_rulespec_apply_content_root(path, overlay_content_root)
-            ] = path.read_text()
+            ] = path.read_bytes().decode("utf-8")
         validations = _validate_overlay_files(
             pipeline,
             dependent_pipeline=dependent_pipeline,
@@ -40799,7 +40799,7 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
                                 _relative_to_rulespec_apply_content_root(
                                     path, overlay_content_root
                                 )
-                            ] = path.read_text()
+                            ] = path.read_bytes().decode("utf-8")
                     validations = _validate_overlay_files(
                         pipeline,
                         dependent_pipeline=dependent_pipeline,
@@ -40835,7 +40835,7 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
                         _relative_to_rulespec_apply_content_root(
                             path, overlay_content_root
                         )
-                    ] = path.read_text()
+                    ] = path.read_bytes().decode("utf-8")
                 validations = _validate_overlay_files(
                     pipeline,
                     dependent_pipeline=dependent_pipeline,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -40769,33 +40769,55 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
                     )
                 )
                 if stamped_supplemental_files != supplemental_files:
+                    stamped_paths = {
+                        relative_path
+                        for relative_path, content in stamped_supplemental_files.items()
+                        if supplemental_files.get(relative_path) != content
+                    }
                     supplemental_files = stamped_supplemental_files
-                    for relative_path, content in supplemental_files.items():
+                    for relative_path in sorted(
+                        stamped_paths, key=lambda path: path.as_posix()
+                    ):
+                        content = supplemental_files[relative_path]
                         overlay_path = (
                             overlay_content_root
                             / _canonical_apply_relative_path(relative_path)
                         )
                         if overlay_path.suffix != RULESPEC_FILE_SUFFIX:
                             continue
-                        overlay_path.write_text(content)
+                        overlay_path.write_bytes(content.encode("utf-8"))
+                    for _cascade in range(len(dependents) + 1):
+                        changed_proof_hash_files = (
+                            _repair_dependent_proof_import_hashes(
+                                dependents=dependents,
+                            )
+                        )
+                        if not changed_proof_hash_files:
+                            break
+                        for path in changed_proof_hash_files:
+                            supplemental_files[
+                                _relative_to_rulespec_apply_content_root(
+                                    path, overlay_content_root
+                                )
+                            ] = path.read_text()
                     validations = _validate_overlay_files(
                         pipeline,
                         dependent_pipeline=dependent_pipeline,
                         overlay_target=overlay_target,
                         dependents=dependents,
                     )
-                    continue
-                _record_successful_apply_validation(
-                    result,
-                    output_root=output_root,
-                    policy_repo_path=policy_repo_path,
-                    relative_output=relative_output,
-                    supplemental_files=supplemental_files,
-                    local_corpus_release=local_corpus_release,
-                    axiom_rules_path=axiom_rules_path,
-                    rulespec_dependency_roots=rulespec_dependency_roots,
-                )
-                return True, [], supplemental_files
+                if all(validation.all_passed for _, validation in validations):
+                    _record_successful_apply_validation(
+                        result,
+                        output_root=output_root,
+                        policy_repo_path=policy_repo_path,
+                        relative_output=relative_output,
+                        supplemental_files=supplemental_files,
+                        local_corpus_release=local_corpus_release,
+                        axiom_rules_path=axiom_rules_path,
+                        rulespec_dependency_roots=rulespec_dependency_roots,
+                    )
+                    return True, [], supplemental_files
             target_validation = next(
                 (
                     validation
@@ -44142,11 +44164,10 @@ def _rulespec_test_path(path: Path) -> Path:
 def _find_rulespec_dependents(
     policy_repo_path: Path, relative_output: Path
 ) -> list[Path]:
-    """Find RuleSpec files that directly import the generated output."""
-    target = _relative_rulespec_import_target(relative_output)
+    """Find the transitive RuleSpec importer closure for the generated output."""
     jurisdiction = _repo_jurisdiction_prefix(policy_repo_path)
     content_root = _rulespec_apply_content_root(policy_repo_path, relative_output)
-    dependents: list[Path] = []
+    candidates: list[tuple[Path, Path]] = []
     for root in sorted(RULESPEC_ATOMIC_MODULE_ROOTS):
         root_path = content_root / root
         if not root_path.exists():
@@ -44158,12 +44179,26 @@ def _find_rulespec_dependents(
                 relative_candidate = candidate.relative_to(content_root)
             except ValueError:
                 continue
-            if relative_candidate == relative_output:
-                continue
-            if _rulespec_file_imports_target(
-                candidate, target=target, jurisdiction=jurisdiction
-            ):
-                dependents.append(candidate)
+            if relative_candidate != relative_output:
+                candidates.append((candidate, relative_candidate))
+
+    dependents: list[Path] = []
+    selected = {relative_output}
+    frontier = [relative_output]
+    while frontier:
+        next_frontier: list[Path] = []
+        for imported_path in frontier:
+            target = _relative_rulespec_import_target(imported_path)
+            for candidate, relative_candidate in candidates:
+                if relative_candidate in selected:
+                    continue
+                if _rulespec_file_imports_target(
+                    candidate, target=target, jurisdiction=jurisdiction
+                ):
+                    dependents.append(candidate)
+                    selected.add(relative_candidate)
+                    next_frontier.append(relative_candidate)
+        frontier = next_frontier
     return dependents
 
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -42903,8 +42903,8 @@ def _repair_dependent_proof_import_hashes(
             if content_root is None:
                 continue
             relative_dependent = dependent.relative_to(content_root)
-            content = dependent.read_text()
-        except (OSError, ValueError):
+            content = dependent.read_bytes().decode("utf-8")
+        except (OSError, UnicodeError, ValueError):
             continue
         target_base = (
             f"{content_root.name}:"
@@ -42918,7 +42918,7 @@ def _repair_dependent_proof_import_hashes(
         )
         if repair_count <= 0 or repaired == content:
             continue
-        dependent.write_text(repaired)
+        dependent.write_bytes(repaired.encode("utf-8"))
         changed.append(dependent)
     return changed
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33244,6 +33244,7 @@ rules: []
         dependent = policy_repo / "statutes/26/63.yaml"
         transitive_dependent = policy_repo / "policies/income_tax/final.yaml"
         third_hop_dependent = policy_repo / "policies/income_tax/payable.yaml"
+        source_digest = "d" * 64
         generated.parent.mkdir(parents=True)
         dependent.parent.mkdir(parents=True)
         transitive_dependent.parent.mkdir(parents=True)
@@ -33262,11 +33263,12 @@ rules:
           0
 """
         )
-        dependent.write_text(
-            """format: rulespec/v1
+        dependent.write_bytes(
+            f"""format: rulespec/v1
 module:
   source_verification:
     corpus_citation_path: us/statute/26/151
+    source_sha256: {source_digest}
 imports:
   - us:statutes/26/151
 rules:
@@ -33288,13 +33290,14 @@ rules:
       - effective_from: '2026-01-01'
         formula: |-
           section_151_exemption_deduction
-"""
+""".replace("\n", "\r\n").encode("utf-8")
         )
-        transitive_dependent.write_text(
-            """format: rulespec/v1
+        transitive_dependent.write_bytes(
+            f"""format: rulespec/v1
 module:
   source_verification:
     corpus_citation_path: us/statute/26/151
+    source_sha256: {source_digest}
 imports:
   - us:statutes/26/63
 rules:
@@ -33316,14 +33319,15 @@ rules:
       - effective_from: '2026-01-01'
         formula: |-
           deductions_referred_to_in_subsection_b
-"""
+""".replace("\n", "\r\n").encode("utf-8")
         )
         third_hop_dependent.write_bytes(
-            """format: rulespec/v1
+            f"""format: rulespec/v1
 module:
   description: Café raw-byte chain
   source_verification:
     corpus_citation_path: us/statute/26/151
+    source_sha256: {source_digest}
 imports:
   - us:policies/income_tax/final
 rules:
@@ -33345,13 +33349,13 @@ rules:
       - effective_from: '2026-01-01'
         formula: |-
           final_deduction
-""".encode("utf-8")
+""".replace("\n", "\r\n").encode("utf-8")
         )
         context_dir = output_root / "context"
         context_dir.mkdir()
         (context_dir / "source.txt").write_text("test source\n")
         source_attestation = _complete_source_attestation(
-            "us/statute/26/151", source_sha256="d" * 64
+            "us/statute/26/151", source_sha256=source_digest
         )
         context_manifest = context_dir / "context-manifest.json"
         context_manifest.write_text(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33242,8 +33242,10 @@ rules: []
         policy_repo = tmp_path / "rulespec-us" / "us"
         generated = output_root / "openai-test-model" / "statutes/26/151.yaml"
         dependent = policy_repo / "statutes/26/63.yaml"
+        transitive_dependent = policy_repo / "policies/income_tax/final.yaml"
         generated.parent.mkdir(parents=True)
         dependent.parent.mkdir(parents=True)
+        transitive_dependent.parent.mkdir(parents=True)
         generated.write_text(
             """format: rulespec/v1
 module:
@@ -33287,6 +33289,34 @@ rules:
           section_151_exemption_deduction
 """
         )
+        transitive_dependent.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/26/151
+imports:
+  - us:statutes/26/63
+rules:
+  - name: final_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/63#deductions_referred_to_in_subsection_b
+              output: deductions_referred_to_in_subsection_b
+              hash: sha256:old
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          deductions_referred_to_in_subsection_b
+"""
+        )
         context_dir = output_root / "context"
         context_dir.mkdir()
         (context_dir / "source.txt").write_text("test source\n")
@@ -33312,7 +33342,7 @@ rules:
             context_manifest_file=str(context_manifest),
             source_attestation=source_attestation,
         )
-        dependent_validations: list[str] = []
+        dependent_validations: dict[str, list[bytes]] = {}
 
         class FakePipeline:
             def __init__(self, **_kwargs):
@@ -33322,8 +33352,11 @@ rules:
                 assert skip_reviewers is True
                 if Path(path).name == "151.yaml":
                     return SimpleNamespace(all_passed=True, results={})
-                content = Path(path).read_text()
-                dependent_validations.append(content)
+                content_bytes = Path(path).read_bytes()
+                content = content_bytes.decode("utf-8")
+                dependent_validations.setdefault(Path(path).name, []).append(
+                    content_bytes
+                )
                 if "hash: sha256:old" in content:
                     return SimpleNamespace(
                         all_passed=False,
@@ -33341,7 +33374,10 @@ rules:
                     )
                 return SimpleNamespace(all_passed=True, results={})
 
-        with patch("axiom_encode.cli.ValidatorPipeline", FakePipeline):
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch("axiom_encode.cli._APPLY_OVERLAY_VALIDATION_REPAIR_LIMIT", 1),
+        ):
             ok, issues, supplemental = _validate_generated_encoding_in_policy_overlay(
                 result,
                 output_root=output_root,
@@ -33358,7 +33394,18 @@ rules:
         assert "hash: sha256:old" not in updated
         assert f"hash: sha256:{_sha256_file(generated)}" in updated
         assert f"source_sha256: {'d' * 64}" in updated
-        assert dependent_validations[-1] == updated
+        assert dependent_validations["63.yaml"][-1] == updated.encode("utf-8")
+        transitive_updated = supplemental[Path("policies/income_tax/final.yaml")]
+        assert "hash: sha256:old" not in transitive_updated
+        assert (
+            "hash: sha256:"
+            f"{hashlib.sha256(updated.encode('utf-8')).hexdigest()}"
+            in transitive_updated
+        )
+        assert f"source_sha256: {'d' * 64}" in transitive_updated
+        assert dependent_validations["final.yaml"][-1] == transitive_updated.encode(
+            "utf-8"
+        )
 
     def test_supplemental_source_stamp_leaves_other_sources_fail_closed(self):
         supplemental = {
@@ -33809,8 +33856,9 @@ rules:
         repo = tmp_path / "rulespec-us" / "us-ny"
         target = repo / "regulations/18-nycrr/387/12/f/3/v/c.yaml"
         dependent = repo / "policies/otda/snap/fy-2026-benefit-calculation.yaml"
+        transitive_dependent = repo / "policies/otda/snap/final-benefit.yaml"
         unrelated = repo / "policies/otda/snap/other.yaml"
-        for path in (target, dependent, unrelated):
+        for path in (target, dependent, transitive_dependent, unrelated):
             path.parent.mkdir(parents=True, exist_ok=True)
         target.write_text("format: rulespec/v1\nrules: []\n")
         dependent.write_text(
@@ -33820,13 +33868,20 @@ imports:
 rules: []
 """
         )
+        transitive_dependent.write_text(
+            """format: rulespec/v1
+imports:
+  - us-ny:policies/otda/snap/fy-2026-benefit-calculation
+rules: []
+"""
+        )
         unrelated.write_text("format: rulespec/v1\nimports: []\nrules: []\n")
 
         dependents = _find_rulespec_dependents(
             repo, Path("regulations/18-nycrr/387/12/f/3/v/c.yaml")
         )
 
-        assert dependents == [dependent]
+        assert dependents == [dependent, transitive_dependent]
 
     def test_insert_false_input_default_uses_base_anchor(self):
         content = """- name: first_case

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -167,6 +167,7 @@ from axiom_encode.cli import (
     _stage_apply_overlay_dependency_root,
     _stage_apply_overlay_dependency_roots,
     _stamp_generated_source_attestation_for_apply,
+    _stamp_matching_supplemental_source_attestations,
     _suppress_rulespec_ancestor_targets_for_subsection_overlay,
     _translate_rulespec_engine_envelope_error,
     _try_repair_generated_aca_36b_b_premium_assistance_compat_for_apply,
@@ -33239,12 +33240,15 @@ rules: []
     ):
         output_root = tmp_path / "out"
         policy_repo = tmp_path / "rulespec-us" / "us"
-        generated = output_root / "codex-test-model" / "statutes/26/151.yaml"
+        generated = output_root / "openai-test-model" / "statutes/26/151.yaml"
         dependent = policy_repo / "statutes/26/63.yaml"
         generated.parent.mkdir(parents=True)
         dependent.parent.mkdir(parents=True)
         generated.write_text(
             """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/26/151
 rules:
   - name: section_151_exemption_deduction
     kind: parameter
@@ -33257,6 +33261,9 @@ rules:
         )
         dependent.write_text(
             """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/26/151
 imports:
   - us:statutes/26/151
 rules:
@@ -33280,9 +33287,32 @@ rules:
           section_151_exemption_deduction
 """
         )
-        result = SimpleNamespace(
-            output_file=str(generated), runner="codex-test-model", backend="codex"
+        context_dir = output_root / "context"
+        context_dir.mkdir()
+        (context_dir / "source.txt").write_text("test source\n")
+        source_attestation = _complete_source_attestation(
+            "us/statute/26/151", source_sha256="d" * 64
         )
+        context_manifest = context_dir / "context-manifest.json"
+        context_manifest.write_text(
+            json.dumps(
+                {
+                    "source_text_file": "source.txt",
+                    "source_metadata": {
+                        "source_attestation": source_attestation,
+                    },
+                }
+            )
+            + "\n"
+        )
+        result = SimpleNamespace(
+            output_file=str(generated),
+            runner="openai-test-model",
+            backend="openai",
+            context_manifest_file=str(context_manifest),
+            source_attestation=source_attestation,
+        )
+        dependent_validations: list[str] = []
 
         class FakePipeline:
             def __init__(self, **_kwargs):
@@ -33293,6 +33323,7 @@ rules:
                 if Path(path).name == "151.yaml":
                     return SimpleNamespace(all_passed=True, results={})
                 content = Path(path).read_text()
+                dependent_validations.append(content)
                 if "hash: sha256:old" in content:
                     return SimpleNamespace(
                         all_passed=False,
@@ -33321,11 +33352,43 @@ rules:
                 ),
             )
 
-        assert ok is True
+        assert ok is True, issues
         assert issues == []
         updated = supplemental[Path("statutes/26/63.yaml")]
         assert "hash: sha256:old" not in updated
         assert f"hash: sha256:{_sha256_file(generated)}" in updated
+        assert f"source_sha256: {'d' * 64}" in updated
+        assert dependent_validations[-1] == updated
+
+    def test_supplemental_source_stamp_leaves_other_sources_fail_closed(self):
+        supplemental = {
+            Path("policies/income_tax/pipeline.yaml"): """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-nc/statute/105/105-153.7
+rules: []
+""",
+            Path("policies/income_tax/other.yaml"): """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-nc/statute/105/105-153.8
+rules: []
+""",
+        }
+        attestation = _complete_source_attestation(
+            "us-nc/statute/105/105-153.7", source_sha256="f" * 64
+        )
+
+        stamped = _stamp_matching_supplemental_source_attestations(
+            supplemental,
+            attestation=attestation,
+        )
+
+        assert (
+            f"source_sha256: {'f' * 64}"
+            in stamped[Path("policies/income_tax/pipeline.yaml")]
+        )
+        assert "source_sha256" not in stamped[Path("policies/income_tax/other.yaml")]
 
     def test_apply_overlay_validation_refreshes_dependent_hashes_after_target_repair(
         self, tmp_path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33243,6 +33243,7 @@ rules: []
         generated = output_root / "openai-test-model" / "statutes/26/151.yaml"
         dependent = policy_repo / "statutes/26/63.yaml"
         transitive_dependent = policy_repo / "policies/income_tax/final.yaml"
+        third_hop_dependent = policy_repo / "policies/income_tax/payable.yaml"
         generated.parent.mkdir(parents=True)
         dependent.parent.mkdir(parents=True)
         transitive_dependent.parent.mkdir(parents=True)
@@ -33317,6 +33318,35 @@ rules:
           deductions_referred_to_in_subsection_b
 """
         )
+        third_hop_dependent.write_bytes(
+            """format: rulespec/v1
+module:
+  description: Café raw-byte chain
+  source_verification:
+    corpus_citation_path: us/statute/26/151
+imports:
+  - us:policies/income_tax/final
+rules:
+  - name: payable_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:policies/income_tax/final#final_deduction
+              output: final_deduction
+              hash: sha256:old
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          final_deduction
+""".encode("utf-8")
+        )
         context_dir = output_root / "context"
         context_dir.mkdir()
         (context_dir / "source.txt").write_text("test source\n")
@@ -33341,6 +33371,9 @@ rules:
             backend="openai",
             context_manifest_file=str(context_manifest),
             source_attestation=source_attestation,
+        )
+        local_corpus_release = _bind_test_corpus_release(
+            policy_repo, tmp_path / "axiom-corpus"
         )
         dependent_validations: dict[str, list[bytes]] = {}
 
@@ -33377,15 +33410,18 @@ rules:
         with (
             patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
             patch("axiom_encode.cli._APPLY_OVERLAY_VALIDATION_REPAIR_LIMIT", 1),
+            patch.object(
+                Path,
+                "write_text",
+                side_effect=AssertionError("apply repair must use explicit bytes"),
+            ),
         ):
             ok, issues, supplemental = _validate_generated_encoding_in_policy_overlay(
                 result,
                 output_root=output_root,
                 policy_repo_path=policy_repo,
                 axiom_rules_path=tmp_path / "axiom-rules-engine",
-                local_corpus_release=_bind_test_corpus_release(
-                    policy_repo, tmp_path / "axiom-corpus"
-                ),
+                local_corpus_release=local_corpus_release,
             )
 
         assert ok is True, issues
@@ -33404,6 +33440,17 @@ rules:
         )
         assert f"source_sha256: {'d' * 64}" in transitive_updated
         assert dependent_validations["final.yaml"][-1] == transitive_updated.encode(
+            "utf-8"
+        )
+        third_hop_updated = supplemental[Path("policies/income_tax/payable.yaml")]
+        assert "hash: sha256:old" not in third_hop_updated
+        assert (
+            "hash: sha256:"
+            f"{hashlib.sha256(transitive_updated.encode('utf-8')).hexdigest()}"
+            in third_hop_updated
+        )
+        assert "Café raw-byte chain" in third_hop_updated
+        assert dependent_validations["payable.yaml"][-1] == third_hop_updated.encode(
             "utf-8"
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1312"
+version = "0.2.1313"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1310"
+version = "0.2.1311"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1311"
+version = "0.2.1312"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1313"
+version = "0.2.1314"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- refresh `source_sha256` only for modified RuleSpec dependents that cite the same resolver-attested corpus source
- discover and validate the full transitive importer closure, cascading proof hashes to a fixed point
- preserve exact UTF-8 bytes through stamping, proof repair, validation, snapshotting, and signed apply
- leave different-source, malformed, and unverifiable supplemental RuleSpecs unchanged so the existing apply guard rejects them

This unblocks protected targeted re-encoding where replacing an atomic module requires same-source proof-import and attestation refreshes in dependent policy modules.

## Review cycle

- Cycle 1 found a P1: supplemental bytes were reserialized after validation. Fixed by staging before revalidation.
- Cycle 2 found no remaining findings on that implementation.
- Cycle 3 found transitive importer, text-I/O, and final repair-iteration gaps. Fixed with importer closure, immediate stamped success recording, exact byte writes, and a one-iteration three-module regression.
- Cycle 4 found locale-dependent proof-repair I/O. Fixed with explicit UTF-8 byte reads/writes and a multi-hop UTF-8 regression.
- Cycle 5 found newline normalization while capturing repaired files. Fixed every proof-repair capture site and added CRLF/no-restamp coverage.
- Cycle 6 independent follow-up review of exact head `7898bdfb8ddc97fee384ca531092bcfdea2b04f7` found no actionable findings.

## Checks

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- focused apply/dependency suite: 70 passed
- provenance guard: passed
- `uv run pytest -q`: 4,386 passed, 114 skipped

An optional whole-repository `ruff format --check` still reports the pre-existing unrelated `scripts/prepare_signed_backfill.py`; this PR does not touch that file.
