### PR TITLE
Allow reviewed Canada TD1 signed regeneration

### DIFF
--- a/changelog.d/allow-reviewed-ca-td1-head.changed.md
+++ b/changelog.d/allow-reviewed-ca-td1-head.changed.md
@@ -1,0 +1,1 @@
+Allow artifact-only signed regeneration from the independently reviewed Canada TD1 migration head.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1322"
+version = "0.2.1323"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -21,6 +21,10 @@ REVIEWED_RULESPEC_REFS = frozenset(
             "us",
             "8645fb934cd02dbf730cf980507bbb2d07731bd1",
         ),
+        (
+            "ca",
+            "f60f7a84c30e38c7d4961d70647eb0457e7d76c2",
+        ),
     }
 )
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1322"
+__version__ = "0.2.1323"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -124,13 +124,26 @@ def test_validate_rulespec_base_accepts_main_ancestor(tmp_path: Path) -> None:
     assert validate_rulespec_base(repo, "us", base, open_pr=True) == "main"
 
 
+@pytest.mark.parametrize(
+    ("country", "reviewed_ref"),
+    [
+        ("us", "8645fb934cd02dbf730cf980507bbb2d07731bd1"),
+        ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
+    ],
+)
 def test_validate_rulespec_base_accepts_exact_reviewed_head_artifact_only(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    country: str,
+    reviewed_ref: str,
 ) -> None:
-    repo = tmp_path / "rulespec-us"
-    reviewed_ref = "8645fb934cd02dbf730cf980507bbb2d07731bd1"
-    assert REVIEWED_RULESPEC_REFS == frozenset({("us", reviewed_ref)})
+    repo = tmp_path / f"rulespec-{country}"
+    assert REVIEWED_RULESPEC_REFS == frozenset(
+        {
+            ("us", "8645fb934cd02dbf730cf980507bbb2d07731bd1"),
+            ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
+        }
+    )
     monkeypatch.setattr(
         "scripts.prepare_signed_backfill._git",
         lambda _repo, *_args: f"{reviewed_ref}\n".encode(),
@@ -141,12 +154,12 @@ def test_validate_rulespec_base_accepts_exact_reviewed_head_artifact_only(
     )
 
     assert (
-        validate_rulespec_base(repo, "us", reviewed_ref, open_pr=False)
+        validate_rulespec_base(repo, country, reviewed_ref, open_pr=False)
         == "reviewed-head-artifact"
     )
 
     with pytest.raises(ValueError, match="artifact-only"):
-        validate_rulespec_base(repo, "us", reviewed_ref, open_pr=True)
+        validate_rulespec_base(repo, country, reviewed_ref, open_pr=True)
 
 
 def test_validate_rulespec_base_rejects_retired_reviewed_head(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1322"
+version = "0.2.1323"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- allow the exact independently reviewed Canada TD1 migration head for artifact-only signed regeneration
- preserve fail-closed exact country/SHA matching and the prohibition on opening PRs from reviewed non-main heads
- bump axiom-encode to 0.2.1323

## Review cycle
- independent reviewer requested for the security allowlist diff
- reviewer CLI repeatedly returned an empty payload despite a healthy control invocation; documented as reviewer-channel infrastructure blocker
- no actionable finding was returned or overridden
- exact-set and artifact-only behavior are covered for both reviewed US and Canada heads

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run ruff format --check src/ tests/`
- `python3.13 -m compileall -q src/axiom_encode scripts`
- `uv run pytest` (4627 passed, 114 skipped)