### PR TITLE
Keep target source binding off dependent validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1337"
+version = "0.2.1338"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1337"
+__version__ = "0.2.1338"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -42083,7 +42083,6 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
                 enforce_repository_layout=False,
                 local_corpus_release=local_corpus_release,
                 rulespec_dependency_roots=staged_dependency_roots,
-                source_metadata=source_metadata,
             )
             if dependents
             else pipeline

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35551,17 +35551,29 @@ rules:
             output_file=str(generated), runner="codex-test-model", backend="codex"
         )
         validated_paths: list[Path] = []
+        pipeline_source_metadata: list[object] = []
+        target_source_metadata = {
+            "source_attestation": {
+                "requested_corpus_citation_path": "us/statute/7/2015/d/2/C"
+            }
+        }
 
         class FakePipeline:
-            def __init__(self, **_kwargs):
-                pass
+            def __init__(self, **kwargs):
+                pipeline_source_metadata.append(kwargs.get("source_metadata"))
 
             def validate(self, path, *, skip_reviewers):
                 assert skip_reviewers is True
                 validated_paths.append(Path(path))
                 return SimpleNamespace(all_passed=True, results={})
 
-        with patch("axiom_encode.cli.ValidatorPipeline", FakePipeline):
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._generated_result_source_metadata",
+                return_value=target_source_metadata,
+            ),
+        ):
             ok, issues, supplemental = _validate_generated_encoding_in_policy_overlay(
                 result,
                 output_root=output_root,
@@ -35576,6 +35588,7 @@ rules:
         assert issues == []
         assert supplemental == {}
         assert [path.name for path in validated_paths] == ["C.yaml", "2.yaml"]
+        assert pipeline_source_metadata == [target_source_metadata, None]
 
     def test_apply_overlay_validation_can_skip_dependents_for_cascading_migration(
         self, tmp_path

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -19181,6 +19181,41 @@ rules: []
     assert any("does not contain `official_amount` = 1055" in issue for issue in issues)
 
 
+def test_target_attestation_binding_does_not_apply_to_dependent_source(tmp_path):
+    target_source = "us/regulation/42/435/555"
+    dependent_source = "us/regulation/42/435/559"
+    target_pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path / "rulespec-us",
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+        local_corpus_release=None,
+        source_metadata={
+            "source_attestation": {
+                "requested_corpus_citation_path": target_source,
+            }
+        },
+    )
+    dependent_pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path / "rulespec-us",
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+        local_corpus_release=None,
+    )
+    dependent_content = f"""format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: {dependent_source}
+rules: []
+"""
+
+    assert target_pipeline._trusted_source_binding_issues(dependent_content) == [
+        "Source verification target mismatch: generated RuleSpec must include "
+        f"the trusted requested source `{target_source}`, but declared "
+        f"`{dependent_source}`."
+    ]
+    assert dependent_pipeline._trusted_source_binding_issues(dependent_content) == []
+
+
 def test_authoritative_corpus_uses_named_canonical_release(tmp_path):
     corpus = tmp_path / "axiom-corpus"
     canonical = corpus / "data/corpus/provisions/us/statute"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1337"
+version = "0.2.1338"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary\n- keep resolver-owned target source metadata on target overlay validation\n- stop applying the target source attestation to existing dependent modules\n- add wiring and real-validator behavioral regressions\n- bump axiom-encode to 0.2.1338\n\n## Production reproduction\nProtected RuleSpec run 29944054982 validated generated 42 CFR 435.555, then rejected existing dependent 435.559 because the dependent validator inherited the 435.555 trusted source. The mismatch requested 435/555 while the dependent correctly declared 435/559.\n\n## Checks\n- ruff check: passed\n- ruff format check: passed\n- Python 3.13 compileall: passed\n- overlay validation cluster: 18 passed\n- source-binding behavioral tests: 2 passed\n- full pytest: 4763 passed, 119 skipped\n- GitHub CI: lint, Python 3.13 tests, Ubuntu build/test, macOS build/test all passed\n\n## Review cycle\nIndependent review found one low-severity test-depth gap. Added a real ValidatorPipeline behavioral test and reran focused/full checks. Second review found no actionable findings. After rebasing onto current main, reran all checks and completed a final independent review with no actionable findings.