### PR TITLE
fix: compare dependent validation against baseline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1341"
+version = "0.2.1342"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1341"
+__version__ = "0.2.1342"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -38,7 +38,7 @@ from dataclasses import asdict, is_dataclass
 from datetime import date, datetime, timezone
 from decimal import Decimal, InvalidOperation, localcontext
 from pathlib import Path
-from typing import Any, Callable, NamedTuple
+from typing import Any, Callable, NamedTuple, Protocol
 
 # receipt is pinned to an exact version and artifact hashes in uv.lock. Any
 # upgrade must rerun this repository's signature tests at the new pin first.
@@ -42241,13 +42241,25 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
             else []
         )
         dependent_pipeline = (
-            ValidatorPipeline(
-                policy_repo_path=overlay_content_root,
-                axiom_rules_path=axiom_rules_path,
-                enable_oracles=False,
-                enforce_repository_layout=False,
-                local_corpus_release=local_corpus_release,
-                rulespec_dependency_roots=staged_dependency_roots,
+            _DependentRegressionPipeline(
+                overlay_pipeline=ValidatorPipeline(
+                    policy_repo_path=overlay_content_root,
+                    axiom_rules_path=axiom_rules_path,
+                    enable_oracles=False,
+                    enforce_repository_layout=False,
+                    local_corpus_release=local_corpus_release,
+                    rulespec_dependency_roots=staged_dependency_roots,
+                ),
+                baseline_pipeline=ValidatorPipeline(
+                    policy_repo_path=policy_content_root,
+                    axiom_rules_path=axiom_rules_path,
+                    enable_oracles=False,
+                    enforce_repository_layout=False,
+                    local_corpus_release=local_corpus_release,
+                    rulespec_dependency_roots=rulespec_dependency_roots,
+                ),
+                overlay_root=overlay_content_root,
+                baseline_root=policy_content_root,
             )
             if dependents
             else pipeline
@@ -42575,10 +42587,19 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
                         dependents=dependents,
                     )
                     continue
+            actionable_validations = [
+                (validated_file, validation)
+                for validated_file, validation in validations
+                if not getattr(
+                    validation,
+                    _DEPENDENT_BASELINE_DEBT_ATTR,
+                    False,
+                )
+            ]
             removed_invalid_inputs = _remove_invalid_dependent_test_inputs(
                 overlay_repo=overlay_content_root,
                 relative_output=relative_output,
-                validations=validations,
+                validations=actionable_validations,
             )
             if removed_invalid_inputs:
                 for path in removed_invalid_inputs:
@@ -42597,7 +42618,7 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
             removed_unknown_outputs = _remove_unknown_dependent_test_outputs(
                 overlay_repo=overlay_content_root,
                 relative_output=relative_output,
-                validations=validations,
+                validations=actionable_validations,
             )
             if removed_unknown_outputs:
                 for path in removed_unknown_outputs:
@@ -42616,7 +42637,7 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
             removed_cross_module_outputs = _remove_cross_module_dependent_test_outputs(
                 overlay_repo=overlay_content_root,
                 relative_output=relative_output,
-                validations=validations,
+                validations=actionable_validations,
             )
             if removed_cross_module_outputs:
                 for path in removed_cross_module_outputs:
@@ -42635,7 +42656,7 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
             changed_tests = _complete_missing_dependent_test_inputs(
                 overlay_repo=overlay_content_root,
                 relative_output=relative_output,
-                validations=validations,
+                validations=actionable_validations,
             )
             if not changed_tests:
                 break
@@ -42651,6 +42672,8 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
             )
         issues: list[str] = []
         for validated_file, validation in validations:
+            if getattr(validation, "all_passed", False):
+                continue
             for validator_result in validation.results.values():
                 if validator_result.error:
                     relative_file = _relative_to_rulespec_apply_content_root(
@@ -44375,10 +44398,47 @@ def _unique_test_case_name(base: str, existing_names: set[str]) -> str:
     return f"{base}_{index}"
 
 
+class _PipelineResultLike(Protocol):
+    @property
+    def all_passed(self) -> bool: ...
+
+    @property
+    def results(self) -> Mapping[str, object]: ...
+
+
+class _ValidationPipelineLike(Protocol):
+    def validate(
+        self,
+        rulespec_file: Path,
+        /,
+        *,
+        skip_reviewers: bool,
+    ) -> _PipelineResultLike: ...
+
+
+_DEPENDENT_BASELINE_DEBT_ATTR = "_axiom_dependent_baseline_debt"
+
+
+class _ToleratedDependentValidation:
+    """Expose a tolerated dependent result without mutating validator output."""
+
+    def __init__(self, validation: _PipelineResultLike) -> None:
+        self._validation = validation
+        setattr(self, _DEPENDENT_BASELINE_DEBT_ATTR, True)
+
+    @property
+    def all_passed(self) -> bool:
+        return True
+
+    @property
+    def results(self) -> Mapping[str, object]:
+        return self._validation.results
+
+
 def _validate_overlay_files(
-    pipeline: ValidatorPipeline,
+    pipeline: _ValidationPipelineLike,
     *,
-    dependent_pipeline: ValidatorPipeline,
+    dependent_pipeline: _ValidationPipelineLike,
     overlay_target: Path,
     dependents: list[Path],
 ) -> list[tuple[Path, object]]:
@@ -44394,6 +44454,74 @@ def _validate_overlay_files(
                 )
             )
     return validations
+
+
+class _DependentRegressionPipeline:
+    """Validate dependents against the overlay without inheriting baseline debt."""
+
+    def __init__(
+        self,
+        *,
+        overlay_pipeline: _ValidationPipelineLike,
+        baseline_pipeline: _ValidationPipelineLike,
+        overlay_root: Path,
+        baseline_root: Path,
+    ) -> None:
+        self.overlay_pipeline = overlay_pipeline
+        self.baseline_pipeline = baseline_pipeline
+        self.overlay_root = overlay_root
+        self.baseline_root = baseline_root
+        self._baseline_cache: dict[Path, _PipelineResultLike] = {}
+
+    def validate(self, path: Path, *, skip_reviewers: bool) -> _PipelineResultLike:
+        relative = Path(path).relative_to(self.overlay_root)
+        overlay = self.overlay_pipeline.validate(
+            path,
+            skip_reviewers=skip_reviewers,
+        )
+        if overlay.all_passed:
+            return overlay
+
+        overlay_failures = _failed_validation_issue_counts(overlay)
+        if not overlay_failures or any(
+            not diagnostics for diagnostics in overlay_failures.values()
+        ):
+            return overlay
+        baseline = self._baseline_cache.get(relative)
+        if baseline is None:
+            baseline = self.baseline_pipeline.validate(
+                self.baseline_root / relative,
+                skip_reviewers=skip_reviewers,
+            )
+            self._baseline_cache[relative] = baseline
+        baseline_failures = _failed_validation_issue_counts(baseline)
+        if all(
+            diagnostics <= baseline_failures.get(validator_name, Counter())
+            for validator_name, diagnostics in overlay_failures.items()
+        ):
+            return _ToleratedDependentValidation(overlay)
+
+        return overlay
+
+
+def _failed_validation_issue_counts(
+    validation: _PipelineResultLike,
+) -> dict[str, Counter[str]]:
+    results = getattr(validation, "results", {})
+    if not isinstance(results, Mapping):
+        return {}
+    failures: dict[str, Counter[str]] = {}
+    for name, result in results.items():
+        if getattr(result, "passed", False):
+            continue
+        diagnostics = Counter(
+            str(issue) for issue in (getattr(result, "issues", []) or [])
+        )
+        error = getattr(result, "error", None)
+        if error:
+            diagnostics[str(error)] += 1
+        failures[str(name)] = diagnostics
+    return failures
 
 
 def _repair_dependent_proof_import_hashes(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35758,7 +35758,308 @@ rules:
         assert issues == []
         assert supplemental == {}
         assert [path.name for path in validated_paths] == ["C.yaml", "2.yaml"]
-        assert pipeline_source_metadata == [target_source_metadata, None]
+        assert pipeline_source_metadata == [target_source_metadata, None, None]
+
+    @pytest.mark.parametrize(
+        (
+            "baseline_issues",
+            "overlay_issues",
+            "baseline_validator",
+            "overlay_validator",
+            "expected_passed",
+        ),
+        [
+            (["legacy failure"], ["legacy failure"], "ci", "ci", True),
+            (
+                ["legacy failure", "resolved failure"],
+                ["legacy failure"],
+                "ci",
+                "ci",
+                True,
+            ),
+            (
+                ["legacy failure"],
+                ["legacy failure", "new failure"],
+                "ci",
+                "ci",
+                False,
+            ),
+            (
+                ["legacy failure"],
+                ["legacy failure", "legacy failure"],
+                "ci",
+                "ci",
+                False,
+            ),
+            (["legacy failure"], ["legacy failure"], "ci", "compile", False),
+        ],
+    )
+    def test_dependent_regression_validation_blocks_only_new_issues(
+        self,
+        tmp_path,
+        baseline_issues,
+        overlay_issues,
+        baseline_validator,
+        overlay_validator,
+        expected_passed,
+    ):
+        from axiom_encode.cli import (
+            _DEPENDENT_BASELINE_DEBT_ATTR,
+            _DependentRegressionPipeline,
+        )
+
+        baseline_root = tmp_path / "baseline"
+        overlay_root = tmp_path / "overlay"
+        relative = Path("regulations/42-cfr/435/559.yaml")
+        baseline_path = baseline_root / relative
+        overlay_path = overlay_root / relative
+        baseline_path.parent.mkdir(parents=True)
+        overlay_path.parent.mkdir(parents=True)
+        baseline_path.write_text("format: rulespec/v1\nrules: []\n")
+        overlay_path.write_text("format: rulespec/v1\nrules: []\n")
+
+        class StaticPipeline:
+            def __init__(self, issues, validator_name):
+                self.issues = issues
+                self.validator_name = validator_name
+                self.validated_paths = []
+
+            def validate(self, path, *, skip_reviewers):
+                assert skip_reviewers is True
+                self.validated_paths.append(Path(path))
+                return SimpleNamespace(
+                    all_passed=not self.issues,
+                    results={
+                        self.validator_name: SimpleNamespace(
+                            passed=not self.issues,
+                            issues=self.issues,
+                            error=None,
+                        ),
+                    },
+                )
+
+        baseline_pipeline = StaticPipeline(baseline_issues, baseline_validator)
+        overlay_pipeline = StaticPipeline(overlay_issues, overlay_validator)
+        pipeline = _DependentRegressionPipeline(
+            overlay_pipeline=overlay_pipeline,
+            baseline_pipeline=baseline_pipeline,
+            overlay_root=overlay_root,
+            baseline_root=baseline_root,
+        )
+
+        result = pipeline.validate(overlay_path, skip_reviewers=True)
+
+        assert result.all_passed is expected_passed
+        assert getattr(result, _DEPENDENT_BASELINE_DEBT_ATTR, False) is expected_passed
+        assert baseline_pipeline.validated_paths == [baseline_path]
+        assert overlay_pipeline.validated_paths == [overlay_path]
+
+    def test_dependent_regression_validation_caches_baseline(self, tmp_path):
+        from axiom_encode.cli import _DependentRegressionPipeline
+
+        baseline_root = tmp_path / "baseline"
+        overlay_root = tmp_path / "overlay"
+        relative = Path("regulations/42-cfr/435/559.yaml")
+        baseline_path = baseline_root / relative
+        overlay_path = overlay_root / relative
+        baseline_path.parent.mkdir(parents=True)
+        overlay_path.parent.mkdir(parents=True)
+        baseline_path.write_text("format: rulespec/v1\nrules: []\n")
+        overlay_path.write_text("format: rulespec/v1\nrules: []\n")
+        failed = SimpleNamespace(
+            all_passed=False,
+            results={
+                "ci": SimpleNamespace(
+                    passed=False,
+                    issues=["legacy failure"],
+                    error=None,
+                )
+            },
+        )
+        baseline_pipeline = MagicMock()
+        baseline_pipeline.validate.return_value = failed
+        overlay_pipeline = MagicMock()
+        overlay_pipeline.validate.return_value = failed
+        pipeline = _DependentRegressionPipeline(
+            overlay_pipeline=overlay_pipeline,
+            baseline_pipeline=baseline_pipeline,
+            overlay_root=overlay_root,
+            baseline_root=baseline_root,
+        )
+
+        first = pipeline.validate(overlay_path, skip_reviewers=True)
+        second = pipeline.validate(overlay_path, skip_reviewers=True)
+
+        assert first.all_passed is True
+        assert second.all_passed is True
+        assert failed.all_passed is False
+        baseline_pipeline.validate.assert_called_once_with(
+            baseline_path,
+            skip_reviewers=True,
+        )
+        assert overlay_pipeline.validate.call_count == 2
+
+    def test_dependent_regression_validation_fails_closed_without_issues(
+        self, tmp_path
+    ):
+        from axiom_encode.cli import _DependentRegressionPipeline
+
+        baseline_root = tmp_path / "baseline"
+        overlay_root = tmp_path / "overlay"
+        relative = Path("regulations/42-cfr/435/559.yaml")
+        overlay_path = overlay_root / relative
+        overlay_path.parent.mkdir(parents=True)
+        overlay_path.write_text("format: rulespec/v1\nrules: []\n")
+        baseline_pipeline = MagicMock()
+        overlay_pipeline = MagicMock()
+        overlay_pipeline.validate.return_value = SimpleNamespace(
+            all_passed=False,
+            results={
+                "ci": SimpleNamespace(passed=False, issues=[], error=None),
+            },
+        )
+        pipeline = _DependentRegressionPipeline(
+            overlay_pipeline=overlay_pipeline,
+            baseline_pipeline=baseline_pipeline,
+            overlay_root=overlay_root,
+            baseline_root=baseline_root,
+        )
+
+        result = pipeline.validate(overlay_path, skip_reviewers=True)
+
+        assert result.all_passed is False
+        baseline_pipeline.validate.assert_not_called()
+
+    def test_dependent_regression_validation_keeps_diagnostics_per_validator(
+        self, tmp_path
+    ):
+        from axiom_encode.cli import _DependentRegressionPipeline
+
+        baseline_root = tmp_path / "baseline"
+        overlay_root = tmp_path / "overlay"
+        relative = Path("regulations/42-cfr/435/559.yaml")
+        overlay_path = overlay_root / relative
+        overlay_path.parent.mkdir(parents=True)
+        overlay_path.write_text("format: rulespec/v1\nrules: []\n")
+
+        def failed_result(ci_issue, compile_issue):
+            return SimpleNamespace(
+                all_passed=False,
+                results={
+                    "ci": SimpleNamespace(
+                        passed=False,
+                        issues=[ci_issue],
+                        error=None,
+                    ),
+                    "compile": SimpleNamespace(
+                        passed=False,
+                        issues=[compile_issue],
+                        error=None,
+                    ),
+                },
+            )
+
+        baseline_pipeline = MagicMock()
+        baseline_pipeline.validate.return_value = failed_result(
+            "ci failure",
+            "compile failure",
+        )
+        overlay_pipeline = MagicMock()
+        overlay_pipeline.validate.return_value = failed_result(
+            "compile failure",
+            "ci failure",
+        )
+        pipeline = _DependentRegressionPipeline(
+            overlay_pipeline=overlay_pipeline,
+            baseline_pipeline=baseline_pipeline,
+            overlay_root=overlay_root,
+            baseline_root=baseline_root,
+        )
+
+        result = pipeline.validate(overlay_path, skip_reviewers=True)
+
+        assert result.all_passed is False
+
+    def test_apply_overlay_validation_excludes_baseline_debt_from_repairs_and_issues(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us" / "us"
+        generated = output_root / "codex-test-model" / "statutes/7/2015/d/2/C.yaml"
+        debt_dependent = policy_repo / "policies/debt.yaml"
+        new_dependent = policy_repo / "policies/new.yaml"
+        generated.parent.mkdir(parents=True)
+        debt_dependent.parent.mkdir(parents=True)
+        generated.write_text("format: rulespec/v1\nrules: []\n")
+        dependent_content = (
+            "format: rulespec/v1\nimports:\n  - us:statutes/7/2015/d/2/C\nrules: []\n"
+        )
+        debt_dependent.write_text(dependent_content)
+        new_dependent.write_text(dependent_content)
+        result = SimpleNamespace(
+            output_file=str(generated),
+            runner="codex-test-model",
+            backend="codex",
+        )
+        repair_validation_paths = []
+
+        def validation(*, passed, error=None):
+            return SimpleNamespace(
+                all_passed=passed,
+                results={
+                    "ci": SimpleNamespace(
+                        validator_name="ci",
+                        passed=passed,
+                        issues=[],
+                        error=error,
+                    )
+                },
+            )
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                self.is_baseline = Path(kwargs["policy_repo_path"]) == policy_repo
+
+            def validate(self, path, *, skip_reviewers):
+                assert skip_reviewers is True
+                path = Path(path)
+                if path.name == "C.yaml":
+                    return validation(passed=True)
+                if path.name == "debt.yaml":
+                    return validation(passed=False, error="legacy failure")
+                if path.name == "new.yaml" and self.is_baseline:
+                    return validation(passed=True)
+                return validation(passed=False, error="new failure")
+
+        def capture_actionable_validations(**kwargs):
+            repair_validation_paths.extend(
+                path.name for path, _validation in kwargs["validations"]
+            )
+            return []
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._remove_invalid_dependent_test_inputs",
+                side_effect=capture_actionable_validations,
+            ),
+        ):
+            ok, issues, supplemental = _validate_generated_encoding_in_policy_overlay(
+                result,
+                output_root=output_root,
+                policy_repo_path=policy_repo,
+                axiom_rules_path=tmp_path / "axiom-rules-engine",
+                local_corpus_release=_bind_test_corpus_release(
+                    policy_repo,
+                    tmp_path / "axiom-corpus",
+                ),
+            )
+
+        assert ok is False
+        assert issues == ["policies/new.yaml: ci: new failure"]
+        assert supplemental == {}
+        assert "debt.yaml" not in repair_validation_paths
+        assert "new.yaml" in repair_validation_paths
 
     def test_apply_overlay_validation_can_skip_dependents_for_cascading_migration(
         self, tmp_path
@@ -35852,12 +36153,14 @@ rules:
         ]
 
         class FakePipeline:
-            def __init__(self, **_kwargs):
-                pass
+            def __init__(self, **kwargs):
+                self.is_baseline = Path(kwargs["policy_repo_path"]) == policy_repo
 
             def validate(self, path, *, skip_reviewers):
                 assert skip_reviewers is True
                 if Path(path).name == "c.yaml":
+                    return SimpleNamespace(all_passed=True, results={})
+                if self.is_baseline:
                     return SimpleNamespace(all_passed=True, results={})
                 test_content = Path(path).with_name("63.test.yaml").read_text()
                 for input_name in required:
@@ -35944,12 +36247,14 @@ rules:
         )
 
         class FakePipeline:
-            def __init__(self, **_kwargs):
-                pass
+            def __init__(self, **kwargs):
+                self.is_baseline = Path(kwargs["policy_repo_path"]) == policy_repo
 
             def validate(self, path, *, skip_reviewers):
                 assert skip_reviewers is True
                 if Path(path).name == "151.yaml":
+                    return SimpleNamespace(all_passed=True, results={})
+                if self.is_baseline:
                     return SimpleNamespace(all_passed=True, results={})
                 test_content = Path(path).with_name("7703.test.yaml").read_text()
                 relation_block = test_content.split(
@@ -36409,8 +36714,8 @@ rules:
         )
 
         class FakePipeline:
-            def __init__(self, **_kwargs):
-                pass
+            def __init__(self, **kwargs):
+                self.is_baseline = Path(kwargs["policy_repo_path"]) == policy_repo
 
             def validate(self, path, *, skip_reviewers):
                 assert skip_reviewers is True
@@ -36429,6 +36734,8 @@ rules:
                         },
                     )
                 if path.name == "63.yaml":
+                    if self.is_baseline:
+                        return SimpleNamespace(all_passed=True, results={})
                     current_hash = _sha256_file(path.parent / "151.yaml")
                     if f"hash: sha256:{current_hash}" not in content:
                         return SimpleNamespace(
@@ -36487,12 +36794,14 @@ rules:
         )
 
         class FakePipeline:
-            def __init__(self, **_kwargs):
-                pass
+            def __init__(self, **kwargs):
+                self.is_baseline = Path(kwargs["policy_repo_path"]) == policy_repo
 
             def validate(self, path, *, skip_reviewers):
                 assert skip_reviewers is True
                 if Path(path).name == "151.yaml":
+                    return SimpleNamespace(all_passed=True, results={})
+                if self.is_baseline:
                     return SimpleNamespace(all_passed=True, results={})
                 content = Path(path).with_name("63.test.yaml").read_text()
                 if "us:statutes/26/151#input.taxable_year_begins_after_2017" in content:
@@ -36564,12 +36873,14 @@ rules: []
         )
 
         class FakePipeline:
-            def __init__(self, **_kwargs):
-                pass
+            def __init__(self, **kwargs):
+                self.is_baseline = Path(kwargs["policy_repo_path"]) == policy_repo
 
             def validate(self, path, *, skip_reviewers):
                 assert skip_reviewers is True
                 if Path(path).name == "151.yaml":
+                    return SimpleNamespace(all_passed=True, results={})
+                if self.is_baseline:
                     return SimpleNamespace(all_passed=True, results={})
                 content = Path(path).with_name("63.test.yaml").read_text()
                 if (
@@ -36655,12 +36966,14 @@ rules: []
         )
 
         class FakePipeline:
-            def __init__(self, **_kwargs):
-                pass
+            def __init__(self, **kwargs):
+                self.is_baseline = Path(kwargs["policy_repo_path"]) == policy_repo
 
             def validate(self, path, *, skip_reviewers):
                 assert skip_reviewers is True
                 if Path(path).name == "151.yaml":
+                    return SimpleNamespace(all_passed=True, results={})
+                if self.is_baseline:
                     return SimpleNamespace(all_passed=True, results={})
                 content = Path(path).with_name("63.test.yaml").read_text()
                 if (

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1341"
+version = "0.2.1342"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- validate direct dependents against both the canonical baseline and staged apply overlay
- tolerate only per-validator, non-empty diagnostic multisets already present in the baseline
- keep baseline debt out of repair prompts and final issue reporting while blocking every new or changed issue
- preserve strict source-attested validation for the generated target

## Checks
- `uv run ruff format --check pyproject.toml src/axiom_encode scripts tests`
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest tests/test_cli.py::TestApplyDependencyValidation -q` (79 passed)
- `uv run pytest -q` (4777 passed, 119 skipped)

## Review cycle
Independent review found and resolved: duplicate diagnostic handling, validator-identity matching, lazy baseline caching, debt leakage into repairs/final reporting, missing mixed integration coverage, protocol accuracy, and mutation of a read-only validation result. The final review of exact commit `9013bb6d` reported no actionable findings and independently passed focused tests, Ruff, formatting, and a structural type probe.