### PR TITLE
Trust-root keyring for corpus-release key rotation (#1201)

### DIFF
--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -81,6 +81,7 @@ jobs:
           TRUST_APPLY_ROOT: ${{ vars.AXIOM_ENCODE_APPLY_SIGNING_PUBLIC_KEY }}
           TRUST_EVAL_ROOT: ${{ vars.AXIOM_ENCODE_EVAL_SIGNING_PUBLIC_KEY }}
           TRUST_CORPUS_RELEASE_ROOT: ${{ vars.AXIOM_CORPUS_RELEASE_PUBLIC_KEY }}
+          TRUST_RETIRED_CORPUS_RELEASE_ROOT: ${{ vars.AXIOM_CORPUS_RELEASE_RETIRED_PUBLIC_KEY }}
         run: |
           CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags='-buildid=' \
             -o "$RUNNER_TEMP/axiom-encode-signing-supervisor" \
@@ -92,6 +93,7 @@ jobs:
             --site-packages "$RUNNER_TEMP/axiom-verification-site-packages" \
             --apply-root "$TRUST_APPLY_ROOT" --eval-root "$TRUST_EVAL_ROOT" \
             --corpus-release-root "$TRUST_CORPUS_RELEASE_ROOT" \
+            --retired-corpus-release-root "$TRUST_RETIRED_CORPUS_RELEASE_ROOT" \
             --git /usr/bin/git
           sudo chown -R 0:0 /opt/axiom-verification
           sudo chmod -R go-w /opt/axiom-verification

--- a/.github/workflows/golden-regeneration.yml
+++ b/.github/workflows/golden-regeneration.yml
@@ -109,6 +109,7 @@ jobs:
           TRUST_APPLY_ROOT: ${{ vars.AXIOM_ENCODE_APPLY_SIGNING_PUBLIC_KEY }}
           TRUST_EVAL_ROOT: ${{ vars.AXIOM_ENCODE_EVAL_SIGNING_PUBLIC_KEY }}
           TRUST_CORPUS_RELEASE_ROOT: ${{ vars.AXIOM_CORPUS_RELEASE_PUBLIC_KEY }}
+          TRUST_RETIRED_CORPUS_RELEASE_ROOT: ${{ vars.AXIOM_CORPUS_RELEASE_RETIRED_PUBLIC_KEY }}
         run: |
           CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags='-buildid=' \
             -o "$RUNNER_TEMP/axiom-encode-signing-supervisor" \
@@ -120,6 +121,7 @@ jobs:
             --site-packages "$RUNNER_TEMP/axiom-verification-site-packages" \
             --apply-root "$TRUST_APPLY_ROOT" --eval-root "$TRUST_EVAL_ROOT" \
             --corpus-release-root "$TRUST_CORPUS_RELEASE_ROOT" \
+            --retired-corpus-release-root "$TRUST_RETIRED_CORPUS_RELEASE_ROOT" \
             --git /usr/bin/git
           sudo chown -R 0:0 /opt/axiom-verification
           sudo chmod -R go-w /opt/axiom-verification

--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -215,6 +215,7 @@ jobs:
           TRUST_APPLY_ROOT: ${{ vars.AXIOM_ENCODE_APPLY_SIGNING_PUBLIC_KEY }}
           TRUST_EVAL_ROOT: ${{ vars.AXIOM_ENCODE_EVAL_SIGNING_PUBLIC_KEY }}
           TRUST_CORPUS_RELEASE_ROOT: ${{ vars.AXIOM_CORPUS_RELEASE_PUBLIC_KEY }}
+          TRUST_RETIRED_CORPUS_RELEASE_ROOT: ${{ vars.AXIOM_CORPUS_RELEASE_RETIRED_PUBLIC_KEY }}
         run: |
           CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags='-buildid=' \
             -o "$RUNNER_TEMP/axiom-encode-signing-supervisor" \
@@ -232,6 +233,7 @@ jobs:
             --apply-root "$TRUST_APPLY_ROOT" \
             --eval-root "$TRUST_EVAL_ROOT" \
             --corpus-release-root "$TRUST_CORPUS_RELEASE_ROOT" \
+            --retired-corpus-release-root "$TRUST_RETIRED_CORPUS_RELEASE_ROOT" \
             --git /usr/bin/git \
             --encoder-git-root "$GITHUB_WORKSPACE/axiom-encode" \
             --encoder-commit "$GITHUB_SHA" \

--- a/changelog.d/1201.fixed.md
+++ b/changelog.d/1201.fixed.md
@@ -1,0 +1,1 @@
+Accept and provision ordered current and retired corpus-release verification keys in v3 signing trust roots so supervised releases remain valid across key rotation.

--- a/cmd/axiom-encode-signing-supervisor/main.go
+++ b/cmd/axiom-encode-signing-supervisor/main.go
@@ -128,31 +128,34 @@ type brokerOptions struct {
 }
 
 type signingTrustRoots struct {
-	Schema                 string `json:"schema"`
-	ApplyPublicKey         string `json:"apply_ed25519_public_key"`
-	EvalPublicKey          string `json:"eval_ed25519_public_key"`
-	CorpusReleasePublicKey string `json:"corpus_release_ed25519_public_key"`
+	Schema                  string   `json:"schema"`
+	ApplyPublicKey          string   `json:"apply_ed25519_public_key"`
+	EvalPublicKey           string   `json:"eval_ed25519_public_key"`
+	CorpusReleasePublicKey  *string  `json:"corpus_release_ed25519_public_key,omitempty"`
+	CorpusReleasePublicKeys []string `json:"corpus_release_ed25519_public_keys,omitempty"`
 }
 
 type brokerRequest struct {
-	Version                int    `json:"version"`
-	ID                     int64  `json:"id"`
-	Operation              string `json:"op"`
-	Payload                []byte `json:"payload,omitempty"`
-	ApplyPublicKey         []byte `json:"apply_public_key,omitempty"`
-	EvalPublicKey          []byte `json:"eval_public_key,omitempty"`
-	CorpusReleasePublicKey []byte `json:"corpus_release_public_key,omitempty"`
-	presentFields          map[string]struct{}
+	Version                 int      `json:"version"`
+	ID                      int64    `json:"id"`
+	Operation               string   `json:"op"`
+	Payload                 []byte   `json:"payload,omitempty"`
+	ApplyPublicKey          []byte   `json:"apply_public_key,omitempty"`
+	EvalPublicKey           []byte   `json:"eval_public_key,omitempty"`
+	CorpusReleasePublicKey  []byte   `json:"corpus_release_public_key,omitempty"`
+	CorpusReleasePublicKeys [][]byte `json:"corpus_release_public_keys,omitempty"`
+	presentFields           map[string]struct{}
 }
 
 var brokerRequestFields = map[string]struct{}{
-	"version":                   {},
-	"id":                        {},
-	"op":                        {},
-	"payload":                   {},
-	"apply_public_key":          {},
-	"eval_public_key":           {},
-	"corpus_release_public_key": {},
+	"version":                    {},
+	"id":                         {},
+	"op":                         {},
+	"payload":                    {},
+	"apply_public_key":           {},
+	"eval_public_key":            {},
+	"corpus_release_public_key":  {},
+	"corpus_release_public_keys": {},
 }
 
 func (request *brokerRequest) UnmarshalJSON(raw []byte) error {
@@ -210,19 +213,39 @@ func (request *brokerRequest) hasExactFields(expected ...string) bool {
 func (request *brokerRequest) hasInitializationFields() bool {
 	return request.hasField("apply_public_key") ||
 		request.hasField("eval_public_key") ||
-		request.hasField("corpus_release_public_key")
+		request.hasField("corpus_release_public_key") ||
+		request.hasField("corpus_release_public_keys")
 }
 
 func (request *brokerRequest) hasValidInitializationShape() bool {
+	if len(request.ApplyPublicKey) != ed25519.PublicKeySize ||
+		len(request.EvalPublicKey) != ed25519.PublicKeySize ||
+		len(request.CorpusReleasePublicKey) != ed25519.PublicKeySize ||
+		len(request.CorpusReleasePublicKeys) == 0 ||
+		!bytes.Equal(request.CorpusReleasePublicKey, request.CorpusReleasePublicKeys[0]) ||
+		bytes.Equal(request.ApplyPublicKey, request.EvalPublicKey) {
+		return false
+	}
+	seen := map[string]struct{}{
+		string(request.ApplyPublicKey): {},
+		string(request.EvalPublicKey):  {},
+	}
+	for _, publicKey := range request.CorpusReleasePublicKeys {
+		if len(publicKey) != ed25519.PublicKeySize {
+			return false
+		}
+		encoded := string(publicKey)
+		if _, duplicate := seen[encoded]; duplicate {
+			return false
+		}
+		seen[encoded] = struct{}{}
+	}
 	return len(request.ApplyPublicKey) == ed25519.PublicKeySize &&
 		len(request.EvalPublicKey) == ed25519.PublicKeySize &&
 		len(request.CorpusReleasePublicKey) == ed25519.PublicKeySize &&
-		!bytes.Equal(request.ApplyPublicKey, request.EvalPublicKey) &&
-		!bytes.Equal(request.ApplyPublicKey, request.CorpusReleasePublicKey) &&
-		!bytes.Equal(request.EvalPublicKey, request.CorpusReleasePublicKey) &&
 		request.hasExactFields(
 			"version", "id", "op", "apply_public_key", "eval_public_key",
-			"corpus_release_public_key",
+			"corpus_release_public_key", "corpus_release_public_keys",
 		)
 }
 
@@ -265,10 +288,11 @@ func validateBrokerRequestOperation(request *brokerRequest) error {
 }
 
 type brokerStatus struct {
-	Capabilities           []string `json:"capabilities"`
-	ApplyPublicKey         []byte   `json:"apply_public_key"`
-	EvalPublicKey          []byte   `json:"eval_public_key"`
-	CorpusReleasePublicKey []byte   `json:"corpus_release_public_key"`
+	Capabilities            []string `json:"capabilities"`
+	ApplyPublicKey          []byte   `json:"apply_public_key"`
+	EvalPublicKey           []byte   `json:"eval_public_key"`
+	CorpusReleasePublicKey  []byte   `json:"corpus_release_public_key"`
+	CorpusReleasePublicKeys [][]byte `json:"corpus_release_public_keys"`
 }
 
 type brokerResponse struct {
@@ -288,11 +312,12 @@ type receivedBrokerResponse struct {
 }
 
 type brokerResult struct {
-	Capabilities           []string `json:"capabilities,omitempty"`
-	ApplyPublicKey         []byte   `json:"apply_public_key,omitempty"`
-	EvalPublicKey          []byte   `json:"eval_public_key,omitempty"`
-	CorpusReleasePublicKey []byte   `json:"corpus_release_public_key,omitempty"`
-	Signature              []byte   `json:"signature,omitempty"`
+	Capabilities            []string `json:"capabilities,omitempty"`
+	ApplyPublicKey          []byte   `json:"apply_public_key,omitempty"`
+	EvalPublicKey           []byte   `json:"eval_public_key,omitempty"`
+	CorpusReleasePublicKey  []byte   `json:"corpus_release_public_key,omitempty"`
+	CorpusReleasePublicKeys [][]byte `json:"corpus_release_public_keys,omitempty"`
+	Signature               []byte   `json:"signature,omitempty"`
 }
 
 type signerRequest struct {
@@ -576,7 +601,7 @@ func supervise(arguments []string) error {
 		}
 	}
 
-	applyPublicKey, evalPublicKey, corpusReleasePublicKey, err := loadProtectedTrustRoots(
+	applyPublicKey, evalPublicKey, corpusReleasePublicKeys, err := loadProtectedTrustRoots(
 		parsed.trustRootsPath,
 	)
 	if err != nil {
@@ -603,7 +628,8 @@ func supervise(arguments []string) error {
 	}
 	initialization.ApplyPublicKey = applyPublicKey
 	initialization.EvalPublicKey = evalPublicKey
-	initialization.CorpusReleasePublicKey = corpusReleasePublicKey
+	initialization.CorpusReleasePublicKey = corpusReleasePublicKeys[0]
+	initialization.CorpusReleasePublicKeys = corpusReleasePublicKeys
 	if err := sendFrame(connection, initialization); err != nil {
 		return fmt.Errorf("could not provision signing broker: %w", err)
 	}
@@ -624,7 +650,7 @@ func supervise(arguments []string) error {
 		initialized.Result,
 		applyPublicKey,
 		evalPublicKey,
-		corpusReleasePublicKey,
+		corpusReleasePublicKeys,
 		parsed.applySignerFD >= 0,
 		parsed.evalSignerFD >= 0,
 	); err != nil {
@@ -929,7 +955,7 @@ func superviseWithCodexSubscription(parsed options, connection *os.File, environ
 	return nil
 }
 
-func loadProtectedTrustRoots(path string) ([]byte, []byte, []byte, error) {
+func loadProtectedTrustRoots(path string) ([]byte, []byte, [][]byte, error) {
 	trustedPath, file, err := inspectTrustedRegularFile(path, false)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("signing trust-root config is not protected: %w", err)
@@ -946,21 +972,23 @@ func loadProtectedTrustRoots(path string) ([]byte, []byte, []byte, error) {
 	if err := rejectDuplicateJSONKeys(raw); err != nil {
 		return nil, nil, nil, fmt.Errorf("signing trust-root config is malformed: %w", err)
 	}
+	return parseProtectedTrustRoots(raw, trustedPath)
+}
+
+func parseProtectedTrustRoots(raw []byte, trustedPath string) ([]byte, []byte, [][]byte, error) {
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &fields); err != nil || fields == nil {
 		return nil, nil, nil, errors.New("signing trust-root config must be one JSON object")
 	}
-	expected := map[string]struct{}{
-		"schema":                            {},
-		"apply_ed25519_public_key":          {},
-		"eval_ed25519_public_key":           {},
-		"corpus_release_ed25519_public_key": {},
-	}
-	if len(fields) != len(expected) {
-		return nil, nil, nil, errors.New("signing trust-root config has the wrong fields")
+	allowed := map[string]struct{}{
+		"schema":                             {},
+		"apply_ed25519_public_key":           {},
+		"eval_ed25519_public_key":            {},
+		"corpus_release_ed25519_public_key":  {},
+		"corpus_release_ed25519_public_keys": {},
 	}
 	for name := range fields {
-		if _, ok := expected[name]; !ok {
+		if _, ok := allowed[name]; !ok {
 			return nil, nil, nil, fmt.Errorf("signing trust-root config has unknown field %q", name)
 		}
 	}
@@ -970,8 +998,26 @@ func loadProtectedTrustRoots(path string) ([]byte, []byte, []byte, error) {
 	if err := decoder.Decode(&config); err != nil {
 		return nil, nil, nil, fmt.Errorf("signing trust-root config is malformed: %w", err)
 	}
-	if config.Schema != "axiom-encode/signing-trust-roots/v2" {
+	const schemaV2 = "axiom-encode/signing-trust-roots/v2"
+	const schemaV3 = "axiom-encode/signing-trust-roots/v3"
+	if config.Schema != schemaV2 && config.Schema != schemaV3 {
 		return nil, nil, nil, errors.New("signing trust-root config schema is unsupported")
+	}
+	for _, required := range []string{
+		"schema", "apply_ed25519_public_key", "eval_ed25519_public_key",
+	} {
+		if _, present := fields[required]; !present {
+			return nil, nil, nil, errors.New("signing trust-root config has the wrong fields")
+		}
+	}
+	_, hasCorpusReleasePublicKey := fields["corpus_release_ed25519_public_key"]
+	_, hasCorpusReleasePublicKeys := fields["corpus_release_ed25519_public_keys"]
+	if config.Schema == schemaV2 {
+		if len(fields) != 4 || !hasCorpusReleasePublicKey || hasCorpusReleasePublicKeys {
+			return nil, nil, nil, errors.New("signing trust-root config has the wrong fields")
+		}
+	} else if (!hasCorpusReleasePublicKey && !hasCorpusReleasePublicKeys) || len(fields) > 5 {
+		return nil, nil, nil, errors.New("signing trust-root config has the wrong fields")
 	}
 	applyPublicKey, err := parsePublicKey([]byte(config.ApplyPublicKey))
 	if err != nil {
@@ -982,27 +1028,116 @@ func loadProtectedTrustRoots(path string) ([]byte, []byte, []byte, error) {
 		zero(applyPublicKey)
 		return nil, nil, nil, fmt.Errorf("invalid eval evidence public key in %s: %w", trustedPath, err)
 	}
-	corpusReleasePublicKey, err := parsePublicKey(
-		[]byte(config.CorpusReleasePublicKey),
-	)
-	if err != nil {
-		zero(applyPublicKey)
-		zero(evalPublicKey)
-		return nil, nil, nil, fmt.Errorf(
-			"invalid corpus release public key in %s: %w", trustedPath, err,
-		)
+	var corpusReleasePublicKeys [][]byte
+	if hasCorpusReleasePublicKeys {
+		if len(config.CorpusReleasePublicKeys) == 0 {
+			zero(applyPublicKey)
+			zero(evalPublicKey)
+			return nil, nil, nil, errors.New("corpus release public keyring must not be empty")
+		}
+		for index, encoded := range config.CorpusReleasePublicKeys {
+			publicKey, parseErr := parseRawPublicKey([]byte(encoded))
+			if parseErr != nil {
+				zero(applyPublicKey)
+				zero(evalPublicKey)
+				zeroPublicKeys(corpusReleasePublicKeys)
+				return nil, nil, nil, fmt.Errorf(
+					"invalid corpus release public key %d in %s: %w",
+					index, trustedPath, parseErr,
+				)
+			}
+			corpusReleasePublicKeys = append(corpusReleasePublicKeys, publicKey)
+		}
+	} else {
+		if config.CorpusReleasePublicKey == nil {
+			zero(applyPublicKey)
+			zero(evalPublicKey)
+			return nil, nil, nil, errors.New("corpus release public key is missing")
+		}
+		publicKey, parseErr := parsePublicKey([]byte(*config.CorpusReleasePublicKey))
+		if parseErr != nil {
+			zero(applyPublicKey)
+			zero(evalPublicKey)
+			return nil, nil, nil, fmt.Errorf(
+				"invalid corpus release public key in %s: %w", trustedPath, parseErr,
+			)
+		}
+		corpusReleasePublicKeys = [][]byte{publicKey}
 	}
-	if bytes.Equal(applyPublicKey, evalPublicKey) ||
-		bytes.Equal(applyPublicKey, corpusReleasePublicKey) ||
-		bytes.Equal(evalPublicKey, corpusReleasePublicKey) {
+	if hasCorpusReleasePublicKey && hasCorpusReleasePublicKeys {
+		if config.CorpusReleasePublicKey == nil {
+			zero(applyPublicKey)
+			zero(evalPublicKey)
+			zeroPublicKeys(corpusReleasePublicKeys)
+			return nil, nil, nil, errors.New("corpus release public key is missing")
+		}
+		singularPublicKey, parseErr := parsePublicKey([]byte(*config.CorpusReleasePublicKey))
+		if parseErr != nil {
+			zero(applyPublicKey)
+			zero(evalPublicKey)
+			zeroPublicKeys(corpusReleasePublicKeys)
+			return nil, nil, nil, fmt.Errorf(
+				"invalid corpus release public key in %s: %w", trustedPath, parseErr,
+			)
+		}
+		matchesCurrent := bytes.Equal(singularPublicKey, corpusReleasePublicKeys[0])
+		zero(singularPublicKey)
+		if !matchesCurrent {
+			zero(applyPublicKey)
+			zero(evalPublicKey)
+			zeroPublicKeys(corpusReleasePublicKeys)
+			return nil, nil, nil, errors.New(
+				"singular and plural corpus release public keys conflict",
+			)
+		}
+	}
+	if bytes.Equal(applyPublicKey, evalPublicKey) {
 		zero(applyPublicKey)
 		zero(evalPublicKey)
-		zero(corpusReleasePublicKey)
+		zeroPublicKeys(corpusReleasePublicKeys)
 		return nil, nil, nil, errors.New(
 			"apply, eval, and corpus release trust roots must be distinct",
 		)
 	}
-	return applyPublicKey, evalPublicKey, corpusReleasePublicKey, nil
+	seen := map[string]struct{}{
+		string(applyPublicKey): {},
+		string(evalPublicKey):  {},
+	}
+	for _, publicKey := range corpusReleasePublicKeys {
+		encoded := string(publicKey)
+		if _, duplicate := seen[encoded]; duplicate {
+			zero(applyPublicKey)
+			zero(evalPublicKey)
+			zeroPublicKeys(corpusReleasePublicKeys)
+			return nil, nil, nil, errors.New(
+				"apply, eval, and corpus release trust roots must be distinct",
+			)
+		}
+		seen[encoded] = struct{}{}
+	}
+	return applyPublicKey, evalPublicKey, corpusReleasePublicKeys, nil
+}
+
+func parseRawPublicKey(material []byte) ([]byte, error) {
+	normalized := bytes.TrimSpace(material)
+	decoded := make([]byte, base64.StdEncoding.DecodedLen(len(normalized)))
+	count, err := base64.StdEncoding.Strict().Decode(decoded, normalized)
+	if err != nil {
+		zero(decoded)
+		return nil, errors.New("key must be base64-encoded raw bytes")
+	}
+	decoded = decoded[:count]
+	if len(decoded) != ed25519.PublicKeySize {
+		zero(decoded)
+		return nil, fmt.Errorf("Ed25519 public key must contain %d raw bytes", ed25519.PublicKeySize)
+	}
+	return decoded, nil
+}
+
+func zeroPublicKeys(publicKeys [][]byte) {
+	for _, publicKey := range publicKeys {
+		zero(publicKey)
+	}
 }
 
 func parsePublicKey(material []byte) ([]byte, error) {
@@ -1157,7 +1292,8 @@ func startBroker(parsed options) (*os.File, *os.Process, error) {
 
 func validateStatus(
 	result brokerResult,
-	applyPublicKey, evalPublicKey, corpusReleasePublicKey []byte,
+	applyPublicKey, evalPublicKey []byte,
+	corpusReleasePublicKeys [][]byte,
 	hasApplyCapability, hasEvalCapability bool,
 ) error {
 	expectedCapabilities := make([]string, 0, 2)
@@ -1173,8 +1309,11 @@ func validateStatus(
 	if !bytes.Equal(result.EvalPublicKey, evalPublicKey) {
 		return errors.New("signing broker returned the wrong eval public key")
 	}
-	if !bytes.Equal(result.CorpusReleasePublicKey, corpusReleasePublicKey) {
+	if !bytes.Equal(result.CorpusReleasePublicKey, corpusReleasePublicKeys[0]) {
 		return errors.New("signing broker returned the wrong corpus release public key")
+	}
+	if !equalByteSlices(result.CorpusReleasePublicKeys, corpusReleasePublicKeys) {
+		return errors.New("signing broker returned the wrong corpus release public keyring")
 	}
 	if !equalStrings(result.Capabilities, expectedCapabilities) {
 		return errors.New("signing broker returned unexpected capabilities")
@@ -1452,6 +1591,9 @@ func serveBroker(descriptor int, parsed brokerOptions) error {
 		CorpusReleasePublicKey: append(
 			[]byte(nil), initialization.CorpusReleasePublicKey...,
 		),
+		CorpusReleasePublicKeys: clonePublicKeys(
+			initialization.CorpusReleasePublicKeys,
+		),
 	}
 	if parsed.applySignerFD >= 0 {
 		var err error
@@ -1583,6 +1725,7 @@ func zeroRequestSecrets(request *brokerRequest) {
 	zero(request.ApplyPublicKey)
 	zero(request.EvalPublicKey)
 	zero(request.CorpusReleasePublicKey)
+	zeroPublicKeys(request.CorpusReleasePublicKeys)
 }
 
 func sendError(connection io.Writer, requestID int64, message string) error {
@@ -1838,6 +1981,26 @@ func equalStrings(left, right []string) bool {
 		}
 	}
 	return true
+}
+
+func equalByteSlices(left, right [][]byte) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if !bytes.Equal(left[index], right[index]) {
+			return false
+		}
+	}
+	return true
+}
+
+func clonePublicKeys(publicKeys [][]byte) [][]byte {
+	cloned := make([][]byte, len(publicKeys))
+	for index, publicKey := range publicKeys {
+		cloned[index] = append([]byte(nil), publicKey...)
+	}
+	return cloned
 }
 
 func zero(value []byte) {

--- a/cmd/axiom-encode-signing-supervisor/main_test.go
+++ b/cmd/axiom-encode-signing-supervisor/main_test.go
@@ -4,13 +4,143 @@ package main
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/binary"
+	"encoding/json"
 	"os"
 	"strings"
 	"testing"
 
 	"golang.org/x/sys/unix"
 )
+
+func encodedTestPublicKey(value byte) string {
+	return base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{value}, 32))
+}
+
+func parseTestTrustRoots(t *testing.T, payload map[string]any) ([]byte, []byte, [][]byte, error) {
+	t.Helper()
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parseProtectedTrustRoots(raw, "/protected/signing-trust-roots.json")
+}
+
+func baseTrustRoots() map[string]any {
+	return map[string]any{
+		"schema":                            "axiom-encode/signing-trust-roots/v2",
+		"apply_ed25519_public_key":          encodedTestPublicKey(0xab),
+		"eval_ed25519_public_key":           encodedTestPublicKey(0xcd),
+		"corpus_release_ed25519_public_key": encodedTestPublicKey(0x17),
+	}
+}
+
+func TestLoadProtectedTrustRootsAcceptsV2AndV3Keyring(t *testing.T) {
+	v2 := baseTrustRoots()
+	apply, eval, corpusKeys, err := parseTestTrustRoots(t, v2)
+	if err != nil {
+		t.Fatalf("v2 trust roots were rejected: %v", err)
+	}
+	if len(apply) != 32 || len(eval) != 32 || len(corpusKeys) != 1 || len(corpusKeys[0]) != 32 {
+		t.Fatalf("v2 trust roots returned an invalid keyring: %#v", corpusKeys)
+	}
+	v2CorpusKey := append([]byte(nil), corpusKeys[0]...)
+
+	v3Single := baseTrustRoots()
+	v3Single["schema"] = "axiom-encode/signing-trust-roots/v3"
+	delete(v3Single, "corpus_release_ed25519_public_key")
+	v3Single["corpus_release_ed25519_public_keys"] = []string{
+		encodedTestPublicKey(0x17),
+	}
+	_, _, corpusKeys, err = parseTestTrustRoots(t, v3Single)
+	if err != nil {
+		t.Fatalf("single-key v3 trust roots were rejected: %v", err)
+	}
+	if len(corpusKeys) != 1 || !bytes.Equal(corpusKeys[0], v2CorpusKey) {
+		t.Fatalf("single-key v3 was not equivalent to v2: %#v", corpusKeys)
+	}
+
+	v3Consistent := baseTrustRoots()
+	v3Consistent["schema"] = "axiom-encode/signing-trust-roots/v3"
+	v3Consistent["corpus_release_ed25519_public_keys"] = []string{
+		encodedTestPublicKey(0x17),
+	}
+	if _, _, _, err = parseTestTrustRoots(t, v3Consistent); err != nil {
+		t.Fatalf("consistent singular/plural v3 trust roots were rejected: %v", err)
+	}
+
+	v3 := baseTrustRoots()
+	v3["schema"] = "axiom-encode/signing-trust-roots/v3"
+	delete(v3, "corpus_release_ed25519_public_key")
+	v3["corpus_release_ed25519_public_keys"] = []string{
+		encodedTestPublicKey(0x18),
+		encodedTestPublicKey(0x17),
+	}
+	_, _, corpusKeys, err = parseTestTrustRoots(t, v3)
+	if err != nil {
+		t.Fatalf("v3 trust roots were rejected: %v", err)
+	}
+	if len(corpusKeys) != 2 || corpusKeys[0][0] != 0x18 || corpusKeys[1][0] != 0x17 {
+		t.Fatalf("v3 trust roots lost keyring order: %#v", corpusKeys)
+	}
+}
+
+func TestLoadProtectedTrustRootsRejectsInvalidV3Keyrings(t *testing.T) {
+	for _, testCase := range []struct {
+		name   string
+		mutate func(map[string]any)
+		error  string
+	}{
+		{
+			name: "empty",
+			mutate: func(payload map[string]any) {
+				payload["corpus_release_ed25519_public_keys"] = []string{}
+			},
+			error: "must not be empty",
+		},
+		{
+			name: "malformed base64",
+			mutate: func(payload map[string]any) {
+				payload["corpus_release_ed25519_public_keys"] = []string{"not-base64!!"}
+			},
+			error: "base64-encoded raw bytes",
+		},
+		{
+			name: "wrong length",
+			mutate: func(payload map[string]any) {
+				payload["corpus_release_ed25519_public_keys"] = []string{base64.StdEncoding.EncodeToString([]byte("short"))}
+			},
+			error: "must contain 32 raw bytes",
+		},
+		{
+			name: "conflicting singular and plural",
+			mutate: func(payload map[string]any) {
+				payload["corpus_release_ed25519_public_key"] = encodedTestPublicKey(0x19)
+			},
+			error: "singular and plural corpus release public keys conflict",
+		},
+		{
+			name: "unknown schema",
+			mutate: func(payload map[string]any) {
+				payload["schema"] = "axiom-encode/signing-trust-roots/v999"
+			},
+			error: "schema is unsupported",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			payload := baseTrustRoots()
+			payload["schema"] = "axiom-encode/signing-trust-roots/v3"
+			payload["corpus_release_ed25519_public_keys"] = []string{encodedTestPublicKey(0x18)}
+			delete(payload, "corpus_release_ed25519_public_key")
+			testCase.mutate(payload)
+			_, _, _, err := parseTestTrustRoots(t, payload)
+			if err == nil || !strings.Contains(err.Error(), testCase.error) {
+				t.Fatalf("expected %q rejection, got %v", testCase.error, err)
+			}
+		})
+	}
+}
 
 func TestCredentialOutboxDestinationRejectsDevice(t *testing.T) {
 	fd, err := unix.Open("/dev", unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
@@ -218,7 +348,7 @@ func TestBrokerInitializationRejectsEmptyOrExtraFields(t *testing.T) {
 func TestBrokerInitializationRequiresThreeDistinctRoots(t *testing.T) {
 	valid := decodedRequest(
 		t,
-		`{"version":4,"id":0,"op":"initialize","apply_public_key":"q6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6s=","eval_public_key":"zc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc0=","corpus_release_public_key":"FxcXFxcXFxcXFxcXFxcXFxcXFxcXFxcXFxcXFxcXFxc="}`,
+		`{"version":4,"id":0,"op":"initialize","apply_public_key":"q6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6s=","eval_public_key":"zc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc0=","corpus_release_public_key":"FxcXFxcXFxcXFxcXFxcXFxcXFxcXFxcXFxcXFxcXFxc=","corpus_release_public_keys":["FxcXFxcXFxcXFxcXFxcXFxcXFxcXFxcXFxcXFxcXFxc="]}`,
 	)
 	if !valid.hasValidInitializationShape() {
 		t.Fatal("expected three distinct initialization roots to be valid")
@@ -228,6 +358,12 @@ func TestBrokerInitializationRequiresThreeDistinctRoots(t *testing.T) {
 	aliased.CorpusReleasePublicKey = append([]byte(nil), valid.ApplyPublicKey...)
 	if aliased.hasValidInitializationShape() {
 		t.Fatal("expected aliased corpus release root to be rejected")
+	}
+
+	conflicting := valid
+	conflicting.CorpusReleasePublicKeys = [][]byte{bytes.Repeat([]byte{0x18}, 32)}
+	if conflicting.hasValidInitializationShape() {
+		t.Fatal("expected conflicting corpus release keyring to be rejected")
 	}
 }
 

--- a/docs/trusted-signing-supervisor.md
+++ b/docs/trusted-signing-supervisor.md
@@ -56,7 +56,32 @@ distinct public roots, even when the command uses no signing capability:
 }
 ```
 
-PKIX public-key PEM is also accepted. Environment public-key values never
+The v2 form remains valid and supplies a one-key corpus-release verification
+ring. During corpus-release key rotation, use the v3 form. The first key is the
+current signing identity; later keys are retired and verification-only:
+
+```json
+{
+  "schema": "axiom-encode/signing-trust-roots/v3",
+  "apply_ed25519_public_key": "BASE64_RAW_32_BYTES",
+  "eval_ed25519_public_key": "DISTINCT_BASE64_RAW_32_BYTES",
+  "corpus_release_ed25519_public_keys": [
+    "CURRENT_BASE64_RAW_32_BYTES",
+    "RETIRED_BASE64_RAW_32_BYTES"
+  ]
+}
+```
+
+A v3 file may retain the singular field, use the plural field, or include both
+when the singular key equals the first plural key. The supervisor rejects an
+empty ring, invalid base64, non-32-byte entries, duplicate or aliased roots,
+unknown schemas, and conflicting singular/plural current keys. The broker
+retains its singular current-key status field and also passes the ordered ring
+to Python release verification. Release signing is unchanged and uses only the
+current private signing identity.
+
+PKIX public-key PEM is also accepted for singular key fields; plural keyring
+entries are raw 32-byte keys in base64. Environment public-key values never
 define trust and are rejected, including `AXIOM_CORPUS_RELEASE_PUBLIC_KEY`.
 These three legacy/current private-key environment names are fatal when
 present, including with an empty value:
@@ -262,11 +287,19 @@ sudo .venv/bin/python scripts/provision_verification_supervisor.py \
   --supervisor build/axiom-encode-signing-supervisor \
   --site-packages .venv/lib/python3.13/site-packages \
   --apply-root "$APPLY_ROOT" --eval-root "$EVAL_ROOT" \
-  --corpus-release-root "$CORPUS_RELEASE_ROOT" --git /usr/bin/git \
+  --corpus-release-root "$CORPUS_RELEASE_ROOT" \
+  --retired-corpus-release-root "$RETIRED_CORPUS_RELEASE_ROOT" \
+  --git /usr/bin/git \
   --encoder-origin-repository github.com/TheAxiomFoundation/axiom-encode \
   --encoder-commit "$(git rev-parse HEAD)" --encoder-git-root "$PWD" \
   --install-pinned-codex-cli
 ```
+
+Omit `--retired-corpus-release-root` to retain the v2 one-key file. Repeat it
+for each retired verification-only key; the provisioner writes a v3 ring with
+the current `--corpus-release-root` first. Repository encode workflows require
+the `AXIOM_CORPUS_RELEASE_RETIRED_PUBLIC_KEY` organization variable during the
+2026-07 rotation so they cannot silently provision only the new key.
 
 Install custody remains with the operator: never automate this sudo invocation.
 For a subscription run, explicitly name the source credential and its refreshed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1326"
+version = "0.2.1327"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/provision_verification_supervisor.py
+++ b/scripts/provision_verification_supervisor.py
@@ -1451,6 +1451,28 @@ def _verify_and_export_encoder_snapshot(
     return declared_version, package
 
 
+def _signing_trust_roots_payload(
+    apply_root: str,
+    eval_root: str,
+    corpus_release_root: str,
+    retired_corpus_release_roots: tuple[str, ...] = (),
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema": "axiom-encode/signing-trust-roots/v2",
+        "apply_ed25519_public_key": apply_root,
+        "eval_ed25519_public_key": eval_root,
+        "corpus_release_ed25519_public_key": corpus_release_root,
+    }
+    if retired_corpus_release_roots:
+        payload["schema"] = "axiom-encode/signing-trust-roots/v3"
+        payload.pop("corpus_release_ed25519_public_key")
+        payload["corpus_release_ed25519_public_keys"] = [
+            corpus_release_root,
+            *retired_corpus_release_roots,
+        ]
+    return payload
+
+
 def provision(
     destination: Path,
     supervisor: Path,
@@ -1467,7 +1489,12 @@ def provision(
     encoder_git_root: Path | None = None,
     codex_cli_archive: Path | None = None,
     install_pinned_codex_cli: bool = False,
+    retired_corpus_release_roots: tuple[str, ...] = (),
 ) -> None:
+    if any(not root.strip() for root in retired_corpus_release_roots):
+        raise SystemExit(
+            "refusing to provision: retired corpus release roots must not be empty"
+        )
     encoder_attestation_args = (
         encoder_origin_repository,
         encoder_commit,
@@ -1540,18 +1567,13 @@ def provision(
         )
         launcher.chmod(0o755)
         trust = destination / "signing-trust-roots.json"
-        trust.write_text(
-            json.dumps(
-                {
-                    "schema": "axiom-encode/signing-trust-roots/v2",
-                    "apply_ed25519_public_key": apply_root,
-                    "eval_ed25519_public_key": eval_root,
-                    "corpus_release_ed25519_public_key": corpus_release_root,
-                },
-                sort_keys=True,
-            )
-            + "\n"
+        trust_payload = _signing_trust_roots_payload(
+            apply_root,
+            eval_root,
+            corpus_release_root,
+            retired_corpus_release_roots,
         )
+        trust.write_text(json.dumps(trust_payload, sort_keys=True) + "\n")
         trust.chmod(0o644)
         if provision_encoder:
             assert encoder_origin_repository is not None
@@ -1581,6 +1603,12 @@ if __name__ == "__main__":
     parser.add_argument("--apply-root", required=True)
     parser.add_argument("--eval-root", required=True)
     parser.add_argument("--corpus-release-root", required=True)
+    parser.add_argument(
+        "--retired-corpus-release-root",
+        action="append",
+        default=[],
+        help="Retired verification-only corpus release root; repeat for each key.",
+    )
     parser.add_argument(
         "--install-pinned-codex-cli",
         action="store_true",
@@ -1659,4 +1687,5 @@ if __name__ == "__main__":
         if args.codex_cli_archive is not None
         else None,
         args.install_pinned_codex_cli,
+        tuple(args.retired_corpus_release_root),
     )

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1326"
+__version__ = "0.2.1327"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/corpus_release.py
+++ b/src/axiom_encode/corpus_release.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import hashlib
 import json
+import logging
 import re
 from base64 import b64decode
 from binascii import Error as BinasciiError
@@ -15,6 +16,8 @@ from typing import Any
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+logger = logging.getLogger(__name__)
 
 RELEASE_OBJECT_SCHEMA_V2 = "axiom-corpus/release-object/v2"
 RELEASE_OBJECT_SCHEMA_VERSION = "axiom-corpus/release-object/v3"
@@ -94,7 +97,7 @@ def canonical_release_object_bytes(payload: Mapping[str, Any]) -> bytes:
 def verify_release_object(
     payload: Mapping[str, Any],
     *,
-    public_key: str,
+    public_key: str | Sequence[str],
 ) -> VerifiedCorpusReleaseObject:
     """Verify a supported canonical axiom-corpus contract and signature."""
 
@@ -126,14 +129,33 @@ def verify_release_object(
         ) from exc
     if len(raw_signature) != 64:
         raise CorpusReleaseObjectError("release object signature has invalid length")
-    try:
-        _load_ed25519_public_key(public_key).verify(
-            raw_signature,
-            canonical_release_object_bytes(materialized),
-        )
-    except InvalidSignature as exc:
-        raise CorpusReleaseObjectError("release object signature is invalid") from exc
+    public_keys = _release_public_keyring(public_key)
+    loaded_public_keys = tuple(_load_ed25519_public_key(key) for key in public_keys)
+    canonical = canonical_release_object_bytes(materialized)
+    for key_index, loaded_public_key in enumerate(loaded_public_keys):
+        try:
+            loaded_public_key.verify(raw_signature, canonical)
+        except InvalidSignature:
+            continue
+        logger.debug("release object signature verified with key index %d", key_index)
+        break
+    else:
+        raise CorpusReleaseObjectError("release object signature is invalid")
     return verified
+
+
+def _release_public_keyring(public_key: str | Sequence[str]) -> tuple[str, ...]:
+    """Normalize one legacy public key or an ordered verification keyring."""
+
+    if isinstance(public_key, str):
+        return (public_key,)
+    if not isinstance(public_key, Sequence) or not public_key:
+        raise CorpusReleaseObjectError("release public keyring must not be empty")
+    if any(not isinstance(key, str) for key in public_key):
+        raise CorpusReleaseObjectError(
+            "release public keyring must contain only encoded public keys"
+        )
+    return tuple(public_key)
 
 
 def _validate_unsigned_release_object(

--- a/src/axiom_encode/corpus_resolver.py
+++ b/src/axiom_encode/corpus_resolver.py
@@ -12,7 +12,7 @@ import json
 import os
 import re
 import stat
-from collections.abc import Iterable, Iterator, Mapping
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import asdict, dataclass, field, replace
 from itertools import islice
 from pathlib import Path
@@ -307,7 +307,7 @@ class LocalCorpusRelease:
     root: Path
     name: str
     content_sha256: str
-    public_key: str = field(repr=False, compare=False)
+    public_key: str | Sequence[str] = field(repr=False, compare=False)
     provisions_root: Path = field(init=False)
     selector_sha256: str = field(init=False)
     scopes: tuple[ReleaseScope, ...] = field(init=False)

--- a/src/axiom_encode/signing_broker.py
+++ b/src/axiom_encode/signing_broker.py
@@ -94,6 +94,9 @@ class SigningBroker(Protocol):
     @property
     def corpus_release_public_key_raw(self) -> bytes | None: ...
 
+    @property
+    def corpus_release_public_keys_raw(self) -> tuple[bytes, ...]: ...
+
     def apply_ed25519_sign(self, payload: bytes) -> bytes: ...
 
     def eval_ed25519_sign(self, payload: bytes) -> bytes: ...
@@ -107,6 +110,7 @@ class BrokerStatus:
     apply_public_key_raw: bytes | None
     eval_public_key_raw: bytes | None
     corpus_release_public_key_raw: bytes | None
+    corpus_release_public_keys_raw: tuple[bytes, ...]
 
 
 def scrub_private_signing_environment(
@@ -176,11 +180,16 @@ class SigningBrokerClient:
         self._closed = False
         os.set_inheritable(self._connection.fileno(), False)
         status = self._request("status")
-        if set(status) != {
+        legacy_status_fields = {
             "capabilities",
             "apply_public_key",
             "eval_public_key",
             "corpus_release_public_key",
+        }
+        status_fields = set(status)
+        if status_fields not in {
+            frozenset(legacy_status_fields),
+            frozenset({*legacy_status_fields, "corpus_release_public_keys"}),
         }:
             raise SigningBrokerError("Signing broker returned malformed status")
         raw_capabilities = status.get("capabilities")
@@ -204,21 +213,52 @@ class SigningBrokerClient:
             status.get("corpus_release_public_key"),
             label="corpus release",
         )
+        encoded_corpus_release_public_keys = status.get("corpus_release_public_keys")
+        if "corpus_release_public_keys" not in status:
+            corpus_release_public_keys_raw = (
+                (corpus_release_public_key_raw,)
+                if corpus_release_public_key_raw is not None
+                else ()
+            )
+        elif not isinstance(encoded_corpus_release_public_keys, list) or not (
+            encoded_corpus_release_public_keys
+        ):
+            raise SigningBrokerError(
+                "Signing broker returned a malformed corpus release public keyring"
+            )
+        else:
+            corpus_release_public_keys_raw = tuple(
+                self._decode_required_status_public_key(
+                    encoded_public,
+                    label="corpus release",
+                )
+                for encoded_public in encoded_corpus_release_public_keys
+            )
+        if (
+            not corpus_release_public_keys_raw
+            or corpus_release_public_keys_raw[0] != corpus_release_public_key_raw
+        ):
+            raise SigningBrokerError(
+                "Signing broker returned a conflicting corpus release public keyring"
+            )
         protected_roots = {
             apply_public_key_raw,
             eval_public_key_raw,
-            corpus_release_public_key_raw,
+            *corpus_release_public_keys_raw,
         }
-        if None in protected_roots or len(protected_roots) != 3:
+        if None in protected_roots or len(protected_roots) != (
+            2 + len(corpus_release_public_keys_raw)
+        ):
             raise SigningBrokerError(
-                "Signing broker must expose three distinct protected apply, eval, "
-                "and corpus release trust roots"
+                "Signing broker must expose distinct protected apply, eval, and "
+                "corpus release trust roots"
             )
         self._status = BrokerStatus(
             frozenset(raw_capabilities),
             apply_public_key_raw,
             eval_public_key_raw,
             corpus_release_public_key_raw,
+            corpus_release_public_keys_raw,
         )
 
     @staticmethod
@@ -248,6 +288,17 @@ class SigningBrokerClient:
                 f"Signing broker returned a malformed {label} public key"
             )
 
+    @classmethod
+    def _decode_required_status_public_key(
+        cls, encoded_public: object, *, label: str
+    ) -> bytes:
+        public_key = cls._decode_status_public_key(encoded_public, label=label)
+        if public_key is None:
+            raise SigningBrokerError(
+                f"Signing broker returned a malformed {label} public key"
+            )
+        return public_key
+
     @property
     def capabilities(self) -> frozenset[str]:
         return self._status.capabilities
@@ -263,6 +314,10 @@ class SigningBrokerClient:
     @property
     def corpus_release_public_key_raw(self) -> bytes | None:
         return self._status.corpus_release_public_key_raw
+
+    @property
+    def corpus_release_public_keys_raw(self) -> tuple[bytes, ...]:
+        return self._status.corpus_release_public_keys_raw
 
     @property
     def broker_pid(self) -> int | None:

--- a/src/axiom_encode/toolchain.py
+++ b/src/axiom_encode/toolchain.py
@@ -255,15 +255,19 @@ def load_rulespec_local_corpus_release(
             "A protected signing broker is required to verify the pinned "
             "corpus release object"
         ) from exc
-    public_key_raw = broker.corpus_release_public_key_raw
-    if public_key_raw is None or len(public_key_raw) != 32:
+    public_keys_raw = broker.corpus_release_public_keys_raw
+    if not public_keys_raw or any(
+        len(public_key) != 32 for public_key in public_keys_raw
+    ):
         raise RuleSpecToolchainError(
-            "The protected signing broker has no valid corpus release public key"
+            "The protected signing broker has no valid corpus release public keyring"
         )
-    public_key = b64encode(public_key_raw).decode("ascii")
+    public_keys = tuple(
+        b64encode(public_key).decode("ascii") for public_key in public_keys_raw
+    )
     return LocalCorpusRelease(
         corpus_root,
         toolchain.corpus_release,
         toolchain.corpus_release_content_sha256,
-        public_key,
+        public_keys,
     )

--- a/tests/signing_broker_fixtures.py
+++ b/tests/signing_broker_fixtures.py
@@ -86,6 +86,7 @@ class SigningBrokerFixture:
         eval_private_key: str | None = None,
         eval_public_key: str | None = None,
         corpus_release_public_key: str | None = None,
+        corpus_release_public_keys: tuple[str, ...] | None = None,
     ):
         self._apply_private_key = (
             _private_key(apply_private_key, label="Apply manifest")
@@ -112,6 +113,31 @@ class SigningBrokerFixture:
             private_key=None,
             public_text=corpus_release_public_key,
         )
+        if corpus_release_public_keys is None:
+            self._corpus_release_public_keys = (
+                (self._corpus_release_public,)
+                if self._corpus_release_public is not None
+                else ()
+            )
+        else:
+            self._corpus_release_public_keys = tuple(
+                self._validate_pair(
+                    label="Corpus release",
+                    private_key=None,
+                    public_text=public_text,
+                )
+                for public_text in corpus_release_public_keys
+            )
+            if not self._corpus_release_public_keys:
+                raise SigningBrokerError(
+                    "Corpus release public keyring must not be empty"
+                )
+            if self._corpus_release_public is None:
+                self._corpus_release_public = self._corpus_release_public_keys[0]
+            elif self._corpus_release_public_keys[0] != self._corpus_release_public:
+                raise SigningBrokerError(
+                    "Corpus release public keyring conflicts with its current key"
+                )
 
     @staticmethod
     def _validate_pair(
@@ -155,6 +181,10 @@ class SigningBrokerFixture:
     @property
     def corpus_release_public_key_raw(self) -> bytes | None:
         return self._corpus_release_public
+
+    @property
+    def corpus_release_public_keys_raw(self) -> tuple[bytes, ...]:
+        return self._corpus_release_public_keys
 
     def apply_ed25519_sign(self, payload: bytes) -> bytes:
         if self._apply_private_key is None:

--- a/tests/test_corpus_release.py
+++ b/tests/test_corpus_release.py
@@ -32,9 +32,11 @@ def _canonical_sha256(payload: dict) -> str:
 
 
 def _signed_release_object(
-    *, schema_version: str = RELEASE_OBJECT_SCHEMA_V2
+    *,
+    schema_version: str = RELEASE_OBJECT_SCHEMA_V2,
+    private_key: Ed25519PrivateKey | None = None,
 ) -> tuple[dict, str]:
-    private_key = Ed25519PrivateKey.generate()
+    private_key = private_key or Ed25519PrivateKey.generate()
     public_key = b64encode(
         private_key.public_key().public_bytes(
             serialization.Encoding.Raw,
@@ -194,6 +196,34 @@ def test_verified_release_object_accepts_profiled_v3() -> None:
 
     assert verified.content_sha256 == payload["content_sha256"]
     assert payload["content"]["quality_profile"] == (COMPLETE_EXPRESSION_DATES_PROFILE)
+
+
+def test_release_object_verifies_with_current_or_retired_key(caplog) -> None:
+    current_private_key = Ed25519PrivateKey.generate()
+    retired_private_key = Ed25519PrivateKey.generate()
+    old_payload, retired_public_key = _signed_release_object(
+        private_key=retired_private_key
+    )
+    new_payload, current_public_key = _signed_release_object(
+        private_key=current_private_key
+    )
+    keyring = (current_public_key, retired_public_key)
+
+    with caplog.at_level("DEBUG", logger="axiom_encode.corpus_release"):
+        old_verified = verify_release_object(old_payload, public_key=keyring)
+        new_verified = verify_release_object(new_payload, public_key=keyring)
+
+    assert old_verified.content_sha256 == old_payload["content_sha256"]
+    assert new_verified.content_sha256 == new_payload["content_sha256"]
+    assert "release object signature verified with key index 1" in caplog.messages
+    assert "release object signature verified with key index 0" in caplog.messages
+
+
+def test_release_object_rejects_empty_keyring() -> None:
+    payload, _public_key = _signed_release_object()
+
+    with pytest.raises(CorpusReleaseObjectError, match="keyring must not be empty"):
+        verify_release_object(payload, public_key=())
 
 
 @pytest.mark.parametrize("schema_version", [[], {}])

--- a/tests/test_provision_verification_supervisor.py
+++ b/tests/test_provision_verification_supervisor.py
@@ -4,6 +4,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from scripts.provision_verification_supervisor import _signing_trust_roots_payload
+
 
 def test_provision_replaces_base_runtime_site_packages(tmp_path: Path) -> None:
     git = shutil.which("git")
@@ -109,3 +111,21 @@ def test_provision_replaces_base_runtime_site_packages(tmp_path: Path) -> None:
         for pattern in forbidden_patterns
         for path in destination.rglob(pattern)
     )
+
+
+def test_provision_writes_v3_corpus_release_keyring() -> None:
+    assert _signing_trust_roots_payload(
+        "apply",
+        "eval",
+        "current",
+        ("retired-one", "retired-two"),
+    ) == {
+        "schema": "axiom-encode/signing-trust-roots/v3",
+        "apply_ed25519_public_key": "apply",
+        "eval_ed25519_public_key": "eval",
+        "corpus_release_ed25519_public_keys": [
+            "current",
+            "retired-one",
+            "retired-two",
+        ],
+    }

--- a/tests/test_signing_broker.py
+++ b/tests/test_signing_broker.py
@@ -70,6 +70,7 @@ def test_typed_apply_and_eval_operations() -> None:
     )
     assert broker.capabilities == frozenset({"apply_ed25519", "eval_ed25519"})
     assert broker.corpus_release_public_key_raw == b"\x17" * 32
+    assert broker.corpus_release_public_keys_raw == (b"\x17" * 32,)
 
 
 def test_apply_and_eval_signatures_are_not_cross_usable_even_with_one_test_key() -> (

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -198,6 +198,10 @@ def main():
             \"corpus_release\": b64encode(
                 broker.corpus_release_public_key_raw
             ).decode(\"ascii\"),
+            \"corpus_release_keys\": [
+                b64encode(public_key).decode(\"ascii\")
+                for public_key in broker.corpus_release_public_keys_raw
+            ],
         },
     }
     if os.environ.get("CODEX_HOME"):
@@ -426,22 +430,22 @@ def _trust_config(
     apply_public: str,
     eval_public: str,
     corpus_release_public: str | None = None,
+    corpus_release_public_keys: tuple[str, ...] | None = None,
 ) -> Path:
     if corpus_release_public is None:
         corpus_release_public, _private_key = _keypair(b"\x17" * 32)
     path = tmp_path.resolve() / "signing-trust-roots.json"
-    path.write_text(
-        json.dumps(
-            {
-                "schema": "axiom-encode/signing-trust-roots/v2",
-                "apply_ed25519_public_key": apply_public,
-                "eval_ed25519_public_key": eval_public,
-                "corpus_release_ed25519_public_key": corpus_release_public,
-            },
-            sort_keys=True,
-        )
-        + "\n"
-    )
+    payload = {
+        "schema": "axiom-encode/signing-trust-roots/v2",
+        "apply_ed25519_public_key": apply_public,
+        "eval_ed25519_public_key": eval_public,
+        "corpus_release_ed25519_public_key": corpus_release_public,
+    }
+    if corpus_release_public_keys is not None:
+        payload["schema"] = "axiom-encode/signing-trust-roots/v3"
+        payload.pop("corpus_release_ed25519_public_key")
+        payload["corpus_release_ed25519_public_keys"] = corpus_release_public_keys
+    path.write_text(json.dumps(payload, sort_keys=True) + "\n")
     path.chmod(0o600)
     return path
 
@@ -1267,17 +1271,90 @@ def test_verification_only_invocation_exposes_roots_without_signing_capability(
         "apply": apply_public,
         "eval": eval_public,
         "corpus_release": corpus_release_public,
+        "corpus_release_keys": [corpus_release_public],
     }
 
 
-def test_verification_only_supervisor_runs_public_guard_generated_with_signed_release(
+def test_v3_trust_config_exposes_ordered_corpus_release_keyring(
+    signing_supervisor: Path,
+    trusted_python_runtime: tuple[Path, Path, Path],
+    tmp_path: Path,
+) -> None:
+    apply_public, _apply_key = _keypair(b"\xab" * 32)
+    eval_public, _eval_key = _keypair(b"\xcd" * 32)
+    current_public, _current_key = _keypair(b"\x18" * 32)
+    retired_public, _retired_key = _keypair(b"\x17" * 32)
+    completed = _invoke(
+        signing_supervisor,
+        trusted_python_runtime,
+        _launcher(tmp_path, trusted_python_runtime),
+        _trust_config(
+            tmp_path,
+            apply_public,
+            eval_public,
+            corpus_release_public_keys=(current_public, retired_public),
+        ),
+        [],
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert json.loads(completed.stdout)["roots"] == {
+        "apply": apply_public,
+        "eval": eval_public,
+        "corpus_release": current_public,
+        "corpus_release_keys": [current_public, retired_public],
+    }
+
+
+@pytest.mark.parametrize("mutation", ["empty", "malformed", "wrong_length", "conflict"])
+def test_v3_trust_config_rejects_invalid_corpus_release_keyrings(
+    signing_supervisor: Path,
+    trusted_python_runtime: tuple[Path, Path, Path],
+    tmp_path: Path,
+    mutation: str,
+) -> None:
+    apply_public, _apply_key = _keypair(b"\xab" * 32)
+    eval_public, _eval_key = _keypair(b"\xcd" * 32)
+    current_public, _current_key = _keypair(b"\x18" * 32)
+    other_public, _other_key = _keypair(b"\x19" * 32)
+    trust_config = _trust_config(
+        tmp_path,
+        apply_public,
+        eval_public,
+        corpus_release_public_keys=(current_public,),
+    )
+    payload = json.loads(trust_config.read_text())
+    if mutation == "empty":
+        payload["corpus_release_ed25519_public_keys"] = []
+    elif mutation == "malformed":
+        payload["corpus_release_ed25519_public_keys"] = ["not-base64!!"]
+    elif mutation == "wrong_length":
+        payload["corpus_release_ed25519_public_keys"] = [b64encode(b"short").decode()]
+    else:
+        payload["corpus_release_ed25519_public_key"] = other_public
+    trust_config.write_text(json.dumps(payload) + "\n")
+
+    completed = _invoke(
+        signing_supervisor,
+        trusted_python_runtime,
+        _launcher(tmp_path, trusted_python_runtime),
+        trust_config,
+        [],
+    )
+
+    assert completed.returncode == 2
+    assert "corpus release public key" in completed.stderr
+
+
+def test_verification_only_supervisor_accepts_retired_release_key_from_v3_keyring(
     signing_supervisor: Path,
     trusted_real_cli_runtime: tuple[Path, Path, Path],
     tmp_path: Path,
 ) -> None:
     apply_public, _apply_key = _keypair(b"\xab" * 32)
     eval_public, _eval_key = _keypair(b"\xcd" * 32)
-    corpus_release_public, _corpus_release_key = _keypair(b"\x17" * 32)
+    current_corpus_release_public, _current_corpus_release_key = _keypair(b"\x18" * 32)
+    retired_corpus_release_public, _retired_corpus_release_key = _keypair(b"\x17" * 32)
     rulespec_root, corpus_root = _write_signed_guard_fixture(
         tmp_path,
         trusted_real_cli_runtime[1],
@@ -1291,7 +1368,10 @@ def test_verification_only_supervisor_runs_public_guard_generated_with_signed_re
             tmp_path,
             apply_public,
             eval_public,
-            corpus_release_public,
+            corpus_release_public_keys=(
+                current_corpus_release_public,
+                retired_corpus_release_public,
+            ),
         ),
         [],
         command_args=(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1326"
+version = "0.2.1327"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
Fixes #1201. Org-wide validate CI + signed-apply are red for every pre-rotation release since 16:04Z today; this makes retired keys verify-only members of an ordered keyring while signing stays current-key-only. v2 files unchanged, fail-closed on malformed input, Go broker forwards the full keyring, real-CLI acceptance test green in a frozen env.

**Merge gate: do NOT merge until the org variable `AXIOM_CORPUS_RELEASE_RETIRED_PUBLIC_KEY` exists** — the provisioned workflows fail closed without it (deliberate). Creating it is a trust-anchor change reserved for Max (trust-root guard). Value = the pre-rotation public key, derived-and-verified from the retired private key against the 2026-07-20 /opt trust roots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)