### PR TITLE
Expose South Dakota and Illinois 2026 tax oracle mappings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1352"
+version = "0.2.1353"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@8ee502c45d111005ffff7c0a090e2cdbaf864ad3",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@06945b5d06435fe79234a38a0ee980dd3acea173",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1352"
+__version__ = "0.2.1353"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1352"
+version = "0.2.1353"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=8ee502c45d111005ffff7c0a090e2cdbaf864ad3" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=06945b5d06435fe79234a38a0ee980dd3acea173" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=8ee502c45d111005ffff7c0a090e2cdbaf864ad3#8ee502c45d111005ffff7c0a090e2cdbaf864ad3" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=06945b5d06435fe79234a38a0ee980dd3acea173#06945b5d06435fe79234a38a0ee980dd3acea173" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- bump the `axiom-oracles` pin from `8ee502c45d111005ffff7c0a090e2cdbaf864ad3` to `06945b5d06435fe79234a38a0ee980dd3acea173`
- expose the newly merged South Dakota and Illinois 2026 state-income-tax mappings while preserving Maine, Connecticut, Florida, and Nevada mappings already carried by prerequisite PR #1260
- bump Axiom Encode coherently from `0.2.1352` to `0.2.1353` and refresh the lock

The target oracle ancestry contains reviewed mapping commits for all six lanes: ME, CT, FL, NV, SD, and IL.

## Independent review

Independent review of exact head `d3e01290afc68c5a6dd1f8a3066c7609088a10a2` over exact base `d5a1f79045f4abf7454a540b609f3bdbef385ae6` returned CLEAN with no actionable findings.

Verified:
- exact three-file diff only
- pin coherence in project metadata and both lock records
- version coherence in all three locations
- target descends from the old pin
- all six state mapping commits and focused tests are present in target ancestry
- no unrelated or secret-shaped material

## Checks

- `uv run --python 3.13 ruff check pyproject.toml src/axiom_encode scripts tests`: passed
- `uv run --python 3.13 python -m compileall -q src/axiom_encode scripts`: passed
- `uv lock --check --python 3.13`: passed (101 packages)
- focused version-provenance guard: passed
- full suite: 4,808 passed, 119 skipped
- `git diff --check`: passed

No actionable review findings remain.