### PR TITLE
Bump axiom-oracles pin for the #296 engine-main bridge ports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@325a12e5f1801f70bd99c75fe3e9b39b74f8dfd3",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@8ee502c45d111005ffff7c0a090e2cdbaf864ad3",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1351"
+version = "0.2.1352"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1351"
+__version__ = "0.2.1352"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=325a12e5f1801f70bd99c75fe3e9b39b74f8dfd3" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=8ee502c45d111005ffff7c0a090e2cdbaf864ad3" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=325a12e5f1801f70bd99c75fe3e9b39b74f8dfd3#325a12e5f1801f70bd99c75fe3e9b39b74f8dfd3" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=8ee502c45d111005ffff7c0a090e2cdbaf864ad3#8ee502c45d111005ffff7c0a090e2cdbaf864ad3" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1351"
+version = "0.2.1352"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
One-line dependency bump per the "bump the SHA to pull bridge changes" convention documented above the pin: `axiom-oracles` 325a12e5 → [8ee502c4](https://github.com/TheAxiomFoundation/axiom-oracles/commit/8ee502c45d111005ffff7c0a090e2cdbaf864ad3) (axiom-oracles PR [#338](https://github.com/TheAxiomFoundation/axiom-oracles/pull/338), cross-family reviewed, fixing axiom-oracles#296), plus the matching `uv lock` refresh.

What the bridge layer gains:
- `bridges/snap_populace`: post-hard-cut engine compile contract — `compile-composed` with explicit staged `--rulespec-root` flags naming canonical `rulespec-<cc>` checkouts, legacy env-resolved fallback for pre-hard-cut engines — and monorepo-first program resolution (state repos are not valid engine roots on engine main).
- `adapters/taxsim`: bundled-binary resolution inside uv `--with` overlay environments (whose `sys.prefix` carries no `share/`).
- `axiom_oracles/engine_compat`: the new shared compile-compat layer both of the above use.

This is the activation step for the snap lane in the encode-invoked path: after it lands, the az/ca/co/ny `*-snap-ecps` affected-rerun legs progress from setup crashes to the honest upstream blockers (rulespec-us#1049/#1050, axiom-oracles#335).

🤖 Generated with [Claude Code](https://claude.com/claude-code)