### PR TITLE
Allow signed PRs on reviewed protected RuleSpec head

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -13,8 +13,13 @@ on:
         default: us
         type: string
       rulespec_ref:
-        description: Immutable main SHA, or an allowlisted reviewed SHA for artifact-only runs
+        description: Immutable main SHA, or allowlisted reviewed SHA (artifact-only unless its approved PR base is exact)
         required: true
+        type: string
+      pr_base_branch:
+        description: Exact RuleSpec branch targeted when open_pr is true
+        required: false
+        default: main
         type: string
       corpus_ref:
         description: Immutable axiom-corpus commit SHA
@@ -107,6 +112,7 @@ jobs:
           RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
           RULESPEC_REF: ${{ inputs.rulespec_ref }}
           OPEN_PR: ${{ inputs.open_pr }}
+          PR_BASE_BRANCH: ${{ inputs.pr_base_branch }}
           CORPUS_REF: ${{ inputs.corpus_ref }}
           RULES_ENGINE_REF: ${{ inputs.rules_engine_ref }}
         run: |
@@ -138,7 +144,7 @@ jobs:
             "https://github.com/TheAxiomFoundation/rulespec-$COUNTRY"
           python axiom-encode/scripts/prepare_signed_backfill.py \
             validate-rulespec-base "$RULESPEC_CHECKOUT" "$COUNTRY" \
-            "$RULESPEC_REF" "$OPEN_PR"
+            "$RULESPEC_REF" "$OPEN_PR" "$PR_BASE_BRANCH"
           git -C axiom-corpus merge-base --is-ancestor HEAD refs/remotes/origin/main
           git -C axiom-rules-engine merge-base --is-ancestor HEAD refs/remotes/origin/main
 
@@ -425,6 +431,7 @@ jobs:
           CITATION: ${{ inputs.citation }}
           DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
           DEPENDENT_REVIEW_FINDING_PRESENT: ${{ inputs.dependent_review_finding != '' }}
+          PR_BASE_BRANCH: ${{ inputs.pr_base_branch }}
           REVIEW_FINDING_PRESENT: ${{ inputs.review_finding != '' }}
           RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
         run: |
@@ -566,6 +573,7 @@ jobs:
               "schema": "axiom-encode/targeted-reencode-artifact/v1",
               "citation": os.environ["CITATION"],
               "dependent_citation": os.environ.get("DEPENDENT_CITATION") or None,
+              "pr_base_branch": os.environ["PR_BASE_BRANCH"],
               "rulespec_base": rev(os.environ["RULESPEC_CHECKOUT"]),
               "encoder_commit": rev("axiom-encode"),
               "corpus_commit": rev("axiom-corpus"),
@@ -604,11 +612,16 @@ jobs:
           COUNTRY: ${{ inputs.country }}
           CITATION: ${{ inputs.citation }}
           RULESPEC_REF: ${{ inputs.rulespec_ref }}
+          PR_BASE_BRANCH: ${{ inputs.pr_base_branch }}
           RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
         run: |
           set -euo pipefail
           test -n "$GH_TOKEN"
           repo="TheAxiomFoundation/rulespec-${COUNTRY}"
+          git -C "$RULESPEC_CHECKOUT" fetch --no-tags origin \
+            "+refs/heads/${PR_BASE_BRANCH}:refs/remotes/origin/${PR_BASE_BRANCH}"
+          test "$(git -C "$RULESPEC_CHECKOUT" rev-parse \
+            "refs/remotes/origin/${PR_BASE_BRANCH}")" = "$RULESPEC_REF"
           branch="$(python axiom-encode/scripts/prepare_signed_backfill.py branch-name \
             "$COUNTRY" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT")"
           body="$(printf '%s\n' \
@@ -616,6 +629,7 @@ jobs:
             '' \
             "Citation: \`${CITATION}\`" \
             "Base commit: \`${RULESPEC_REF}\`" \
+            "Base branch: \`${PR_BASE_BRANCH}\`" \
             "Axiom Encode run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
             '' \
             'This draft PR was produced by the protected country-general signed-apply workflow. Review all RuleSpec and manifest changes before marking it ready.')"
@@ -625,9 +639,27 @@ jobs:
           gh api --method POST "repos/${repo}/pulls" \
             -f title="Add signed encoding manifest for ${CITATION}" \
             -f head="TheAxiomFoundation:${branch}" \
-            -f base=main \
+            -f base="$PR_BASE_BRANCH" \
             -f body="$body" \
             -F draft=true > "$RUNNER_TEMP/lane-pull-request.json"
+          if ! jq -e \
+            --arg branch "$PR_BASE_BRANCH" \
+            --arg sha "$RULESPEC_REF" \
+            '.base.ref == $branch and .base.sha == $sha' \
+            "$RUNNER_TEMP/lane-pull-request.json" > /dev/null; then
+            pr_number="$(jq -r '.number // empty' \
+              "$RUNNER_TEMP/lane-pull-request.json")"
+            if test -n "$pr_number"; then
+              gh api --method PATCH "repos/${repo}/pulls/${pr_number}" \
+                -f state=closed || echo "warning: failed to close stale-base PR" >&2
+            fi
+            git -C "$RULESPEC_CHECKOUT" push \
+              "https://github.com/${repo}.git" \
+              ":refs/heads/${branch}" ||
+              echo "warning: failed to delete stale-base lane branch" >&2
+            echo "created pull request does not target the reviewed base SHA" >&2
+            exit 1
+          fi
           cp "$RUNNER_TEMP/lane-pull-request.json" \
             "$RUNNER_TEMP/targeted-reencode/lane-pull-request.json"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1349"
+version = "0.2.1350"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -27,6 +27,11 @@ REVIEWED_RULESPEC_REFS = frozenset(
         ),
     }
 )
+REVIEWED_RULESPEC_PR_BASE_BRANCHES = frozenset(
+    {
+        ("us", "hard-cut/canonical-layout-us"),
+    }
+)
 
 
 def validate_country(value: str) -> str:
@@ -48,8 +53,9 @@ def validate_rulespec_base(
     requested_ref: str,
     *,
     open_pr: bool,
+    pr_base_branch: str = "main",
 ) -> str:
-    """Admit main ancestry or one exact independently reviewed migration head."""
+    """Admit main ancestry or an exact independently reviewed protected head."""
 
     validate_country(country)
     if COMMIT_PATTERN.fullmatch(requested_ref) is None:
@@ -73,16 +79,45 @@ def validate_rulespec_base(
         == 0
     )
     if main_ancestor:
+        if open_pr:
+            if pr_base_branch != "main":
+                raise ValueError("main-ancestor pull requests must target main")
+            _require_remote_branch_tip(repo, pr_base_branch, requested_ref)
         return "main"
     if (country, requested_ref) not in REVIEWED_RULESPEC_REFS:
         raise ValueError(
             "rulespec ref is neither on main nor an approved reviewed head"
         )
     if open_pr:
-        raise ValueError(
-            "reviewed-head runs are artifact-only and cannot open a pull request"
-        )
+        if (country, pr_base_branch) not in REVIEWED_RULESPEC_PR_BASE_BRANCHES:
+            raise ValueError(
+                "reviewed-head runs are artifact-only unless the pull request "
+                "targets an approved protected base branch"
+            )
+        _require_remote_branch_tip(repo, pr_base_branch, requested_ref)
+        return "reviewed-head-pr"
     return "reviewed-head-artifact"
+
+
+def _require_remote_branch_tip(
+    repo: Path,
+    branch: str,
+    requested_ref: str,
+) -> None:
+    try:
+        branch_ref = (
+            _git(repo, "rev-parse", f"refs/remotes/origin/{branch}")
+            .decode()
+            .strip()
+        )
+    except subprocess.CalledProcessError as exc:
+        raise ValueError(
+            f"pull request base branch is unavailable: {branch}"
+        ) from exc
+    if branch_ref != requested_ref:
+        raise ValueError(
+            "rulespec ref is not the exact pull request base branch tip"
+        )
 
 
 def _citation_rulespec_path(citation: str) -> tuple[str, PurePosixPath]:
@@ -313,6 +348,7 @@ def main() -> None:
     base_parser.add_argument("country")
     base_parser.add_argument("requested_ref")
     base_parser.add_argument("open_pr", choices=("true", "false"))
+    base_parser.add_argument("pr_base_branch", nargs="?", default="main")
     stage_parser = subparsers.add_parser("stage")
     stage_parser.add_argument("repo", type=Path)
     cascade_parser = subparsers.add_parser("validate-dependent-cascade")
@@ -332,6 +368,7 @@ def main() -> None:
                     args.country,
                     args.requested_ref,
                     open_pr=args.open_pr == "true",
+                    pr_base_branch=args.pr_base_branch,
                 )
             )
         elif args.command == "validate-dependent-cascade":

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1349"
+__version__ = "0.2.1350"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from scripts.prepare_signed_backfill import (
+    REVIEWED_RULESPEC_PR_BASE_BRANCHES,
     REVIEWED_RULESPEC_REFS,
     branch_name,
     stage_authorized_changes,
@@ -204,6 +205,43 @@ def test_validate_rulespec_base_accepts_main_ancestor(tmp_path: Path) -> None:
     assert validate_rulespec_base(repo, "us", base, open_pr=True) == "main"
 
 
+def test_validate_rulespec_base_rejects_non_main_pr_for_main_ancestor(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    base = _add_origin_main(repo)
+
+    with pytest.raises(ValueError, match="must target main"):
+        validate_rulespec_base(
+            repo,
+            "us",
+            base,
+            open_pr=True,
+            pr_base_branch="hard-cut/canonical-layout-us",
+        )
+
+
+def test_validate_rulespec_base_rejects_stale_main_pr_base(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    stale_base = _add_origin_main(repo)
+    (repo / "README.md").write_text("advanced\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "advance main")
+    advanced_base = _git(repo, "rev-parse", "HEAD")
+    _git(
+        repo,
+        "update-ref",
+        "refs/remotes/origin/main",
+        advanced_base,
+    )
+    _git(repo, "checkout", "--detach", stale_base)
+
+    with pytest.raises(ValueError, match="exact pull request base branch tip"):
+        validate_rulespec_base(repo, "us", stale_base, open_pr=True)
+
+
 @pytest.mark.parametrize(
     ("country", "reviewed_ref"),
     [
@@ -224,6 +262,9 @@ def test_validate_rulespec_base_accepts_exact_reviewed_head_artifact_only(
             ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
         }
     )
+    assert REVIEWED_RULESPEC_PR_BASE_BRANCHES == frozenset(
+        {("us", "hard-cut/canonical-layout-us")}
+    )
     monkeypatch.setattr(
         "scripts.prepare_signed_backfill._git",
         lambda _repo, *_args: f"{reviewed_ref}\n".encode(),
@@ -240,6 +281,93 @@ def test_validate_rulespec_base_accepts_exact_reviewed_head_artifact_only(
 
     with pytest.raises(ValueError, match="artifact-only"):
         validate_rulespec_base(repo, country, reviewed_ref, open_pr=True)
+
+
+def test_validate_rulespec_base_accepts_exact_reviewed_protected_branch_tip(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "rulespec-us"
+    reviewed_ref = "8f224620540f9e285428ec839d094835396f7d99"
+    git_calls: list[tuple[str, ...]] = []
+
+    def fake_git(_repo: Path, *args: str) -> bytes:
+        git_calls.append(args)
+        return f"{reviewed_ref}\n".encode()
+
+    monkeypatch.setattr("scripts.prepare_signed_backfill._git", fake_git)
+    monkeypatch.setattr(
+        "scripts.prepare_signed_backfill.subprocess.run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 1),
+    )
+
+    assert (
+        validate_rulespec_base(
+            repo,
+            "us",
+            reviewed_ref,
+            open_pr=True,
+            pr_base_branch="hard-cut/canonical-layout-us",
+        )
+        == "reviewed-head-pr"
+    )
+    assert (
+        "rev-parse",
+        "refs/remotes/origin/hard-cut/canonical-layout-us",
+    ) in git_calls
+
+
+def test_validate_rulespec_base_rejects_stale_reviewed_protected_branch_tip(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "rulespec-us"
+    reviewed_ref = "8f224620540f9e285428ec839d094835396f7d99"
+
+    def fake_git(_repo: Path, *args: str) -> bytes:
+        if args[-1] == "refs/remotes/origin/hard-cut/canonical-layout-us":
+            return f"{'f' * 40}\n".encode()
+        return f"{reviewed_ref}\n".encode()
+
+    monkeypatch.setattr("scripts.prepare_signed_backfill._git", fake_git)
+    monkeypatch.setattr(
+        "scripts.prepare_signed_backfill.subprocess.run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 1),
+    )
+
+    with pytest.raises(ValueError, match="exact pull request base branch tip"):
+        validate_rulespec_base(
+            repo,
+            "us",
+            reviewed_ref,
+            open_pr=True,
+            pr_base_branch="hard-cut/canonical-layout-us",
+        )
+
+
+def test_validate_rulespec_base_rejects_unapproved_reviewed_pr_branch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "rulespec-us"
+    reviewed_ref = "8f224620540f9e285428ec839d094835396f7d99"
+    monkeypatch.setattr(
+        "scripts.prepare_signed_backfill._git",
+        lambda _repo, *_args: f"{reviewed_ref}\n".encode(),
+    )
+    monkeypatch.setattr(
+        "scripts.prepare_signed_backfill.subprocess.run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 1),
+    )
+
+    with pytest.raises(ValueError, match="artifact-only"):
+        validate_rulespec_base(
+            repo,
+            "us",
+            reviewed_ref,
+            open_pr=True,
+            pr_base_branch="migration/other",
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1832,6 +1832,8 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     }
     assert inputs["open_pr"]["type"] == "boolean"
     assert inputs["open_pr"]["default"] is False
+    assert inputs["pr_base_branch"]["type"] == "string"
+    assert inputs["pr_base_branch"]["default"] == "main"
     assert inputs["dependent_citation"]["required"] is False
     assert inputs["dependent_review_finding"]["required"] is False
 
@@ -1866,8 +1868,11 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "rev-parse HEAD" in identity_command
     assert "merge-base --is-ancestor" in identity_command
     assert "validate-rulespec-base" in identity_command
-    assert '"$RULESPEC_REF" "$OPEN_PR"' in identity_command
+    assert '"$RULESPEC_REF" "$OPEN_PR" "$PR_BASE_BRANCH"' in identity_command
     assert identity_step["env"]["OPEN_PR"] == "${{ inputs.open_pr }}"
+    assert identity_step["env"]["PR_BASE_BRANCH"] == (
+        "${{ inputs.pr_base_branch }}"
+    )
     assert '"https://github.com/TheAxiomFoundation/rulespec-$COUNTRY"' in (
         identity_command
     )
@@ -1985,6 +1990,9 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert package_step["env"]["DEPENDENT_REVIEW_FINDING_PRESENT"] == (
         "${{ inputs.dependent_review_finding != '' }}"
     )
+    assert package_step["env"]["PR_BASE_BRANCH"] == (
+        "${{ inputs.pr_base_branch }}"
+    )
     assert '"$artifact/context-manifest.json"' in package_command
     assert '".axiom/encoding-manifests"' in package_command
     assert 'citation = payload.get("citation")' in package_command
@@ -1993,6 +2001,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert 'finding.get("content")' in package_command
     assert 'finding.get("sha256")' in package_command
     assert '"dependent-context-manifest.json"' in package_command
+    assert '"pr_base_branch": os.environ["PR_BASE_BRANCH"]' in package_command
 
     guard_step = next(
         step for step in steps if step.get("name") == "Verify generated provenance"
@@ -2014,15 +2023,28 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     )
     assert publish_step["if"] == "${{ inputs.open_pr }}"
     assert publish_step["env"]["GH_TOKEN"] == "${{ secrets.AXIOM_REPO_TOKEN }}"
+    assert publish_step["env"]["PR_BASE_BRANCH"] == (
+        "${{ inputs.pr_base_branch }}"
+    )
     assert "AXIOM_ENCODE_APPLY_SIGNING_KEY" not in publish_step["env"]
     publish_command = publish_step["run"]
     assert 'repo="TheAxiomFoundation/rulespec-${COUNTRY}"' in publish_command
     assert '"$COUNTRY" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT"' in publish_command
     assert "core.hooksPath=/dev/null" in publish_command
+    assert 'fetch --no-tags origin \\\n' in publish_command
+    assert "refs/remotes/origin/${PR_BASE_BRANCH}" in publish_command
+    assert '" = "$RULESPEC_REF"' in publish_command
     assert '"HEAD:refs/heads/${branch}"' in publish_command
     assert "gh api --method POST" in publish_command
-    assert "-f base=main" in publish_command
+    assert '-f base="$PR_BASE_BRANCH"' in publish_command
     assert "-F draft=true" in publish_command
+    assert "'.base.ref == $branch and .base.sha == $sha'" in publish_command
+    assert 'pulls/${pr_number}' in publish_command
+    assert "-f state=closed" in publish_command
+    assert '":refs/heads/${branch}"' in publish_command
+    assert "created pull request does not target the reviewed base SHA" in (
+        publish_command
+    )
     assert "SHA256SUMS" not in publish_command
 
     checksum_step = next(

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1870,9 +1870,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "validate-rulespec-base" in identity_command
     assert '"$RULESPEC_REF" "$OPEN_PR" "$PR_BASE_BRANCH"' in identity_command
     assert identity_step["env"]["OPEN_PR"] == "${{ inputs.open_pr }}"
-    assert identity_step["env"]["PR_BASE_BRANCH"] == (
-        "${{ inputs.pr_base_branch }}"
-    )
+    assert identity_step["env"]["PR_BASE_BRANCH"] == ("${{ inputs.pr_base_branch }}")
     assert '"https://github.com/TheAxiomFoundation/rulespec-$COUNTRY"' in (
         identity_command
     )
@@ -1990,9 +1988,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert package_step["env"]["DEPENDENT_REVIEW_FINDING_PRESENT"] == (
         "${{ inputs.dependent_review_finding != '' }}"
     )
-    assert package_step["env"]["PR_BASE_BRANCH"] == (
-        "${{ inputs.pr_base_branch }}"
-    )
+    assert package_step["env"]["PR_BASE_BRANCH"] == ("${{ inputs.pr_base_branch }}")
     assert '"$artifact/context-manifest.json"' in package_command
     assert '".axiom/encoding-manifests"' in package_command
     assert 'citation = payload.get("citation")' in package_command
@@ -2023,15 +2019,13 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     )
     assert publish_step["if"] == "${{ inputs.open_pr }}"
     assert publish_step["env"]["GH_TOKEN"] == "${{ secrets.AXIOM_REPO_TOKEN }}"
-    assert publish_step["env"]["PR_BASE_BRANCH"] == (
-        "${{ inputs.pr_base_branch }}"
-    )
+    assert publish_step["env"]["PR_BASE_BRANCH"] == ("${{ inputs.pr_base_branch }}")
     assert "AXIOM_ENCODE_APPLY_SIGNING_KEY" not in publish_step["env"]
     publish_command = publish_step["run"]
     assert 'repo="TheAxiomFoundation/rulespec-${COUNTRY}"' in publish_command
     assert '"$COUNTRY" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT"' in publish_command
     assert "core.hooksPath=/dev/null" in publish_command
-    assert 'fetch --no-tags origin \\\n' in publish_command
+    assert "fetch --no-tags origin \\\n" in publish_command
     assert "refs/remotes/origin/${PR_BASE_BRANCH}" in publish_command
     assert '" = "$RULESPEC_REF"' in publish_command
     assert '"HEAD:refs/heads/${branch}"' in publish_command
@@ -2039,7 +2033,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert '-f base="$PR_BASE_BRANCH"' in publish_command
     assert "-F draft=true" in publish_command
     assert "'.base.ref == $branch and .base.sha == $sha'" in publish_command
-    assert 'pulls/${pr_number}' in publish_command
+    assert "pulls/${pr_number}" in publish_command
     assert "-f state=closed" in publish_command
     assert '":refs/heads/${branch}"' in publish_command
     assert "created pull request does not target the reviewed base SHA" in (

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1349"
+version = "0.2.1350"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- allow the targeted protected encoder workflow to open draft PRs against one exact reviewed RuleSpec protected branch
- preserve artifact-only behavior for every other reviewed-head run
- verify the remote branch before publication and GitHub’s returned base SHA/ref after PR creation
- close the draft and delete its lane branch if the protected base moved

## Trust boundary
- approved country/base: `us` / `hard-cut/canonical-layout-us`
- approved immutable head: `8f224620540f9e285428ec839d094835396f7d99`
- all refs remain exact full SHAs
- signing remains restricted to the `production-signing` environment

## Review cycle
Independent read-only security review found a PR-base race and a test realism gap. Both were fixed. A second review found no remaining actionable findings.

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest -q` (`4800 passed, 119 skipped`)

Closes no issue; prerequisite for #1257.