### PR TITLE
Repair complete conditional proof excerpts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1346"
+version = "0.2.1347"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1346"
+__version__ = "0.2.1347"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -28870,7 +28870,11 @@ def _closest_exact_source_excerpt(*, source_text: str, excerpt: str) -> str | No
     )[1]
     if selected.kind == "table_row":
         return selected.text
-    return _governing_source_excerpt_candidate([selected], candidates)
+    return _governing_source_excerpt_candidate(
+        [selected],
+        candidates,
+        allow_complete_conditional_fallback=True,
+    )
 
 
 def _safe_wrapped_direct_source_match(
@@ -29079,6 +29083,8 @@ def _safe_wrapped_direct_source_match(
 def _governing_source_excerpt_candidate(
     selected: list[_SourceExcerptCandidate],
     candidates: list[_SourceExcerptCandidate],
+    *,
+    allow_complete_conditional_fallback: bool = False,
 ) -> str | None:
     marked_parent = next(
         (candidate.marked_parent for candidate in selected if candidate.marked_parent),
@@ -29094,7 +29100,42 @@ def _governing_source_excerpt_candidate(
             ),
             None,
         )
-        return governing.text if governing is not None else None
+        if governing is not None:
+            return governing.text
+        complete_condition = min(
+            selected,
+            key=lambda candidate: len(re.sub(r"\s+", " ", candidate.text)),
+        )
+        preceding_sentences = [
+            candidate
+            for candidate in candidates
+            if candidate.kind == "sentence"
+            and candidate.marked_parent == marked_parent
+            and candidate.end <= complete_condition.start
+        ]
+        heading_match = (
+            _source_paragraph_marker_match(
+                re.sub(r"\s+", " ", preceding_sentences[0].text).strip()
+            )
+            if len(preceding_sentences) == 1
+            and preceding_sentences[0].start == marked_parent[0]
+            else None
+        )
+        if (
+            allow_complete_conditional_fallback
+            and complete_condition.kind == "sentence"
+            and _SOURCE_PRIOR_CONDITION_PATTERN.search(complete_condition.text)
+            is not None
+            and heading_match is not None
+            and re.match(
+                r"requirements?\s+to\b",
+                heading_match.group("body"),
+                flags=re.IGNORECASE,
+            )
+            is not None
+        ):
+            return complete_condition.text
+        return None
     return min(
         selected,
         key=lambda candidate: len(re.sub(r"\s+", " ", candidate.text)),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9669,6 +9669,52 @@ rules:
     assert not validation.passed
 
 
+def test_closest_exact_source_excerpt_uses_complete_condition_from_long_paragraph():
+    expected = (
+        "If the agency has sufficient information to verify an individual meets "
+        "or is deemed to meet the community engagement requirement and has "
+        "information that suggests, but needs more information to verify that the "
+        "individual is a specified excluded individual, the agency must enroll the "
+        "individual promptly using the verified information and attempt to verify "
+        "eligibility for the exclusion post-enrollment or, if the individual is "
+        "already enrolled, following the redetermination of eligibility."
+    )
+    source_text = (
+        "(3) Requirement to enroll eligible individuals and verify potential "
+        "exclusion post-enrollment. " + expected
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=(
+            "If compliance is verified but exclusion needs more information, "
+            "enroll promptly and verify the exclusion after enrollment."
+        ),
+    )
+
+    assert len(source_text) > 500
+    assert repaired == expected
+
+
+def test_closest_exact_source_excerpt_rejects_later_condition_after_substantive_rule():
+    source_text = (
+        "(3) Eligibility is limited to State residents. "
+        + ("Administrative background applies. " * 14)
+        + "If the household submits a timely request, the agency must issue the "
+        "benefit."
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=(
+            "A timely household request requires the agency to issue the benefit."
+        ),
+    )
+
+    assert len(source_text) > 500
+    assert repaired is None
+
+
 def test_repair_generated_wrapped_proof_excerpt_in_over_limit_paragraph(
     tmp_path, monkeypatch
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1346"
+version = "0.2.1347"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- recover an exact, complete conditional sentence from an oversized marked source paragraph when its only preceding sentence is a `Requirement(s) to ...` paragraph heading
- keep direct matching and paragraphs with substantive preceding rules fail-closed
- add positive CMS §435.557-shaped coverage and a negative omitted-condition regression
- bump `axiom-encode` to `0.2.1347`

## Why

Protected targeted re-encode run `30076968676` compiled all three §435.557 candidates but correctly failed proof excerpt validation. The operative §435.557(c)(3) conditional sentence is exact and under the proof limit, while its marked parent exceeds the limit. The prior governing-source selection rejected that structure rather than selecting the complete conditional sentence.

## Review cycle

1. Independent review found one HIGH issue: the initial fallback could omit a substantive preceding sentence in the same marked paragraph.
2. The fallback was narrowed to require exactly one paragraph-start sentence with a marker and a `Requirement(s) to ...` heading body; a negative regression test was added.
3. Focused checks and the full suite were rerun.
4. Repeat independent review of the substantive diff at commit `6a852015c9284ee25f303bb7b0fbb04bb72057e4` found no actionable findings and confirmed the original counterexample fails closed.
5. A format-only amendment produced head `ac9b1db5`; `ruff check`, `ruff format --check`, and 222 focused matcher tests pass on that head. No behavior changed after review.

## Checks

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- focused proof-excerpt matcher suite before review: `225 passed, 792 deselected`
- full suite before format-only amendment: `4794 passed, 119 skipped`
- post-format amendment matcher suite: `222 passed, 795 deselected`
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- exact corrected-corpus reproduction: repaired excerpt is literal source text and within the proof limit
