### PR TITLE
Gate the signed-apply battery across all jurisdiction roots (#1243)

### DIFF
--- a/.github/workflows/signed-apply-reusable.yml
+++ b/.github/workflows/signed-apply-reusable.yml
@@ -348,11 +348,9 @@ jobs:
               --trusted-python-package-root "/opt/axiom-verification/python/lib/$pyseg/site-packages/axiom_encode" \
               -- /opt/axiom-verification/axiom-encode "$@"
           }
-          jur="$(cd "$genroot" && ls -d */ | grep -vE '^(tests|data|bulk|docs)/' | grep -E '^[a-z]{2}(-[a-z0-9-]+)*/' | head -1 | tr -d '/')"
-
           # validate AND proof-validate were both hard-cut to explicit RuleSpec
           # file paths (the --root tree form was removed in the named-corpus
-          # cut). Select atomic RuleSpec modules under the jurisdiction's
+          # cut). Select atomic RuleSpec modules under every jurisdiction's
           # canonical content roots (statutes/ regulations/ policies/
           # legislation/), excluding *.test.* and composition specs under
           # programs/, and skip ACTIVE validation waivers. Both gates take the
@@ -364,9 +362,16 @@ jobs:
 
           (
             cd "$genroot"
-            find "$jur" -type f \( -name "*.yaml" -o -name "*.yml" \) \
-              ! -name "*.test.yaml" ! -name "*.test.yml" \
-              ! -path "*/programs/*" -print0
+            while IFS= read -r jur; do
+              find "$jur" -type f \( -name "*.yaml" -o -name "*.yml" \) \
+                ! -name "*.test.yaml" ! -name "*.test.yml" \
+                ! -path "*/programs/*" -print0
+            done < <(
+              ls -d */ |
+                grep -vE '^(tests|data|bulk|docs)/' |
+                grep -E '^[a-z]{2}(-[a-z0-9-]+)*/' |
+                tr -d '/'
+            )
           ) > "$gate_tmp/candidates"
 
           # Only consult waivers when the file exists: the CLI's waiver loader


### PR DESCRIPTION
Fixes #1243.

**Mechanism (verified from run rulespec-tz 30009956871 + repo state):** the gate battery picked ONE jurisdiction root via `ls -d */ | … | head -1`. rulespec-tz has two matching roots and `tz-znz/` sorts before `tz/` (`-` < `/`), so the battery scanned the tz#25 federation scaffold (only `.gitkeep` files) and hard-errored on zero candidates — while the freshly applied and signed `tz/statutes/cap-148` module (`outcome=apply_applied final_success=True`) was never gated. The quiet variant is worse: a populated `tz-znz/` would gate only Zanzibar modules and pass the applied `tz/` module to `open_pr` ungated.

**Change (least-diff, this one step only):** replace the first-root pick with a per-root union — same root filter (excludes `tests/data/bulk/docs`, same jurisdiction-shape regex), same find (primary `*.yaml/*.yml`, no `*.test.*`, no `*/programs/*`), same canonical-subdir case filter, waiver filtering byte-identical (`active-paths` emits repo-relative paths incl. the jurisdiction prefix — cli.py:985/3357, validation_waivers.py:207 — matching the candidates' relpaths). The zero-unwaived fail-closed tripwire is retained; an empty jurisdiction list degrades to that same hard error (a failing process substitution feeds the loop nothing).

**Verification:** `bash -n` + ShellCheck on the extracted step, `actionlint -shellcheck ''` on the workflow, and dry-runs against two fixture trees — the exact tz failure layout (scaffold + applied module → selects `tz/statutes/cap-148/value-added-tax-act.yaml`) and a multi-root populated case (unions both roots, excludes tests/programs) — reproduced independently by the reviewer.

**Follow-up worth considering (not in this diff):** assert the applied files are members of the gated spec set, which requires plumbing the apply outcome's file list into this step.

Implemented by gpt-5.6-sol (codex), reviewed line-by-line + independently dry-run by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)