### PR TITLE
Add cents-per-dollar numeric extraction (companion to #1186)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1350"
+version = "0.2.1351"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1350"
+__version__ = "0.2.1351"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -793,6 +793,12 @@ GLUED_UNIT_NUMBER_PATTERN = re.compile(
     r"(?![A-Za-z0-9])",
     re.IGNORECASE,
 )
+CENTS_VALUE_NUMBER_PATTERN = re.compile(
+    r"(?<![\w.,/\-])"
+    r"(?P<number>-?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?)"
+    r"\s+cents?\b",
+    re.IGNORECASE,
+)
 EUROPEAN_DECIMAL_NUMBER_PATTERN = re.compile(
     r"(?:^|(?<=[\s$£€(\[,+\-−*/\"'`“”‘’]))"
     r"(-?(?:\d{1,3}(?:[.\u00a0\u202f]\d{3})+|\d+),(?:\d{1,2}|\d{4}))"
@@ -3726,6 +3732,18 @@ def extract_numbers_from_text(text: str) -> set[float]:
         span = match.span()
         with contextlib.suppress(ValueError):
             numbers.add(float(match.group("number").replace(",", "")))
+            occupied_spans.append(span)
+
+    for match in CENTS_VALUE_NUMBER_PATTERN.finditer(text):
+        span = match.span()
+        if _span_overlaps(span, occupied_spans):
+            continue
+        with contextlib.suppress(ValueError):
+            value = float(match.group("number").replace(",", ""))
+            # The explicit cents unit is the context guard. Keep the existing
+            # bare-number candidate and add its substantive currency fraction.
+            numbers.add(value)
+            numbers.add(value / 100)
             occupied_spans.append(span)
 
     for span, value in _iter_normalized_special_numeric_matches(text):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -7402,6 +7402,53 @@ def test_numeric_extraction_ignores_non_quantity_quarter():
     assert 0.25 not in extract_numbers_from_text("the quarter ended in March")
 
 
+def test_numeric_extraction_reads_nz_social_security_cents_per_dollar_rate():
+    source_text = (
+        "must be reduced by 50 cents for every $1 of the combined weekly income"
+    )
+    assert 0.5 in extract_numbers_from_text(source_text)
+
+
+def test_numeric_extraction_reads_nz_familyboost_cents_per_dollar_rate():
+    source_text = (
+        "Subject to subsection (3), the abatement amount is calculated at the "
+        "rate of 7 cents for each complete dollar of the person’s tax credit "
+        "income for the tax credit quarter that is greater than $35,000."
+    )
+    assert 0.07 in extract_numbers_from_text(source_text)
+
+
+@pytest.mark.parametrize(
+    ("source_text", "expected"),
+    [
+        ("1 cent", 0.01),
+        ("9.75 cents", 0.0975),
+    ],
+)
+def test_numeric_extraction_maps_integer_and_decimal_cents_values(
+    source_text, expected
+):
+    assert expected in extract_numbers_from_text(source_text)
+
+
+def test_numeric_extraction_preserves_bare_cents_value():
+    assert {0.5, 50.0} <= extract_numbers_from_text("50 cents")
+
+
+@pytest.mark.parametrize(
+    ("source_text", "excluded_values"),
+    [
+        ("MUZ-R13 cents", {0.13}),
+        ("R13.1 cents", {0.131, 0.01}),
+        ("effective 2025-07-01 cents", {0.01}),
+    ],
+)
+def test_numeric_extraction_cents_pattern_ignores_identifiers_and_dates(
+    source_text, excluded_values
+):
+    assert extract_numbers_from_text(source_text).isdisjoint(excluded_values)
+
+
 def test_numeric_extraction_handles_ghana_cedi_grouped_thousands():
     # The Ghana cedi symbol glued to a grouped-thousands amount ("GH¢5,880")
     # must still yield the full value, not just the trailing "880". Mirrors

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1350"
+version = "0.2.1351"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
Statutes state abatement rates in cents: Social Security Act 2018 sched 4 pt 6 cl 12 reduces partnered youth-payment rates "by 50 cents for every $1" of combined income, and ITA s MH 5(2) (FamilyBoost) abates "7 cents" per complete dollar of excess. `extract_numbers_from_text` reads "50 cents" as 50 and "7 cents" as 7, so rate parameters `0.50`/`0.07` fail numeric grounding against the only official texts that state them.

This adds a cents pass that emits **both** N and N/100 for "N cents" ("50 cents" → 50, 0.5; "9.75 cents" → 9.75, 0.0975) — cents are hundredths of the unit currency, so the fractional value is the substantive one for rate grounding; keeping the bare N preserves existing behavior, and additive candidates only weaken grounding strictness marginally (same tradeoff as the word-fraction pass). Identifier/date non-fire guards included.

## Motivating blocked cases
rulespec-nz#93 (youth/young parent payment income test, cl 12's 50c rate) and rulespec-nz#94 (FamilyBoost's 7c abatement — currently a caller input precisely because 0.07 can't ground; the cross-family review flagged that as delegating law to callers).

## Verification
- Full suite: 8 failed / 4885 passed locally — the 8 are the known mac-environmental TrustedGit + site-packages set, byte-identical to the baseline. Zero regressions.
- New tests ×5: both motivating sentences, integer+decimal mapping, bare-N preservation, identifier/date non-fire.
- ruff format + check clean; version triple-bumped (pyproject + `__init__` + uv.lock).

## Provenance
Author: gpt-5.6-sol via codex-run (worktree from origin/main @ 212f6671), prompt `ops/nz-lane/sol-cents-prompt.md`, report `sol-cents-report.md`. Reviewer: Claude Fable 5 — diff review + independent full-suite run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
