### PR TITLE
Open README with orientation: what encode does, who runs it, uv install

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,58 @@
 
 AI-assisted Axiom RuleSpec encoding infrastructure. This repo owns the automation layer for turning source legal text into jurisdiction-repo `*.yaml` RuleSpec artifacts and validating them with `axiom-rules-engine`.
 
+## What this does
+
+`axiom-encode` sits between the corpus and the jurisdiction rules repos in
+the Axiom pipeline:
+
+```
+axiom-corpus (signed source releases)
+  → axiom-encode (model generation + compile/proof/oracle gates)
+  → rulespec-* repos (RuleSpec YAML + companion tests + signed apply manifests)
+```
+
+Given a citation (for example `26 USC 32(a)(1)`), it resolves the exact
+provision text from the signed corpus release pinned by the target RuleSpec
+checkout, prompts a model to draft the RuleSpec encoding, and only applies
+output that passes the validation gates: RuleSpec compilation, proof-tree
+validation against release-bound source text, companion tests, and oracle
+comparisons where configured. Applies are recorded as signed manifests under
+the target repo's `.axiom/encoding-manifests/`.
+
+A checkout whose `.axiom/toolchain.toml` still declares the legacy
+commit-ref schema (a repo mid-migration to signed-release pins) fails
+current `axiom-encode` toolchain validation by design; the legacy file's
+`axiom_encode_version` field names the encoder release that matches it.
+
+## Who runs this
+
+The Foundation team, on its supervised encoding runtime: generation runs on
+operator-controlled compute, and the migrated jurisdiction repos require
+RuleSpec content changes to carry the signed encoding manifests this
+pipeline produces. The chartered admission model — where generation runs,
+what gets signed, and what CI is allowed to do — is
+[axiom-encode#1192](https://github.com/TheAxiomFoundation/axiom-encode/issues/1192).
+
+If you are not running the supervised pipeline, you generally do not need
+this repo:
+
+- **Use the encodings** — consume published RuleSpec from the `rulespec-*`
+  repos and the signed corpus releases they pin.
+- **Contribute sources** — scrapers and corpus ingest live in
+  [axiom-scrapers](https://github.com/TheAxiomFoundation/axiom-scrapers) and
+  [axiom-corpus](https://github.com/TheAxiomFoundation/axiom-corpus).
+- **Report problems** — a wrong or missing encoding is an issue on the
+  relevant `rulespec-*` repo; fixes route through the supervised pipeline.
+
 ## Installation
 
 ```bash
-pip install -e ".[dev]"
+uv sync
 ```
+
+Without [uv](https://docs.astral.sh/uv/), create and activate a virtualenv,
+then `pip install -e ".[dev]"`.
 
 ## Usage
 

--- a/changelog.d/readme-orientation.changed.md
+++ b/changelog.d/readme-orientation.changed.md
@@ -1,0 +1,1 @@
+README opens with "What this does" / "Who runs this" orientation — pipeline position, validation gates, supervised-runtime admission model (#1192), external contribution paths — and installs via uv.


### PR DESCRIPTION
## Why

Feedback from Owen Barton (CivicActions CTO), who test-drove the pipeline 7/20–21 as our first external contributor: the README "felt a bit wordy, but also missing some of the high-level *what does this do* and *how might you use this* context." His setup confusion (backends, signing-supervisor keys, wiring a Vertex backend) traces to the same gap — the README never says who is expected to run this repo.

Per team direction, we're not investing in multi-backend onboarding for external encoding runs; the platform message is: generation runs on the Foundation's supervised runtime, and external contribution flows through corpus/scrapers/rulespec issues.

## What

Docs-only, three additions at the top:

- **What this does** — pipeline position (`axiom-corpus → axiom-encode → rulespec-*`), the validation gates (compile, proof-tree, companion tests, oracles), signed apply manifests, and an explicit note that a legacy commit-ref `.axiom/toolchain.toml` (repo mid-migration, e.g. rulespec-us pre-#911 bind) fails current toolchain validation **by design** — the exact wall Owen hit.
- **Who runs this** — supervised runtime; migrated repos require signed encoding manifests (per the .github#39 regime); admission model chartered in #1192. Then three concrete paths for everyone else: consume releases, contribute via [axiom-scrapers](https://github.com/TheAxiomFoundation/axiom-scrapers)/[axiom-corpus](https://github.com/TheAxiomFoundation/axiom-corpus), file rulespec-* issues.
- **Installation** — `uv sync` (matches CLAUDE.md), with a no-uv virtualenv fallback note.

## Lightweight cycle (docs-only, per CLAUDE.md PR discipline)

- Claims cross-checked against `src/axiom_encode/toolchain.py` strict-field validation, the org pipeline reference, the #39 provenance rules, and the #1192 charter; CI-mechanics claims deliberately omitted (interim gated generation workflow exists, so "CI never generates" would be premature as a current-state claim).
- Checks: `uv run ruff check …` → all passed; `uv run python -m compileall …` → clean; `uv run --extra dev pytest -q tests/test_cli.py tests/test_rulespec_validation.py tests/test_evals.py -k "rulespec or EncoderPrompt"` → **1067 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
