### PR TITLE
Rotate reviewed federal RuleSpec head

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1344"
+version = "0.2.1345"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -19,7 +19,7 @@ REVIEWED_RULESPEC_REFS = frozenset(
     {
         (
             "us",
-            "670e6d6642c70168a4ecfcd7ccfc47c3e7cf51c3",
+            "08f7d595d7d4b9ed8565eb90b1e19308fd7aecdd",
         ),
         (
             "ca",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1344"
+__version__ = "0.2.1345"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -207,7 +207,7 @@ def test_validate_rulespec_base_accepts_main_ancestor(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     ("country", "reviewed_ref"),
     [
-        ("us", "670e6d6642c70168a4ecfcd7ccfc47c3e7cf51c3"),
+        ("us", "08f7d595d7d4b9ed8565eb90b1e19308fd7aecdd"),
         ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
     ],
 )
@@ -220,7 +220,7 @@ def test_validate_rulespec_base_accepts_exact_reviewed_head_artifact_only(
     repo = tmp_path / f"rulespec-{country}"
     assert REVIEWED_RULESPEC_REFS == frozenset(
         {
-            ("us", "670e6d6642c70168a4ecfcd7ccfc47c3e7cf51c3"),
+            ("us", "08f7d595d7d4b9ed8565eb90b1e19308fd7aecdd"),
             ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
         }
     )
@@ -247,6 +247,7 @@ def test_validate_rulespec_base_accepts_exact_reviewed_head_artifact_only(
     [
         "991f5375b92dffca57b08069093c24a463365cbc",
         "10f7a16ef4a40cf1e26d6273e1aff9ebb79d002f",
+        "670e6d6642c70168a4ecfcd7ccfc47c3e7cf51c3",
     ],
 )
 def test_validate_rulespec_base_rejects_retired_reviewed_head(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1344"
+version = "0.2.1345"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- rotate the artifact-only reviewed US RuleSpec head from `670e6d66` to merged hard-cut commit `08f7d595`
- explicitly reject the retired `670e6d66` head
- bump axiom-encode to `0.2.1345`

This remains fail-closed: reviewed-head runs cannot open RuleSpec PRs, and only the exact country/SHA pair is admitted.

## Review cycle
- independent read-only review found no actionable regression
- verified the allowlist, retirement coverage, and all version declarations are synchronized

## Checks
- focused: `19 passed`
- full suite after commit: `4791 passed, 119 skipped`
- full ruff: passed
- compileall: passed
- `git diff --check`: passed