### PR TITLE
Isolate dependent re-encode output lanes

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -345,6 +345,7 @@ jobs:
             local citation="$1"
             local review_finding="$2"
             local target_only="$3"
+            local output_lane="$4"
             local review_finding_path=""
             local -a args=(
               /opt/axiom-verification/axiom-encode encode
@@ -352,7 +353,7 @@ jobs:
               --corpus-path "$GITHUB_WORKSPACE/axiom-corpus"
               --axiom-rules-engine-path "$GITHUB_WORKSPACE/axiom-rules-engine"
               --policy-repo-path "$RULESPEC_CHECKOUT"
-              --output "$RUNNER_TEMP/generated"
+              --output "$RUNNER_TEMP/generated/$output_lane"
               --mode repo-augmented
               --db "$RUNNER_TEMP/encodings.db"
               --no-sync
@@ -392,15 +393,15 @@ jobs:
               echo "dependent review finding is required with dependent citation" >&2
               exit 1
             fi
-            run_signed_encode "$CITATION" "$REVIEW_FINDING" true
+            run_signed_encode "$CITATION" "$REVIEW_FINDING" true target
             run_signed_encode \
-              "$DEPENDENT_CITATION" "$DEPENDENT_REVIEW_FINDING" false
+              "$DEPENDENT_CITATION" "$DEPENDENT_REVIEW_FINDING" false dependent
           else
             if [ -n "$DEPENDENT_REVIEW_FINDING" ]; then
               echo "dependent citation is required with dependent review finding" >&2
               exit 1
             fi
-            run_signed_encode "$CITATION" "$REVIEW_FINDING" false
+            run_signed_encode "$CITATION" "$REVIEW_FINDING" false target
           fi
 
       - name: Verify generated provenance
@@ -484,6 +485,7 @@ jobs:
                   os.environ["CITATION"],
                   os.environ["REVIEW_FINDING_PRESENT"] == "true",
                   Path(sys.argv[1]),
+                  "target",
               )
           ]
           if dependent_citation:
@@ -492,11 +494,12 @@ jobs:
                       dependent_citation,
                       os.environ["DEPENDENT_REVIEW_FINDING_PRESENT"] == "true",
                       Path(sys.argv[1]).with_name("dependent-context-manifest.json"),
+                      "dependent",
                   )
               )
 
           generated_root = (Path(os.environ["RUNNER_TEMP"]) / "generated").resolve()
-          for citation, finding_required, destination in expected:
+          for citation, finding_required, destination, lane in expected:
               citation_matches = matches.get(citation, [])
               if len(citation_matches) != 1:
                   raise SystemExit(
@@ -506,10 +509,10 @@ jobs:
               applied_manifest = citation_matches[0]
               context_path = Path(applied_manifest["context_manifest_file"]).resolve()
               try:
-                  context_path.relative_to(generated_root)
+                  context_path.relative_to(generated_root / lane)
               except ValueError as exc:
                   raise SystemExit(
-                      "signed context manifest is outside generated root"
+                      f"signed context manifest is outside assigned {lane} lane"
                   ) from exc
               context_bytes = context_path.read_bytes()
               context_digest = hashlib.sha256(context_bytes).hexdigest()
@@ -517,6 +520,10 @@ jobs:
                   raise SystemExit("signed context manifest digest does not match")
 
               context_payload = json.loads(context_bytes)
+              if context_payload.get("citation") != citation:
+                  raise SystemExit(
+                      "signed context manifest citation does not match"
+                  )
               review_findings = context_payload.get("review_findings_files")
               if not isinstance(review_findings, list):
                   raise SystemExit(

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1966,8 +1966,12 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "printf '%s\\n' \"$review_finding\"" in command
     assert 'args+=(--review-findings "$review_finding_path")' in command
     assert "args+=(--apply-target-only)" in command
-    assert 'run_signed_encode "$CITATION" "$REVIEW_FINDING" true' in command
-    assert '"$DEPENDENT_CITATION" "$DEPENDENT_REVIEW_FINDING" false' in command
+    assert '--output "$RUNNER_TEMP/generated/$output_lane"' in command
+    assert 'run_signed_encode "$CITATION" "$REVIEW_FINDING" true target' in command
+    assert (
+        '"$DEPENDENT_CITATION" "$DEPENDENT_REVIEW_FINDING" false dependent' in command
+    )
+    assert 'run_signed_encode "$CITATION" "$REVIEW_FINDING" false target' in command
     assert "dependent review finding is required with dependent citation" in command
     assert steps.index(cascade_step) < steps.index(apply_step)
 
@@ -2176,8 +2180,8 @@ def test_targeted_artifact_packages_signed_review_context(tmp_path: Path) -> Non
         ],
     }
     context_bytes = json.dumps(context_payload, sort_keys=True).encode()
-    context_path = tmp_path / "generated" / "context-manifest.json"
-    context_path.parent.mkdir()
+    context_path = tmp_path / "generated" / "target" / "context-manifest.json"
+    context_path.parent.mkdir(parents=True)
     context_path.write_bytes(context_bytes)
     applied_manifest = {
         "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
@@ -2213,8 +2217,36 @@ def test_targeted_artifact_packages_signed_review_context(tmp_path: Path) -> Non
     assert packaged_context.read_bytes() == context_bytes
 
 
-def test_targeted_artifact_packages_target_and_dependent_contexts(
+@pytest.mark.parametrize(
+    ("target_lane", "dependent_lane", "dependent_context_citation", "error"),
+    [
+        ("target", "dependent", None, None),
+        (
+            "dependent",
+            "target",
+            None,
+            "signed context manifest is outside assigned target lane",
+        ),
+        (
+            "target",
+            "target",
+            None,
+            "signed context manifest is outside assigned dependent lane",
+        ),
+        (
+            "target",
+            "dependent",
+            "us/regulation/42/435/555",
+            "signed context manifest citation does not match",
+        ),
+    ],
+)
+def test_targeted_artifact_enforces_target_and_dependent_context_lanes(
     tmp_path: Path,
+    target_lane: str,
+    dependent_lane: str,
+    dependent_context_citation: str | None,
+    error: str | None,
 ) -> None:
     workflow = yaml.safe_load(
         (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
@@ -2247,12 +2279,24 @@ def test_targeted_artifact_packages_target_and_dependent_contexts(
     dependent_citation = "us/regulation/42/435/559"
     generated_root = tmp_path / "generated"
     contexts: dict[str, bytes] = {}
-    for citation, section, finding in (
-        (target_citation, "555", "Preserve the target source.\n"),
-        (dependent_citation, "559", "Preserve the dependent source.\n"),
+    for citation, context_citation, lane, section, finding in (
+        (
+            target_citation,
+            target_citation,
+            target_lane,
+            "555",
+            "Preserve the target source.\n",
+        ),
+        (
+            dependent_citation,
+            dependent_context_citation or dependent_citation,
+            dependent_lane,
+            "559",
+            "Preserve the dependent source.\n",
+        ),
     ):
         context_payload = {
-            "citation": citation,
+            "citation": context_citation,
             "review_findings_files": [
                 {
                     "content": finding,
@@ -2262,7 +2306,11 @@ def test_targeted_artifact_packages_target_and_dependent_contexts(
         }
         context_bytes = json.dumps(context_payload, sort_keys=True).encode()
         context_path = (
-            generated_root / "_eval_workspaces" / section / "context-manifest.json"
+            generated_root
+            / lane
+            / "_eval_workspaces"
+            / section
+            / "context-manifest.json"
         )
         context_path.parent.mkdir(parents=True)
         context_path.write_bytes(context_bytes)
@@ -2306,6 +2354,11 @@ def test_targeted_artifact_packages_target_and_dependent_contexts(
             "RULESPEC_CHECKOUT": "rulespec-us",
         },
     )
+
+    if error is not None:
+        assert completed.returncode != 0
+        assert error in completed.stderr
+        return
 
     assert completed.returncode == 0, completed.stderr
     assert packaged_target.read_bytes() == contexts[target_citation]


### PR DESCRIPTION
## Summary
- isolate target and dependent signed re-encode outputs under `generated/target` and `generated/dependent`
- bind packaged context manifests to their assigned lanes and expected citation
- add positive and fail-closed regression coverage for swapped, shared, and citation-mismatched contexts

## Failure addressed
Workflow run `30045604265` successfully applied and signed the target, then the dependent encode crashed because the shared generated runner tree contained a conflicting repaired target context. Separate lanes preserve the atomic RuleSpec checkout while removing that hydration collision.

## Review cycle
- independent review found packaging did not initially bind manifests to lanes
- fixed lane binding, added citation validation, and added rejection tests
- repeat independent review: no actionable findings

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- focused: 8 passed
- full: 4,785 passed, 119 skipped