### PR TITLE
Preserve review-mandated proof excerpts

### DIFF
--- a/changelog.d/protected-review-excerpts.fixed.md
+++ b/changelog.d/protected-review-excerpts.fixed.md
@@ -1,0 +1,1 @@
+Preserve exact proof excerpts quoted in mandatory review findings during deterministic source-whitespace repair.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1343"
+version = "0.2.1344"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1343"
+__version__ = "0.2.1344"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -19685,6 +19685,9 @@ def _run_encode_attempt(
 
     skip_reviewers = bool(getattr(args, "skip_reviewers", False))
     policyengine_rule_hint = getattr(args, "policyengine_rule_hint", None)
+    review_findings_paths = [
+        Path(path) for path in getattr(args, "review_findings", [])
+    ]
     results = run_model_eval(
         citations=[args.citation],
         runner_specs=[runner],
@@ -19694,9 +19697,7 @@ def _run_encode_attempt(
         corpus_release=corpus_release,
         mode=args.mode,
         extra_context_paths=[Path(path) for path in args.allow_context],
-        review_findings_paths=[
-            Path(path) for path in getattr(args, "review_findings", [])
-        ],
+        review_findings_paths=review_findings_paths,
         include_tests=True,
         skip_reviewers=skip_reviewers,
         policyengine_rule_hint=policyengine_rule_hint,
@@ -19704,6 +19705,14 @@ def _run_encode_attempt(
     )
 
     result = results[0]
+    protected_review_excerpts = (
+        _quoted_review_finding_excerpts(
+            result.context_manifest_file,
+            expected_manifest_sha256=result.context_manifest_sha256,
+        )
+        if review_findings_paths
+        else set()
+    )
     print(f"Output root: {args.output}")
     print(f"Axiom Corpus: {corpus_path}")
     print(f"Corpus release: {corpus_release.name} ({corpus_release.content_sha256})")
@@ -21403,6 +21412,7 @@ def _run_encode_attempt(
                             output_root=args.output,
                             corpus_release=corpus_release,
                             issues=apply_issues,
+                            protected_review_excerpts=protected_review_excerpts,
                         )
                     )
                     if not repaired_refs:
@@ -28542,14 +28552,98 @@ class _SourceExcerptCandidate(NamedTuple):
     marked_parent: tuple[int, int] | None
 
 
+def _quoted_review_finding_excerpts(
+    context_manifest_file: str | Path,
+    *,
+    expected_manifest_sha256: str,
+) -> set[str]:
+    """Return quoted phrases from the validated review snapshot used by the model."""
+    manifest_path = Path(context_manifest_file)
+    try:
+        manifest_bytes = read_bounded_regular_file(
+            manifest_path.parent,
+            manifest_path,
+            label="eval context manifest",
+            max_bytes=32 * 1024 * 1024,
+        )
+        manifest = json.loads(manifest_bytes.decode("utf-8"))
+    except (
+        OSError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        RecursionError,
+        UnsafeCorpusPathError,
+    ) as exc:
+        raise RuntimeError(
+            "Cannot read protected excerpts from the eval context manifest"
+        ) from exc
+    if not re.fullmatch(r"[0-9a-f]{64}", str(expected_manifest_sha256)):
+        raise RuntimeError("Eval context manifest digest is missing or invalid")
+    if hashlib.sha256(manifest_bytes).hexdigest() != expected_manifest_sha256:
+        raise RuntimeError("Eval context manifest digest does not match the result")
+    if not isinstance(manifest, dict):
+        raise RuntimeError("Eval context manifest must be a JSON object")
+
+    excerpts: set[str] = set()
+    review_findings = manifest.get("review_findings_files", [])
+    if not isinstance(review_findings, list):
+        raise RuntimeError("Eval context review_findings_files must be a list")
+    for evidence in review_findings:
+        if not isinstance(evidence, dict):
+            raise RuntimeError("Eval review findings evidence must be an object")
+        content = evidence.get("content")
+        expected_sha256 = evidence.get("sha256")
+        if not isinstance(content, str) or not isinstance(expected_sha256, str):
+            raise RuntimeError("Eval review findings evidence is incomplete")
+        if hashlib.sha256(content.encode("utf-8")).hexdigest() != expected_sha256:
+            raise RuntimeError("Eval review findings evidence digest does not match")
+        excerpts.update(
+            match.group("excerpt").strip()
+            for match in re.finditer(
+                r'"(?P<excerpt>[^"]+)"',
+                content,
+            )
+            if match.group("excerpt").strip()
+        )
+    return excerpts
+
+
+def _normalized_proof_excerpt(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip().casefold()
+
+
+def _source_excerpt_preserving_whitespace(
+    *,
+    source_text: str,
+    excerpt: str,
+) -> str | None:
+    """Map a whitespace-normalized quote to only its literal source span."""
+    parts = str(excerpt).split()
+    if not parts:
+        return None
+    match = re.search(
+        r"\s+".join(re.escape(part) for part in parts),
+        str(source_text),
+        flags=re.IGNORECASE,
+    )
+    if match is None:
+        return None
+    return str(source_text)[match.start() : match.end()].strip()
+
+
 def _try_repair_generated_nonexact_proof_excerpts_for_apply(
     result,
     *,
     output_root: Path,
     corpus_release: LocalCorpusRelease | None = None,
     issues: list[str],
+    protected_review_excerpts: set[str] | None = None,
 ) -> list[str]:
     """Align near-match generated proof excerpts to their exact cited source text."""
+    protected_normalized = {
+        _normalized_proof_excerpt(excerpt)
+        for excerpt in (protected_review_excerpts or set())
+    }
     targets: dict[tuple[str, int], bool] = {}
     for issue in issues:
         issue_text = str(issue)
@@ -28623,10 +28717,16 @@ def _try_repair_generated_nonexact_proof_excerpts_for_apply(
                 )
                 if not source_text:
                     continue
-            exact_excerpt = _closest_exact_source_excerpt(
-                source_text=source_text,
-                excerpt=excerpt,
-            )
+            if _normalized_proof_excerpt(excerpt) in protected_normalized:
+                exact_excerpt = _source_excerpt_preserving_whitespace(
+                    source_text=source_text,
+                    excerpt=excerpt,
+                )
+            else:
+                exact_excerpt = _closest_exact_source_excerpt(
+                    source_text=source_text,
+                    excerpt=excerpt,
+                )
             if exact_excerpt is None or exact_excerpt == excerpt:
                 continue
             source["excerpt"] = exact_excerpt

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -96,6 +96,7 @@ from axiom_encode.cli import (
     _person_scoped_definition_issue_names,
     _promote_boolean_comparison_predicates_to_judgment,
     _qualify_deferred_output_subsection_paths,
+    _quoted_review_finding_excerpts,
     _read_only_guard_encoder_execution_identity,
     _record_successful_apply_validation,
     _recover_apply_transaction,
@@ -7250,6 +7251,217 @@ rules:
     }
 
 
+def test_quoted_review_finding_excerpts_extracts_mandatory_phrases(tmp_path):
+    content = (
+        'Use exact "The applicable individual resides\n'
+        'in a county" and "8 percent". Leave unquoted guidance unchanged.\n'
+    )
+    manifest = tmp_path / "context-manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "review_findings_files": [
+                    {
+                        "content": content,
+                        "sha256": hashlib.sha256(content.encode()).hexdigest(),
+                    }
+                ]
+            }
+        )
+    )
+    manifest_sha256 = hashlib.sha256(manifest.read_bytes()).hexdigest()
+
+    assert _quoted_review_finding_excerpts(
+        manifest,
+        expected_manifest_sha256=manifest_sha256,
+    ) == {
+        "The applicable individual resides\nin a county",
+        "8 percent",
+    }
+
+
+def test_quoted_review_finding_excerpts_rejects_manifest_tampering(tmp_path):
+    manifest = tmp_path / "context-manifest.json"
+    original_content = 'Use exact "8 percent".'
+    manifest.write_text(
+        json.dumps(
+            {
+                "review_findings_files": [
+                    {
+                        "content": original_content,
+                        "sha256": hashlib.sha256(original_content.encode()).hexdigest(),
+                    }
+                ]
+            }
+        )
+    )
+    original_manifest_sha256 = hashlib.sha256(manifest.read_bytes()).hexdigest()
+    tampered_content = 'Use exact "80 percent".'
+    manifest.write_text(
+        json.dumps(
+            {
+                "review_findings_files": [
+                    {
+                        "content": tampered_content,
+                        "sha256": hashlib.sha256(tampered_content.encode()).hexdigest(),
+                    }
+                ]
+            }
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="manifest digest does not match"):
+        _quoted_review_finding_excerpts(
+            manifest,
+            expected_manifest_sha256=original_manifest_sha256,
+        )
+
+
+def test_quoted_review_finding_excerpts_accepts_manifest_above_ten_mib(tmp_path):
+    content = 'Use exact "8 percent".'
+    manifest = tmp_path / "context-manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "padding": "x" * (10 * 1024 * 1024),
+                "review_findings_files": [
+                    {
+                        "content": content,
+                        "sha256": hashlib.sha256(content.encode()).hexdigest(),
+                    }
+                ],
+            }
+        )
+    )
+
+    assert _quoted_review_finding_excerpts(
+        manifest,
+        expected_manifest_sha256=hashlib.sha256(manifest.read_bytes()).hexdigest(),
+    ) == {"8 percent"}
+
+
+def test_repair_generated_protected_review_excerpt_does_not_broaden_paragraph(
+    tmp_path, monkeypatch
+):
+    source_text = (
+        "(2) The applicable individual resides in a county or equivalent unit of\n"
+        "local government in which there exists an emergency or disaster declared\n"
+        "by the President under applicable law.\n"
+    )
+    protected_excerpt = (
+        "The applicable individual resides in a county or equivalent unit of local "
+        "government in which there exists an emergency or disaster"
+    )
+    expected_excerpt = (
+        "The applicable individual resides in a county or equivalent unit of\n"
+        "local government in which there exists an emergency or disaster"
+    )
+    output_root = tmp_path / "out"
+    rules_file = output_root / "model" / "regulations" / "435" / "555.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(
+        f"""format: rulespec/v1
+rules:
+- name: presidential_emergency_or_disaster_short_term_hardship_event
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  source: 42 CFR 435.555(d)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/555
+          excerpt: {protected_excerpt!r}
+  versions:
+  - effective_from: '0001-01-01'
+    formula: individual_resides_in_presidential_emergency_area
+"""
+    )
+    monkeypatch.setattr(
+        "axiom_encode.cli._local_source_text_for_corpus_path",
+        lambda citation_path, *, corpus_release: source_text,
+    )
+
+    repaired = _try_repair_generated_nonexact_proof_excerpts_for_apply(
+        SimpleNamespace(output_file=str(rules_file)),
+        output_root=output_root,
+        corpus_release=SimpleNamespace(name="test-release"),
+        issues=[
+            "Proof source evidence not found: rule "
+            "`presidential_emergency_or_disaster_short_term_hardship_event` "
+            "proof atom 0 `source.excerpt` does not appear in "
+            "`us/regulation/42/435/555`."
+        ],
+        protected_review_excerpts={protected_excerpt},
+    )
+
+    payload = yaml.safe_load(rules_file.read_text())
+    repaired_excerpt = payload["rules"][0]["metadata"]["proof"]["atoms"][0]["source"][
+        "excerpt"
+    ]
+    assert repaired == [
+        "presidential_emergency_or_disaster_short_term_hardship_event[0]"
+    ]
+    assert repaired_excerpt == expected_excerpt
+    assert repaired_excerpt in source_text
+    assert not repaired_excerpt.startswith("(2)")
+    assert "declared by the President" not in repaired_excerpt
+
+
+def test_repair_generated_protected_review_excerpt_fails_closed_without_exact_match(
+    tmp_path, monkeypatch
+):
+    source_text = (
+        "(2) A person lives in an area with a presidentially declared emergency.\n"
+    )
+    protected_excerpt = "The applicable individual resides in an emergency area"
+    output_root = tmp_path / "out"
+    rules_file = output_root / "model" / "regulations" / "435" / "555.yaml"
+    rules_file.parent.mkdir(parents=True)
+    original = f"""format: rulespec/v1
+rules:
+- name: presidential_emergency_or_disaster_short_term_hardship_event
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/555
+          excerpt: {protected_excerpt!r}
+  versions:
+  - effective_from: '0001-01-01'
+    formula: individual_resides_in_presidential_emergency_area
+"""
+    rules_file.write_text(original)
+    monkeypatch.setattr(
+        "axiom_encode.cli._local_source_text_for_corpus_path",
+        lambda citation_path, *, corpus_release: source_text,
+    )
+
+    repaired = _try_repair_generated_nonexact_proof_excerpts_for_apply(
+        SimpleNamespace(output_file=str(rules_file)),
+        output_root=output_root,
+        corpus_release=SimpleNamespace(name="test-release"),
+        issues=[
+            "Proof source evidence not found: rule "
+            "`presidential_emergency_or_disaster_short_term_hardship_event` "
+            "proof atom 0 `source.excerpt` does not appear in "
+            "`us/regulation/42/435/555`."
+        ],
+        protected_review_excerpts={protected_excerpt},
+    )
+
+    assert repaired == []
+    assert rules_file.read_text() == original
+
+
 def test_repair_generated_nonexact_proof_excerpt_uses_child_citation(
     tmp_path, monkeypatch
 ):
@@ -10526,6 +10738,9 @@ class TestCmdEncode:
         Path(result.context_manifest_file).write_text(
             json.dumps({"source_text_file": source.name}) + "\n"
         )
+        result.context_manifest_sha256 = hashlib.sha256(
+            Path(result.context_manifest_file).read_bytes()
+        ).hexdigest()
 
     def _bind_apply_source_release(
         self,
@@ -17823,6 +18038,23 @@ rules:
         args.apply = True
         result = self._make_eval_result(False)
         result.error = "Generated RuleSpec failed CI validation"
+        protected_excerpt = "Preserve this exact review phrase"
+        context_manifest = Path(result.context_manifest_file)
+        context_payload = json.loads(context_manifest.read_text())
+        findings_content = f'Use exact "{protected_excerpt}".\n'
+        context_payload["review_findings_files"] = [
+            {
+                "content": findings_content,
+                "sha256": hashlib.sha256(findings_content.encode()).hexdigest(),
+            }
+        ]
+        context_manifest.write_text(json.dumps(context_payload))
+        result.context_manifest_sha256 = hashlib.sha256(
+            context_manifest.read_bytes()
+        ).hexdigest()
+        findings_path = tmp_path / "review-findings.md"
+        findings_path.write_text(findings_content)
+        args.review_findings = [findings_path]
         output_file = (
             tmp_path / "out" / "codex-test-model" / "policies" / "benefit.yaml"
         )
@@ -17884,6 +18116,10 @@ rules:
                 ],
             ) as mock_overlay,
             patch(
+                "axiom_encode.cli._try_repair_generated_nonexact_proof_excerpts_for_apply",
+                wraps=_try_repair_generated_nonexact_proof_excerpts_for_apply,
+            ) as mock_excerpt_repair,
+            patch(
                 "axiom_encode.cli._apply_generated_encoding_result",
                 return_value=[applied_file],
             ) as mock_apply,
@@ -17894,6 +18130,11 @@ rules:
 
         assert exc_info.value.code == 0
         assert mock_overlay.call_count == 3
+        assert mock_excerpt_repair.call_count == 2
+        assert all(
+            call.kwargs["protected_review_excerpts"] == {protected_excerpt}
+            for call in mock_excerpt_repair.call_args_list
+        )
         mock_apply.assert_called_once()
         run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
         assert run.outcome["auto_repaired_nonexact_proof_excerpts"] == [

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1343"
+version = "0.2.1344"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- preserve exact quoted proof excerpts from mandatory review findings during deterministic proof repair
- source protected excerpts from the bounded, SHA-256-bound eval context snapshot instead of rereading caller paths
- fail closed when a protected quote has no exact whitespace-normalized source span while retaining ordinary repair behavior
- support multiline review quotes and the evaluator's 32 MiB manifest contract

## Review cycle
Independent review was requested before PR creation. The first pass found unsafe pre-validation path reads and missing multiline support; both were fixed. The second pass found missing outer manifest-digest binding and a mismatched size limit; both were fixed. The final pass reported no actionable findings.

## Checks
- `uv run --python 3.13 ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `PYTHONPATH="$PWD/src" /private/tmp/axiom-encode-dependent-baseline-0723/.venv/bin/python -m pytest -q` (`4790 passed, 119 skipped`)
- focused review-protection and failed-overlay integration tests (`8 passed`)
