### PR TITLE
Repair wrapped legal proof excerpts

### DIFF
--- a/changelog.d/repair-long-wrapped-proof-excerpts.fixed.md
+++ b/changelog.d/repair-long-wrapped-proof-excerpts.fixed.md
@@ -1,0 +1,1 @@
+Repair exact proof excerpts that cross source line wraps inside an oversized legal paragraph while preserving the fail-closed behavior for non-wrapped oversized conditions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1321"
+version = "0.2.1322"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1321"
+__version__ = "0.2.1322"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -18528,6 +18528,11 @@ def _require_axiom_encode_version_provenance(
 
 
 def _latest_axiom_encode_version_commit(repo: Path) -> str | None:
+    head_versions = _axiom_encode_versions_at_ref(repo, "HEAD")
+    head_version = head_versions.get("pyproject")
+    if not head_version:
+        return None
+    fallback_commit = None
     commits = _git_name_only(
         repo,
         "log",
@@ -18541,11 +18546,17 @@ def _latest_axiom_encode_version_commit(repo: Path) -> str | None:
             continue
         parent = _git_first_parent(repo, commit)
         if parent is None:
+            increased = True
+        else:
+            previous = _axiom_encode_versions_at_ref(repo, parent)
+            increased = _axiom_encode_version_increased(current, previous)
+        if not increased:
+            continue
+        if fallback_commit is None:
+            fallback_commit = commit
+        if current.get("pyproject") == head_version:
             return commit
-        previous = _axiom_encode_versions_at_ref(repo, parent)
-        if _axiom_encode_version_increased(current, previous):
-            return commit
-    return None
+    return fallback_commit
 
 
 def _axiom_encode_version_increased(
@@ -27588,19 +27599,89 @@ _PROOF_EXCERPT_TOKEN_STOPWORDS = frozenset(
     }
 )
 _SOURCE_PARAGRAPH_MARKER_PATTERN = re.compile(
-    r"^(?:(?:\((?:\d+|[A-Za-z]|[ivxlcdmIVXLCDM]{2,6})\))+|"
-    r"(?:\d+(?:\.\d+){2,}\.?|\d{1,3}\.|[A-Za-z]\.))\s+(?P<body>.*)"
+    r"^(?:(?:\((?:\d+|[A-Za-z]{1,2}|[ivxlcdmIVXLCDM]{2,6})\))+|"
+    r"(?:\d+(?:\.\d+){2,}(?:\([A-Za-z0-9]+\))*\.?|"
+    r"(?:\d{1,3}[.]|\d{1,6}[)])|"
+    r"(?:[A-Za-z]{1,2}|[ivxlcdmIVXLCDM]{2,6})[.)]|"
+    r"\u00a7+\s*\d+(?:\.\d+)*(?:\([A-Za-z0-9]+\))*|"
+    r"[-*]|\u2022))\s+(?P<body>.*)"
+)
+_SOURCE_BARE_PARAGRAPH_MARKER_PATTERN = re.compile(
+    r"^(?:(?:\((?:\d+|[A-Za-z]{1,2}|[ivxlcdmIVXLCDM]{2,6})\))+|"
+    r"(?:\d+(?:\.\d+)+(?:\([A-Za-z0-9]+\))*\.?|"
+    r"(?:\d{1,3}[.]|\d{1,6}[)])|"
+    r"(?:[A-Za-z]{1,2}|[ivxlcdmIVXLCDM]{2,6})[.)]|"
+    r"\u00a7+\s*\d+(?:\.\d+)*(?:\([A-Za-z0-9]+\))*|[-*]|\u2022))$"
+)
+_SOURCE_BARE_DECIMAL_QUANTITY_PATTERN = re.compile(r"^\d+\.\d+$")
+_SOURCE_LEADING_ABBREVIATION_PATTERN = re.compile(
+    r"^(?:(?i:No|Nos|Mr|Mrs|Ms|Dr|Pt|Pts|Ch|Fig|Reg|Art|St|Ft|Mt|Rt|Id|Ex)\."
+    r"|v\.)\s"
+)
+_SOURCE_TWO_LEVEL_PARAGRAPH_MARKER_PATTERN = re.compile(
+    r"^\d+\.\d+(?:\([A-Za-z0-9]+\))*\.?\s+(?P<body>.+)"
+)
+_SOURCE_QUANTITY_BODY_PATTERN = re.compile(
+    r"^(?:%|percent(?:age)?\b|basis points?\b|fte\b|seconds?\b|minutes?\b|"
+    r"hours?\b|days?\b|weeks?\b|months?\b|years?\b|grams?\b|kilograms?\b|"
+    r"milligrams?\b|pounds?\b|ounces?\b|tons?\b|meters?\b|kilometers?\b|"
+    r"feet\b|foot\b|inches?\b|miles?\b|acres?\b|gallons?\b|liters?\b|"
+    r"litres?\b|watts?\b|kilowatts?\b|bytes?\b|dollars?\b|cents?\b|"
+    r"times?\b|units?\b|square (?:feet|foot|inches|meters|kilometers)\b|"
+    r"full-time equivalents?\b|"
+    r"degrees? (?:[Cc]elsius|[Ff]ahrenheit)\b|million\b|billion\b|"
+    r"federal poverty\b|"
+    r"poverty (?:level|guideline)s?\b|FTE\b|USD\b|CAD\b|EUR\b|GBP\b|KG\b|"
+    r"KM\b|LB\b|OZ\b|W\b|KW\b|KWH\b|MB\b|GB\b|TB\b|kg\b|km\b|lb\b|"
+    r"oz\b|w\b|kw\b|kwh\b|mb\b|gb\b|tb\b|kW\b|kWh\b|mL\b|dB\b|"
+    r"\u00b0[CF]\b)"
+)
+_SOURCE_QUANTITY_LEAD_IN_PATTERN = re.compile(
+    r"\b(?:at least|at most|no more than|not less than|not more than|be|is|are|"
+    r"was|were|equals?|equal to|exactly|set at|fixed at|totals?|uses?|using|"
+    r"used|exceeds?|receives?|received|employs?|employed|contains?|contained|"
+    r"requires?|required|"
+    r"exceed|of|at|to|through|than|by|from|between|approximately|about)\s*$",
+    flags=re.IGNORECASE,
 )
 _SOURCE_CROSS_REFERENCE_LEAD_IN_PATTERN = re.compile(
     r"\b(?:paragraph|subparagraph|section|subsection|clause|item|"
-    r"described in|specified in)\s*$",
+    r"described (?:in|under)|specified in)\s*$",
     flags=re.IGNORECASE,
 )
 _SOURCE_CROSS_REFERENCE_BODY_PATTERN = re.compile(
-    r"^of\s+(?:this|the)\b",
+    r"^of\s+(?:this|the)\s+(?:section|paragraph|subparagraph|subsection|"
+    r"clause|item|part|subpart|chapter|title|act|code|regulation|rule|"
+    r"state plan|plan|program|agreement|waiver)\b",
     flags=re.IGNORECASE,
 )
-_SOURCE_SENTENCE_BOUNDARY_PATTERN = re.compile(r"[.!?](?=\s+[A-Z0-9(])")
+_SOURCE_NAMED_CROSS_REFERENCE_BODY_PATTERN = re.compile(
+    r"^of\s+(?:the\s+(?:[A-Z][A-Za-z0-9'/-]*\s+){1,8}"
+    r"(?:Act|Code|Constitution|Statute|Regulations?)|"
+    r"(?:title|chapter|part|subpart)\s+[A-Z0-9IVXLCDM-]+)\b",
+    flags=re.IGNORECASE,
+)
+_SOURCE_MODIFIED_PROGRAM_CROSS_REFERENCE_BODY_PATTERN = re.compile(
+    r"^of\s+(?:this|the)\s+(?:[A-Za-z][A-Za-z0-9'/-]*\s+){0,6}"
+    r"(?:plan|program|agreement|waiver)\b",
+    flags=re.IGNORECASE,
+)
+_SOURCE_CLOSING_PUNCTUATION = r"""["')\]\u2019\u201d]"""
+_SOURCE_TRAILING_SENTENCE_MARK = (
+    rf"(?:{_SOURCE_CLOSING_PUNCTUATION}+|\[[^\]\r\n]{{1,20}}\]|"
+    r"\((?!\s*(?:\d+|[A-Za-z]{1,2}|[ivxlcdmIVXLCDM]{2,6})\s*\))"
+    r"[^()\r\n]{1,20}\))"
+)
+_SOURCE_TERMINAL_PUNCTUATION_PATTERN = re.compile(
+    rf"[.;:!?](?:\s*{_SOURCE_TRAILING_SENTENCE_MARK})*\s*$"
+)
+_SOURCE_SENTENCE_END_PATTERN = re.compile(
+    rf"[.!?](?:\s*{_SOURCE_TRAILING_SENTENCE_MARK})*\s*$"
+)
+_SOURCE_SENTENCE_BOUNDARY_PATTERN = re.compile(
+    rf"""[.!?](?:\s*{_SOURCE_TRAILING_SENTENCE_MARK})*"""
+    r"""(?=\s+(?:[A-Z0-9(\[]|["'\u2018\u201c]))"""
+)
 _SOURCE_ABBREVIATION_PATTERN = re.compile(
     r"\b(?:U\.S\.C|C\.F\.R|U\.S|e\.g|i\.e|No|Nos|Sec|Secs|Pt|Pts|"
     r"Para|Paras|Subsec|Subsecs|Ch|Fig|Mr|Mrs|Ms|Dr|Pub|L|Rev|Proc|"
@@ -27610,6 +27691,347 @@ _SOURCE_ABBREVIATION_PATTERN = re.compile(
 _SOURCE_TABLE_ROW_PATTERN = re.compile(
     r"^(?:\$|[-+]?\d[\d,.]*\s+\$\s*\d|.*(?:\t|\s{2,}|\|))"
 )
+_SOURCE_TABULAR_AMOUNT_ROW_PATTERN = re.compile(r"^[-+]?\d[\d,.]*\s+\$\s*\d")
+_SOURCE_STANDALONE_HEADING_PATTERN = re.compile(r"^[A-Z][A-Z0-9 &/',()\-]{2,}:?$")
+_SOURCE_STRUCTURAL_HEADING_PATTERN = re.compile(
+    r"^(?:(?:Part|Subpart|Chapter|Title)\s+[A-Z0-9IVXLCDM-]+"
+    r"\s*[\u2013\u2014-]\s*[A-Z]\S*(?:\s+.*)?|"
+    r"SECTION\s+\d+(?:\.\d+)*(?:\([A-Za-z0-9]+\))*"
+    r"\s*[\u2013\u2014-]\s*[A-Z]\S*(?:\s+.*)?|"
+    r"Sec\.\s+\d+(?:\.\d+)*(?:\([A-Za-z0-9]+\))*"
+    r"\s+[A-Z]\S*(?:\s+.*)?)$"
+)
+_SOURCE_TITLE_CASE_HEADING_PATTERN = re.compile(
+    r"^[A-Z][A-Za-z0-9'/-]*(?:\s+(?:[A-Z][A-Za-z0-9'/-]*|of|and|or|the|for|"
+    r"to|in|on|under)){0,9}:?$"
+)
+_SOURCE_CURRENCY_LEAD_IN_PATTERN = re.compile(
+    r"\b(?:pay|pays|paid|paying|set at|fixed at|is|are|be|equals?|totals?|"
+    r"limited to|exceeds?|not exceed|no more than|not more than|up to)\s*$",
+    flags=re.IGNORECASE,
+)
+_SOURCE_LEGAL_CITATION_ABBREVIATION_PATTERN = re.compile(
+    r"\b(?:U\.S\.C|C\.F\.R)\.(?:\s*\u00a7+)?$",
+    flags=re.IGNORECASE,
+)
+_SOURCE_LEGAL_CITATION_CONTINUATION_PATTERN = re.compile(
+    r"^(?:\u00a7+\s*)?(?:(?:pt|part)\.?\s+\d+(?:\.\d+)*|"
+    r"(?:ch|chapter)\.?\s+[IVXLCDM0-9]+|subpt\.?\s+[A-Z0-9]+|"
+    r"no\.?\s+\d+|\d+(?:\.\d+)*(?:\([A-Za-z0-9]+\))*)"
+    r"(?=\s|[,;)]|$)",
+    flags=re.IGNORECASE,
+)
+_SOURCE_TITLE_TERM_LEAD_IN_PATTERN = re.compile(
+    r"\b(?:a|an|the|of|in|on|at|to|for|from|by|with|under|as|use|using|"
+    r"including|called|known as|defined as|based on|"
+    r"covers?|"
+    r"(?:shall|must|may|will|to)\s+(?:use|apply|include))\s*$",
+    flags=re.IGNORECASE,
+)
+_SOURCE_TITLE_TERM_FOLLOWING_CONTINUATION_PATTERN = re.compile(
+    r"^(?:to|for|of|under|when|in|on|by|with|as)\b",
+    flags=re.IGNORECASE,
+)
+_SOURCE_PRIOR_CONDITION_PATTERN = re.compile(
+    r"\b(?:provided\s+further\s+that|"
+    r"provided(?:\s*,?\s*however\s*,?)?(?:\s+that|\s+(?=(?:the|a|an|"
+    r"such|each|every|any|no|household|individual|applicant|person|recipient|"
+    r"income|eligibility)\b))|in the event that|on (?:the )?condition that|"
+    r"conditioned on|conditional upon|contingent upon|in case|except that|"
+    r"except as (?:otherwise\s+)?provided|"
+    r"except as (?:required|permitted|authorized|specified) by|"
+    r"notwithstanding|to the extent that|during any period in which|"
+    r"after [^,.;:\r\n]{1,80}\b(?:determines?|finds?|establishes?|verifies?)|"
+    r"upon (?:a\s+)?(?:finding|determination) that|"
+    r"as long as|so long as|only if|"
+    r"subject(?:\s*,\s*however\s*,)?\s+to|unless|except when|whenever|"
+    r"where|if|when)\b",
+    flags=re.IGNORECASE,
+)
+
+
+def _is_wrapped_currency_continuation(previous_line: str, current_line: str) -> bool:
+    previous = re.sub(r"\s+", " ", previous_line).strip()
+    current = re.sub(r"\s+", " ", current_line).strip()
+    return (
+        _SOURCE_CURRENCY_LEAD_IN_PATTERN.search(previous) is not None
+        and re.match(r"^\$\s*\d", current) is not None
+    )
+
+
+def _is_standalone_source_heading(
+    value: str,
+    *,
+    previous_line: str = "",
+    following_line: str = "",
+) -> bool:
+    heading = re.sub(r"\s+", " ", value).strip()
+    if _SOURCE_STRUCTURAL_HEADING_PATTERN.match(heading) is not None:
+        return True
+    is_heading_form = (
+        _SOURCE_STANDALONE_HEADING_PATTERN.match(heading) is not None
+        or _SOURCE_TITLE_CASE_HEADING_PATTERN.match(heading) is not None
+    )
+    if not is_heading_form:
+        return False
+    if heading.endswith(":"):
+        return True
+
+    previous = re.sub(r"\s+", " ", previous_line).strip()
+    following = re.sub(r"\s+", " ", following_line).strip()
+    return not (
+        previous
+        and _SOURCE_TERMINAL_PUNCTUATION_PATTERN.search(previous) is None
+        and (
+            _SOURCE_TITLE_TERM_LEAD_IN_PATTERN.search(previous) is not None
+            or (following and re.match(r"^[a-z]", following) is not None)
+            or _SOURCE_TITLE_TERM_FOLLOWING_CONTINUATION_PATTERN.match(following)
+            is not None
+        )
+    )
+
+
+def _is_wrapped_legal_citation_continuation(
+    previous_line: str,
+    current_line: str,
+) -> bool:
+    previous = re.sub(r"\s+", " ", previous_line).strip()
+    current = re.sub(r"\s+", " ", current_line).strip()
+    return (
+        _SOURCE_LEGAL_CITATION_ABBREVIATION_PATTERN.search(previous) is not None
+        and _SOURCE_LEGAL_CITATION_CONTINUATION_PATTERN.match(current) is not None
+    )
+
+
+def _has_source_sentence_boundary(value: str) -> bool:
+    for match in _SOURCE_SENTENCE_BOUNDARY_PATTERN.finditer(value):
+        prefix = value[max(0, match.end() - 48) : match.end()].rstrip()
+        continuation = value[match.end() :].lstrip()
+        if value[match.start()] == "." and _is_source_abbreviation_continuation(
+            prefix,
+            continuation,
+        ):
+            continue
+        return True
+    return False
+
+
+def _is_source_abbreviation_continuation(prefix: str, continuation: str) -> bool:
+    if _SOURCE_LEGAL_CITATION_ABBREVIATION_PATTERN.search(prefix):
+        return (
+            _SOURCE_LEGAL_CITATION_CONTINUATION_PATTERN.match(continuation) is not None
+        )
+    abbreviation = _SOURCE_ABBREVIATION_PATTERN.search(prefix)
+    if abbreviation is None:
+        return False
+    token = abbreviation.group().casefold()
+    if token in {"e.g.", "i.e.", "mr.", "mrs.", "ms.", "dr.", "v."}:
+        return True
+    if token == "u.s.":
+        return (
+            re.match(
+                r"^(?:Department|Code|Constitution|Government|Supreme|District|"
+                r"Treasury|Postal|Virgin Islands|Armed Forces|Attorney(?: General)?|"
+                r"Secretary|Bureau|Congress|mail|citizens?|nationals?|"
+                r"territor(?:y|ies)|persons?|dollars?)\b",
+                continuation,
+                flags=re.IGNORECASE,
+            )
+            is not None
+        )
+    if token == "pub.":
+        return re.match(r"^L\.\s", continuation, flags=re.IGNORECASE) is not None
+    if token == "rev.":
+        return re.match(r"^Proc\.\s", continuation, flags=re.IGNORECASE) is not None
+    if token == "l.":
+        return (
+            re.search(r"\bPub\.\s+L\.$", prefix, flags=re.IGNORECASE) is not None
+            or re.match(r"^(?:No\.\s*)?\d", continuation, flags=re.IGNORECASE)
+            is not None
+        )
+    return (
+        re.match(r"^(?:No\.\s*)?\d", continuation, flags=re.IGNORECASE) is not None
+        or re.match(r"^(?:No\.\s*)?[IVXLCDM]+\b", continuation) is not None
+    )
+
+
+def _is_wrapped_source_cross_reference(
+    previous_line: str,
+    marker_body: str,
+    current_line: str = "",
+) -> bool:
+    previous = re.sub(r"\s+", " ", previous_line).strip()
+    previous_is_open = _SOURCE_TERMINAL_PUNCTUATION_PATTERN.search(previous) is None
+    return previous_is_open and (
+        _SOURCE_CROSS_REFERENCE_LEAD_IN_PATTERN.search(previous) is not None
+        or _SOURCE_CROSS_REFERENCE_BODY_PATTERN.match(marker_body) is not None
+        or _SOURCE_NAMED_CROSS_REFERENCE_BODY_PATTERN.match(marker_body) is not None
+        or _SOURCE_MODIFIED_PROGRAM_CROSS_REFERENCE_BODY_PATTERN.match(marker_body)
+        is not None
+        or _is_explicit_section_cross_reference(previous, current_line)
+    )
+
+
+def _is_explicit_section_cross_reference(previous_line: str, current_line: str) -> bool:
+    previous = re.sub(r"\s+", " ", previous_line).strip()
+    current = re.sub(r"\s+", " ", current_line).strip()
+    return current.startswith("\N{SECTION SIGN}") and (
+        re.search(
+            r"\b(?:under|pursuant to|required by|set forth in)\s*$",
+            previous,
+            flags=re.IGNORECASE,
+        )
+        is not None
+    )
+
+
+def _is_wrapped_bare_source_cross_reference(
+    previous_line: str,
+    following_line: str,
+    current_line: str = "",
+) -> bool:
+    previous = re.sub(r"\s+", " ", previous_line).strip()
+    following = re.sub(r"\s+", " ", following_line).strip()
+    current = re.sub(r"\s+", " ", current_line).strip()
+    previous_is_open = _SOURCE_TERMINAL_PUNCTUATION_PATTERN.search(previous) is None
+    return previous_is_open and (
+        _SOURCE_CROSS_REFERENCE_LEAD_IN_PATTERN.search(previous) is not None
+        or _SOURCE_CROSS_REFERENCE_BODY_PATTERN.match(following) is not None
+        or _SOURCE_NAMED_CROSS_REFERENCE_BODY_PATTERN.match(following) is not None
+        or _SOURCE_MODIFIED_PROGRAM_CROSS_REFERENCE_BODY_PATTERN.match(following)
+        is not None
+        or _is_explicit_section_cross_reference(previous, current)
+    )
+
+
+def _source_paragraph_marker_match(value: str) -> re.Match[str] | None:
+    if _SOURCE_LEADING_ABBREVIATION_PATTERN.match(value):
+        return None
+    return _SOURCE_PARAGRAPH_MARKER_PATTERN.match(
+        value
+    ) or _SOURCE_TWO_LEVEL_PARAGRAPH_MARKER_PATTERN.match(value)
+
+
+def _source_line_paragraph_marker_match(
+    value: str,
+    *,
+    previous_line: str,
+) -> re.Match[str] | None:
+    if _is_wrapped_legal_citation_continuation(
+        previous_line,
+        value,
+    ) or _is_source_abbreviation_continuation(previous_line, value):
+        return None
+    if _SOURCE_BARE_PARAGRAPH_MARKER_PATTERN.fullmatch(value):
+        return None
+    primary_match = _SOURCE_PARAGRAPH_MARKER_PATTERN.match(value)
+    if primary_match is not None:
+        if _SOURCE_LEADING_ABBREVIATION_PATTERN.match(value):
+            return None
+        return primary_match
+    two_level_match = _SOURCE_TWO_LEVEL_PARAGRAPH_MARKER_PATTERN.match(value)
+    if two_level_match is None:
+        return None
+    if _is_decimal_quantity_continuation(
+        previous_line,
+        two_level_match.group("body"),
+    ):
+        return None
+    return two_level_match
+
+
+def _is_decimal_quantity_continuation(
+    previous_line: str,
+    quantity_body: str,
+) -> bool:
+    previous = re.sub(r"\s+", " ", previous_line).strip()
+    body = re.sub(r"\s+", " ", quantity_body).strip()
+    lead_in = previous[:-1].rstrip() if previous.endswith(":") else previous
+    return (
+        bool(previous)
+        and (
+            _SOURCE_TERMINAL_PUNCTUATION_PATTERN.search(previous) is None
+            or previous.endswith(":")
+        )
+        and _SOURCE_QUANTITY_BODY_PATTERN.match(body) is not None
+        and _SOURCE_QUANTITY_LEAD_IN_PATTERN.search(lead_in) is not None
+    )
+
+
+def _is_bare_decimal_continuation(
+    previous_line: str,
+    following_line: str,
+) -> bool:
+    return _is_decimal_quantity_continuation(previous_line, following_line)
+
+
+def _source_context_before_match(source: str, position: int) -> str:
+    """Return the current structural paragraph prefix before a direct match."""
+    current_line_end = source.find("\n", position)
+    if current_line_end < 0:
+        current_line_end = len(source)
+    match_line_suffix = source[position:current_line_end]
+    context_start = 0
+    for blank_boundary in re.finditer(r"\r?\n[ \t]*\r?\n", source[:position]):
+        context_start = blank_boundary.end()
+
+    context_lines = source[context_start:position].splitlines(keepends=True)
+    previous_line = ""
+    cursor = context_start
+    for index, line in enumerate(context_lines):
+        collapsed = re.sub(r"\s+", " ", line).strip()
+        if collapsed:
+            following_line = (
+                context_lines[index + 1]
+                if index + 1 < len(context_lines)
+                else match_line_suffix
+            )
+            marker_match = _source_line_paragraph_marker_match(
+                collapsed,
+                previous_line=previous_line,
+            )
+            bare_marker = _SOURCE_BARE_PARAGRAPH_MARKER_PATTERN.match(collapsed)
+            bare_decimal_is_quantity = _SOURCE_BARE_DECIMAL_QUANTITY_PATTERN.match(
+                collapsed
+            ) is not None and _is_bare_decimal_continuation(
+                previous_line, following_line
+            )
+            if (
+                (
+                    marker_match is not None
+                    and not _is_wrapped_source_cross_reference(
+                        previous_line,
+                        marker_match.group("body"),
+                        collapsed,
+                    )
+                )
+                or (
+                    bare_marker is not None
+                    and not bare_decimal_is_quantity
+                    and not _is_wrapped_legal_citation_continuation(
+                        previous_line,
+                        collapsed,
+                    )
+                    and not _is_source_abbreviation_continuation(
+                        previous_line,
+                        collapsed,
+                    )
+                    and not _is_wrapped_bare_source_cross_reference(
+                        previous_line,
+                        following_line,
+                        collapsed,
+                    )
+                )
+                or _is_standalone_source_heading(
+                    collapsed,
+                    previous_line=previous_line,
+                    following_line=following_line,
+                )
+            ):
+                context_start = cursor
+            previous_line = line
+        cursor += len(line)
+    return source[context_start:position]
 
 
 class _SourceExcerptCandidate(NamedTuple):
@@ -27737,13 +28159,25 @@ def _closest_exact_source_excerpt(*, source_text: str, excerpt: str) -> str | No
             and candidate.end >= direct_match.end()
         ]
         if not enclosing:
-            return None
+            return _safe_wrapped_direct_source_match(source, direct_match)
         table_rows = [
             candidate for candidate in enclosing if candidate.kind == "table_row"
         ]
         if table_rows:
             return min(table_rows, key=lambda candidate: len(candidate.text)).text
-        return _governing_source_excerpt_candidate(enclosing, candidates)
+        governing = _governing_source_excerpt_candidate(enclosing, candidates)
+        if governing is not None:
+            return governing
+        if any(
+            candidate.marked_parent is not None
+            and _SOURCE_PRIOR_CONDITION_PATTERN.search(
+                source[candidate.marked_parent[0] : direct_match.start()]
+            )
+            is not None
+            for candidate in enclosing
+        ):
+            return None
+        return _safe_wrapped_direct_source_match(source, direct_match)
 
     query_tokens = _proof_excerpt_match_tokens(query)
     query_numbers = set(extract_numbers_from_text(query))
@@ -27781,6 +28215,209 @@ def _closest_exact_source_excerpt(*, source_text: str, excerpt: str) -> str | No
     if selected.kind == "table_row":
         return selected.text
     return _governing_source_excerpt_candidate([selected], candidates)
+
+
+def _safe_wrapped_direct_source_match(
+    source: str,
+    direct_match: re.Match[str],
+) -> str | None:
+    raw_match = source[direct_match.start() : direct_match.end()]
+    raw_lines = raw_match.splitlines(keepends=True)
+    if len(raw_lines) < 2 or len(re.sub(r"\s+", " ", raw_match)) > 500:
+        return None
+
+    source_line_start = direct_match.start()
+    first_complete_line_start = source.rfind("\n", 0, direct_match.start()) + 1
+    first_complete_line_end = source.find("\n", direct_match.start())
+    if first_complete_line_end < 0:
+        first_complete_line_end = len(source)
+    first_complete_line = source[
+        first_complete_line_start:first_complete_line_end
+    ].strip()
+    first_line_prefix = source[first_complete_line_start : direct_match.start()]
+    if (
+        _SOURCE_PRIOR_CONDITION_PATTERN.search(
+            _source_context_before_match(source, direct_match.start())
+        )
+        is not None
+    ):
+        return None
+    preceding_line_end = max(0, first_complete_line_start - 1)
+    preceding_line_start = source.rfind("\n", 0, preceding_line_end) + 1
+    preceding_line = source[preceding_line_start:preceding_line_end]
+    first_following_line = re.sub(r"\s+", " ", raw_lines[1]).strip()
+    match_starts_at_line_content = not first_line_prefix.strip()
+    continued_bare_decimal = _SOURCE_BARE_DECIMAL_QUANTITY_PATTERN.match(
+        first_complete_line
+    ) is not None and _is_bare_decimal_continuation(
+        preceding_line, first_following_line
+    )
+    if _is_standalone_source_heading(
+        first_complete_line,
+        previous_line=preceding_line,
+        following_line=first_following_line,
+    ):
+        return None
+    if re.search(
+        r"(?:\t|\|[ \t]*|[^\s.!?][ \t]{2,})$",
+        first_line_prefix,
+    ):
+        return None
+    if match_starts_at_line_content:
+        first_marker_match = _source_line_paragraph_marker_match(
+            first_complete_line,
+            previous_line=preceding_line,
+        )
+        if first_marker_match is not None and not _is_wrapped_source_cross_reference(
+            preceding_line,
+            first_marker_match.group("body"),
+            first_complete_line,
+        ):
+            return None
+        if (
+            first_marker_match is None
+            and _SOURCE_BARE_PARAGRAPH_MARKER_PATTERN.match(first_complete_line)
+            is not None
+            and not continued_bare_decimal
+            and not _is_wrapped_legal_citation_continuation(
+                preceding_line,
+                first_complete_line,
+            )
+            and not _is_source_abbreviation_continuation(
+                preceding_line,
+                first_complete_line,
+            )
+            and not _is_wrapped_bare_source_cross_reference(
+                preceding_line,
+                first_following_line,
+                first_complete_line,
+            )
+        ):
+            return None
+        if (
+            _SOURCE_TABULAR_AMOUNT_ROW_PATTERN.match(first_complete_line) is not None
+            or re.match(r"^\$\s*\d", first_complete_line) is not None
+        ):
+            return None
+        if _SOURCE_TABLE_ROW_PATTERN.match(first_complete_line) and (
+            _SOURCE_TABLE_ROW_PATTERN.match(preceding_line.strip())
+            or _SOURCE_TABLE_ROW_PATTERN.match(first_following_line)
+        ):
+            return None
+    continued_wrapped_currency = False
+    for index in range(1, len(raw_lines)):
+        source_line_start += len(raw_lines[index - 1])
+        raw_line = raw_lines[index].rstrip("\r\n")
+        if not raw_line.strip():
+            return None
+        source_line_end = source.find("\n", source_line_start)
+        if source_line_end < 0:
+            source_line_end = len(source)
+        complete_line = source[source_line_start:source_line_end].strip()
+        previous_line = re.sub(r"\s+", " ", raw_lines[index - 1]).strip()
+        if _has_source_sentence_boundary(previous_line):
+            return None
+        if _SOURCE_SENTENCE_END_PATTERN.search(previous_line) is not None and not (
+            _is_source_abbreviation_continuation(previous_line, complete_line)
+        ):
+            return None
+        previous_line_start = source.rfind("\n", 0, max(0, source_line_start - 1)) + 1
+        previous_complete_line = source[
+            previous_line_start : max(previous_line_start, source_line_start - 1)
+        ].strip()
+        following_line_start = source_line_end + 1
+        following_line_end = source.find("\n", following_line_start)
+        if following_line_end < 0:
+            following_line_end = len(source)
+        following_line = source[following_line_start:following_line_end]
+        previous_is_table_row = _SOURCE_TABLE_ROW_PATTERN.match(previous_complete_line)
+        previous_match_fragment_is_table_row = _SOURCE_TABLE_ROW_PATTERN.match(
+            raw_lines[index - 1].strip()
+        )
+        current_is_table_row = _SOURCE_TABLE_ROW_PATTERN.match(complete_line)
+        following_is_table_row = _SOURCE_TABLE_ROW_PATTERN.match(following_line.strip())
+        is_wrapped_currency = (
+            _is_wrapped_currency_continuation(
+                previous_complete_line,
+                complete_line,
+            )
+            and following_is_table_row is None
+        )
+        current_is_dollar_amount = re.match(r"^\$\s*\d", complete_line) is not None
+        if current_is_dollar_amount and (
+            not is_wrapped_currency or continued_wrapped_currency
+        ):
+            return None
+        if _SOURCE_TABULAR_AMOUNT_ROW_PATTERN.match(complete_line) is not None:
+            return None
+        if _is_standalone_source_heading(
+            complete_line,
+            previous_line=previous_complete_line,
+            following_line=following_line,
+        ) and not (
+            continued_bare_decimal
+            and _SOURCE_QUANTITY_BODY_PATTERN.match(complete_line) is not None
+        ):
+            return None
+        if (
+            current_is_table_row
+            and not is_wrapped_currency
+            and (previous_is_table_row or following_is_table_row)
+        ):
+            return None
+        if (
+            previous_match_fragment_is_table_row
+            and current_is_table_row is None
+            and not (is_wrapped_currency or continued_wrapped_currency)
+        ):
+            return None
+        previous_is_amount_row = (
+            _SOURCE_TABULAR_AMOUNT_ROW_PATTERN.match(previous_complete_line) is not None
+            or re.match(r"^\$\s*\d", previous_complete_line) is not None
+        )
+        if previous_is_amount_row and not (
+            is_wrapped_currency or continued_wrapped_currency
+        ):
+            return None
+        marker_match = _source_line_paragraph_marker_match(
+            complete_line,
+            previous_line=previous_complete_line,
+        )
+        if marker_match is not None and not _is_wrapped_source_cross_reference(
+            previous_complete_line,
+            marker_match.group("body"),
+            complete_line,
+        ):
+            return None
+        if (
+            marker_match is None
+            and _SOURCE_BARE_PARAGRAPH_MARKER_PATTERN.match(complete_line) is not None
+        ):
+            if _is_wrapped_legal_citation_continuation(
+                previous_complete_line,
+                complete_line,
+            ) or _is_source_abbreviation_continuation(
+                previous_complete_line,
+                complete_line,
+            ):
+                continue
+            if _SOURCE_BARE_DECIMAL_QUANTITY_PATTERN.match(
+                complete_line
+            ) is not None and _is_bare_decimal_continuation(
+                previous_complete_line,
+                following_line,
+            ):
+                continued_bare_decimal = True
+                continue
+            if not _is_wrapped_bare_source_cross_reference(
+                previous_complete_line,
+                following_line,
+                complete_line,
+            ):
+                return None
+        continued_bare_decimal = False
+        continued_wrapped_currency = continued_wrapped_currency or is_wrapped_currency
+    return raw_match
 
 
 def _governing_source_excerpt_candidate(
@@ -27851,8 +28488,8 @@ def _exact_source_excerpt_candidate_spans(
         paragraph_end = paragraph_lines[-1][2]
         paragraph = source_text[paragraph_start:paragraph_end]
         collapsed_paragraph = re.sub(r"\s+", " ", paragraph).strip()
-        is_marked_paragraph = bool(
-            _SOURCE_PARAGRAPH_MARKER_PATTERN.match(collapsed_paragraph)
+        is_marked_paragraph = (
+            _source_paragraph_marker_match(collapsed_paragraph) is not None
         )
         trimmed_start = paragraph_start
         trimmed_end = paragraph_end
@@ -27874,7 +28511,11 @@ def _exact_source_excerpt_candidate_spans(
             prefix = paragraph[
                 max(sentence_start, sentence_end - 48) : sentence_end
             ].rstrip()
-            if match.group() == "." and _SOURCE_ABBREVIATION_PATTERN.search(prefix):
+            continuation = paragraph[sentence_end:].lstrip()
+            if paragraph[match.start()] == "." and _is_source_abbreviation_continuation(
+                prefix,
+                continuation,
+            ):
                 continue
             add_candidate(
                 paragraph_start + sentence_start,
@@ -27890,11 +28531,23 @@ def _exact_source_excerpt_candidate_spans(
             marked_parent=marked_parent,
         )
 
-        table_rows = [
-            (line, start, end)
-            for line, start, end in paragraph_lines
-            if line.strip() and _SOURCE_TABLE_ROW_PATTERN.match(line.strip())
-        ]
+        table_rows = []
+        for index, (line, start, end) in enumerate(paragraph_lines):
+            previous_line = paragraph_lines[index - 1][0] if index else ""
+            next_line = (
+                paragraph_lines[index + 1][0]
+                if index + 1 < len(paragraph_lines)
+                else ""
+            )
+            if (
+                line.strip()
+                and _SOURCE_TABLE_ROW_PATTERN.match(line.strip())
+                and not (
+                    _is_wrapped_currency_continuation(previous_line, line)
+                    and _SOURCE_TABLE_ROW_PATTERN.match(next_line.strip()) is None
+                )
+            ):
+                table_rows.append((line, start, end))
         if len(table_rows) > 1:
             for _line, start, end in table_rows:
                 add_candidate(
@@ -27903,28 +28556,84 @@ def _exact_source_excerpt_candidate_spans(
                     kind="table_row",
                     marked_parent=marked_parent,
                 )
+        elif table_rows and _SOURCE_TABULAR_AMOUNT_ROW_PATTERN.match(
+            table_rows[0][0].strip()
+        ):
+            _line, start, end = table_rows[0]
+            add_candidate(
+                start,
+                end,
+                kind="table_row",
+                marked_parent=marked_parent,
+            )
         paragraph_lines.clear()
 
+    source_lines: list[tuple[str, int, int]] = []
     offset = 0
     for line in source_text.splitlines(keepends=True):
         line_start = offset
         line_end = offset + len(line)
         offset = line_end
+        source_lines.append((line, line_start, line_end))
+
+    for index, (line, line_start, line_end) in enumerate(source_lines):
         collapsed = re.sub(r"\s+", " ", line).strip()
         if not collapsed:
             flush_paragraph()
             continue
-        marker_match = _SOURCE_PARAGRAPH_MARKER_PATTERN.match(collapsed)
-        if paragraph_lines and marker_match is not None:
-            previous_line = re.sub(r"\s+", " ", paragraph_lines[-1][0]).strip()
-            body = marker_match.group("body")
-            previous_is_open = re.search(r"[.;:!?]\s*$", previous_line) is None
-            is_wrapped_cross_reference = previous_is_open and (
-                _SOURCE_CROSS_REFERENCE_LEAD_IN_PATTERN.search(previous_line)
-                is not None
-                or _SOURCE_CROSS_REFERENCE_BODY_PATTERN.match(body) is not None
+        previous_source_line = source_lines[index - 1][0] if index else ""
+        following_line = (
+            source_lines[index + 1][0] if index + 1 < len(source_lines) else ""
+        )
+        is_wrapped_quantity_unit = (
+            len(paragraph_lines) >= 2
+            and _SOURCE_BARE_DECIMAL_QUANTITY_PATTERN.match(
+                re.sub(r"\s+", " ", paragraph_lines[-1][0]).strip()
             )
-            if not is_wrapped_cross_reference:
+            is not None
+            and _is_decimal_quantity_continuation(
+                paragraph_lines[-2][0],
+                collapsed,
+            )
+        )
+        if (
+            _is_standalone_source_heading(
+                collapsed,
+                previous_line=previous_source_line,
+                following_line=following_line,
+            )
+            and not is_wrapped_quantity_unit
+        ):
+            flush_paragraph()
+            paragraph_lines.append((line, line_start, line_end))
+            flush_paragraph()
+            continue
+        previous_line = paragraph_lines[-1][0] if paragraph_lines else ""
+        marker_match = _source_line_paragraph_marker_match(
+            collapsed,
+            previous_line=previous_line,
+        )
+        bare_marker_match = _SOURCE_BARE_PARAGRAPH_MARKER_PATTERN.match(collapsed)
+        if bare_marker_match is not None and (
+            _is_wrapped_legal_citation_continuation(previous_line, collapsed)
+            or _is_source_abbreviation_continuation(previous_line, collapsed)
+        ):
+            bare_marker_match = None
+        if (
+            bare_marker_match is not None
+            and _SOURCE_BARE_DECIMAL_QUANTITY_PATTERN.match(collapsed) is not None
+            and _is_bare_decimal_continuation(previous_line, following_line)
+        ):
+            bare_marker_match = None
+        if paragraph_lines and marker_match is not None:
+            if not _is_wrapped_source_cross_reference(
+                paragraph_lines[-1][0], marker_match.group("body"), collapsed
+            ):
+                flush_paragraph()
+        elif paragraph_lines and bare_marker_match is not None:
+            if not _is_wrapped_bare_source_cross_reference(
+                paragraph_lines[-1][0], following_line, collapsed
+            ):
                 flush_paragraph()
         paragraph_lines.append((line, line_start, line_end))
     flush_paragraph()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -80,6 +80,7 @@ from axiom_encode.cli import (
     _insert_false_input_default,
     _install_apply_transaction,
     _install_eval_suite_revalidation_transaction,
+    _latest_axiom_encode_version_commit,
     _load_verified_applied_encoding_manifest_payload,
     _local_factual_input_names_from_rules_content,
     _looks_like_absolute_rulespec_output_target,
@@ -160,6 +161,7 @@ from axiom_encode.cli import (
     _rulespec_file_for_absolute_module_ref,
     _rulespec_module_source_path,
     _rulespec_scalar_matches,
+    _safe_wrapped_direct_source_match,
     _sha256_file,
     _sha256_text,
     _sign_applied_encoding_manifest,
@@ -758,6 +760,51 @@ def test_current_encoder_affecting_changes_are_behind_version_bump():
     provenance = _require_axiom_encode_version_provenance(repo)
 
     assert provenance["version"] == AXIOM_ENCODE_TEST_VERSION
+
+
+def test_latest_encoder_version_commit_matches_merge_checkout_version(tmp_path):
+    repo = tmp_path / "axiom-encode"
+    base_commit = _init_encoder_identity_checkout(repo, version="0.2.1320")
+
+    def bump_version(old: str, new: str) -> None:
+        for relative in (
+            "pyproject.toml",
+            "src/axiom_encode/__init__.py",
+            "uv.lock",
+        ):
+            path = repo / relative
+            path.write_text(path.read_text().replace(old, new))
+
+    _git(repo, "checkout", "-b", "feature", base_commit)
+    bump_version("0.2.1320", "0.2.1322")
+    (repo / "src/axiom_encode/cli.py").write_text(
+        (repo / "src/axiom_encode/cli.py").read_text() + "\n# feature change\n"
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "feature version bump")
+    feature_commit = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    _git(repo, "checkout", "-b", "base-line", base_commit)
+    bump_version("0.2.1320", "0.2.1321")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "base version bump")
+    base_line_commit = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    feature_tree = _git(repo, "rev-parse", f"{feature_commit}^{{tree}}").stdout.strip()
+    merge_commit = _git(
+        repo,
+        "commit-tree",
+        feature_tree,
+        "-p",
+        base_line_commit,
+        "-p",
+        feature_commit,
+        "-m",
+        "synthetic pull request merge",
+    ).stdout.strip()
+    _git(repo, "checkout", "--detach", merge_commit)
+
+    assert _latest_axiom_encode_version_commit(repo) == feature_commit
 
 
 def test_colorado_snap_ecps_uses_absolute_member_relation_only():
@@ -7422,6 +7469,227 @@ agency shall pay $500 per month.
 
 
 @pytest.mark.parametrize(
+    "excerpt",
+    [
+        "The agency shall pay $500 per month.",
+        "The agency shall pay $500",
+    ],
+)
+def test_closest_exact_source_excerpt_rejects_fragment_of_oversized_marked_paragraph(
+    excerpt,
+):
+    source_text = (
+        "(a) This benefit is available only if "
+        + ("household eligibility context remains satisfied and " * 10)
+        + "household income is below the limit. The agency shall\n"
+        + "pay $500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=excerpt,
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_rejects_wrapped_fragment_after_same_line_condition():
+    source_text = (
+        "(a) If household income is below the limit, "
+        + ("all documentation requirements must be satisfied and " * 10)
+        + "the agency shall\npay $500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="the agency shall pay $500 per month.",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_rejects_fragment_after_so_long_as_condition():
+    source_text = (
+        "(a) So long as household income is below the limit, "
+        + ("all documentation requirements must be satisfied and " * 10)
+        + "the agency shall\npay $500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="the agency shall pay $500 per month.",
+    )
+
+    assert repaired is None
+
+
+@pytest.mark.parametrize("condition_lead", ["As long as", "Provided"])
+def test_closest_exact_source_excerpt_rejects_other_legal_condition_leads(
+    condition_lead,
+):
+    source_text = (
+        f"(a) {condition_lead} the household income is below the limit, "
+        + ("all documentation requirements must be satisfied and " * 10)
+        + "the agency shall\npay $500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="the agency shall pay $500 per month.",
+    )
+
+    assert repaired is None
+
+
+@pytest.mark.parametrize(
+    "condition_lead",
+    [
+        "On condition that",
+        "On the condition that",
+        "Conditioned on",
+        "Conditional upon",
+        "Contingent upon",
+        "In case",
+        "Except that",
+    ],
+)
+def test_closest_exact_source_excerpt_rejects_additional_legal_conditions(
+    condition_lead,
+):
+    source_text = (
+        f"(a) {condition_lead} household income is below the limit, "
+        + ("all documentation requirements must be satisfied and " * 10)
+        + "the agency shall\npay $500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="the agency shall pay $500 per month.",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_keeps_condition_across_wrapped_cross_reference():
+    source_text = (
+        "(a) If household income is below the limit, "
+        + ("all documentation requirements remain satisfied and " * 11)
+        + "the authority provided under\n(a)(1)\nof this section the agency shall\n"
+        + "pay $500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="of this section the agency shall pay $500 per month.",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_uses_current_line_provision_boundary():
+    source_text = (
+        "(a) If household income is below the limit, eligibility applies.\n"
+        "(b) "
+        + ("Administrative background and program context " * 14)
+        + "The agency shall\npay $500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="The agency shall pay $500 per month.",
+    )
+
+    assert repaired == "The agency shall\npay $500 per month."
+
+
+def test_closest_exact_source_excerpt_uses_standalone_decimal_provision_boundary():
+    source_text = (
+        "1.1 If household income is below the limit, eligibility applies.\n"
+        "1.2\n"
+        + ("Administrative background and program context " * 14)
+        + "The agency shall\npay $500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="The agency shall pay $500 per month.",
+    )
+
+    assert repaired == "The agency shall\npay $500 per month."
+
+
+def test_closest_exact_source_excerpt_rejects_fragment_after_prior_line_condition():
+    source_text = (
+        "(a) If household income is below the limit,\n"
+        + "all documentation requirements remain satisfied and " * 12
+        + "the agency shall\npay $500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="the agency shall pay $500 per month.",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_rejects_enclosed_fragment_after_condition():
+    source_text = (
+        "(a) "
+        + "Administrative background applies. " * 18
+        + "If household income is below the limit,\n"
+        + "the agency shall\npay $500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="the agency shall pay $500 per month.",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_rejects_fragment_after_when_condition():
+    source_text = (
+        "(a) Eligibility exists when household income is below the limit. "
+        + "Administrative requirements apply. " * 16
+        + "The agency shall\npay $500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="The agency shall pay $500 per month.",
+    )
+
+    assert repaired is None
+
+
+@pytest.mark.parametrize(
+    "condition",
+    [
+        "Where household income is below the limit, ",
+        "Whenever household income is below the limit, ",
+        "In the event that household income is below the limit, ",
+        "Provided, however, that household income is below the limit, ",
+    ],
+)
+def test_closest_exact_source_excerpt_rejects_common_legal_condition(condition):
+    source_text = (
+        "(a) "
+        + condition
+        + "all documentation requirements must be satisfied and " * 12
+        + "the agency shall\npay $500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="the agency shall pay $500 per month.",
+    )
+
+    assert repaired is None
+
+
+@pytest.mark.parametrize(
     ("source_text", "excerpt"),
     [
         (
@@ -7456,6 +7724,204 @@ def test_closest_exact_source_excerpt_keeps_numeric_wrapped_prose_condition(
     assert repaired == source_text.strip()
 
 
+@pytest.mark.parametrize(
+    ("source_text", "excerpt"),
+    [
+        (
+            """(a) If the staffing cap applies, the agency shall not exceed
+1.5 FTE positions when calculating staffing.
+""",
+            "1.5 FTE positions when calculating staffing.",
+        ),
+        (
+            """(a) If the income test applies, the agency shall use
+1.5
+percent of household income when calculating the benefit.
+""",
+            "1.5 percent of household income",
+        ),
+        (
+            """(a) If the staffing cap applies, the agency shall not exceed
+1.5
+FTE
+positions when calculating staffing.
+""",
+            "shall not exceed 1.5 FTE positions",
+        ),
+        (
+            """(a) The applicable rate is
+1.5 percent of household income.
+""",
+            "the applicable rate is 1.5 percent of household income.",
+        ),
+        (
+            """(a) The shipment allowance is
+1.5 kilograms per household.
+""",
+            "the shipment allowance is 1.5 kilograms per household.",
+        ),
+        (
+            """(a) The shipment allowance is
+1.5 kg per household.
+""",
+            "the shipment allowance is 1.5 kg per household.",
+        ),
+        (
+            """(a) The conversion amount is
+1.5 USD per unit.
+""",
+            "the conversion amount is 1.5 USD per unit.",
+        ),
+        (
+            """(a) The allowance equals
+1.5 units per household.
+""",
+            "the allowance equals 1.5 units per household.",
+        ),
+        (
+            """(a) The area equals
+1.5 square feet.
+""",
+            "the area equals 1.5 square feet.",
+        ),
+        (
+            """(a) The threshold equals
+1.5 degrees Celsius.
+""",
+            "the threshold equals 1.5 degrees Celsius.",
+        ),
+        (
+            """(a) The capacity is
+1.5 kW per unit.
+""",
+            "the capacity is 1.5 kW per unit.",
+        ),
+        (
+            """(a) The threshold is
+1.5 \N{DEGREE SIGN}C above baseline.
+""",
+            "the threshold is 1.5 \N{DEGREE SIGN}C above baseline.",
+        ),
+        (
+            """(a) The permitted range is between
+1.5 hours and 2 hours.
+""",
+            "the permitted range is between 1.5 hours and 2 hours.",
+        ),
+        (
+            """(a) The service must last at least
+1.5 hours before eligibility.
+""",
+            "the service must last at least 1.5 hours before eligibility.",
+        ),
+        (
+            """(a) Staffing is
+1.5 full-time equivalent positions.
+""",
+            "staffing is 1.5 full-time equivalent positions.",
+        ),
+    ],
+)
+def test_closest_exact_source_excerpt_keeps_decimal_quantity_condition(
+    source_text,
+    excerpt,
+):
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=excerpt,
+    )
+
+    assert repaired == source_text.strip()
+
+
+@pytest.mark.parametrize("lead_in", ["is exactly", "is:"])
+def test_closest_exact_source_excerpt_keeps_decimal_after_common_lead_in(lead_in):
+    source_text = f"""(a) If household income is below the limit, the rate {lead_in}
+1.5 percent of household
+income.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="1.5 percent of household income.",
+    )
+
+    assert repaired == source_text.strip()
+
+
+@pytest.mark.parametrize("lead_in", ["receive", "employs", "contains"])
+def test_closest_exact_source_excerpt_keeps_decimal_quantity_after_open_prose(
+    lead_in,
+):
+    source_text = f"""(a) If the household is eligible, it {lead_in}
+1.5 million dollars annually.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="1.5 million dollars annually.",
+    )
+
+    assert repaired == source_text.strip()
+
+
+def test_closest_exact_source_excerpt_rejects_decimal_provision_after_open_prose():
+    source_text = """1.4 Eligibility applies to the household under
+1.5 days for processing are permitted by the agency.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="Eligibility applies to the household under 1.5 days for processing",
+    )
+
+    assert repaired is None
+
+
+@pytest.mark.parametrize("abbreviation", ["No.", "Mr.", "Dr."])
+def test_closest_exact_source_excerpt_keeps_leading_abbreviation_in_condition(
+    abbreviation,
+):
+    source_text = f"""(a) If the applicant is eligible, the application identifies
+{abbreviation} 5 as the recipient of the monthly payment.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=f"{abbreviation} 5 as the recipient of the monthly payment.",
+    )
+
+    assert repaired == source_text.strip()
+
+
+def test_closest_exact_source_excerpt_splits_before_inline_provision_marker():
+    source_text = "Eligibility applies. (a) The agency shall pay $500 per month."
+
+    candidates = _exact_source_excerpt_candidates(source_text)
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="(a) The agency shall pay $500 per month.",
+    )
+
+    assert "(a) The agency shall pay $500 per month." in candidates
+    assert repaired == "(a) The agency shall pay $500 per month."
+
+
+def test_closest_exact_source_excerpt_seeds_bare_decimal_continuation():
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + "the agency shall not exceed\n1.5\nFTE\npositions when calculating staffing.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="1.5 FTE positions",
+    )
+
+    assert repaired == "1.5\nFTE\npositions"
+
+
 def test_closest_exact_source_excerpt_keeps_indented_wrapped_cross_reference():
     source_text = """(i) If the household meets the condition described in paragraph
     (a)(1) of this section, the agency shall pay the benefit.
@@ -7470,6 +7936,151 @@ def test_closest_exact_source_excerpt_keeps_indented_wrapped_cross_reference():
     assert repaired is not None
     assert repaired.startswith("(i) If the household meets the condition")
     assert repaired.endswith("the agency shall pay the benefit.")
+
+
+def test_closest_exact_source_excerpt_keeps_described_under_cross_reference():
+    source_text = """(i) If the household meets the condition described under
+(a)(1) of the State plan, the agency shall pay the benefit.
+(ii) Otherwise, no benefit is paid.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="the agency shall pay the benefit",
+    )
+
+    assert repaired == (
+        "(i) If the household meets the condition described under\n"
+        "(a)(1) of the State plan, the agency shall pay the benefit."
+    )
+
+
+@pytest.mark.parametrize("lead_in", ["provided under", "qualifies under"])
+@pytest.mark.parametrize(
+    "program_reference",
+    [
+        "of the State plan",
+        "of the approved State plan",
+        "of the applicable waiver",
+        "of the Medicaid program",
+    ],
+)
+def test_closest_exact_source_excerpt_keeps_state_plan_cross_reference(
+    lead_in,
+    program_reference,
+):
+    source_text = f"""(i) If the household {lead_in}
+(a)(1) {program_reference}, the agency shall pay the benefit.
+(ii) Otherwise, no benefit is paid.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="the agency shall pay the benefit",
+    )
+
+    assert repaired == (
+        f"(i) If the household {lead_in}\n"
+        f"(a)(1) {program_reference}, the agency shall pay the benefit."
+    )
+
+
+def test_closest_exact_source_excerpt_uses_full_line_for_wrapped_cross_reference():
+    source_text = """(a) The eligibility scope is described under
+(a)(1) eligibility applies to the household, and the agency shall pay the benefit.
+"""
+
+    direct_match = re.search(
+        r"under\s+\(a\)\(1\) eligibility applies to the household, "
+        r"and the agency shall pay the benefit\.",
+        source_text,
+    )
+
+    assert direct_match is not None
+    assert _safe_wrapped_direct_source_match(source_text, direct_match) == (
+        "under\n(a)(1) eligibility applies to the household, "
+        "and the agency shall pay the benefit."
+    )
+
+
+def test_closest_exact_source_excerpt_keeps_wrapped_cfr_part_citation():
+    source_text = """(i) If the household meets the rule in 42 C.F.R.
+pt. 435, the agency shall pay the benefit.
+(ii) Otherwise, no benefit is paid.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="the agency shall pay the benefit",
+    )
+
+    assert repaired == (
+        "(i) If the household meets the rule in 42 C.F.R.\n"
+        "pt. 435, the agency shall pay the benefit."
+    )
+
+
+@pytest.mark.parametrize("reference", ["ch. IV", "subpt. A", "no. 5"])
+def test_closest_exact_source_excerpt_keeps_other_wrapped_cfr_references(reference):
+    source_text = f"""(i) If the household meets the rule in 42 C.F.R.
+{reference}, the agency shall pay the benefit.
+(ii) Otherwise, no benefit is paid.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="the agency shall pay the benefit",
+    )
+
+    assert repaired == (
+        "(i) If the household meets the rule in 42 C.F.R.\n"
+        f"{reference}, the agency shall pay the benefit."
+    )
+
+
+def test_closest_exact_source_excerpt_fails_closed_after_except_as_provided_condition():
+    source_text = (
+        "(a) Except as provided in subsection (b), "
+        + "all documentation requirements remain satisfied and " * 11
+        + "the agency shall\npay $500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="the agency shall pay $500 per month.",
+    )
+
+    assert repaired is None
+
+
+@pytest.mark.parametrize(
+    "condition",
+    [
+        "Notwithstanding subsection (b),",
+        "To the extent that household income is below the limit,",
+        "Upon a finding that household income is below the limit,",
+        "Except as required by subsection (b),",
+        "Subject, however, to subsection (b),",
+        "Provided further that household income is below the limit,",
+        "After the Secretary determines eligibility,",
+        "During any period in which household income is below the limit,",
+    ],
+)
+def test_closest_exact_source_excerpt_fails_closed_after_additional_governing_clause(
+    condition,
+):
+    source_text = (
+        f"(a) {condition} "
+        + "all documentation requirements remain satisfied and " * 11
+        + "the agency shall\npay $500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="the agency shall pay $500 per month.",
+    )
+
+    assert repaired is None
 
 
 def test_exact_source_excerpt_candidates_do_not_join_under_lead_in_provisions():
@@ -7521,6 +8132,1229 @@ def test_closest_exact_source_excerpt_fails_closed_for_over_limit_condition():
     repaired = _closest_exact_source_excerpt(
         source_text=source_text,
         excerpt="The agency shall pay $500 per month.",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_repairs_wrapped_match_in_long_paragraph():
+    source_text = (
+        "(i) The applicable individual receives "
+        + "inpatient and other listed medical services " * 12
+        + "for \nindividuals under the age of 21 without regard to setting; or\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="for individuals under the age of 21",
+    )
+
+    assert repaired == "for \nindividuals under the age of 21"
+
+
+def test_closest_exact_source_excerpt_keeps_wrapped_cross_reference_in_long_paragraph():
+    source_text = (
+        "(i) The applicable individual satisfies "
+        + "all other eligibility requirements and " * 14
+        + "the condition described in paragraph\n"
+        + "(a)(1) of this section before receiving the benefit.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="described in paragraph (a)(1) of this section",
+    )
+
+    assert repaired == "described in paragraph\n(a)(1) of this section"
+
+
+def test_closest_exact_source_excerpt_rejects_wrapped_match_across_blank_line():
+    source_text = "first eligibility condition\n\nsecond eligibility condition\n"
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="first eligibility condition second eligibility condition",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_rejects_match_ending_at_new_marker():
+    source_text = """(a) Eligibility applies to
+(b) The agency excludes gifts from income.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="applies to (b)",
+    )
+
+    assert repaired is None
+
+
+@pytest.mark.parametrize("marker", ["2)", "-", "*", "\N{BULLET}"])
+def test_closest_exact_source_excerpt_rejects_list_item_boundary(marker):
+    source_text = (
+        "1) "
+        + "Administrative background and eligibility context " * 12
+        + f"eligibility applies\n{marker} The agency excludes gifts from income.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=f"eligibility applies {marker} The agency excludes gifts",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_rejects_standalone_heading_boundary():
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + "eligibility applies\nEXCLUSIONS\nThe agency excludes gifts from income.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="eligibility applies EXCLUSIONS The agency excludes gifts",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_rejects_title_case_heading_boundary():
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + "eligibility applies\nGeneral Exclusions\nThe agency excludes gifts.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="eligibility applies General Exclusions The agency excludes gifts.",
+    )
+
+    assert repaired is None
+
+
+@pytest.mark.parametrize("heading", ["Exclusions", "EXCLUSIONS:"])
+def test_closest_exact_source_excerpt_rejects_punctuated_or_single_word_heading(
+    heading,
+):
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + f"eligibility applies\n{heading}\nThe agency excludes gifts.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=f"eligibility applies {heading} The agency excludes gifts.",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_keeps_wrapped_title_case_legal_term():
+    source_text = """(a) The agency shall use the
+Federal Poverty Level
+when determining eligibility.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="eligibility uses the federal poverty level",
+    )
+
+    assert repaired == source_text.strip()
+
+
+def test_closest_exact_source_excerpt_keeps_wrapped_all_caps_legal_term():
+    source_text = """(a) The agency shall use the
+FEDERAL POVERTY LEVEL
+when determining eligibility.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="eligibility uses the federal poverty level",
+    )
+
+    assert repaired == source_text.strip()
+
+
+@pytest.mark.parametrize(
+    "lead_in", ["shall apply", "calculates benefits using", "covers"]
+)
+def test_closest_exact_source_excerpt_keeps_wrapped_title_term_after_verb(lead_in):
+    source_text = f"""(a) If household income is below the limit, the agency {lead_in}
+Standard Benefit Amount
+To every qualifying
+household.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="To every qualifying household.",
+    )
+
+    assert repaired == source_text.strip()
+
+
+def test_closest_exact_source_excerpt_rejects_standalone_new_marker():
+    source_text = """(a) Eligibility applies to
+(b)
+The agency excludes gifts from income.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="applies to (b)",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_keeps_standalone_cross_reference_marker():
+    source_text = (
+        "(i) "
+        + "Administrative background and eligibility context " * 12
+        + "described in paragraph\n(a)(1)\nof this section.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="described in paragraph (a)(1)",
+    )
+
+    assert repaired == "described in paragraph\n(a)(1)"
+
+
+def test_closest_exact_source_excerpt_keeps_bare_marker_followed_by_cross_reference():
+    source_text = (
+        "(i) "
+        + "Administrative background and eligibility context " * 12
+        + "provided under\n(a)(1)\nof this section.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="provided under (a)(1) of this section",
+    )
+
+    assert repaired == "provided under\n(a)(1)\nof this section"
+
+
+def test_closest_exact_source_excerpt_keeps_bare_marker_followed_by_act_reference():
+    source_text = (
+        "(i) "
+        + "Administrative background and eligibility context " * 12
+        + "provided under\n(a)(1)\nof this Act before payment.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="provided under (a)(1) of this Act",
+    )
+
+    assert repaired == "provided under\n(a)(1)\nof this Act"
+
+
+@pytest.mark.parametrize(
+    ("following", "excerpt"),
+    [
+        (
+            "of the Social Security Act before payment.",
+            "described under (a)(1) of the Social Security Act",
+        ),
+        (
+            "of title XIX of the Social Security Act.",
+            "described under (a)(1) of title XIX",
+        ),
+    ],
+)
+def test_closest_exact_source_excerpt_keeps_bare_named_act_reference(
+    following,
+    excerpt,
+):
+    source_text = (
+        "(i) "
+        + "Administrative background and eligibility context " * 12
+        + f"described under\n(a)(1)\n{following}\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=excerpt,
+    )
+
+    assert repaired is not None
+    assert repaired in source_text
+    assert "described under\n(a)(1)" in repaired
+
+
+def test_closest_exact_source_excerpt_keeps_bare_marker_followed_by_subpart_reference():
+    source_text = (
+        "(i) "
+        + "Administrative background and eligibility context " * 12
+        + "provided under\n(a)(1)\nof this subpart before payment.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="provided under (a)(1) of this subpart",
+    )
+
+    assert repaired == "provided under\n(a)(1)\nof this subpart"
+
+
+def test_closest_exact_source_excerpt_rejects_bare_marker_before_ordinary_prose():
+    source_text = """(a)(1) General amount applies to
+(a)(2)
+Of this amount, $100 shall be excluded.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="General amount applies to (a)(2) Of this amount",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_rejects_two_level_provision_boundary():
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + "eligibility applies to\n1.2 The agency excludes gifts from income.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="eligibility applies to 1.2 The agency excludes gifts",
+    )
+
+    assert repaired is None
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        "1.2. The agency excludes gifts from income.",
+        "1.2 (a) The agency excludes gifts from income.",
+        "1.2 \N{LEFT DOUBLE QUOTATION MARK}Income\N{RIGHT DOUBLE QUOTATION MARK} means all receipts.",
+    ],
+)
+def test_closest_exact_source_excerpt_rejects_common_two_level_markers(marker):
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + f"eligibility applies to\n{marker}\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=f"eligibility applies to {marker[:-1]}",
+    )
+
+    assert repaired is None
+
+
+@pytest.mark.parametrize(
+    "lead_in",
+    [
+        "the preceding requirement is governed under",
+        "the chapter consists of",
+        "the agency must use",
+    ],
+)
+def test_closest_exact_source_excerpt_checks_body_before_decimal_suppression(
+    lead_in,
+):
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + f"{lead_in}\n1.2 The agency excludes gifts from income.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=f"{lead_in} 1.2 The agency excludes gifts",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_rejects_parenthesized_two_level_marker():
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + "eligibility applies to\n1.2(a) The agency excludes gifts.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="eligibility applies to 1.2(a) The agency excludes gifts",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_rejects_parenthesized_three_level_marker():
+    source_text = (
+        "4.407.0 "
+        + "Administrative background and eligibility context " * 12
+        + "eligibility applies\n4.407.1(a) The agency excludes gifts.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="eligibility applies 4.407.1(a) The agency excludes gifts.",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_rejects_bare_two_level_provision_boundary():
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + "eligibility applies to\n1.2\nThe agency excludes gifts from income.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="eligibility applies to 1.2 The agency excludes gifts",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_rejects_parenthesized_bare_two_level_boundary():
+    source_text = """1.1 Eligibility applies
+1.2(a)
+The agency excludes gifts from income.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="Eligibility applies 1.2(a) The agency excludes gifts",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_keeps_lowercase_unit_after_parenthetical_marker():
+    source_text = """(a)(1) Eligibility
+(a)(2)
+hours of service are counted.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="hours of service are counted.",
+    )
+
+    assert repaired == "(a)(2)\nhours of service are counted."
+
+
+@pytest.mark.parametrize(
+    "source_text",
+    [
+        "1.1 eligibility\n1.2 the agency excludes gifts from income.\n",
+        "1.1 Eligibility applies\n1.2(a)\nthe agency excludes gifts from income.\n",
+        "1.1 ELIGIBILITY\n1.2 INCOME LIMITS\nThe agency excludes gifts from income.\n",
+        "1.4 Eligibility\n1.5 Hours of service. The agency excludes gifts from income.\n",
+    ],
+)
+def test_closest_exact_source_excerpt_rejects_lowercase_two_level_boundary(
+    source_text,
+):
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="the agency excludes gifts from income.",
+    )
+
+    assert repaired is not None
+    assert "the agency excludes gifts from income." in repaired.casefold()
+    assert "1.1" not in repaired
+
+
+def test_closest_exact_source_excerpt_keeps_two_level_governing_condition():
+    source_text = """1. Introduction.
+1.2 If household income is low. The agency shall pay $500.
+2. Other rule.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="The agency shall pay $500.",
+    )
+
+    assert repaired == "1.2 If household income is low. The agency shall pay $500."
+
+
+def test_closest_exact_source_excerpt_rejects_wrapped_sentence_boundary():
+    source_text = (
+        "(a) If household income is below the limit, "
+        + "all documentation requirements must be satisfied and " * 10
+        + "eligibility is established.\nThe agency shall pay $500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="eligibility is established. The agency shall pay $500 per month.",
+    )
+
+    assert repaired is None
+
+
+@pytest.mark.parametrize(
+    "closing",
+    [")", '"', "']", "\N{RIGHT DOUBLE QUOTATION MARK}", "[1]", " (citation)"],
+)
+def test_closest_exact_source_excerpt_rejects_closed_sentence_boundary(closing):
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + f"eligibility is established.{closing}\n"
+        + "The agency shall pay $500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=f"eligibility is established.{closing} The agency shall pay $500",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_rejects_inline_closed_sentence_boundary():
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + "Eligibility is established.\N{RIGHT DOUBLE QUOTATION MARK} The agency shall\n"
+        + "pay $500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=(
+            "Eligibility is established.\N{RIGHT DOUBLE QUOTATION MARK} "
+            "The agency shall pay $500"
+        ),
+    )
+
+    assert repaired is None
+
+
+@pytest.mark.parametrize(
+    "opening",
+    ['"', "'", "\N{LEFT SINGLE QUOTATION MARK}", "\N{LEFT DOUBLE QUOTATION MARK}", "["],
+)
+def test_closest_exact_source_excerpt_rejects_sentence_before_opening_quote(opening):
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + f"Eligibility is established. {opening}The agency shall\n"
+        + "pay $500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=f"Eligibility is established. {opening}The agency shall pay $500",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_rejects_sentence_after_appendix_letter():
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + "Requirements are listed in appendix L. The agency shall\n"
+        + "pay $500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="appendix L. The agency shall pay $500 per month.",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_rejects_sentence_after_us_abbreviation():
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + "Applicants reside in the U.S. The agency shall\n"
+        + "pay $500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="U.S. The agency shall pay $500 per month.",
+    )
+
+    assert repaired is None
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    [
+        "Virgin Islands",
+        "Armed Forces",
+        "Attorney General",
+        "Secretary",
+        "Bureau",
+        "Congress",
+        "mail",
+    ],
+)
+def test_closest_exact_source_excerpt_keeps_wrapped_us_term(continuation):
+    source_text = f"""(a) If the applicant is served through the U.S.
+{continuation}, the agency shall pay the benefit.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="the agency shall pay the benefit",
+    )
+
+    assert repaired == source_text.strip()
+
+
+def test_closest_exact_source_excerpt_rejects_roman_letter_word_after_sentence():
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + "The applicable rule appears in the Reg.\n"
+        + "Civil penalties apply. The agency shall pay the benefit.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="Reg. Civil penalties apply. The agency shall pay the benefit.",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_rejects_adjacent_table_rows():
+    source_text = "\n".join(f"row {index}  ${index * 100}" for index in range(1, 50))
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="row 20 $2000 row 21 $2100",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_rejects_prose_to_first_table_row():
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + "benefits are\n1  $291\n2  $535\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="benefits are 1 $291",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_rejects_prose_to_single_numeric_table_row():
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + "benefits are\n1 $291\n"
+    )
+
+    spanning = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="benefits are 1 $291",
+    )
+    row = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="1 $291",
+    )
+
+    assert spanning is None
+    assert row == "1 $291"
+
+
+def test_closest_exact_source_excerpt_rejects_table_row_to_prose():
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + "benefits are\n1 $291\nThe agency excludes gifts.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="1 $291 The agency excludes gifts",
+    )
+
+    assert repaired is None
+
+
+@pytest.mark.parametrize(
+    ("separator", "excerpt"),
+    [
+        ("  ", "Description The agency excludes gifts"),
+        ("  ", "Category Description The agency excludes gifts"),
+        ("\t", "Description The agency excludes gifts"),
+        (" | ", "Description The agency excludes gifts"),
+        ("| ", "Description The agency excludes gifts"),
+    ],
+)
+def test_closest_exact_source_excerpt_rejects_single_table_header_to_prose(
+    separator,
+    excerpt,
+):
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + f"Category{separator}Description\nThe agency excludes gifts.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=excerpt,
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_keeps_wrapped_legal_abbreviation():
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + "the rule is defined under 29 U.S.C.\n206(a)(1)(C) for every household.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="defined under 29 U.S.C. 206(a)(1)(C)",
+    )
+
+    assert repaired == "defined under 29 U.S.C.\n206(a)(1)(C)"
+
+
+def test_closest_exact_source_excerpt_keeps_wrapped_cfr_citation():
+    source_text = """(a) The eligibility rule is defined under 42 C.F.R.
+435.119(a) for applicable households.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="defined under 42 C.F.R. 435.119(a)",
+    )
+
+    assert repaired == source_text.strip()
+
+
+def test_closest_exact_source_excerpt_keeps_section_symbol_cfr_citation_wrap():
+    section = "\N{SECTION SIGN}"
+    source_text = f"""(a) The eligibility rule is defined under 42 C.F.R. {section}
+435.119(a) for applicable households.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=f"defined under 42 C.F.R. {section} 435.119(a)",
+    )
+
+    assert repaired == source_text.strip()
+
+
+@pytest.mark.parametrize("reference", ["435.119(a)", "\N{SECTION SIGN} 435.119(a)"])
+def test_closest_exact_source_excerpt_keeps_bare_wrapped_cfr_reference(reference):
+    source_text = f"""(i) If the household meets the rule in 42 C.F.R.
+{reference}
+that applies, the agency shall pay the benefit.
+(ii) Otherwise, no benefit is paid.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="the agency shall pay the benefit",
+    )
+
+    assert repaired == (
+        "(i) If the household meets the rule in 42 C.F.R.\n"
+        f"{reference}\n"
+        "that applies, the agency shall pay the benefit."
+    )
+
+
+def test_closest_exact_source_excerpt_keeps_conditional_section_reference():
+    source_text = """(i) If the requirements under
+\N{SECTION SIGN} 435.119(a) apply to the household, the agency shall pay the benefit.
+(ii) Otherwise, no benefit is paid.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="the agency shall pay the benefit",
+    )
+
+    assert repaired == (
+        "(i) If the requirements under\n"
+        "\N{SECTION SIGN} 435.119(a) apply to the household, "
+        "the agency shall pay the benefit."
+    )
+
+
+@pytest.mark.parametrize(
+    ("source_text", "excerpt"),
+    [
+        (
+            "(a) The benefit was authorized by Pub.\nL. No. 117-2 for 2026.\n",
+            "authorized by Pub. L. No. 117-2",
+        ),
+        (
+            "(a) The procedure is described in Rev.\nProc. 2026-1 for applicants.\n",
+            "described in Rev. Proc. 2026-1",
+        ),
+        (
+            "(a) The eligibility rule is defined under 42 C.F.R.\n"
+            "\N{SECTION SIGN} 435.119(a) for applicable households.\n",
+            "defined under 42 C.F.R. \N{SECTION SIGN} 435.119(a)",
+        ),
+    ],
+)
+def test_closest_exact_source_excerpt_keeps_split_legal_abbreviation_sequence(
+    source_text,
+    excerpt,
+):
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=excerpt,
+    )
+
+    assert repaired == source_text.strip()
+
+
+@pytest.mark.parametrize(
+    "reference_body",
+    ["of the SOCIAL SECURITY ACT", "of Title XIX"],
+)
+def test_closest_exact_source_excerpt_keeps_cased_named_cross_reference(
+    reference_body,
+):
+    source_text = (
+        "(i) "
+        + "Administrative background and eligibility context " * 12
+        + "described under\n(a)(1)\n"
+        + f"{reference_body} before payment.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=f"described under (a)(1) {reference_body}",
+    )
+
+    assert repaired == f"described under\n(a)(1)\n{reference_body}"
+
+
+def test_closest_exact_source_excerpt_rejects_sentence_after_legal_abbreviation():
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + "the rule is governed by 29 U.S.C.\nThe agency shall pay $500.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="29 U.S.C. The agency shall pay $500.",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_keeps_double_spaced_wrapped_prose():
+    source_text = (
+        "(a) "
+        + "Administrative background applies.  " * 20
+        + "the agency shall\npay $500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="the agency shall pay $500 per month.",
+    )
+
+    assert repaired == "the agency shall\npay $500 per month."
+
+
+def test_closest_exact_source_excerpt_keeps_wrapped_currency_prose():
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + "the agency shall pay\n$500 per month to each household.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="shall pay $500 per month",
+    )
+
+    assert repaired == "shall pay\n$500 per month"
+
+
+def test_closest_exact_source_excerpt_keeps_multiline_wrapped_currency_prose():
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + "the agency shall pay\n$500 per month to\neach qualifying household.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="shall pay $500 per month to each qualifying household",
+    )
+
+    assert repaired == "shall pay\n$500 per month to\neach qualifying household"
+
+
+def test_closest_exact_source_excerpt_rejects_second_currency_wrap():
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + "the agency shall pay\n$500 per month to\neach household under the program\n"
+        + "benefits are\n$291\nfor category one\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=(
+            "shall pay $500 per month to each household under the program "
+            "benefits are $291 for category one"
+        ),
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_rejects_isolated_dollar_row():
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + "benefit schedule follows\n$291\nDetails follow.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="benefit schedule follows $291",
+    )
+
+    assert repaired is None
+
+
+@pytest.mark.parametrize(
+    "lead_in",
+    [
+        "the benefit amount is",
+        "the benefit equals",
+        "the benefit shall not exceed",
+        "the benefit may be up to",
+    ],
+)
+def test_closest_exact_source_excerpt_keeps_wrapped_currency_amount(lead_in):
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + f"{lead_in}\n$500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=f"{lead_in} $500 per month",
+    )
+
+    assert repaired == f"{lead_in}\n$500 per month"
+
+
+def test_closest_exact_source_excerpt_keeps_solitary_wrapped_amount_with_condition():
+    source_text = """(a) If household income is below the limit, the benefit shall be
+$500 per month.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="payment of $500 per month",
+    )
+
+    assert repaired == source_text.strip()
+
+
+def test_closest_exact_source_excerpt_rejects_wrapped_currency_table_rows():
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + "benefits are\n$291\n$535\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="benefits are $291",
+    )
+
+    assert repaired is None
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    ["applies to every applicant.\n", ""],
+)
+def test_closest_exact_source_excerpt_keeps_standalone_lead_in_cross_reference(
+    suffix,
+):
+    source_text = (
+        "(i) "
+        + "Administrative background and eligibility context " * 12
+        + "described in paragraph\n(a)(1)\n"
+        + suffix
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="described in paragraph (a)(1)",
+    )
+
+    assert repaired == "described in paragraph\n(a)(1)"
+
+
+@pytest.mark.parametrize(
+    "lead_in", ["under", "pursuant to", "required by", "set forth in"]
+)
+def test_closest_exact_source_excerpt_rejects_ambiguous_bare_reference_lead_in(
+    lead_in,
+):
+    source_text = f"""(a)(1) Scope governed {lead_in}
+(a)(2)
+The agency shall exclude gifts from income.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=f"Scope governed {lead_in} (a)(2) The agency shall exclude gifts",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_repairs_orphaned_wrapped_sentence():
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context. " * 12
+        + "The agency shall\npay $500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="The agency shall pay $500 per month.",
+    )
+
+    assert repaired == "The agency shall\npay $500 per month."
+
+
+def test_closest_exact_source_excerpt_rejects_internal_sentence_boundary_before_wrap():
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + "eligibility is established. The agency shall\npay $500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="eligibility is established. The agency shall pay $500",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_rejects_sentence_after_inline_legal_citation():
+    source_text = (
+        "(a) "
+        + "Administrative background applies. " * 20
+        + "The rule is governed by 29 U.S.C. The agency shall\n"
+        + "pay $500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="29 U.S.C. The agency shall pay $500",
+    )
+
+    assert repaired is None
+
+
+@pytest.mark.parametrize("heading", ["General Exclusions", "Income or Resources"])
+def test_closest_exact_source_excerpt_rejects_structural_first_line_before_wrap(
+    heading,
+):
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context. " * 12
+        + f"\n{heading}\nThe agency excludes gifts.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=f"{heading} The agency excludes gifts",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_rejects_heading_suffix_before_wrap():
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context. " * 12
+        + "\nGeneral Exclusions\nThe agency excludes gifts from income.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="Exclusions The agency excludes gifts",
+    )
+
+    assert repaired is None
+
+
+@pytest.mark.parametrize(
+    "heading",
+    [
+        "Subpart A\N{EM DASH}General Provisions",
+        "SECTION 435.1\N{EM DASH}SCOPE",
+        "Sec. 435.1 Scope",
+    ],
+)
+def test_closest_exact_source_excerpt_rejects_regulation_heading_before_wrap(
+    heading,
+):
+    source_text = f"""(a) Administrative background applies.
+{heading}
+The agency excludes gifts from income.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=f"{heading} The agency excludes gifts from income.",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_keeps_wrapped_lowercase_section_reference():
+    source_text = """(a) If the household incurs medical expenses as defined in
+section 213(d) of the Internal Revenue Code, the agency shall pay the benefit.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="the agency shall pay the benefit",
+    )
+
+    assert repaired == source_text.strip()
+
+
+@pytest.mark.parametrize(
+    "abbreviation",
+    ["St. Louis County", "Ft. Worth", "Mt. Vernon", "Rt. 5", "Id. at 5", "Ex. B"],
+)
+def test_closest_exact_source_excerpt_keeps_wrapped_two_letter_abbreviation(
+    abbreviation,
+):
+    source_text = f"""(a) If the applicant resides in
+{abbreviation}, the agency shall pay the benefit.
+"""
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="the agency shall pay the benefit",
+    )
+
+    assert repaired == source_text.strip()
+
+
+@pytest.mark.parametrize(
+    ("marker", "marker_body"),
+    [
+        ("(aa)", "\nThe agency excludes gifts from income."),
+        ("(bb)", " The agency excludes gifts from income."),
+        ("(AA)", " The agency excludes gifts from income."),
+    ],
+)
+def test_closest_exact_source_excerpt_rejects_double_letter_marker_boundary(
+    marker,
+    marker_body,
+):
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + f"eligibility applies\n{marker}{marker_body}\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=f"eligibility applies {marker} The agency excludes gifts",
+    )
+
+    assert repaired is None
+
+
+@pytest.mark.parametrize("marker", ["II)", "IV)", "AA)", "1000)"])
+def test_closest_exact_source_excerpt_rejects_multichar_list_marker_boundary(marker):
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + f"eligibility applies\n{marker} The agency shall\npay $500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=f"eligibility applies {marker} The agency shall pay $500",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_rejects_uppercase_roman_dot_marker_boundary():
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + "eligibility applies\nV. The agency shall\npay $500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="eligibility applies V. The agency shall pay $500",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_rejects_section_symbol_marker_boundary():
+    source_text = (
+        "(a) "
+        + "Administrative background and eligibility context " * 12
+        + "eligibility applies\n"
+        + "\N{SECTION SIGN} 435.1 Scope\nThe agency shall\npay $500 per month.\n"
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=(
+            "eligibility applies \N{SECTION SIGN} 435.1 Scope The agency shall pay $500"
+        ),
     )
 
     assert repaired is None
@@ -7619,6 +9453,66 @@ rules:
 
     assert repaired == []
     assert not validation.passed
+
+
+def test_repair_generated_wrapped_proof_excerpt_in_over_limit_paragraph(
+    tmp_path, monkeypatch
+):
+    source_text = (
+        "(i) The applicable individual receives "
+        + "inpatient and other listed medical services " * 12
+        + "for \nindividuals under the age of 21 without regard to setting; or\n"
+    )
+    output_root = tmp_path / "out"
+    rules_file = output_root / "model" / "regulations" / "435" / "555.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+rules:
+- name: inpatient_psychiatric_service_under_age_limit
+  kind: parameter
+  entity: Person
+  dtype: Boolean
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/regulation/42/435/555
+          excerpt: for individuals under the age of 21
+  versions:
+  - effective_from: '2026-01-01'
+    formula: true
+"""
+    )
+    monkeypatch.setattr(
+        "axiom_encode.cli._local_source_text_for_corpus_path",
+        lambda citation_path, *, corpus_release: source_text,
+    )
+
+    repaired = _try_repair_generated_nonexact_proof_excerpts_for_apply(
+        SimpleNamespace(output_file=str(rules_file)),
+        output_root=output_root,
+        corpus_release=SimpleNamespace(name="test-release"),
+        issues=[
+            "Proof source evidence not found: rule "
+            "`inpatient_psychiatric_service_under_age_limit` proof atom 0 "
+            "`source.excerpt` does not appear in `us/regulation/42/435/555`."
+        ],
+    )
+    payload = yaml.safe_load(rules_file.read_text())
+    exact_excerpt = payload["rules"][0]["metadata"]["proof"]["atoms"][0]["source"][
+        "excerpt"
+    ]
+    validation = validate_rulespec_proofs(
+        rules_file.read_text(),
+        source_texts={"us/regulation/42/435/555": source_text},
+    )
+
+    assert repaired == ["inpatient_psychiatric_service_under_age_limit[0]"]
+    assert exact_excerpt == "for \nindividuals under the age of 21"
+    assert validation.passed
 
 
 def test_closest_exact_source_excerpt_splits_long_line_without_splitting_citation():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1321"
+version = "0.2.1322"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- repair near-match proof excerpts across legal source line wraps without crossing paragraph, sentence, heading, citation, or table boundaries
- preserve governing conditions and wrapped legal cross-references while failing closed on ambiguous structures
- bump `axiom-encode` to 0.2.1321 and add focused regression coverage

## Review cycle
- Independent review cycle 1 found abbreviation, quantity, inline-marker, and uppercase-marker boundaries; fixed with focused tests.
- Independent review cycle 2 found qualified governing clauses, bare wrapped citations, modified plan references, section-symbol references, and em-dash headings; fixed with focused tests.
- Independent review cycle 3 found structural-heading case sensitivity, two-letter abbreviations, Roman numeral continuation case, U.S. legal continuations, decimal lead-in breadth, and partial-line cross-reference context; fixed with focused tests.
- Final review found no remaining valid actionable defect. Its sole blank-line concern is precluded by `_source_context_before_match` moving `context_start` past the last blank boundary before constructing `context_lines`.
- Post-commit cloud ultrareview is running; this PR remains draft until that result and hosted CI are green.

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest` (`4618 passed, 114 skipped`)
- focused exact-source repair suite (`227 passed`)
- `tests/test_cli.py` excluding the pre-commit-only provenance assertion (`981 passed, 10 skipped` before commit)
