### PR TITLE
Fix generated test periods and proof subsection scope

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1323"
+version = "0.2.1324"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1323"
+__version__ = "0.2.1324"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -13296,6 +13296,56 @@ def _oracle_parameter_test_period(
     }
 
 
+def _generated_test_period_for_rule(
+    rule: dict[str, object] | None,
+) -> dict[str, str]:
+    """Return a generated companion-test period matching the target rule."""
+    period_kind = str((rule or {}).get("period") or "Year").strip().lower()
+    effective_from: str | None = None
+    versions = (rule or {}).get("versions")
+    if isinstance(versions, list):
+        valid_dates: list[date] = []
+        for version in versions:
+            if not isinstance(version, dict):
+                continue
+            raw_effective_from = str(version.get("effective_from") or "").strip()
+            with contextlib.suppress(ValueError):
+                candidate = date.fromisoformat(raw_effective_from)
+                if candidate.year >= 1900:
+                    valid_dates.append(candidate)
+        if valid_dates:
+            effective_from = max(valid_dates).isoformat()
+
+    start = date.fromisoformat(effective_from or "2026-01-01")
+    if period_kind == "month":
+        if start.day != 1:
+            start = date(
+                start.year + (1 if start.month == 12 else 0),
+                1 if start.month == 12 else start.month + 1,
+                1,
+            )
+        return {
+            "period_kind": "month",
+            "start": start.isoformat(),
+            "end": date(
+                start.year,
+                start.month,
+                monthrange(start.year, start.month)[1],
+            ).isoformat(),
+        }
+    if period_kind == "day":
+        return {
+            "period_kind": "day",
+            "start": start.isoformat(),
+            "end": start.isoformat(),
+        }
+    return {
+        "period_kind": "tax_year",
+        "start": f"{start.year:04d}-01-01",
+        "end": f"{start.year:04d}-12-31",
+    }
+
+
 def _scalar_formula_value(formula: object) -> int | float | str | bool | None:
     if isinstance(formula, (int, float, bool)):
         return formula
@@ -13857,12 +13907,12 @@ def _append_generic_zero_branch_tests_if_missing(
     rules = rules_payload.get("rules")
     if not isinstance(rules, list):
         return []
-    rule_names = {
-        str(rule.get("name") or "").strip()
+    rules_by_name = {
+        name: rule
         for rule in rules
         if isinstance(rule, dict)
         and str(rule.get("kind") or "").strip().lower() in {"derived", "parameter"}
-        and str(rule.get("name") or "").strip()
+        and (name := str(rule.get("name") or "").strip())
     }
     target_base = _rulespec_anchor_base_for_output(repo_path, relative_output)
     factual_inputs = _local_factual_input_names_from_rules_content(rules_content)
@@ -13881,7 +13931,7 @@ def _append_generic_zero_branch_tests_if_missing(
         if isinstance(test_case, dict)
     }
     for output_name in output_names:
-        if output_name not in rule_names:
+        if output_name not in rules_by_name:
             continue
         if valid_output_names is not None and output_name not in valid_output_names:
             continue
@@ -13903,11 +13953,9 @@ def _append_generic_zero_branch_tests_if_missing(
         test_payload.append(
             {
                 "name": case_name,
-                "period": {
-                    "period_kind": "tax_year",
-                    "start": "2026-01-01",
-                    "end": "2026-12-31",
-                },
+                "period": _generated_test_period_for_rule(
+                    rules_by_name.get(output_name)
+                ),
                 "input": case_inputs,
                 "output": {target: 0},
             }
@@ -14263,11 +14311,7 @@ def _append_generated_derived_output_tests_if_missing(
         test_payload.append(
             {
                 "name": case_name,
-                "period": {
-                    "period_kind": "tax_year",
-                    "start": "2026-01-01",
-                    "end": "2026-12-31",
-                },
+                "period": _generated_test_period_for_rule(rule),
                 "input": dict(input_defaults),
                 "output": {
                     target: _default_generated_test_output_value(
@@ -14479,11 +14523,7 @@ def _build_generated_positive_judgment_case(
 
     return {
         "name": case_name,
-        "period": {
-            "period_kind": "tax_year",
-            "start": "2026-01-01",
-            "end": "2026-12-31",
-        },
+        "period": _generated_test_period_for_rule(rule),
         "input": inputs,
         "output": {target: "holds"},
     }
@@ -28050,12 +28090,16 @@ def _try_repair_generated_nonexact_proof_excerpts_for_apply(
     issues: list[str],
 ) -> list[str]:
     """Align near-match generated proof excerpts to their exact cited source text."""
-    targets = {
-        (match.group("rule"), int(match.group("atom")))
-        for issue in issues
-        if (match := _NONEXACT_PROOF_EXCERPT_ISSUE_PATTERN.search(str(issue)))
-        is not None
-    }
+    targets: dict[tuple[str, int], bool] = {}
+    for issue in issues:
+        issue_text = str(issue)
+        match = _NONEXACT_PROOF_EXCERPT_ISSUE_PATTERN.search(issue_text)
+        if match is None:
+            continue
+        target = (match.group("rule"), int(match.group("atom")))
+        targets[target] = targets.get(target, False) or (
+            "outside the rule's declared subsection scope" in issue_text
+        )
     if not targets:
         return []
     try:
@@ -28090,7 +28134,8 @@ def _try_repair_generated_nonexact_proof_excerpts_for_apply(
         if not isinstance(atoms, list):
             continue
         for atom_index, atom in enumerate(atoms):
-            if (rule_name, atom_index) not in targets or not isinstance(atom, dict):
+            target = (rule_name, atom_index)
+            if target not in targets or not isinstance(atom, dict):
                 continue
             source = atom.get("source")
             if not isinstance(source, dict):
@@ -28111,6 +28156,13 @@ def _try_repair_generated_nonexact_proof_excerpts_for_apply(
                 source_text = cited_source_texts[corpus_citation_path] or source_text
             if not source_text:
                 continue
+            if targets[target]:
+                source_text = _declared_rule_subsection_source_text(
+                    source_text,
+                    rule_source=rule.get("source"),
+                )
+                if not source_text:
+                    continue
             exact_excerpt = _closest_exact_source_excerpt(
                 source_text=source_text,
                 excerpt=excerpt,
@@ -28125,6 +28177,31 @@ def _try_repair_generated_nonexact_proof_excerpts_for_apply(
     if not _install_generated_yaml_payload(rules_file, payload):
         return []
     return repaired
+
+
+def _declared_rule_subsection_source_text(
+    source_text: str,
+    *,
+    rule_source: object,
+) -> str | None:
+    """Limit repair candidates to explicit top-level rule-source subsections."""
+    if not isinstance(rule_source, str):
+        return None
+    declared = {
+        match.group("marker")
+        for match in re.finditer(r"\((?P<marker>[a-z])\)", rule_source)
+    }
+    if not declared:
+        return None
+    source = str(source_text)
+    markers = list(re.finditer(r"(?m)^[ \t]*\((?P<marker>[a-z])\)[ \t]+", source))
+    blocks: list[str] = []
+    for index, marker in enumerate(markers):
+        if marker.group("marker") not in declared:
+            continue
+        end = markers[index + 1].start() if index + 1 < len(markers) else len(source)
+        blocks.append(source[marker.start() : end])
+    return "\n\n".join(blocks) or None
 
 
 def _install_generated_yaml_payload(rules_file: Path, payload: dict) -> bool:

--- a/src/axiom_encode/harness/proof_validator.py
+++ b/src/axiom_encode/harness/proof_validator.py
@@ -370,6 +370,7 @@ def _validate_proof_atom(
                 source=atom.get("source"),
                 label=label,
                 kind=kind,
+                rule_source=rule.get("source"),
                 source_texts=source_texts,
             )
         )
@@ -456,6 +457,7 @@ def _validate_source_proof_atom(
     source: Any,
     label: str,
     kind: str,
+    rule_source: Any,
     source_texts: Mapping[str, str | None] | None,
 ) -> list[str]:
     if not isinstance(source, dict):
@@ -488,6 +490,15 @@ def _validate_source_proof_atom(
                         "Proof source evidence not found: "
                         f"{label} `source.{field}` does not appear in "
                         f"`{citation_path}`."
+                    )
+                else:
+                    issues.extend(
+                        _proof_excerpt_subsection_scope_issues(
+                            evidence_text=evidence_text,
+                            rule_source=rule_source,
+                            label=label,
+                            field=field,
+                        )
                     )
 
     table = source.get("table")
@@ -527,6 +538,33 @@ def _validate_source_proof_atom(
             )
 
     return issues
+
+
+def _proof_excerpt_subsection_scope_issues(
+    *,
+    evidence_text: str,
+    rule_source: Any,
+    label: str,
+    field: str,
+) -> list[str]:
+    """Reject an explicit top-level excerpt marker outside the rule citation."""
+    if not isinstance(rule_source, str):
+        return []
+    declared = {
+        match.group("marker")
+        for match in re.finditer(r"\((?P<marker>[a-z])\)", rule_source)
+    }
+    excerpt_marker = re.match(r"^\s*\((?P<marker>[a-z])\)(?:\s|$)", evidence_text)
+    if not declared or excerpt_marker is None:
+        return []
+    marker = excerpt_marker.group("marker")
+    if marker in declared:
+        return []
+    return [
+        "Proof source evidence not found: "
+        f"{label} `source.{field}` appears outside the rule's declared "
+        f"subsection scope `{rule_source}` (excerpt begins at `({marker})`)."
+    ]
 
 
 def _validate_import_proof_atom(raw_import: Any, label: str) -> list[str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9611,6 +9611,74 @@ rules:
     assert validation.passed, validation.issues
 
 
+def test_repair_generated_proof_excerpt_from_wrong_declared_subsection(
+    tmp_path, monkeypatch
+):
+    correct_excerpt = (
+        "(f) Monthly income. (1) An applicable individual demonstrates community "
+        "engagement for a month if the individual has a monthly income that is not "
+        "less than the applicable Federal minimum wage requirement under 29 U.S.C. "
+        "206(a)(1)(C) multiplied by 80 hours."
+    )
+    wrong_excerpt = (
+        "(g) Average monthly income for seasonal workers. (1) An applicable "
+        "individual demonstrates community engagement for a month if the individual "
+        "is a seasonal worker and had an average monthly income over the preceding "
+        "six months that is not less than the applicable Federal minimum wage "
+        "requirement multiplied by 80 hours."
+    )
+    source_text = f"{correct_excerpt}\n{wrong_excerpt}\n"
+    output_root = tmp_path / "out"
+    rules_file = output_root / "model" / "regulations" / "435" / "552.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(
+        f"""format: rulespec/v1
+rules:
+- name: monthly_income_threshold_for_community_engagement
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Month
+  source: 42 CFR 435.552(a)(6), (f)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/42/435/552
+          excerpt: {wrong_excerpt!r}
+  versions:
+  - effective_from: '0001-01-01'
+    formula: applicable_federal_minimum_wage_requirement * 80
+"""
+    )
+    monkeypatch.setattr(
+        "axiom_encode.cli._local_source_text_for_corpus_path",
+        lambda citation_path, *, corpus_release: source_text,
+    )
+
+    repaired = _try_repair_generated_nonexact_proof_excerpts_for_apply(
+        SimpleNamespace(output_file=str(rules_file)),
+        output_root=output_root,
+        corpus_release=SimpleNamespace(name="test-release"),
+        issues=[
+            "Proof source evidence not found: rule "
+            "`monthly_income_threshold_for_community_engagement` proof atom 0 "
+            "`source.excerpt` appears outside the rule's declared subsection scope "
+            "`42 CFR 435.552(a)(6), (f)(1)` (excerpt begins at `(g)`)."
+        ],
+    )
+
+    payload = yaml.safe_load(rules_file.read_text())
+    repaired_excerpt = payload["rules"][0]["metadata"]["proof"]["atoms"][0]["source"][
+        "excerpt"
+    ]
+    assert repaired == ["monthly_income_threshold_for_community_engagement[0]"]
+    assert repaired_excerpt == correct_excerpt
+    assert repaired_excerpt in source_text
+
+
 class TestCmdInventory:
     def test_inventory_counts_rulespec_files_and_kinds(self, capsys, tmp_path):
         statute_file = (
@@ -23681,6 +23749,11 @@ rules:
 
         assert repaired == ["auto_output_snap_standard_utility_allowance_state_value"]
         test_payload = yaml.safe_load(test_file.read_text())
+        assert test_payload[0]["period"] == {
+            "period_kind": "month",
+            "start": "2026-01-01",
+            "end": "2026-01-31",
+        }
         assert test_payload[0]["input"] == {
             "us-tn:regulations/1240-01/04/27/block-1#input.household_member_count": 1
         }
@@ -24128,6 +24201,11 @@ rules:
         assert repaired == ["auto_positive_magi_income_determination_parent_applies"]
         test_payload = yaml.safe_load(test_file.read_text())
         synthesized = test_payload[1]
+        assert synthesized["period"] == {
+            "period_kind": "month",
+            "start": "2026-01-01",
+            "end": "2026-01-31",
+        }
         assert synthesized["input"] == {
             "us:statutes/42/1396a/e/14#input.income_determination_required_under_state_plan_or_waiver": True
         }

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -9436,6 +9436,44 @@ def test_rulespec_proof_validator_rejects_direct_source_evidence_mismatch():
     assert any("source.quote" in issue for issue in result.issues)
 
 
+def test_rulespec_proof_validator_rejects_excerpt_from_wrong_rule_subsection():
+    excerpt = (
+        "(g) Average monthly income for seasonal workers. (1) An applicable "
+        "individual demonstrates community engagement based on six-month income."
+    )
+    content = f"""format: rulespec/v1
+rules:
+  - name: monthly_income_threshold_for_community_engagement
+    kind: derived
+    dtype: Money
+    source: 42 CFR 435.552(a)(6), (f)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/regulation/42/435/552
+              excerpt: {excerpt!r}
+    versions:
+      - effective_from: '2026-01-01'
+        formula: minimum_wage * 80
+"""
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us/regulation/42/435/552": excerpt},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        and "(g)" in issue
+        and "(f)(1)" in issue
+        for issue in result.issues
+    )
+
+
 def _anchor_probe_content(atom_path: str, *, version: str) -> str:
     """A single money parameter with a table version and one proof atom.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1323"
+version = "0.2.1324"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- generate companion-test periods that match `Month`, `Day`, and annual RuleSpec rules
- reject exact proof excerpts that begin in a subsection outside the rule source citation
- constrain deterministic proof repair to the rule's declared top-level subsections
- bump encoder version to `0.2.1324`

## Motivation
A protected encoding of 42 CFR 435.552 generated annual test periods for monthly rules and grounded regular-income rules in the adjacent seasonal-income subsection. This fixes both encoder-level causes before rerunning the protected encoding.

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run ruff format --check src/ tests/`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest` (`4629 passed, 114 skipped`)

## Review cycle
Independent Claude review completed on committed diff. It requested verification that `calendar.monthrange` is imported and that the new test fixtures are monthly; both were verified. It found no actionable security, false-positive, or coverage issues. No substantive changes followed review.