### PR TITLE
Support atomic dependent re-encoding

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -28,6 +28,14 @@ on:
         description: Validator or independent-review finding to address
         required: false
         type: string
+      dependent_citation:
+        description: Direct dependent to re-encode atomically after a breaking target
+        required: false
+        type: string
+      dependent_review_finding:
+        description: Independent-review finding for the direct dependent
+        required: false
+        type: string
       open_pr:
         description: Commit, push, and open a draft RuleSpec pull request
         required: false
@@ -308,45 +316,92 @@ jobs:
               raise SystemExit("hardened RuleSpec routing rejected checkout")
           PY
 
+      - name: Validate dependent cascade
+        if: ${{ inputs.dependent_citation != '' }}
+        env:
+          CITATION: ${{ inputs.citation }}
+          DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
+          RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
+        run: |
+          set -euo pipefail
+          axiom-encode/.venv/bin/python \
+            axiom-encode/scripts/prepare_signed_backfill.py \
+            validate-dependent-cascade \
+            "$RULESPEC_CHECKOUT" "$CITATION" "$DEPENDENT_CITATION"
+
       - name: Encode, review, validate, and apply
         env:
           AXIOM_ENCODE_APPLY_SIGNING_KEY: ${{ secrets.AXIOM_ENCODE_APPLY_SIGNING_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CITATION: ${{ inputs.citation }}
           REVIEW_FINDING: ${{ inputs.review_finding }}
+          DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
+          DEPENDENT_REVIEW_FINDING: ${{ inputs.dependent_review_finding }}
           RULESPEC_CHECKOUT: ${{ github.workspace }}/rulespec-${{ inputs.country }}
         run: |
-          args=(
-            /opt/axiom-verification/axiom-encode encode
-            --backend openai
-            --corpus-path "$GITHUB_WORKSPACE/axiom-corpus"
-            --axiom-rules-engine-path "$GITHUB_WORKSPACE/axiom-rules-engine"
-            --policy-repo-path "$RULESPEC_CHECKOUT"
-            --output "$RUNNER_TEMP/generated"
-            --mode repo-augmented
-            --db "$RUNNER_TEMP/encodings.db"
-            --no-sync
-            --apply
-          )
-          if [ -n "$REVIEW_FINDING" ]; then
-            review_finding_path="$(mktemp "$RUNNER_TEMP/axiom-targeted-review-finding.XXXXXX.txt")"
-            printf '%s\n' "$REVIEW_FINDING" > "$review_finding_path"
-            args+=(--review-findings "$review_finding_path")
-          fi
-          args+=("$CITATION")
+          set -euo pipefail
 
-          exec /opt/axiom-verification/axiom-encode-apply-signer run \
-            --scope apply_ed25519 \
-            --key-env AXIOM_ENCODE_APPLY_SIGNING_KEY \
-            --supervisor /opt/axiom-verification/axiom-encode-signing-supervisor \
-            --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
-            --trusted-python-runtime-root /opt/axiom-verification/python \
-            --trusted-python-import-root /opt/axiom-verification/python/lib/python3.13/site-packages \
-            --trusted-python-package-root /opt/axiom-verification/python/lib/python3.13/site-packages/axiom_encode \
-            --expected-github-repository TheAxiomFoundation/axiom-encode \
-            --allowed-workflow-ref TheAxiomFoundation/axiom-encode/.github/workflows/targeted-signed-reencode.yml@refs/heads/main \
-            --allowed-event-name workflow_dispatch \
-            -- "${args[@]}"
+          run_signed_encode() {
+            local citation="$1"
+            local review_finding="$2"
+            local target_only="$3"
+            local review_finding_path=""
+            local -a args=(
+              /opt/axiom-verification/axiom-encode encode
+              --backend openai
+              --corpus-path "$GITHUB_WORKSPACE/axiom-corpus"
+              --axiom-rules-engine-path "$GITHUB_WORKSPACE/axiom-rules-engine"
+              --policy-repo-path "$RULESPEC_CHECKOUT"
+              --output "$RUNNER_TEMP/generated"
+              --mode repo-augmented
+              --db "$RUNNER_TEMP/encodings.db"
+              --no-sync
+              --apply
+            )
+            if [ "$target_only" = "true" ]; then
+              args+=(--apply-target-only)
+            fi
+            if [ -n "$review_finding" ]; then
+              review_finding_dir="$(mktemp -d "$RUNNER_TEMP/axiom-targeted-review-finding.XXXXXX")"
+              review_finding_path="$review_finding_dir/review-finding.txt"
+              printf '%s\n' "$review_finding" > "$review_finding_path"
+              args+=(--review-findings "$review_finding_path")
+            fi
+            args+=("$citation")
+
+            /opt/axiom-verification/axiom-encode-apply-signer run \
+              --scope apply_ed25519 \
+              --key-env AXIOM_ENCODE_APPLY_SIGNING_KEY \
+              --supervisor /opt/axiom-verification/axiom-encode-signing-supervisor \
+              --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
+              --trusted-python-runtime-root /opt/axiom-verification/python \
+              --trusted-python-import-root /opt/axiom-verification/python/lib/python3.13/site-packages \
+              --trusted-python-package-root /opt/axiom-verification/python/lib/python3.13/site-packages/axiom_encode \
+              --expected-github-repository TheAxiomFoundation/axiom-encode \
+              --allowed-workflow-ref TheAxiomFoundation/axiom-encode/.github/workflows/targeted-signed-reencode.yml@refs/heads/main \
+              --allowed-event-name workflow_dispatch \
+              -- "${args[@]}"
+          }
+
+          if [ -n "$DEPENDENT_CITATION" ]; then
+            if [ "$DEPENDENT_CITATION" = "$CITATION" ]; then
+              echo "dependent citation must differ from the target citation" >&2
+              exit 1
+            fi
+            if [ -z "$DEPENDENT_REVIEW_FINDING" ]; then
+              echo "dependent review finding is required with dependent citation" >&2
+              exit 1
+            fi
+            run_signed_encode "$CITATION" "$REVIEW_FINDING" true
+            run_signed_encode \
+              "$DEPENDENT_CITATION" "$DEPENDENT_REVIEW_FINDING" false
+          else
+            if [ -n "$DEPENDENT_REVIEW_FINDING" ]; then
+              echo "dependent citation is required with dependent review finding" >&2
+              exit 1
+            fi
+            run_signed_encode "$CITATION" "$REVIEW_FINDING" false
+          fi
 
       - name: Verify generated provenance
         env:
@@ -367,6 +422,8 @@ jobs:
       - name: Package exact generated changes
         env:
           CITATION: ${{ inputs.citation }}
+          DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
+          DEPENDENT_REVIEW_FINDING_PRESENT: ${{ inputs.dependent_review_finding != '' }}
           REVIEW_FINDING_PRESENT: ${{ inputs.review_finding != '' }}
           RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
         run: |
@@ -405,53 +462,87 @@ jobs:
                   ".axiom/encoding-manifests",
               )
           )
-          matches = []
+          dependent_citation = os.environ.get("DEPENDENT_CITATION") or ""
+          expected_citations = {os.environ["CITATION"]}
+          if dependent_citation:
+              expected_citations.add(dependent_citation)
+
+          matches = {}
           for relative_path in sorted(manifest_paths):
               manifest_path = Path(os.environ["RULESPEC_CHECKOUT"]) / relative_path
               payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+              citation = payload.get("citation")
               if (
                   payload.get("schema_version")
                   == "axiom-encode/applied-rulespec/v5"
-                  and payload.get("citation") == os.environ["CITATION"]
+                  and citation in expected_citations
               ):
-                  matches.append(payload)
-          if len(matches) != 1:
-              raise SystemExit(
-                  "expected exactly one changed signed apply manifest for citation; "
-                  f"found {len(matches)}"
+                  matches.setdefault(citation, []).append(payload)
+
+          expected = [
+              (
+                  os.environ["CITATION"],
+                  os.environ["REVIEW_FINDING_PRESENT"] == "true",
+                  Path(sys.argv[1]),
+              )
+          ]
+          if dependent_citation:
+              expected.append(
+                  (
+                      dependent_citation,
+                      os.environ["DEPENDENT_REVIEW_FINDING_PRESENT"] == "true",
+                      Path(sys.argv[1]).with_name("dependent-context-manifest.json"),
+                  )
               )
 
-          applied_manifest = matches[0]
-          context_path = Path(applied_manifest["context_manifest_file"]).resolve()
           generated_root = (Path(os.environ["RUNNER_TEMP"]) / "generated").resolve()
-          try:
-              context_path.relative_to(generated_root)
-          except ValueError as exc:
-              raise SystemExit("signed context manifest is outside generated root") from exc
-          context_bytes = context_path.read_bytes()
-          context_digest = hashlib.sha256(context_bytes).hexdigest()
-          if context_digest != applied_manifest.get("context_manifest_sha256"):
-              raise SystemExit("signed context manifest digest does not match")
+          for citation, finding_required, destination in expected:
+              citation_matches = matches.get(citation, [])
+              if len(citation_matches) != 1:
+                  raise SystemExit(
+                      "expected exactly one changed signed apply manifest for "
+                      f"{citation}; found {len(citation_matches)}"
+                  )
+              applied_manifest = citation_matches[0]
+              context_path = Path(applied_manifest["context_manifest_file"]).resolve()
+              try:
+                  context_path.relative_to(generated_root)
+              except ValueError as exc:
+                  raise SystemExit(
+                      "signed context manifest is outside generated root"
+                  ) from exc
+              context_bytes = context_path.read_bytes()
+              context_digest = hashlib.sha256(context_bytes).hexdigest()
+              if context_digest != applied_manifest.get("context_manifest_sha256"):
+                  raise SystemExit("signed context manifest digest does not match")
 
-          context_payload = json.loads(context_bytes)
-          review_findings = context_payload.get("review_findings_files")
-          if not isinstance(review_findings, list):
-              raise SystemExit("context manifest review findings evidence is malformed")
-          if os.environ["REVIEW_FINDING_PRESENT"] == "true" and not review_findings:
-              raise SystemExit("context manifest omits supplied review finding")
-          for finding in review_findings:
-              if not isinstance(finding, dict):
-                  raise SystemExit("context manifest review finding is malformed")
-              content = finding.get("content")
-              digest = finding.get("sha256")
-              if not isinstance(content, str) or not content.strip():
-                  raise SystemExit("context manifest review finding content is empty")
-              if "\r" in content:
-                  raise SystemExit("context manifest review finding is not normalized")
-              if hashlib.sha256(content.encode("utf-8")).hexdigest() != digest:
-                  raise SystemExit("context manifest review finding digest does not match")
+              context_payload = json.loads(context_bytes)
+              review_findings = context_payload.get("review_findings_files")
+              if not isinstance(review_findings, list):
+                  raise SystemExit(
+                      "context manifest review findings evidence is malformed"
+                  )
+              if finding_required and not review_findings:
+                  raise SystemExit("context manifest omits supplied review finding")
+              for finding in review_findings:
+                  if not isinstance(finding, dict):
+                      raise SystemExit("context manifest review finding is malformed")
+                  content = finding.get("content")
+                  digest = finding.get("sha256")
+                  if not isinstance(content, str) or not content.strip():
+                      raise SystemExit(
+                          "context manifest review finding content is empty"
+                      )
+                  if "\r" in content:
+                      raise SystemExit(
+                          "context manifest review finding is not normalized"
+                      )
+                  if hashlib.sha256(content.encode("utf-8")).hexdigest() != digest:
+                      raise SystemExit(
+                          "context manifest review finding digest does not match"
+                      )
 
-          Path(sys.argv[1]).write_bytes(context_bytes)
+              destination.write_bytes(context_bytes)
           PY
           python - "$artifact/metadata.json" <<'PY'
           import json
@@ -467,6 +558,7 @@ jobs:
           payload = {
               "schema": "axiom-encode/targeted-reencode-artifact/v1",
               "citation": os.environ["CITATION"],
+              "dependent_citation": os.environ.get("DEPENDENT_CITATION") or None,
               "rulespec_base": rev(os.environ["RULESPEC_CHECKOUT"]),
               "encoder_commit": rev("axiom-encode"),
               "corpus_commit": rev("axiom-corpus"),

--- a/changelog.d/targeted-dependent-cascade.fixed.md
+++ b/changelog.d/targeted-dependent-cascade.fixed.md
@@ -1,0 +1,1 @@
+Allow protected targeted re-encodes to atomically re-encode one direct dependent after a breaking target migration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1342"
+version = "0.2.1343"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -85,6 +85,104 @@ def validate_rulespec_base(
     return "reviewed-head-artifact"
 
 
+def _citation_rulespec_path(citation: str) -> tuple[str, PurePosixPath]:
+    from axiom_encode.harness.evals import _resolve_eval_output_path
+
+    jurisdiction, separator, _remainder = citation.partition("/")
+    if not separator:
+        raise ValueError("citation must be a canonical corpus citation path")
+    relative = PurePosixPath(_resolve_eval_output_path(citation).as_posix())
+    if (
+        relative.is_absolute()
+        or ".." in relative.parts
+        or len(relative.parts) < 2
+        or relative.parts[0] not in RULESPEC_ATOMIC_ROOTS
+        or relative.suffix != ".yaml"
+    ):
+        raise ValueError("citation does not resolve to a canonical RuleSpec path")
+    return jurisdiction, relative
+
+
+def validate_dependent_cascade(
+    repo: Path,
+    target_citation: str,
+    dependent_citation: str,
+) -> PurePosixPath:
+    """Require the supplied module to be the target's only direct dependent."""
+
+    import yaml
+
+    target_jurisdiction, target_relative = _citation_rulespec_path(target_citation)
+    dependent_jurisdiction, dependent_relative = _citation_rulespec_path(
+        dependent_citation
+    )
+    if target_jurisdiction != dependent_jurisdiction:
+        raise ValueError("target and dependent must use the same jurisdiction")
+    if target_relative == dependent_relative:
+        raise ValueError("dependent citation must differ from the target citation")
+
+    repo_prefix = "rulespec-"
+    if not repo.name.startswith(repo_prefix):
+        raise ValueError("repository directory must use the rulespec-<country> name")
+    country = validate_country(repo.name.removeprefix(repo_prefix))
+    if target_jurisdiction != country and not target_jurisdiction.startswith(
+        f"{country}-"
+    ):
+        raise ValueError("citation jurisdiction does not belong to the RuleSpec repo")
+
+    content_root = repo / target_jurisdiction
+    target_path = content_root / target_relative
+    dependent_path = content_root / dependent_relative
+    if not target_path.is_file() or target_path.is_symlink():
+        raise ValueError("target citation has no regular baseline RuleSpec module")
+    if not dependent_path.is_file() or dependent_path.is_symlink():
+        raise ValueError("dependent citation has no regular baseline RuleSpec module")
+
+    target_import = target_relative.with_suffix("").as_posix()
+    canonical_target_import = f"{target_jurisdiction}:{target_import}"
+    direct_dependents: set[PurePosixPath] = set()
+    for atomic_root in sorted(RULESPEC_ATOMIC_ROOTS):
+        root = content_root / atomic_root
+        if not root.exists():
+            continue
+        for candidate in sorted(root.rglob("*.yaml")):
+            if candidate.name.endswith(".test.yaml") or candidate == target_path:
+                continue
+            if not candidate.is_file() or candidate.is_symlink():
+                raise ValueError(
+                    "baseline RuleSpec scan encountered a non-regular module"
+                )
+            try:
+                payload = yaml.safe_load(candidate.read_text(encoding="utf-8"))
+            except (OSError, UnicodeError, yaml.YAMLError) as exc:
+                raise ValueError(
+                    f"cannot inspect baseline RuleSpec module {candidate}"
+                ) from exc
+            if not isinstance(payload, dict):
+                continue
+            imports = payload.get("imports")
+            if not isinstance(imports, list):
+                continue
+            if any(
+                isinstance(raw_import, str)
+                and raw_import.split("#", 1)[0].strip().strip("/")
+                in {target_import, canonical_target_import}
+                for raw_import in imports
+            ):
+                direct_dependents.add(
+                    PurePosixPath(candidate.relative_to(content_root).as_posix())
+                )
+
+    expected = {dependent_relative}
+    if direct_dependents != expected:
+        rendered = ", ".join(map(str, sorted(direct_dependents))) or "<none>"
+        raise ValueError(
+            "target direct-dependent set does not exactly match supplied dependent: "
+            f"{rendered}"
+        )
+    return dependent_relative
+
+
 def _git(repo: Path, *args: str) -> bytes:
     return subprocess.check_output(["git", "-C", str(repo), *args])
 
@@ -217,6 +315,10 @@ def main() -> None:
     base_parser.add_argument("open_pr", choices=("true", "false"))
     stage_parser = subparsers.add_parser("stage")
     stage_parser.add_argument("repo", type=Path)
+    cascade_parser = subparsers.add_parser("validate-dependent-cascade")
+    cascade_parser.add_argument("repo", type=Path)
+    cascade_parser.add_argument("target_citation")
+    cascade_parser.add_argument("dependent_citation")
     args = parser.parse_args()
     try:
         if args.command == "validate-country":
@@ -230,6 +332,14 @@ def main() -> None:
                     args.country,
                     args.requested_ref,
                     open_pr=args.open_pr == "true",
+                )
+            )
+        elif args.command == "validate-dependent-cascade":
+            print(
+                validate_dependent_cascade(
+                    args.repo,
+                    args.target_citation,
+                    args.dependent_citation,
                 )
             )
         else:

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1342"
+__version__ = "0.2.1343"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -11,6 +11,7 @@ from scripts.prepare_signed_backfill import (
     branch_name,
     stage_authorized_changes,
     validate_country,
+    validate_dependent_cascade,
     validate_rulespec_base,
 )
 
@@ -60,6 +61,27 @@ def _write_signed_change(repo: Path) -> tuple[Path, Path]:
         encoding="utf-8",
     )
     return rule, manifest
+
+
+def _write_module(
+    repo: Path,
+    relative: str,
+    *,
+    imports: tuple[str, ...] = (),
+) -> Path:
+    path = repo / "us" / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "format: rulespec/v1\n"
+        + (
+            "imports:\n" + "".join(f"  - {value}\n" for value in imports)
+            if imports
+            else "imports: []\n"
+        )
+        + "rules: []\n",
+        encoding="utf-8",
+    )
+    return path
 
 
 @pytest.mark.parametrize("country", ["../x", "us/x", "${{ inputs.x }}", "us\n"])
@@ -115,6 +137,64 @@ def test_rerun_attempt_uses_recoverable_distinct_branch() -> None:
     assert first == "axiom/signed-backfill-us-12345-1"
     assert rerun == "axiom/signed-backfill-us-12345-2"
     assert rerun != first
+
+
+def test_validate_dependent_cascade_accepts_only_direct_dependent(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    _write_module(repo, "regulations/42-cfr/435/555.yaml")
+    dependent = _write_module(
+        repo,
+        "regulations/42-cfr/435/559.yaml",
+        imports=("us:regulations/42-cfr/435/555#target_rule",),
+    )
+
+    assert validate_dependent_cascade(
+        repo,
+        "us/regulation/42/435/555",
+        "us/regulation/42/435/559",
+    ) == dependent.relative_to(repo / "us")
+
+
+def test_validate_dependent_cascade_rejects_unrelated_dependent(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    _write_module(repo, "regulations/42-cfr/435/555.yaml")
+    _write_module(
+        repo,
+        "regulations/42-cfr/435/559.yaml",
+        imports=("us:regulations/42-cfr/435/555",),
+    )
+    _write_module(repo, "regulations/42-cfr/435/561.yaml")
+
+    with pytest.raises(ValueError, match="does not exactly match"):
+        validate_dependent_cascade(
+            repo,
+            "us/regulation/42/435/555",
+            "us/regulation/42/435/561",
+        )
+
+
+def test_validate_dependent_cascade_rejects_multiple_direct_dependents(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    _write_module(repo, "regulations/42-cfr/435/555.yaml")
+    for section in ("559", "561"):
+        _write_module(
+            repo,
+            f"regulations/42-cfr/435/{section}.yaml",
+            imports=("regulations/42-cfr/435/555",),
+        )
+
+    with pytest.raises(ValueError, match="does not exactly match"):
+        validate_dependent_cascade(
+            repo,
+            "us/regulation/42/435/555",
+            "us/regulation/42/435/559",
+        )
 
 
 def test_validate_rulespec_base_accepts_main_ancestor(tmp_path: Path) -> None:

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1832,6 +1832,8 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     }
     assert inputs["open_pr"]["type"] == "boolean"
     assert inputs["open_pr"]["default"] is False
+    assert inputs["dependent_citation"]["required"] is False
+    assert inputs["dependent_review_finding"]["required"] is False
 
     job = workflow["jobs"]["encode"]
     assert job["environment"] == "production-signing"
@@ -1928,6 +1930,16 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "protected RuleSpec routing rejected checkout" in routing_command
     assert "hardened RuleSpec routing rejected checkout" in routing_command
 
+    cascade_step = next(
+        step for step in steps if step.get("name") == "Validate dependent cascade"
+    )
+    assert cascade_step["if"] == "${{ inputs.dependent_citation != '' }}"
+    assert "validate-dependent-cascade" in cascade_step["run"]
+    assert (
+        '"$RULESPEC_CHECKOUT" "$CITATION" "$DEPENDENT_CITATION"'
+        in (cascade_step["run"])
+    )
+
     apply_step = next(
         step
         for step in steps
@@ -1938,7 +1950,8 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     )
     assert "AXIOM_ENCODE_APPLY_CHECKOUT" not in apply_step["env"]
     command = apply_step["run"]
-    assert "exec /opt/axiom-verification/axiom-encode-apply-signer run" in command
+    assert "run_signed_encode()" in command
+    assert "/opt/axiom-verification/axiom-encode-apply-signer run" in command
     assert "--key-env AXIOM_ENCODE_APPLY_SIGNING_KEY" in command
     assert (
         "TheAxiomFoundation/axiom-encode/.github/workflows/"
@@ -1947,10 +1960,16 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "--allowed-event-name workflow_dispatch" in command
     assert "--apply" in command
     assert "--skip-reviewers" not in command
-    assert 'mktemp "$RUNNER_TEMP/axiom-targeted-review-finding.XXXXXX.txt"' in command
+    assert 'mktemp -d "$RUNNER_TEMP/axiom-targeted-review-finding.XXXXXX"' in command
+    assert 'review_finding_path="$review_finding_dir/review-finding.txt"' in command
     assert "$GITHUB_WORKSPACE/axiom-rules-engine/.axiom-targeted" not in command
-    assert "printf '%s\\n' \"$REVIEW_FINDING\"" in command
+    assert "printf '%s\\n' \"$review_finding\"" in command
     assert 'args+=(--review-findings "$review_finding_path")' in command
+    assert "args+=(--apply-target-only)" in command
+    assert 'run_signed_encode "$CITATION" "$REVIEW_FINDING" true' in command
+    assert '"$DEPENDENT_CITATION" "$DEPENDENT_REVIEW_FINDING" false' in command
+    assert "dependent review finding is required with dependent citation" in command
+    assert steps.index(cascade_step) < steps.index(apply_step)
 
     package_step = next(
         step for step in steps if step.get("name") == "Package exact generated changes"
@@ -1959,13 +1978,17 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert package_step["env"]["REVIEW_FINDING_PRESENT"] == (
         "${{ inputs.review_finding != '' }}"
     )
+    assert package_step["env"]["DEPENDENT_REVIEW_FINDING_PRESENT"] == (
+        "${{ inputs.dependent_review_finding != '' }}"
+    )
     assert '"$artifact/context-manifest.json"' in package_command
     assert '".axiom/encoding-manifests"' in package_command
-    assert 'payload.get("citation") == os.environ["CITATION"]' in package_command
+    assert 'citation = payload.get("citation")' in package_command
     assert 'applied_manifest["context_manifest_file"]' in package_command
     assert 'applied_manifest.get("context_manifest_sha256")' in package_command
     assert 'finding.get("content")' in package_command
     assert 'finding.get("sha256")' in package_command
+    assert '"dependent-context-manifest.json"' in package_command
 
     guard_step = next(
         step for step in steps if step.get("name") == "Verify generated provenance"
@@ -2013,6 +2036,78 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         step for step in steps if step.get("name") == "Upload signed re-encode artifact"
     )
     assert steps.index(checksum_step) + 1 == steps.index(upload_step)
+
+
+def test_targeted_signed_reencode_orders_target_and_dependent(tmp_path: Path) -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
+    )
+    command = next(
+        step["run"]
+        for step in workflow["jobs"]["encode"]["steps"]
+        if step.get("name") == "Encode, review, validate, and apply"
+    )
+    command = command.replace(
+        "/opt/axiom-verification/axiom-encode-apply-signer run",
+        '"$SIGNER_STUB"',
+    )
+
+    calls_path = tmp_path / "calls.jsonl"
+    signer_stub = tmp_path / "signer-stub"
+    signer_stub.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
+    stream.write(json.dumps(sys.argv[1:]) + "\\n")
+"""
+    )
+    signer_stub.chmod(0o700)
+    runner_temp = tmp_path / "runner-temp"
+    runner_temp.mkdir()
+
+    subprocess.run(
+        ["bash", "-c", command],
+        check=True,
+        env={
+            **os.environ,
+            "AXIOM_ENCODE_APPLY_SIGNING_KEY": "test-key",
+            "CALLS_PATH": str(calls_path),
+            "CITATION": "us/regulation/42/435/555",
+            "DEPENDENT_CITATION": "us/regulation/42/435/559",
+            "DEPENDENT_REVIEW_FINDING": "Preserve the dependent source.",
+            "GITHUB_WORKSPACE": str(tmp_path),
+            "REVIEW_FINDING": "Preserve the target source.",
+            "RULESPEC_CHECKOUT": str(tmp_path / "rulespec-us"),
+            "RUNNER_TEMP": str(runner_temp),
+            "SIGNER_STUB": str(signer_stub),
+        },
+    )
+
+    calls = [
+        json.loads(line) for line in calls_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert len(calls) == 2
+    encode_args = [call[call.index("--") + 1 :] for call in calls]
+    assert encode_args[0][-1] == "us/regulation/42/435/555"
+    assert "--apply-target-only" in encode_args[0]
+    assert encode_args[1][-1] == "us/regulation/42/435/559"
+    assert "--apply-target-only" not in encode_args[1]
+    assert (
+        Path(encode_args[0][encode_args[0].index("--review-findings") + 1])
+        .read_text(encoding="utf-8")
+        .strip()
+        == "Preserve the target source."
+    )
+    assert (
+        Path(encode_args[1][encode_args[1].index("--review-findings") + 1])
+        .read_text(encoding="utf-8")
+        .strip()
+        == "Preserve the dependent source."
+    )
 
 
 def test_targeted_review_finding_temp_file_is_valid_context(tmp_path: Path) -> None:
@@ -2116,6 +2211,107 @@ def test_targeted_artifact_packages_signed_review_context(tmp_path: Path) -> Non
 
     assert completed.returncode == 0, completed.stderr
     assert packaged_context.read_bytes() == context_bytes
+
+
+def test_targeted_artifact_packages_target_and_dependent_contexts(
+    tmp_path: Path,
+) -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
+    )
+    package_command = next(
+        step
+        for step in workflow["jobs"]["encode"]["steps"]
+        if step.get("name") == "Package exact generated changes"
+    )["run"]
+    marker = "python - \"$artifact/context-manifest.json\" <<'PY'\n"
+    script = package_command.split(marker, 1)[1].split(
+        '\nPY\npython - "$artifact/metadata.json"', 1
+    )[0]
+
+    rulespec = tmp_path / "rulespec-us"
+    rulespec.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=rulespec, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=rulespec,
+        check=True,
+    )
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=rulespec, check=True)
+    base = rulespec / "README.md"
+    base.write_text("fixture\n")
+    subprocess.run(["git", "add", "README.md"], cwd=rulespec, check=True)
+    subprocess.run(["git", "commit", "-qm", "fixture"], cwd=rulespec, check=True)
+
+    target_citation = "us/regulation/42/435/555"
+    dependent_citation = "us/regulation/42/435/559"
+    generated_root = tmp_path / "generated"
+    contexts: dict[str, bytes] = {}
+    for citation, section, finding in (
+        (target_citation, "555", "Preserve the target source.\n"),
+        (dependent_citation, "559", "Preserve the dependent source.\n"),
+    ):
+        context_payload = {
+            "citation": citation,
+            "review_findings_files": [
+                {
+                    "content": finding,
+                    "sha256": hashlib.sha256(finding.encode()).hexdigest(),
+                }
+            ],
+        }
+        context_bytes = json.dumps(context_payload, sort_keys=True).encode()
+        context_path = (
+            generated_root / "_eval_workspaces" / section / "context-manifest.json"
+        )
+        context_path.parent.mkdir(parents=True)
+        context_path.write_bytes(context_bytes)
+        contexts[citation] = context_bytes
+
+        applied_manifest = {
+            "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+            "citation": citation,
+            "context_manifest_file": str(context_path),
+            "context_manifest_sha256": hashlib.sha256(context_bytes).hexdigest(),
+        }
+        applied_path = (
+            rulespec
+            / ".axiom"
+            / "encoding-manifests"
+            / "regulations"
+            / "42-cfr"
+            / "435"
+            / f"{section}.yaml.json"
+        )
+        applied_path.parent.mkdir(parents=True, exist_ok=True)
+        applied_path.write_text(json.dumps(applied_manifest))
+
+    artifact = tmp_path / "artifact"
+    artifact.mkdir()
+    packaged_target = artifact / "context-manifest.json"
+    completed = subprocess.run(
+        [sys.executable, "-", str(packaged_target)],
+        cwd=tmp_path,
+        input=script,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "CITATION": target_citation,
+            "DEPENDENT_CITATION": dependent_citation,
+            "DEPENDENT_REVIEW_FINDING_PRESENT": "true",
+            "REVIEW_FINDING_PRESENT": "true",
+            "RUNNER_TEMP": str(tmp_path),
+            "RULESPEC_CHECKOUT": "rulespec-us",
+        },
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert packaged_target.read_bytes() == contexts[target_citation]
+    assert (artifact / "dependent-context-manifest.json").read_bytes() == contexts[
+        dependent_citation
+    ]
 
 
 def test_apply_signing_key_migration_workflow_is_main_only() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1342"
+version = "0.2.1343"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- let the protected targeted lane encode a breaking target with `--apply-target-only`, then re-encode one direct dependent normally in the same checkout
- require the baseline target direct-dependent set to equal exactly the supplied dependent before signing
- package and verify each signed context manifest independently
- cover shell ordering, target-only scoping, dual-context packaging, unrelated dependents, and multiple direct dependents

## Validation

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest` (`4782 passed, 119 skipped`)
- four required GitHub CI checks passed on `4be80890bdc9602069d35ebbbc63182b90187edf`

## Review cycle

- independent review found a high-severity unrestricted dependent-bypass risk
- fixed with fail-closed exact direct-dependent validation and negative tests
- repeated focused and full validation
- second independent review found no actionable findings