### PR TITLE
Rotate reviewed federal RuleSpec pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1345"
+version = "0.2.1346"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -19,7 +19,7 @@ REVIEWED_RULESPEC_REFS = frozenset(
     {
         (
             "us",
-            "08f7d595d7d4b9ed8565eb90b1e19308fd7aecdd",
+            "eb43611e4fdc2d3bdd93f123a2ee5e0b97b2fed0",
         ),
         (
             "ca",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1345"
+__version__ = "0.2.1346"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -207,7 +207,7 @@ def test_validate_rulespec_base_accepts_main_ancestor(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     ("country", "reviewed_ref"),
     [
-        ("us", "08f7d595d7d4b9ed8565eb90b1e19308fd7aecdd"),
+        ("us", "eb43611e4fdc2d3bdd93f123a2ee5e0b97b2fed0"),
         ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
     ],
 )
@@ -220,7 +220,7 @@ def test_validate_rulespec_base_accepts_exact_reviewed_head_artifact_only(
     repo = tmp_path / f"rulespec-{country}"
     assert REVIEWED_RULESPEC_REFS == frozenset(
         {
-            ("us", "08f7d595d7d4b9ed8565eb90b1e19308fd7aecdd"),
+            ("us", "eb43611e4fdc2d3bdd93f123a2ee5e0b97b2fed0"),
             ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
         }
     )
@@ -248,6 +248,7 @@ def test_validate_rulespec_base_accepts_exact_reviewed_head_artifact_only(
         "991f5375b92dffca57b08069093c24a463365cbc",
         "10f7a16ef4a40cf1e26d6273e1aff9ebb79d002f",
         "670e6d6642c70168a4ecfcd7ccfc47c3e7cf51c3",
+        "08f7d595d7d4b9ed8565eb90b1e19308fd7aecdd",
     ],
 )
 def test_validate_rulespec_base_rejects_retired_reviewed_head(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1345"
+version = "0.2.1346"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- rotate the artifact-only reviewed US RuleSpec head from `08f7d595` to merged hard-cut commit `eb43611e`
- explicitly reject the retired `08f7d595` head
- bump axiom-encode to `0.2.1346`

This remains fail-closed: reviewed-head runs cannot open RuleSpec PRs, and only the exact country/SHA pair is admitted.

## Review cycle
- independent read-only review on `83e46146` found no actionable findings
- verified exact fail-closed admission, retirement coverage, merged RuleSpec identity/content tree, and synchronized version declarations

## Checks
- focused provenance and signing/backfill checks: `33 passed, 51 skipped`
- full suite after commit: `4792 passed, 119 skipped`
- full Ruff: passed
- compileall: passed
- `git diff --check`: passed