### PR TITLE
Converge generated proof excerpt repairs

### DIFF
--- a/changelog.d/converge-proof-excerpt-repairs.fixed.md
+++ b/changelog.d/converge-proof-excerpt-repairs.fixed.md
@@ -1,0 +1,1 @@
+Repeat generated proof-excerpt repair and overlay validation until all repairable cited-source mismatches converge.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1315"
+version = "0.2.1316"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1315"
+__version__ = "0.2.1316"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -20867,19 +20867,23 @@ def _run_encode_attempt(
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
-                repaired_excerpts = (
-                    _try_repair_generated_nonexact_proof_excerpts_for_apply(
-                        result,
-                        output_root=args.output,
-                        corpus_release=corpus_release,
-                        issues=apply_issues,
+                repaired_excerpts: list[str] = []
+                while not can_apply:
+                    repaired_refs = (
+                        _try_repair_generated_nonexact_proof_excerpts_for_apply(
+                            result,
+                            output_root=args.output,
+                            corpus_release=corpus_release,
+                            issues=apply_issues,
+                        )
                     )
-                )
-                if repaired_excerpts:
+                    if not repaired_refs:
+                        break
+                    repaired_excerpts.extend(repaired_refs)
                     outcome["auto_repaired_nonexact_proof_excerpts"] = repaired_excerpts
                     print(
                         "  apply=auto_repaired_nonexact_proof_excerpts:"
-                        + ",".join(repaired_excerpts)
+                        + ",".join(repaired_refs)
                     )
                     can_apply, apply_issues, supplemental_files = (
                         _validate_generated_encoding_in_policy_overlay(
@@ -20893,6 +20897,8 @@ def _run_encode_attempt(
                         )
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
+                if repaired_excerpts:
+                    outcome["auto_repaired_nonexact_proof_excerpts"] = repaired_excerpts
             if not can_apply:
                 repaired_hashes = _try_repair_generated_proof_import_hashes_for_apply(
                     result,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15312,6 +15312,92 @@ rules:
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
 
+    def test_encode_apply_converges_nonexact_proof_excerpt_repairs(
+        self, capsys, tmp_path
+    ):
+        args = self._make_args(tmp_path, backend="codex", sync=False)
+        args.apply = True
+        result = self._make_eval_result(False)
+        result.error = "Generated RuleSpec failed CI validation"
+        output_file = (
+            tmp_path / "out" / "codex-test-model" / "policies" / "benefit.yaml"
+        )
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+module:
+  summary: |-
+    $533 with 2 children
+    $267 with no children
+rules:
+- name: two_children
+  kind: parameter
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: ca/policy/example
+          excerpt: maximum payment of $533 for 2 children
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 533
+- name: no_children
+  kind: parameter
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: ca/policy/example
+          excerpt: maximum payment of $267 for no children
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 267
+"""
+        )
+        result.output_file = str(output_file)
+        first_issue = (
+            "Proof source evidence not found: rule `two_children` proof atom 0 "
+            "`source.excerpt` does not appear in `ca/policy/example`."
+        )
+        second_issue = (
+            "Proof source evidence not found: rule `no_children` proof atom 0 "
+            "`source.excerpt` does not appear in `ca/policy/example`."
+        )
+        applied_file = args.policy_repo_path / "us/policies/benefit.yaml"
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                side_effect=[
+                    (False, [first_issue], {}),
+                    (False, [second_issue], {}),
+                    (True, [], {}),
+                ],
+            ) as mock_overlay,
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, TEST_APPLY_SIGNING_ENV, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        assert mock_overlay.call_count == 3
+        mock_apply.assert_called_once()
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert run.outcome["auto_repaired_nonexact_proof_excerpts"] == [
+            "two_children[0]",
+            "no_children[0]",
+        ]
+        assert run.outcome["overlay_validation_success"] is True
+
     def test_encode_apply_repairs_generated_proof_import_hashes(self, capsys, tmp_path):
         args = self._make_args(tmp_path, backend="codex", sync=False)
         args.apply = True

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1315"
+version = "0.2.1316"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- repeat cited-source proof excerpt repair and overlay validation until no repair applies
- accumulate repaired atom labels across validation passes
- release as 0.2.1315

## Checks
- Ruff format/check passed
- compileall passed
- CLI suite: 752 passed, 10 skipped
- full suite: 4383 passed, 117 skipped

## Review cycle
Pending independent review.