### PR TITLE
Advance reviewed federal migration head

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1325"
+version = "0.2.1326"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -19,7 +19,7 @@ REVIEWED_RULESPEC_REFS = frozenset(
     {
         (
             "us",
-            "8645fb934cd02dbf730cf980507bbb2d07731bd1",
+            "10f7a16ef4a40cf1e26d6273e1aff9ebb79d002f",
         ),
         (
             "ca",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1325"
+__version__ = "0.2.1326"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -127,7 +127,7 @@ def test_validate_rulespec_base_accepts_main_ancestor(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     ("country", "reviewed_ref"),
     [
-        ("us", "8645fb934cd02dbf730cf980507bbb2d07731bd1"),
+        ("us", "10f7a16ef4a40cf1e26d6273e1aff9ebb79d002f"),
         ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
     ],
 )
@@ -140,7 +140,7 @@ def test_validate_rulespec_base_accepts_exact_reviewed_head_artifact_only(
     repo = tmp_path / f"rulespec-{country}"
     assert REVIEWED_RULESPEC_REFS == frozenset(
         {
-            ("us", "8645fb934cd02dbf730cf980507bbb2d07731bd1"),
+            ("us", "10f7a16ef4a40cf1e26d6273e1aff9ebb79d002f"),
             ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
         }
     )

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1325"
+version = "0.2.1326"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- replace the approved reviewed US RuleSpec migration head with the merged 42 CFR 435.552 child SHA
- preserve the Canada reviewed head and artifact-only fail-closed behavior
- bump axiom-encode to 0.2.1326

This allows the next protected federal hard-cut artifact run to use the exact reviewed base produced by rulespec-us PR #996.

## Tests
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run ruff format --check src/ tests/`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest` (4634 passed, 114 skipped)

## Review cycle
Independent Claude Haiku security/control-plane review verified exact-SHA fail-closed behavior, preservation of the Canada head, artifact-only enforcement, version consistency, and test updates. Its requested deployment verification was resolved: rulespec-us PR #996 is merged into `hard-cut/canonical-layout-us`, and GitHub, `FETCH_HEAD`, and the remote branch all resolve to `10f7a16ef4a40cf1e26d6273e1aff9ebb79d002f`. No actionable findings remain.
