### PR TITLE
Bump oracle pin for state income-tax mappings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@9901e2479ac39bba865b8232e1c7d879ba447d8d",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@325a12e5f1801f70bd99c75fe3e9b39b74f8dfd3",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1347"
+version = "0.2.1348"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1347"
+__version__ = "0.2.1348"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=9901e2479ac39bba865b8232e1c7d879ba447d8d" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=325a12e5f1801f70bd99c75fe3e9b39b74f8dfd3" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=9901e2479ac39bba865b8232e1c7d879ba447d8d#9901e2479ac39bba865b8232e1c7d879ba447d8d" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=325a12e5f1801f70bd99c75fe3e9b39b74f8dfd3#325a12e5f1801f70bd99c75fe3e9b39b74f8dfd3" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1347"
+version = "0.2.1348"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- update the pinned `axiom-oracles` revision to merged oracle main `325a12e5f1801f70bd99c75fe3e9b39b74f8dfd3`
- refresh the exact git source in `uv.lock`
- expose the merged DC (14), Arizona (16), Alabama (15), and Arkansas (13) state income-tax mappings to RuleSpec changed-file oracle coverage

This unblocks the bounded 2026 resident income-tax RuleSpec lanes. It does not change Axiom Encode runtime logic.

## Validation
- `uv run --python 3.13 ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run --python 3.13 python -m compileall -q src/axiom_encode scripts`
- `uv run --python 3.13 python -m pytest -q tests/test_policyengine_coverage.py tests/test_oracle_coverage_pending.py tests/test_policyengine_classifier.py` (459 passed)
- `uv run --python 3.13 python -m pytest -q` (4,794 passed, 119 skipped)

## Review cycle
Independent review requested at exact head `7fe70133`; outcome will be recorded before merge.