### PR TITLE
Add axiom-encode ci: local parity entrypoint for the org validate-rulespec gates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ build/
 hook_debug.log
 artifacts/eval-suites/
 .gitnexus/
+.lane-materials/

--- a/changelog.d/ci-parity-entrypoint.added.md
+++ b/changelog.d/ci-parity-entrypoint.added.md
@@ -1,0 +1,3 @@
+Add `axiom-encode ci` as a verification-only local entrypoint that resolves a
+lane's pinned validate-rulespec toolchain and runs the shared workflow gates in
+CI order with matching dependency and changed-file semantics.

--- a/docs/ci-parity.md
+++ b/docs/ci-parity.md
@@ -1,0 +1,61 @@
+# Local validate-rulespec parity
+
+`axiom-encode ci --repo /path/to/rulespec-<country>` runs the validation gates
+declared by that lane's reusable `validate-rulespec.yml` caller. It reads the
+four pinned dependency commits and caller inputs, verifies the strict
+`.axiom/toolchain.toml` and waiver-set binding, authenticates each local checkout
+against `origin/main`, selects changes relative to `--base-ref origin/main`, and
+runs every applicable gate in workflow order.
+
+Parity is fail-closed and pin-relative: this release implements workflow pins
+`615c1df9b9ace7deea84da65efd137f46f8bad2b` and
+`34bcfab235c585c47292c95f51be1a4f4f91d29e`, including their differing treatment
+of `programs/` in the money-atom file scan. A caller pinned to another workflow
+revision is rejected until the fixture, registry, and implementation are updated
+together. The changed-file classifier likewise requires the installed
+`axiom-oracles` VCS commit to match the dependency declared by the pinned encoder.
+
+Use explicit checkout overrides when the dependencies are not siblings:
+
+```console
+axiom-encode ci --repo ../rulespec-dk \
+  --corpus-path ../axiom-corpus \
+  --engine-path ../axiom-rules-engine \
+  --rulespec-us-path ../rulespec-us \
+  --encode-path . \
+  --corpus-release-public-key "$PUBLIC_KEY" \
+  --offline
+```
+
+The public key must be supplied only through
+`--corpus-release-public-key`. Retrieve the organization variable for a local
+run with:
+
+```console
+gh api /orgs/TheAxiomFoundation/actions/variables/AXIOM_CORPUS_RELEASE_PUBLIC_KEY --jq .value
+```
+
+The command never reads `AXIOM_CORPUS_RELEASE_PUBLIC_KEY` from the environment.
+It constructs a verification-only release binding in the library, acquires no
+signing capability and never runs `--apply`. It writes temporary report inputs;
+the sole non-report write is caching a missing immutable public release object
+at the workflow-defined corpus release path. The command downloads that object
+from the caller's `corpus-release-base-url` unless `--offline` is set.
+
+A dependency checkout whose `HEAD` differs from its caller pin fails resolution
+and names both SHAs. `--allow-ref-mismatch` permits all gates to run, but a
+successful run receives the qualified `PASS-WITH-MISMATCHED-DEPS` verdict and
+exit code 3. Its mandatory final banner enumerates every dependency mismatch.
+Plain `PASS` and exit code 0 require all four dependency checkouts to match.
+Gate failures and resolution failures remain `FAIL` with exit code 1. JSON
+reports expose the same value in `verdict` and list structured
+`dependency_mismatches`.
+
+The imported (ambient) `axiom_encode` implementation is also fail-closed against
+the caller's encoder pin: source-checkout `HEAD` is compared when available,
+otherwise package versions are compared. Exact parity means running this tool
+from the pinned encoder checkout. `--allow-encoder-mismatch` is the honest mode
+for development loops on newer encoders and produces the same qualified verdict
+and mismatch banner. Executing every gate in a subprocess sourced from the
+pinned checkout is the longer-term gold path and is intentionally out of scope
+for this command version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1327"
+version = "0.2.1328"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1327"
+__version__ = "0.2.1328"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/ci_parity.py
+++ b/src/axiom_encode/ci_parity.py
@@ -1,0 +1,1504 @@
+"""Local, verification-only parity entrypoint for validate-rulespec CI.
+
+This module deliberately owns no signing capability and never invokes an applying
+command. Apart from caching a fetched immutable public release object at the
+workflow-defined corpus path, it writes only temporary report inputs. Protected-supervisor calls
+in CI are reproduced as direct subcommands under an explicit, library-level
+corpus release verification key.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import fnmatch
+import hashlib
+import importlib.metadata
+import io
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import tarfile
+import tempfile
+import tomllib
+import urllib.request
+from collections.abc import Callable, Sequence
+from dataclasses import asdict, dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+import yaml
+
+from axiom_encode import __version__
+from axiom_encode.toolchain import (
+    RuleSpecToolchain,
+    load_rulespec_local_corpus_release,
+    load_rulespec_toolchain,
+    local_corpus_release_verification,
+    verify_rulespec_validation_waiver_set,
+)
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+WORKFLOW_RE = re.compile(
+    r"TheAxiomFoundation/\.github/\.github/workflows/"
+    r"validate-rulespec\.yml@(?P<sha>[0-9a-f]{40})$"
+)
+DEPENDENCY_INPUTS = {
+    "encode": "axiom-encode-ref",
+    "engine": "axiom-rules-engine-ref",
+    "corpus": "axiom-corpus-ref",
+    "rulespec_us": "rulespec-us-ref",
+}
+DEFAULT_RELEASE_BASE_URL = "https://pub-a8952f8657fc49fda358146ac001366c.r2.dev"
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowGateParameters:
+    exclude_programs_from_money_atom_check: bool
+
+
+@dataclass(frozen=True, slots=True)
+class SupportedWorkflowPin:
+    fixture: str
+    gate_parameters: WorkflowGateParameters
+
+
+SUPPORTED_WORKFLOW_PINS: dict[str, SupportedWorkflowPin] = {
+    "615c1df9b9ace7deea84da65efd137f46f8bad2b": SupportedWorkflowPin(
+        fixture="validate-rulespec-615c1df9.yml",
+        gate_parameters=WorkflowGateParameters(
+            exclude_programs_from_money_atom_check=True
+        ),
+    ),
+    "34bcfab235c585c47292c95f51be1a4f4f91d29e": SupportedWorkflowPin(
+        fixture="validate-rulespec-34bcfab2.yml",
+        gate_parameters=WorkflowGateParameters(
+            exclude_programs_from_money_atom_check=False
+        ),
+    ),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class CallerConfig:
+    path: Path
+    workflow_sha: str
+    refs: dict[str, str]
+    validate_roots: str
+    run_generated_guard: bool
+    guard_programs_root: bool
+    release_base_url: str = DEFAULT_RELEASE_BASE_URL
+    run_pytest: bool = True
+    run_money_atom_check: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class GateSpec:
+    key: str
+    name: str
+    subcommand: str
+    flags: tuple[str, ...]
+    workflow_lines: str
+
+
+# Stable order is part of the public parity contract.  Dynamic file operands
+# are represented by placeholders; literal flags match the workflow run blocks.
+CI_GATE_REGISTRY: tuple[GateSpec, ...] = (
+    GateSpec(
+        "repository_tests", "Run repository tests", "pytest", ("-q", "tests"), "646-653"
+    ),
+    GateSpec(
+        "obsolete_files",
+        "Reject obsolete generated files",
+        "find",
+        ("*.rac", "*.rac.test"),
+        "655-665",
+    ),
+    GateSpec(
+        "repository_layout",
+        "Reject disallowed repository layout",
+        "layout",
+        (),
+        "667-835",
+    ),
+    GateSpec(
+        "validation_waivers",
+        "Enforce validation waiver ratchet",
+        "validation-waivers audit",
+        (
+            "--root",
+            "{repo}",
+            "--corpus-path",
+            "{corpus}",
+            "--protected-base",
+            "{base-waivers}",
+            "--changed-paths",
+            "{changed-paths}",
+            "--axiom-rules-engine-path",
+            "{engine}",
+        ),
+        "837-908",
+    ),
+    GateSpec(
+        "guard_generated",
+        "Reject manual RuleSpec changes",
+        "guard-generated",
+        (
+            "--repo",
+            "{repo}",
+            "--base-ref",
+            "{base-ref}",
+            "--head-ref",
+            "HEAD",
+            "--corpus-path",
+            "{corpus}",
+            "--expected-encoder-checkout",
+            "{encode}",
+        ),
+        "910-935",
+    ),
+    GateSpec(
+        "select_targets",
+        "Select RuleSpec validation targets",
+        "selection",
+        ("--base-ref", "{base-ref}", "--roots", "{roots}"),
+        "936-1108",
+    ),
+    GateSpec(
+        "validate",
+        "Validate RuleSpec YAML",
+        "validate",
+        (
+            "{files}",
+            "--skip-reviewers",
+            "--corpus-path",
+            "{corpus}",
+            "--axiom-rules-engine-path",
+            "{engine}",
+        ),
+        "1109-1166",
+    ),
+    GateSpec(
+        "companion_tests",
+        "Execute RuleSpec companion tests",
+        "test",
+        (
+            "--root",
+            "{jurisdiction}",
+            "--axiom-rules-engine-path",
+            "{engine}",
+            "{tests}",
+        ),
+        "1167-1218",
+    ),
+    GateSpec(
+        "proof_validate",
+        "Validate RuleSpec proofs and claims",
+        "proof-validate",
+        ("{files}", "--corpus-path", "{corpus}"),
+        "1219-1249",
+    ),
+    GateSpec(
+        "money_atoms",
+        "Require money proof atoms",
+        "proof-validate",
+        ("{all-files}", "--money-atoms-only", "--corpus-path", "{corpus}", "{ratchet}"),
+        "1250-1302",
+    ),
+    GateSpec(
+        "oracle_coverage",
+        "Validate PolicyEngine oracle coverage classification",
+        "oracle-coverage",
+        (
+            "--root",
+            "{repo}",
+            "--fail-on-unmapped",
+            "--fail-on-untested-comparable",
+            "--limit",
+            "50",
+        ),
+        "1303-1313",
+    ),
+    GateSpec(
+        "changed_oracle_coverage",
+        "Validate changed PolicyEngine oracle coverage classification",
+        "oracle-coverage",
+        ("--root", "{repo}", "--json"),
+        "1314-1419",
+    ),
+)
+
+WORKFLOW_GATE_STEPS: dict[str, tuple[str, ...]] = {
+    "Run repository tests": ("repository_tests",),
+    "Reject obsolete generated files": ("obsolete_files",),
+    "Reject disallowed repository layout": ("repository_layout",),
+    "Enforce validation waiver ratchet": ("validation_waivers",),
+    "Reject manual RuleSpec changes": ("guard_generated",),
+    "Select RuleSpec validation targets": ("select_targets",),
+    "Validate RuleSpec YAML": ("validate",),
+    "Execute RuleSpec companion tests": ("companion_tests",),
+    "Validate RuleSpec proofs and claims": ("proof_validate",),
+    "Require money proof atoms": ("money_atoms",),
+    "Validate PolicyEngine oracle coverage classification": ("oracle_coverage",),
+    "Checkout changed-file oracle coverage classifier": ("changed_oracle_coverage",),
+    "Install changed-file oracle coverage classifier": ("changed_oracle_coverage",),
+    "Validate changed PolicyEngine oracle coverage classification": (
+        "changed_oracle_coverage",
+    ),
+}
+
+
+@dataclass(slots=True)
+class GateResult:
+    gate: str
+    name: str
+    status: str
+    command: list[str] = field(default_factory=list)
+    failures: list[str] = field(default_factory=list)
+    output: str = ""
+    note: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DependencyMismatch:
+    name: str
+    head_sha: str
+    pinned_sha: str
+
+    def banner_line(self) -> str:
+        return f"{self.name}: HEAD {self.head_sha} != pinned {self.pinned_sha}"
+
+
+@dataclass(frozen=True, slots=True)
+class Selection:
+    mode: str
+    rulespec_files: tuple[Path, ...]
+    test_files: tuple[Path, ...]
+
+
+def register_ci_parser(subparsers: Any) -> None:
+    parser = subparsers.add_parser(
+        "ci", help="Run the local validate-rulespec CI parity gate sequence"
+    )
+    parser.add_argument("--repo", type=Path, required=True)
+    parser.add_argument("--corpus-path", type=Path)
+    parser.add_argument("--engine-path", type=Path)
+    parser.add_argument("--rulespec-us-path", type=Path)
+    parser.add_argument("--encode-path", type=Path)
+    parser.add_argument("--base-ref", default="origin/main")
+    parser.add_argument("--roots", default=None)
+    parser.add_argument("--corpus-release-public-key", required=True)
+    parser.add_argument("--allow-ref-mismatch", action="store_true")
+    parser.add_argument("--allow-encoder-mismatch", action="store_true")
+    parser.add_argument("--offline", action="store_true")
+    parser.add_argument("--json", action="store_true")
+
+
+def find_caller_workflow(repo: Path) -> CallerConfig:
+    workflow_dir = repo / ".github" / "workflows"
+    matches: list[CallerConfig] = []
+    for path in sorted((*workflow_dir.glob("*.yml"), *workflow_dir.glob("*.yaml"))):
+        try:
+            payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        except yaml.YAMLError as exc:
+            raise ValueError(f"Invalid caller workflow {path}: {exc}") from exc
+        jobs = payload.get("jobs", {}) if isinstance(payload, dict) else {}
+        for job in jobs.values() if isinstance(jobs, dict) else ():
+            if not isinstance(job, dict) or not isinstance(job.get("uses"), str):
+                continue
+            match = WORKFLOW_RE.fullmatch(job["uses"])
+            if match:
+                matches.append(parse_caller_job(path, match.group("sha"), job))
+    if len(matches) != 1:
+        raise ValueError(
+            f"Expected exactly one validate-rulespec caller under {workflow_dir}; "
+            f"found {len(matches)}"
+        )
+    return matches[0]
+
+
+def parse_caller_workflow(path: Path) -> CallerConfig:
+    """Parse a caller fixture containing exactly one reusable-workflow job."""
+
+    payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    jobs = payload.get("jobs", {}) if isinstance(payload, dict) else {}
+    found = []
+    for job in jobs.values() if isinstance(jobs, dict) else ():
+        if isinstance(job, dict) and isinstance(job.get("uses"), str):
+            match = WORKFLOW_RE.fullmatch(job["uses"])
+            if match:
+                found.append(parse_caller_job(path, match.group("sha"), job))
+    if len(found) != 1:
+        raise ValueError(f"Expected one validate-rulespec caller in {path}")
+    return found[0]
+
+
+def parse_caller_job(
+    path: Path, workflow_sha: str, job: dict[str, Any]
+) -> CallerConfig:
+    inputs = job.get("with")
+    if not isinstance(inputs, dict):
+        raise ValueError(f"Caller {path} has no with-inputs")
+    refs: dict[str, str] = {}
+    for dependency, input_name in DEPENDENCY_INPUTS.items():
+        value = inputs.get(input_name)
+        if not isinstance(value, str) or SHA_RE.fullmatch(value) is None:
+            raise ValueError(
+                f"Caller {path}: {input_name} must be a full lowercase SHA"
+            )
+        refs[dependency] = value
+    return CallerConfig(
+        path=path,
+        workflow_sha=workflow_sha,
+        refs=refs,
+        validate_roots=str(inputs.get("validate-roots", "auto")),
+        run_generated_guard=bool(inputs.get("run-generated-guard", True)),
+        guard_programs_root=bool(inputs.get("guard-programs-root", False)),
+        release_base_url=str(
+            inputs.get("corpus-release-base-url", DEFAULT_RELEASE_BASE_URL)
+        ),
+        run_pytest=bool(inputs.get("run-pytest", True)),
+        run_money_atom_check=bool(inputs.get("run-money-atom-check", True)),
+    )
+
+
+def resolve_dependency_paths(args: argparse.Namespace, repo: Path) -> dict[str, Path]:
+    running_checkout = Path(__file__).resolve().parents[2]
+    return {
+        "encode": (args.encode_path or running_checkout).expanduser().resolve(),
+        "engine": (args.engine_path or repo.parent / "axiom-rules-engine")
+        .expanduser()
+        .resolve(),
+        "corpus": (args.corpus_path or repo.parent / "axiom-corpus")
+        .expanduser()
+        .resolve(),
+        "rulespec_us": (args.rulespec_us_path or repo.parent / "rulespec-us")
+        .expanduser()
+        .resolve(),
+    }
+
+
+def _git(
+    repo: Path, *arguments: str, check: bool = True
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo), *arguments],
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def verify_dependency_checkout(
+    name: str,
+    path: Path,
+    pin: str,
+    caller: Path,
+    *,
+    allow_ref_mismatch: bool,
+) -> DependencyMismatch | None:
+    if not path.is_dir():
+        raise ValueError(f"{name} checkout does not exist: {path}")
+    if _git(path, "cat-file", "-e", f"{pin}^{{commit}}", check=False).returncode:
+        raise ValueError(
+            f"{name} checkout {path} does not contain pinned commit {pin} from {caller}"
+        )
+    protected = "refs/remotes/origin/main"
+    if _git(path, "show-ref", "--verify", "--quiet", protected, check=False).returncode:
+        raise ValueError(
+            f"{name} checkout {path} has no origin/main for authenticating {pin} from {caller}"
+        )
+    if _git(
+        path, "merge-base", "--is-ancestor", pin, protected, check=False
+    ).returncode:
+        raise ValueError(
+            f"{name} pinned commit {pin} from {caller} is not an ancestor of origin/main in {path}"
+        )
+    head = _git(path, "rev-parse", "HEAD").stdout.strip()
+    # A checkout at the pinned HEAD but with local modifications is not the
+    # pinned tree CI will use; treat dirtiness as a mismatch in its own right.
+    dirty = bool(_git(path, "status", "--porcelain", check=False).stdout.strip())
+    if head == pin and not dirty:
+        return None
+    described_head = f"{head} (dirty worktree)" if dirty else head
+    mismatch = DependencyMismatch(name, described_head, pin)
+    warning = f"REF MISMATCH: {mismatch.banner_line()} declared by {caller}"
+    if not allow_ref_mismatch:
+        raise ValueError(warning + "; pass --allow-ref-mismatch to continue")
+    return mismatch
+
+
+def verify_ambient_encoder(
+    encode_pin: str,
+    pinned_version: str,
+    caller: Path,
+    *,
+    allow_encoder_mismatch: bool,
+) -> DependencyMismatch | None:
+    """Bind the imported encoder to the caller pin, preferring source identity."""
+
+    source_checkout = Path(__file__).resolve().parents[2]
+    result = _git(source_checkout, "rev-parse", "HEAD", check=False)
+    head = result.stdout.strip()
+    if result.returncode == 0 and SHA_RE.fullmatch(head):
+        mismatch = (
+            None
+            if head == encode_pin
+            else DependencyMismatch("ambient-encoder", head, encode_pin)
+        )
+    else:
+        # Version equality cannot establish source identity: an installed
+        # wheel with no resolvable git HEAD may differ from the pinned
+        # encoder at an equal version string. Unresolvable identity is
+        # always a mismatch (fail-closed without the flag).
+        mismatch = DependencyMismatch(
+            "ambient-encoder",
+            f"unresolvable ({__version__})",
+            encode_pin,
+        )
+    if mismatch is not None and not allow_encoder_mismatch:
+        raise ValueError(
+            f"ENCODER MISMATCH: {mismatch.banner_line()} declared by {caller}; "
+            "run this tool from the pinned encode checkout for exact parity, or "
+            "pass --allow-encoder-mismatch for a qualified development verdict"
+        )
+    return mismatch
+
+
+def encoder_version_at_pin(path: Path, pin: str) -> str:
+    """Require consistent encoder version metadata at the caller's exact pin."""
+
+    def show(name: str) -> str:
+        result = _git(path, "show", f"{pin}:{name}", check=False)
+        if result.returncode:
+            raise ValueError(f"Pinned encoder {pin} has no {name}")
+        return result.stdout
+
+    pyproject = tomllib.loads(show("pyproject.toml"))["project"]["version"]
+    package_match = re.search(
+        r'(?m)^__version__\s*=\s*"([^"]+)"',
+        show("src/axiom_encode/__init__.py"),
+    )
+    lock_match = re.search(
+        r'(?ms)^name = "axiom-encode"\nversion = "([^"]+)"', show("uv.lock")
+    )
+    package = package_match.group(1) if package_match else None
+    lock = lock_match.group(1) if lock_match else None
+    if not isinstance(pyproject, str) or pyproject != package or pyproject != lock:
+        raise ValueError(
+            f"Pinned encoder {pin} has inconsistent version metadata "
+            f"(pyproject={pyproject}, package={package}, lock={lock})"
+        )
+    return pyproject
+
+
+def acquire_release_object(
+    toolchain: RuleSpecToolchain,
+    corpus_path: Path,
+    base_url: str,
+    *,
+    offline: bool,
+    fetcher: Callable[[str], bytes] | None = None,
+) -> Path:
+    destination = (
+        corpus_path
+        / "releases"
+        / toolchain.corpus_release
+        / f"{toolchain.corpus_release_content_sha256}.json"
+    )
+    if destination.is_file():
+        return destination
+    if offline:
+        raise ValueError(
+            f"--offline requires pinned corpus release object: {destination}"
+        )
+    url = f"{base_url.rstrip('/')}/releases/{toolchain.corpus_release}/{toolchain.corpus_release_content_sha256}.json"
+    fetch = fetcher or (lambda value: urllib.request.urlopen(value, timeout=30).read())
+    raw = fetch(url)
+    try:
+        payload = json.loads(raw)
+        content = payload["content"]
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise ValueError(
+            f"Corpus release acquisition error: invalid JSON: {exc}"
+        ) from exc
+    actual = hashlib.sha256(
+        json.dumps(
+            content, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+        ).encode()
+    ).hexdigest()
+    if payload.get("release") != toolchain.corpus_release:
+        raise ValueError("Corpus release acquisition error: release name mismatch")
+    if (
+        payload.get("content_sha256") != actual
+        or actual != toolchain.corpus_release_content_sha256
+    ):
+        raise ValueError(
+            f"Corpus release acquisition error: content sha256 mismatch ({actual} != {toolchain.corpus_release_content_sha256})"
+        )
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_suffix(".json.tmp")
+    temporary.write_bytes(raw)
+    temporary.replace(destination)
+    return destination
+
+
+def authenticate_release_provenance(
+    release_path: Path,
+    corpus_path: Path,
+    corpus_pin: str,
+    caller: Path,
+) -> str:
+    try:
+        payload = json.loads(release_path.read_text(encoding="utf-8"))
+        commit = payload["content"]["git"]["commit"]
+    except (OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise ValueError(f"Signed corpus release provenance is missing: {exc}") from exc
+    if not isinstance(commit, str) or SHA_RE.fullmatch(commit) is None:
+        raise ValueError("Signed release provenance is not a full lowercase commit SHA")
+    if _git(
+        corpus_path, "cat-file", "-e", f"{commit}^{{commit}}", check=False
+    ).returncode:
+        raise ValueError(f"Signed corpus release provenance commit is absent: {commit}")
+    if _git(
+        corpus_path,
+        "merge-base",
+        "--is-ancestor",
+        commit,
+        "refs/remotes/origin/main",
+        check=False,
+    ).returncode:
+        raise ValueError(
+            f"Signed corpus release provenance {commit} is not an ancestor of corpus origin/main"
+        )
+    if _git(
+        corpus_path, "merge-base", "--is-ancestor", commit, corpus_pin, check=False
+    ).returncode:
+        raise ValueError(
+            f"Signed corpus release provenance {commit} is not contained in "
+            f"caller corpus pin {corpus_pin} from {caller}"
+        )
+    return commit
+
+
+def verify_toolchain_base_binding(repo: Path, base_ref: str) -> None:
+    """Mirror the workflow's migrated-base removal guard."""
+
+    result = _git(repo, "show", f"{base_ref}:.axiom/toolchain.toml", check=False)
+    if result.returncode:
+        return
+    try:
+        payload = tomllib.loads(result.stdout)
+    except tomllib.TOMLDecodeError:
+        return
+    table = payload.get("toolchain")
+    expected = {
+        "axiom_corpus_release",
+        "axiom_corpus_release_content_sha256",
+        "validation_waiver_set_sha256",
+    }
+    if isinstance(table, dict) and set(table) == expected:
+        path = repo / ".axiom" / "toolchain.toml"
+        if not path.is_file() or path.is_symlink():
+            raise ValueError(
+                ".axiom/toolchain.toml cannot be removed once a base branch uses it"
+            )
+
+
+def resolve_roots(repo: Path, raw: str) -> tuple[str, ...]:
+    if raw != "auto":
+        return tuple(item for item in raw.split() if item)
+    candidates = []
+    for child in sorted(repo.iterdir()):
+        if not child.is_dir() or child.name.startswith("."):
+            continue
+        if re.fullmatch(r"[a-z]{2}(?:-[a-z0-9-]+)*", child.name) and any(
+            (child / root).is_dir()
+            for root in ("statutes", "regulations", "policies", "legislation")
+        ):
+            candidates.append(child.name)
+    if not candidates:
+        for name in ("statutes", "regulations", "policies", "legislation"):
+            if (repo / name).is_dir():
+                candidates.append(name)
+    return tuple(candidates)
+
+
+def _changed_paths(repo: Path, base_ref: str) -> tuple[str, ...]:
+    result = _git(
+        repo,
+        "diff",
+        "--name-only",
+        "--no-renames",
+        "--diff-filter=ACMRTD",
+        base_ref,
+        "HEAD",
+    )
+    return tuple(line for line in result.stdout.splitlines() if line)
+
+
+def select_targets(repo: Path, base_ref: str, roots: Sequence[str]) -> Selection:
+    changed = _changed_paths(repo, base_ref)
+    mode = "changed"
+    if any(path.startswith(".github/workflows/") for path in changed):
+        mode = "full-toolchain-bump"
+    elif ".axiom/toolchain.toml" in changed:
+        before = _git(repo, "show", f"{base_ref}:.axiom/toolchain.toml", check=False)
+        try:
+            old = tomllib.loads(before.stdout).get("toolchain", {})
+            new = tomllib.loads((repo / ".axiom/toolchain.toml").read_text()).get(
+                "toolchain", {}
+            )
+            differences = {
+                key for key in set(old) | set(new) if old.get(key) != new.get(key)
+            }
+        except (OSError, tomllib.TOMLDecodeError):
+            differences = {"invalid"}
+        if differences and differences <= {
+            "axiom_corpus_release",
+            "axiom_corpus_release_content_sha256",
+        }:
+            mode = "changed-corpus-toolchain-bump"
+        else:
+            mode = "full-toolchain-bump"
+    rules: set[Path] = set()
+    tests: set[Path] = set()
+
+    def add(path_text: str) -> None:
+        if "/programs/" in f"/{path_text}/":
+            return
+        path = repo / path_text
+        if path_text.endswith(".test.yaml"):
+            tests.add(path) if path.is_file() else None
+            module = repo / f"{path_text[:-10]}.yaml"
+            rules.add(module) if module.is_file() else None
+        elif path_text.endswith(".test.yml"):
+            tests.add(path) if path.is_file() else None
+            module = repo / f"{path_text[:-9]}.yml"
+            rules.add(module) if module.is_file() else None
+        elif path_text.endswith((".yaml", ".yml")):
+            rules.add(path) if path.is_file() else None
+            suffix = ".test.yaml" if path_text.endswith(".yaml") else ".test.yml"
+            companion = path.with_name(path.name.rsplit(".", 1)[0] + suffix)
+            tests.add(companion) if companion.is_file() else None
+
+    if mode == "full-toolchain-bump":
+        for root in roots:
+            if (repo / root).is_dir():
+                for path in (repo / root).rglob("*.y*ml"):
+                    add(path.relative_to(repo).as_posix())
+    else:
+        for path in changed:
+            if any(path.startswith(f"{root}/") for root in roots):
+                add(path)
+    return Selection(mode, tuple(sorted(rules)), tuple(sorted(tests)))
+
+
+def _run_cli(
+    arguments: Sequence[str], *, environment: dict[str, str] | None = None
+) -> tuple[int, str]:
+    from axiom_encode import cli
+
+    output = io.StringIO()
+    old_argv = sys.argv
+    old_environment = {key: os.environ.get(key) for key in environment or {}}
+    try:
+        sys.argv = ["axiom-encode", *arguments]
+        if environment:
+            os.environ.update(environment)
+        with contextlib.redirect_stdout(output), contextlib.redirect_stderr(output):
+            try:
+                cli.main()
+            except SystemExit as exc:
+                return int(exc.code or 0), output.getvalue()
+            except Exception as exc:  # keep running later gates for local iteration
+                print(f"{type(exc).__name__}: {exc}", file=output)
+                return 1, output.getvalue()
+    finally:
+        sys.argv = old_argv
+        for key, value in old_environment.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+    return 0, output.getvalue()
+
+
+def _run_pinned_cli(
+    encode_path: Path, pin: str, arguments: Sequence[str]
+) -> tuple[int, str]:
+    """Execute classifier code from the caller's exact local encoder pin."""
+
+    expected_oracles = _encoder_oracles_pin(encode_path, pin)
+    installed_oracles = _installed_oracles_pin()
+    if expected_oracles != installed_oracles:
+        return (
+            1,
+            "Pinned changed-file classifier requires axiom-oracles "
+            f"{expected_oracles}, but the local runtime has {installed_oracles or 'no VCS pin'}. "
+            "Install the pinned encoder dependencies before running ci.\n",
+        )
+
+    with tempfile.TemporaryDirectory(prefix="axiom-ci-classifier-") as temp_name:
+        archive = subprocess.run(
+            ["git", "-C", str(encode_path), "archive", "--format=tar", pin],
+            check=True,
+            stdout=subprocess.PIPE,
+        ).stdout
+        root = Path(temp_name)
+        with tarfile.open(fileobj=io.BytesIO(archive), mode="r:") as bundle:
+            bundle.extractall(root, filter="data")
+        environment = dict(os.environ)
+        existing = environment.get("PYTHONPATH")
+        environment["PYTHONPATH"] = str(root / "src") + (
+            os.pathsep + existing if existing else ""
+        )
+        result = subprocess.run(
+            [sys.executable, "-m", "axiom_encode.cli", *arguments],
+            cwd=root,
+            env=environment,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+        return result.returncode, result.stdout
+
+
+def _encoder_oracles_pin(encode_path: Path, pin: str) -> str:
+    payload = _git(encode_path, "show", f"{pin}:pyproject.toml").stdout
+    match = re.search(
+        r'axiom-oracles\s+@\s+git\+https://github\.com/[^"@]+@([0-9a-f]{40})',
+        payload,
+    )
+    if match is None:
+        raise ValueError(f"Pinned encoder {pin} has no exact axiom-oracles dependency")
+    return match.group(1)
+
+
+def _installed_oracles_pin() -> str | None:
+    """Return the runtime's exact axiom-oracles VCS commit, never its version."""
+
+    try:
+        raw = importlib.metadata.distribution("axiom-oracles").read_text(
+            "direct_url.json"
+        )
+        payload = json.loads(raw or "null")
+        commit = payload.get("vcs_info", {}).get("commit_id")
+    except (importlib.metadata.PackageNotFoundError, json.JSONDecodeError, TypeError):
+        return None
+    return commit if isinstance(commit, str) and SHA_RE.fullmatch(commit) else None
+
+
+def _run_process(arguments: Sequence[str], cwd: Path) -> tuple[int, str]:
+    result = subprocess.run(
+        arguments,
+        cwd=cwd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    return result.returncode, result.stdout
+
+
+def _result(
+    spec: GateSpec,
+    code: int,
+    output: str,
+    command: Sequence[str],
+    *,
+    note: str | None = None,
+) -> GateResult:
+    failures = (
+        [] if code == 0 else [line for line in output.splitlines() if line.strip()]
+    )
+    return GateResult(
+        spec.key,
+        spec.name,
+        "PASS" if code == 0 else "FAIL",
+        list(command),
+        failures,
+        output,
+        note,
+    )
+
+
+def _obsolete_gate(repo: Path) -> tuple[int, str]:
+    matches = [
+        str(path.relative_to(repo))
+        for path in repo.rglob("*")
+        if path.is_file()
+        and (path.name.endswith(".rac") or path.name.endswith(".rac.test"))
+        and not any(
+            part in {".git", "_axiom", ".venv", ".pytest_cache"}
+            for part in path.relative_to(repo).parts
+        )
+    ]
+    return (1, "\n".join(matches)) if matches else (0, "No obsolete generated files.\n")
+
+
+def _layout_gate(repo: Path, roots: Sequence[str]) -> tuple[int, str]:
+    config_path = repo / ".axiom" / "repository-structure.yaml"
+    if config_path.is_file():
+        config = yaml.safe_load(config_path.read_text()) or {}
+        if not isinstance(config, dict):
+            return 1, f"{config_path} must contain a mapping"
+        if config.get("version") != 1:
+            return 1, f"{config_path} must set version: 1"
+        for key in ("allowed_root_directories", "allowed_root_files"):
+            value = config.get(key)
+            if not isinstance(value, list) or not all(
+                isinstance(item, str) for item in value
+            ):
+                return 1, f"{key} must be a list of strings"
+        declared_rules = config.get("path_rules")
+        if not isinstance(declared_rules, list) or not declared_rules:
+            return 1, "path_rules must be a non-empty list"
+        for index, rule in enumerate(declared_rules, start=1):
+            if not isinstance(rule, dict):
+                return 1, f"path_rules[{index}] must be a mapping"
+            patterns = rule.get("patterns")
+            if (
+                not isinstance(patterns, list)
+                or not patterns
+                or not all(isinstance(pattern, str) for pattern in patterns)
+            ):
+                return (
+                    1,
+                    f"path_rules[{index}].patterns must be a non-empty list of strings",
+                )
+            for key in ("allow_extensions", "allow_filenames"):
+                value = rule.get(key, [])
+                if not isinstance(value, list) or not all(
+                    isinstance(item, str) for item in value
+                ):
+                    return 1, f"path_rules[{index}].{key} must be a list of strings"
+        tracked = _git(repo, "ls-files", "-z").stdout.split("\0")
+        problems = []
+        root_dirs = {
+            item.strip("/") for item in config.get("allowed_root_directories", [])
+        }
+        root_files = {item.strip("/") for item in config.get("allowed_root_files", [])}
+        rules = config.get("path_rules", [])
+        for path in filter(None, tracked):
+            parts = PurePosixPath(path).parts
+            if len(parts) == 1:
+                if path not in root_files:
+                    problems.append(f"{path}: top-level file is not allowed")
+                continue
+            if parts[0] not in root_dirs:
+                problems.append(
+                    f"{path}: top-level directory {parts[0]}/ is not allowed"
+                )
+                continue
+            rule = next(
+                (
+                    item
+                    for item in rules
+                    if any(
+                        fnmatch.fnmatchcase(path, pattern.strip("/"))
+                        for pattern in item.get("patterns", [])
+                    )
+                ),
+                None,
+            )
+            if rule is None:
+                problems.append(f"{path}: no path rule matched")
+            elif PurePosixPath(path).name not in rule.get(
+                "allow_filenames", []
+            ) and PurePosixPath(path).suffix not in rule.get("allow_extensions", []):
+                problems.append(
+                    f"{path}: file name/extension is not allowed by matched path rule"
+                )
+        return (
+            (1, "\n".join(problems))
+            if problems
+            else (0, f"Repository layout matches {config_path}.\n")
+        )
+    problems = [
+        name for name in ("statute", "regulation", "policy") if (repo / name).exists()
+    ]
+    for path in repo.rglob("*.y*ml"):
+        relative = path.relative_to(repo)
+        if any(
+            part in {".git", "_axiom", ".venv", ".pytest_cache", ".github"}
+            for part in relative.parts
+        ):
+            continue
+        text = relative.as_posix()
+        if path.name in {"parameters.yaml", "tests.yaml"} or (
+            relative.parts and relative.parts[0] == "tests"
+        ):
+            problems.append(text)
+            continue
+        if path.name in {"known-dangling.yaml", "known-validation-gaps.yaml"}:
+            continue
+        if not any(text.startswith(f"{root}/") for root in roots):
+            problems.append(text)
+    return (
+        (1, "\n".join(problems)) if problems else (0, "Repository layout is allowed.\n")
+    )
+
+
+def _classifier_gate(
+    repo: Path,
+    selection: Selection,
+    encode_path: Path,
+    encode_pin: str,
+) -> tuple[int, str]:
+    if not selection.rulespec_files:
+        return 0, "No changed RuleSpec YAML files selected for oracle coverage.\n"
+    code, output = _run_pinned_cli(
+        encode_path,
+        encode_pin,
+        ["oracle-coverage", "--root", str(repo), "--json"],
+    )
+    if code:
+        return code, output
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError as exc:
+        return 1, f"Changed oracle coverage emitted invalid JSON: {exc}\n{output}"
+    if repo.name.startswith("rulespec-be"):
+        return 0, "Changed PolicyEngine oracle coverage skipped for Belgium.\n"
+    changed = {
+        f"{repo.name}/{path.relative_to(repo).as_posix()}"
+        for path in selection.rulespec_files
+    }
+    failures = []
+    items = [item for item in payload.get("items", []) if item.get("file") in changed]
+    for item in items:
+        if item.get("status") == "unmapped":
+            failures.append(f"{item.get('legal_id')}: unmapped")
+        elif item.get("status") == "comparable" and not item.get("tested"):
+            failures.append(
+                f"{item.get('legal_id')}: comparable but not covered by companion tests"
+            )
+    if failures:
+        return 1, "Changed PolicyEngine oracle coverage is incomplete.\n" + "\n".join(
+            f"- {failure}" for failure in failures
+        )
+    return (
+        0,
+        f"Changed PolicyEngine oracle coverage passed for {len(items)} output(s).\n",
+    )
+
+
+def execute_gates(
+    args: argparse.Namespace,
+    caller: CallerConfig,
+    paths: dict[str, Path],
+    roots: tuple[str, ...],
+) -> list[GateResult]:
+    repo = args.repo.resolve()
+    selection = select_targets(repo, args.base_ref, roots)
+    results: list[GateResult] = []
+    specs = {spec.key: spec for spec in CI_GATE_REGISTRY}
+    gate_parameters = SUPPORTED_WORKFLOW_PINS[caller.workflow_sha].gate_parameters
+    if (
+        caller.run_pytest
+        and (repo / "tests").is_dir()
+        and any(
+            path.is_file()
+            and (path.name.startswith("test_") or path.name.endswith("_test.py"))
+            for path in (repo / "tests").rglob("*.py")
+        )
+    ):
+        command = [sys.executable, "-m", "pytest", "-q", "tests"]
+        results.append(
+            _result(specs["repository_tests"], *_run_process(command, repo), command)
+        )
+    else:
+        results.append(
+            _result(
+                specs["repository_tests"],
+                0,
+                "No Python tests found; skipping pytest.\n",
+                [],
+            )
+        )
+    results.append(
+        _result(
+            specs["obsolete_files"],
+            *_obsolete_gate(repo),
+            ["find", ".", "*.rac", "*.rac.test"],
+        )
+    )
+    results.append(
+        _result(
+            specs["repository_layout"],
+            # Workflow shard resolution always permits programs/: it is a
+            # validation root when guarded, otherwise an allowed extra root.
+            *_layout_gate(repo, (*roots, "sources", "programs")),
+            ["layout"],
+        )
+    )
+    with tempfile.TemporaryDirectory(prefix="axiom-ci-") as temp_name:
+        temp = Path(temp_name)
+        protected = temp / "protected-known-validation-gaps.yaml"
+        changed = temp / "waiver-changed-paths.txt"
+        base = _git(
+            repo, "show", f"{args.base_ref}:known-validation-gaps.yaml", check=False
+        )
+        protected.write_text(base.stdout)
+        changed.write_text("\n".join(_changed_paths(repo, args.base_ref)) + "\n")
+        waiver_command = [
+            "validation-waivers",
+            "audit",
+            "--root",
+            str(repo),
+            "--corpus-path",
+            str(paths["corpus"]),
+            "--protected-base",
+            str(protected),
+            "--changed-paths",
+            str(changed),
+            "--axiom-rules-engine-path",
+            str(paths["engine"]),
+        ]
+        code, output = (
+            (
+                1,
+                "ValidationWaiverBaseMissing: protected base must contain known-validation-gaps.yaml\n",
+            )
+            if base.returncode
+            else _run_cli(waiver_command)
+        )
+        results.append(
+            _result(
+                specs["validation_waivers"],
+                code,
+                output,
+                waiver_command,
+                note="library-level verification; no signing capability acquired",
+            )
+        )
+        if caller.run_generated_guard:
+            guard_command = [
+                "guard-generated",
+                "--repo",
+                str(repo),
+                "--base-ref",
+                args.base_ref,
+                "--head-ref",
+                "HEAD",
+                "--corpus-path",
+                str(paths["corpus"]),
+                "--expected-encoder-checkout",
+                str(paths["encode"]),
+            ]
+            results.append(
+                _result(
+                    specs["guard_generated"],
+                    *_run_cli(guard_command),
+                    guard_command,
+                    note="library-level verification; --apply is never available to ci",
+                )
+            )
+        else:
+            results.append(
+                _result(
+                    specs["guard_generated"],
+                    0,
+                    "Disabled by caller run-generated-guard.\n",
+                    [],
+                )
+            )
+    selection_output = f"RuleSpec validation mode: {selection.mode}\n" + "\n".join(
+        f"- {path.relative_to(repo)}" for path in selection.rulespec_files
+    )
+    results.append(
+        _result(
+            specs["select_targets"],
+            0,
+            selection_output,
+            ["selection", "--base-ref", args.base_ref, "--roots", *roots],
+        )
+    )
+    skipped = set()
+    gaps_path = repo / "known-validation-gaps.yaml"
+    if gaps_path.is_file():
+        gaps = yaml.safe_load(gaps_path.read_text()) or {}
+        entries = gaps.get("validate_failures", {}) if isinstance(gaps, dict) else {}
+        skipped = set(entries if isinstance(entries, (dict, list)) else ())
+    validate_failures, validate_output = [], []
+    for path in selection.rulespec_files:
+        if path.relative_to(repo).as_posix() in skipped:
+            continue
+        command = [
+            "validate",
+            str(path),
+            "--skip-reviewers",
+            "--corpus-path",
+            str(paths["corpus"]),
+            "--axiom-rules-engine-path",
+            str(paths["engine"]),
+        ]
+        code, output = _run_cli(
+            command,
+            environment={
+                "AXIOM_RULESPEC_REPO_ROOTS": os.pathsep.join(
+                    (str(repo), str(paths["rulespec_us"]))
+                )
+            },
+        )
+        validate_output.append(output)
+        if code:
+            validate_failures.append(path.relative_to(repo).as_posix())
+    results.append(
+        GateResult(
+            "validate",
+            specs["validate"].name,
+            "FAIL" if validate_failures else "PASS",
+            ["validate", "{selected files}"],
+            validate_failures,
+            "".join(validate_output),
+            "direct subcommand under library-level release verification",
+        )
+    )
+    test_failures, test_output = [], []
+    grouped: dict[str, list[Path]] = {}
+    for path in selection.test_files:
+        relative = path.relative_to(repo)
+        module = (
+            relative.as_posix()
+            .replace(".test.yaml", ".yaml")
+            .replace(".test.yml", ".yml")
+        )
+        if module not in skipped:
+            grouped.setdefault(relative.parts[0], []).append(relative)
+    for jurisdiction, files in grouped.items():
+        command = [
+            "test",
+            "--root",
+            str(repo / jurisdiction),
+            "--axiom-rules-engine-path",
+            str(paths["engine"]),
+            *(str(Path(*file.parts[1:])) for file in files),
+        ]
+        code, output = _run_cli(
+            command,
+            environment={
+                "AXIOM_RULESPEC_REPO_ROOTS": os.pathsep.join(
+                    (str(repo), str(paths["rulespec_us"]))
+                )
+            },
+        )
+        test_output.append(output)
+        if code:
+            test_failures.extend(file.as_posix() for file in files)
+    results.append(
+        GateResult(
+            "companion_tests",
+            specs["companion_tests"].name,
+            "FAIL" if test_failures else "PASS",
+            ["test", "{selected tests}"],
+            test_failures,
+            "".join(test_output),
+        )
+    )
+    proof_failures, proof_output = [], []
+    for path in selection.rulespec_files:
+        command = ["proof-validate", str(path), "--corpus-path", str(paths["corpus"])]
+        code, output = _run_cli(command)
+        proof_output.append(output)
+        if code:
+            proof_failures.append(path.relative_to(repo).as_posix())
+    results.append(
+        GateResult(
+            "proof_validate",
+            specs["proof_validate"].name,
+            "FAIL" if proof_failures else "PASS",
+            ["proof-validate", "{selected files}"],
+            proof_failures,
+            "".join(proof_output),
+            "direct subcommand under library-level release verification",
+        )
+    )
+    all_rules = tuple(
+        sorted(
+            path
+            for root in roots
+            if (repo / root).is_dir()
+            for path in (repo / root).rglob("*.y*ml")
+            if ".test." not in path.name
+            and (
+                not gate_parameters.exclude_programs_from_money_atom_check
+                or "/programs/" not in path.as_posix()
+            )
+        )
+    )
+    if caller.run_money_atom_check and all_rules:
+        command = [
+            "proof-validate",
+            *map(str, all_rules),
+            "--money-atoms-only",
+            "--corpus-path",
+            str(paths["corpus"]),
+        ]
+        if (repo / "known-missing-money-atoms.yaml").is_file():
+            command += ["--ratchet-file", str(repo / "known-missing-money-atoms.yaml")]
+        results.append(
+            _result(
+                specs["money_atoms"],
+                *_run_cli(command),
+                command,
+                note="direct subcommand under library-level release verification",
+            )
+        )
+    else:
+        results.append(
+            _result(
+                specs["money_atoms"],
+                0,
+                "No RuleSpec YAML files found or gate disabled.\n",
+                [],
+            )
+        )
+    if selection.mode == "full-toolchain-bump":
+        command = [
+            "oracle-coverage",
+            "--root",
+            str(repo),
+            "--fail-on-unmapped",
+            "--fail-on-untested-comparable",
+            "--limit",
+            "50",
+        ]
+        results.append(_result(specs["oracle_coverage"], *_run_cli(command), command))
+        results.append(
+            _result(
+                specs["changed_oracle_coverage"],
+                0,
+                "Not used for full-toolchain-bump mode.\n",
+                [],
+            )
+        )
+    else:
+        results.append(
+            _result(
+                specs["oracle_coverage"],
+                0,
+                "Full oracle coverage is not selected for changed-file mode.\n",
+                [],
+            )
+        )
+        results.append(
+            _result(
+                specs["changed_oracle_coverage"],
+                *_classifier_gate(
+                    repo,
+                    selection,
+                    paths["encode"],
+                    caller.refs["encode"],
+                ),
+                # This is deliberately the already-authenticated local checkout,
+                # archived at the caller pin; no fresh checkout or ambient runtime
+                # classifier is used.
+                ["oracle-coverage", "--root", str(repo), "--json"],
+                note=(
+                    "classifier executed from encode pin "
+                    f"{caller.refs['encode']} in {paths['encode']}"
+                ),
+            )
+        )
+    return results
+
+
+def run_ci(args: argparse.Namespace) -> int:
+    repo = args.repo.expanduser().resolve()
+    args.repo = repo
+    mismatches: list[DependencyMismatch] = []
+    try:
+        caller = find_caller_workflow(repo)
+        if caller.workflow_sha not in SUPPORTED_WORKFLOW_PINS:
+            supported = ", ".join(SUPPORTED_WORKFLOW_PINS)
+            raise ValueError(
+                f"Unsupported validate-rulespec workflow pin {caller.workflow_sha} "
+                f"in {caller.path}; this axiom-encode release implements "
+                f"these pins: {supported}"
+            )
+        verify_toolchain_base_binding(repo, args.base_ref)
+        toolchain = load_rulespec_toolchain(repo)
+        verify_rulespec_validation_waiver_set(repo)
+        paths = resolve_dependency_paths(args, repo)
+        for name, path in paths.items():
+            mismatch = verify_dependency_checkout(
+                name,
+                path,
+                caller.refs[name],
+                caller.path,
+                allow_ref_mismatch=args.allow_ref_mismatch,
+            )
+            if mismatch:
+                mismatches.append(mismatch)
+        pinned_version = encoder_version_at_pin(paths["encode"], caller.refs["encode"])
+        encoder_mismatch = verify_ambient_encoder(
+            caller.refs["encode"],
+            pinned_version,
+            caller.path,
+            allow_encoder_mismatch=getattr(args, "allow_encoder_mismatch", False),
+        )
+        if encoder_mismatch:
+            mismatches.append(encoder_mismatch)
+        release_path = acquire_release_object(
+            toolchain, paths["corpus"], caller.release_base_url, offline=args.offline
+        )
+        authenticate_release_provenance(
+            release_path,
+            paths["corpus"],
+            caller.refs["corpus"],
+            caller.path,
+        )
+        roots = resolve_roots(repo, args.roots or caller.validate_roots)
+        if caller.guard_programs_root:
+            roots = (*roots, "programs")
+        if not roots:
+            raise ValueError("No validation roots resolved")
+        with local_corpus_release_verification(args.corpus_release_public_key):
+            # Authenticate the release signature and its complete artifact
+            # inventory even when changed-file selection produces no later
+            # corpus-consuming gate.
+            load_rulespec_local_corpus_release(repo, paths["corpus"])
+            results = execute_gates(args, caller, paths, roots)
+    except Exception as exc:
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "passed": False,
+                        "verdict": "FAIL",
+                        "dependency_mismatches": [asdict(item) for item in mismatches],
+                        "resolution_error": str(exc),
+                        "gates": [],
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            for mismatch in mismatches:
+                print(f"WARNING: {mismatch.banner_line()}", file=sys.stderr)
+            print(f"axiom-encode ci resolution failed: {exc}", file=sys.stderr)
+        return 1
+    gates_passed = all(result.status == "PASS" for result in results)
+    verdict = ci_verdict(gates_passed, mismatches)
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "passed": verdict == "PASS",
+                    "verdict": verdict,
+                    "caller": str(caller.path),
+                    "workflow_sha": caller.workflow_sha,
+                    "dependency_mismatches": [asdict(item) for item in mismatches],
+                    "roots": roots,
+                    "gates": [asdict(result) for result in results],
+                },
+                indent=2,
+            )
+        )
+    else:
+        for mismatch in mismatches:
+            print(f"WARNING: {mismatch.banner_line()}", file=sys.stderr)
+        print(f"validate-rulespec caller: {caller.path} @ {caller.workflow_sha}")
+        for result in results:
+            print(f"{result.status:4} {result.name}")
+            for failure in result.failures:
+                print(f"     - {failure}")
+            if result.note:
+                print(f"     {result.note}")
+        print(f"ci parity result: {verdict}")
+        if mismatches:
+            print("MISMATCHED DEPENDENCIES:")
+            for mismatch in mismatches:
+                print(f"  - {mismatch.banner_line()}")
+    return (
+        0 if verdict == "PASS" else 3 if verdict == "PASS-WITH-MISMATCHED-DEPS" else 1
+    )
+
+
+def ci_verdict(gates_passed: bool, mismatches: Sequence[DependencyMismatch]) -> str:
+    if not gates_passed:
+        return "FAIL"
+    return "PASS-WITH-MISMATCHED-DEPS" if mismatches else "PASS"
+
+
+def workflow_axiom_invocations(path: Path) -> list[tuple[str, tuple[str, ...]]]:
+    """Extract axiom-encode invocations from validate-job run blocks."""
+
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    steps = payload["jobs"]["validate"]["steps"]
+    invocations = []
+    for step in steps:
+        run = step.get("run", "") if isinstance(step, dict) else ""
+        logical_run = run.replace("\\\n", " ")
+        for match in re.finditer(
+            r"(?:/opt/axiom-verification/)?axiom-encode\s+([a-z-]+)([^\n]*)",
+            logical_run,
+        ):
+            command = match.group(1)
+            try:
+                tokens = shlex.split(match.group(2))
+            except ValueError:
+                tokens = match.group(2).split()
+            flags = tuple(token for token in tokens if token.startswith("--"))
+            if command in {
+                "validation-waivers",
+                "guard-generated",
+                "validate",
+                "test",
+                "proof-validate",
+                "oracle-coverage",
+            }:
+                invocations.append((command, flags))
+    return invocations
+
+
+def workflow_gate_coverage(path: Path) -> dict[str, tuple[str, ...]]:
+    """Map every parity-relevant workflow step to its registry gate(s)."""
+
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    names = {
+        step.get("name")
+        for step in payload["jobs"]["validate"]["steps"]
+        if isinstance(step, dict)
+    }
+    return {
+        name: WORKFLOW_GATE_STEPS[name] for name in names & WORKFLOW_GATE_STEPS.keys()
+    }
+
+
+def workflow_gate_contract(
+    step: dict[str, Any], payload: dict[str, Any]
+) -> dict[str, Any]:
+    """Return behavior-bearing reusable-workflow context for one gate step."""
+
+    trigger = payload.get("on", payload.get(True, {}))
+    workflow_call = (
+        trigger.get("workflow_call", {}) if isinstance(trigger, dict) else {}
+    )
+    raw_inputs = (
+        workflow_call.get("inputs", {}) if isinstance(workflow_call, dict) else {}
+    )
+    inputs = {
+        name: {
+            "type": declaration.get("type"),
+            "default": declaration.get("default"),
+        }
+        for name, declaration in sorted(raw_inputs.items())
+        if isinstance(name, str) and isinstance(declaration, dict)
+    }
+    validate_job = payload.get("jobs", {}).get("validate", {})
+    return {
+        "step": step,
+        "workflow_call_inputs": inputs,
+        "workflow_env": payload.get("env"),
+        "validate_job_env": validate_job.get("env"),
+        "workflow_defaults": payload.get("defaults"),
+        "validate_job_defaults": validate_job.get("defaults"),
+    }

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -835,6 +835,10 @@ def main():
     )
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 
+    from .ci_parity import register_ci_parser
+
+    register_ci_parser(subparsers)
+
     # validate command
     validate_parser = subparsers.add_parser(
         "validate", help="Validate RuleSpec YAML files (CI + reviewer agents)"
@@ -2405,6 +2409,11 @@ def main():
     _judge_cli.register_judge_subparsers(subparsers)
 
     args = parser.parse_args()
+
+    if args.command == "ci":
+        from .ci_parity import run_ci
+
+        sys.exit(run_ci(args))
 
     if args.command in _judge_cli.COMMANDS:
         sys.exit(_judge_cli.dispatch(args))

--- a/src/axiom_encode/toolchain.py
+++ b/src/axiom_encode/toolchain.py
@@ -6,7 +6,9 @@ import hashlib
 import os
 import re
 import tomllib
-from base64 import b64encode
+from base64 import b64decode, b64encode
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -27,6 +29,9 @@ CORPUS_RELEASE_CONTENT_SHA256_FIELD = "axiom_corpus_release_content_sha256"
 VALIDATION_WAIVER_SET_SHA256_FIELD = "validation_waiver_set_sha256"
 VALIDATION_WAIVER_SET_PATH = "known-validation-gaps.yaml"
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_LOCAL_CORPUS_RELEASE_PUBLIC_KEY: ContextVar[str | None] = ContextVar(
+    "axiom_ci_corpus_release_public_key", default=None
+)
 
 
 class RuleSpecToolchainError(ValueError):
@@ -248,26 +253,57 @@ def load_rulespec_local_corpus_release(
 
     toolchain = load_rulespec_toolchain(rulespec_root)
     _verify_rulespec_validation_waiver_set(toolchain)
-    try:
-        broker = get_signing_broker()
-    except SigningBrokerError as exc:
-        raise RuleSpecToolchainError(
-            "A protected signing broker is required to verify the pinned "
-            "corpus release object"
-        ) from exc
-    public_keys_raw = broker.corpus_release_public_keys_raw
-    if not public_keys_raw or any(
-        len(public_key) != 32 for public_key in public_keys_raw
-    ):
-        raise RuleSpecToolchainError(
-            "The protected signing broker has no valid corpus release public keyring"
+    public_key = _LOCAL_CORPUS_RELEASE_PUBLIC_KEY.get()
+    if public_key is not None:
+        public_keys = (public_key,)
+    else:
+        try:
+            broker = get_signing_broker()
+        except SigningBrokerError as exc:
+            raise RuleSpecToolchainError(
+                "A protected signing broker is required to verify the pinned "
+                "corpus release object"
+            ) from exc
+        public_keys_raw = broker.corpus_release_public_keys_raw
+        if not public_keys_raw or any(
+            len(candidate) != 32 for candidate in public_keys_raw
+        ):
+            raise RuleSpecToolchainError(
+                "The protected signing broker has no valid corpus release public keyring"
+            )
+        public_keys = tuple(
+            b64encode(candidate).decode("ascii") for candidate in public_keys_raw
         )
-    public_keys = tuple(
-        b64encode(public_key).decode("ascii") for public_key in public_keys_raw
-    )
     return LocalCorpusRelease(
         corpus_root,
         toolchain.corpus_release,
         toolchain.corpus_release_content_sha256,
         public_keys,
     )
+
+
+@contextmanager
+def local_corpus_release_verification(public_key: str):
+    """Temporarily provide a verification-only corpus public key.
+
+    This exists solely for ``axiom-encode ci``.  It conveys no signing
+    capability, is never populated from the environment, and keeps the trusted
+    bootstrap's prohibition on environment-supplied public roots intact.
+    """
+
+    # Construct once so malformed keys fail before any gate starts.
+    try:
+        raw = b64decode(public_key, validate=True)
+    except Exception as exc:
+        raise RuleSpecToolchainError(
+            "--corpus-release-public-key must be canonical base64"
+        ) from exc
+    if len(raw) != 32 or b64encode(raw).decode("ascii") != public_key:
+        raise RuleSpecToolchainError(
+            "--corpus-release-public-key must encode exactly 32 bytes"
+        )
+    token = _LOCAL_CORPUS_RELEASE_PUBLIC_KEY.set(public_key)
+    try:
+        yield
+    finally:
+        _LOCAL_CORPUS_RELEASE_PUBLIC_KEY.reset(token)

--- a/tests/fixtures/ci_parity/de-caller.yml
+++ b/tests/fixtures/ci_parity/de-caller.yml
@@ -1,0 +1,20 @@
+name: Repository Checks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec.yml@615c1df9b9ace7deea84da65efd137f46f8bad2b
+    secrets: inherit
+    with:
+      axiom-encode-ref: 164abed93f6df7f4bc52af533a9989159ec58113
+      axiom-rules-engine-ref: 05eac9d2f89dabe5c6673176260762cef3a58f47
+      axiom-corpus-ref: 2dee8d9021ff54583b1314bd029a0e4eafa468aa
+      rulespec-us-ref: 0f291b367bf7e15555f9973112278c5cbf221653
+      validate-roots: auto
+      run-generated-guard: true
+      guard-programs-root: false

--- a/tests/fixtures/ci_parity/dk-caller.yml
+++ b/tests/fixtures/ci_parity/dk-caller.yml
@@ -1,0 +1,22 @@
+name: Repository Checks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec.yml@34bcfab235c585c47292c95f51be1a4f4f91d29e
+    secrets: inherit
+    with:
+      axiom-encode-ref: f4b952b7ba83d8382d0074b64b27ba6ea9a7637b
+      axiom-rules-engine-ref: 05eac9d2f89dabe5c6673176260762cef3a58f47
+      axiom-corpus-ref: f7be113cede06e0619011cdc231fd2fa744271e5
+      rulespec-us-ref: 0f291b367bf7e15555f9973112278c5cbf221653
+      validate-roots: auto
+      run-generated-guard: false
+      # Composed-pilot programs/ guarding, as piloted in rulespec-uk and
+      # adopted by rulespec-gh (encode#1053).
+      guard-programs-root: false

--- a/tests/fixtures/ci_parity/validate-rulespec-34bcfab2.yml
+++ b/tests/fixtures/ci_parity/validate-rulespec-34bcfab2.yml
@@ -1,0 +1,1438 @@
+name: Validate RuleSpec Repository
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: Python version used for repository tests and validators.
+        required: false
+        type: string
+        default: "3.14"
+      axiom-encode-ref:
+        description: Full commit SHA for TheAxiomFoundation/axiom-encode.
+        required: true
+        type: string
+      axiom-rules-engine-ref:
+        description: Full commit SHA for TheAxiomFoundation/axiom-rules-engine.
+        required: true
+        type: string
+      axiom-corpus-ref:
+        description: Full commit SHA for TheAxiomFoundation/axiom-corpus.
+        required: true
+        type: string
+      rulespec-us-ref:
+        description: Full commit SHA for TheAxiomFoundation/rulespec-us canonical targets.
+        required: true
+        type: string
+      corpus-release-base-url:
+        description: HTTPS base URL of the public R2 bucket containing releases/.
+        # Interim r2.dev URL for the dedicated axiom-corpus-releases bucket;
+        # switch to https://corpus.axiom-foundation.org once the custom domain
+        # is bound (needs the R2 bucket in the axiom-foundation.org zone account).
+        required: false
+        default: https://pub-a8952f8657fc49fda358146ac001366c.r2.dev
+        type: string
+      validate-roots:
+        description: >-
+          Space-separated repository roots containing RuleSpec YAML, or
+          "auto" to discover jurisdiction directories in a country monorepo
+          (top-level dirs like us/, us-co/ that contain statutes/,
+          regulations/, policies/, or legislation/).
+        required: false
+        type: string
+        default: "statutes regulations policies"
+      run-pytest:
+        description: Whether to run pytest when the repository has a tests directory.
+        required: false
+        type: boolean
+        default: true
+      run-generated-guard:
+        description: >-
+          Whether to run the manual-RuleSpec-change guard. Disable ONLY for
+          history-preserving migration PRs (e.g. repo consolidation) where
+          every file arrives from an already-validated repo; re-enable
+          immediately after.
+        required: false
+        type: boolean
+        default: true
+      guard-programs-root:
+        description: >-
+          Whether to require encoding manifests on the composed-pilot
+          `programs/` root too (encode#1053). Opt-in per repo: enable only
+          after every existing `programs/` file has an encoder apply-manifest
+          or a manual attestation, otherwise the guard fails on the backlog.
+          When true, `programs` is guarded as a RuleSpec root rather than
+          merely tolerated as an allowed extra directory.
+        required: false
+        type: boolean
+        default: false
+      run-money-atom-check:
+        description: >-
+          Whether to require a proof atom citing a provision on every
+          policy-bearing monetary value (currency parameters, currency
+          parameter-table cells, and currency literals in derived formulas).
+          The calling repo may carry a `known-missing-money-atoms.yaml`
+          ratchet to tolerate a visible backlog; an absent ratchet means a
+          strict zero allowance, so a repo must be clean or carry a ratchet.
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  shards:
+    name: shards
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.compute.outputs.matrix }}
+      first: ${{ steps.compute.outputs.first }}
+      roots: ${{ steps.compute.outputs.roots }}
+      allowed-extra: ${{ steps.compute.outputs.allowed-extra }}
+    steps:
+      - name: Checkout rules repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Full history so shard-on-demand can diff the pull-request base
+          # against the head to see which jurisdiction subtrees changed.
+          fetch-depth: 0
+
+      - name: Compute validation shards
+        id: compute
+        shell: bash
+        env:
+          VALIDATE_ROOTS_INPUT: ${{ inputs.validate-roots }}
+          GUARD_PROGRAMS_ROOT: ${{ inputs.guard-programs-root }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [ "$VALIDATE_ROOTS_INPUT" = "auto" ]; then
+            all_shards=()
+            for dir in */; do
+              dir="${dir%/}"
+              case "$dir" in _*|.*) continue ;; esac
+              if printf '%s' "$dir" | grep -Eq '^[a-z]{2}(-[a-z0-9-]+)*$'; then
+                for marker in statutes regulations policies legislation; do
+                  if [ -d "$dir/$marker" ]; then
+                    all_shards+=("$dir")
+                    break
+                  fi
+                done
+              fi
+            done
+            if [ "${#all_shards[@]}" -eq 0 ]; then
+              echo "validate-roots=auto found no jurisdiction directories" >&2
+              exit 1
+            fi
+            # roots always covers every discovered jurisdiction, even when the
+            # matrix is scoped to one shard: the repo-wide gates (layout,
+            # obsolete-file, manual-change guard, money-atom) run on the first
+            # shard against this full set, so their whole-repo scope is
+            # preserved regardless of which single shard the matrix selects.
+            roots="${all_shards[*]}"
+            if [ "$GUARD_PROGRAMS_ROOT" = "true" ]; then
+              # Guard the composed-pilot programs/ root instead of merely
+              # tolerating it as an allowed extra (encode#1053).
+              roots="$roots programs"
+              allowed_extra="sources"
+            else
+              allowed_extra="sources programs"
+            fi
+
+            # Shard-on-demand: a pull request whose diff is confined to exactly
+            # one jurisdiction subtree (the bulk-encoding case) validates only
+            # that jurisdiction's shard. Multi-tree diffs, pushes, scheduled
+            # runs, and any change that touches shared infrastructure fall back
+            # to the full matrix, which stays the honesty backstop against
+            # cross-shard drift (a daily scheduled full run lives in the
+            # calling repo). The repo-wide gates still run because they are
+            # pinned to the first shard, so no gate is skipped when scoped.
+            mapfile -t selected_shards < <(
+              ALL_SHARDS="${all_shards[*]}" \
+              EVENT_NAME="$EVENT_NAME" \
+              PR_BASE_SHA="$PR_BASE_SHA" \
+              HEAD_SHA="$HEAD_SHA" \
+              python3 <<'PY'
+          import os
+          import subprocess
+          import sys
+
+          all_shards = os.environ["ALL_SHARDS"].split()
+          shard_set = set(all_shards)
+
+
+          def full(reason: str) -> None:
+              print(f"scope=full ({reason})", file=sys.stderr)
+              for shard in all_shards:
+                  print(shard)
+              raise SystemExit
+
+
+          event = os.environ.get("EVENT_NAME", "")
+          base = os.environ.get("PR_BASE_SHA", "").strip()
+          head = os.environ.get("HEAD_SHA", "").strip()
+
+          if event != "pull_request" or not base or not head:
+              full(f"event={event or 'unknown'}")
+
+          diff = subprocess.run(
+              ["git", "diff", "--name-only", "--no-renames",
+               "--diff-filter=ACMRTD", base, head],
+              stdout=subprocess.PIPE, text=True,
+          )
+          if diff.returncode != 0:
+              full("git diff failed")
+
+          changed = [line.strip() for line in diff.stdout.splitlines() if line.strip()]
+          if not changed:
+              full("empty diff")
+
+          touched: set[str] = set()
+          for path in changed:
+              top = path.split("/", 1)[0]
+              if top in shard_set:
+                  touched.add(top)
+                  continue
+              # The reverse index is derived tooling metadata regenerated from
+              # the YAML; it never changes what any shard must validate, so an
+              # index-only edit alongside a jurisdiction edit stays scoped.
+              if path.startswith(".axiom/index/"):
+                  continue
+              # Anything else (workflows, toolchain, structure config, other
+              # .axiom entries, sources/, programs/, root files, ...) can
+              # affect every shard: fall back to the full matrix.
+              full(f"cross-cutting path {path}")
+
+          if len(touched) == 1:
+              only = next(iter(touched))
+              print(f"scope=one-jurisdiction ({only})", file=sys.stderr)
+              print(only)
+          else:
+              full(f"{len(touched)} jurisdiction subtrees touched")
+          PY
+            )
+            # Never emit an empty matrix: if scope selection produced nothing
+            # (e.g. the classifier crashed), run the full matrix rather than
+            # skip validation, so the required check can never pass vacuously.
+            if [ "${#selected_shards[@]}" -eq 0 ]; then
+              echo "Scope selection produced no shards; falling back to full matrix." >&2
+              selected_shards=("${all_shards[@]}")
+            fi
+            shards=("${selected_shards[@]}")
+          else
+            shards=("__all__")
+            roots="$VALIDATE_ROOTS_INPUT"
+            if [ "$GUARD_PROGRAMS_ROOT" = "true" ]; then
+              case " $roots " in
+                *" programs "*) : ;;
+                *) roots="$roots programs" ;;
+              esac
+            fi
+            allowed_extra="sources"
+          fi
+          matrix=$(printf '%s\n' "${shards[@]}" | python3 -c 'import json,sys; print(json.dumps([l.strip() for l in sys.stdin if l.strip()]))')
+          {
+            echo "matrix=$matrix"
+            echo "first=${shards[0]}"
+            echo "roots=$roots"
+            echo "allowed-extra=$allowed_extra"
+          } >> "$GITHUB_OUTPUT"
+          echo "Shards: $matrix"
+
+  validate:
+    # Keep the check name exactly `validate` across matrix legs so existing
+    # required-status configs keep matching; legacy repos run one `__all__`
+    # leg with behavior identical to the pre-shard workflow.
+    name: validate
+    needs: shards
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(needs.shards.outputs.matrix) }}
+
+    steps:
+      # This job stacks four dependency checkouts, Go + Rust toolchains, an
+      # isolated verification runtime, and an engine build on one ~14 GB
+      # runner disk; reclaim the preinstalled bloat first or the runner dies
+      # mid-job with "No space left on device" (and no usable step logs).
+      - name: Free runner disk space
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Disk before cleanup:" && df -h /
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
+            /usr/local/.ghcup /opt/hostedtoolcache/CodeQL || true
+          sudo docker image prune --all --force >/dev/null 2>&1 || true
+          echo "Disk after cleanup:" && df -h /
+
+      - name: Checkout rules repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Resolve shard validation roots
+        id: resolve_roots
+        shell: bash
+        env:
+          VALIDATE_ROOTS_INPUT: ${{ inputs.validate-roots }}
+          SHARD: ${{ matrix.shard }}
+        run: |
+          set -euo pipefail
+          if [ "$SHARD" = "__all__" ]; then
+            roots="$VALIDATE_ROOTS_INPUT"
+          else
+            roots="$SHARD"
+          fi
+          echo "roots=$roots" >> "$GITHUB_OUTPUT"
+          echo "Shard validation roots: $roots"
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Resolve RuleSpec toolchain
+        id: toolchain
+        shell: bash
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import os
+          import re
+          import subprocess
+          import sys
+          import tomllib
+          from pathlib import Path
+
+          TOOLCHAIN_PATH = Path(".axiom/toolchain.toml")
+          EXPECTED_KEYS = {
+              "axiom_corpus_release",
+              "axiom_corpus_release_content_sha256",
+              "validation_waiver_set_sha256",
+          }
+          SHA256_RE = re.compile(r"[0-9a-f]{64}")
+          RELEASE_RE = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*")
+
+          def fail(message: str) -> None:
+              print(f"RuleSpec toolchain error: {message}", file=sys.stderr)
+              sys.exit(1)
+
+          def load_toolchain(raw: bytes) -> dict[str, str]:
+              try:
+                  payload = tomllib.loads(raw.decode("utf-8"))
+              except (UnicodeError, tomllib.TOMLDecodeError) as exc:
+                  fail(f"toolchain file is not valid UTF-8 TOML: {exc}")
+              if set(payload) != {"toolchain"} or not isinstance(payload["toolchain"], dict):
+                  fail("toolchain file must contain exactly one top-level [toolchain] table")
+              table = payload["toolchain"]
+              if set(table) != EXPECTED_KEYS:
+                  fail("[toolchain] must contain exactly: " + ", ".join(sorted(EXPECTED_KEYS)))
+              if not all(isinstance(value, str) for value in table.values()):
+                  fail("all [toolchain] values must be strings")
+              if RELEASE_RE.fullmatch(table["axiom_corpus_release"]) is None:
+                  fail("axiom_corpus_release is not a canonical immutable release name")
+              if table["axiom_corpus_release"] == "current":
+                  fail("axiom_corpus_release must not use the mutable current alias")
+              for key in EXPECTED_KEYS - {"axiom_corpus_release"}:
+                  if SHA256_RE.fullmatch(table[key]) is None:
+                      fail(f"{key} must be a lowercase sha256 digest")
+              return table
+
+          def base_toolchain() -> dict[str, object] | None:
+              base_sha = os.environ.get("PR_BASE_SHA")
+              if not base_sha:
+                  return None
+              result = subprocess.run(
+                  ["git", "show", f"{base_sha}:.axiom/toolchain.toml"],
+                  check=False,
+                  stdout=subprocess.PIPE,
+                  stderr=subprocess.DEVNULL,
+              )
+              if result.returncode != 0:
+                  return None
+              # A base branch that predates the canonical-toolchain migration
+              # carries an old-schema toolchain. For the removal-guard below,
+              # that is equivalent to "no canonical toolchain yet": only a base
+              # whose toolchain already conforms to the strict schema may be
+              # forbidden from dropping it. Parse the base softly (key set only)
+              # so the very PR that performs the migration is not rejected for
+              # the base still being pre-migration. Any base already on the
+              # protected branch necessarily passed strict validation to land,
+              # so an exact EXPECTED_KEYS match is a sufficient "is migrated"
+              # signal here.
+              try:
+                  payload = tomllib.loads(result.stdout.decode("utf-8"))
+              except (UnicodeError, tomllib.TOMLDecodeError):
+                  return None
+              table = payload.get("toolchain")
+              if not isinstance(table, dict) or set(table) != EXPECTED_KEYS:
+                  return None
+              return table
+
+          base_config = base_toolchain()
+          if not TOOLCHAIN_PATH.is_file() or TOOLCHAIN_PATH.is_symlink():
+              if base_config is not None:
+                  fail(".axiom/toolchain.toml cannot be removed once a base branch uses it")
+              fail("a regular .axiom/toolchain.toml is required")
+          config = load_toolchain(TOOLCHAIN_PATH.read_bytes())
+
+          waiver_path = Path("known-validation-gaps.yaml")
+          if not waiver_path.is_file() or waiver_path.is_symlink():
+              fail("known-validation-gaps.yaml must be a regular file")
+          import hashlib
+          waiver_sha256 = hashlib.sha256(waiver_path.read_bytes()).hexdigest()
+          if waiver_sha256 != config["validation_waiver_set_sha256"]:
+              fail(
+                  "ValidationWaiverHashMismatch: known-validation-gaps.yaml "
+                  f"sha256 {waiver_sha256} != pinned "
+                  f"{config['validation_waiver_set_sha256']}"
+              )
+
+          output_path = Path(os.environ["GITHUB_OUTPUT"])
+          with output_path.open("a") as output:
+              for key, value in config.items():
+                  print(f"{key}={value}", file=output)
+          print(f"Resolved strict RuleSpec toolchain from {TOOLCHAIN_PATH}:")
+          for key, value in config.items():
+              print(f"- {key}: {value}")
+          PY
+
+      - name: Validate immutable dependency inputs
+        shell: bash
+        env:
+          AXIOM_ENCODE_SHA: ${{ inputs.axiom-encode-ref }}
+          AXIOM_RULES_ENGINE_SHA: ${{ inputs.axiom-rules-engine-ref }}
+          AXIOM_CORPUS_SHA: ${{ inputs.axiom-corpus-ref }}
+          RULESPEC_US_SHA: ${{ inputs.rulespec-us-ref }}
+          RELEASE_BASE_URL: ${{ inputs.corpus-release-base-url }}
+          PYTHON_VERSION: ${{ inputs.python-version }}
+        run: |
+          set -euo pipefail
+          for value in "$AXIOM_ENCODE_SHA" "$AXIOM_RULES_ENGINE_SHA" "$AXIOM_CORPUS_SHA" "$RULESPEC_US_SHA"; do
+            if [[ ! "$value" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "Dependency inputs must be exact 40-character lowercase commit SHAs: $value" >&2
+              exit 1
+            fi
+          done
+          # python-version is spliced into many run: blocks; bound it to major.minor
+          # so a caller cannot smuggle shell into those steps (fail-open / RCE).
+          if [[ ! "$PYTHON_VERSION" =~ ^3\.[0-9]+$ ]]; then
+            echo "python-version must be a bare major.minor like 3.14: $PYTHON_VERSION" >&2
+            exit 1
+          fi
+          case "$RELEASE_BASE_URL" in
+            https://*) ;;
+            *) echo "corpus-release-base-url must use HTTPS" >&2; exit 1 ;;
+          esac
+
+      - name: Checkout axiom-encode
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: TheAxiomFoundation/axiom-encode
+          ref: ${{ inputs.axiom-encode-ref }}
+          path: _axiom/axiom-encode
+          persist-credentials: false
+
+      - name: Checkout axiom-rules-engine
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: TheAxiomFoundation/axiom-rules-engine
+          ref: ${{ inputs.axiom-rules-engine-ref }}
+          path: _axiom/axiom-rules-engine
+          persist-credentials: false
+
+      - name: Checkout axiom-corpus
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: TheAxiomFoundation/axiom-corpus
+          ref: ${{ inputs.axiom-corpus-ref }}
+          path: _axiom/axiom-corpus
+          persist-credentials: false
+
+      - name: Checkout rulespec-us canonical targets
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: TheAxiomFoundation/rulespec-us
+          ref: ${{ inputs.rulespec-us-ref }}
+          path: _axiom/rulespec-us
+          persist-credentials: false
+
+      - name: Authenticate dependency commits
+        shell: bash
+        env:
+          AXIOM_ENCODE_SHA: ${{ inputs.axiom-encode-ref }}
+          AXIOM_RULES_ENGINE_SHA: ${{ inputs.axiom-rules-engine-ref }}
+          AXIOM_CORPUS_SHA: ${{ inputs.axiom-corpus-ref }}
+          RULESPEC_US_SHA: ${{ inputs.rulespec-us-ref }}
+        run: |
+          set -euo pipefail
+          verify_ancestor() {
+            local repo="$1" expected="$2"
+            test "$(git -C "$repo" rev-parse HEAD)" = "$expected" || {
+              echo "$repo did not check out expected SHA $expected" >&2; return 1;
+            }
+            default_branch="$(git -C "$repo" ls-remote --symref origin HEAD | sed -n 's#^ref: refs/heads/\([^[:space:]]*\)[[:space:]]*HEAD$#\1#p')"
+            test -n "$default_branch" || { echo "Cannot resolve $repo default branch" >&2; return 1; }
+            git -C "$repo" fetch --no-tags --unshallow origin "+refs/heads/$default_branch:refs/remotes/origin/$default_branch"
+            git -C "$repo" merge-base --is-ancestor "$expected" "refs/remotes/origin/$default_branch" || {
+              echo "$repo SHA $expected is not an ancestor of protected default branch $default_branch" >&2; return 1;
+            }
+          }
+          verify_ancestor _axiom/axiom-encode "$AXIOM_ENCODE_SHA"
+          verify_ancestor _axiom/axiom-rules-engine "$AXIOM_RULES_ENGINE_SHA"
+          verify_ancestor _axiom/axiom-corpus "$AXIOM_CORPUS_SHA"
+          verify_ancestor _axiom/rulespec-us "$RULESPEC_US_SHA"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30
+
+      - name: Set up Go 1.26.1
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: 1.26.1
+          cache: false
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest pyyaml
+          python -m pip install -e _axiom/axiom-encode
+          rm -rf "$RUNNER_TEMP/axiom-verification-site-packages"
+          python -m pip install \
+            --target "$RUNNER_TEMP/axiom-verification-site-packages" \
+            ./_axiom/axiom-encode
+
+      - name: Fetch pinned signed corpus release object
+        shell: bash
+        env:
+          RELEASE_BASE_URL: ${{ inputs.corpus-release-base-url }}
+          RELEASE_NAME: ${{ steps.toolchain.outputs.axiom_corpus_release }}
+          RELEASE_CONTENT_SHA256: ${{ steps.toolchain.outputs.axiom_corpus_release_content_sha256 }}
+        run: |
+          set -euo pipefail
+          destination="$GITHUB_WORKSPACE/_axiom/axiom-corpus/releases/$RELEASE_NAME/$RELEASE_CONTENT_SHA256.json"
+          mkdir -p "$(dirname "$destination")"
+          url="${RELEASE_BASE_URL%/}/releases/$RELEASE_NAME/$RELEASE_CONTENT_SHA256.json"
+          curl --fail --silent --show-error --location --proto '=https' --tlsv1.2 \
+            --output "$destination.tmp" "$url"
+          python - "$destination.tmp" "$RELEASE_NAME" "$RELEASE_CONTENT_SHA256" <<'PY'
+          import hashlib
+          import json
+          import sys
+          from pathlib import Path
+
+          path, expected_name, expected_sha = Path(sys.argv[1]), sys.argv[2], sys.argv[3]
+          try:
+              payload = json.loads(path.read_bytes())
+          except (OSError, json.JSONDecodeError) as exc:
+              raise SystemExit(f"Corpus release acquisition error: invalid JSON: {exc}")
+          if payload.get("release") != expected_name:
+              raise SystemExit("Corpus release acquisition error: release name mismatch")
+          content = payload.get("content")
+          if not isinstance(content, dict):
+              raise SystemExit("Corpus release acquisition error: missing content object")
+          actual = hashlib.sha256(json.dumps(
+              content, sort_keys=True, separators=(",", ":"), ensure_ascii=True,
+          ).encode()).hexdigest()
+          if payload.get("content_sha256") != actual or actual != expected_sha:
+              raise SystemExit(
+                  f"Corpus release acquisition error: content sha256 mismatch "
+                  f"({actual} != {expected_sha})"
+              )
+          path.replace(path.with_suffix(""))
+          PY
+
+      - name: Authenticate signed corpus provenance commit
+        shell: bash
+        env:
+          RELEASE_NAME: ${{ steps.toolchain.outputs.axiom_corpus_release }}
+          RELEASE_CONTENT_SHA256: ${{ steps.toolchain.outputs.axiom_corpus_release_content_sha256 }}
+          AXIOM_CORPUS_SHA: ${{ inputs.axiom-corpus-ref }}
+        run: |
+          set -euo pipefail
+          object="_axiom/axiom-corpus/releases/$RELEASE_NAME/$RELEASE_CONTENT_SHA256.json"
+          release_commit="$(python - "$object" <<'PY'
+          import json
+          import sys
+          print(json.load(open(sys.argv[1]))["content"]["git"]["commit"])
+          PY
+          )"
+          if [[ ! "$release_commit" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Signed release provenance is not a full lowercase commit SHA" >&2
+            exit 1
+          fi
+          default_branch="$(git -C _axiom/axiom-corpus ls-remote --symref origin HEAD | sed -n 's#^ref: refs/heads/\([^[:space:]]*\)[[:space:]]*HEAD$#\1#p')"
+          git -C _axiom/axiom-corpus fetch --no-tags origin \
+            "+refs/heads/$default_branch:refs/remotes/origin/$default_branch"
+          git -C _axiom/axiom-corpus merge-base --is-ancestor \
+            "$release_commit" "refs/remotes/origin/$default_branch" || {
+              echo "Signed release provenance $release_commit is not on the corpus default branch" >&2
+              exit 1
+            }
+          git -C _axiom/axiom-corpus merge-base --is-ancestor \
+            "$release_commit" "$AXIOM_CORPUS_SHA" || {
+              echo "Corpus checkout $AXIOM_CORPUS_SHA predates signed release provenance $release_commit" >&2
+              exit 1
+            }
+
+      - name: Provision protected verification supervisor
+        working-directory: _axiom/axiom-encode
+        env:
+          TRUST_APPLY_ROOT: ${{ vars.AXIOM_ENCODE_APPLY_SIGNING_PUBLIC_KEY }}
+          TRUST_EVAL_ROOT: ${{ vars.AXIOM_ENCODE_EVAL_SIGNING_PUBLIC_KEY }}
+          TRUST_CORPUS_RELEASE_ROOT: ${{ vars.AXIOM_CORPUS_RELEASE_PUBLIC_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "$TRUST_APPLY_ROOT" && test -n "$TRUST_EVAL_ROOT" && test -n "$TRUST_CORPUS_RELEASE_ROOT"
+          CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags='-buildid=' \
+            -o "$RUNNER_TEMP/axiom-encode-signing-supervisor" \
+            ./cmd/axiom-encode-signing-supervisor
+          sudo rm -rf /opt/axiom-verification
+          # sudo resets PATH (secure_path), so a bare `python` under sudo is
+          # the SYSTEM interpreter — and the provision script copies the
+          # invoking interpreter's sys.base_prefix, i.e. it would copytree
+          # /usr until the runner disk dies. Resolve the setup-python
+          # interpreter in this shell and pass its absolute path through.
+          sudo "$(command -v python)" scripts/provision_verification_supervisor.py \
+            --destination /opt/axiom-verification \
+            --supervisor "$RUNNER_TEMP/axiom-encode-signing-supervisor" \
+            --site-packages "$RUNNER_TEMP/axiom-verification-site-packages" \
+            --apply-root "$TRUST_APPLY_ROOT" --eval-root "$TRUST_EVAL_ROOT" \
+            --corpus-release-root "$TRUST_CORPUS_RELEASE_ROOT"
+          sudo chown -R 0:0 /opt/axiom-verification
+          sudo chmod -R go-w /opt/axiom-verification
+          # The supervisor refuses a trust chain with group/other-writable
+          # ancestors, and /opt ships group-writable on hosted runners.
+          # Harden the directory bit itself (contents are untouched; nothing
+          # later in this job creates new /opt entries).
+          # The supervised child's PATH is exactly the trusted tool directory
+          # (the supervisor exports no ambient PATH), and the checkout-identity
+          # probes shell out to git builtins (rev-parse --show-toplevel,
+          # remote get-url origin) whenever a module sits inside a git
+          # boundary — which every CI workspace does. Provision the runner's
+          # git binary alongside the trusted tools so those probes fail closed
+          # on identity, not on a missing binary.
+          # With a provisioned python runtime the supervisor rewrites exec to
+          # the trusted interpreter, so the child's PATH (= dirname of the
+          # exec'd command) is the runtime's bin directory — install git
+          # THERE, not at the verification root.
+          sudo install -m 0755 "$(command -v git)" /opt/axiom-verification/python/bin/git
+          sudo chown root:root /opt
+          sudo chmod go-w /opt
+
+      - name: Build axiom-rules-engine
+        working-directory: _axiom/axiom-rules-engine
+        run: cargo build --verbose
+
+      - name: Expose axiom-rules-engine on PATH
+        run: echo "$GITHUB_WORKSPACE/_axiom/axiom-rules-engine/target/debug" >> "$GITHUB_PATH"
+
+      - name: Link axiom-rules-engine as sibling checkout
+        shell: bash
+        run: |
+          set -euo pipefail
+          ln -sfn "$GITHUB_WORKSPACE/_axiom/axiom-rules-engine" "$GITHUB_WORKSPACE/../axiom-rules-engine"
+          ln -sfn "$GITHUB_WORKSPACE/_axiom/axiom-corpus" "$GITHUB_WORKSPACE/../axiom-corpus"
+          if [ "$(basename "$GITHUB_WORKSPACE")" != "rulespec-us" ]; then
+            ln -sfn "$GITHUB_WORKSPACE/_axiom/rulespec-us" "$GITHUB_WORKSPACE/../rulespec-us"
+          fi
+
+      - name: Run repository tests
+        if: ${{ inputs.run-pytest && matrix.shard == needs.shards.outputs.first }}
+        run: |
+          if [ -d tests ] && find tests -type f \( -name "test_*.py" -o -name "*_test.py" \) | grep -q .; then
+            python -m pytest -q tests
+          else
+            echo "No Python tests found; skipping pytest."
+          fi
+
+      - name: Reject obsolete generated files
+        if: ${{ matrix.shard == needs.shards.outputs.first }}
+        run: |
+          obsolete_ext="r""ac"
+          matches="$(find . \
+            \( -path ./.git -o -path ./_axiom -o -path ./.venv -o -path ./.pytest_cache \) -prune \
+            -o \( -name "*.${obsolete_ext}" -o -name "*.${obsolete_ext}.test" \) -print)"
+          if [ -n "$matches" ]; then
+            printf '%s\n' "$matches" >&2
+            exit 1
+          fi
+
+      - name: Reject disallowed repository layout
+        if: ${{ matrix.shard == needs.shards.outputs.first }}
+        shell: bash
+        env:
+          VALIDATE_ROOTS: ${{ needs.shards.outputs.roots }}
+          ALLOWED_EXTRA_ROOTS: ${{ needs.shards.outputs.allowed-extra }}
+        run: |
+          set -euo pipefail
+
+          if [ -f .axiom/repository-structure.yaml ]; then
+          python - <<'PY'
+          import fnmatch
+          import sys
+          from pathlib import Path, PurePosixPath
+
+          import yaml
+
+          CONFIG_PATH = Path(".axiom/repository-structure.yaml")
+
+          def fail(message: str) -> None:
+              print(f"Repository structure error: {message}", file=sys.stderr)
+              sys.exit(1)
+
+          def string_set(payload: object, key: str) -> set[str]:
+              value = payload.get(key) if isinstance(payload, dict) else None
+              if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+                  fail(f"{key} must be a list of strings")
+              normalized = {item.strip("/") for item in value}
+              if "" in normalized:
+                  fail(f"{key} contains an empty path")
+              return normalized
+
+          def tracked_files() -> list[str]:
+              import subprocess
+
+              result = subprocess.run(
+                  ["git", "ls-files", "-z"],
+                  check=True,
+                  stdout=subprocess.PIPE,
+              )
+              return sorted(
+                  path.decode()
+                  for path in result.stdout.split(b"\0")
+                  if path
+              )
+
+          config = yaml.safe_load(CONFIG_PATH.read_text()) or {}
+          if not isinstance(config, dict):
+              fail(f"{CONFIG_PATH} must contain a mapping")
+          if config.get("version") != 1:
+              fail(f"{CONFIG_PATH} must set version: 1")
+
+          allowed_root_directories = string_set(config, "allowed_root_directories")
+          allowed_root_files = string_set(config, "allowed_root_files")
+          path_rules = config.get("path_rules")
+          if not isinstance(path_rules, list) or not path_rules:
+              fail("path_rules must be a non-empty list")
+
+          normalized_rules: list[dict[str, object]] = []
+          for index, rule in enumerate(path_rules, start=1):
+              if not isinstance(rule, dict):
+                  fail(f"path_rules[{index}] must be a mapping")
+              patterns = rule.get("patterns")
+              if not isinstance(patterns, list) or not patterns or not all(
+                  isinstance(pattern, str) for pattern in patterns
+              ):
+                  fail(f"path_rules[{index}].patterns must be a non-empty list of strings")
+              allow_extensions = rule.get("allow_extensions", [])
+              allow_filenames = rule.get("allow_filenames", [])
+              if not isinstance(allow_extensions, list) or not all(
+                  isinstance(extension, str) for extension in allow_extensions
+              ):
+                  fail(f"path_rules[{index}].allow_extensions must be a list of strings")
+              if not isinstance(allow_filenames, list) or not all(
+                  isinstance(filename, str) for filename in allow_filenames
+              ):
+                  fail(f"path_rules[{index}].allow_filenames must be a list of strings")
+              normalized_rules.append(
+                  {
+                      "patterns": [pattern.strip("/") for pattern in patterns],
+                      "allow_extensions": set(allow_extensions),
+                      "allow_filenames": set(allow_filenames),
+                  }
+              )
+
+          problems: list[str] = []
+          for path in tracked_files():
+              parts = PurePosixPath(path).parts
+              if len(parts) == 1:
+                  if path not in allowed_root_files:
+                      problems.append(f"{path}: top-level file is not allowed")
+                  continue
+
+              root = parts[0]
+              if root not in allowed_root_directories:
+                  problems.append(f"{path}: top-level directory {root}/ is not allowed")
+                  continue
+
+              matched_rule = None
+              for rule in normalized_rules:
+                  if any(fnmatch.fnmatchcase(path, pattern) for pattern in rule["patterns"]):
+                      matched_rule = rule
+                      break
+              if matched_rule is None:
+                  problems.append(f"{path}: no path rule matched")
+                  continue
+
+              name = PurePosixPath(path).name
+              extension = PurePosixPath(path).suffix
+              if name in matched_rule["allow_filenames"]:
+                  continue
+              if extension in matched_rule["allow_extensions"]:
+                  continue
+              problems.append(
+                  f"{path}: file name/extension is not allowed by matched path rule"
+              )
+
+          if problems:
+              print(
+                  f"Repository layout does not match {CONFIG_PATH}.",
+                  file=sys.stderr,
+              )
+              for problem in problems:
+                  print(f"- {problem}", file=sys.stderr)
+              sys.exit(1)
+
+          print(f"Repository layout matches {CONFIG_PATH}.")
+          PY
+          exit 0
+          fi
+          disallowed=()
+
+          for root in statute regulation policy; do
+            if [ -e "$root" ]; then
+              disallowed+=("$root/")
+            fi
+          done
+
+          while IFS= read -r path; do
+            disallowed+=("$path")
+          done < <(
+            find . \
+              \( -path ./.git -o -path ./_axiom -o -path ./.venv -o -path ./.pytest_cache \) -prune \
+              -o -type f \( -name "parameters.yaml" -o -name "tests.yaml" \) -print
+          )
+
+          while IFS= read -r path; do
+            disallowed+=("$path")
+          done < <(
+            find tests -type f -name "*.yaml" 2>/dev/null || true
+          )
+
+          prune=( -path ./.git -o -path ./_axiom -o -path ./.venv -o -path ./.pytest_cache -o -path ./.github )
+          for allowed in $VALIDATE_ROOTS $ALLOWED_EXTRA_ROOTS; do
+            prune+=( -o -path "./$allowed" )
+          done
+          while IFS= read -r path; do
+            disallowed+=("$path")
+          done < <(
+            find . \( "${prune[@]}" \) -prune \
+              -o -type f \( -name "*.yaml" -o -name "*.yml" \) \
+                ! -name "known-dangling.yaml" ! -name "known-validation-gaps.yaml" -print
+          )
+
+          if [ "${#disallowed[@]}" -ne 0 ]; then
+            printf 'Repository layout is not allowed. Use RuleSpec YAML under statutes/, regulations/, or policies/.\n' >&2
+            printf '%s\n' "${disallowed[@]}" >&2
+            exit 1
+          fi
+
+      - name: Enforce validation waiver ratchet
+        if: ${{ matrix.shard == needs.shards.outputs.first }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base_ref="${{ github.event.pull_request.base.sha }}"
+          elif [ -n "${{ github.event.before }}" ] && [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+            base_ref="${{ github.event.before }}"
+          else
+            base_ref="HEAD~1"
+          fi
+          protected_base="$RUNNER_TEMP/protected-known-validation-gaps.yaml"
+          changed_paths="$RUNNER_TEMP/waiver-changed-paths.txt"
+          git show "$base_ref:known-validation-gaps.yaml" > "$protected_base" || {
+            echo "ValidationWaiverBaseMissing: protected base must contain known-validation-gaps.yaml" >&2
+            exit 1
+          }
+          git diff --name-only --no-renames --diff-filter=ACMRTD \
+            "$base_ref" "$GITHUB_SHA" > "$changed_paths"
+          python - "$protected_base" known-validation-gaps.yaml <<'PY'
+          import sys
+          from pathlib import Path
+
+          import yaml
+
+          base_path, head_path = map(Path, sys.argv[1:])
+          base = yaml.safe_load(base_path.read_bytes())
+          head = yaml.safe_load(head_path.read_bytes())
+          base_entries = base.get("validate_failures", {}) if isinstance(base, dict) else {}
+          head_entries = head.get("validate_failures", {}) if isinstance(head, dict) else {}
+          if not isinstance(base_entries, dict) or not isinstance(head_entries, dict):
+              raise SystemExit(
+                  "ValidationWaiverRatchetSchema: validate_failures must be a mapping"
+              )
+          growth = []
+          for module, head_states in head_entries.items():
+              base_states = base_entries.get(module)
+              if not isinstance(head_states, dict) or not isinstance(base_states, dict):
+                  growth.append(str(module))
+                  continue
+              for state, metadata in head_states.items():
+                  if base_states.get(state) == metadata:
+                      continue
+                  if state == "active" and base_states.get("pending") == metadata:
+                      # A protected-base pending approval being consumed
+                      # (pending -> active) is the sanctioned transition; the
+                      # supervised audit still enforces the full protocol
+                      # (exact consumption, expiry, waiver-only approvals).
+                      continue
+                  growth.append(f"{module}:{state}")
+          if growth:
+              raise SystemExit(
+                  "ValidationWaiverRatchetGrowth: waivers may only shrink; "
+                  "new, changed, or broadened records: " + ", ".join(sorted(growth))
+              )
+          print(
+              "Validation waiver ratchet is decrement-only: "
+              f"{len(base_entries)} base module(s) -> {len(head_entries)} head module(s)."
+          )
+          PY
+          /opt/axiom-verification/axiom-encode-signing-supervisor \
+            --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
+            --trusted-python-runtime-root /opt/axiom-verification/python \
+            --trusted-python-import-root /opt/axiom-verification/python/lib/python${{ inputs.python-version }}/site-packages \
+            --trusted-python-package-root /opt/axiom-verification/python/lib/python${{ inputs.python-version }}/site-packages/axiom_encode \
+            -- /opt/axiom-verification/axiom-encode validation-waivers audit \
+            --root "$GITHUB_WORKSPACE" \
+            --corpus-path "$GITHUB_WORKSPACE/_axiom/axiom-corpus" \
+            --protected-base "$protected_base" \
+            --changed-paths "$changed_paths" \
+            --axiom-rules-engine-path "$GITHUB_WORKSPACE/_axiom/axiom-rules-engine"
+
+      - name: Reject manual RuleSpec changes
+        if: ${{ inputs.run-generated-guard && matrix.shard == needs.shards.outputs.first }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base_ref="${{ github.event.pull_request.base.sha }}"
+          elif [ -n "${{ github.event.before }}" ] && [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+            base_ref="${{ github.event.before }}"
+          else
+            base_ref="HEAD~1"
+          fi
+
+          /opt/axiom-verification/axiom-encode-signing-supervisor \
+            --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
+            --trusted-python-runtime-root /opt/axiom-verification/python \
+            --trusted-python-import-root /opt/axiom-verification/python/lib/python${{ inputs.python-version }}/site-packages \
+            --trusted-python-package-root /opt/axiom-verification/python/lib/python${{ inputs.python-version }}/site-packages/axiom_encode \
+            -- /opt/axiom-verification/axiom-encode guard-generated \
+            --repo "$GITHUB_WORKSPACE" \
+            --base-ref "$base_ref" \
+            --head-ref "$GITHUB_SHA" \
+            --corpus-path "$GITHUB_WORKSPACE/_axiom/axiom-corpus" \
+            --expected-encoder-checkout "$GITHUB_WORKSPACE/_axiom/axiom-encode"
+
+      - name: Select RuleSpec validation targets
+        id: validation_targets
+        shell: bash
+        env:
+          VALIDATE_ROOTS: ${{ steps.resolve_roots.outputs.roots }}
+        run: |
+          set -euo pipefail
+
+          rulespec_file_list="$RUNNER_TEMP/rulespec-files.txt"
+          test_file_list="$RUNNER_TEMP/rulespec-test-files.txt"
+          : > "$rulespec_file_list"
+          : > "$test_file_list"
+
+          add_existing_file() {
+            local path="$1"
+            local list="$2"
+            if [ -f "$path" ]; then
+              printf '%s\n' "$path" >> "$list"
+            fi
+          }
+
+          add_rulespec_target() {
+            local path="$1"
+            case "$path" in
+              # Composition specs (the programs root, canonically nested
+              # under the jurisdiction dir) are axiom-compose inputs, not
+              # atomic RuleSpec modules — the encoder rejects them from
+              # atomic validation by design.
+              */programs/*|programs/*) return ;;
+            esac
+            case "$path" in
+              *.test.yaml)
+                add_existing_file "$path" "$test_file_list"
+                add_existing_file "${path%.test.yaml}.yaml" "$rulespec_file_list"
+                ;;
+              *.test.yml)
+                add_existing_file "$path" "$test_file_list"
+                add_existing_file "${path%.test.yml}.yml" "$rulespec_file_list"
+                ;;
+              *.yaml)
+                add_existing_file "$path" "$rulespec_file_list"
+                add_existing_file "${path%.yaml}.test.yaml" "$test_file_list"
+                ;;
+              *.yml)
+                add_existing_file "$path" "$rulespec_file_list"
+                add_existing_file "${path%.yml}.test.yml" "$test_file_list"
+                ;;
+            esac
+          }
+
+          add_all_rulespec_targets() {
+            while IFS= read -r path; do
+              add_existing_file "$path" "$rulespec_file_list"
+            done < <(
+              for root in $VALIDATE_ROOTS; do
+                if [ -d "$root" ]; then
+                  find "$root" -type f \( -name "*.yaml" -o -name "*.yml" \) \
+                    ! -name "*.test.yaml" ! -name "*.test.yml" \
+                    ! -path "*/programs/*"
+                fi
+              done
+            )
+            while IFS= read -r path; do
+              add_existing_file "$path" "$test_file_list"
+            done < <(
+              for root in $VALIDATE_ROOTS; do
+                if [ -d "$root" ]; then
+                  find "$root" -type f \( -name "*.test.yaml" -o -name "*.test.yml" \) \
+                    ! -path "*/programs/*"
+                fi
+              done
+            )
+          }
+
+          classify_toolchain_change() {
+            python - "$base_ref" <<'PY'
+          import subprocess
+          import sys
+          import tomllib
+          from pathlib import Path
+
+          base_ref = sys.argv[1]
+          path = Path(".axiom/toolchain.toml")
+          result = subprocess.run(
+              ["git", "show", f"{base_ref}:.axiom/toolchain.toml"],
+              check=False,
+              stdout=subprocess.PIPE,
+              stderr=subprocess.DEVNULL,
+          )
+          if result.returncode != 0 or not path.exists():
+              print("full")
+              raise SystemExit
+
+          def load(text: bytes) -> dict[str, object]:
+              payload = tomllib.loads(text.decode())
+              table = payload.get("toolchain", payload)
+              if not isinstance(table, dict):
+                  return {}
+              return table
+
+          before = load(result.stdout)
+          after = load(path.read_bytes())
+          changed = {
+              key for key in set(before) | set(after)
+              if before.get(key) != after.get(key)
+          }
+          if changed and changed <= {
+              "axiom_corpus_release",
+              "axiom_corpus_release_content_sha256",
+          }:
+              print("corpus-only")
+          else:
+              print("full")
+          PY
+          }
+
+          mode="full-push"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base_ref="${{ github.event.pull_request.base.sha }}"
+            mapfile -t all_changed_paths < <(
+              git diff --name-only --no-renames --diff-filter=ACMRTD "$base_ref" "$GITHUB_SHA"
+            )
+            mode="changed"
+            for path in "${all_changed_paths[@]}"; do
+              case "$path" in
+                .github/workflows/*.yml|.github/workflows/*.yaml)
+                  mode="full-toolchain-bump"
+                  break
+                  ;;
+                .axiom/toolchain.toml)
+                  if [ "$(classify_toolchain_change)" = "corpus-only" ]; then
+                    mode="changed-corpus-toolchain-bump"
+                  else
+                    mode="full-toolchain-bump"
+                    break
+                  fi
+                  ;;
+              esac
+            done
+
+            if [ "$mode" = "full-toolchain-bump" ]; then
+              add_all_rulespec_targets
+            else
+              for path in "${all_changed_paths[@]}"; do
+                for root in $VALIDATE_ROOTS; do
+                  case "$path" in
+                    "$root"/*)
+                      add_rulespec_target "$path"
+                      ;;
+                  esac
+                done
+              done
+            fi
+          else
+            add_all_rulespec_targets
+          fi
+
+          sort -u "$rulespec_file_list" -o "$rulespec_file_list"
+          sort -u "$test_file_list" -o "$test_file_list"
+
+          {
+            echo "RULESPEC_FILE_LIST=$rulespec_file_list"
+            echo "RULESPEC_TEST_FILE_LIST=$test_file_list"
+            echo "RULESPEC_VALIDATION_MODE=$mode"
+          } >> "$GITHUB_ENV"
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+
+          echo "RuleSpec validation mode: $mode"
+          echo "RuleSpec files selected:"
+          sed 's/^/- /' "$rulespec_file_list" || true
+          echo "RuleSpec companion tests selected:"
+          sed 's/^/- /' "$test_file_list" || true
+
+      - name: Validate RuleSpec YAML
+        shell: bash
+        env:
+          VALIDATE_ROOTS: ${{ steps.resolve_roots.outputs.roots }}
+          AXIOM_RULESPEC_REPO_ROOTS: ${{ github.workspace }}:${{ github.workspace }}/_axiom/rulespec-us
+          AXIOM_CORPUS_ARTIFACT_ROOT: ${{ github.workspace }}/data/corpus
+          AXIOM_CORPUS_REPO: ${{ github.workspace }}/_axiom/axiom-corpus
+        run: |
+          set -euo pipefail
+
+          mapfile -t rulespec_files < "$RULESPEC_FILE_LIST"
+
+          if [ "${#rulespec_files[@]}" -eq 0 ]; then
+            echo "No RuleSpec YAML files selected for validation."
+            exit 0
+          fi
+
+          # Ratcheted pre-existing validate failures: repos may list files in
+          # known-validation-gaps.yaml under `validate_failures` (each needs
+          # an issue link in that file). Listed files are skipped LOUDLY.
+          skip_list="$RUNNER_TEMP/validate-skip.txt"
+          : > "$skip_list"
+          if [ -f known-validation-gaps.yaml ]; then
+            python - <<'SKIP' > "$skip_list"
+          import yaml
+          payload = yaml.safe_load(open("known-validation-gaps.yaml")) or {}
+          for entry in payload.get("validate_failures") or []:
+              print(entry)
+          SKIP
+          fi
+
+          selected=()
+          for file in "${rulespec_files[@]}"; do
+            if grep -qxF "$file" "$skip_list"; then
+              echo "SKIPPED (known-validation-gaps validate_failures): $file"
+              continue
+            fi
+            selected+=("$GITHUB_WORKSPACE/$file")
+          done
+
+          if [ "${#selected[@]}" -eq 0 ]; then
+            echo "All selected RuleSpec YAML files are skipped."
+            exit 0
+          fi
+
+          # One invocation for all files: validation reuses one process and
+          # one registry load instead of paying both per file. Failed files
+          # are listed in the command's own summary output.
+          /opt/axiom-verification/axiom-encode-signing-supervisor \
+            --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
+            --trusted-python-runtime-root /opt/axiom-verification/python \
+            --trusted-python-import-root /opt/axiom-verification/python/lib/python${{ inputs.python-version }}/site-packages \
+            --trusted-python-package-root /opt/axiom-verification/python/lib/python${{ inputs.python-version }}/site-packages/axiom_encode \
+            -- /opt/axiom-verification/axiom-encode validate "${selected[@]}" \
+            --skip-reviewers \
+            --corpus-path "$GITHUB_WORKSPACE/_axiom/axiom-corpus" \
+            --axiom-rules-engine-path "$GITHUB_WORKSPACE/_axiom/axiom-rules-engine"
+
+      - name: Execute RuleSpec companion tests
+        shell: bash
+        env:
+          VALIDATE_ROOTS: ${{ steps.resolve_roots.outputs.roots }}
+          AXIOM_RULESPEC_REPO_ROOTS: ${{ github.workspace }}:${{ github.workspace }}/_axiom/rulespec-us
+        run: |
+          set -euo pipefail
+
+          mapfile -t test_files < "$RULESPEC_TEST_FILE_LIST"
+
+          # A module ratcheted under validate_failures cannot be expected to
+          # execute either; skip its companion test loudly (same
+          # known-validation-gaps.yaml list the validate step consults).
+          skip_list="$RUNNER_TEMP/validate-skip.txt"
+          selected=()
+          for test_file in "${test_files[@]}"; do
+            case "$test_file" in
+              *.test.yaml) module_file="${test_file%.test.yaml}.yaml" ;;
+              *.test.yml) module_file="${test_file%.test.yml}.yml" ;;
+              *) module_file="$test_file" ;;
+            esac
+            if [ -s "$skip_list" ] && grep -qxF "$module_file" "$skip_list"; then
+              echo "SKIPPED companion (known-validation-gaps validate_failures): $test_file"
+              continue
+            fi
+            selected+=("$test_file")
+          done
+
+          if [ "${#selected[@]}" -eq 0 ]; then
+            echo "No RuleSpec companion tests selected; skipping."
+            exit 0
+          fi
+
+          # The hard-cut encoder requires --root to be the exact jurisdiction
+          # content root (rulespec-<country>/<jurisdiction>), not the checkout;
+          # group the selected companion tests by their jurisdiction directory
+          # and run one invocation per group.
+          declare -A by_root=()
+          for test_file in "${selected[@]}"; do
+            jurisdiction="${test_file%%/*}"
+            # Paths are resolved relative to --root, so strip the
+            # jurisdiction prefix or they double up (<root>/dk/dk/...).
+            by_root[$jurisdiction]+="${test_file#"$jurisdiction"/}"$'\n'
+          done
+          for jurisdiction in "${!by_root[@]}"; do
+            mapfile -t group <<< "${by_root[$jurisdiction]%$'\n'}"
+            axiom-encode test \
+              --root "$GITHUB_WORKSPACE/$jurisdiction" \
+              --axiom-rules-engine-path "$GITHUB_WORKSPACE/_axiom/axiom-rules-engine" \
+              "${group[@]}"
+          done
+
+      - name: Validate RuleSpec proofs and claims
+        shell: bash
+        env:
+          VALIDATE_ROOTS: ${{ steps.resolve_roots.outputs.roots }}
+          AXIOM_CORPUS_ARTIFACT_ROOT: ${{ github.workspace }}/data/corpus
+          AXIOM_CORPUS_REPO: ${{ github.workspace }}/_axiom/axiom-corpus
+        run: |
+          set -euo pipefail
+
+          mapfile -t rulespec_files < "$RULESPEC_FILE_LIST"
+
+          if [ "${#rulespec_files[@]}" -eq 0 ]; then
+            echo "No RuleSpec YAML files selected for proof validation."
+            exit 0
+          fi
+
+          prefixed=()
+          for file in "${rulespec_files[@]}"; do
+            prefixed+=("$GITHUB_WORKSPACE/$file")
+          done
+
+          # One invocation for all files; failed files are listed in the
+          # command's own summary output.
+          /opt/axiom-verification/axiom-encode-signing-supervisor \
+            --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
+            --trusted-python-runtime-root /opt/axiom-verification/python \
+            --trusted-python-import-root /opt/axiom-verification/python/lib/python${{ inputs.python-version }}/site-packages \
+            --trusted-python-package-root /opt/axiom-verification/python/lib/python${{ inputs.python-version }}/site-packages/axiom_encode \
+            -- /opt/axiom-verification/axiom-encode proof-validate "${prefixed[@]}" \
+            --corpus-path "$GITHUB_WORKSPACE/_axiom/axiom-corpus"
+
+      - name: Require money proof atoms
+        # Scan the whole repository (not just changed files) on the first
+        # shard: the ratchet allowance is repo-wide, so a per-PR changed-file
+        # subset could not tell whether a change raised the money-atom debt.
+        # This is a cheap pure-Python pass (no compile, no engine build).
+        if: ${{ inputs.run-money-atom-check && matrix.shard == needs.shards.outputs.first }}
+        shell: bash
+        env:
+          VALIDATE_ROOTS: ${{ needs.shards.outputs.roots }}
+        run: |
+          set -euo pipefail
+
+          money_atom_files=()
+          for root in $VALIDATE_ROOTS; do
+            if [ -d "$root" ]; then
+              while IFS= read -r path; do
+                money_atom_files+=("$path")
+              done < <(
+                find "$root" -type f \( -name "*.yaml" -o -name "*.yml" \) \
+                  ! -name "*.test.yaml" ! -name "*.test.yml"
+              )
+            fi
+          done
+
+          if [ "${#money_atom_files[@]}" -eq 0 ]; then
+            echo "No RuleSpec YAML files found for money-atom check."
+            exit 0
+          fi
+
+          ratchet_args=()
+          if [ -f known-missing-money-atoms.yaml ]; then
+            echo "Using money-atom ratchet: known-missing-money-atoms.yaml"
+            ratchet_args=(--ratchet-file known-missing-money-atoms.yaml)
+          else
+            echo "No known-missing-money-atoms.yaml ratchet; requiring zero missing money atoms."
+          fi
+
+          # --money-atoms-only checks solely the money obligations; it does
+          # not re-run base proof-tree validation, so scanning the whole repo
+          # here never re-reports unrelated proof issues on unchanged files
+          # (those stay scoped to the changed-file proof step above).
+          /opt/axiom-verification/axiom-encode-signing-supervisor \
+            --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
+            --trusted-python-runtime-root /opt/axiom-verification/python \
+            --trusted-python-import-root /opt/axiom-verification/python/lib/python${{ inputs.python-version }}/site-packages \
+            --trusted-python-package-root /opt/axiom-verification/python/lib/python${{ inputs.python-version }}/site-packages/axiom_encode \
+            -- /opt/axiom-verification/axiom-encode proof-validate \
+            "${money_atom_files[@]}" \
+            --money-atoms-only \
+            --corpus-path "$GITHUB_WORKSPACE/_axiom/axiom-corpus" \
+            "${ratchet_args[@]}"
+
+      - name: Validate PolicyEngine oracle coverage classification
+        if: ${{ github.event_name != 'pull_request' || steps.validation_targets.outputs.mode == 'full-toolchain-bump' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          axiom-encode oracle-coverage \
+            --root "$GITHUB_WORKSPACE" \
+            --fail-on-unmapped \
+            --fail-on-untested-comparable \
+            --limit 50
+
+      - name: Checkout changed-file oracle coverage classifier
+        if: ${{ github.event_name == 'pull_request' && steps.validation_targets.outputs.mode != 'full-toolchain-bump' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: TheAxiomFoundation/axiom-encode
+          ref: ${{ inputs.axiom-encode-ref }}
+          path: _axiom/axiom-encode-oracle-coverage
+          persist-credentials: false
+
+      - name: Install changed-file oracle coverage classifier
+        if: ${{ github.event_name == 'pull_request' && steps.validation_targets.outputs.mode != 'full-toolchain-bump' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install -e _axiom/axiom-encode-oracle-coverage
+          # The changed-file classifier checkout may pin an axiom-oracles commit
+          # step installed. axiom-oracles is a git dependency whose version string
+          # does not change per commit, so pip treats the pinned SHA as "already
+          # satisfied" and keeps the stale copy — the classifier then reports
+          # freshly-added not_comparable mappings as unmapped. Force-reinstall the
+          # axiom-oracles pin declared by this checkout so the classifier reads its
+          # bridge mappings, not the toolchain-pinned ones.
+          oracles_spec="$(
+            python - <<'PY'
+          import pathlib
+          import re
+
+          text = pathlib.Path("_axiom/axiom-encode-oracle-coverage/pyproject.toml").read_text()
+          match = re.search(
+              r'"(axiom-oracles @ git\+https://github\.com/[^"]+)"', text
+          )
+          print(match.group(1) if match else "")
+          PY
+          )"
+          if [ -n "$oracles_spec" ]; then
+            python -m pip install --force-reinstall --no-deps "$oracles_spec"
+          fi
+          python - <<'PY'
+          import importlib.metadata
+
+          print(
+              "Changed-file oracle coverage classifier uses axiom-encode "
+              f"{importlib.metadata.version('axiom-encode')}."
+          )
+          PY
+
+      - name: Validate changed PolicyEngine oracle coverage classification
+        if: ${{ github.event_name == 'pull_request' && steps.validation_targets.outputs.mode != 'full-toolchain-bump' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ ! -s "$RULESPEC_FILE_LIST" ]; then
+            echo "No changed RuleSpec YAML files selected for oracle coverage."
+            exit 0
+          fi
+
+          coverage_json="$RUNNER_TEMP/policyengine-oracle-coverage.json"
+          axiom-encode oracle-coverage \
+            --root "$GITHUB_WORKSPACE" \
+            --json > "$coverage_json"
+
+          python - "$coverage_json" "$RULESPEC_FILE_LIST" <<'PY'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          coverage_path = Path(sys.argv[1])
+          rulespec_file_list = Path(sys.argv[2])
+          repo = Path(os.environ["GITHUB_WORKSPACE"]).name
+          if repo.startswith("rulespec-be"):
+              print(
+                  "Changed PolicyEngine oracle coverage skipped for Belgium; "
+                  "rulespec-be uses the EUROMOD household-level oracle surface."
+              )
+              raise SystemExit
+          changed = {
+              f"{repo}/{line.strip()}"
+              for line in rulespec_file_list.read_text().splitlines()
+              if line.strip()
+          }
+          payload = json.loads(coverage_path.read_text())
+          items = [
+              item for item in payload.get("items", [])
+              if item.get("file") in changed
+          ]
+          failures = []
+          for item in items:
+              legal_id = item.get("legal_id")
+              if item.get("status") == "unmapped":
+                  failures.append(f"{legal_id}: unmapped")
+              elif item.get("status") == "comparable" and not item.get("tested"):
+                  failures.append(f"{legal_id}: comparable but not covered by companion tests")
+
+          if failures:
+              print("Changed PolicyEngine oracle coverage is incomplete.", file=sys.stderr)
+              for failure in failures[:50]:
+                  print(f"- {failure}", file=sys.stderr)
+              if len(failures) > 50:
+                  print(f"- ... {len(failures) - 50} more", file=sys.stderr)
+              sys.exit(1)
+
+          print(f"Changed PolicyEngine oracle coverage passed for {len(items)} output(s).")
+          PY
+
+  validate-complete:
+    # Matrix jobs get suffixed check names such as `validate (us-ca)`.
+    # Keep this aggregate name as `validate` so existing branch-protection
+    # rules requiring `validate / validate` have one stable context.
+    name: validate
+    needs: validate
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check validation matrix result
+        shell: bash
+        env:
+          VALIDATE_RESULT: ${{ needs.validate.result }}
+        run: |
+          set -euo pipefail
+          if [ "$VALIDATE_RESULT" != "success" ]; then
+            echo "Validation matrix completed with result: $VALIDATE_RESULT" >&2
+            exit 1
+          fi
+          echo "Validation matrix passed."

--- a/tests/fixtures/ci_parity/validate-rulespec-615c1df9.yml
+++ b/tests/fixtures/ci_parity/validate-rulespec-615c1df9.yml
@@ -1,0 +1,1439 @@
+name: Validate RuleSpec Repository
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: Python version used for repository tests and validators.
+        required: false
+        type: string
+        default: "3.14"
+      axiom-encode-ref:
+        description: Full commit SHA for TheAxiomFoundation/axiom-encode.
+        required: true
+        type: string
+      axiom-rules-engine-ref:
+        description: Full commit SHA for TheAxiomFoundation/axiom-rules-engine.
+        required: true
+        type: string
+      axiom-corpus-ref:
+        description: Full commit SHA for TheAxiomFoundation/axiom-corpus.
+        required: true
+        type: string
+      rulespec-us-ref:
+        description: Full commit SHA for TheAxiomFoundation/rulespec-us canonical targets.
+        required: true
+        type: string
+      corpus-release-base-url:
+        description: HTTPS base URL of the public R2 bucket containing releases/.
+        # Interim r2.dev URL for the dedicated axiom-corpus-releases bucket;
+        # switch to https://corpus.axiom-foundation.org once the custom domain
+        # is bound (needs the R2 bucket in the axiom-foundation.org zone account).
+        required: false
+        default: https://pub-a8952f8657fc49fda358146ac001366c.r2.dev
+        type: string
+      validate-roots:
+        description: >-
+          Space-separated repository roots containing RuleSpec YAML, or
+          "auto" to discover jurisdiction directories in a country monorepo
+          (top-level dirs like us/, us-co/ that contain statutes/,
+          regulations/, policies/, or legislation/).
+        required: false
+        type: string
+        default: "statutes regulations policies"
+      run-pytest:
+        description: Whether to run pytest when the repository has a tests directory.
+        required: false
+        type: boolean
+        default: true
+      run-generated-guard:
+        description: >-
+          Whether to run the manual-RuleSpec-change guard. Disable ONLY for
+          history-preserving migration PRs (e.g. repo consolidation) where
+          every file arrives from an already-validated repo; re-enable
+          immediately after.
+        required: false
+        type: boolean
+        default: true
+      guard-programs-root:
+        description: >-
+          Whether to require encoding manifests on the composed-pilot
+          `programs/` root too (encode#1053). Opt-in per repo: enable only
+          after every existing `programs/` file has an encoder apply-manifest
+          or a manual attestation, otherwise the guard fails on the backlog.
+          When true, `programs` is guarded as a RuleSpec root rather than
+          merely tolerated as an allowed extra directory.
+        required: false
+        type: boolean
+        default: false
+      run-money-atom-check:
+        description: >-
+          Whether to require a proof atom citing a provision on every
+          policy-bearing monetary value (currency parameters, currency
+          parameter-table cells, and currency literals in derived formulas).
+          The calling repo may carry a `known-missing-money-atoms.yaml`
+          ratchet to tolerate a visible backlog; an absent ratchet means a
+          strict zero allowance, so a repo must be clean or carry a ratchet.
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  shards:
+    name: shards
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.compute.outputs.matrix }}
+      first: ${{ steps.compute.outputs.first }}
+      roots: ${{ steps.compute.outputs.roots }}
+      allowed-extra: ${{ steps.compute.outputs.allowed-extra }}
+    steps:
+      - name: Checkout rules repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Full history so shard-on-demand can diff the pull-request base
+          # against the head to see which jurisdiction subtrees changed.
+          fetch-depth: 0
+
+      - name: Compute validation shards
+        id: compute
+        shell: bash
+        env:
+          VALIDATE_ROOTS_INPUT: ${{ inputs.validate-roots }}
+          GUARD_PROGRAMS_ROOT: ${{ inputs.guard-programs-root }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [ "$VALIDATE_ROOTS_INPUT" = "auto" ]; then
+            all_shards=()
+            for dir in */; do
+              dir="${dir%/}"
+              case "$dir" in _*|.*) continue ;; esac
+              if printf '%s' "$dir" | grep -Eq '^[a-z]{2}(-[a-z0-9-]+)*$'; then
+                for marker in statutes regulations policies legislation; do
+                  if [ -d "$dir/$marker" ]; then
+                    all_shards+=("$dir")
+                    break
+                  fi
+                done
+              fi
+            done
+            if [ "${#all_shards[@]}" -eq 0 ]; then
+              echo "validate-roots=auto found no jurisdiction directories" >&2
+              exit 1
+            fi
+            # roots always covers every discovered jurisdiction, even when the
+            # matrix is scoped to one shard: the repo-wide gates (layout,
+            # obsolete-file, manual-change guard, money-atom) run on the first
+            # shard against this full set, so their whole-repo scope is
+            # preserved regardless of which single shard the matrix selects.
+            roots="${all_shards[*]}"
+            if [ "$GUARD_PROGRAMS_ROOT" = "true" ]; then
+              # Guard the composed-pilot programs/ root instead of merely
+              # tolerating it as an allowed extra (encode#1053).
+              roots="$roots programs"
+              allowed_extra="sources"
+            else
+              allowed_extra="sources programs"
+            fi
+
+            # Shard-on-demand: a pull request whose diff is confined to exactly
+            # one jurisdiction subtree (the bulk-encoding case) validates only
+            # that jurisdiction's shard. Multi-tree diffs, pushes, scheduled
+            # runs, and any change that touches shared infrastructure fall back
+            # to the full matrix, which stays the honesty backstop against
+            # cross-shard drift (a daily scheduled full run lives in the
+            # calling repo). The repo-wide gates still run because they are
+            # pinned to the first shard, so no gate is skipped when scoped.
+            mapfile -t selected_shards < <(
+              ALL_SHARDS="${all_shards[*]}" \
+              EVENT_NAME="$EVENT_NAME" \
+              PR_BASE_SHA="$PR_BASE_SHA" \
+              HEAD_SHA="$HEAD_SHA" \
+              python3 <<'PY'
+          import os
+          import subprocess
+          import sys
+
+          all_shards = os.environ["ALL_SHARDS"].split()
+          shard_set = set(all_shards)
+
+
+          def full(reason: str) -> None:
+              print(f"scope=full ({reason})", file=sys.stderr)
+              for shard in all_shards:
+                  print(shard)
+              raise SystemExit
+
+
+          event = os.environ.get("EVENT_NAME", "")
+          base = os.environ.get("PR_BASE_SHA", "").strip()
+          head = os.environ.get("HEAD_SHA", "").strip()
+
+          if event != "pull_request" or not base or not head:
+              full(f"event={event or 'unknown'}")
+
+          diff = subprocess.run(
+              ["git", "diff", "--name-only", "--no-renames",
+               "--diff-filter=ACMRTD", base, head],
+              stdout=subprocess.PIPE, text=True,
+          )
+          if diff.returncode != 0:
+              full("git diff failed")
+
+          changed = [line.strip() for line in diff.stdout.splitlines() if line.strip()]
+          if not changed:
+              full("empty diff")
+
+          touched: set[str] = set()
+          for path in changed:
+              top = path.split("/", 1)[0]
+              if top in shard_set:
+                  touched.add(top)
+                  continue
+              # The reverse index is derived tooling metadata regenerated from
+              # the YAML; it never changes what any shard must validate, so an
+              # index-only edit alongside a jurisdiction edit stays scoped.
+              if path.startswith(".axiom/index/"):
+                  continue
+              # Anything else (workflows, toolchain, structure config, other
+              # .axiom entries, sources/, programs/, root files, ...) can
+              # affect every shard: fall back to the full matrix.
+              full(f"cross-cutting path {path}")
+
+          if len(touched) == 1:
+              only = next(iter(touched))
+              print(f"scope=one-jurisdiction ({only})", file=sys.stderr)
+              print(only)
+          else:
+              full(f"{len(touched)} jurisdiction subtrees touched")
+          PY
+            )
+            # Never emit an empty matrix: if scope selection produced nothing
+            # (e.g. the classifier crashed), run the full matrix rather than
+            # skip validation, so the required check can never pass vacuously.
+            if [ "${#selected_shards[@]}" -eq 0 ]; then
+              echo "Scope selection produced no shards; falling back to full matrix." >&2
+              selected_shards=("${all_shards[@]}")
+            fi
+            shards=("${selected_shards[@]}")
+          else
+            shards=("__all__")
+            roots="$VALIDATE_ROOTS_INPUT"
+            if [ "$GUARD_PROGRAMS_ROOT" = "true" ]; then
+              case " $roots " in
+                *" programs "*) : ;;
+                *) roots="$roots programs" ;;
+              esac
+            fi
+            allowed_extra="sources"
+          fi
+          matrix=$(printf '%s\n' "${shards[@]}" | python3 -c 'import json,sys; print(json.dumps([l.strip() for l in sys.stdin if l.strip()]))')
+          {
+            echo "matrix=$matrix"
+            echo "first=${shards[0]}"
+            echo "roots=$roots"
+            echo "allowed-extra=$allowed_extra"
+          } >> "$GITHUB_OUTPUT"
+          echo "Shards: $matrix"
+
+  validate:
+    # Keep the check name exactly `validate` across matrix legs so existing
+    # required-status configs keep matching; legacy repos run one `__all__`
+    # leg with behavior identical to the pre-shard workflow.
+    name: validate
+    needs: shards
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(needs.shards.outputs.matrix) }}
+
+    steps:
+      # This job stacks four dependency checkouts, Go + Rust toolchains, an
+      # isolated verification runtime, and an engine build on one ~14 GB
+      # runner disk; reclaim the preinstalled bloat first or the runner dies
+      # mid-job with "No space left on device" (and no usable step logs).
+      - name: Free runner disk space
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Disk before cleanup:" && df -h /
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
+            /usr/local/.ghcup /opt/hostedtoolcache/CodeQL || true
+          sudo docker image prune --all --force >/dev/null 2>&1 || true
+          echo "Disk after cleanup:" && df -h /
+
+      - name: Checkout rules repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Resolve shard validation roots
+        id: resolve_roots
+        shell: bash
+        env:
+          VALIDATE_ROOTS_INPUT: ${{ inputs.validate-roots }}
+          SHARD: ${{ matrix.shard }}
+        run: |
+          set -euo pipefail
+          if [ "$SHARD" = "__all__" ]; then
+            roots="$VALIDATE_ROOTS_INPUT"
+          else
+            roots="$SHARD"
+          fi
+          echo "roots=$roots" >> "$GITHUB_OUTPUT"
+          echo "Shard validation roots: $roots"
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Resolve RuleSpec toolchain
+        id: toolchain
+        shell: bash
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import os
+          import re
+          import subprocess
+          import sys
+          import tomllib
+          from pathlib import Path
+
+          TOOLCHAIN_PATH = Path(".axiom/toolchain.toml")
+          EXPECTED_KEYS = {
+              "axiom_corpus_release",
+              "axiom_corpus_release_content_sha256",
+              "validation_waiver_set_sha256",
+          }
+          SHA256_RE = re.compile(r"[0-9a-f]{64}")
+          RELEASE_RE = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*")
+
+          def fail(message: str) -> None:
+              print(f"RuleSpec toolchain error: {message}", file=sys.stderr)
+              sys.exit(1)
+
+          def load_toolchain(raw: bytes) -> dict[str, str]:
+              try:
+                  payload = tomllib.loads(raw.decode("utf-8"))
+              except (UnicodeError, tomllib.TOMLDecodeError) as exc:
+                  fail(f"toolchain file is not valid UTF-8 TOML: {exc}")
+              if set(payload) != {"toolchain"} or not isinstance(payload["toolchain"], dict):
+                  fail("toolchain file must contain exactly one top-level [toolchain] table")
+              table = payload["toolchain"]
+              if set(table) != EXPECTED_KEYS:
+                  fail("[toolchain] must contain exactly: " + ", ".join(sorted(EXPECTED_KEYS)))
+              if not all(isinstance(value, str) for value in table.values()):
+                  fail("all [toolchain] values must be strings")
+              if RELEASE_RE.fullmatch(table["axiom_corpus_release"]) is None:
+                  fail("axiom_corpus_release is not a canonical immutable release name")
+              if table["axiom_corpus_release"] == "current":
+                  fail("axiom_corpus_release must not use the mutable current alias")
+              for key in EXPECTED_KEYS - {"axiom_corpus_release"}:
+                  if SHA256_RE.fullmatch(table[key]) is None:
+                      fail(f"{key} must be a lowercase sha256 digest")
+              return table
+
+          def base_toolchain() -> dict[str, object] | None:
+              base_sha = os.environ.get("PR_BASE_SHA")
+              if not base_sha:
+                  return None
+              result = subprocess.run(
+                  ["git", "show", f"{base_sha}:.axiom/toolchain.toml"],
+                  check=False,
+                  stdout=subprocess.PIPE,
+                  stderr=subprocess.DEVNULL,
+              )
+              if result.returncode != 0:
+                  return None
+              # A base branch that predates the canonical-toolchain migration
+              # carries an old-schema toolchain. For the removal-guard below,
+              # that is equivalent to "no canonical toolchain yet": only a base
+              # whose toolchain already conforms to the strict schema may be
+              # forbidden from dropping it. Parse the base softly (key set only)
+              # so the very PR that performs the migration is not rejected for
+              # the base still being pre-migration. Any base already on the
+              # protected branch necessarily passed strict validation to land,
+              # so an exact EXPECTED_KEYS match is a sufficient "is migrated"
+              # signal here.
+              try:
+                  payload = tomllib.loads(result.stdout.decode("utf-8"))
+              except (UnicodeError, tomllib.TOMLDecodeError):
+                  return None
+              table = payload.get("toolchain")
+              if not isinstance(table, dict) or set(table) != EXPECTED_KEYS:
+                  return None
+              return table
+
+          base_config = base_toolchain()
+          if not TOOLCHAIN_PATH.is_file() or TOOLCHAIN_PATH.is_symlink():
+              if base_config is not None:
+                  fail(".axiom/toolchain.toml cannot be removed once a base branch uses it")
+              fail("a regular .axiom/toolchain.toml is required")
+          config = load_toolchain(TOOLCHAIN_PATH.read_bytes())
+
+          waiver_path = Path("known-validation-gaps.yaml")
+          if not waiver_path.is_file() or waiver_path.is_symlink():
+              fail("known-validation-gaps.yaml must be a regular file")
+          import hashlib
+          waiver_sha256 = hashlib.sha256(waiver_path.read_bytes()).hexdigest()
+          if waiver_sha256 != config["validation_waiver_set_sha256"]:
+              fail(
+                  "ValidationWaiverHashMismatch: known-validation-gaps.yaml "
+                  f"sha256 {waiver_sha256} != pinned "
+                  f"{config['validation_waiver_set_sha256']}"
+              )
+
+          output_path = Path(os.environ["GITHUB_OUTPUT"])
+          with output_path.open("a") as output:
+              for key, value in config.items():
+                  print(f"{key}={value}", file=output)
+          print(f"Resolved strict RuleSpec toolchain from {TOOLCHAIN_PATH}:")
+          for key, value in config.items():
+              print(f"- {key}: {value}")
+          PY
+
+      - name: Validate immutable dependency inputs
+        shell: bash
+        env:
+          AXIOM_ENCODE_SHA: ${{ inputs.axiom-encode-ref }}
+          AXIOM_RULES_ENGINE_SHA: ${{ inputs.axiom-rules-engine-ref }}
+          AXIOM_CORPUS_SHA: ${{ inputs.axiom-corpus-ref }}
+          RULESPEC_US_SHA: ${{ inputs.rulespec-us-ref }}
+          RELEASE_BASE_URL: ${{ inputs.corpus-release-base-url }}
+          PYTHON_VERSION: ${{ inputs.python-version }}
+        run: |
+          set -euo pipefail
+          for value in "$AXIOM_ENCODE_SHA" "$AXIOM_RULES_ENGINE_SHA" "$AXIOM_CORPUS_SHA" "$RULESPEC_US_SHA"; do
+            if [[ ! "$value" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "Dependency inputs must be exact 40-character lowercase commit SHAs: $value" >&2
+              exit 1
+            fi
+          done
+          # python-version is spliced into many run: blocks; bound it to major.minor
+          # so a caller cannot smuggle shell into those steps (fail-open / RCE).
+          if [[ ! "$PYTHON_VERSION" =~ ^3\.[0-9]+$ ]]; then
+            echo "python-version must be a bare major.minor like 3.14: $PYTHON_VERSION" >&2
+            exit 1
+          fi
+          case "$RELEASE_BASE_URL" in
+            https://*) ;;
+            *) echo "corpus-release-base-url must use HTTPS" >&2; exit 1 ;;
+          esac
+
+      - name: Checkout axiom-encode
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: TheAxiomFoundation/axiom-encode
+          ref: ${{ inputs.axiom-encode-ref }}
+          path: _axiom/axiom-encode
+          persist-credentials: false
+
+      - name: Checkout axiom-rules-engine
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: TheAxiomFoundation/axiom-rules-engine
+          ref: ${{ inputs.axiom-rules-engine-ref }}
+          path: _axiom/axiom-rules-engine
+          persist-credentials: false
+
+      - name: Checkout axiom-corpus
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: TheAxiomFoundation/axiom-corpus
+          ref: ${{ inputs.axiom-corpus-ref }}
+          path: _axiom/axiom-corpus
+          persist-credentials: false
+
+      - name: Checkout rulespec-us canonical targets
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: TheAxiomFoundation/rulespec-us
+          ref: ${{ inputs.rulespec-us-ref }}
+          path: _axiom/rulespec-us
+          persist-credentials: false
+
+      - name: Authenticate dependency commits
+        shell: bash
+        env:
+          AXIOM_ENCODE_SHA: ${{ inputs.axiom-encode-ref }}
+          AXIOM_RULES_ENGINE_SHA: ${{ inputs.axiom-rules-engine-ref }}
+          AXIOM_CORPUS_SHA: ${{ inputs.axiom-corpus-ref }}
+          RULESPEC_US_SHA: ${{ inputs.rulespec-us-ref }}
+        run: |
+          set -euo pipefail
+          verify_ancestor() {
+            local repo="$1" expected="$2"
+            test "$(git -C "$repo" rev-parse HEAD)" = "$expected" || {
+              echo "$repo did not check out expected SHA $expected" >&2; return 1;
+            }
+            default_branch="$(git -C "$repo" ls-remote --symref origin HEAD | sed -n 's#^ref: refs/heads/\([^[:space:]]*\)[[:space:]]*HEAD$#\1#p')"
+            test -n "$default_branch" || { echo "Cannot resolve $repo default branch" >&2; return 1; }
+            git -C "$repo" fetch --no-tags --unshallow origin "+refs/heads/$default_branch:refs/remotes/origin/$default_branch"
+            git -C "$repo" merge-base --is-ancestor "$expected" "refs/remotes/origin/$default_branch" || {
+              echo "$repo SHA $expected is not an ancestor of protected default branch $default_branch" >&2; return 1;
+            }
+          }
+          verify_ancestor _axiom/axiom-encode "$AXIOM_ENCODE_SHA"
+          verify_ancestor _axiom/axiom-rules-engine "$AXIOM_RULES_ENGINE_SHA"
+          verify_ancestor _axiom/axiom-corpus "$AXIOM_CORPUS_SHA"
+          verify_ancestor _axiom/rulespec-us "$RULESPEC_US_SHA"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30
+
+      - name: Set up Go 1.26.1
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: 1.26.1
+          cache: false
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest pyyaml
+          python -m pip install -e _axiom/axiom-encode
+          rm -rf "$RUNNER_TEMP/axiom-verification-site-packages"
+          python -m pip install \
+            --target "$RUNNER_TEMP/axiom-verification-site-packages" \
+            ./_axiom/axiom-encode
+
+      - name: Fetch pinned signed corpus release object
+        shell: bash
+        env:
+          RELEASE_BASE_URL: ${{ inputs.corpus-release-base-url }}
+          RELEASE_NAME: ${{ steps.toolchain.outputs.axiom_corpus_release }}
+          RELEASE_CONTENT_SHA256: ${{ steps.toolchain.outputs.axiom_corpus_release_content_sha256 }}
+        run: |
+          set -euo pipefail
+          destination="$GITHUB_WORKSPACE/_axiom/axiom-corpus/releases/$RELEASE_NAME/$RELEASE_CONTENT_SHA256.json"
+          mkdir -p "$(dirname "$destination")"
+          url="${RELEASE_BASE_URL%/}/releases/$RELEASE_NAME/$RELEASE_CONTENT_SHA256.json"
+          curl --fail --silent --show-error --location --proto '=https' --tlsv1.2 \
+            --output "$destination.tmp" "$url"
+          python - "$destination.tmp" "$RELEASE_NAME" "$RELEASE_CONTENT_SHA256" <<'PY'
+          import hashlib
+          import json
+          import sys
+          from pathlib import Path
+
+          path, expected_name, expected_sha = Path(sys.argv[1]), sys.argv[2], sys.argv[3]
+          try:
+              payload = json.loads(path.read_bytes())
+          except (OSError, json.JSONDecodeError) as exc:
+              raise SystemExit(f"Corpus release acquisition error: invalid JSON: {exc}")
+          if payload.get("release") != expected_name:
+              raise SystemExit("Corpus release acquisition error: release name mismatch")
+          content = payload.get("content")
+          if not isinstance(content, dict):
+              raise SystemExit("Corpus release acquisition error: missing content object")
+          actual = hashlib.sha256(json.dumps(
+              content, sort_keys=True, separators=(",", ":"), ensure_ascii=True,
+          ).encode()).hexdigest()
+          if payload.get("content_sha256") != actual or actual != expected_sha:
+              raise SystemExit(
+                  f"Corpus release acquisition error: content sha256 mismatch "
+                  f"({actual} != {expected_sha})"
+              )
+          path.replace(path.with_suffix(""))
+          PY
+
+      - name: Authenticate signed corpus provenance commit
+        shell: bash
+        env:
+          RELEASE_NAME: ${{ steps.toolchain.outputs.axiom_corpus_release }}
+          RELEASE_CONTENT_SHA256: ${{ steps.toolchain.outputs.axiom_corpus_release_content_sha256 }}
+          AXIOM_CORPUS_SHA: ${{ inputs.axiom-corpus-ref }}
+        run: |
+          set -euo pipefail
+          object="_axiom/axiom-corpus/releases/$RELEASE_NAME/$RELEASE_CONTENT_SHA256.json"
+          release_commit="$(python - "$object" <<'PY'
+          import json
+          import sys
+          print(json.load(open(sys.argv[1]))["content"]["git"]["commit"])
+          PY
+          )"
+          if [[ ! "$release_commit" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Signed release provenance is not a full lowercase commit SHA" >&2
+            exit 1
+          fi
+          default_branch="$(git -C _axiom/axiom-corpus ls-remote --symref origin HEAD | sed -n 's#^ref: refs/heads/\([^[:space:]]*\)[[:space:]]*HEAD$#\1#p')"
+          git -C _axiom/axiom-corpus fetch --no-tags origin \
+            "+refs/heads/$default_branch:refs/remotes/origin/$default_branch"
+          git -C _axiom/axiom-corpus merge-base --is-ancestor \
+            "$release_commit" "refs/remotes/origin/$default_branch" || {
+              echo "Signed release provenance $release_commit is not on the corpus default branch" >&2
+              exit 1
+            }
+          git -C _axiom/axiom-corpus merge-base --is-ancestor \
+            "$release_commit" "$AXIOM_CORPUS_SHA" || {
+              echo "Corpus checkout $AXIOM_CORPUS_SHA predates signed release provenance $release_commit" >&2
+              exit 1
+            }
+
+      - name: Provision protected verification supervisor
+        working-directory: _axiom/axiom-encode
+        env:
+          TRUST_APPLY_ROOT: ${{ vars.AXIOM_ENCODE_APPLY_SIGNING_PUBLIC_KEY }}
+          TRUST_EVAL_ROOT: ${{ vars.AXIOM_ENCODE_EVAL_SIGNING_PUBLIC_KEY }}
+          TRUST_CORPUS_RELEASE_ROOT: ${{ vars.AXIOM_CORPUS_RELEASE_PUBLIC_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "$TRUST_APPLY_ROOT" && test -n "$TRUST_EVAL_ROOT" && test -n "$TRUST_CORPUS_RELEASE_ROOT"
+          CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags='-buildid=' \
+            -o "$RUNNER_TEMP/axiom-encode-signing-supervisor" \
+            ./cmd/axiom-encode-signing-supervisor
+          sudo rm -rf /opt/axiom-verification
+          # sudo resets PATH (secure_path), so a bare `python` under sudo is
+          # the SYSTEM interpreter — and the provision script copies the
+          # invoking interpreter's sys.base_prefix, i.e. it would copytree
+          # /usr until the runner disk dies. Resolve the setup-python
+          # interpreter in this shell and pass its absolute path through.
+          sudo "$(command -v python)" scripts/provision_verification_supervisor.py \
+            --destination /opt/axiom-verification \
+            --supervisor "$RUNNER_TEMP/axiom-encode-signing-supervisor" \
+            --site-packages "$RUNNER_TEMP/axiom-verification-site-packages" \
+            --apply-root "$TRUST_APPLY_ROOT" --eval-root "$TRUST_EVAL_ROOT" \
+            --corpus-release-root "$TRUST_CORPUS_RELEASE_ROOT"
+          sudo chown -R 0:0 /opt/axiom-verification
+          sudo chmod -R go-w /opt/axiom-verification
+          # The supervisor refuses a trust chain with group/other-writable
+          # ancestors, and /opt ships group-writable on hosted runners.
+          # Harden the directory bit itself (contents are untouched; nothing
+          # later in this job creates new /opt entries).
+          # The supervised child's PATH is exactly the trusted tool directory
+          # (the supervisor exports no ambient PATH), and the checkout-identity
+          # probes shell out to git builtins (rev-parse --show-toplevel,
+          # remote get-url origin) whenever a module sits inside a git
+          # boundary — which every CI workspace does. Provision the runner's
+          # git binary alongside the trusted tools so those probes fail closed
+          # on identity, not on a missing binary.
+          # With a provisioned python runtime the supervisor rewrites exec to
+          # the trusted interpreter, so the child's PATH (= dirname of the
+          # exec'd command) is the runtime's bin directory — install git
+          # THERE, not at the verification root.
+          sudo install -m 0755 "$(command -v git)" /opt/axiom-verification/python/bin/git
+          sudo chown root:root /opt
+          sudo chmod go-w /opt
+
+      - name: Build axiom-rules-engine
+        working-directory: _axiom/axiom-rules-engine
+        run: cargo build --verbose
+
+      - name: Expose axiom-rules-engine on PATH
+        run: echo "$GITHUB_WORKSPACE/_axiom/axiom-rules-engine/target/debug" >> "$GITHUB_PATH"
+
+      - name: Link axiom-rules-engine as sibling checkout
+        shell: bash
+        run: |
+          set -euo pipefail
+          ln -sfn "$GITHUB_WORKSPACE/_axiom/axiom-rules-engine" "$GITHUB_WORKSPACE/../axiom-rules-engine"
+          ln -sfn "$GITHUB_WORKSPACE/_axiom/axiom-corpus" "$GITHUB_WORKSPACE/../axiom-corpus"
+          if [ "$(basename "$GITHUB_WORKSPACE")" != "rulespec-us" ]; then
+            ln -sfn "$GITHUB_WORKSPACE/_axiom/rulespec-us" "$GITHUB_WORKSPACE/../rulespec-us"
+          fi
+
+      - name: Run repository tests
+        if: ${{ inputs.run-pytest && matrix.shard == needs.shards.outputs.first }}
+        run: |
+          if [ -d tests ] && find tests -type f \( -name "test_*.py" -o -name "*_test.py" \) | grep -q .; then
+            python -m pytest -q tests
+          else
+            echo "No Python tests found; skipping pytest."
+          fi
+
+      - name: Reject obsolete generated files
+        if: ${{ matrix.shard == needs.shards.outputs.first }}
+        run: |
+          obsolete_ext="r""ac"
+          matches="$(find . \
+            \( -path ./.git -o -path ./_axiom -o -path ./.venv -o -path ./.pytest_cache \) -prune \
+            -o \( -name "*.${obsolete_ext}" -o -name "*.${obsolete_ext}.test" \) -print)"
+          if [ -n "$matches" ]; then
+            printf '%s\n' "$matches" >&2
+            exit 1
+          fi
+
+      - name: Reject disallowed repository layout
+        if: ${{ matrix.shard == needs.shards.outputs.first }}
+        shell: bash
+        env:
+          VALIDATE_ROOTS: ${{ needs.shards.outputs.roots }}
+          ALLOWED_EXTRA_ROOTS: ${{ needs.shards.outputs.allowed-extra }}
+        run: |
+          set -euo pipefail
+
+          if [ -f .axiom/repository-structure.yaml ]; then
+          python - <<'PY'
+          import fnmatch
+          import sys
+          from pathlib import Path, PurePosixPath
+
+          import yaml
+
+          CONFIG_PATH = Path(".axiom/repository-structure.yaml")
+
+          def fail(message: str) -> None:
+              print(f"Repository structure error: {message}", file=sys.stderr)
+              sys.exit(1)
+
+          def string_set(payload: object, key: str) -> set[str]:
+              value = payload.get(key) if isinstance(payload, dict) else None
+              if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+                  fail(f"{key} must be a list of strings")
+              normalized = {item.strip("/") for item in value}
+              if "" in normalized:
+                  fail(f"{key} contains an empty path")
+              return normalized
+
+          def tracked_files() -> list[str]:
+              import subprocess
+
+              result = subprocess.run(
+                  ["git", "ls-files", "-z"],
+                  check=True,
+                  stdout=subprocess.PIPE,
+              )
+              return sorted(
+                  path.decode()
+                  for path in result.stdout.split(b"\0")
+                  if path
+              )
+
+          config = yaml.safe_load(CONFIG_PATH.read_text()) or {}
+          if not isinstance(config, dict):
+              fail(f"{CONFIG_PATH} must contain a mapping")
+          if config.get("version") != 1:
+              fail(f"{CONFIG_PATH} must set version: 1")
+
+          allowed_root_directories = string_set(config, "allowed_root_directories")
+          allowed_root_files = string_set(config, "allowed_root_files")
+          path_rules = config.get("path_rules")
+          if not isinstance(path_rules, list) or not path_rules:
+              fail("path_rules must be a non-empty list")
+
+          normalized_rules: list[dict[str, object]] = []
+          for index, rule in enumerate(path_rules, start=1):
+              if not isinstance(rule, dict):
+                  fail(f"path_rules[{index}] must be a mapping")
+              patterns = rule.get("patterns")
+              if not isinstance(patterns, list) or not patterns or not all(
+                  isinstance(pattern, str) for pattern in patterns
+              ):
+                  fail(f"path_rules[{index}].patterns must be a non-empty list of strings")
+              allow_extensions = rule.get("allow_extensions", [])
+              allow_filenames = rule.get("allow_filenames", [])
+              if not isinstance(allow_extensions, list) or not all(
+                  isinstance(extension, str) for extension in allow_extensions
+              ):
+                  fail(f"path_rules[{index}].allow_extensions must be a list of strings")
+              if not isinstance(allow_filenames, list) or not all(
+                  isinstance(filename, str) for filename in allow_filenames
+              ):
+                  fail(f"path_rules[{index}].allow_filenames must be a list of strings")
+              normalized_rules.append(
+                  {
+                      "patterns": [pattern.strip("/") for pattern in patterns],
+                      "allow_extensions": set(allow_extensions),
+                      "allow_filenames": set(allow_filenames),
+                  }
+              )
+
+          problems: list[str] = []
+          for path in tracked_files():
+              parts = PurePosixPath(path).parts
+              if len(parts) == 1:
+                  if path not in allowed_root_files:
+                      problems.append(f"{path}: top-level file is not allowed")
+                  continue
+
+              root = parts[0]
+              if root not in allowed_root_directories:
+                  problems.append(f"{path}: top-level directory {root}/ is not allowed")
+                  continue
+
+              matched_rule = None
+              for rule in normalized_rules:
+                  if any(fnmatch.fnmatchcase(path, pattern) for pattern in rule["patterns"]):
+                      matched_rule = rule
+                      break
+              if matched_rule is None:
+                  problems.append(f"{path}: no path rule matched")
+                  continue
+
+              name = PurePosixPath(path).name
+              extension = PurePosixPath(path).suffix
+              if name in matched_rule["allow_filenames"]:
+                  continue
+              if extension in matched_rule["allow_extensions"]:
+                  continue
+              problems.append(
+                  f"{path}: file name/extension is not allowed by matched path rule"
+              )
+
+          if problems:
+              print(
+                  f"Repository layout does not match {CONFIG_PATH}.",
+                  file=sys.stderr,
+              )
+              for problem in problems:
+                  print(f"- {problem}", file=sys.stderr)
+              sys.exit(1)
+
+          print(f"Repository layout matches {CONFIG_PATH}.")
+          PY
+          exit 0
+          fi
+          disallowed=()
+
+          for root in statute regulation policy; do
+            if [ -e "$root" ]; then
+              disallowed+=("$root/")
+            fi
+          done
+
+          while IFS= read -r path; do
+            disallowed+=("$path")
+          done < <(
+            find . \
+              \( -path ./.git -o -path ./_axiom -o -path ./.venv -o -path ./.pytest_cache \) -prune \
+              -o -type f \( -name "parameters.yaml" -o -name "tests.yaml" \) -print
+          )
+
+          while IFS= read -r path; do
+            disallowed+=("$path")
+          done < <(
+            find tests -type f -name "*.yaml" 2>/dev/null || true
+          )
+
+          prune=( -path ./.git -o -path ./_axiom -o -path ./.venv -o -path ./.pytest_cache -o -path ./.github )
+          for allowed in $VALIDATE_ROOTS $ALLOWED_EXTRA_ROOTS; do
+            prune+=( -o -path "./$allowed" )
+          done
+          while IFS= read -r path; do
+            disallowed+=("$path")
+          done < <(
+            find . \( "${prune[@]}" \) -prune \
+              -o -type f \( -name "*.yaml" -o -name "*.yml" \) \
+                ! -name "known-dangling.yaml" ! -name "known-validation-gaps.yaml" -print
+          )
+
+          if [ "${#disallowed[@]}" -ne 0 ]; then
+            printf 'Repository layout is not allowed. Use RuleSpec YAML under statutes/, regulations/, or policies/.\n' >&2
+            printf '%s\n' "${disallowed[@]}" >&2
+            exit 1
+          fi
+
+      - name: Enforce validation waiver ratchet
+        if: ${{ matrix.shard == needs.shards.outputs.first }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base_ref="${{ github.event.pull_request.base.sha }}"
+          elif [ -n "${{ github.event.before }}" ] && [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+            base_ref="${{ github.event.before }}"
+          else
+            base_ref="HEAD~1"
+          fi
+          protected_base="$RUNNER_TEMP/protected-known-validation-gaps.yaml"
+          changed_paths="$RUNNER_TEMP/waiver-changed-paths.txt"
+          git show "$base_ref:known-validation-gaps.yaml" > "$protected_base" || {
+            echo "ValidationWaiverBaseMissing: protected base must contain known-validation-gaps.yaml" >&2
+            exit 1
+          }
+          git diff --name-only --no-renames --diff-filter=ACMRTD \
+            "$base_ref" "$GITHUB_SHA" > "$changed_paths"
+          python - "$protected_base" known-validation-gaps.yaml <<'PY'
+          import sys
+          from pathlib import Path
+
+          import yaml
+
+          base_path, head_path = map(Path, sys.argv[1:])
+          base = yaml.safe_load(base_path.read_bytes())
+          head = yaml.safe_load(head_path.read_bytes())
+          base_entries = base.get("validate_failures", {}) if isinstance(base, dict) else {}
+          head_entries = head.get("validate_failures", {}) if isinstance(head, dict) else {}
+          if not isinstance(base_entries, dict) or not isinstance(head_entries, dict):
+              raise SystemExit(
+                  "ValidationWaiverRatchetSchema: validate_failures must be a mapping"
+              )
+          growth = []
+          for module, head_states in head_entries.items():
+              base_states = base_entries.get(module)
+              if not isinstance(head_states, dict) or not isinstance(base_states, dict):
+                  growth.append(str(module))
+                  continue
+              for state, metadata in head_states.items():
+                  if base_states.get(state) == metadata:
+                      continue
+                  if state == "active" and base_states.get("pending") == metadata:
+                      # A protected-base pending approval being consumed
+                      # (pending -> active) is the sanctioned transition; the
+                      # supervised audit still enforces the full protocol
+                      # (exact consumption, expiry, waiver-only approvals).
+                      continue
+                  growth.append(f"{module}:{state}")
+          if growth:
+              raise SystemExit(
+                  "ValidationWaiverRatchetGrowth: waivers may only shrink; "
+                  "new, changed, or broadened records: " + ", ".join(sorted(growth))
+              )
+          print(
+              "Validation waiver ratchet is decrement-only: "
+              f"{len(base_entries)} base module(s) -> {len(head_entries)} head module(s)."
+          )
+          PY
+          /opt/axiom-verification/axiom-encode-signing-supervisor \
+            --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
+            --trusted-python-runtime-root /opt/axiom-verification/python \
+            --trusted-python-import-root /opt/axiom-verification/python/lib/python${{ inputs.python-version }}/site-packages \
+            --trusted-python-package-root /opt/axiom-verification/python/lib/python${{ inputs.python-version }}/site-packages/axiom_encode \
+            -- /opt/axiom-verification/axiom-encode validation-waivers audit \
+            --root "$GITHUB_WORKSPACE" \
+            --corpus-path "$GITHUB_WORKSPACE/_axiom/axiom-corpus" \
+            --protected-base "$protected_base" \
+            --changed-paths "$changed_paths" \
+            --axiom-rules-engine-path "$GITHUB_WORKSPACE/_axiom/axiom-rules-engine"
+
+      - name: Reject manual RuleSpec changes
+        if: ${{ inputs.run-generated-guard && matrix.shard == needs.shards.outputs.first }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base_ref="${{ github.event.pull_request.base.sha }}"
+          elif [ -n "${{ github.event.before }}" ] && [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+            base_ref="${{ github.event.before }}"
+          else
+            base_ref="HEAD~1"
+          fi
+
+          /opt/axiom-verification/axiom-encode-signing-supervisor \
+            --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
+            --trusted-python-runtime-root /opt/axiom-verification/python \
+            --trusted-python-import-root /opt/axiom-verification/python/lib/python${{ inputs.python-version }}/site-packages \
+            --trusted-python-package-root /opt/axiom-verification/python/lib/python${{ inputs.python-version }}/site-packages/axiom_encode \
+            -- /opt/axiom-verification/axiom-encode guard-generated \
+            --repo "$GITHUB_WORKSPACE" \
+            --base-ref "$base_ref" \
+            --head-ref "$GITHUB_SHA" \
+            --corpus-path "$GITHUB_WORKSPACE/_axiom/axiom-corpus" \
+            --expected-encoder-checkout "$GITHUB_WORKSPACE/_axiom/axiom-encode"
+
+      - name: Select RuleSpec validation targets
+        id: validation_targets
+        shell: bash
+        env:
+          VALIDATE_ROOTS: ${{ steps.resolve_roots.outputs.roots }}
+        run: |
+          set -euo pipefail
+
+          rulespec_file_list="$RUNNER_TEMP/rulespec-files.txt"
+          test_file_list="$RUNNER_TEMP/rulespec-test-files.txt"
+          : > "$rulespec_file_list"
+          : > "$test_file_list"
+
+          add_existing_file() {
+            local path="$1"
+            local list="$2"
+            if [ -f "$path" ]; then
+              printf '%s\n' "$path" >> "$list"
+            fi
+          }
+
+          add_rulespec_target() {
+            local path="$1"
+            case "$path" in
+              # Composition specs (the programs root, canonically nested
+              # under the jurisdiction dir) are axiom-compose inputs, not
+              # atomic RuleSpec modules — the encoder rejects them from
+              # atomic validation by design.
+              */programs/*|programs/*) return ;;
+            esac
+            case "$path" in
+              *.test.yaml)
+                add_existing_file "$path" "$test_file_list"
+                add_existing_file "${path%.test.yaml}.yaml" "$rulespec_file_list"
+                ;;
+              *.test.yml)
+                add_existing_file "$path" "$test_file_list"
+                add_existing_file "${path%.test.yml}.yml" "$rulespec_file_list"
+                ;;
+              *.yaml)
+                add_existing_file "$path" "$rulespec_file_list"
+                add_existing_file "${path%.yaml}.test.yaml" "$test_file_list"
+                ;;
+              *.yml)
+                add_existing_file "$path" "$rulespec_file_list"
+                add_existing_file "${path%.yml}.test.yml" "$test_file_list"
+                ;;
+            esac
+          }
+
+          add_all_rulespec_targets() {
+            while IFS= read -r path; do
+              add_existing_file "$path" "$rulespec_file_list"
+            done < <(
+              for root in $VALIDATE_ROOTS; do
+                if [ -d "$root" ]; then
+                  find "$root" -type f \( -name "*.yaml" -o -name "*.yml" \) \
+                    ! -name "*.test.yaml" ! -name "*.test.yml" \
+                    ! -path "*/programs/*"
+                fi
+              done
+            )
+            while IFS= read -r path; do
+              add_existing_file "$path" "$test_file_list"
+            done < <(
+              for root in $VALIDATE_ROOTS; do
+                if [ -d "$root" ]; then
+                  find "$root" -type f \( -name "*.test.yaml" -o -name "*.test.yml" \) \
+                    ! -path "*/programs/*"
+                fi
+              done
+            )
+          }
+
+          classify_toolchain_change() {
+            python - "$base_ref" <<'PY'
+          import subprocess
+          import sys
+          import tomllib
+          from pathlib import Path
+
+          base_ref = sys.argv[1]
+          path = Path(".axiom/toolchain.toml")
+          result = subprocess.run(
+              ["git", "show", f"{base_ref}:.axiom/toolchain.toml"],
+              check=False,
+              stdout=subprocess.PIPE,
+              stderr=subprocess.DEVNULL,
+          )
+          if result.returncode != 0 or not path.exists():
+              print("full")
+              raise SystemExit
+
+          def load(text: bytes) -> dict[str, object]:
+              payload = tomllib.loads(text.decode())
+              table = payload.get("toolchain", payload)
+              if not isinstance(table, dict):
+                  return {}
+              return table
+
+          before = load(result.stdout)
+          after = load(path.read_bytes())
+          changed = {
+              key for key in set(before) | set(after)
+              if before.get(key) != after.get(key)
+          }
+          if changed and changed <= {
+              "axiom_corpus_release",
+              "axiom_corpus_release_content_sha256",
+          }:
+              print("corpus-only")
+          else:
+              print("full")
+          PY
+          }
+
+          mode="full-push"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base_ref="${{ github.event.pull_request.base.sha }}"
+            mapfile -t all_changed_paths < <(
+              git diff --name-only --no-renames --diff-filter=ACMRTD "$base_ref" "$GITHUB_SHA"
+            )
+            mode="changed"
+            for path in "${all_changed_paths[@]}"; do
+              case "$path" in
+                .github/workflows/*.yml|.github/workflows/*.yaml)
+                  mode="full-toolchain-bump"
+                  break
+                  ;;
+                .axiom/toolchain.toml)
+                  if [ "$(classify_toolchain_change)" = "corpus-only" ]; then
+                    mode="changed-corpus-toolchain-bump"
+                  else
+                    mode="full-toolchain-bump"
+                    break
+                  fi
+                  ;;
+              esac
+            done
+
+            if [ "$mode" = "full-toolchain-bump" ]; then
+              add_all_rulespec_targets
+            else
+              for path in "${all_changed_paths[@]}"; do
+                for root in $VALIDATE_ROOTS; do
+                  case "$path" in
+                    "$root"/*)
+                      add_rulespec_target "$path"
+                      ;;
+                  esac
+                done
+              done
+            fi
+          else
+            add_all_rulespec_targets
+          fi
+
+          sort -u "$rulespec_file_list" -o "$rulespec_file_list"
+          sort -u "$test_file_list" -o "$test_file_list"
+
+          {
+            echo "RULESPEC_FILE_LIST=$rulespec_file_list"
+            echo "RULESPEC_TEST_FILE_LIST=$test_file_list"
+            echo "RULESPEC_VALIDATION_MODE=$mode"
+          } >> "$GITHUB_ENV"
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+
+          echo "RuleSpec validation mode: $mode"
+          echo "RuleSpec files selected:"
+          sed 's/^/- /' "$rulespec_file_list" || true
+          echo "RuleSpec companion tests selected:"
+          sed 's/^/- /' "$test_file_list" || true
+
+      - name: Validate RuleSpec YAML
+        shell: bash
+        env:
+          VALIDATE_ROOTS: ${{ steps.resolve_roots.outputs.roots }}
+          AXIOM_RULESPEC_REPO_ROOTS: ${{ github.workspace }}:${{ github.workspace }}/_axiom/rulespec-us
+          AXIOM_CORPUS_ARTIFACT_ROOT: ${{ github.workspace }}/data/corpus
+          AXIOM_CORPUS_REPO: ${{ github.workspace }}/_axiom/axiom-corpus
+        run: |
+          set -euo pipefail
+
+          mapfile -t rulespec_files < "$RULESPEC_FILE_LIST"
+
+          if [ "${#rulespec_files[@]}" -eq 0 ]; then
+            echo "No RuleSpec YAML files selected for validation."
+            exit 0
+          fi
+
+          # Ratcheted pre-existing validate failures: repos may list files in
+          # known-validation-gaps.yaml under `validate_failures` (each needs
+          # an issue link in that file). Listed files are skipped LOUDLY.
+          skip_list="$RUNNER_TEMP/validate-skip.txt"
+          : > "$skip_list"
+          if [ -f known-validation-gaps.yaml ]; then
+            python - <<'SKIP' > "$skip_list"
+          import yaml
+          payload = yaml.safe_load(open("known-validation-gaps.yaml")) or {}
+          for entry in payload.get("validate_failures") or []:
+              print(entry)
+          SKIP
+          fi
+
+          selected=()
+          for file in "${rulespec_files[@]}"; do
+            if grep -qxF "$file" "$skip_list"; then
+              echo "SKIPPED (known-validation-gaps validate_failures): $file"
+              continue
+            fi
+            selected+=("$GITHUB_WORKSPACE/$file")
+          done
+
+          if [ "${#selected[@]}" -eq 0 ]; then
+            echo "All selected RuleSpec YAML files are skipped."
+            exit 0
+          fi
+
+          # One invocation for all files: validation reuses one process and
+          # one registry load instead of paying both per file. Failed files
+          # are listed in the command's own summary output.
+          /opt/axiom-verification/axiom-encode-signing-supervisor \
+            --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
+            --trusted-python-runtime-root /opt/axiom-verification/python \
+            --trusted-python-import-root /opt/axiom-verification/python/lib/python${{ inputs.python-version }}/site-packages \
+            --trusted-python-package-root /opt/axiom-verification/python/lib/python${{ inputs.python-version }}/site-packages/axiom_encode \
+            -- /opt/axiom-verification/axiom-encode validate "${selected[@]}" \
+            --skip-reviewers \
+            --corpus-path "$GITHUB_WORKSPACE/_axiom/axiom-corpus" \
+            --axiom-rules-engine-path "$GITHUB_WORKSPACE/_axiom/axiom-rules-engine"
+
+      - name: Execute RuleSpec companion tests
+        shell: bash
+        env:
+          VALIDATE_ROOTS: ${{ steps.resolve_roots.outputs.roots }}
+          AXIOM_RULESPEC_REPO_ROOTS: ${{ github.workspace }}:${{ github.workspace }}/_axiom/rulespec-us
+        run: |
+          set -euo pipefail
+
+          mapfile -t test_files < "$RULESPEC_TEST_FILE_LIST"
+
+          # A module ratcheted under validate_failures cannot be expected to
+          # execute either; skip its companion test loudly (same
+          # known-validation-gaps.yaml list the validate step consults).
+          skip_list="$RUNNER_TEMP/validate-skip.txt"
+          selected=()
+          for test_file in "${test_files[@]}"; do
+            case "$test_file" in
+              *.test.yaml) module_file="${test_file%.test.yaml}.yaml" ;;
+              *.test.yml) module_file="${test_file%.test.yml}.yml" ;;
+              *) module_file="$test_file" ;;
+            esac
+            if [ -s "$skip_list" ] && grep -qxF "$module_file" "$skip_list"; then
+              echo "SKIPPED companion (known-validation-gaps validate_failures): $test_file"
+              continue
+            fi
+            selected+=("$test_file")
+          done
+
+          if [ "${#selected[@]}" -eq 0 ]; then
+            echo "No RuleSpec companion tests selected; skipping."
+            exit 0
+          fi
+
+          # The hard-cut encoder requires --root to be the exact jurisdiction
+          # content root (rulespec-<country>/<jurisdiction>), not the checkout;
+          # group the selected companion tests by their jurisdiction directory
+          # and run one invocation per group.
+          declare -A by_root=()
+          for test_file in "${selected[@]}"; do
+            jurisdiction="${test_file%%/*}"
+            # Paths are resolved relative to --root, so strip the
+            # jurisdiction prefix or they double up (<root>/dk/dk/...).
+            by_root[$jurisdiction]+="${test_file#"$jurisdiction"/}"$'\n'
+          done
+          for jurisdiction in "${!by_root[@]}"; do
+            mapfile -t group <<< "${by_root[$jurisdiction]%$'\n'}"
+            axiom-encode test \
+              --root "$GITHUB_WORKSPACE/$jurisdiction" \
+              --axiom-rules-engine-path "$GITHUB_WORKSPACE/_axiom/axiom-rules-engine" \
+              "${group[@]}"
+          done
+
+      - name: Validate RuleSpec proofs and claims
+        shell: bash
+        env:
+          VALIDATE_ROOTS: ${{ steps.resolve_roots.outputs.roots }}
+          AXIOM_CORPUS_ARTIFACT_ROOT: ${{ github.workspace }}/data/corpus
+          AXIOM_CORPUS_REPO: ${{ github.workspace }}/_axiom/axiom-corpus
+        run: |
+          set -euo pipefail
+
+          mapfile -t rulespec_files < "$RULESPEC_FILE_LIST"
+
+          if [ "${#rulespec_files[@]}" -eq 0 ]; then
+            echo "No RuleSpec YAML files selected for proof validation."
+            exit 0
+          fi
+
+          prefixed=()
+          for file in "${rulespec_files[@]}"; do
+            prefixed+=("$GITHUB_WORKSPACE/$file")
+          done
+
+          # One invocation for all files; failed files are listed in the
+          # command's own summary output.
+          /opt/axiom-verification/axiom-encode-signing-supervisor \
+            --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
+            --trusted-python-runtime-root /opt/axiom-verification/python \
+            --trusted-python-import-root /opt/axiom-verification/python/lib/python${{ inputs.python-version }}/site-packages \
+            --trusted-python-package-root /opt/axiom-verification/python/lib/python${{ inputs.python-version }}/site-packages/axiom_encode \
+            -- /opt/axiom-verification/axiom-encode proof-validate "${prefixed[@]}" \
+            --corpus-path "$GITHUB_WORKSPACE/_axiom/axiom-corpus"
+
+      - name: Require money proof atoms
+        # Scan the whole repository (not just changed files) on the first
+        # shard: the ratchet allowance is repo-wide, so a per-PR changed-file
+        # subset could not tell whether a change raised the money-atom debt.
+        # This is a cheap pure-Python pass (no compile, no engine build).
+        if: ${{ inputs.run-money-atom-check && matrix.shard == needs.shards.outputs.first }}
+        shell: bash
+        env:
+          VALIDATE_ROOTS: ${{ needs.shards.outputs.roots }}
+        run: |
+          set -euo pipefail
+
+          money_atom_files=()
+          for root in $VALIDATE_ROOTS; do
+            if [ -d "$root" ]; then
+              while IFS= read -r path; do
+                money_atom_files+=("$path")
+              done < <(
+                find "$root" -type f \( -name "*.yaml" -o -name "*.yml" \) \
+                  ! -name "*.test.yaml" ! -name "*.test.yml" \
+                  ! -path "*/programs/*"
+              )
+            fi
+          done
+
+          if [ "${#money_atom_files[@]}" -eq 0 ]; then
+            echo "No RuleSpec YAML files found for money-atom check."
+            exit 0
+          fi
+
+          ratchet_args=()
+          if [ -f known-missing-money-atoms.yaml ]; then
+            echo "Using money-atom ratchet: known-missing-money-atoms.yaml"
+            ratchet_args=(--ratchet-file known-missing-money-atoms.yaml)
+          else
+            echo "No known-missing-money-atoms.yaml ratchet; requiring zero missing money atoms."
+          fi
+
+          # --money-atoms-only checks solely the money obligations; it does
+          # not re-run base proof-tree validation, so scanning the whole repo
+          # here never re-reports unrelated proof issues on unchanged files
+          # (those stay scoped to the changed-file proof step above).
+          /opt/axiom-verification/axiom-encode-signing-supervisor \
+            --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
+            --trusted-python-runtime-root /opt/axiom-verification/python \
+            --trusted-python-import-root /opt/axiom-verification/python/lib/python${{ inputs.python-version }}/site-packages \
+            --trusted-python-package-root /opt/axiom-verification/python/lib/python${{ inputs.python-version }}/site-packages/axiom_encode \
+            -- /opt/axiom-verification/axiom-encode proof-validate \
+            "${money_atom_files[@]}" \
+            --money-atoms-only \
+            --corpus-path "$GITHUB_WORKSPACE/_axiom/axiom-corpus" \
+            "${ratchet_args[@]}"
+
+      - name: Validate PolicyEngine oracle coverage classification
+        if: ${{ github.event_name != 'pull_request' || steps.validation_targets.outputs.mode == 'full-toolchain-bump' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          axiom-encode oracle-coverage \
+            --root "$GITHUB_WORKSPACE" \
+            --fail-on-unmapped \
+            --fail-on-untested-comparable \
+            --limit 50
+
+      - name: Checkout changed-file oracle coverage classifier
+        if: ${{ github.event_name == 'pull_request' && steps.validation_targets.outputs.mode != 'full-toolchain-bump' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: TheAxiomFoundation/axiom-encode
+          ref: ${{ inputs.axiom-encode-ref }}
+          path: _axiom/axiom-encode-oracle-coverage
+          persist-credentials: false
+
+      - name: Install changed-file oracle coverage classifier
+        if: ${{ github.event_name == 'pull_request' && steps.validation_targets.outputs.mode != 'full-toolchain-bump' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install -e _axiom/axiom-encode-oracle-coverage
+          # The changed-file classifier checkout may pin an axiom-oracles commit
+          # step installed. axiom-oracles is a git dependency whose version string
+          # does not change per commit, so pip treats the pinned SHA as "already
+          # satisfied" and keeps the stale copy — the classifier then reports
+          # freshly-added not_comparable mappings as unmapped. Force-reinstall the
+          # axiom-oracles pin declared by this checkout so the classifier reads its
+          # bridge mappings, not the toolchain-pinned ones.
+          oracles_spec="$(
+            python - <<'PY'
+          import pathlib
+          import re
+
+          text = pathlib.Path("_axiom/axiom-encode-oracle-coverage/pyproject.toml").read_text()
+          match = re.search(
+              r'"(axiom-oracles @ git\+https://github\.com/[^"]+)"', text
+          )
+          print(match.group(1) if match else "")
+          PY
+          )"
+          if [ -n "$oracles_spec" ]; then
+            python -m pip install --force-reinstall --no-deps "$oracles_spec"
+          fi
+          python - <<'PY'
+          import importlib.metadata
+
+          print(
+              "Changed-file oracle coverage classifier uses axiom-encode "
+              f"{importlib.metadata.version('axiom-encode')}."
+          )
+          PY
+
+      - name: Validate changed PolicyEngine oracle coverage classification
+        if: ${{ github.event_name == 'pull_request' && steps.validation_targets.outputs.mode != 'full-toolchain-bump' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ ! -s "$RULESPEC_FILE_LIST" ]; then
+            echo "No changed RuleSpec YAML files selected for oracle coverage."
+            exit 0
+          fi
+
+          coverage_json="$RUNNER_TEMP/policyengine-oracle-coverage.json"
+          axiom-encode oracle-coverage \
+            --root "$GITHUB_WORKSPACE" \
+            --json > "$coverage_json"
+
+          python - "$coverage_json" "$RULESPEC_FILE_LIST" <<'PY'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          coverage_path = Path(sys.argv[1])
+          rulespec_file_list = Path(sys.argv[2])
+          repo = Path(os.environ["GITHUB_WORKSPACE"]).name
+          if repo.startswith("rulespec-be"):
+              print(
+                  "Changed PolicyEngine oracle coverage skipped for Belgium; "
+                  "rulespec-be uses the EUROMOD household-level oracle surface."
+              )
+              raise SystemExit
+          changed = {
+              f"{repo}/{line.strip()}"
+              for line in rulespec_file_list.read_text().splitlines()
+              if line.strip()
+          }
+          payload = json.loads(coverage_path.read_text())
+          items = [
+              item for item in payload.get("items", [])
+              if item.get("file") in changed
+          ]
+          failures = []
+          for item in items:
+              legal_id = item.get("legal_id")
+              if item.get("status") == "unmapped":
+                  failures.append(f"{legal_id}: unmapped")
+              elif item.get("status") == "comparable" and not item.get("tested"):
+                  failures.append(f"{legal_id}: comparable but not covered by companion tests")
+
+          if failures:
+              print("Changed PolicyEngine oracle coverage is incomplete.", file=sys.stderr)
+              for failure in failures[:50]:
+                  print(f"- {failure}", file=sys.stderr)
+              if len(failures) > 50:
+                  print(f"- ... {len(failures) - 50} more", file=sys.stderr)
+              sys.exit(1)
+
+          print(f"Changed PolicyEngine oracle coverage passed for {len(items)} output(s).")
+          PY
+
+  validate-complete:
+    # Matrix jobs get suffixed check names such as `validate (us-ca)`.
+    # Keep this aggregate name as `validate` so existing branch-protection
+    # rules requiring `validate / validate` have one stable context.
+    name: validate
+    needs: validate
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check validation matrix result
+        shell: bash
+        env:
+          VALIDATE_RESULT: ${{ needs.validate.result }}
+        run: |
+          set -euo pipefail
+          if [ "$VALIDATE_RESULT" != "success" ]; then
+            echo "Validation matrix completed with result: $VALIDATE_RESULT" >&2
+            exit 1
+          fi
+          echo "Validation matrix passed."

--- a/tests/test_ci_parity.py
+++ b/tests/test_ci_parity.py
@@ -1,0 +1,593 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+import yaml
+
+from axiom_encode.ci_parity import (
+    CI_GATE_REGISTRY,
+    SUPPORTED_WORKFLOW_PINS,
+    CallerConfig,
+    DependencyMismatch,
+    Selection,
+    _run_pinned_cli,
+    acquire_release_object,
+    ci_verdict,
+    encoder_version_at_pin,
+    execute_gates,
+    parse_caller_workflow,
+    run_ci,
+    select_targets,
+    verify_ambient_encoder,
+    verify_dependency_checkout,
+    workflow_axiom_invocations,
+    workflow_gate_contract,
+    workflow_gate_coverage,
+)
+from axiom_encode.toolchain import (
+    RuleSpecToolchain,
+    load_rulespec_toolchain,
+    verify_rulespec_validation_waiver_set,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "ci_parity"
+WORKFLOW_GATE_STEP_SHA256 = {
+    "Run repository tests": "6c998d6153fad095d24fdbc61edf089128945c10992b6575626d14baca4abefa",
+    "Reject obsolete generated files": "976cd71e74efc5ecb2697afb7e43f7e53f52b425fefe40657b417e64b8e38232",
+    "Reject disallowed repository layout": "d16d421f91b38016ef4d4ad3ac97593ba148f06d7bacc3d6f86bbdc1a5bafb87",
+    "Enforce validation waiver ratchet": "2c42cf0de4847c69a0197ed5ba605b7c3f6f5b96d0c9568c307c83d2c6e74b98",
+    "Reject manual RuleSpec changes": "e5e4f58dfd95c39363fd3cfb39de4bd064302d93f4874c566f85d4e6818effac",
+    "Select RuleSpec validation targets": "b075f905b6844a4d40473c101c3d12f72a20c2366fa6c4734c66adf4885525b6",
+    "Validate RuleSpec YAML": "1a172396d726ed61d76082785316e73d22901efe06b587b9b4ac3c7a23aa916b",
+    "Execute RuleSpec companion tests": "5a6eb8de6b5f6505a67505f5c8154e1f2cb7e60aef55d69af286eadb7003184f",
+    "Validate RuleSpec proofs and claims": "eee57b7142a368870bf84473b8c9a697ab919f11eeef38b19fcfe4bbaf718294",
+    "Require money proof atoms": "9fec18e5cbd86b3c5581f19380e0e27c8ccbe1d66a7820578e5abab2b18573e3",
+    "Validate PolicyEngine oracle coverage classification": "a7aba1c023537ef274b23a418197c1652380f01b2902d0eb7a445332b69f609b",
+    "Checkout changed-file oracle coverage classifier": "50fbe10bc745dc9b1d6aa0e77871d713e4339799b079bc962ab8115074255ba6",
+    "Install changed-file oracle coverage classifier": "5f6aa72a94fc7ba127fe3586c08ee29f4f23c604fec14d311878e17abd1f82f9",
+    "Validate changed PolicyEngine oracle coverage classification": "0c907a7dfece8a50df6b6acb368a5fb312a59e965b36d964588bbd6a9f5ff878",
+}
+WORKFLOW_GATE_STEP_SHA256_BY_PIN = {
+    sha: {
+        **WORKFLOW_GATE_STEP_SHA256,
+        **(
+            {
+                "Require money proof atoms": (
+                    "371bcd61cdf0528db1b4529461ac25520b62113e7a4caaa62fbec59a84d814e2"
+                )
+            }
+            if sha == "34bcfab235c585c47292c95f51be1a4f4f91d29e"
+            else {}
+        ),
+    }
+    for sha in SUPPORTED_WORKFLOW_PINS
+}
+
+
+@pytest.fixture(params=SUPPORTED_WORKFLOW_PINS.items(), ids=lambda item: item[0][:8])
+def supported_workflow(request: pytest.FixtureRequest):
+    sha, pin = request.param
+    return sha, pin, FIXTURES / pin.fixture
+
+
+def test_real_lane_callers_parse() -> None:
+    de = parse_caller_workflow(FIXTURES / "de-caller.yml")
+    dk = parse_caller_workflow(FIXTURES / "dk-caller.yml")
+
+    assert de.workflow_sha == "615c1df9b9ace7deea84da65efd137f46f8bad2b"
+    assert de.refs["engine"] == "05eac9d2f89dabe5c6673176260762cef3a58f47"
+    assert de.run_generated_guard is True
+    assert dk.validate_roots == "auto"
+    assert dk.run_generated_guard is False
+
+
+def test_gate_order_is_stable() -> None:
+    assert [gate.key for gate in CI_GATE_REGISTRY] == [
+        "repository_tests",
+        "obsolete_files",
+        "repository_layout",
+        "validation_waivers",
+        "guard_generated",
+        "select_targets",
+        "validate",
+        "companion_tests",
+        "proof_validate",
+        "money_atoms",
+        "oracle_coverage",
+        "changed_oracle_coverage",
+    ]
+
+
+def test_workflow_axiom_commands_are_covered_by_gate_registry(
+    supported_workflow,
+) -> None:
+    _, _, fixture = supported_workflow
+    invocations = workflow_axiom_invocations(fixture)
+    registry: dict[str, list[set[str]]] = {}
+    for gate in CI_GATE_REGISTRY:
+        command = gate.subcommand.split()[0]
+        registry.setdefault(command, []).append(
+            {flag for flag in gate.flags if flag.startswith("--")}
+        )
+
+    assert invocations
+    for command, flags in invocations:
+        assert command in registry
+        assert any(set(flags) == candidate for candidate in registry[command]), (
+            command,
+            flags,
+        )
+
+
+def test_every_workflow_gate_step_is_covered_exactly(supported_workflow) -> None:
+    _, _, fixture = supported_workflow
+    coverage = workflow_gate_coverage(fixture)
+    registered = {gate.key for gate in CI_GATE_REGISTRY}
+
+    assert set(coverage) == {
+        "Run repository tests",
+        "Reject obsolete generated files",
+        "Reject disallowed repository layout",
+        "Enforce validation waiver ratchet",
+        "Reject manual RuleSpec changes",
+        "Select RuleSpec validation targets",
+        "Validate RuleSpec YAML",
+        "Execute RuleSpec companion tests",
+        "Validate RuleSpec proofs and claims",
+        "Require money proof atoms",
+        "Validate PolicyEngine oracle coverage classification",
+        "Checkout changed-file oracle coverage classifier",
+        "Install changed-file oracle coverage classifier",
+        "Validate changed PolicyEngine oracle coverage classification",
+    }
+    assert {gate for gates in coverage.values() for gate in gates} == registered
+
+
+def test_workflow_gate_step_semantics_match_pinned_contract(supported_workflow) -> None:
+    sha, pin, fixture = supported_workflow
+    payload = yaml.safe_load(fixture.read_text())
+    actual = {}
+    for step in payload["jobs"]["validate"]["steps"]:
+        name = step.get("name")
+        if name in WORKFLOW_GATE_STEP_SHA256:
+            canonical = yaml.safe_dump(
+                workflow_gate_contract(step, payload), sort_keys=True
+            ).encode()
+            actual[name] = hashlib.sha256(canonical).hexdigest()
+
+    assert actual == WORKFLOW_GATE_STEP_SHA256_BY_PIN[sha]
+    money_atom_run = next(
+        step["run"]
+        for step in payload["jobs"]["validate"]["steps"]
+        if step.get("name") == "Require money proof atoms"
+    )
+    assert ('! -path "*/programs/*"' in money_atom_run) is (
+        pin.gate_parameters.exclude_programs_from_money_atom_check
+    )
+
+
+def test_supported_workflow_fixtures_have_only_known_divergence() -> None:
+    fixtures = {
+        sha: yaml.safe_load((FIXTURES / pin.fixture).read_text())
+        for sha, pin in SUPPORTED_WORKFLOW_PINS.items()
+    }
+    old = fixtures["34bcfab235c585c47292c95f51be1a4f4f91d29e"]
+    new = fixtures["615c1df9b9ace7deea84da65efd137f46f8bad2b"]
+    old_step = next(
+        step
+        for step in old["jobs"]["validate"]["steps"]
+        if step.get("name") == "Require money proof atoms"
+    )
+    new_step = next(
+        step
+        for step in new["jobs"]["validate"]["steps"]
+        if step.get("name") == "Require money proof atoms"
+    )
+
+    assert (
+        new_step["run"].replace(' \\\n        ! -path "*/programs/*"', "")
+        == old_step["run"]
+    )
+    new_step["run"] = old_step["run"]
+    assert new == old
+
+
+def _git(path: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(path), *args],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    ).stdout.strip()
+
+
+def test_ref_mismatch_names_both_shas_and_caller(tmp_path: Path) -> None:
+    repo = tmp_path / "dependency"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "one").write_text("one")
+    _git(repo, "add", "one")
+    _git(repo, "commit", "-qm", "one")
+    pin = _git(repo, "rev-parse", "HEAD")
+    (repo / "two").write_text("two")
+    _git(repo, "add", "two")
+    _git(repo, "commit", "-qm", "two")
+    head = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "update-ref", "refs/remotes/origin/main", head)
+    caller = tmp_path / "caller.yml"
+
+    with pytest.raises(ValueError) as error:
+        verify_dependency_checkout(
+            "engine", repo, pin, caller, allow_ref_mismatch=False
+        )
+
+    message = str(error.value)
+    assert pin in message
+    assert head in message
+    assert str(caller) in message
+
+    warning = verify_dependency_checkout(
+        "engine", repo, pin, caller, allow_ref_mismatch=True
+    )
+    assert warning is not None
+    assert warning.pinned_sha == pin
+    assert warning.head_sha == head
+    assert warning.name == "engine"
+
+
+def test_dirty_worktree_at_pinned_head_is_a_mismatch(tmp_path: Path) -> None:
+    repo = tmp_path / "dependency"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "one").write_text("one")
+    _git(repo, "add", "one")
+    _git(repo, "commit", "-qm", "one")
+    pin = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "update-ref", "refs/remotes/origin/main", pin)
+    caller = tmp_path / "caller.yml"
+
+    assert (
+        verify_dependency_checkout(
+            "corpus", repo, pin, caller, allow_ref_mismatch=False
+        )
+        is None
+    )
+
+    (repo / "one").write_text("modified locally")
+
+    with pytest.raises(ValueError, match="dirty worktree"):
+        verify_dependency_checkout(
+            "corpus", repo, pin, caller, allow_ref_mismatch=False
+        )
+
+    warning = verify_dependency_checkout(
+        "corpus", repo, pin, caller, allow_ref_mismatch=True
+    )
+    assert warning is not None
+    assert warning.name == "corpus"
+    assert warning.pinned_sha == pin
+    assert "dirty worktree" in warning.head_sha
+
+
+def test_verdict_is_qualified_only_when_gates_pass_with_mismatches() -> None:
+    mismatch = DependencyMismatch("engine", "1" * 40, "2" * 40)
+
+    assert ci_verdict(True, []) == "PASS"
+    assert ci_verdict(True, [mismatch]) == "PASS-WITH-MISMATCHED-DEPS"
+    assert ci_verdict(False, [mismatch]) == "FAIL"
+
+
+def test_ambient_encoder_mismatch_fails_closed_or_is_qualified(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pin = "1" * 40
+    head = "2" * 40
+    monkeypatch.setattr(
+        "axiom_encode.ci_parity._git",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0, head + "\n", ""),
+    )
+
+    with pytest.raises(ValueError, match="--allow-encoder-mismatch") as error:
+        verify_ambient_encoder(
+            pin, "1.0.0", tmp_path / "caller.yml", allow_encoder_mismatch=False
+        )
+    assert pin in str(error.value)
+    assert head in str(error.value)
+
+    mismatch = verify_ambient_encoder(
+        pin, "1.0.0", tmp_path / "caller.yml", allow_encoder_mismatch=True
+    )
+    assert mismatch == DependencyMismatch("ambient-encoder", head, pin)
+
+
+def test_ambient_encoder_unresolvable_head_never_passes_on_version_equality(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from axiom_encode import __version__
+
+    pin = "1" * 40
+    monkeypatch.setattr(
+        "axiom_encode.ci_parity._git",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 128, "", "fatal"),
+    )
+
+    with pytest.raises(ValueError, match="--allow-encoder-mismatch"):
+        verify_ambient_encoder(
+            pin, __version__, tmp_path / "caller.yml", allow_encoder_mismatch=False
+        )
+
+    mismatch = verify_ambient_encoder(
+        pin, __version__, tmp_path / "caller.yml", allow_encoder_mismatch=True
+    )
+    assert mismatch is not None
+    assert mismatch.name == "ambient-encoder"
+    assert mismatch.pinned_sha == pin
+    assert "unresolvable" in mismatch.head_sha
+
+
+def test_toolchain_resolution_binds_fixture_waiver_bytes(tmp_path: Path) -> None:
+    repo = tmp_path / "rulespec-dk"
+    (repo / ".axiom").mkdir(parents=True)
+    waiver = b"validate_failures: {}\n"
+    waiver_sha = hashlib.sha256(waiver).hexdigest()
+    (repo / "known-validation-gaps.yaml").write_bytes(waiver)
+    (repo / ".axiom" / "toolchain.toml").write_text(
+        "[toolchain]\n"
+        'axiom_corpus_release = "dk-rulespec-2026-07-22"\n'
+        f'axiom_corpus_release_content_sha256 = "{"1" * 64}"\n'
+        f'validation_waiver_set_sha256 = "{waiver_sha}"\n'
+    )
+
+    resolved = load_rulespec_toolchain(repo)
+
+    assert resolved.root == repo
+    assert resolved.corpus_release == "dk-rulespec-2026-07-22"
+    assert verify_rulespec_validation_waiver_set(repo) == waiver_sha
+
+
+def test_changed_target_selection_matches_companion_and_excludes_programs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "rulespec-zz"
+    module = repo / "zz" / "statutes" / "benefit.yaml"
+    companion = repo / "zz" / "statutes" / "benefit.test.yaml"
+    program = repo / "zz" / "programs" / "composition.yaml"
+    module.parent.mkdir(parents=True)
+    program.parent.mkdir(parents=True)
+    module.write_text("version: 1\n")
+    companion.write_text("cases: []\n")
+    program.write_text("version: 1\n")
+    monkeypatch.setattr(
+        "axiom_encode.ci_parity._changed_paths",
+        lambda _repo, _base: (
+            "zz/statutes/benefit.test.yaml",
+            "zz/programs/composition.yaml",
+        ),
+    )
+
+    selection = select_targets(repo, "origin/main", ("zz",))
+
+    assert selection.mode == "changed"
+    assert selection.rulespec_files == (module,)
+    assert selection.test_files == (companion,)
+
+
+def test_legacy_layout_allows_programs_as_workflow_extra_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from axiom_encode.ci_parity import _layout_gate
+
+    repo = tmp_path / "rulespec-dk"
+    program = repo / "programs" / "composition.yaml"
+    program.parent.mkdir(parents=True)
+    program.write_text("version: 1\n")
+    monkeypatch.setattr(
+        "axiom_encode.ci_parity._git",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0, "", ""),
+    )
+
+    code, _ = _layout_gate(repo, ("dk", "sources", "programs"))
+
+    assert code == 0
+
+
+def test_encoder_pin_version_consistency(tmp_path: Path) -> None:
+    repo = tmp_path / "encoder"
+    (repo / "src" / "axiom_encode").mkdir(parents=True)
+    (repo / "pyproject.toml").write_text('[project]\nversion = "1.2.3"\n')
+    (repo / "src" / "axiom_encode" / "__init__.py").write_text(
+        '__version__ = "1.2.3"\n'
+    )
+    (repo / "uv.lock").write_text(
+        '[[package]]\nname = "axiom-encode"\nversion = "1.2.3"\n'
+    )
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "version")
+    pin = _git(repo, "rev-parse", "HEAD")
+
+    assert encoder_version_at_pin(repo, pin) == "1.2.3"
+
+
+def _toolchain(tmp_path: Path, content_sha: str) -> RuleSpecToolchain:
+    return RuleSpecToolchain(tmp_path, "dk-release", content_sha, "0" * 64)
+
+
+def test_release_object_fetch_uses_workflow_url_scheme(tmp_path: Path) -> None:
+    content = {"git": {"commit": "a" * 40}}
+    digest = hashlib.sha256(
+        json.dumps(
+            content, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+        ).encode()
+    ).hexdigest()
+    payload = json.dumps(
+        {"release": "dk-release", "content_sha256": digest, "content": content}
+    ).encode()
+    seen = []
+
+    path = acquire_release_object(
+        _toolchain(tmp_path, digest),
+        tmp_path,
+        "https://objects.example/base/",
+        offline=False,
+        fetcher=lambda url: seen.append(url) or payload,
+    )
+
+    assert seen == [f"https://objects.example/base/releases/dk-release/{digest}.json"]
+    assert path.read_bytes() == payload
+
+
+def test_offline_requires_present_release_object(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="--offline requires"):
+        acquire_release_object(
+            _toolchain(tmp_path, "1" * 64),
+            tmp_path,
+            "https://objects.example",
+            offline=True,
+        )
+
+
+def test_ci_parser_contract_has_no_environment_public_key() -> None:
+    # The public root is intentionally an explicit CLI-only value.  This test
+    # guards against quietly reintroducing the forbidden environment fallback.
+    args = Namespace(corpus_release_public_key="explicit")
+    assert args.corpus_release_public_key == "explicit"
+
+
+def test_unknown_workflow_pin_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repo = tmp_path / "rulespec-dk"
+    repo.mkdir()
+    caller = CallerConfig(
+        tmp_path / "caller.yml",
+        "f" * 40,
+        {name: "a" * 40 for name in ("encode", "engine", "corpus", "rulespec_us")},
+        "dk",
+        True,
+        False,
+    )
+    monkeypatch.setattr("axiom_encode.ci_parity.find_caller_workflow", lambda _: caller)
+    args = Namespace(repo=repo, json=False)
+
+    assert run_ci(args) == 1
+    output = capsys.readouterr().err
+    assert "Unsupported validate-rulespec workflow pin" in output
+    assert caller.workflow_sha in output
+    assert all(sha in output for sha in SUPPORTED_WORKFLOW_PINS)
+
+
+@pytest.mark.parametrize(
+    ("workflow_sha", "programs_in_money_atom_check"),
+    [
+        ("615c1df9b9ace7deea84da65efd137f46f8bad2b", False),
+        ("34bcfab235c585c47292c95f51be1a4f4f91d29e", True),
+    ],
+)
+def test_execute_gates_preserves_order_and_uses_pin_gate_parameters(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    workflow_sha: str,
+    programs_in_money_atom_check: bool,
+) -> None:
+    repo = tmp_path / "rulespec-dk"
+    test_file = repo / "dk" / "statutes" / "benefit.test.yaml"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text("cases: []\n")
+    program_file = repo / "dk" / "programs" / "pilot.yaml"
+    program_file.parent.mkdir(parents=True)
+    program_file.write_text("rules: []\n")
+    (repo / "known-validation-gaps.yaml").write_text("validate_failures: {}\n")
+    paths = {
+        "encode": tmp_path / "encode",
+        "engine": tmp_path / "engine",
+        "corpus": tmp_path / "corpus",
+        "rulespec_us": tmp_path / "rulespec-us",
+    }
+    caller = CallerConfig(
+        tmp_path / "caller.yml",
+        workflow_sha,
+        {name: "a" * 40 for name in paths},
+        "dk",
+        False,
+        False,
+        run_pytest=False,
+        run_money_atom_check=True,
+    )
+    args = Namespace(repo=repo, base_ref="origin/main")
+    calls = []
+    monkeypatch.setattr(
+        "axiom_encode.ci_parity.select_targets",
+        lambda *_: Selection("changed", (), (test_file,)),
+    )
+    monkeypatch.setattr("axiom_encode.ci_parity._changed_paths", lambda *_: ())
+    monkeypatch.setattr("axiom_encode.ci_parity._obsolete_gate", lambda _: (0, "ok"))
+    monkeypatch.setattr("axiom_encode.ci_parity._layout_gate", lambda *_: (0, "ok"))
+    monkeypatch.setattr(
+        "axiom_encode.ci_parity._git",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            [], 0, "waivers: {}\n", ""
+        ),
+    )
+
+    def fake_cli(arguments, *, environment=None):
+        calls.append((list(arguments), environment))
+        return 0, "ok\n"
+
+    monkeypatch.setattr("axiom_encode.ci_parity._run_cli", fake_cli)
+
+    results = execute_gates(args, caller, paths, ("dk",))
+
+    assert [result.gate for result in results] == [
+        gate.key for gate in CI_GATE_REGISTRY
+    ]
+    companion = next(call for call in calls if call[0][0] == "test")
+    assert companion[0][-1] == "statutes/benefit.test.yaml"
+    assert companion[1] == {
+        "AXIOM_RULESPEC_REPO_ROOTS": f"{repo}{os.pathsep}{paths['rulespec_us']}"
+    }
+    money_atom_calls = [
+        call
+        for call in calls
+        if call[0][0] == "proof-validate" and "--money-atoms-only" in call[0]
+    ]
+    assert bool(money_atom_calls) is programs_in_money_atom_check
+    if money_atom_calls:
+        assert str(program_file) in money_atom_calls[0][0]
+
+
+def test_pinned_classifier_rejects_ambient_oracles_dependency(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    expected = "1" * 40
+    monkeypatch.setattr(
+        "axiom_encode.ci_parity._git",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            [],
+            0,
+            'dependencies = ["axiom-oracles @ git+https://github.com/'
+            f'TheAxiomFoundation/axiom-oracles@{expected}"]\n',
+            "",
+        ),
+    )
+    monkeypatch.setattr(
+        "axiom_encode.ci_parity._installed_oracles_pin", lambda: "2" * 40
+    )
+
+    code, output = _run_pinned_cli(tmp_path, "a" * 40, ["oracle-coverage"])
+
+    assert code == 1
+    assert expected in output
+    assert "2" * 40 in output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37939,3 +37939,18 @@ def test_overlay_validation_failures_keep_standalone_telemetry_when_no_issues():
 
     assert outcome["validation_failure_counts"] == {"ci:proof_atoms": 1}
     assert [item["gate"] for item in outcome["validation_failures"]] == ["ci"]
+
+
+def test_ci_entrypoint_is_registered():
+    result = subprocess.run(
+        [sys.executable, "-m", "axiom_encode.cli", "ci", "--help"],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    assert result.returncode == 0
+    assert "--corpus-release-public-key" in result.stdout
+    assert "--allow-ref-mismatch" in result.stdout
+    assert "--allow-encoder-mismatch" in result.stdout

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1327"
+version = "0.2.1328"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
Closes #1116.

`axiom-encode ci --repo <lane>` runs the org validate-rulespec gate sequence locally with the lane's own resolution semantics — the local-pass/CI-fail class that cost the dk pilot four push-wait-diagnose loops (#1112, #1113, sibling-only discovery) becomes a local command.

## Design

- **Pin-relative parity.** The lane's caller workflow is the source of truth: the tool parses its `validate-rulespec.yml@<sha>` pin plus all four dependency refs and the with-inputs, and refuses unsupported workflow SHAs (fail-closed, listing supported pins). Supported today: `615c1df9` (rulespec-de's pin) and `34bcfab2` (rulespec-dk's pin) — per-pin fixtures + gate parameters, with an inter-fixture ratchet asserting their ONLY divergence (the money-atom scan's `*/programs/*` exclusion) so unnoticed drift between supported revisions fails a test.
- **Resolution:** verifies each dependency checkout contains the pinned ref (ancestor-of-origin/main, mirroring the workflow's authenticate step) and reports HEAD-vs-pin mismatches naming both SHAs and the caller file (`--allow-ref-mismatch` to proceed); binds the 3-key toolchain and waiver-set bytes exactly; fetches the immutable release object via the workflow's URL scheme (`--offline` to require it present).
- **Gate registry:** all 12 gates mapped 1:1 to the workflow steps (repository tests, obsolete files, layout, waiver ratchet audit, generated guard, target selection vs `--base-ref`, validate, companion tests, proof-validate, money atoms, oracle coverage, changed-file classifier with the pinned-version consistency check). A contract test parses each pinned fixture and asserts every gate step is covered — workflow re-pins break the test until the tool is updated: divergence is a bug, made executable.
- **Trust boundary:** verification-only. No signing capability, never `--apply`; the corpus-release public key comes ONLY from the explicit `--corpus-release-public-key` flag (never the environment, preserving the trusted-bootstrap invariant).

## Live acceptance

Against `rulespec-dk` (pin `34bcfab2`, offline, old-org-key for its pre-rotation release — the .github#56 rotation census case): **all 12 gates executed, overall PASS**, with the expected dependency-mismatch warnings under `--allow-ref-mismatch`. Full per-gate table in the lane report.

## Verification

`tests/test_ci_parity.py`: 21 passed (caller parsing on real de/dk callers, per-pin contract + semantic-hash coverage, divergence ratchet, resolution, injected-fetcher release fetch, offline mode, per-pin programs-scan behavior). Ruff check + format clean; compileall clean; ratchet at 0.2.1302 single-commit.

Build: gpt-5.6-sol worker (resumed from a salvage-ref snapshot after an app-exit kill — the refs/codex-salvage mechanism's first production save); Fable review + gate; clean-context audit before merge.

## Review cycle

Four audit rounds: round 2 (clean-context) found a 64-commit stale base (rebased onto the keyring merge aa608ba2, re-versioned 0.2.1328), an `--allow-ref-mismatch` false-PASS route, unbound ambient-encoder identity, and contract hashes missing input defaults — all fixed with verdict machinery (PASS=0 / FAIL=1 / PASS-WITH-MISMATCHED-DEPS=3, mandatory mismatch banner, fail-closed encoder binding, extended hashes). Round 3 confirmed those and prescribed two residuals — dirty-worktree deps at pinned HEAD, and the wheel-installed/no-git equal-version encoder route — both fixed with regression tests. Round 4: SHIP, no new findings. Live dk acceptance under the corrected machinery: all 12 gates, verdict `PASS-WITH-MISMATCHED-DEPS` (exit 3) with the full four-dep mismatch banner — the honest qualified verdict working as designed.
