### PR TITLE
Allow guarded post-apply waiver retirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1320"
+version = "0.2.1321"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1320"
+__version__ = "0.2.1321"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -16732,7 +16732,7 @@ def guard_generated_change_issues(
         ]
     try:
         load_rulespec_toolchain(repo_path)
-        verify_rulespec_validation_waiver_set(repo_path)
+        current_waiver_set_sha256 = verify_rulespec_validation_waiver_set(repo_path)
         local_corpus_release = load_rulespec_local_corpus_release(
             repo_path,
             Path(corpus_path),
@@ -16787,6 +16787,18 @@ def guard_generated_change_issues(
     if not protected:
         return []
 
+    expected_manifest_waiver_set_sha256, waiver_transition_issues = (
+        _guard_manifest_waiver_set_identity(
+            repo_path,
+            base_ref=base_ref,
+            changed=changed,
+            protected=protected,
+            current_waiver_set_sha256=current_waiver_set_sha256,
+        )
+    )
+    if waiver_transition_issues:
+        return waiver_transition_issues
+
     manifest_paths = (
         _all_applied_encoding_manifest_paths(repo_path, roots=roots)
         if all_files
@@ -16830,6 +16842,7 @@ def guard_generated_change_issues(
         roots=roots,
         local_corpus_release=local_corpus_release,
         expected_encoder_identity=expected_encoder_identity,
+        expected_waiver_set_sha256=expected_manifest_waiver_set_sha256,
     )
     if manifest_issues:
         return manifest_issues
@@ -16872,6 +16885,7 @@ def guard_generated_change_issues(
             roots=roots,
             local_corpus_release=local_corpus_release,
             expected_encoder_identity=expected_encoder_identity,
+            expected_waiver_set_sha256=expected_manifest_waiver_set_sha256,
         )
     )
 
@@ -16883,6 +16897,123 @@ def guard_generated_change_issues(
     return issues
 
 
+def _guard_manifest_waiver_set_identity(
+    repo_path: Path,
+    *,
+    base_ref: str | None,
+    changed: list[str],
+    protected: list[str],
+    current_waiver_set_sha256: str,
+) -> tuple[str, list[str]]:
+    """Resolve the waiver identity a changed apply manifest must carry.
+
+    Model manifests bind the policy state immediately before apply. A pull
+    request may then retire active waivers made obsolete by those generated
+    files, but only as an exact decrement from the protected base.
+    """
+
+    waiver_path = _validation_waivers.DEFAULT_WAIVER_PATH
+    toolchain_path = ".axiom/toolchain.toml"
+    changed_set = {Path(path).as_posix() for path in changed}
+    metadata_changes = changed_set & {waiver_path, toolchain_path}
+    if waiver_path not in metadata_changes:
+        return current_waiver_set_sha256, []
+
+    prefix = "RuleSpec post-apply waiver retirement is invalid: "
+    if metadata_changes != {waiver_path, toolchain_path}:
+        return current_waiver_set_sha256, [
+            prefix
+            + f"{waiver_path} and {toolchain_path} must change together"
+        ]
+    if base_ref is None:
+        return current_waiver_set_sha256, [
+            prefix + "a protected base ref is required"
+        ]
+
+    base_bytes = _git_show_bytes(repo_path, base_ref, waiver_path)
+    if base_bytes is None:
+        return current_waiver_set_sha256, [
+            prefix + f"cannot read {waiver_path} from protected base {base_ref}"
+        ]
+    base_sha256 = hashlib.sha256(base_bytes).hexdigest()
+    if base_sha256 == current_waiver_set_sha256:
+        return current_waiver_set_sha256, [
+            prefix + "the waiver set did not remove any protected-base entry"
+        ]
+
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".yaml") as base_file:
+            base_file.write(base_bytes)
+            base_file.flush()
+            base_waivers = _validation_waivers.load_validation_waivers(
+                base_file.name,
+                repo_root=repo_path,
+                allow_expired=True,
+                require_paths=False,
+            )
+        head_waivers = _validation_waivers.load_validation_waivers(
+            repo_path / waiver_path,
+            repo_root=repo_path,
+        )
+    except _validation_waivers.ValidationWaiverError as exc:
+        return current_waiver_set_sha256, [prefix + str(exc)]
+
+    transition_issues = _validation_waivers.protected_base_transition_issues(
+        base_waivers,
+        head_waivers,
+        changed_paths=changed_set,
+        waiver_path=waiver_path,
+    )
+    if transition_issues:
+        return current_waiver_set_sha256, [
+            prefix + issue for issue in transition_issues
+        ]
+
+    base_entries = dict(base_waivers.entries)
+    head_entries = dict(head_waivers.entries)
+    added = sorted(set(head_entries) - set(base_entries))
+    if added:
+        return current_waiver_set_sha256, [
+            prefix + "new waiver entries are not allowed: " + ", ".join(added)
+        ]
+    changed_entries = sorted(
+        path
+        for path in set(base_entries) & set(head_entries)
+        if base_entries[path] != head_entries[path]
+    )
+    if changed_entries:
+        return current_waiver_set_sha256, [
+            prefix
+            + "retained waiver entries must remain exactly unchanged: "
+            + ", ".join(changed_entries)
+        ]
+
+    removed = sorted(set(base_entries) - set(head_entries))
+    if not removed:
+        return current_waiver_set_sha256, [
+            prefix + "the waiver set did not remove any protected-base entry"
+        ]
+    invalid_states = [
+        path
+        for path in removed
+        if base_entries[path].active is None or base_entries[path].pending is not None
+    ]
+    if invalid_states:
+        return current_waiver_set_sha256, [
+            prefix
+            + "only active entries without pending state may be removed: "
+            + ", ".join(invalid_states)
+        ]
+    unrelated = sorted(set(removed) - set(protected))
+    if unrelated:
+        return current_waiver_set_sha256, [
+            prefix
+            + "removed entries must name changed protected RuleSpec modules: "
+            + ", ".join(unrelated)
+        ]
+    return base_sha256, []
+
+
 def _generated_provenance_gate_issues(
     repo_path: Path,
     *,
@@ -16891,6 +17022,7 @@ def _generated_provenance_gate_issues(
     roots: tuple[str, ...],
     local_corpus_release: LocalCorpusRelease,
     expected_encoder_identity: Mapping[str, str],
+    expected_waiver_set_sha256: str,
 ) -> list[str]:
     """Reject protected files authorized only by manual attestations."""
 
@@ -16900,6 +17032,7 @@ def _generated_provenance_gate_issues(
         roots=roots,
         local_corpus_release=local_corpus_release,
         expected_encoder_identity=expected_encoder_identity,
+        expected_waiver_set_sha256=expected_waiver_set_sha256,
     )
     issues: list[str] = []
     for path in protected:
@@ -17096,6 +17229,7 @@ def _manifest_coverage_by_file(
     roots: tuple[str, ...] = tuple(sorted(RULESPEC_ATOMIC_MODULE_ROOTS)),
     local_corpus_release: LocalCorpusRelease | None = None,
     expected_encoder_identity: Mapping[str, str] | None = None,
+    expected_waiver_set_sha256: str | None = None,
 ) -> dict[str, list[dict[str, object]]]:
     """Map each non-deleted covered file to a list of covering-manifest records.
 
@@ -17118,6 +17252,7 @@ def _manifest_coverage_by_file(
                 roots=roots,
                 local_corpus_release=local_corpus_release,
                 expected_encoder_identity=expected_encoder_identity,
+                expected_waiver_set_sha256=expected_waiver_set_sha256,
             )
         )
         if issues or payload is None or root_prefix is None:
@@ -18189,6 +18324,7 @@ def _load_applied_encoding_manifest_entries(
     roots: tuple[str, ...] = tuple(sorted(RULESPEC_ATOMIC_MODULE_ROOTS)),
     local_corpus_release: LocalCorpusRelease | None = None,
     expected_encoder_identity: Mapping[str, str] | None = None,
+    expected_waiver_set_sha256: str | None = None,
 ) -> tuple[dict[str, set[str]], list[str]]:
     entries: dict[str, set[str]] = defaultdict(set)
     issues: list[str] = []
@@ -18204,10 +18340,13 @@ def _load_applied_encoding_manifest_entries(
                 "trust config is required to verify encoder apply manifests"
             ],
         )
-    try:
-        expected_waiver_set_sha256 = verify_rulespec_validation_waiver_set(repo_path)
-    except ValueError as exc:
-        return entries, [f"RuleSpec waiver-set binding is invalid: {exc}"]
+    if expected_waiver_set_sha256 is None:
+        try:
+            expected_waiver_set_sha256 = verify_rulespec_validation_waiver_set(
+                repo_path
+            )
+        except ValueError as exc:
+            return entries, [f"RuleSpec waiver-set binding is invalid: {exc}"]
     if expected_encoder_identity is None:
         try:
             expected_encoder_identity = _current_guard_encoder_execution_identity()
@@ -18588,6 +18727,17 @@ def _git_show_text(repo: Path, ref: str, path: str) -> str | None:
             capture_output=True,
             check=True,
             text=True,
+        ).stdout
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def _git_show_bytes(repo: Path, ref: str, path: str) -> bytes | None:
+    try:
+        return subprocess.run(
+            ["git", "-C", str(repo), "show", f"{ref}:{path}"],
+            capture_output=True,
+            check=True,
         ).stdout
     except (OSError, subprocess.CalledProcessError):
         return None

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -16922,13 +16922,10 @@ def _guard_manifest_waiver_set_identity(
     prefix = "RuleSpec post-apply waiver retirement is invalid: "
     if metadata_changes != {waiver_path, toolchain_path}:
         return current_waiver_set_sha256, [
-            prefix
-            + f"{waiver_path} and {toolchain_path} must change together"
+            prefix + f"{waiver_path} and {toolchain_path} must change together"
         ]
     if base_ref is None:
-        return current_waiver_set_sha256, [
-            prefix + "a protected base ref is required"
-        ]
+        return current_waiver_set_sha256, [prefix + "a protected base ref is required"]
 
     base_bytes = _git_show_bytes(repo_path, base_ref, waiver_path)
     if base_bytes is None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import tempfile
 import tomllib
+from datetime import date, timedelta
 from decimal import Decimal
 from pathlib import Path
 from types import SimpleNamespace
@@ -29265,6 +29266,70 @@ class TestGuardGenerated:
             }
         )
 
+    def _waiver_entry_text(
+        self,
+        path: str,
+        *,
+        state: str = "active",
+        fingerprint: str = "1" * 64,
+    ) -> str:
+        expires = (date.today() + timedelta(days=30)).isoformat()
+        return (
+            f"  {path}:\n"
+            f"    {state}:\n"
+            f"      fingerprint: sha256:{fingerprint}\n"
+            "      owner: '@axiom-test'\n"
+            "      issue: https://github.com/TheAxiomFoundation/axiom-encode/issues/1\n"
+            f"      expires: '{expires}'\n"
+        )
+
+    def _waiver_retirement_repo(
+        self,
+        tmp_path: Path,
+        *,
+        base_waiver_text: str,
+        head_waiver_text: str = TEST_VALIDATION_WAIVER_TEXT,
+    ) -> tuple[Path, str]:
+        repo = self._canonical_guard_repo(tmp_path)
+        _git(repo, "init")
+        _git(repo, "config", "user.email", "test@example.com")
+        _git(repo, "config", "user.name", "Test User")
+        relative = "us/regulations/example.yaml"
+        rule = repo / relative
+        self._source_backed_rule(rule)
+        rule.write_text(rule.read_text() + "# protected-base version\n")
+        waiver = repo / "known-validation-gaps.yaml"
+        waiver.write_text(base_waiver_text)
+        _write_test_rulespec_toolchain(
+            repo,
+            release_content_sha256=self.corpus_release.content_sha256,
+        )
+        base_waiver_sha256 = hashlib.sha256(waiver.read_bytes()).hexdigest()
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "add protected-base waiver")
+        base_ref = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+        self._source_backed_rule(rule)
+        waiver.write_text(head_waiver_text)
+        _write_test_rulespec_toolchain(
+            repo,
+            release_content_sha256=self.corpus_release.content_sha256,
+        )
+        payload = self._model_manifest(
+            [{"path": relative, "sha256": _sha256_file(rule)}]
+        )
+        payload["validation_waiver_set_sha256"] = base_waiver_sha256
+        payload["validation_execution"]["policy_pre_apply"][
+            "validation_waiver_set_sha256"
+        ] = base_waiver_sha256
+        _sign_applied_encoding_manifest(payload, TEST_APPLY_SIGNING_BROKER)
+        manifest = repo / ".axiom/encoding-manifests/us/regulations/example.json"
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text(json.dumps(payload) + "\n")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "apply encoding and retire waiver")
+        return repo, base_ref
+
     def _retirement_manifest(
         self,
         deleted_paths: list[str],
@@ -29608,10 +29673,70 @@ class TestGuardGenerated:
                 changed_files=[
                     "us/regulations/example.yaml",
                     ".axiom/encoding-manifests/us/regulations/example.json",
+                    ".axiom/toolchain.toml",
                 ],
             )
 
         assert issues == []
+
+    def test_accepts_post_apply_retirement_of_matching_active_waiver(self, tmp_path):
+        relative = "us/regulations/example.yaml"
+        repo, base_ref = self._waiver_retirement_repo(
+            tmp_path,
+            base_waiver_text=(
+                "validate_failures:\n" + self._waiver_entry_text(relative)
+            ),
+        )
+
+        issues = guard_generated_change_issues(
+            repo,
+            corpus_path=self.corpus_path,
+            base_ref=base_ref,
+            head_ref="HEAD",
+        )
+
+        assert issues == []
+
+    @pytest.mark.parametrize(
+        ("base_waiver_text", "expected_issue"),
+        [
+            (
+                "pending",
+                "only active entries without pending state may be removed",
+            ),
+            (
+                "unrelated",
+                "removed entries must name changed protected RuleSpec modules",
+            ),
+        ],
+    )
+    def test_rejects_unsafe_post_apply_waiver_retirement(
+        self,
+        tmp_path,
+        base_waiver_text,
+        expected_issue,
+    ):
+        target = "us/regulations/example.yaml"
+        waiver_path = (
+            target if base_waiver_text == "pending" else "us/statutes/26/99.yaml"
+        )
+        state = "pending" if base_waiver_text == "pending" else "active"
+        repo, base_ref = self._waiver_retirement_repo(
+            tmp_path,
+            base_waiver_text=(
+                "validate_failures:\n"
+                + self._waiver_entry_text(waiver_path, state=state)
+            ),
+        )
+
+        issues = guard_generated_change_issues(
+            repo,
+            corpus_path=self.corpus_path,
+            base_ref=base_ref,
+            head_ref="HEAD",
+        )
+
+        assert any(expected_issue in issue for issue in issues)
 
     def test_rejects_legacy_deterministic_manifest(self, tmp_path):
         rule = tmp_path / "us/regulations/example.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1320"
+version = "0.2.1321"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- preserve signed model manifests as pre-apply policy attestations
- allow guard-generated to resolve the protected-base waiver identity only for exact active-only waiver removals tied to changed protected modules
- reject additions, retained-entry mutations, pending-state removals, unrelated removals, and unbound waiver metadata changes
- bump axiom-encode to 0.2.1321

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest -q` (4417 passed, 117 skipped)
- `uv run pytest -q tests/test_cli.py::TestGuardGenerated --no-cov` (55 passed)

## Review cycle
- Independent review requested; outcome will be recorded before ready-for-review.