### PR TITLE
Repair proof excerpts across wrapped source lines

### DIFF
--- a/changelog.d/reflow-wrapped-proof-excerpts.fixed.md
+++ b/changelog.d/reflow-wrapped-proof-excerpts.fixed.md
@@ -1,0 +1,1 @@
+Reflow wrapped regulatory paragraphs when repairing generated proof excerpts so one physical source line cannot win with incomplete evidence.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1319"
+version = "0.2.1320"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1319"
+__version__ = "0.2.1320"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -27580,23 +27580,27 @@ _SOURCE_CROSS_REFERENCE_LEAD_IN_PATTERN = re.compile(
     flags=re.IGNORECASE,
 )
 _SOURCE_CROSS_REFERENCE_BODY_PATTERN = re.compile(
-    r"^(?:of|under|through|in|from)\s+(?:this|the|paragraph|section|subsection)\b",
+    r"^of\s+(?:this|the)\b",
     flags=re.IGNORECASE,
 )
 _SOURCE_SENTENCE_BOUNDARY_PATTERN = re.compile(r"[.!?](?=\s+[A-Z0-9(])")
 _SOURCE_ABBREVIATION_PATTERN = re.compile(
     r"\b(?:U\.S\.C|C\.F\.R|U\.S|e\.g|i\.e|No|Nos|Sec|Secs|Pt|Pts|"
-    r"Para|Paras|Subsec|Subsecs|Ch|Fig|Mr|Mrs|Ms|Dr|v)\.$",
+    r"Para|Paras|Subsec|Subsecs|Ch|Fig|Mr|Mrs|Ms|Dr|Pub|L|Rev|Proc|"
+    r"Reg|Stat|Art|v)\.$",
     flags=re.IGNORECASE,
 )
-_SOURCE_TABLE_ROW_PATTERN = re.compile(r"^(?:\$|.*(?:\t|\s{2,}|\|))")
+_SOURCE_TABLE_ROW_PATTERN = re.compile(
+    r"^(?:\$|[-+]?\d[\d,.]*\s+\$\s*\d|.*(?:\t|\s{2,}|\|))"
+)
 
 
 class _SourceExcerptCandidate(NamedTuple):
     text: str
     start: int
     end: int
-    is_marked_paragraph: bool
+    kind: str
+    marked_parent: tuple[int, int] | None
 
 
 def _try_repair_generated_nonexact_proof_excerpts_for_apply(
@@ -27717,14 +27721,12 @@ def _closest_exact_source_excerpt(*, source_text: str, excerpt: str) -> str | No
         ]
         if not enclosing:
             return None
-        marked_paragraphs = [
-            candidate for candidate in enclosing if candidate.is_marked_paragraph
+        table_rows = [
+            candidate for candidate in enclosing if candidate.kind == "table_row"
         ]
-        selected = min(
-            marked_paragraphs or enclosing,
-            key=lambda candidate: len(re.sub(r"\s+", " ", candidate.text)),
-        )
-        return selected.text
+        if table_rows:
+            return min(table_rows, key=lambda candidate: len(candidate.text)).text
+        return _governing_source_excerpt_candidate(enclosing, candidates)
 
     query_tokens = _proof_excerpt_match_tokens(query)
     query_numbers = set(extract_numbers_from_text(query))
@@ -27751,14 +27753,42 @@ def _closest_exact_source_excerpt(*, source_text: str, excerpt: str) -> str | No
         scored.append((score, candidate))
     if not scored:
         return None
-    return max(
+    selected = max(
         scored,
         key=lambda item: (
             item[0],
-            item[1].is_marked_paragraph,
+            item[1].kind == "paragraph",
             -len(re.sub(r"\s+", " ", item[1].text)),
         ),
-    )[1].text
+    )[1]
+    if selected.kind == "table_row":
+        return selected.text
+    return _governing_source_excerpt_candidate([selected], candidates)
+
+
+def _governing_source_excerpt_candidate(
+    selected: list[_SourceExcerptCandidate],
+    candidates: list[_SourceExcerptCandidate],
+) -> str | None:
+    marked_parent = next(
+        (candidate.marked_parent for candidate in selected if candidate.marked_parent),
+        None,
+    )
+    if marked_parent is not None:
+        governing = next(
+            (
+                candidate
+                for candidate in candidates
+                if candidate.kind == "paragraph"
+                and (candidate.start, candidate.end) == marked_parent
+            ),
+            None,
+        )
+        return governing.text if governing is not None else None
+    return min(
+        selected,
+        key=lambda candidate: len(re.sub(r"\s+", " ", candidate.text)),
+    ).text
 
 
 def _exact_source_excerpt_candidates(source_text: str) -> list[str]:
@@ -27775,7 +27805,11 @@ def _exact_source_excerpt_candidate_spans(
     seen: set[tuple[int, int]] = set()
 
     def add_candidate(
-        start: int, end: int, *, is_marked_paragraph: bool = False
+        start: int,
+        end: int,
+        *,
+        kind: str,
+        marked_parent: tuple[int, int] | None = None,
     ) -> None:
         while start < end and source_text[start].isspace():
             start += 1
@@ -27788,7 +27822,7 @@ def _exact_source_excerpt_candidate_spans(
             return
         seen.add(span)
         candidates.append(
-            _SourceExcerptCandidate(candidate, start, end, is_marked_paragraph)
+            _SourceExcerptCandidate(candidate, start, end, kind, marked_parent)
         )
 
     paragraph_lines: list[tuple[str, int, int]] = []
@@ -27803,23 +27837,41 @@ def _exact_source_excerpt_candidate_spans(
         is_marked_paragraph = bool(
             _SOURCE_PARAGRAPH_MARKER_PATTERN.match(collapsed_paragraph)
         )
+        trimmed_start = paragraph_start
+        trimmed_end = paragraph_end
+        while trimmed_start < trimmed_end and source_text[trimmed_start].isspace():
+            trimmed_start += 1
+        while trimmed_end > trimmed_start and source_text[trimmed_end - 1].isspace():
+            trimmed_end -= 1
+        marked_parent = (trimmed_start, trimmed_end) if is_marked_paragraph else None
         add_candidate(
             paragraph_start,
             paragraph_end,
-            is_marked_paragraph=is_marked_paragraph,
+            kind="paragraph",
+            marked_parent=marked_parent,
         )
 
         sentence_start = 0
         for match in _SOURCE_SENTENCE_BOUNDARY_PATTERN.finditer(paragraph):
             sentence_end = match.end()
-            prefix = paragraph[sentence_start:sentence_end].rstrip()
+            prefix = paragraph[
+                max(sentence_start, sentence_end - 48) : sentence_end
+            ].rstrip()
             if match.group() == "." and _SOURCE_ABBREVIATION_PATTERN.search(prefix):
                 continue
             add_candidate(
-                paragraph_start + sentence_start, paragraph_start + sentence_end
+                paragraph_start + sentence_start,
+                paragraph_start + sentence_end,
+                kind="sentence",
+                marked_parent=marked_parent,
             )
             sentence_start = sentence_end
-        add_candidate(paragraph_start + sentence_start, paragraph_end)
+        add_candidate(
+            paragraph_start + sentence_start,
+            paragraph_end,
+            kind="sentence",
+            marked_parent=marked_parent,
+        )
 
         table_rows = [
             (line, start, end)
@@ -27828,7 +27880,12 @@ def _exact_source_excerpt_candidate_spans(
         ]
         if len(table_rows) > 1:
             for _line, start, end in table_rows:
-                add_candidate(start, end)
+                add_candidate(
+                    start,
+                    end,
+                    kind="table_row",
+                    marked_parent=marked_parent,
+                )
         paragraph_lines.clear()
 
     offset = 0
@@ -27844,7 +27901,8 @@ def _exact_source_excerpt_candidate_spans(
         if paragraph_lines and marker_match is not None:
             previous_line = re.sub(r"\s+", " ", paragraph_lines[-1][0]).strip()
             body = marker_match.group("body")
-            is_wrapped_cross_reference = (
+            previous_is_open = re.search(r"[.;:!?]\s*$", previous_line) is None
+            is_wrapped_cross_reference = previous_is_open and (
                 _SOURCE_CROSS_REFERENCE_LEAD_IN_PATTERN.search(previous_line)
                 is not None
                 or _SOURCE_CROSS_REFERENCE_BODY_PATTERN.match(body) is not None

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -27572,10 +27572,10 @@ _PROOF_EXCERPT_TOKEN_STOPWORDS = frozenset(
 )
 _SOURCE_PARAGRAPH_MARKER_PATTERN = re.compile(
     r"^(?:(?:\((?:\d+|[A-Za-z]|[ivxlcdmIVXLCDM]{2,6})\))+|"
-    r"(?:\d+(?:\.\d+)+\.?|\d+\.|[A-Za-z]\.))\s+(?P<body>.*)"
+    r"(?:\d+(?:\.\d+){2,}\.?|\d{1,3}\.|[A-Za-z]\.))\s+(?P<body>.*)"
 )
 _SOURCE_CROSS_REFERENCE_LEAD_IN_PATTERN = re.compile(
-    r"\b(?:paragraph|subparagraph|section|subsection|clause|item|under|"
+    r"\b(?:paragraph|subparagraph|section|subsection|clause|item|"
     r"described in|specified in)\s*$",
     flags=re.IGNORECASE,
 )
@@ -27589,6 +27589,14 @@ _SOURCE_ABBREVIATION_PATTERN = re.compile(
     r"Para|Paras|Subsec|Subsecs|Ch|Fig|Mr|Mrs|Ms|Dr|v)\.$",
     flags=re.IGNORECASE,
 )
+_SOURCE_TABLE_ROW_PATTERN = re.compile(r"^(?:\$|.*(?:\t|\s{2,}|\|))")
+
+
+class _SourceExcerptCandidate(NamedTuple):
+    text: str
+    start: int
+    end: int
+    is_marked_paragraph: bool
 
 
 def _try_repair_generated_nonexact_proof_excerpts_for_apply(
@@ -27697,24 +27705,35 @@ def _closest_exact_source_excerpt(*, source_text: str, excerpt: str) -> str | No
     if not source or not query:
         return None
 
-    candidates = _exact_source_excerpt_candidates(source)
+    candidates = _exact_source_excerpt_candidate_spans(source)
     whitespace_pattern = r"\s+".join(re.escape(part) for part in query.split())
     direct_match = re.search(whitespace_pattern, source, flags=re.IGNORECASE)
     if direct_match is not None:
-        exact_span = source[direct_match.start() : direct_match.end()].strip()
-        enclosing = [candidate for candidate in candidates if exact_span in candidate]
+        enclosing = [
+            candidate
+            for candidate in candidates
+            if candidate.start <= direct_match.start()
+            and candidate.end >= direct_match.end()
+        ]
         if not enclosing:
             return None
-        return min(enclosing, key=lambda value: len(re.sub(r"\s+", " ", value)))
+        marked_paragraphs = [
+            candidate for candidate in enclosing if candidate.is_marked_paragraph
+        ]
+        selected = min(
+            marked_paragraphs or enclosing,
+            key=lambda candidate: len(re.sub(r"\s+", " ", candidate.text)),
+        )
+        return selected.text
 
     query_tokens = _proof_excerpt_match_tokens(query)
     query_numbers = set(extract_numbers_from_text(query))
-    scored: list[tuple[float, str]] = []
+    scored: list[tuple[float, _SourceExcerptCandidate]] = []
     for candidate in candidates:
-        normalized_candidate = re.sub(r"\s+", " ", candidate).strip()
-        candidate_tokens = _proof_excerpt_match_tokens(candidate)
+        normalized_candidate = re.sub(r"\s+", " ", candidate.text).strip()
+        candidate_tokens = _proof_excerpt_match_tokens(candidate.text)
         shared_tokens = query_tokens & candidate_tokens
-        candidate_numbers = set(extract_numbers_from_text(candidate))
+        candidate_numbers = set(extract_numbers_from_text(candidate.text))
         shared_numbers = query_numbers & candidate_numbers
         if query_numbers and not shared_numbers:
             continue
@@ -27734,29 +27753,61 @@ def _closest_exact_source_excerpt(*, source_text: str, excerpt: str) -> str | No
         return None
     return max(
         scored,
-        key=lambda item: (item[0], -len(re.sub(r"\s+", " ", item[1]))),
-    )[1]
+        key=lambda item: (
+            item[0],
+            item[1].is_marked_paragraph,
+            -len(re.sub(r"\s+", " ", item[1].text)),
+        ),
+    )[1].text
 
 
 def _exact_source_excerpt_candidates(source_text: str) -> list[str]:
-    candidates: list[str] = []
-    seen: set[str] = set()
+    return [
+        candidate.text
+        for candidate in _exact_source_excerpt_candidate_spans(source_text)
+    ]
 
-    def add_candidate(value: str) -> None:
-        candidate = value.strip()
+
+def _exact_source_excerpt_candidate_spans(
+    source_text: str,
+) -> list[_SourceExcerptCandidate]:
+    candidates: list[_SourceExcerptCandidate] = []
+    seen: set[tuple[int, int]] = set()
+
+    def add_candidate(
+        start: int, end: int, *, is_marked_paragraph: bool = False
+    ) -> None:
+        while start < end and source_text[start].isspace():
+            start += 1
+        while end > start and source_text[end - 1].isspace():
+            end -= 1
+        candidate = source_text[start:end]
         normalized = re.sub(r"\s+", " ", candidate)
-        if not candidate or len(normalized) > 500 or candidate in seen:
+        span = (start, end)
+        if not candidate or len(normalized) > 500 or span in seen:
             return
-        seen.add(candidate)
-        candidates.append(candidate)
+        seen.add(span)
+        candidates.append(
+            _SourceExcerptCandidate(candidate, start, end, is_marked_paragraph)
+        )
 
-    paragraph_lines: list[str] = []
+    paragraph_lines: list[tuple[str, int, int]] = []
 
     def flush_paragraph() -> None:
         if not paragraph_lines:
             return
-        paragraph = "".join(paragraph_lines).strip()
-        add_candidate(paragraph)
+        paragraph_start = paragraph_lines[0][1]
+        paragraph_end = paragraph_lines[-1][2]
+        paragraph = source_text[paragraph_start:paragraph_end]
+        collapsed_paragraph = re.sub(r"\s+", " ", paragraph).strip()
+        is_marked_paragraph = bool(
+            _SOURCE_PARAGRAPH_MARKER_PATTERN.match(collapsed_paragraph)
+        )
+        add_candidate(
+            paragraph_start,
+            paragraph_end,
+            is_marked_paragraph=is_marked_paragraph,
+        )
 
         sentence_start = 0
         for match in _SOURCE_SENTENCE_BOUNDARY_PATTERN.finditer(paragraph):
@@ -27764,37 +27815,43 @@ def _exact_source_excerpt_candidates(source_text: str) -> list[str]:
             prefix = paragraph[sentence_start:sentence_end].rstrip()
             if match.group() == "." and _SOURCE_ABBREVIATION_PATTERN.search(prefix):
                 continue
-            add_candidate(paragraph[sentence_start:sentence_end])
+            add_candidate(
+                paragraph_start + sentence_start, paragraph_start + sentence_end
+            )
             sentence_start = sentence_end
-        add_candidate(paragraph[sentence_start:])
+        add_candidate(paragraph_start + sentence_start, paragraph_end)
 
-        stripped_lines = [line.strip() for line in paragraph_lines if line.strip()]
         table_rows = [
-            line for line in stripped_lines if re.match(r"^(?:\$|-?\d)", line)
+            (line, start, end)
+            for line, start, end in paragraph_lines
+            if line.strip() and _SOURCE_TABLE_ROW_PATTERN.match(line.strip())
         ]
         if len(table_rows) > 1:
-            for line in table_rows:
-                add_candidate(line)
+            for _line, start, end in table_rows:
+                add_candidate(start, end)
         paragraph_lines.clear()
 
+    offset = 0
     for line in source_text.splitlines(keepends=True):
+        line_start = offset
+        line_end = offset + len(line)
+        offset = line_end
         collapsed = re.sub(r"\s+", " ", line).strip()
         if not collapsed:
             flush_paragraph()
             continue
         marker_match = _SOURCE_PARAGRAPH_MARKER_PATTERN.match(collapsed)
         if paragraph_lines and marker_match is not None:
-            previous_line = re.sub(r"\s+", " ", paragraph_lines[-1]).strip()
+            previous_line = re.sub(r"\s+", " ", paragraph_lines[-1][0]).strip()
             body = marker_match.group("body")
-            is_indented_marker = bool(line[:1].isspace())
-            is_wrapped_cross_reference = not is_indented_marker and (
+            is_wrapped_cross_reference = (
                 _SOURCE_CROSS_REFERENCE_LEAD_IN_PATTERN.search(previous_line)
                 is not None
                 or _SOURCE_CROSS_REFERENCE_BODY_PATTERN.match(body) is not None
             )
             if not is_wrapped_cross_reference:
                 flush_paragraph()
-        paragraph_lines.append(line)
+        paragraph_lines.append((line, line_start, line_end))
     flush_paragraph()
     return candidates
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -27570,6 +27570,25 @@ _PROOF_EXCERPT_TOKEN_STOPWORDS = frozenset(
         "your",
     }
 )
+_SOURCE_PARAGRAPH_MARKER_PATTERN = re.compile(
+    r"^(?:(?:\((?:\d+|[A-Za-z]|[ivxlcdmIVXLCDM]{2,6})\))+|"
+    r"(?:\d+(?:\.\d+)+\.?|\d+\.|[A-Za-z]\.))\s+(?P<body>.*)"
+)
+_SOURCE_CROSS_REFERENCE_LEAD_IN_PATTERN = re.compile(
+    r"\b(?:paragraph|subparagraph|section|subsection|clause|item|under|"
+    r"described in|specified in)\s*$",
+    flags=re.IGNORECASE,
+)
+_SOURCE_CROSS_REFERENCE_BODY_PATTERN = re.compile(
+    r"^(?:of|under|through|in|from)\s+(?:this|the|paragraph|section|subsection)\b",
+    flags=re.IGNORECASE,
+)
+_SOURCE_SENTENCE_BOUNDARY_PATTERN = re.compile(r"[.!?](?=\s+[A-Z0-9(])")
+_SOURCE_ABBREVIATION_PATTERN = re.compile(
+    r"\b(?:U\.S\.C|C\.F\.R|U\.S|e\.g|i\.e|No|Nos|Sec|Secs|Pt|Pts|"
+    r"Para|Paras|Subsec|Subsecs|Ch|Fig|Mr|Mrs|Ms|Dr|v)\.$",
+    flags=re.IGNORECASE,
+)
 
 
 def _try_repair_generated_nonexact_proof_excerpts_for_apply(
@@ -27678,16 +27697,21 @@ def _closest_exact_source_excerpt(*, source_text: str, excerpt: str) -> str | No
     if not source or not query:
         return None
 
+    candidates = _exact_source_excerpt_candidates(source)
     whitespace_pattern = r"\s+".join(re.escape(part) for part in query.split())
     direct_match = re.search(whitespace_pattern, source, flags=re.IGNORECASE)
     if direct_match is not None:
-        return source[direct_match.start() : direct_match.end()].strip()
+        exact_span = source[direct_match.start() : direct_match.end()].strip()
+        enclosing = [candidate for candidate in candidates if exact_span in candidate]
+        if not enclosing:
+            return None
+        return min(enclosing, key=lambda value: len(re.sub(r"\s+", " ", value)))
 
     query_tokens = _proof_excerpt_match_tokens(query)
     query_numbers = set(extract_numbers_from_text(query))
-    candidates = _exact_source_excerpt_candidates(source)
     scored: list[tuple[float, str]] = []
     for candidate in candidates:
+        normalized_candidate = re.sub(r"\s+", " ", candidate).strip()
         candidate_tokens = _proof_excerpt_match_tokens(candidate)
         shared_tokens = query_tokens & candidate_tokens
         candidate_numbers = set(extract_numbers_from_text(candidate))
@@ -27699,32 +27723,79 @@ def _closest_exact_source_excerpt(*, source_text: str, excerpt: str) -> str | No
         similarity = difflib.SequenceMatcher(
             None,
             query.casefold(),
-            candidate.casefold(),
+            normalized_candidate.casefold(),
         ).ratio()
         token_coverage = len(shared_tokens) / max(1, len(query_tokens))
         if similarity < 0.55 and token_coverage < 0.6:
             continue
-        score = similarity + (0.25 * token_coverage) + (0.1 * len(shared_numbers))
+        score = similarity + (1.25 * token_coverage) + (0.1 * len(shared_numbers))
         scored.append((score, candidate))
     if not scored:
         return None
-    return max(scored, key=lambda item: (item[0], -len(item[1])))[1]
+    return max(
+        scored,
+        key=lambda item: (item[0], -len(re.sub(r"\s+", " ", item[1]))),
+    )[1]
 
 
 def _exact_source_excerpt_candidates(source_text: str) -> list[str]:
     candidates: list[str] = []
     seen: set[str] = set()
-    for line in source_text.splitlines():
+
+    def add_candidate(value: str) -> None:
+        candidate = value.strip()
+        normalized = re.sub(r"\s+", " ", candidate)
+        if not candidate or len(normalized) > 500 or candidate in seen:
+            return
+        seen.add(candidate)
+        candidates.append(candidate)
+
+    paragraph_lines: list[str] = []
+
+    def flush_paragraph() -> None:
+        if not paragraph_lines:
+            return
+        paragraph = "".join(paragraph_lines).strip()
+        add_candidate(paragraph)
+
+        sentence_start = 0
+        for match in _SOURCE_SENTENCE_BOUNDARY_PATTERN.finditer(paragraph):
+            sentence_end = match.end()
+            prefix = paragraph[sentence_start:sentence_end].rstrip()
+            if match.group() == "." and _SOURCE_ABBREVIATION_PATTERN.search(prefix):
+                continue
+            add_candidate(paragraph[sentence_start:sentence_end])
+            sentence_start = sentence_end
+        add_candidate(paragraph[sentence_start:])
+
+        stripped_lines = [line.strip() for line in paragraph_lines if line.strip()]
+        table_rows = [
+            line for line in stripped_lines if re.match(r"^(?:\$|-?\d)", line)
+        ]
+        if len(table_rows) > 1:
+            for line in table_rows:
+                add_candidate(line)
+        paragraph_lines.clear()
+
+    for line in source_text.splitlines(keepends=True):
         collapsed = re.sub(r"\s+", " ", line).strip()
         if not collapsed:
+            flush_paragraph()
             continue
-        segments = re.split(r"(?<=[.!?;])\s+", collapsed)
-        for candidate in (collapsed, *segments):
-            candidate = candidate.strip()
-            if not candidate or len(candidate) > 500 or candidate in seen:
-                continue
-            seen.add(candidate)
-            candidates.append(candidate)
+        marker_match = _SOURCE_PARAGRAPH_MARKER_PATTERN.match(collapsed)
+        if paragraph_lines and marker_match is not None:
+            previous_line = re.sub(r"\s+", " ", paragraph_lines[-1]).strip()
+            body = marker_match.group("body")
+            is_indented_marker = bool(line[:1].isspace())
+            is_wrapped_cross_reference = not is_indented_marker and (
+                _SOURCE_CROSS_REFERENCE_LEAD_IN_PATTERN.search(previous_line)
+                is not None
+                or _SOURCE_CROSS_REFERENCE_BODY_PATTERN.match(body) is not None
+            )
+            if not is_wrapped_cross_reference:
+                flush_paragraph()
+        paragraph_lines.append(line)
+    flush_paragraph()
     return candidates
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7484,6 +7484,143 @@ def test_exact_source_excerpt_candidates_do_not_join_under_lead_in_provisions():
     )
 
 
+def test_exact_source_excerpt_candidates_do_not_join_under_body_provisions():
+    source_text = """(a)(1) General eligibility rule applies.
+(a)(2) Under this paragraph, the agency shall exclude gifts from income.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="the agency shall exclude gifts from income.",
+    )
+
+    assert repaired is not None
+    assert repaired.startswith("(a)(2) Under this paragraph")
+    assert "General eligibility" not in repaired
+
+
+def test_closest_exact_source_excerpt_promotes_fuzzy_match_to_marked_condition():
+    source_text = """(a) If household income is below the limit, eligibility is established. The agency shall pay $500 per month.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="agency payment equals $500 monthly",
+    )
+
+    assert repaired == source_text.strip()
+
+
+def test_closest_exact_source_excerpt_fails_closed_for_over_limit_condition():
+    source_text = (
+        "(a) If household income is below the limit, "
+        + ("all documentation requirements must be satisfied and " * 10)
+        + "eligibility is established. The agency shall pay $500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="The agency shall pay $500 per month.",
+    )
+
+    assert repaired is None
+
+
+@pytest.mark.parametrize(
+    "source_text",
+    [
+        """Household size Monthly benefit
+1 $291
+2 $535
+""",
+        """(a) Benefits are shown below:
+Size  Amount
+1  $291
+2  $535
+""",
+    ],
+)
+def test_closest_exact_source_excerpt_prefers_numeric_table_row(source_text):
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="2 $535",
+    )
+
+    assert repaired is not None
+    assert re.sub(r"\s+", " ", repaired).strip() == "2 $535"
+    assert repaired in source_text
+
+
+def test_exact_source_excerpt_candidates_keep_public_law_citation_together():
+    sentence = (
+        "The benefit was authorized by Pub. L. No. 117-2 and equals $500 per month."
+    )
+    source_text = sentence + " " + ("Administrative background applies. " * 20)
+
+    candidates = _exact_source_excerpt_candidates(source_text)
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="authorized by Pub. L. No. 117-2",
+    )
+
+    assert sentence in candidates
+    assert repaired == sentence
+
+
+def test_repair_generated_over_limit_marked_proof_excerpt_fails_closed(
+    tmp_path, monkeypatch
+):
+    source_text = (
+        "(a) If household income is below the limit, "
+        + ("all documentation requirements must be satisfied and " * 10)
+        + "eligibility is established. The agency shall pay $500 per month.\n"
+    )
+    output_root = tmp_path / "out"
+    rules_file = output_root / "model" / "regulations" / "435" / "552.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+rules:
+- name: benefit
+  kind: derived
+  entity: Person
+  dtype: Decimal
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/42/435/552
+          excerpt: agency payment equals $500 monthly
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 500
+"""
+    )
+    monkeypatch.setattr(
+        "axiom_encode.cli._local_source_text_for_corpus_path",
+        lambda citation_path, *, corpus_release: source_text,
+    )
+
+    repaired = _try_repair_generated_nonexact_proof_excerpts_for_apply(
+        SimpleNamespace(output_file=str(rules_file)),
+        output_root=output_root,
+        corpus_release=SimpleNamespace(name="test-release"),
+        issues=[
+            "Proof source evidence not found: rule `benefit` proof atom 0 "
+            "`source.excerpt` does not appear in `us/regulation/42/435/552`."
+        ],
+    )
+    validation = validate_rulespec_proofs(
+        rules_file.read_text(),
+        source_texts={"us/regulation/42/435/552": source_text},
+    )
+
+    assert repaired == []
+    assert not validation.passed
+
+
 def test_closest_exact_source_excerpt_splits_long_line_without_splitting_citation():
     source_text = (
         "The threshold is defined under 29 U.S.C. 206. "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,6 +65,7 @@ from axiom_encode.cli import (
     _ensure_rulespec_import,
     _eval_suite_json_sha256,
     _eval_suite_summary_payload,
+    _exact_source_excerpt_candidates,
     _exclusive_apply_transaction_lock,
     _execute_rulespec_test_file,
     _expected_proof_import_hash,
@@ -284,6 +285,7 @@ from axiom_encode.harness.evals import (
     summarize_readiness,
 )
 from axiom_encode.harness.policyengine_runtime import PolicyEngineRuntimeError
+from axiom_encode.harness.proof_validator import validate_rulespec_proofs
 from axiom_encode.harness.validator_pipeline import (
     _authoritative_rulespec_dependency_scope,
 )
@@ -7254,6 +7256,237 @@ rules:
         payload["rules"][0]["metadata"]["proof"]["atoms"][0]["source"]["excerpt"]
         == "The maximum amount for age is $6,100."
     )
+
+
+def test_closest_exact_source_excerpt_reflows_wrapped_regulatory_paragraph():
+    source_text = """    (i) If the monthly income is less than the applicable Federal
+minimum wage requirement under 29 U.S.C. 206(a)(1)(C) multiplied by 80
+hours, and the agency does not have documentation regarding the number
+of hours worked, the agency may calculate the hours for work under
+paragraph (a)(1) of this section based on the monthly income as
+determined under paragraph (f)(2) of this section provided that the
+agency must use a reasonable method to allocate work hours between
+members of the household.
+    (ii) If the agency uses the option under paragraph (e)(2)(i) of
+this section, the agency must calculate the hours for work by dividing
+the monthly income as determined under paragraph (f)(2) of this section
+by the applicable Federal minimum wage requirement under 29 U.S.C.
+206(a)(1)(C).
+"""
+
+    first = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="may calculate the hours for work based on the monthly income",
+    )
+    second = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=(
+            "calculate the hours for work by dividing the monthly income by the "
+            "applicable Federal minimum wage requirement"
+        ),
+    )
+
+    assert first is not None
+    assert first in source_text
+    assert first.startswith("(i) If the monthly income")
+    assert first.endswith("members of the household.")
+    normalized_first = re.sub(r"\s+", " ", first)
+    assert "may calculate the hours for work" in normalized_first
+    assert "based on the monthly income" in normalized_first
+    assert second is not None
+    assert second in source_text
+    assert second.startswith("(ii) If the agency uses the option")
+    assert second.endswith("206(a)(1)(C).")
+    normalized_second = re.sub(r"\s+", " ", second)
+    assert "dividing the monthly income" in normalized_second
+    assert "applicable Federal minimum wage requirement" in normalized_second
+
+
+@pytest.mark.parametrize(
+    "source_text",
+    [
+        """(a)(1) The agency shall use gross income when determining eligibility.
+(a)(2) The agency shall exclude gifts from gross income.
+""",
+        """1. The agency shall use gross income when determining eligibility.
+2. The agency shall exclude gifts from gross income.
+""",
+        """4.407.1 The agency shall use gross income when determining eligibility.
+4.407.2 The agency shall exclude gifts from gross income.
+""",
+    ],
+)
+def test_closest_exact_source_excerpt_does_not_join_distinct_provisions(source_text):
+    candidates = _exact_source_excerpt_candidates(source_text)
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="exclude gifts when determining eligibility",
+    )
+
+    assert not any(
+        "use gross income" in candidate and "exclude gifts" in candidate
+        for candidate in candidates
+    )
+    assert repaired is None or repaired in source_text
+    assert repaired is None or "\n" not in repaired
+    cross_provision_query = re.sub(r"\s+", " ", source_text).strip()
+    assert (
+        _closest_exact_source_excerpt(
+            source_text=source_text,
+            excerpt=cross_provision_query,
+        )
+        is None
+    )
+
+
+def test_closest_exact_source_excerpt_keeps_parenthetical_continuation():
+    source_text = """The agency shall include all income received by the household
+(except) excluded income when determining eligibility.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="include all income except excluded income when determining eligibility",
+    )
+
+    assert repaired is not None
+    assert repaired in source_text
+    assert repaired.startswith("The agency shall include all income")
+    assert repaired.endswith("when determining eligibility.")
+
+
+def test_closest_exact_source_excerpt_keeps_wrapped_cross_reference_in_condition():
+    source_text = """(i) If the household meets the income condition described in paragraph
+(a)(1) of this section, the agency may calculate work hours by dividing
+monthly income by the applicable minimum wage.
+(ii) Otherwise, the agency must verify hours directly.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="calculate work hours by dividing monthly income by minimum wage",
+    )
+
+    assert repaired is not None
+    assert repaired in source_text
+    assert repaired.startswith("(i) If the household meets the income condition")
+    assert repaired.endswith("monthly income by the applicable minimum wage.")
+
+
+def test_closest_exact_source_excerpt_expands_direct_wrapped_match_to_condition():
+    source_text = """(i) If household income is below the threshold and the agency lacks documentation,
+the agency may calculate the hours based on monthly income, provided that the agency
+must use a reasonable allocation method.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=(
+            "the agency may calculate the hours based on monthly income, provided "
+            "that the agency must use a reasonable allocation method."
+        ),
+    )
+
+    assert repaired is not None
+    assert repaired in source_text
+    assert repaired.startswith("(i) If household income is below the threshold")
+    assert repaired.endswith("must use a reasonable allocation method.")
+
+
+def test_closest_exact_source_excerpt_splits_long_line_without_splitting_citation():
+    source_text = (
+        "The threshold is defined under 29 U.S.C. 206. "
+        + ("Background sentence. " * 30)
+        + "The monthly benefit is $500 per month."
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="monthly benefit amount of $500",
+    )
+
+    assert repaired == "The monthly benefit is $500 per month."
+
+
+@pytest.mark.parametrize(
+    "citation",
+    [
+        "42 C.F.R. pt. 435",
+        "42 C.F.R. para. 435",
+        "the eligibility rule, e.g. Families with dependent children",
+        "the eligibility rule, i.e. Families with dependent children",
+    ],
+)
+def test_exact_source_excerpt_candidates_do_not_split_legal_abbreviations(citation):
+    first_sentence = f"The agency applies {citation} when determining eligibility."
+    source_text = (
+        first_sentence
+        + " "
+        + ("Administrative background applies. " * 20)
+        + "The monthly benefit is $500 per month."
+    )
+
+    candidates = _exact_source_excerpt_candidates(source_text)
+
+    assert first_sentence in candidates
+
+
+def test_repair_generated_wrapped_proof_excerpt_passes_literal_validation(
+    tmp_path, monkeypatch
+):
+    source_text = """(ii) If the agency uses the option under paragraph (e)(2)(i) of
+this section, the agency must calculate the hours for work by dividing
+the monthly income as determined under paragraph (f)(2) of this section
+by the applicable Federal minimum wage requirement under 29 U.S.C.
+206(a)(1)(C).
+"""
+    output_root = tmp_path / "out"
+    rules_file = output_root / "model" / "regulations" / "435" / "552.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+rules:
+- name: work_hours
+  kind: derived
+  entity: Person
+  dtype: Decimal
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/42/435/552
+          excerpt: calculate work hours by dividing monthly income by minimum wage
+  versions:
+  - effective_from: '2026-01-01'
+    formula: monthly_income / minimum_wage
+"""
+    )
+    monkeypatch.setattr(
+        "axiom_encode.cli._local_source_text_for_corpus_path",
+        lambda citation_path, *, corpus_release: source_text,
+    )
+
+    repaired = _try_repair_generated_nonexact_proof_excerpts_for_apply(
+        SimpleNamespace(output_file=str(rules_file)),
+        output_root=output_root,
+        corpus_release=SimpleNamespace(name="test-release"),
+        issues=[
+            "Proof source evidence not found: rule `work_hours` proof atom 0 "
+            "`source.excerpt` does not appear in `us/regulation/42/435/552`."
+        ],
+    )
+
+    assert repaired == ["work_hours[0]"]
+    payload = yaml.safe_load(rules_file.read_text())
+    excerpt = payload["rules"][0]["metadata"]["proof"]["atoms"][0]["source"]["excerpt"]
+    assert excerpt in source_text
+    validation = validate_rulespec_proofs(
+        rules_file.read_text(),
+        source_texts={"us/regulation/42/435/552": source_text},
+    )
+    assert validation.passed, validation.issues
 
 
 class TestCmdInventory:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7393,6 +7393,97 @@ must use a reasonable allocation method.
     assert repaired.endswith("must use a reasonable allocation method.")
 
 
+def test_closest_exact_source_excerpt_uses_direct_match_source_coordinates():
+    source_text = """(a) If household income is below the threshold and all documentation requirements are satisfied, the agency shall pay $500.
+(b) If fraud is found, the agency shall pay $500.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="the agency shall pay $500.",
+    )
+
+    assert repaired is not None
+    assert repaired.startswith("(a) If household income is below the threshold")
+    assert "fraud" not in repaired
+
+
+def test_closest_exact_source_excerpt_keeps_prior_sentence_condition():
+    source_text = """(a) This benefit is available only if household income is below the limit. The
+agency shall pay $500 per month.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="The agency shall pay $500 per month.",
+    )
+
+    assert repaired == source_text.strip()
+
+
+@pytest.mark.parametrize(
+    ("source_text", "excerpt"),
+    [
+        (
+            """(a) If the income test applies, the agency shall use
+1.5 percent of household income when calculating the benefit.
+""",
+            "1.5 percent of household income",
+        ),
+        (
+            """(a) If the renewal rule applies, coverage continues through
+2026. The agency shall then redetermine eligibility.
+""",
+            "2026. The agency shall then redetermine eligibility.",
+        ),
+        (
+            """(a) If the agency applies the monthly standard, it shall use
+80 hours as the divisor and account for changes occurring after
+2026 when calculating the benefit.
+""",
+            "80 hours as the divisor and account for changes occurring after",
+        ),
+    ],
+)
+def test_closest_exact_source_excerpt_keeps_numeric_wrapped_prose_condition(
+    source_text, excerpt
+):
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=excerpt,
+    )
+
+    assert repaired == source_text.strip()
+
+
+def test_closest_exact_source_excerpt_keeps_indented_wrapped_cross_reference():
+    source_text = """(i) If the household meets the condition described in paragraph
+    (a)(1) of this section, the agency shall pay the benefit.
+(ii) Otherwise, no benefit is paid.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="the agency shall pay the benefit",
+    )
+
+    assert repaired is not None
+    assert repaired.startswith("(i) If the household meets the condition")
+    assert repaired.endswith("the agency shall pay the benefit.")
+
+
+def test_exact_source_excerpt_candidates_do_not_join_under_lead_in_provisions():
+    source_text = """(a)(1) Scope governed under
+(a)(2) The agency shall exclude gifts from income.
+"""
+
+    candidates = _exact_source_excerpt_candidates(source_text)
+
+    assert not any(
+        "Scope governed" in item and "exclude gifts" in item for item in candidates
+    )
+
+
 def test_closest_exact_source_excerpt_splits_long_line_without_splitting_citation():
     source_text = (
         "The threshold is defined under 29 U.S.C. 206. "

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1319"
+version = "0.2.1320"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- derive proof candidates from source-coordinate spans so excerpts remain literal substrings of the captured source
- promote governing marked paragraphs for wrapped legal provisions while preserving table-row precedence
- fail closed when the governing paragraph exceeds the proof excerpt limit and bound suffix scanning for large sources

## Motivation
Protected signed re-encode run 29897461837 exposed a wrapped-source excerpt failure for 42 CFR 435.552. The previous repair path could combine normalized lines into text that did not occur literally in the source artifact.

## Validation
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest`: 4417 passed, 114 skipped
- actual 42 CFR 435.552 source probes for the education paragraph and subdivisions `(i)` and `(ii)` are exact source substrings

## Review cycle
Six independent review/fix cycles were completed. The final post-rebase review compared exact head `8675ae672126f534c1d90a6d9f957e85379b9214` against exact main `029d61ef8ebcc2b781e4712d8fe0c7614e929c7c` and reported no actionable findings. The review also confirmed that the parameter snapshot behavior merged in #1221 remains intact.