### PR TITLE
Fix proof validation for numeric subsection scope

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1324"
+version = "0.2.1325"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1324"
+__version__ = "0.2.1325"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -190,6 +190,7 @@ from .harness.proof_validator import (
     MONEY_UNITS,
     MoneyAtomRatchet,
     ProofValidationResult,
+    _rule_source_subsection_scope,
     emit_money_atom_ratchet,
     evaluate_money_atoms,
     find_noncanonical_corpus_citation_path_issues,
@@ -28184,23 +28185,42 @@ def _declared_rule_subsection_source_text(
     *,
     rule_source: object,
 ) -> str | None:
-    """Limit repair candidates to explicit top-level rule-source subsections."""
+    """Limit repair candidates to explicit rule-source subsections."""
     if not isinstance(rule_source, str):
         return None
-    declared = {
-        match.group("marker")
-        for match in re.finditer(r"\((?P<marker>[a-z])\)", rule_source)
-    }
-    if not declared:
+    scope = _rule_source_subsection_scope(rule_source)
+    if not scope:
         return None
     source = str(source_text)
     markers = list(re.finditer(r"(?m)^[ \t]*\((?P<marker>[a-z])\)[ \t]+", source))
     blocks: list[str] = []
     for index, marker in enumerate(markers):
-        if marker.group("marker") not in declared:
+        top = marker.group("marker")
+        if top not in scope:
             continue
         end = markers[index + 1].start() if index + 1 < len(markers) else len(source)
-        blocks.append(source[marker.start() : end])
+        block = source[marker.start() : end]
+        children = scope[top]
+        if children is None:
+            blocks.append(block)
+            continue
+        child_markers = list(
+            re.finditer(r"(?m)^[ \t]*\((?P<marker>\d+)\)[ \t]+", block)
+        )
+        selected_children: list[str] = []
+        for child_index, child in enumerate(child_markers):
+            if child.group("marker") not in children:
+                continue
+            child_end = (
+                child_markers[child_index + 1].start()
+                if child_index + 1 < len(child_markers)
+                else len(block)
+            )
+            selected_children.append(block[child.start() : child_end])
+        if selected_children:
+            blocks.extend(selected_children)
+        elif not child_markers:
+            blocks.append(block)
     return "\n\n".join(blocks) or None
 
 

--- a/src/axiom_encode/harness/proof_validator.py
+++ b/src/axiom_encode/harness/proof_validator.py
@@ -547,24 +547,73 @@ def _proof_excerpt_subsection_scope_issues(
     label: str,
     field: str,
 ) -> list[str]:
-    """Reject an explicit top-level excerpt marker outside the rule citation."""
+    """Reject an explicit excerpt marker outside the rule citation."""
     if not isinstance(rule_source, str):
         return []
+    scope = _rule_source_subsection_scope(rule_source)
     declared = {
         match.group("marker")
         for match in re.finditer(r"\((?P<marker>[a-z])\)", rule_source)
     }
     excerpt_marker = re.match(r"^\s*\((?P<marker>[a-z])\)(?:\s|$)", evidence_text)
-    if not declared or excerpt_marker is None:
+    marker = excerpt_marker.group("marker") if excerpt_marker is not None else None
+    if declared and marker is not None and marker not in declared:
+        return [
+            "Proof source evidence not found: "
+            f"{label} `source.{field}` appears outside the rule's declared "
+            f"subsection scope `{rule_source}` (excerpt begins at `({marker})`)."
+        ]
+
+    numeric_marker = re.match(r"^\s*\((?P<marker>\d+)\)(?:\s|$)", evidence_text)
+    if numeric_marker is None or not scope:
         return []
-    marker = excerpt_marker.group("marker")
-    if marker in declared:
+    # A broad top-level citation, such as ``(f)``, admits all of its children.
+    # Only reject a numeric sibling when every declared top-level subsection is
+    # itself narrowed to explicit numeric children.
+    if any(children is None for children in scope.values()):
+        return []
+    numeric = numeric_marker.group("marker")
+    declared_numeric = {
+        child for children in scope.values() for child in (children or ())
+    }
+    if numeric in declared_numeric:
         return []
     return [
         "Proof source evidence not found: "
         f"{label} `source.{field}` appears outside the rule's declared "
-        f"subsection scope `{rule_source}` (excerpt begins at `({marker})`)."
+        f"subsection scope `{rule_source}` (excerpt begins at `({numeric})`)."
     ]
+
+
+def _rule_source_subsection_scope(
+    rule_source: str,
+) -> dict[str, frozenset[str] | None]:
+    """Parse top-level CFR markers and any explicit numeric child ranges."""
+    scope: dict[str, set[str] | None] = {}
+    for segment in str(rule_source).split(","):
+        top_match = re.search(r"\((?P<top>[a-z])\)", segment)
+        if top_match is None:
+            continue
+        top = top_match.group("top")
+        suffix = segment[top_match.end() :]
+        numeric = {
+            match.group("value") for match in re.finditer(r"\((?P<value>\d+)\)", suffix)
+        }
+        for match in re.finditer(r"\((?P<start>\d+)\)\s*-\s*\((?P<end>\d+)\)", suffix):
+            start = int(match.group("start"))
+            end = int(match.group("end"))
+            if start <= end and end - start <= 100:
+                numeric.update(str(value) for value in range(start, end + 1))
+        if not numeric:
+            scope[top] = None
+        elif scope.get(top, set()) is not None:
+            current = scope.setdefault(top, set())
+            assert isinstance(current, set)
+            current.update(numeric)
+    return {
+        top: None if children is None else frozenset(children)
+        for top, children in scope.items()
+    }
 
 
 def _validate_import_proof_atom(raw_import: Any, label: str) -> list[str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9679,6 +9679,84 @@ rules:
     assert repaired_excerpt in source_text
 
 
+def test_repair_generated_proof_excerpt_from_wrong_numeric_subsection(
+    tmp_path, monkeypatch
+):
+    correct_excerpt = (
+        "(1) An applicable individual demonstrates community engagement for a "
+        "month if the individual has a monthly income that is not less than the "
+        "applicable Federal minimum wage requirement multiplied by 80 hours."
+    )
+    wrong_excerpt = (
+        "(7) The individual had an average monthly income over the preceding 6 months "
+        "that is not less than the applicable minimum wage requirement multiplied by "
+        "80 hours, and is a seasonal worker."
+    )
+    source_text = (
+        "(a) Pathways.\n"
+        "(6) The individual has monthly income that is not less than the applicable "
+        "minimum wage requirement multiplied by 80 hours.\n"
+        f"{wrong_excerpt}\n"
+        "(f) Monthly income.\n"
+        f"{correct_excerpt}\n"
+        "(2) The agency determines monthly income using MAGI.\n"
+        "(g) Average monthly income for seasonal workers.\n"
+    )
+    output_root = tmp_path / "out"
+    rules_file = output_root / "model" / "regulations" / "435" / "552.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(
+        f"""format: rulespec/v1
+rules:
+- name: monthly_income_threshold_for_community_engagement
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Month
+  source: 42 CFR 435.552(a)(6), (f)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/42/435/552
+          excerpt: {wrong_excerpt!r}
+  versions:
+  - effective_from: '0001-01-01'
+    formula: applicable_federal_minimum_wage_requirement * 80
+"""
+    )
+    monkeypatch.setattr(
+        "axiom_encode.cli._local_source_text_for_corpus_path",
+        lambda citation_path, *, corpus_release: source_text,
+    )
+
+    repaired = _try_repair_generated_nonexact_proof_excerpts_for_apply(
+        SimpleNamespace(output_file=str(rules_file)),
+        output_root=output_root,
+        corpus_release=SimpleNamespace(name="test-release"),
+        issues=[
+            "Proof source evidence not found: rule "
+            "`monthly_income_threshold_for_community_engagement` proof atom 0 "
+            "`source.excerpt` appears outside the rule's declared subsection scope "
+            "`42 CFR 435.552(a)(6), (f)(1)` (excerpt begins at `(7)`)."
+        ],
+    )
+
+    payload = yaml.safe_load(rules_file.read_text())
+    repaired_excerpt = payload["rules"][0]["metadata"]["proof"]["atoms"][0]["source"][
+        "excerpt"
+    ]
+    assert repaired == ["monthly_income_threshold_for_community_engagement[0]"]
+    assert repaired_excerpt != wrong_excerpt
+    validation = validate_rulespec_proofs(
+        rules_file.read_text(),
+        source_texts={"us/regulation/42/435/552": source_text},
+    )
+    assert validation.passed, validation.issues
+
+
 class TestCmdInventory:
     def test_inventory_counts_rulespec_files_and_kinds(self, capsys, tmp_path):
         statute_file = (

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -9474,6 +9474,134 @@ rules:
     )
 
 
+def test_rulespec_proof_validator_rejects_excerpt_from_wrong_numeric_subsection():
+    excerpt = (
+        "(7) The individual had an average monthly income over the preceding "
+        "6 months and is a seasonal worker."
+    )
+    content = f"""format: rulespec/v1
+rules:
+  - name: monthly_income_threshold_for_community_engagement
+    kind: derived
+    dtype: Money
+    source: 42 CFR 435.552(a)(6), (f)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/regulation/42/435/552
+              excerpt: {excerpt!r}
+    versions:
+      - effective_from: '2026-01-01'
+        formula: minimum_wage * 80
+"""
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us/regulation/42/435/552": excerpt},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue
+        and "(7)" in issue
+        and "(f)(1)" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_allows_numeric_excerpt_in_declared_range():
+    excerpt = "(7) A declared pathway applies."
+    content = f"""format: rulespec/v1
+rules:
+  - name: declared_range
+    kind: derived
+    dtype: Judgment
+    source: 42 CFR 435.552(a)(5)-(7)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/42/435/552
+              excerpt: {excerpt!r}
+    versions:
+      - effective_from: '2026-01-01'
+        formula: pathway_applies
+"""
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us/regulation/42/435/552": excerpt},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_allows_numeric_excerpt_under_broad_subsection():
+    excerpt = "(2) The agency determines monthly income using MAGI."
+    content = f"""format: rulespec/v1
+rules:
+  - name: monthly_income
+    kind: derived
+    dtype: Money
+    source: 42 CFR 435.552(f)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/regulation/42/435/552
+              excerpt: {excerpt!r}
+    versions:
+      - effective_from: '2026-01-01'
+        formula: monthly_income
+"""
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us/regulation/42/435/552": excerpt},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_allows_declared_nested_roman_excerpt():
+    excerpt = "(i) The agency may calculate hours from monthly income."
+    content = f"""format: rulespec/v1
+rules:
+  - name: work_hours
+    kind: derived
+    dtype: Decimal
+    source: 42 CFR 435.552(e)(2)(i)-(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/regulation/42/435/552
+              excerpt: {excerpt!r}
+    versions:
+      - effective_from: '2026-01-01'
+        formula: monthly_income / minimum_wage
+"""
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us/regulation/42/435/552": excerpt},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
 def _anchor_probe_content(atom_path: str, *, version: str) -> str:
     """A single money parameter with a table version and one proof atom.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1324"
+version = "0.2.1325"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- parse explicit numeric CFR child subsections and ranges from rule sources
- reject proof excerpts beginning at undeclared numeric sibling subsections
- constrain deterministic proof repair to declared numeric child blocks
- bump axiom-encode to 0.2.1325

## Tests
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run ruff format --check src/ tests/`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest` (4634 passed, 114 skipped)

## Review cycle
Independent Claude Haiku review completed against commit 9a4b9c4a. It reviewed broad subsection citations, numeric ranges, nested roman markers, ambiguous source parsing, and deterministic excerpt repair. No actionable findings remained.
