### PR TITLE
Make targeted artifact checksums portable

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -533,8 +533,11 @@ jobs:
       - name: Finalize signed re-encode artifact checksums
         run: |
           set -euo pipefail
-          sha256sum "$RUNNER_TEMP/targeted-reencode"/* \
-            > "$RUNNER_TEMP/targeted-reencode/SHA256SUMS"
+          artifact="$RUNNER_TEMP/targeted-reencode"
+          (
+            cd "$artifact"
+            sha256sum * > SHA256SUMS
+          )
 
       - name: Upload signed re-encode artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/changelog.d/portable-targeted-artifact-checksums.fixed.md
+++ b/changelog.d/portable-targeted-artifact-checksums.fixed.md
@@ -1,0 +1,1 @@
+Emit targeted signed re-encode artifact checksums with relocatable file names so downloaded artifacts can be verified directly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1314"
+version = "0.2.1315"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1314"
+__version__ = "0.2.1315"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1924,7 +1924,11 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         if step.get("name") == "Finalize signed re-encode artifact checksums"
     )
     assert "if" not in checksum_step
-    assert 'sha256sum "$RUNNER_TEMP/targeted-reencode"/*' in checksum_step["run"]
+    checksum_command = checksum_step["run"]
+    assert 'artifact="$RUNNER_TEMP/targeted-reencode"' in checksum_command
+    assert 'cd "$artifact"' in checksum_command
+    assert "sha256sum * > SHA256SUMS" in checksum_command
+    assert 'sha256sum "$RUNNER_TEMP/targeted-reencode"/*' not in checksum_command
     upload_step = next(
         step for step in steps if step.get("name") == "Upload signed re-encode artifact"
     )

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1314"
+version = "0.2.1315"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- generate targeted re-encode checksums from inside the artifact directory
- record relocatable basenames instead of ephemeral runner paths
- add workflow-contract regression coverage and bump the attested encoder version to `0.2.1315`

## Why
Protected run `29893673823` produced correct hashes, but `SHA256SUMS` named `/home/runner/...` paths. Downloaded artifacts therefore required a custom basename verifier instead of a direct `sha256sum --check SHA256SUMS`.

## Checks
- `uv run --python 3.13 --extra dev ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- focused signing workflow tests: 2 passed
- `uv run --python 3.13 --extra dev towncrier check`

## Review cycle
- pending independent exact-head review
- full pytest and hosted CI required before merge
