### PR TITLE
Advance reviewed RuleSpec re-encode head

### DIFF
--- a/changelog.d/reviewed-rulespec-la-release-head.fixed.md
+++ b/changelog.d/reviewed-rulespec-la-release-head.fixed.md
@@ -1,0 +1,1 @@
+Advance the artifact-only protected re-encode bridge to the exact reviewed RuleSpec US head pinned to the corrected Louisiana corpus release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1317"
+version = "0.2.1318"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -19,7 +19,7 @@ REVIEWED_RULESPEC_REFS = frozenset(
     {
         (
             "us",
-            "52467ee7d99f4aa31882dfa7ec16835db2613eb3",
+            "8645fb934cd02dbf730cf980507bbb2d07731bd1",
         ),
     }
 )
@@ -53,24 +53,31 @@ def validate_rulespec_base(
     actual_ref = _git(repo, "rev-parse", "HEAD").decode().strip()
     if actual_ref != requested_ref:
         raise ValueError("rulespec checkout does not match the requested ref")
-    main_ancestor = subprocess.run(
-        [
-            "git",
-            "-C",
-            str(repo),
-            "merge-base",
-            "--is-ancestor",
-            "HEAD",
-            "refs/remotes/origin/main",
-        ],
-        check=False,
-    ).returncode == 0
+    main_ancestor = (
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo),
+                "merge-base",
+                "--is-ancestor",
+                "HEAD",
+                "refs/remotes/origin/main",
+            ],
+            check=False,
+        ).returncode
+        == 0
+    )
     if main_ancestor:
         return "main"
     if (country, requested_ref) not in REVIEWED_RULESPEC_REFS:
-        raise ValueError("rulespec ref is neither on main nor an approved reviewed head")
+        raise ValueError(
+            "rulespec ref is neither on main nor an approved reviewed head"
+        )
     if open_pr:
-        raise ValueError("reviewed-head runs are artifact-only and cannot open a pull request")
+        raise ValueError(
+            "reviewed-head runs are artifact-only and cannot open a pull request"
+        )
     return "reviewed-head-artifact"
 
 
@@ -87,7 +94,9 @@ def _changed_paths(repo: Path) -> set[PurePosixPath]:
         entry = fields[index]
         status = entry[:2]
         if len(entry) < 4 or status[:1] in {b"R", b"C"} or status[1:] in {b"R", b"C"}:
-            raise ValueError("renamed/copied or malformed changed paths are not publishable")
+            raise ValueError(
+                "renamed/copied or malformed changed paths are not publishable"
+            )
         paths.add(PurePosixPath(entry[3:].decode("utf-8")))
         index += 1
     return paths
@@ -124,7 +133,9 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
         if path.is_relative_to(MANIFEST_ROOT) and path.suffix == ".json"
     }
     if not manifests:
-        raise ValueError("no changed signed apply manifest is available to authorize publication")
+        raise ValueError(
+            "no changed signed apply manifest is available to authorize publication"
+        )
 
     authorized = set(manifests)
     for relative in manifests:
@@ -136,16 +147,16 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
             raise ValueError(f"changed manifest has an unsupported schema: {relative}")
         applied_files = payload.get("applied_files")
         if not isinstance(applied_files, list) or not applied_files:
-            raise ValueError(f"changed manifest has no applied_files authorization: {relative}")
+            raise ValueError(
+                f"changed manifest has no applied_files authorization: {relative}"
+            )
         for index, entry in enumerate(applied_files):
             if not isinstance(entry, dict):
                 raise ValueError(f"{relative} applied_files[{index}] is malformed")
             label = f"{relative} applied_files[{index}].path"
             applied_path = _safe_relative_path(entry.get("path"), label=label)
             _validate_rulespec_path(repo, applied_path, label=label)
-            authorized.add(
-                applied_path
-            )
+            authorized.add(applied_path)
 
     unexpected = changed - authorized
     missing = authorized - changed
@@ -219,7 +230,12 @@ def main() -> None:
             )
         else:
             stage_authorized_changes(args.repo)
-    except (OSError, ValueError, json.JSONDecodeError, subprocess.CalledProcessError) as exc:
+    except (
+        OSError,
+        ValueError,
+        json.JSONDecodeError,
+        subprocess.CalledProcessError,
+    ) as exc:
         parser.exit(1, f"error: {exc}\n")
 
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1317"
+__version__ = "0.2.1318"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -129,9 +129,8 @@ def test_validate_rulespec_base_accepts_exact_reviewed_head_artifact_only(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repo = tmp_path / "rulespec-us"
-    reviewed_ref = next(
-        ref for country, ref in REVIEWED_RULESPEC_REFS if country == "us"
-    )
+    reviewed_ref = "8645fb934cd02dbf730cf980507bbb2d07731bd1"
+    assert REVIEWED_RULESPEC_REFS == frozenset({("us", reviewed_ref)})
     monkeypatch.setattr(
         "scripts.prepare_signed_backfill._git",
         lambda _repo, *_args: f"{reviewed_ref}\n".encode(),
@@ -148,6 +147,25 @@ def test_validate_rulespec_base_accepts_exact_reviewed_head_artifact_only(
 
     with pytest.raises(ValueError, match="artifact-only"):
         validate_rulespec_base(repo, "us", reviewed_ref, open_pr=True)
+
+
+def test_validate_rulespec_base_rejects_retired_reviewed_head(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "rulespec-us"
+    retired_ref = "991f5375b92dffca57b08069093c24a463365cbc"
+    monkeypatch.setattr(
+        "scripts.prepare_signed_backfill._git",
+        lambda _repo, *_args: f"{retired_ref}\n".encode(),
+    )
+    monkeypatch.setattr(
+        "scripts.prepare_signed_backfill.subprocess.run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 1),
+    )
+
+    with pytest.raises(ValueError, match="neither on main nor an approved"):
+        validate_rulespec_base(repo, "us", retired_ref, open_pr=False)
 
 
 def test_validate_rulespec_base_rejects_unreviewed_non_main_head(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1317"
+version = "0.2.1318"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- replace the retired exact migration-head exception with RuleSpec US `8645fb934cd02dbf730cf980507bbb2d07731bd1`
- keep the exception artifact-only and reject PR-publishing runs
- bump axiom-encode to 0.2.1318

## Context
The reviewed RuleSpec migration head pins the activated signed corpus release `us-rulespec-2026-07-22-current-la-status-fix` (`6bfd97b24cb63cb709fa52e9a5e6764c916dec95c5557447e11f47778ee4768f`) and provenance corpus commit `01e00777cb05db84792c0de004b4fa24cfd453c3`.

## Checks
- `uv run --python 3.13 pytest -q`: 4,389 passed, 114 skipped
- focused bridge tests: 12 passed
- Ruff check and format: passed
- compileall and diff check: passed
- independent cycle: first pass found missing exact-singleton regression coverage; fixed by asserting the exact allowlist and rejecting retired head `991f5375`; second pass found no actionable findings on exact head `993adf31f7b6cfa838e11ef57d77542fdd31e5f2`