### PR TITLE
Rotate reviewed federal RuleSpec head

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1338"
+version = "0.2.1339"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -19,7 +19,7 @@ REVIEWED_RULESPEC_REFS = frozenset(
     {
         (
             "us",
-            "10f7a16ef4a40cf1e26d6273e1aff9ebb79d002f",
+            "670e6d6642c70168a4ecfcd7ccfc47c3e7cf51c3",
         ),
         (
             "ca",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1338"
+__version__ = "0.2.1339"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -162,12 +162,19 @@ def test_validate_rulespec_base_accepts_exact_reviewed_head_artifact_only(
         validate_rulespec_base(repo, country, reviewed_ref, open_pr=True)
 
 
+@pytest.mark.parametrize(
+    "retired_ref",
+    [
+        "991f5375b92dffca57b08069093c24a463365cbc",
+        "10f7a16ef4a40cf1e26d6273e1aff9ebb79d002f",
+    ],
+)
 def test_validate_rulespec_base_rejects_retired_reviewed_head(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    retired_ref: str,
 ) -> None:
     repo = tmp_path / "rulespec-us"
-    retired_ref = "991f5375b92dffca57b08069093c24a463365cbc"
     monkeypatch.setattr(
         "scripts.prepare_signed_backfill._git",
         lambda _repo, *_args: f"{retired_ref}\n".encode(),

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -127,7 +127,7 @@ def test_validate_rulespec_base_accepts_main_ancestor(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     ("country", "reviewed_ref"),
     [
-        ("us", "10f7a16ef4a40cf1e26d6273e1aff9ebb79d002f"),
+        ("us", "670e6d6642c70168a4ecfcd7ccfc47c3e7cf51c3"),
         ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
     ],
 )
@@ -140,7 +140,7 @@ def test_validate_rulespec_base_accepts_exact_reviewed_head_artifact_only(
     repo = tmp_path / f"rulespec-{country}"
     assert REVIEWED_RULESPEC_REFS == frozenset(
         {
-            ("us", "10f7a16ef4a40cf1e26d6273e1aff9ebb79d002f"),
+            ("us", "670e6d6642c70168a4ecfcd7ccfc47c3e7cf51c3"),
             ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
         }
     )

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1338"
+version = "0.2.1339"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary\n- rotate the exact US reviewed RuleSpec artifact-only head from 10f7a16e to 670e6d66\n- preserve the Canada reviewed head and artifact-only open-PR rejection\n- explicitly reject the newly retired 10f7a16e head\n- bump axiom-encode to 0.2.1339\n\n## Reviewed-head provenance\nVerified on 2026-07-23 through two independent paths:\n- GitHub ref API for TheAxiomFoundation/rulespec-us heads/hard-cut/canonical-layout-us returned 670e6d6642c70168a4ecfcd7ccfc47c3e7cf51c3.\n- A fresh git fetch of origin hard-cut/canonical-layout-us in the local canonical rulespec-us checkout resolved FETCH_HEAD to the same commit.\n- The commit is 85 commits ahead of the previously reviewed 10f7a16e head; compare inspection showed the intervening strict-cutover and merged canonical work, with no 435.555 signed migration.\n\n## Checks\n- ruff check: passed\n- ruff format check: passed\n- Python 3.13 compileall: passed\n- tests/test_prepare_signed_backfill.py: 14 passed\n- full pytest: 4763 passed, 119 skipped\n- GitHub CI: lint, Python 3.13 tests, Ubuntu build/test, and macOS build/test all passed\n\n## Review cycle\nFirst independent review confirmed no trust broadening and requested explicit external SHA provenance plus direct rejection coverage for the newly retired head. Added both. Second independent review found no actionable findings and confirmed both prior findings resolved.