### PR TITLE
Rotate reviewed RuleSpec SNAP corpus head

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1348"
+version = "0.2.1349"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -19,7 +19,7 @@ REVIEWED_RULESPEC_REFS = frozenset(
     {
         (
             "us",
-            "eb43611e4fdc2d3bdd93f123a2ee5e0b97b2fed0",
+            "8f224620540f9e285428ec839d094835396f7d99",
         ),
         (
             "ca",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1348"
+__version__ = "0.2.1349"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -207,7 +207,7 @@ def test_validate_rulespec_base_accepts_main_ancestor(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     ("country", "reviewed_ref"),
     [
-        ("us", "eb43611e4fdc2d3bdd93f123a2ee5e0b97b2fed0"),
+        ("us", "8f224620540f9e285428ec839d094835396f7d99"),
         ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
     ],
 )
@@ -220,7 +220,7 @@ def test_validate_rulespec_base_accepts_exact_reviewed_head_artifact_only(
     repo = tmp_path / f"rulespec-{country}"
     assert REVIEWED_RULESPEC_REFS == frozenset(
         {
-            ("us", "eb43611e4fdc2d3bdd93f123a2ee5e0b97b2fed0"),
+            ("us", "8f224620540f9e285428ec839d094835396f7d99"),
             ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
         }
     )
@@ -249,6 +249,7 @@ def test_validate_rulespec_base_accepts_exact_reviewed_head_artifact_only(
         "10f7a16ef4a40cf1e26d6273e1aff9ebb79d002f",
         "670e6d6642c70168a4ecfcd7ccfc47c3e7cf51c3",
         "08f7d595d7d4b9ed8565eb90b1e19308fd7aecdd",
+        "eb43611e4fdc2d3bdd93f123a2ee5e0b97b2fed0",
     ],
 )
 def test_validate_rulespec_base_rejects_retired_reviewed_head(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1348"
+version = "0.2.1349"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- rotate the artifact-only reviewed US RuleSpec head to the merged protected SNAP/CMS/PIT corpus pin (`8f224620`)
- explicitly retire the prior `eb43611e` reviewed head
- bump axiom-encode to `0.2.1349`

The bridge remains fail-closed: reviewed-head runs are artifact-only, cannot open RuleSpec PRs, and only the exact country/SHA pair is admitted.

## Review cycle
- independent read-only review found no actionable findings
- reviewer independently verified PR #1051, the protected branch head and merge parent, retirement coverage, artifact-only enforcement, synchronized version declarations, and lock integrity

## Checks
- focused signed-backfill/signing checks: `28 passed, 56 deselected`
- full suite after commit: `4795 passed, 119 skipped`
- full Ruff: passed
- compileall: passed
- `uv lock --check`: passed in independent review
- `git diff --check`: passed