### PR TITLE
Validate generated test repairs in canonical overlay

### DIFF
--- a/changelog.d/generated-positive-test-validation-root.fixed.md
+++ b/changelog.d/generated-positive-test-validation-root.fixed.md
@@ -1,0 +1,1 @@
+Stage generated Judgment companion-test repairs in an isolated canonical RuleSpec checkout before validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1316"
+version = "0.2.1317"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1316"
+__version__ = "0.2.1317"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -13330,12 +13330,14 @@ def _rulespec_companion_test_failures(
     *,
     root: Path,
     axiom_rules_path: Path,
+    rulespec_dependency_roots: Sequence[Path] = (),
 ) -> list[dict[str, str | None]]:
     pipeline = ValidatorPipeline(
         policy_repo_path=root,
         axiom_rules_path=axiom_rules_path,
         local_corpus_release=None,
         enable_oracles=False,
+        rulespec_dependency_roots=rulespec_dependency_roots,
     )
     binary = pipeline._axiom_rules_binary()
     rulespec_env = pipeline._rulespec_engine_env()
@@ -33186,6 +33188,29 @@ def _try_repair_generated_judgment_positive_tests_for_apply(
 
     rules_file = Path(str(getattr(result, "output_file", "") or ""))
     test_file = _rulespec_test_path(rules_file)
+    return _append_generated_judgment_positive_tests_in_overlay(
+        rules_file=rules_file,
+        test_file=test_file,
+        policy_repo_path=policy_repo_path,
+        axiom_rules_path=axiom_rules_path,
+        relative_output=relative_output,
+        issues=issues,
+    )
+
+
+def _append_generated_judgment_positive_tests_in_overlay(
+    *,
+    rules_file: Path,
+    test_file: Path,
+    policy_repo_path: Path,
+    axiom_rules_path: Path,
+    relative_output: Path,
+    issues: list[str],
+    rulespec_dependency_roots: Sequence[Path] = (),
+) -> list[str]:
+    """Validate generated Judgment tests in a canonical temporary checkout."""
+    if not _judgment_positive_output_targets_from_issues(issues):
+        return []
     policy_content_root = _rulespec_apply_content_root(
         policy_repo_path,
         relative_output,
@@ -33197,6 +33222,12 @@ def _try_repair_generated_judgment_positive_tests_for_apply(
     with tempfile.TemporaryDirectory() as tmpdir:
         overlay_parent = Path(tmpdir).resolve(strict=True)
         overlay_checkout = overlay_parent / policy_checkout_path.name
+        staged_dependency_roots = _stage_apply_overlay_dependency_roots(
+            overlay_parent=overlay_parent,
+            policy_repo_path=policy_checkout_path,
+            overlay_repo_name=policy_checkout_path.name,
+            rulespec_dependency_roots=rulespec_dependency_roots,
+        )
         _stage_apply_overlay_dependency_root(
             source=policy_checkout_path,
             target=overlay_checkout,
@@ -33227,6 +33258,7 @@ def _try_repair_generated_judgment_positive_tests_for_apply(
                 overlay_test_file,
                 root=overlay_content_root,
                 axiom_rules_path=axiom_rules_path,
+                rulespec_dependency_roots=staged_dependency_roots,
             )
 
         return _append_generated_judgment_positive_tests_if_missing(

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -6572,6 +6572,7 @@ def _evaluate_generated_artifact_with_repairs(
         policy_repo_root=policy_repo_root,
         axiom_rules_path=axiom_rules_path,
         issues=metrics.ci_issues,
+        rulespec_dependency_roots=rulespec_dependency_roots,
     )
     if not repairs:
         return metrics
@@ -6610,6 +6611,7 @@ def _apply_generated_eval_repairs(
     policy_repo_root: Path,
     axiom_rules_path: Path,
     issues: list[str],
+    rulespec_dependency_roots: Sequence[Path] = (),
 ) -> list[str]:
     """Apply deterministic generated-artifact repairs before final eval scoring."""
     repairs: list[str] = []
@@ -6673,14 +6675,14 @@ def _apply_generated_eval_repairs(
     )
     repairs.extend(
         f"judgment_positive:{name}"
-        for name in cli_helpers._append_generated_judgment_positive_tests_if_missing(
+        for name in cli_helpers._append_generated_judgment_positive_tests_in_overlay(
             rules_file=rulespec_file,
             test_file=test_file,
-            repo_path=policy_repo_root,
+            policy_repo_path=policy_repo_root,
             axiom_rules_path=axiom_rules_path,
             relative_output=relative_output,
             issues=companion_issues,
-            test_failure_checker=cli_helpers._rulespec_companion_test_failures,
+            rulespec_dependency_roots=rulespec_dependency_roots,
         )
     )
     repairs.extend(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,6 +40,7 @@ from axiom_encode.cli import (
     _append_exception_positive_companion_tests_if_missing,
     _append_generated_derived_output_tests_if_missing,
     _append_generated_judgment_positive_tests_if_missing,
+    _append_generated_judgment_positive_tests_in_overlay,
     _append_generated_zero_branch_tests_if_missing,
     _applied_encoding_manifest_path,
     _applied_encoding_manifest_signature_issue,
@@ -20453,7 +20454,14 @@ rules:
         with pytest.raises(UnsafeRulespecContextPath):
             _canonical_rulespec_compile_path(rules_file, policy_repo)
 
-        def check_companion(staged_test_file, *, root, axiom_rules_path):
+        def check_companion(
+            staged_test_file,
+            *,
+            root,
+            axiom_rules_path,
+            rulespec_dependency_roots=(),
+        ):
+            assert rulespec_dependency_roots == ()
             staged_rules_file = staged_test_file.with_name(
                 "vat-electricity-water-exemption-directive.yaml"
             )
@@ -20496,6 +20504,20 @@ rules:
             "vat-electricity-water-exemption-directive#input.receives_water": True,
         }
         assert case["output"] == {target: "holds"}
+
+    def test_judgment_positive_overlay_skips_unrelated_companion_issues(self, tmp_path):
+        with patch("axiom_encode.cli._stage_apply_overlay_dependency_root") as stage:
+            repaired = _append_generated_judgment_positive_tests_in_overlay(
+                rules_file=tmp_path / "generated/example.yaml",
+                test_file=tmp_path / "generated/example.test.yaml",
+                policy_repo_path=tmp_path / "rulespec-us/us",
+                axiom_rules_path=tmp_path / "axiom-rules-engine",
+                relative_output=Path("regulations/example.yaml"),
+                issues=["Derived rule missing companion output coverage: example"],
+            )
+
+        assert repaired == []
+        stage.assert_not_called()
 
     def test_imported_output_repair_satisfies_positive_judgment_composition(
         self, tmp_path

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -5620,7 +5620,13 @@ rules:
 
     def test_generated_eval_repairs_positive_judgment_companions(self, tmp_path):
         repo = _canonical_rulespec_content_root(tmp_path, "us-co")
-        rulespec_file = repo / "regulations" / "example.yaml"
+        dependency_content_root = _canonical_rulespec_content_root(tmp_path, "uk")
+        dependency_marker = dependency_content_root / "statutes/1/dependency.yaml"
+        dependency_marker.parent.mkdir(parents=True)
+        dependency_marker.write_text("format: rulespec/v1\nrules: []\n")
+        dependency_root = dependency_content_root.parent
+        relative_output = Path("regulations/example.yaml")
+        rulespec_file = tmp_path / "generated" / "openai" / relative_output
         rulespec_file.parent.mkdir(parents=True)
         rulespec_file.write_text(
             """format: rulespec/v1
@@ -5652,6 +5658,27 @@ rules:
             "`us-co:regulations/example#work_study_exemption` is not asserted "
             "as `holds` by the companion `.test.yaml` file."
         )
+        checked: dict[str, Path] = {}
+
+        def check_companion(
+            staged_test_file,
+            *,
+            root,
+            axiom_rules_path,
+            rulespec_dependency_roots=(),
+        ):
+            staged_rules_file = staged_test_file.with_name("example.yaml")
+            checked["rules"] = validator_pipeline._canonical_rulespec_compile_path(
+                staged_rules_file,
+                root,
+            )
+            checked["test"] = staged_test_file.resolve()
+            checked["root"] = root.resolve()
+            [staged_dependency_root] = rulespec_dependency_roots
+            checked["dependency"] = staged_dependency_root.resolve()
+            assert (staged_dependency_root / "uk/statutes/1/dependency.yaml").is_file()
+            return []
+
         with (
             patch.object(
                 ValidatorPipeline,
@@ -5668,7 +5695,7 @@ rules:
             ) as mock_ci,
             patch(
                 "axiom_encode.cli._rulespec_companion_test_failures",
-                return_value=[],
+                side_effect=check_companion,
             ),
         ):
             metrics = _evaluate_generated_artifact_with_repairs(
@@ -5680,6 +5707,7 @@ rules:
                 axiom_rules_path=Path("/tmp/axiom-rules-engine"),
                 source_text="Students in work study are exempt.",
                 skip_reviewers=True,
+                rulespec_dependency_roots=(dependency_root,),
             )
 
         repaired_tests = yaml.safe_load(
@@ -5687,6 +5715,12 @@ rules:
         )
         assert mock_ci.call_count == 2
         assert metrics.ci_pass
+        assert checked["rules"].is_relative_to(checked["root"])
+        assert checked["test"].is_relative_to(checked["root"])
+        assert checked["root"] != repo.resolve()
+        assert checked["dependency"] != dependency_root.resolve()
+        assert checked["dependency"].parent == checked["root"].parent.parent
+        assert not (repo / relative_output).exists()
         assert any(
             case.get("output", {}).get("us-co:regulations/example#work_study_exemption")
             == "holds"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1316"
+version = "0.2.1317"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- route deterministic Judgment companion-test repair validation through an isolated canonical RuleSpec checkout
- reuse the same trust boundary for apply and generated-artifact eval repair paths
- cover external generated output roots with regression assertions

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run towncrier check --compare-with origin/main`
- focused overlay repair tests: 2 passed
- `uv run pytest -q`: rerun in progress after committed version provenance bump

## Cycle
Independent review requested; findings and follow-up checks will be recorded before readiness.