### PR TITLE
Add durable protected SNAP encoding queue

### DIFF
--- a/.github/workflows/dispatch-signed-snap-queue.yml
+++ b/.github/workflows/dispatch-signed-snap-queue.yml
@@ -1,0 +1,356 @@
+name: Dispatch protected SNAP queue
+run-name: "SNAP queue dispatch=${{ inputs.dispatch }} items=${{ inputs.item_ids || 'next' }} limit=${{ inputs.limit }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      item_ids:
+        description: Optional comma-separated queue item IDs; defaults to the next items
+        required: false
+        type: string
+      limit:
+        description: Maximum bounded tranche size
+        required: true
+        default: "1"
+        type: choice
+        options:
+          - "1"
+          - "2"
+          - "3"
+          - "4"
+      dispatch:
+        description: Dispatch protected targeted runs; false is a preview
+        required: true
+        default: false
+        type: boolean
+      activation_merge_run_id:
+        description: Trusted successful queue activation merge workflow run ID
+        required: false
+        type: string
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+
+concurrency:
+  group: dispatch-signed-snap-queue
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    name: Dispatch protected SNAP queue
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch'
+        && github.ref == 'refs/heads/main'
+        && github.run_attempt == 1
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout immutable encoder main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Select and validate bounded queue tranche
+        id: selection
+        env:
+          ACTIVATION_MERGE_RUN_ID: ${{ inputs.activation_merge_run_id }}
+          GH_TOKEN: ${{ github.token }}
+          ITEM_IDS: ${{ inputs.item_ids }}
+          LIMIT: ${{ inputs.limit }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          queue="data/encoding-queues/us-snap-or-ut-2026-07.json"
+          python3 scripts/prepare_signed_queue.py validate "$queue"
+          if [ "$(jq -r '.state' "$queue")" = "active" ]; then
+            if [[ ! "$ACTIVATION_MERGE_RUN_ID" =~ ^[0-9]+$ ]]; then
+              echo "active queue requires activation_merge_run_id" >&2
+              exit 1
+            fi
+            api_version="2026-03-10"
+            merge_run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$ACTIVATION_MERGE_RUN_ID"
+            gh api \
+              --header "Accept: application/vnd.github+json" \
+              --header "X-GitHub-Api-Version: $api_version" \
+              "repos/$GITHUB_REPOSITORY/actions/runs/$ACTIVATION_MERGE_RUN_ID" \
+              > "$RUNNER_TEMP/activation-merge-run.json"
+            gh api --paginate --slurp \
+              --header "Accept: application/vnd.github+json" \
+              --header "X-GitHub-Api-Version: $api_version" \
+              "repos/$GITHUB_REPOSITORY/actions/runs/$ACTIVATION_MERGE_RUN_ID/jobs?filter=all&per_page=100" \
+              > "$RUNNER_TEMP/activation-merge-jobs.json"
+            gh api \
+              --header "Accept: application/vnd.github+json" \
+              --header "X-GitHub-Api-Version: $api_version" \
+              "repos/$GITHUB_REPOSITORY/actions/runs/$ACTIVATION_MERGE_RUN_ID/artifacts?per_page=100" \
+              > "$RUNNER_TEMP/activation-merge-artifacts.json"
+            archive_url="$(jq -er \
+              --arg name "snap-queue-merge-authorization-$ACTIVATION_MERGE_RUN_ID" '
+                [
+                  .artifacts[]
+                  | select(.name == $name and .expired == false)
+                  | .archive_download_url
+                ]
+                | if length == 1 then .[0] else error("merge authorization artifact is unavailable") end
+              ' "$RUNNER_TEMP/activation-merge-artifacts.json")"
+            gh api "$archive_url" > "$RUNNER_TEMP/activation-merge-authorization.zip"
+            mkdir "$RUNNER_TEMP/activation-merge-authorization"
+            unzip -q "$RUNNER_TEMP/activation-merge-authorization.zip" \
+              -d "$RUNNER_TEMP/activation-merge-authorization"
+            authorization="$RUNNER_TEMP/activation-merge-authorization/snap-queue-merge-authorization.json"
+            test "$(jq -r '.merge_workflow_run_url' "$authorization")" = \
+              "$merge_run_url"
+            pr_number="$(jq -er '.activation_pr_number' "$authorization")"
+            gh api \
+              --header "Accept: application/vnd.github+json" \
+              --header "X-GitHub-Api-Version: $api_version" \
+              "repos/$GITHUB_REPOSITORY/pulls/$pr_number" \
+              > "$RUNNER_TEMP/activation-pull-request.json"
+            merge_commit="$(jq -er '.merge_commit' "$authorization")"
+            git merge-base --is-ancestor "$merge_commit" "$GITHUB_SHA"
+            queue_change_sha="$(git log --first-parent -1 --format=%H \
+              "$GITHUB_SHA" -- "$queue")"
+            python3 scripts/prepare_signed_queue.py verify-merge-authorization \
+              "$queue" \
+              --authorization "$authorization" \
+              --merge-run "$RUNNER_TEMP/activation-merge-run.json" \
+              --merge-jobs "$RUNNER_TEMP/activation-merge-jobs.json" \
+              --pull-request "$RUNNER_TEMP/activation-pull-request.json" \
+              --current-head-sha "$GITHUB_SHA" \
+              --queue-change-sha "$queue_change_sha"
+
+            rulespec_ref="$(jq -r '.dispatch.rulespec_ref' "$queue")"
+            test "$(gh api \
+              --header "Accept: application/vnd.github+json" \
+              --header "X-GitHub-Api-Version: $api_version" \
+              repos/TheAxiomFoundation/rulespec-us/git/ref/heads/hard-cut/canonical-layout-us \
+              --jq '.object.sha')" = "$rulespec_ref"
+            gh api --paginate --slurp \
+              --header "Accept: application/vnd.github+json" \
+              --header "X-GitHub-Api-Version: $api_version" \
+              "repos/TheAxiomFoundation/rulespec-us/commits/$rulespec_ref/check-runs?per_page=100" \
+              > "$RUNNER_TEMP/live-rulespec-check-runs.json"
+            jq -e '
+              [.[].check_runs[]] as $checks
+              | ($checks | length) > 0
+              and all(
+                $checks[];
+                .status == "completed"
+                and (.conclusion | IN("success", "neutral", "skipped"))
+              )
+            ' "$RUNNER_TEMP/live-rulespec-check-runs.json" > /dev/null
+          fi
+          python3 scripts/prepare_signed_queue.py select "$queue" \
+            --item-ids "$ITEM_IDS" --limit "$LIMIT" \
+            > "$RUNNER_TEMP/snap-queue-seed.json"
+          python3 scripts/prepare_signed_queue.py candidates "$queue" \
+            > "$RUNNER_TEMP/snap-queue-candidates.json"
+          digest="$(python3 scripts/prepare_signed_queue.py sha256 "$queue")"
+          echo "manifest_sha256=$digest" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Protected SNAP queue selection"
+            echo
+            echo "Manifest SHA-256: \`$digest\`"
+            echo
+            jq -r '.items[] | "- `\(.id)`: `\(.citation)`"' \
+              "$RUNNER_TEMP/snap-queue-seed.json"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Plan or dispatch idempotent protected runs
+        env:
+          DO_DISPATCH: ${{ inputs.dispatch }}
+          EXPLICIT_ITEM_IDS: ${{ inputs.item_ids }}
+          GH_TOKEN: ${{ github.token }}
+          LIMIT: ${{ inputs.limit }}
+          MANIFEST_SHA256: ${{ steps.selection.outputs.manifest_sha256 }}
+        run: |
+          set -euo pipefail
+          candidates="$RUNNER_TEMP/snap-queue-candidates.json"
+          selection="$RUNNER_TEMP/snap-queue-reconciled.json"
+          summary="$RUNNER_TEMP/snap-queue-dispatch.md"
+          plan_jsonl="$RUNNER_TEMP/snap-queue-plan.jsonl"
+          run_records="$RUNNER_TEMP/dispatched-run-records.jsonl"
+          : > "$plan_jsonl"
+          : > "$run_records"
+          queue_id="$(jq -r '.queue_id' "$candidates")"
+          issue="$(jq -r '.issue' "$candidates")"
+          queue_state="$(jq -r '.state' "$candidates")"
+          workflow="targeted-signed-reencode.yml"
+          selected_count=0
+          skipped_count=0
+          {
+            if [ "$DO_DISPATCH" = "true" ]; then
+              echo "### Protected SNAP queue dispatch"
+            else
+              echo "### Protected SNAP queue preview"
+            fi
+            echo
+            echo "Queue: \`$queue_id\`"
+            echo "State: \`$queue_state\`"
+            echo "Manifest SHA-256: \`$MANIFEST_SHA256\`"
+            echo "Dispatcher: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            if [ "$queue_state" = "paused" ]; then
+              echo "Pause reason: $(jq -r '.pause_reason' "$candidates")"
+            fi
+            echo
+          } > "$summary"
+
+          run_pages="$RUNNER_TEMP/workflow-runs.json"
+          pull_pages="$RUNNER_TEMP/rulespec-pull-requests.json"
+          gh api --paginate --slurp \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2026-03-10" \
+            "repos/$GITHUB_REPOSITORY/actions/workflows/$workflow/runs?event=workflow_dispatch&per_page=100" \
+            > "$run_pages"
+          gh api --paginate --slurp \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2026-03-10" \
+            "repos/TheAxiomFoundation/rulespec-us/pulls?state=all&sort=updated&direction=desc&per_page=100" \
+            > "$pull_pages"
+          python3 scripts/prepare_signed_queue.py reconcile "$candidates" \
+            --pull-requests "$pull_pages" \
+            --workflow-runs "$run_pages" \
+            > "$selection"
+
+          if jq -e 'any(.items[]; .dispatchable == false)' "$selection" \
+            > /dev/null; then
+            {
+              echo "- No new items selected: the current tranche must be finalized."
+              jq -r \
+                '.items[] | select(.dispatchable == false) | "- `\(.id)`: \(.reason): \(.history_url // \"\")"' \
+                "$selection"
+            } >> "$summary"
+          else
+          while IFS= read -r item; do
+            if [ "$selected_count" -ge "$LIMIT" ]; then
+              break
+            fi
+            item_id="$(jq -r '.id' <<< "$item")"
+            if [ -n "$EXPLICIT_ITEM_IDS" ] && ! jq -e \
+              --arg item_id "$item_id" \
+              'any(.items[]; .id == $item_id)' \
+              "$RUNNER_TEMP/snap-queue-seed.json" > /dev/null; then
+              continue
+            fi
+            citation="$(jq -r '.citation' <<< "$item")"
+            generation_sha256="$(jq -r '.generation_sha256' <<< "$item")"
+            if [ "$(jq -r '.dispatchable' <<< "$item")" != "true" ]; then
+              skipped_count=$((skipped_count + 1))
+              if [ -n "$EXPLICIT_ITEM_IDS" ]; then
+                reason="$(jq -r '.reason' <<< "$item")"
+                history_url="$(jq -r '.history_url // \"\"' <<< "$item")"
+                printf -- '- `%s`: skipped; %s: %s\n' \
+                  "$item_id" "$reason" "$history_url" >> "$summary"
+              fi
+              continue
+            fi
+
+            jq -c \
+              --arg action "$(
+                if [ "$DO_DISPATCH" = "true" ]; then
+                  echo dispatch
+                else
+                  echo preview
+                fi
+              )" \
+              'del(.dispatchable, .history_url, .reason) + {action: $action}' \
+              <<< "$item" >> "$plan_jsonl"
+            selected_count=$((selected_count + 1))
+            if [ "$DO_DISPATCH" != "true" ]; then
+              printf -- '- `%s`: would dispatch `%s`\n' \
+                "$item_id" "$citation" >> "$summary"
+              continue
+            fi
+
+            dispatch_response="$RUNNER_TEMP/workflow-dispatch-${item_id}.json"
+            jq -n \
+              --arg citation "$citation" \
+              --arg corpus_ref "$(jq -r '.dispatch.corpus_ref' "$selection")" \
+              --arg country "$(jq -r '.dispatch.country' "$selection")" \
+              --arg item_id "$item_id" \
+              --arg item_generation_sha "$generation_sha256" \
+              --arg manifest_sha "$MANIFEST_SHA256" \
+              --arg pr_base "$(jq -r '.dispatch.pr_base_branch' "$selection")" \
+              --arg queue_id "$queue_id" \
+              --arg rules_engine_ref "$(jq -r '.dispatch.rules_engine_ref' "$selection")" \
+              --arg rulespec_ref "$(jq -r '.dispatch.rulespec_ref' "$selection")" \
+              --arg dispatcher_run_id "$GITHUB_RUN_ID" \
+              '{
+                ref: "main",
+                inputs: {
+                  citation: $citation,
+                  country: $country,
+                  rulespec_ref: $rulespec_ref,
+                  pr_base_branch: $pr_base,
+                  corpus_ref: $corpus_ref,
+                  rules_engine_ref: $rules_engine_ref,
+                  open_pr: "true",
+                  queue_id: $queue_id,
+                  queue_item_id: $item_id,
+                  queue_item_generation_sha256: $item_generation_sha,
+                  queue_manifest_sha256: $manifest_sha,
+                  queue_dispatcher_run_id: $dispatcher_run_id
+                }
+              }' |
+              gh api --method POST \
+                --header "Accept: application/vnd.github+json" \
+                --header "X-GitHub-Api-Version: 2026-03-10" \
+                "repos/$GITHUB_REPOSITORY/actions/workflows/$workflow/dispatches" \
+                --input - > "$dispatch_response"
+            created_id="$(jq -er '.workflow_run_id' "$dispatch_response")"
+            created_url="$(jq -er '.html_url' "$dispatch_response")"
+            printf -- '- `%s`: dispatched `%s`: %s\n' \
+              "$item_id" "$citation" "$created_url" >> "$summary"
+            jq -n \
+              --arg id "$created_id" \
+              --arg item_id "$item_id" \
+              --arg url "$created_url" \
+              '{
+                item_id: $item_id,
+                workflow_run_attempt: 1,
+                workflow_run_id: $id,
+                url: $url
+              }' \
+              >> "$run_records"
+          done < <(jq -c '.items[]' "$selection")
+          fi
+
+          jq -s \
+            --arg queue_id "$queue_id" \
+            --arg manifest_sha256 "$MANIFEST_SHA256" \
+            '{
+              schema: "axiom-encode/signed-encoding-queue-plan/v1",
+              queue_id: $queue_id,
+              manifest_sha256: $manifest_sha256,
+              items: .
+            }' "$plan_jsonl" > "$RUNNER_TEMP/snap-queue-plan.json"
+          {
+            echo
+            echo "Selected: $selected_count; skipped from prior history: $skipped_count."
+          } >> "$summary"
+          cat "$summary" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$DO_DISPATCH" = "true" ]; then
+            gh issue comment "$issue" --repo "$GITHUB_REPOSITORY" \
+              --body-file "$summary"
+          fi
+          cp "$summary" "$RUNNER_TEMP/snap-queue-dispatch-summary.md"
+
+      - name: Upload queue reconciliation record
+        if: ${{ always() && steps.selection.outcome == 'success' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: snap-queue-reconciliation-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/snap-queue-seed.json
+            ${{ runner.temp }}/snap-queue-candidates.json
+            ${{ runner.temp }}/snap-queue-reconciled.json
+            ${{ runner.temp }}/snap-queue-plan.json
+            ${{ runner.temp }}/snap-queue-dispatch-summary.md
+            ${{ runner.temp }}/dispatched-run-records.jsonl
+          if-no-files-found: warn
+          retention-days: 90

--- a/.github/workflows/finalize-signed-snap-queue.yml
+++ b/.github/workflows/finalize-signed-snap-queue.yml
@@ -1,0 +1,294 @@
+name: Finalize protected SNAP queue tranche
+run-name: "Finalize SNAP queue at ${{ inputs.new_rulespec_ref }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      new_rulespec_ref:
+        description: Independently reviewed and allowlisted current RuleSpec branch tip
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: finalize-signed-snap-queue
+  cancel-in-progress: false
+
+jobs:
+  finalize:
+    name: Finalize protected SNAP queue tranche
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch'
+        && github.ref == 'refs/heads/main'
+        && github.run_attempt == 1
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout immutable encoder main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout exact RuleSpec branch tip
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: TheAxiomFoundation/rulespec-us
+          ref: hard-cut/canonical-layout-us
+          path: rulespec-us
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.11.7"
+
+      - name: Fetch live finalization evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_RULESPEC_REF: ${{ inputs.new_rulespec_ref }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_RUN_ATTEMPT" = "1"
+          if [[ ! "$NEW_RULESPEC_REF" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "new_rulespec_ref must be a full lowercase commit SHA" >&2
+            exit 1
+          fi
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          test "$(git -C rulespec-us rev-parse HEAD)" = "$NEW_RULESPEC_REF"
+          queue="data/encoding-queues/us-snap-or-ut-2026-07.json"
+          python3 scripts/prepare_signed_queue.py validate "$queue"
+          test "$(jq -r '.state' "$queue")" = "paused"
+
+          api_version="2026-03-10"
+          branch_ref="repos/TheAxiomFoundation/rulespec-us/git/ref/heads/hard-cut/canonical-layout-us"
+          live_tip="$(gh api \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: $api_version" \
+            "$branch_ref" --jq '.object.sha')"
+          test "$live_tip" = "$NEW_RULESPEC_REF"
+
+          gh api --paginate --slurp \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: $api_version" \
+            "repos/TheAxiomFoundation/rulespec-us/commits/$NEW_RULESPEC_REF/check-runs?per_page=100" \
+            > "$RUNNER_TEMP/rulespec-check-runs.json"
+          jq -e '
+            [.[].check_runs[]] as $checks
+            | ($checks | length) > 0
+            and all(
+              $checks[];
+              .status == "completed"
+              and (.conclusion | IN("success", "neutral", "skipped"))
+            )
+          ' "$RUNNER_TEMP/rulespec-check-runs.json" > /dev/null
+
+          gh api --paginate --slurp \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: $api_version" \
+            "repos/TheAxiomFoundation/rulespec-us/pulls?state=all&sort=updated&direction=desc&per_page=100" \
+            > "$RUNNER_TEMP/rulespec-pull-requests.json"
+          gh api --paginate --slurp \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: $api_version" \
+            "repos/$GITHUB_REPOSITORY/actions/workflows/targeted-signed-reencode.yml/runs?event=workflow_dispatch&per_page=100" \
+            > "$RUNNER_TEMP/targeted-workflow-runs.json"
+
+          python3 scripts/prepare_signed_queue.py finalization-target-plan \
+            "$queue" \
+            --pull-requests "$RUNNER_TEMP/rulespec-pull-requests.json" \
+            --workflow-runs "$RUNNER_TEMP/targeted-workflow-runs.json" \
+            > "$RUNNER_TEMP/finalization-target-plan.json"
+          : > "$RUNNER_TEMP/target-evidence-entries.jsonl"
+          while IFS= read -r target; do
+            item_id="$(jq -r '.id' <<< "$target")"
+            run_url="$(jq -r '.target_run_url' <<< "$target")"
+            run_id="${run_url##*/}"
+            item_root="$RUNNER_TEMP/target-evidence-$item_id"
+            mkdir "$item_root"
+            gh api \
+              --header "Accept: application/vnd.github+json" \
+              --header "X-GitHub-Api-Version: $api_version" \
+              "repos/$GITHUB_REPOSITORY/actions/runs/$run_id" \
+              > "$item_root/run.json"
+            gh api --paginate --slurp \
+              --header "Accept: application/vnd.github+json" \
+              --header "X-GitHub-Api-Version: $api_version" \
+              "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/jobs?filter=all&per_page=100" \
+              > "$item_root/jobs.json"
+            gh api \
+              --header "Accept: application/vnd.github+json" \
+              --header "X-GitHub-Api-Version: $api_version" \
+              "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/artifacts?per_page=100" \
+              > "$item_root/artifacts.json"
+            archive_url="$(jq -er \
+              --arg name "targeted-reencode-$run_id" '
+                [
+                  .artifacts[]
+                  | select(.name == $name and .expired == false)
+                  | .archive_download_url
+                ]
+                | if length == 1 then .[0] else error("target artifact is unavailable") end
+              ' "$item_root/artifacts.json")"
+            gh api "$archive_url" > "$item_root/artifact.zip"
+            mkdir "$item_root/artifact"
+            unzip -q "$item_root/artifact.zip" -d "$item_root/artifact"
+            (
+              cd "$item_root/artifact"
+              sha256sum -c SHA256SUMS
+            )
+            jq -n \
+              --arg item_id "$item_id" \
+              --slurpfile apply_manifests "$item_root/artifact/apply-manifests.json" \
+              --slurpfile jobs "$item_root/jobs.json" \
+              --slurpfile metadata "$item_root/artifact/metadata.json" \
+              --slurpfile pull_request "$item_root/artifact/lane-pull-request.json" \
+              --slurpfile run "$item_root/run.json" \
+              '{
+                key: $item_id,
+                value: {
+                  apply_manifests: $apply_manifests[0],
+                  jobs: $jobs[0],
+                  metadata: $metadata[0],
+                  pull_request: $pull_request[0],
+                  run: $run[0]
+                }
+              }' >> "$RUNNER_TEMP/target-evidence-entries.jsonl"
+          done < <(jq -c '.items[]' "$RUNNER_TEMP/finalization-target-plan.json")
+          jq -s 'from_entries' "$RUNNER_TEMP/target-evidence-entries.jsonl" \
+            > "$RUNNER_TEMP/target-evidence.json"
+
+          python3 scripts/prepare_signed_queue.py finalize-repin \
+            "$queue" rulespec-us \
+            --check-runs "$RUNNER_TEMP/rulespec-check-runs.json" \
+            --pull-requests "$RUNNER_TEMP/rulespec-pull-requests.json" \
+            --workflow-runs "$RUNNER_TEMP/targeted-workflow-runs.json" \
+            --target-evidence "$RUNNER_TEMP/target-evidence.json" \
+            --new-rulespec-ref "$NEW_RULESPEC_REF" \
+            --finalizer-head-sha "$GITHUB_SHA" \
+            --finalizer-run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            > "$RUNNER_TEMP/finalized-snap-queue.json"
+
+          test "$(gh api \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: $api_version" \
+            "$branch_ref" --jq '.object.sha')" = "$NEW_RULESPEC_REF"
+
+      - name: Create exact queue activation commit
+        id: activation
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_RULESPEC_REF: ${{ inputs.new_rulespec_ref }}
+        run: |
+          set -euo pipefail
+          queue="data/encoding-queues/us-snap-or-ut-2026-07.json"
+          cp "$RUNNER_TEMP/finalized-snap-queue.json" "$queue"
+          old_version="$(uv version --short)"
+          new_version="$(uv version --bump patch --short --no-sync)"
+          python3 - "$old_version" "$new_version" <<'PY'
+          import sys
+          from pathlib import Path
+
+          path = Path("src/axiom_encode/__init__.py")
+          old, new = sys.argv[1:3]
+          body = path.read_text(encoding="utf-8")
+          needle = f'__version__ = "{old}"'
+          if body.count(needle) != 1:
+              raise SystemExit("package version marker is unavailable")
+          path.write_text(body.replace(needle, f'__version__ = "{new}"'), encoding="utf-8")
+          PY
+          uv lock --offline
+          python3 scripts/prepare_signed_queue.py validate "$queue"
+          git diff --check
+          git fetch --no-tags origin main
+          test "$(git rev-parse refs/remotes/origin/main)" = "$GITHUB_SHA"
+
+          branch="axiom/snap-queue-repin-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          git switch -c "$branch"
+          git add "$queue" pyproject.toml src/axiom_encode/__init__.py uv.lock
+          git -c user.name=axiom-encode-bot \
+            -c user.email=axiom-encode-bot@users.noreply.github.com \
+            commit -m "Finalize SNAP queue tranche at ${NEW_RULESPEC_REF}"
+          gh auth setup-git
+          git push "https://github.com/${GITHUB_REPOSITORY}.git" \
+            "HEAD:refs/heads/${branch}"
+          head_sha="$(git rev-parse HEAD)"
+          tree_sha="$(git rev-parse 'HEAD^{tree}')"
+          git diff --name-only "$GITHUB_SHA" "$head_sha" \
+            | jq -R -s 'split("\n") | map(select(length > 0))' \
+            > "$RUNNER_TEMP/activation-changed-files.json"
+          jq -e '
+            . == [
+              "data/encoding-queues/us-snap-or-ut-2026-07.json",
+              "pyproject.toml",
+              "src/axiom_encode/__init__.py",
+              "uv.lock"
+            ]
+          ' "$RUNNER_TEMP/activation-changed-files.json" > /dev/null
+          queue_sha256="$(python3 scripts/prepare_signed_queue.py sha256 "$queue")"
+          jq -n \
+            --arg base_sha "$GITHUB_SHA" \
+            --arg head_sha "$head_sha" \
+            --arg queue_sha256 "$queue_sha256" \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg tree_sha "$tree_sha" \
+            --slurpfile changed_files "$RUNNER_TEMP/activation-changed-files.json" \
+            '{
+              schema: "axiom-encode/snap-queue-activation-commit/v1",
+              repository: $repository,
+              base_sha: $base_sha,
+              head_sha: $head_sha,
+              tree_sha: $tree_sha,
+              queue_path: "data/encoding-queues/us-snap-or-ut-2026-07.json",
+              queue_sha256: $queue_sha256,
+              changed_files: $changed_files[0]
+            }' > "$RUNNER_TEMP/activation-commit.json"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Upload finalization evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: snap-queue-finalization-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/activation-changed-files.json
+            ${{ runner.temp }}/activation-commit.json
+            ${{ runner.temp }}/finalized-snap-queue.json
+            ${{ runner.temp }}/rulespec-check-runs.json
+            ${{ runner.temp }}/rulespec-pull-requests.json
+            ${{ runner.temp }}/finalization-target-plan.json
+            ${{ runner.temp }}/target-evidence.json
+            ${{ runner.temp }}/targeted-workflow-runs.json
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Open reviewed queue activation pull request
+        env:
+          BRANCH: ${{ steps.activation.outputs.branch }}
+          EXPECTED_HEAD_SHA: ${{ steps.activation.outputs.head_sha }}
+          GH_TOKEN: ${{ github.token }}
+          NEW_RULESPEC_REF: ${{ inputs.new_rulespec_ref }}
+        run: |
+          set -euo pipefail
+          test "$(jq -r '.head_sha' "$RUNNER_TEMP/activation-commit.json")" = \
+            "$EXPECTED_HEAD_SHA"
+          body="$(printf '%s\n' \
+            '## Protected SNAP queue finalization' \
+            '' \
+            "RuleSpec tip: \`${NEW_RULESPEC_REF}\`" \
+            "Finalizer run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            '' \
+            'This draft records merged queue items and activates the next bounded tranche. Run the required independent review-fix cycle before merge.')"
+          gh api --method POST "repos/$GITHUB_REPOSITORY/pulls" \
+            -f title="Finalize protected SNAP queue tranche" \
+            -f head="TheAxiomFoundation:${BRANCH}" \
+            -f base=main \
+            -f body="$body" \
+            -F draft=true > "$RUNNER_TEMP/finalization-pull-request.json"

--- a/.github/workflows/merge-snap-queue-activation.yml
+++ b/.github/workflows/merge-snap-queue-activation.yml
@@ -1,0 +1,239 @@
+name: Merge reviewed SNAP queue activation
+run-name: "Merge SNAP queue activation PR #${{ inputs.pull_request_number }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: Reviewed, ready, green SNAP queue activation pull request
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: merge-snap-queue-activation
+  cancel-in-progress: false
+
+jobs:
+  merge:
+    name: Merge reviewed SNAP queue activation
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch'
+        && github.ref == 'refs/heads/main'
+        && github.run_attempt == 1
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Resolve exact reviewed pull request head
+        id: pull
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PULL_REQUEST_NUMBER: ${{ inputs.pull_request_number }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_RUN_ATTEMPT" = "1"
+          if [[ ! "$PULL_REQUEST_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "pull_request_number must be decimal" >&2
+            exit 1
+          fi
+          gh api \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2026-03-10" \
+            "repos/$GITHUB_REPOSITORY/pulls/$PULL_REQUEST_NUMBER" \
+            > "$RUNNER_TEMP/activation-pr.json"
+          jq -e '
+            .state == "open"
+            and .draft == false
+            and .base.ref == "main"
+            and .head.repo.full_name == env.GITHUB_REPOSITORY
+          ' "$RUNNER_TEMP/activation-pr.json" > /dev/null
+          echo "head_sha=$(jq -r '.head.sha' "$RUNNER_TEMP/activation-pr.json")" \
+            >> "$GITHUB_OUTPUT"
+          echo "base_sha=$(jq -r '.base.sha' "$RUNNER_TEMP/activation-pr.json")" \
+            >> "$GITHUB_OUTPUT"
+
+      - name: Checkout trusted pull request base
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.pull.outputs.base_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Revalidate evidence and merge against live RuleSpec tip
+        id: merge
+        env:
+          BASE_SHA: ${{ steps.pull.outputs.base_sha }}
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ steps.pull.outputs.head_sha }}
+          PULL_REQUEST_NUMBER: ${{ inputs.pull_request_number }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$BASE_SHA"
+          git fetch --no-tags origin "$HEAD_SHA"
+          test "$(git rev-parse FETCH_HEAD)" = "$HEAD_SHA"
+          test "$(git rev-parse "${HEAD_SHA}^")" = "$BASE_SHA"
+          queue="data/encoding-queues/us-snap-or-ut-2026-07.json"
+          candidate_queue="$RUNNER_TEMP/candidate-snap-queue.json"
+          git show "$HEAD_SHA:$queue" > "$candidate_queue"
+          python3 scripts/prepare_signed_queue.py validate "$candidate_queue"
+          test "$(jq -r '.state' "$candidate_queue")" = "active"
+
+          run_url="$(jq -r '.activation.finalizer_run_url' "$candidate_queue")"
+          run_id="${run_url##*/}"
+          test "$run_url" = \
+            "https://github.com/$GITHUB_REPOSITORY/actions/runs/$run_id"
+          api_version="2026-03-10"
+          gh api \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: $api_version" \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$run_id" \
+            > "$RUNNER_TEMP/finalizer-run.json"
+          gh api --paginate --slurp \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: $api_version" \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/jobs?filter=all&per_page=100" \
+            > "$RUNNER_TEMP/finalizer-jobs.json"
+          gh api \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: $api_version" \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/artifacts?per_page=100" \
+            > "$RUNNER_TEMP/finalizer-artifacts.json"
+          archive_url="$(jq -er \
+            --arg name "snap-queue-finalization-$run_id" '
+              [
+                .artifacts[]
+                | select(.name == $name and .expired == false)
+                | .archive_download_url
+              ]
+              | if length == 1 then .[0] else error("activation artifact is unavailable") end
+            ' "$RUNNER_TEMP/finalizer-artifacts.json")"
+          gh api "$archive_url" > "$RUNNER_TEMP/finalizer-evidence.zip"
+          mkdir "$RUNNER_TEMP/finalizer-evidence"
+          unzip -q "$RUNNER_TEMP/finalizer-evidence.zip" \
+            -d "$RUNNER_TEMP/finalizer-evidence"
+          evidence="$RUNNER_TEMP/finalizer-evidence"
+          git diff --name-only "$BASE_SHA" "$HEAD_SHA" \
+            | jq -R -s 'split("\n") | map(select(length > 0))' \
+            > "$RUNNER_TEMP/current-activation-changed-files.json"
+          tree_sha="$(git rev-parse "${HEAD_SHA}^{tree}")"
+          python3 scripts/prepare_signed_queue.py verify-activation-commit \
+            "$candidate_queue" \
+            --provenance "$evidence/activation-commit.json" \
+            --pull-request "$RUNNER_TEMP/activation-pr.json" \
+            --current-base-sha "$BASE_SHA" \
+            --current-head-sha "$HEAD_SHA" \
+            --current-tree-sha "$tree_sha" \
+            --current-changed-files "$RUNNER_TEMP/current-activation-changed-files.json"
+          git show "$BASE_SHA:$queue" > "$RUNNER_TEMP/previous-snap-queue.json"
+          python3 scripts/prepare_signed_queue.py verify-activation "$candidate_queue" \
+            --previous-queue "$RUNNER_TEMP/previous-snap-queue.json" \
+            --expected-base-sha "$BASE_SHA" \
+            --finalized-queue "$evidence/finalized-snap-queue.json" \
+            --check-runs "$evidence/rulespec-check-runs.json" \
+            --pull-requests "$evidence/rulespec-pull-requests.json" \
+            --workflow-runs "$evidence/targeted-workflow-runs.json" \
+            --finalizer-run "$RUNNER_TEMP/finalizer-run.json" \
+            --finalizer-jobs "$RUNNER_TEMP/finalizer-jobs.json" \
+            --require-success true
+
+          gh api --paginate --slurp \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: $api_version" \
+            "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/check-runs?per_page=100" \
+            > "$RUNNER_TEMP/activation-pr-checks.json"
+          jq -e '
+            [.[].check_runs[]] as $checks
+            | ($checks | length) > 0
+            and all(
+              $checks[];
+              .status == "completed"
+              and (.conclusion | IN("success", "neutral", "skipped"))
+            )
+          ' "$RUNNER_TEMP/activation-pr-checks.json" > /dev/null
+
+          rulespec_ref="$(jq -r '.dispatch.rulespec_ref' "$candidate_queue")"
+          gh api --paginate --slurp \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: $api_version" \
+            "repos/TheAxiomFoundation/rulespec-us/commits/$rulespec_ref/check-runs?per_page=100" \
+            > "$RUNNER_TEMP/live-rulespec-check-runs.json"
+          jq -e '
+            [.[].check_runs[]] as $checks
+            | ($checks | length) > 0
+            and all(
+              $checks[];
+              .status == "completed"
+              and (.conclusion | IN("success", "neutral", "skipped"))
+            )
+          ' "$RUNNER_TEMP/live-rulespec-check-runs.json" > /dev/null
+          test "$(gh api \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: $api_version" \
+            repos/TheAxiomFoundation/rulespec-us/git/ref/heads/hard-cut/canonical-layout-us \
+            --jq '.object.sha')" = "$rulespec_ref"
+          gh pr merge "$PULL_REQUEST_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" \
+            --merge \
+            --match-head-commit "$HEAD_SHA" \
+            --delete-branch
+          gh api \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: $api_version" \
+            "repos/$GITHUB_REPOSITORY/pulls/$PULL_REQUEST_NUMBER" \
+            > "$RUNNER_TEMP/merged-activation-pr.json"
+          merge_commit="$(jq -er '
+            select(
+              .state == "closed"
+              and .merged_at != null
+              and .head.sha == env.HEAD_SHA
+              and .merged_by.login == "github-actions[bot]"
+            )
+            | .merge_commit_sha
+          ' "$RUNNER_TEMP/merged-activation-pr.json")"
+          if [[ ! "$merge_commit" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "trusted activation merge commit is unavailable" >&2
+            exit 1
+          fi
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "$merge_commit" refs/remotes/origin/main
+          queue_change_sha="$(git log --first-parent -1 --format=%H \
+            refs/remotes/origin/main -- "$queue")"
+          test "$queue_change_sha" = "$merge_commit"
+          queue_sha256="$(python3 scripts/prepare_signed_queue.py sha256 \
+            "$candidate_queue")"
+          jq -n \
+            --arg head_sha "$HEAD_SHA" \
+            --arg merge_commit "$merge_commit" \
+            --arg queue_sha256 "$queue_sha256" \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg run_url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            --argjson pr_number "$PULL_REQUEST_NUMBER" \
+            --argjson run_id "$GITHUB_RUN_ID" \
+            '{
+              schema: "axiom-encode/snap-queue-merge-authorization/v1",
+              repository: $repository,
+              queue_path: "data/encoding-queues/us-snap-or-ut-2026-07.json",
+              queue_sha256: $queue_sha256,
+              activation_pr_number: $pr_number,
+              activation_pr_head_sha: $head_sha,
+              merge_commit: $merge_commit,
+              merge_workflow_run_id: $run_id,
+              merge_workflow_run_attempt: 1,
+              merge_workflow_run_url: $run_url
+            }' > "$RUNNER_TEMP/snap-queue-merge-authorization.json"
+
+      - name: Upload trusted queue merge authorization
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: snap-queue-merge-authorization-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/snap-queue-merge-authorization.json
+            ${{ runner.temp }}/merged-activation-pr.json
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -1,4 +1,5 @@
 name: Targeted signed RuleSpec re-encode
+run-name: "Targeted signed RuleSpec re-encode [${{ inputs.queue_id || 'adhoc' }}:${{ inputs.queue_item_id || 'adhoc' }}:${{ inputs.queue_item_generation_sha256 || 'adhoc' }}] ${{ inputs.citation }}"
 
 on:
   workflow_dispatch:
@@ -46,8 +47,29 @@ on:
         required: false
         default: false
         type: boolean
+      queue_id:
+        description: Optional durable encoding queue identifier
+        required: false
+        type: string
+      queue_item_id:
+        description: Optional durable encoding queue item identifier
+        required: false
+        type: string
+      queue_manifest_sha256:
+        description: Optional SHA-256 of the durable queue manifest
+        required: false
+        type: string
+      queue_item_generation_sha256:
+        description: Optional stable SHA-256 identity of the queue item attempt
+        required: false
+        type: string
+      queue_dispatcher_run_id:
+        description: Dispatcher run that authorized this queue-target workflow run
+        required: false
+        type: string
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -56,7 +78,19 @@ concurrency:
 
 jobs:
   encode:
-    if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
+    name: Queue protected signed RuleSpec re-encode
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch'
+        && github.ref == 'refs/heads/main'
+        && (
+          inputs.queue_id == ''
+          || (
+            github.actor == 'github-actions[bot]'
+            && github.run_attempt == 1
+          )
+        )
+      }}
     environment: production-signing
     runs-on: ubuntu-latest
     timeout-minutes: 120
@@ -70,11 +104,135 @@ jobs:
 
       - name: Validate country routing input
         env:
+          CITATION: ${{ inputs.citation }}
+          CORPUS_REF: ${{ inputs.corpus_ref }}
           COUNTRY: ${{ inputs.country }}
+          OPEN_PR: ${{ inputs.open_pr }}
+          PR_BASE_BRANCH: ${{ inputs.pr_base_branch }}
+          QUEUE_DISPATCHER_RUN_ID: ${{ inputs.queue_dispatcher_run_id }}
+          QUEUE_ID: ${{ inputs.queue_id }}
+          QUEUE_ITEM_ID: ${{ inputs.queue_item_id }}
+          QUEUE_ITEM_GENERATION_SHA256: ${{ inputs.queue_item_generation_sha256 }}
+          QUEUE_MANIFEST_SHA256: ${{ inputs.queue_manifest_sha256 }}
+          RULES_ENGINE_REF: ${{ inputs.rules_engine_ref }}
+          RULESPEC_REF: ${{ inputs.rulespec_ref }}
         run: |
           set -euo pipefail
           python axiom-encode/scripts/prepare_signed_backfill.py \
             validate-country "$COUNTRY"
+          python axiom-encode/scripts/prepare_signed_backfill.py \
+            validate-queue-tracking "$QUEUE_ID" "$QUEUE_ITEM_ID" \
+            "$QUEUE_MANIFEST_SHA256" "$QUEUE_ITEM_GENERATION_SHA256"
+          if [ -n "$QUEUE_ID" ]; then
+            if [ "$GITHUB_ACTOR" != "github-actions[bot]" ] || \
+              [ "$GITHUB_RUN_ATTEMPT" != "1" ] || \
+              [[ ! "$QUEUE_DISPATCHER_RUN_ID" =~ ^[0-9]+$ ]]; then
+              echo "queue target must be created by an authenticated dispatcher" >&2
+              exit 1
+            fi
+            python axiom-encode/scripts/prepare_signed_queue.py \
+              validate-dispatch \
+              "axiom-encode/data/encoding-queues/${QUEUE_ID}.json" \
+              --queue-id "$QUEUE_ID" \
+              --item-id "$QUEUE_ITEM_ID" \
+              --manifest-sha256 "$QUEUE_MANIFEST_SHA256" \
+              --item-generation-sha256 "$QUEUE_ITEM_GENERATION_SHA256" \
+              --citation "$CITATION" \
+              --country "$COUNTRY" \
+              --rulespec-ref "$RULESPEC_REF" \
+              --pr-base-branch "$PR_BASE_BRANCH" \
+              --corpus-ref "$CORPUS_REF" \
+              --rules-engine-ref "$RULES_ENGINE_REF" \
+              --open-pr "$OPEN_PR"
+
+            api_version="2026-03-10"
+            dispatcher_run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$QUEUE_DISPATCHER_RUN_ID"
+            for _ in $(seq 1 60); do
+              gh api \
+                --header "Accept: application/vnd.github+json" \
+                --header "X-GitHub-Api-Version: $api_version" \
+                "repos/$GITHUB_REPOSITORY/actions/runs/$QUEUE_DISPATCHER_RUN_ID" \
+                > "$RUNNER_TEMP/queue-dispatcher-run.json"
+              if jq -e '.status == "completed"' \
+                "$RUNNER_TEMP/queue-dispatcher-run.json" > /dev/null; then
+                break
+              fi
+              sleep 2
+            done
+            jq -e \
+              --arg head_sha "$GITHUB_SHA" \
+              --arg url "$dispatcher_run_url" '
+                .status == "completed"
+                and .conclusion == "success"
+                and .event == "workflow_dispatch"
+                and .head_branch == "main"
+                and .head_sha == $head_sha
+                and (.run_attempt | type) == "number"
+                and .run_attempt >= 1
+                and .html_url == $url
+                and .path == ".github/workflows/dispatch-signed-snap-queue.yml"
+              ' "$RUNNER_TEMP/queue-dispatcher-run.json" > /dev/null
+            gh api --paginate --slurp \
+              --header "Accept: application/vnd.github+json" \
+              --header "X-GitHub-Api-Version: $api_version" \
+              "repos/$GITHUB_REPOSITORY/actions/runs/$QUEUE_DISPATCHER_RUN_ID/jobs?filter=all&per_page=100" \
+              > "$RUNNER_TEMP/queue-dispatcher-jobs.json"
+            dispatcher_attempts="$(jq -r '.run_attempt' \
+              "$RUNNER_TEMP/queue-dispatcher-run.json")"
+            jq -e --argjson attempts "$dispatcher_attempts" '
+              [.[].jobs[] | select(.name == "Dispatch protected SNAP queue")] as $jobs
+              | ($jobs | length) == $attempts
+              and ([range(1; $attempts + 1)] ==
+                ([$jobs[].run_attempt] | sort))
+              and all(
+                $jobs[];
+                if .run_attempt == 1
+                then .status == "completed" and .conclusion == "success"
+                else .status == "completed" and .conclusion == "skipped"
+                end
+              )
+            ' "$RUNNER_TEMP/queue-dispatcher-jobs.json" > /dev/null
+            gh api \
+              --header "Accept: application/vnd.github+json" \
+              --header "X-GitHub-Api-Version: $api_version" \
+              "repos/$GITHUB_REPOSITORY/actions/runs/$QUEUE_DISPATCHER_RUN_ID/artifacts?per_page=100" \
+              > "$RUNNER_TEMP/queue-dispatcher-artifacts.json"
+            archive_url="$(jq -er \
+              --arg name "snap-queue-reconciliation-$QUEUE_DISPATCHER_RUN_ID" '
+                [
+                  .artifacts[]
+                  | select(.name == $name and .expired == false)
+                  | .archive_download_url
+                ]
+                | if length == 1 then .[0] else error("dispatcher artifact is unavailable") end
+              ' "$RUNNER_TEMP/queue-dispatcher-artifacts.json")"
+            gh api "$archive_url" > "$RUNNER_TEMP/queue-dispatcher.zip"
+            mkdir "$RUNNER_TEMP/queue-dispatcher"
+            unzip -q "$RUNNER_TEMP/queue-dispatcher.zip" \
+              -d "$RUNNER_TEMP/queue-dispatcher"
+            jq -e \
+              --arg generation "$QUEUE_ITEM_GENERATION_SHA256" \
+              --arg item_id "$QUEUE_ITEM_ID" \
+              --arg manifest "$QUEUE_MANIFEST_SHA256" '
+                .manifest_sha256 == $manifest
+                and any(
+                  .items[];
+                  .id == $item_id
+                  and .generation_sha256 == $generation
+                  and .action == "dispatch"
+                )
+              ' "$RUNNER_TEMP/queue-dispatcher/snap-queue-plan.json" > /dev/null
+            jq -e \
+              --arg item_id "$QUEUE_ITEM_ID" \
+              --arg run_id "$GITHUB_RUN_ID" '
+                select(
+                  .item_id == $item_id
+                  and .workflow_run_attempt == 1
+                  and .workflow_run_id == $run_id
+                )
+              ' "$RUNNER_TEMP/queue-dispatcher/dispatched-run-records.jsonl" \
+              > /dev/null
+          fi
 
       - name: Checkout canonical RuleSpec country
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -185,6 +343,8 @@ jobs:
           SUPABASE_URL: https://swocpijqqahhuwtuahwc.supabase.co
           SUPABASE_ANON_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
           RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
+          QUEUE_ID: ${{ inputs.queue_id }}
+          QUEUE_MANIFEST_SHA256: ${{ inputs.queue_manifest_sha256 }}
         run: |
           set -euo pipefail
           test -n "$SUPABASE_ANON_KEY"
@@ -199,6 +359,14 @@ jobs:
           fi
           release_name="${release_pin[0]}"
           release_sha="${release_pin[1]}"
+          if [ -n "$QUEUE_ID" ]; then
+            axiom-encode/.venv/bin/python \
+              axiom-encode/scripts/prepare_signed_queue.py \
+              validate-release-pin \
+              "axiom-encode/data/encoding-queues/${QUEUE_ID}.json" \
+              --toolchain "$toolchain" \
+              --manifest-sha256 "$QUEUE_MANIFEST_SHA256"
+          fi
           response="$(mktemp "$RUNNER_TEMP/corpus-release-response.XXXXXX")"
           trap 'rm -f "$response"' EXIT
           url="${SUPABASE_URL%/}/rest/v1/release_objects?select=release_object&release_name=eq.${release_name}&content_sha256=eq.${release_sha}&limit=2"
@@ -432,6 +600,10 @@ jobs:
           DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
           DEPENDENT_REVIEW_FINDING_PRESENT: ${{ inputs.dependent_review_finding != '' }}
           PR_BASE_BRANCH: ${{ inputs.pr_base_branch }}
+          QUEUE_ID: ${{ inputs.queue_id }}
+          QUEUE_ITEM_ID: ${{ inputs.queue_item_id }}
+          QUEUE_ITEM_GENERATION_SHA256: ${{ inputs.queue_item_generation_sha256 }}
+          QUEUE_MANIFEST_SHA256: ${{ inputs.queue_manifest_sha256 }}
           REVIEW_FINDING_PRESENT: ${{ inputs.review_finding != '' }}
           RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
         run: |
@@ -442,7 +614,9 @@ jobs:
             | tar -C "$RULESPEC_CHECKOUT" --null -czf "$artifact/untracked.tar.gz" --files-from -
           git -C "$RULESPEC_CHECKOUT" status --short > "$artifact/status.txt"
           cp "$RUNNER_TEMP/guard-generated.json" "$artifact/guard-generated.json"
-          python - "$artifact/context-manifest.json" <<'PY'
+          python - \
+            "$artifact/context-manifest.json" \
+            "$artifact/apply-manifests.json" <<'PY'
           import hashlib
           import json
           import os
@@ -485,7 +659,7 @@ jobs:
                   == "axiom-encode/applied-rulespec/v5"
                   and citation in expected_citations
               ):
-                  matches.setdefault(citation, []).append(payload)
+                  matches.setdefault(citation, []).append((relative_path, payload))
 
           expected = [
               (
@@ -506,6 +680,7 @@ jobs:
               )
 
           generated_root = (Path(os.environ["RUNNER_TEMP"]) / "generated").resolve()
+          applied_inventory = []
           for citation, finding_required, destination, lane in expected:
               citation_matches = matches.get(citation, [])
               if len(citation_matches) != 1:
@@ -513,7 +688,8 @@ jobs:
                       "expected exactly one changed signed apply manifest for "
                       f"{citation}; found {len(citation_matches)}"
                   )
-              applied_manifest = citation_matches[0]
+              relative_path, applied_manifest = citation_matches[0]
+              manifest_path = Path(os.environ["RULESPEC_CHECKOUT"]) / relative_path
               context_path = Path(applied_manifest["context_manifest_file"]).resolve()
               try:
                   context_path.relative_to(generated_root / lane)
@@ -557,6 +733,25 @@ jobs:
                       )
 
               destination.write_bytes(context_bytes)
+              applied_inventory.append(
+                  {
+                      "citation": citation,
+                      "path": relative_path.as_posix(),
+                      "sha256": hashlib.sha256(manifest_path.read_bytes()).hexdigest(),
+                  }
+              )
+          Path(sys.argv[2]).write_text(
+              json.dumps(
+                  {
+                      "schema": "axiom-encode/applied-manifest-inventory/v1",
+                      "items": applied_inventory,
+                  },
+                  indent=2,
+                  sort_keys=True,
+              )
+              + "\n",
+              encoding="utf-8",
+          )
           PY
           python - "$artifact/metadata.json" <<'PY'
           import json
@@ -574,10 +769,19 @@ jobs:
               "citation": os.environ["CITATION"],
               "dependent_citation": os.environ.get("DEPENDENT_CITATION") or None,
               "pr_base_branch": os.environ["PR_BASE_BRANCH"],
+              "queue_id": os.environ.get("QUEUE_ID") or None,
+              "queue_item_id": os.environ.get("QUEUE_ITEM_ID") or None,
+              "queue_item_generation_sha256": (
+                  os.environ.get("QUEUE_ITEM_GENERATION_SHA256") or None
+              ),
+              "queue_manifest_sha256": (
+                  os.environ.get("QUEUE_MANIFEST_SHA256") or None
+              ),
               "rulespec_base": rev(os.environ["RULESPEC_CHECKOUT"]),
               "encoder_commit": rev("axiom-encode"),
               "corpus_commit": rev("axiom-corpus"),
               "rules_engine_commit": rev("axiom-rules-engine"),
+              "workflow_run_attempt": int(os.environ["GITHUB_RUN_ATTEMPT"]),
               "workflow_run_id": os.environ["GITHUB_RUN_ID"],
           }
           with open(sys.argv[1], "w", encoding="utf-8") as stream:
@@ -613,6 +817,10 @@ jobs:
           CITATION: ${{ inputs.citation }}
           RULESPEC_REF: ${{ inputs.rulespec_ref }}
           PR_BASE_BRANCH: ${{ inputs.pr_base_branch }}
+          QUEUE_ID: ${{ inputs.queue_id }}
+          QUEUE_ITEM_ID: ${{ inputs.queue_item_id }}
+          QUEUE_ITEM_GENERATION_SHA256: ${{ inputs.queue_item_generation_sha256 }}
+          QUEUE_MANIFEST_SHA256: ${{ inputs.queue_manifest_sha256 }}
           RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
         run: |
           set -euo pipefail
@@ -630,6 +838,9 @@ jobs:
             "Citation: \`${CITATION}\`" \
             "Base commit: \`${RULESPEC_REF}\`" \
             "Base branch: \`${PR_BASE_BRANCH}\`" \
+            "Queue item: \`${QUEUE_ID:-ad-hoc}/${QUEUE_ITEM_ID:-ad-hoc}\`" \
+            "Queue generation SHA-256: \`${QUEUE_ITEM_GENERATION_SHA256:-n/a}\`" \
+            "Queue manifest SHA-256: \`${QUEUE_MANIFEST_SHA256:-n/a}\`" \
             "Axiom Encode run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
             '' \
             'This draft PR was produced by the protected country-general signed-apply workflow. Review all RuleSpec and manifest changes before marking it ready.')"
@@ -678,4 +889,4 @@ jobs:
           name: targeted-reencode-${{ github.run_id }}
           path: ${{ runner.temp }}/targeted-reencode
           if-no-files-found: error
-          retention-days: 7
+          retention-days: 90

--- a/.github/workflows/validate-snap-queue-activation.yml
+++ b/.github/workflows/validate-snap-queue-activation.yml
@@ -1,0 +1,221 @@
+name: Validate SNAP queue activation
+
+on:
+  pull_request:
+    paths:
+      - data/encoding-queues/us-snap-or-ut-2026-07.json
+      - scripts/prepare_signed_queue.py
+      - .github/workflows/finalize-signed-snap-queue.yml
+      - .github/workflows/validate-snap-queue-activation.yml
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Authenticate activation evidence and current RuleSpec tip
+        id: transition
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$HEAD_SHA"
+          queue="data/encoding-queues/us-snap-or-ut-2026-07.json"
+          python3 scripts/prepare_signed_queue.py validate "$queue"
+          previous_queue="$RUNNER_TEMP/previous-snap-queue.json"
+          initial=false
+          if git cat-file -e "$BASE_SHA:$queue" 2> /dev/null; then
+            git show "$BASE_SHA:$queue" > "$previous_queue"
+          elif [ "$(jq -r '.state' "$queue")" != "paused" ] || ! jq -e '
+            all(.items[]; .status == "pending" and .attempt == 1)
+          ' "$queue" > /dev/null; then
+            echo "new queue must start paused with untouched pending items" >&2
+            exit 1
+          else
+            initial=true
+          fi
+          echo "initial=$initial" >> "$GITHUB_OUTPUT"
+          if [ "$initial" = "true" ]; then
+            for field in corpus_ref rules_engine_ref rulespec_ref; do
+              printf '%s=%s\n' "$field" \
+                "$(jq -r --arg field "$field" '.dispatch[$field]' "$queue")" \
+                >> "$GITHUB_OUTPUT"
+            done
+            printf 'release_name=%s\n' "$(jq -r '.release.name' "$queue")" \
+              >> "$GITHUB_OUTPUT"
+            printf 'release_sha=%s\n' \
+              "$(jq -r '.release.content_sha256' "$queue")" >> "$GITHUB_OUTPUT"
+          fi
+          if [ "$(jq -r '.state' "$queue")" = "paused" ]; then
+            if [ -f "$previous_queue" ]; then
+              python3 scripts/prepare_signed_queue.py verify-paused-transition \
+                "$queue" --previous-queue "$previous_queue"
+            fi
+            echo "Queue is paused; no activation evidence is required."
+            exit 0
+          fi
+
+          run_url="$(jq -r '.activation.finalizer_run_url' "$queue")"
+          run_id="${run_url##*/}"
+          test "$run_url" = \
+            "https://github.com/$GITHUB_REPOSITORY/actions/runs/$run_id"
+          api_version="2026-03-10"
+          gh api \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: $api_version" \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$run_id" \
+            > "$RUNNER_TEMP/finalizer-run.json"
+          gh api --paginate --slurp \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: $api_version" \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/jobs?filter=all&per_page=100" \
+            > "$RUNNER_TEMP/finalizer-jobs.json"
+          gh api \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: $api_version" \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/artifacts?per_page=100" \
+            > "$RUNNER_TEMP/finalizer-artifacts.json"
+          archive_url="$(jq -er \
+            --arg name "snap-queue-finalization-$run_id" '
+              [
+                .artifacts[]
+                | select(.name == $name and .expired == false)
+                | .archive_download_url
+              ]
+              | if length == 1 then .[0] else error("activation artifact is unavailable") end
+            ' "$RUNNER_TEMP/finalizer-artifacts.json")"
+          gh api "$archive_url" > "$RUNNER_TEMP/finalizer-evidence.zip"
+          mkdir "$RUNNER_TEMP/finalizer-evidence"
+          unzip -q "$RUNNER_TEMP/finalizer-evidence.zip" \
+            -d "$RUNNER_TEMP/finalizer-evidence"
+
+          evidence="$RUNNER_TEMP/finalizer-evidence"
+          jq '.pull_request' "$GITHUB_EVENT_PATH" \
+            > "$RUNNER_TEMP/activation-pr.json"
+          git diff --name-only "$BASE_SHA" "$HEAD_SHA" \
+            | jq -R -s 'split("\n") | map(select(length > 0))' \
+            > "$RUNNER_TEMP/current-activation-changed-files.json"
+          tree_sha="$(git rev-parse "${HEAD_SHA}^{tree}")"
+          python3 scripts/prepare_signed_queue.py verify-activation-commit "$queue" \
+            --provenance "$evidence/activation-commit.json" \
+            --pull-request "$RUNNER_TEMP/activation-pr.json" \
+            --current-base-sha "$BASE_SHA" \
+            --current-head-sha "$HEAD_SHA" \
+            --current-tree-sha "$tree_sha" \
+            --current-changed-files "$RUNNER_TEMP/current-activation-changed-files.json"
+          python3 scripts/prepare_signed_queue.py verify-activation "$queue" \
+            --previous-queue "$previous_queue" \
+            --expected-base-sha "$BASE_SHA" \
+            --finalized-queue "$evidence/finalized-snap-queue.json" \
+            --check-runs "$evidence/rulespec-check-runs.json" \
+            --pull-requests "$evidence/rulespec-pull-requests.json" \
+            --workflow-runs "$evidence/targeted-workflow-runs.json" \
+            --finalizer-run "$RUNNER_TEMP/finalizer-run.json" \
+            --finalizer-jobs "$RUNNER_TEMP/finalizer-jobs.json" \
+            --require-success false
+
+          rulespec_ref="$(jq -r '.dispatch.rulespec_ref' "$queue")"
+          test "$(gh api \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: $api_version" \
+            repos/TheAxiomFoundation/rulespec-us/git/ref/heads/hard-cut/canonical-layout-us \
+            --jq '.object.sha')" = "$rulespec_ref"
+
+      - name: Checkout exact queue corpus source
+        if: ${{ steps.transition.outputs.initial == 'true' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: TheAxiomFoundation/axiom-corpus
+          ref: ${{ steps.transition.outputs.corpus_ref }}
+          path: initial-axiom-corpus
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout exact queue RuleSpec source
+        if: ${{ steps.transition.outputs.initial == 'true' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: TheAxiomFoundation/rulespec-us
+          ref: ${{ steps.transition.outputs.rulespec_ref }}
+          path: initial-rulespec-us
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout exact queue rules engine source
+        if: ${{ steps.transition.outputs.initial == 'true' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: TheAxiomFoundation/axiom-rules-engine
+          ref: ${{ steps.transition.outputs.rules_engine_ref }}
+          path: initial-axiom-rules-engine
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install uv for initial queue provenance
+        if: ${{ steps.transition.outputs.initial == 'true' }}
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Regenerate and authenticate initial queue
+        if: ${{ steps.transition.outputs.initial == 'true' }}
+        env:
+          CORPUS_RELEASE_PUBLIC_KEY: ${{ vars.AXIOM_CORPUS_RELEASE_PUBLIC_KEY }}
+          RELEASE_NAME: ${{ steps.transition.outputs.release_name }}
+          RELEASE_SHA: ${{ steps.transition.outputs.release_sha }}
+          SUPABASE_ANON_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          SUPABASE_URL: https://swocpijqqahhuwtuahwc.supabase.co
+        run: |
+          set -euo pipefail
+          test -n "$CORPUS_RELEASE_PUBLIC_KEY"
+          test -n "$SUPABASE_ANON_KEY"
+          test "$(git -C initial-axiom-corpus rev-parse HEAD)" = \
+            "${{ steps.transition.outputs.corpus_ref }}"
+          test "$(git -C initial-rulespec-us rev-parse HEAD)" = \
+            "${{ steps.transition.outputs.rulespec_ref }}"
+          test "$(git -C initial-axiom-rules-engine rev-parse HEAD)" = \
+            "${{ steps.transition.outputs.rules_engine_ref }}"
+
+          response="$RUNNER_TEMP/corpus-release-response.json"
+          release_object="$RUNNER_TEMP/corpus-release-object.json"
+          release_public_key="$RUNNER_TEMP/corpus-release-public-key"
+          generated_queue="$RUNNER_TEMP/generated-snap-queue.json"
+          url="${SUPABASE_URL%/}/rest/v1/release_objects?select=release_object&release_name=eq.${RELEASE_NAME}&content_sha256=eq.${RELEASE_SHA}&limit=2"
+          curl --fail --silent --show-error --location \
+            --proto '=https' --proto-redir '=https' --tlsv1.2 \
+            --max-filesize 16777216 \
+            --header "apikey: $SUPABASE_ANON_KEY" \
+            --header "Authorization: Bearer $SUPABASE_ANON_KEY" \
+            --header "Accept-Profile: corpus" \
+            --output "$response" "$url"
+          jq -e 'if length == 1 then .[0].release_object else
+            error("expected exactly one signed corpus release object") end' \
+            "$response" > "$release_object"
+          printf '%s\n' "$CORPUS_RELEASE_PUBLIC_KEY" > "$release_public_key"
+
+          uv run --frozen --python 3.13 python scripts/prepare_signed_queue.py \
+            build-snap initial-axiom-corpus initial-rulespec-us \
+            --corpus-ref "${{ steps.transition.outputs.corpus_ref }}" \
+            --rulespec-ref "${{ steps.transition.outputs.rulespec_ref }}" \
+            --rules-engine-ref "${{ steps.transition.outputs.rules_engine_ref }}" \
+            --release-name "$RELEASE_NAME" \
+            --release-content-sha256 "$RELEASE_SHA" \
+            --release-object "$release_object" \
+            --release-public-key "$release_public_key" \
+            --state paused \
+            --pause-reason \
+              "Awaiting a green, independently reviewed exact RuleSpec protected-branch tip." \
+            > "$generated_queue"
+          cmp --silent \
+            data/encoding-queues/us-snap-or-ut-2026-07.json "$generated_queue"

--- a/data/encoding-queues/us-snap-or-ut-2026-07.json
+++ b/data/encoding-queues/us-snap-or-ut-2026-07.json
@@ -1,0 +1,8339 @@
+{
+  "description": "Conservative Oregon and Utah SNAP manual source-unit inventory. Each item requires an explicit encoder disposition.",
+  "dispatch": {
+    "corpus_ref": "0fd35bfbda98836c406ec539a492c4e661c6695d",
+    "country": "us",
+    "max_batch_size": 4,
+    "open_pr": true,
+    "pr_base_branch": "hard-cut/canonical-layout-us",
+    "rules_engine_ref": "05eac9d2f89dabe5c6673176260762cef3a58f47",
+    "rulespec_ref": "8f224620540f9e285428ec839d094835396f7d99"
+  },
+  "expected_counts": {
+    "total": 831,
+    "us-or": 530,
+    "us-ut": 301
+  },
+  "issue": 1257,
+  "items": [
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/tables-appendicies-and-charts-tables-appendicies-and-charts-table-2-snap-monthly-income-limits-and-m/block-2",
+      "id": "ut-0001",
+      "jurisdiction": "us-ut",
+      "label": "Table Effective: October 1, 2025",
+      "sequence": 1,
+      "source_kind": "block",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-272",
+      "id": "or-0001",
+      "jurisdiction": "us-or",
+      "label": "Page 272",
+      "sequence": 2,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-273",
+      "id": "or-0002",
+      "jurisdiction": "us-or",
+      "label": "Page 273",
+      "sequence": 3,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-274",
+      "id": "or-0003",
+      "jurisdiction": "us-or",
+      "label": "Page 274",
+      "sequence": 4,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open",
+      "id": "or-0004",
+      "jurisdiction": "us-or",
+      "label": "Oregon Programs Eligibility Notebook (OPEN)",
+      "sequence": 5,
+      "source_kind": "document",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-10",
+      "id": "or-0005",
+      "jurisdiction": "us-or",
+      "label": "Page 10",
+      "sequence": 6,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1003",
+      "id": "or-0006",
+      "jurisdiction": "us-or",
+      "label": "Page 1003",
+      "sequence": 7,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1004",
+      "id": "or-0007",
+      "jurisdiction": "us-or",
+      "label": "Page 1004",
+      "sequence": 8,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1006",
+      "id": "or-0008",
+      "jurisdiction": "us-or",
+      "label": "Page 1006",
+      "sequence": 9,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1008",
+      "id": "or-0009",
+      "jurisdiction": "us-or",
+      "label": "Page 1008",
+      "sequence": 10,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1009",
+      "id": "or-0010",
+      "jurisdiction": "us-or",
+      "label": "Page 1009",
+      "sequence": 11,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1011",
+      "id": "or-0011",
+      "jurisdiction": "us-or",
+      "label": "Page 1011",
+      "sequence": 12,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1013",
+      "id": "or-0012",
+      "jurisdiction": "us-or",
+      "label": "Page 1013",
+      "sequence": 13,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1014",
+      "id": "or-0013",
+      "jurisdiction": "us-or",
+      "label": "Page 1014",
+      "sequence": 14,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1016",
+      "id": "or-0014",
+      "jurisdiction": "us-or",
+      "label": "Page 1016",
+      "sequence": 15,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1017",
+      "id": "or-0015",
+      "jurisdiction": "us-or",
+      "label": "Page 1017",
+      "sequence": 16,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-103",
+      "id": "or-0016",
+      "jurisdiction": "us-or",
+      "label": "Page 103",
+      "sequence": 17,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-104",
+      "id": "or-0017",
+      "jurisdiction": "us-or",
+      "label": "Page 104",
+      "sequence": 18,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-105",
+      "id": "or-0018",
+      "jurisdiction": "us-or",
+      "label": "Page 105",
+      "sequence": 19,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1059",
+      "id": "or-0019",
+      "jurisdiction": "us-or",
+      "label": "Page 1059",
+      "sequence": 20,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1061",
+      "id": "or-0020",
+      "jurisdiction": "us-or",
+      "label": "Page 1061",
+      "sequence": 21,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-107",
+      "id": "or-0021",
+      "jurisdiction": "us-or",
+      "label": "Page 107",
+      "sequence": 22,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1070",
+      "id": "or-0022",
+      "jurisdiction": "us-or",
+      "label": "Page 1070",
+      "sequence": 23,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1071",
+      "id": "or-0023",
+      "jurisdiction": "us-or",
+      "label": "Page 1071",
+      "sequence": 24,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1072",
+      "id": "or-0024",
+      "jurisdiction": "us-or",
+      "label": "Page 1072",
+      "sequence": 25,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1073",
+      "id": "or-0025",
+      "jurisdiction": "us-or",
+      "label": "Page 1073",
+      "sequence": 26,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1074",
+      "id": "or-0026",
+      "jurisdiction": "us-or",
+      "label": "Page 1074",
+      "sequence": 27,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1075",
+      "id": "or-0027",
+      "jurisdiction": "us-or",
+      "label": "Page 1075",
+      "sequence": 28,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1076",
+      "id": "or-0028",
+      "jurisdiction": "us-or",
+      "label": "Page 1076",
+      "sequence": 29,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1077",
+      "id": "or-0029",
+      "jurisdiction": "us-or",
+      "label": "Page 1077",
+      "sequence": 30,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1078",
+      "id": "or-0030",
+      "jurisdiction": "us-or",
+      "label": "Page 1078",
+      "sequence": 31,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1079",
+      "id": "or-0031",
+      "jurisdiction": "us-or",
+      "label": "Page 1079",
+      "sequence": 32,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-108",
+      "id": "or-0032",
+      "jurisdiction": "us-or",
+      "label": "Page 108",
+      "sequence": 33,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1080",
+      "id": "or-0033",
+      "jurisdiction": "us-or",
+      "label": "Page 1080",
+      "sequence": 34,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1081",
+      "id": "or-0034",
+      "jurisdiction": "us-or",
+      "label": "Page 1081",
+      "sequence": 35,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1082",
+      "id": "or-0035",
+      "jurisdiction": "us-or",
+      "label": "Page 1082",
+      "sequence": 36,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1083",
+      "id": "or-0036",
+      "jurisdiction": "us-or",
+      "label": "Page 1083",
+      "sequence": 37,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1084",
+      "id": "or-0037",
+      "jurisdiction": "us-or",
+      "label": "Page 1084",
+      "sequence": 38,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1085",
+      "id": "or-0038",
+      "jurisdiction": "us-or",
+      "label": "Page 1085",
+      "sequence": 39,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1086",
+      "id": "or-0039",
+      "jurisdiction": "us-or",
+      "label": "Page 1086",
+      "sequence": 40,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1087",
+      "id": "or-0040",
+      "jurisdiction": "us-or",
+      "label": "Page 1087",
+      "sequence": 41,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1088",
+      "id": "or-0041",
+      "jurisdiction": "us-or",
+      "label": "Page 1088",
+      "sequence": 42,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1089",
+      "id": "or-0042",
+      "jurisdiction": "us-or",
+      "label": "Page 1089",
+      "sequence": 43,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-109",
+      "id": "or-0043",
+      "jurisdiction": "us-or",
+      "label": "Page 109",
+      "sequence": 44,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1090",
+      "id": "or-0044",
+      "jurisdiction": "us-or",
+      "label": "Page 1090",
+      "sequence": 45,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1091",
+      "id": "or-0045",
+      "jurisdiction": "us-or",
+      "label": "Page 1091",
+      "sequence": 46,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1092",
+      "id": "or-0046",
+      "jurisdiction": "us-or",
+      "label": "Page 1092",
+      "sequence": 47,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1093",
+      "id": "or-0047",
+      "jurisdiction": "us-or",
+      "label": "Page 1093",
+      "sequence": 48,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1094",
+      "id": "or-0048",
+      "jurisdiction": "us-or",
+      "label": "Page 1094",
+      "sequence": 49,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1095",
+      "id": "or-0049",
+      "jurisdiction": "us-or",
+      "label": "Page 1095",
+      "sequence": 50,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1096",
+      "id": "or-0050",
+      "jurisdiction": "us-or",
+      "label": "Page 1096",
+      "sequence": 51,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-11",
+      "id": "or-0051",
+      "jurisdiction": "us-or",
+      "label": "Page 11",
+      "sequence": 52,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1109",
+      "id": "or-0052",
+      "jurisdiction": "us-or",
+      "label": "Page 1109",
+      "sequence": 53,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1118",
+      "id": "or-0053",
+      "jurisdiction": "us-or",
+      "label": "Page 1118",
+      "sequence": 54,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1119",
+      "id": "or-0054",
+      "jurisdiction": "us-or",
+      "label": "Page 1119",
+      "sequence": 55,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-112",
+      "id": "or-0055",
+      "jurisdiction": "us-or",
+      "label": "Page 112",
+      "sequence": 56,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1128",
+      "id": "or-0056",
+      "jurisdiction": "us-or",
+      "label": "Page 1128",
+      "sequence": 57,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-115",
+      "id": "or-0057",
+      "jurisdiction": "us-or",
+      "label": "Page 115",
+      "sequence": 58,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1163",
+      "id": "or-0058",
+      "jurisdiction": "us-or",
+      "label": "Page 1163",
+      "sequence": 59,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1166",
+      "id": "or-0059",
+      "jurisdiction": "us-or",
+      "label": "Page 1166",
+      "sequence": 60,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1167",
+      "id": "or-0060",
+      "jurisdiction": "us-or",
+      "label": "Page 1167",
+      "sequence": 61,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1169",
+      "id": "or-0061",
+      "jurisdiction": "us-or",
+      "label": "Page 1169",
+      "sequence": 62,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-117",
+      "id": "or-0062",
+      "jurisdiction": "us-or",
+      "label": "Page 117",
+      "sequence": 63,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1170",
+      "id": "or-0063",
+      "jurisdiction": "us-or",
+      "label": "Page 1170",
+      "sequence": 64,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1171",
+      "id": "or-0064",
+      "jurisdiction": "us-or",
+      "label": "Page 1171",
+      "sequence": 65,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1172",
+      "id": "or-0065",
+      "jurisdiction": "us-or",
+      "label": "Page 1172",
+      "sequence": 66,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1173",
+      "id": "or-0066",
+      "jurisdiction": "us-or",
+      "label": "Page 1173",
+      "sequence": 67,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1174",
+      "id": "or-0067",
+      "jurisdiction": "us-or",
+      "label": "Page 1174",
+      "sequence": 68,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1175",
+      "id": "or-0068",
+      "jurisdiction": "us-or",
+      "label": "Page 1175",
+      "sequence": 69,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1176",
+      "id": "or-0069",
+      "jurisdiction": "us-or",
+      "label": "Page 1176",
+      "sequence": 70,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1177",
+      "id": "or-0070",
+      "jurisdiction": "us-or",
+      "label": "Page 1177",
+      "sequence": 71,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1178",
+      "id": "or-0071",
+      "jurisdiction": "us-or",
+      "label": "Page 1178",
+      "sequence": 72,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1179",
+      "id": "or-0072",
+      "jurisdiction": "us-or",
+      "label": "Page 1179",
+      "sequence": 73,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-118",
+      "id": "or-0073",
+      "jurisdiction": "us-or",
+      "label": "Page 118",
+      "sequence": 74,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1180",
+      "id": "or-0074",
+      "jurisdiction": "us-or",
+      "label": "Page 1180",
+      "sequence": 75,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1181",
+      "id": "or-0075",
+      "jurisdiction": "us-or",
+      "label": "Page 1181",
+      "sequence": 76,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1182",
+      "id": "or-0076",
+      "jurisdiction": "us-or",
+      "label": "Page 1182",
+      "sequence": 77,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1184",
+      "id": "or-0077",
+      "jurisdiction": "us-or",
+      "label": "Page 1184",
+      "sequence": 78,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-119",
+      "id": "or-0078",
+      "jurisdiction": "us-or",
+      "label": "Page 119",
+      "sequence": 79,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1192",
+      "id": "or-0079",
+      "jurisdiction": "us-or",
+      "label": "Page 1192",
+      "sequence": 80,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1193",
+      "id": "or-0080",
+      "jurisdiction": "us-or",
+      "label": "Page 1193",
+      "sequence": 81,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1194",
+      "id": "or-0081",
+      "jurisdiction": "us-or",
+      "label": "Page 1194",
+      "sequence": 82,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-12",
+      "id": "or-0082",
+      "jurisdiction": "us-or",
+      "label": "Page 12",
+      "sequence": 83,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1200",
+      "id": "or-0083",
+      "jurisdiction": "us-or",
+      "label": "Page 1200",
+      "sequence": 84,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1209",
+      "id": "or-0084",
+      "jurisdiction": "us-or",
+      "label": "Page 1209",
+      "sequence": 85,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-121",
+      "id": "or-0085",
+      "jurisdiction": "us-or",
+      "label": "Page 121",
+      "sequence": 86,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1212",
+      "id": "or-0086",
+      "jurisdiction": "us-or",
+      "label": "Page 1212",
+      "sequence": 87,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1213",
+      "id": "or-0087",
+      "jurisdiction": "us-or",
+      "label": "Page 1213",
+      "sequence": 88,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1214",
+      "id": "or-0088",
+      "jurisdiction": "us-or",
+      "label": "Page 1214",
+      "sequence": 89,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1217",
+      "id": "or-0089",
+      "jurisdiction": "us-or",
+      "label": "Page 1217",
+      "sequence": 90,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1219",
+      "id": "or-0090",
+      "jurisdiction": "us-or",
+      "label": "Page 1219",
+      "sequence": 91,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1220",
+      "id": "or-0091",
+      "jurisdiction": "us-or",
+      "label": "Page 1220",
+      "sequence": 92,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1222",
+      "id": "or-0092",
+      "jurisdiction": "us-or",
+      "label": "Page 1222",
+      "sequence": 93,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1226",
+      "id": "or-0093",
+      "jurisdiction": "us-or",
+      "label": "Page 1226",
+      "sequence": 94,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1227",
+      "id": "or-0094",
+      "jurisdiction": "us-or",
+      "label": "Page 1227",
+      "sequence": 95,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1228",
+      "id": "or-0095",
+      "jurisdiction": "us-or",
+      "label": "Page 1228",
+      "sequence": 96,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1229",
+      "id": "or-0096",
+      "jurisdiction": "us-or",
+      "label": "Page 1229",
+      "sequence": 97,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-123",
+      "id": "or-0097",
+      "jurisdiction": "us-or",
+      "label": "Page 123",
+      "sequence": 98,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1230",
+      "id": "or-0098",
+      "jurisdiction": "us-or",
+      "label": "Page 1230",
+      "sequence": 99,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1231",
+      "id": "or-0099",
+      "jurisdiction": "us-or",
+      "label": "Page 1231",
+      "sequence": 100,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1232",
+      "id": "or-0100",
+      "jurisdiction": "us-or",
+      "label": "Page 1232",
+      "sequence": 101,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1233",
+      "id": "or-0101",
+      "jurisdiction": "us-or",
+      "label": "Page 1233",
+      "sequence": 102,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-124",
+      "id": "or-0102",
+      "jurisdiction": "us-or",
+      "label": "Page 124",
+      "sequence": 103,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1243",
+      "id": "or-0103",
+      "jurisdiction": "us-or",
+      "label": "Page 1243",
+      "sequence": 104,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1244",
+      "id": "or-0104",
+      "jurisdiction": "us-or",
+      "label": "Page 1244",
+      "sequence": 105,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1245",
+      "id": "or-0105",
+      "jurisdiction": "us-or",
+      "label": "Page 1245",
+      "sequence": 106,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1246",
+      "id": "or-0106",
+      "jurisdiction": "us-or",
+      "label": "Page 1246",
+      "sequence": 107,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1247",
+      "id": "or-0107",
+      "jurisdiction": "us-or",
+      "label": "Page 1247",
+      "sequence": 108,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-125",
+      "id": "or-0108",
+      "jurisdiction": "us-or",
+      "label": "Page 125",
+      "sequence": 109,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1265",
+      "id": "or-0109",
+      "jurisdiction": "us-or",
+      "label": "Page 1265",
+      "sequence": 110,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1266",
+      "id": "or-0110",
+      "jurisdiction": "us-or",
+      "label": "Page 1266",
+      "sequence": 111,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1269",
+      "id": "or-0111",
+      "jurisdiction": "us-or",
+      "label": "Page 1269",
+      "sequence": 112,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-127",
+      "id": "or-0112",
+      "jurisdiction": "us-or",
+      "label": "Page 127",
+      "sequence": 113,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1270",
+      "id": "or-0113",
+      "jurisdiction": "us-or",
+      "label": "Page 1270",
+      "sequence": 114,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1274",
+      "id": "or-0114",
+      "jurisdiction": "us-or",
+      "label": "Page 1274",
+      "sequence": 115,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1279",
+      "id": "or-0115",
+      "jurisdiction": "us-or",
+      "label": "Page 1279",
+      "sequence": 116,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1280",
+      "id": "or-0116",
+      "jurisdiction": "us-or",
+      "label": "Page 1280",
+      "sequence": 117,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1281",
+      "id": "or-0117",
+      "jurisdiction": "us-or",
+      "label": "Page 1281",
+      "sequence": 118,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1286",
+      "id": "or-0118",
+      "jurisdiction": "us-or",
+      "label": "Page 1286",
+      "sequence": 119,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1287",
+      "id": "or-0119",
+      "jurisdiction": "us-or",
+      "label": "Page 1287",
+      "sequence": 120,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1288",
+      "id": "or-0120",
+      "jurisdiction": "us-or",
+      "label": "Page 1288",
+      "sequence": 121,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1289",
+      "id": "or-0121",
+      "jurisdiction": "us-or",
+      "label": "Page 1289",
+      "sequence": 122,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-129",
+      "id": "or-0122",
+      "jurisdiction": "us-or",
+      "label": "Page 129",
+      "sequence": 123,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1290",
+      "id": "or-0123",
+      "jurisdiction": "us-or",
+      "label": "Page 1290",
+      "sequence": 124,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1296",
+      "id": "or-0124",
+      "jurisdiction": "us-or",
+      "label": "Page 1296",
+      "sequence": 125,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1309",
+      "id": "or-0125",
+      "jurisdiction": "us-or",
+      "label": "Page 1309",
+      "sequence": 126,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1315",
+      "id": "or-0126",
+      "jurisdiction": "us-or",
+      "label": "Page 1315",
+      "sequence": 127,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1316",
+      "id": "or-0127",
+      "jurisdiction": "us-or",
+      "label": "Page 1316",
+      "sequence": 128,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1319",
+      "id": "or-0128",
+      "jurisdiction": "us-or",
+      "label": "Page 1319",
+      "sequence": 129,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-132",
+      "id": "or-0129",
+      "jurisdiction": "us-or",
+      "label": "Page 132",
+      "sequence": 130,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1320",
+      "id": "or-0130",
+      "jurisdiction": "us-or",
+      "label": "Page 1320",
+      "sequence": 131,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-1322",
+      "id": "or-0131",
+      "jurisdiction": "us-or",
+      "label": "Page 1322",
+      "sequence": 132,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-133",
+      "id": "or-0132",
+      "jurisdiction": "us-or",
+      "label": "Page 133",
+      "sequence": 133,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-14",
+      "id": "or-0133",
+      "jurisdiction": "us-or",
+      "label": "Page 14",
+      "sequence": 134,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-141",
+      "id": "or-0134",
+      "jurisdiction": "us-or",
+      "label": "Page 141",
+      "sequence": 135,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-142",
+      "id": "or-0135",
+      "jurisdiction": "us-or",
+      "label": "Page 142",
+      "sequence": 136,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-143",
+      "id": "or-0136",
+      "jurisdiction": "us-or",
+      "label": "Page 143",
+      "sequence": 137,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-144",
+      "id": "or-0137",
+      "jurisdiction": "us-or",
+      "label": "Page 144",
+      "sequence": 138,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-145",
+      "id": "or-0138",
+      "jurisdiction": "us-or",
+      "label": "Page 145",
+      "sequence": 139,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-149",
+      "id": "or-0139",
+      "jurisdiction": "us-or",
+      "label": "Page 149",
+      "sequence": 140,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-151",
+      "id": "or-0140",
+      "jurisdiction": "us-or",
+      "label": "Page 151",
+      "sequence": 141,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-152",
+      "id": "or-0141",
+      "jurisdiction": "us-or",
+      "label": "Page 152",
+      "sequence": 142,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-157",
+      "id": "or-0142",
+      "jurisdiction": "us-or",
+      "label": "Page 157",
+      "sequence": 143,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-159",
+      "id": "or-0143",
+      "jurisdiction": "us-or",
+      "label": "Page 159",
+      "sequence": 144,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-160",
+      "id": "or-0144",
+      "jurisdiction": "us-or",
+      "label": "Page 160",
+      "sequence": 145,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-164",
+      "id": "or-0145",
+      "jurisdiction": "us-or",
+      "label": "Page 164",
+      "sequence": 146,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-168",
+      "id": "or-0146",
+      "jurisdiction": "us-or",
+      "label": "Page 168",
+      "sequence": 147,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-169",
+      "id": "or-0147",
+      "jurisdiction": "us-or",
+      "label": "Page 169",
+      "sequence": 148,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-171",
+      "id": "or-0148",
+      "jurisdiction": "us-or",
+      "label": "Page 171",
+      "sequence": 149,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-172",
+      "id": "or-0149",
+      "jurisdiction": "us-or",
+      "label": "Page 172",
+      "sequence": 150,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-173",
+      "id": "or-0150",
+      "jurisdiction": "us-or",
+      "label": "Page 173",
+      "sequence": 151,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-174",
+      "id": "or-0151",
+      "jurisdiction": "us-or",
+      "label": "Page 174",
+      "sequence": 152,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-175",
+      "id": "or-0152",
+      "jurisdiction": "us-or",
+      "label": "Page 175",
+      "sequence": 153,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-176",
+      "id": "or-0153",
+      "jurisdiction": "us-or",
+      "label": "Page 176",
+      "sequence": 154,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-177",
+      "id": "or-0154",
+      "jurisdiction": "us-or",
+      "label": "Page 177",
+      "sequence": 155,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-178",
+      "id": "or-0155",
+      "jurisdiction": "us-or",
+      "label": "Page 178",
+      "sequence": 156,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-183",
+      "id": "or-0156",
+      "jurisdiction": "us-or",
+      "label": "Page 183",
+      "sequence": 157,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-184",
+      "id": "or-0157",
+      "jurisdiction": "us-or",
+      "label": "Page 184",
+      "sequence": 158,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-186",
+      "id": "or-0158",
+      "jurisdiction": "us-or",
+      "label": "Page 186",
+      "sequence": 159,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-187",
+      "id": "or-0159",
+      "jurisdiction": "us-or",
+      "label": "Page 187",
+      "sequence": 160,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-189",
+      "id": "or-0160",
+      "jurisdiction": "us-or",
+      "label": "Page 189",
+      "sequence": 161,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-19",
+      "id": "or-0161",
+      "jurisdiction": "us-or",
+      "label": "Page 19",
+      "sequence": 162,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-190",
+      "id": "or-0162",
+      "jurisdiction": "us-or",
+      "label": "Page 190",
+      "sequence": 163,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-191",
+      "id": "or-0163",
+      "jurisdiction": "us-or",
+      "label": "Page 191",
+      "sequence": 164,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-193",
+      "id": "or-0164",
+      "jurisdiction": "us-or",
+      "label": "Page 193",
+      "sequence": 165,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-195",
+      "id": "or-0165",
+      "jurisdiction": "us-or",
+      "label": "Page 195",
+      "sequence": 166,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-196",
+      "id": "or-0166",
+      "jurisdiction": "us-or",
+      "label": "Page 196",
+      "sequence": 167,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-197",
+      "id": "or-0167",
+      "jurisdiction": "us-or",
+      "label": "Page 197",
+      "sequence": 168,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-198",
+      "id": "or-0168",
+      "jurisdiction": "us-or",
+      "label": "Page 198",
+      "sequence": 169,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-2",
+      "id": "or-0169",
+      "jurisdiction": "us-or",
+      "label": "Page 2",
+      "sequence": 170,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-20",
+      "id": "or-0170",
+      "jurisdiction": "us-or",
+      "label": "Page 20",
+      "sequence": 171,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-201",
+      "id": "or-0171",
+      "jurisdiction": "us-or",
+      "label": "Page 201",
+      "sequence": 172,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-202",
+      "id": "or-0172",
+      "jurisdiction": "us-or",
+      "label": "Page 202",
+      "sequence": 173,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-205",
+      "id": "or-0173",
+      "jurisdiction": "us-or",
+      "label": "Page 205",
+      "sequence": 174,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-207",
+      "id": "or-0174",
+      "jurisdiction": "us-or",
+      "label": "Page 207",
+      "sequence": 175,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-208",
+      "id": "or-0175",
+      "jurisdiction": "us-or",
+      "label": "Page 208",
+      "sequence": 176,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-210",
+      "id": "or-0176",
+      "jurisdiction": "us-or",
+      "label": "Page 210",
+      "sequence": 177,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-211",
+      "id": "or-0177",
+      "jurisdiction": "us-or",
+      "label": "Page 211",
+      "sequence": 178,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-212",
+      "id": "or-0178",
+      "jurisdiction": "us-or",
+      "label": "Page 212",
+      "sequence": 179,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-213",
+      "id": "or-0179",
+      "jurisdiction": "us-or",
+      "label": "Page 213",
+      "sequence": 180,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-214",
+      "id": "or-0180",
+      "jurisdiction": "us-or",
+      "label": "Page 214",
+      "sequence": 181,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-215",
+      "id": "or-0181",
+      "jurisdiction": "us-or",
+      "label": "Page 215",
+      "sequence": 182,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-217",
+      "id": "or-0182",
+      "jurisdiction": "us-or",
+      "label": "Page 217",
+      "sequence": 183,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-22",
+      "id": "or-0183",
+      "jurisdiction": "us-or",
+      "label": "Page 22",
+      "sequence": 184,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-224",
+      "id": "or-0184",
+      "jurisdiction": "us-or",
+      "label": "Page 224",
+      "sequence": 185,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-228",
+      "id": "or-0185",
+      "jurisdiction": "us-or",
+      "label": "Page 228",
+      "sequence": 186,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-229",
+      "id": "or-0186",
+      "jurisdiction": "us-or",
+      "label": "Page 229",
+      "sequence": 187,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-230",
+      "id": "or-0187",
+      "jurisdiction": "us-or",
+      "label": "Page 230",
+      "sequence": 188,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-232",
+      "id": "or-0188",
+      "jurisdiction": "us-or",
+      "label": "Page 232",
+      "sequence": 189,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-235",
+      "id": "or-0189",
+      "jurisdiction": "us-or",
+      "label": "Page 235",
+      "sequence": 190,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-237",
+      "id": "or-0190",
+      "jurisdiction": "us-or",
+      "label": "Page 237",
+      "sequence": 191,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-239",
+      "id": "or-0191",
+      "jurisdiction": "us-or",
+      "label": "Page 239",
+      "sequence": 192,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-240",
+      "id": "or-0192",
+      "jurisdiction": "us-or",
+      "label": "Page 240",
+      "sequence": 193,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-242",
+      "id": "or-0193",
+      "jurisdiction": "us-or",
+      "label": "Page 242",
+      "sequence": 194,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-243",
+      "id": "or-0194",
+      "jurisdiction": "us-or",
+      "label": "Page 243",
+      "sequence": 195,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-247",
+      "id": "or-0195",
+      "jurisdiction": "us-or",
+      "label": "Page 247",
+      "sequence": 196,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-249",
+      "id": "or-0196",
+      "jurisdiction": "us-or",
+      "label": "Page 249",
+      "sequence": 197,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-25",
+      "id": "or-0197",
+      "jurisdiction": "us-or",
+      "label": "Page 25",
+      "sequence": 198,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-250",
+      "id": "or-0198",
+      "jurisdiction": "us-or",
+      "label": "Page 250",
+      "sequence": 199,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-251",
+      "id": "or-0199",
+      "jurisdiction": "us-or",
+      "label": "Page 251",
+      "sequence": 200,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-253",
+      "id": "or-0200",
+      "jurisdiction": "us-or",
+      "label": "Page 253",
+      "sequence": 201,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-254",
+      "id": "or-0201",
+      "jurisdiction": "us-or",
+      "label": "Page 254",
+      "sequence": 202,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-255",
+      "id": "or-0202",
+      "jurisdiction": "us-or",
+      "label": "Page 255",
+      "sequence": 203,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-256",
+      "id": "or-0203",
+      "jurisdiction": "us-or",
+      "label": "Page 256",
+      "sequence": 204,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-257",
+      "id": "or-0204",
+      "jurisdiction": "us-or",
+      "label": "Page 257",
+      "sequence": 205,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-258",
+      "id": "or-0205",
+      "jurisdiction": "us-or",
+      "label": "Page 258",
+      "sequence": 206,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-26",
+      "id": "or-0206",
+      "jurisdiction": "us-or",
+      "label": "Page 26",
+      "sequence": 207,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-261",
+      "id": "or-0207",
+      "jurisdiction": "us-or",
+      "label": "Page 261",
+      "sequence": 208,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-262",
+      "id": "or-0208",
+      "jurisdiction": "us-or",
+      "label": "Page 262",
+      "sequence": 209,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-263",
+      "id": "or-0209",
+      "jurisdiction": "us-or",
+      "label": "Page 263",
+      "sequence": 210,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-269",
+      "id": "or-0210",
+      "jurisdiction": "us-or",
+      "label": "Page 269",
+      "sequence": 211,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-270",
+      "id": "or-0211",
+      "jurisdiction": "us-or",
+      "label": "Page 270",
+      "sequence": 212,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-271",
+      "id": "or-0212",
+      "jurisdiction": "us-or",
+      "label": "Page 271",
+      "sequence": 213,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-275",
+      "id": "or-0213",
+      "jurisdiction": "us-or",
+      "label": "Page 275",
+      "sequence": 214,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-277",
+      "id": "or-0214",
+      "jurisdiction": "us-or",
+      "label": "Page 277",
+      "sequence": 215,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-278",
+      "id": "or-0215",
+      "jurisdiction": "us-or",
+      "label": "Page 278",
+      "sequence": 216,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-279",
+      "id": "or-0216",
+      "jurisdiction": "us-or",
+      "label": "Page 279",
+      "sequence": 217,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-280",
+      "id": "or-0217",
+      "jurisdiction": "us-or",
+      "label": "Page 280",
+      "sequence": 218,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-281",
+      "id": "or-0218",
+      "jurisdiction": "us-or",
+      "label": "Page 281",
+      "sequence": 219,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-286",
+      "id": "or-0219",
+      "jurisdiction": "us-or",
+      "label": "Page 286",
+      "sequence": 220,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-287",
+      "id": "or-0220",
+      "jurisdiction": "us-or",
+      "label": "Page 287",
+      "sequence": 221,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-29",
+      "id": "or-0221",
+      "jurisdiction": "us-or",
+      "label": "Page 29",
+      "sequence": 222,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-290",
+      "id": "or-0222",
+      "jurisdiction": "us-or",
+      "label": "Page 290",
+      "sequence": 223,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-291",
+      "id": "or-0223",
+      "jurisdiction": "us-or",
+      "label": "Page 291",
+      "sequence": 224,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-294",
+      "id": "or-0224",
+      "jurisdiction": "us-or",
+      "label": "Page 294",
+      "sequence": 225,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-295",
+      "id": "or-0225",
+      "jurisdiction": "us-or",
+      "label": "Page 295",
+      "sequence": 226,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-299",
+      "id": "or-0226",
+      "jurisdiction": "us-or",
+      "label": "Page 299",
+      "sequence": 227,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-30",
+      "id": "or-0227",
+      "jurisdiction": "us-or",
+      "label": "Page 30",
+      "sequence": 228,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-301",
+      "id": "or-0228",
+      "jurisdiction": "us-or",
+      "label": "Page 301",
+      "sequence": 229,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-303",
+      "id": "or-0229",
+      "jurisdiction": "us-or",
+      "label": "Page 303",
+      "sequence": 230,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-306",
+      "id": "or-0230",
+      "jurisdiction": "us-or",
+      "label": "Page 306",
+      "sequence": 231,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-307",
+      "id": "or-0231",
+      "jurisdiction": "us-or",
+      "label": "Page 307",
+      "sequence": 232,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-308",
+      "id": "or-0232",
+      "jurisdiction": "us-or",
+      "label": "Page 308",
+      "sequence": 233,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-312",
+      "id": "or-0233",
+      "jurisdiction": "us-or",
+      "label": "Page 312",
+      "sequence": 234,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-314",
+      "id": "or-0234",
+      "jurisdiction": "us-or",
+      "label": "Page 314",
+      "sequence": 235,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-315",
+      "id": "or-0235",
+      "jurisdiction": "us-or",
+      "label": "Page 315",
+      "sequence": 236,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-319",
+      "id": "or-0236",
+      "jurisdiction": "us-or",
+      "label": "Page 319",
+      "sequence": 237,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-320",
+      "id": "or-0237",
+      "jurisdiction": "us-or",
+      "label": "Page 320",
+      "sequence": 238,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-321",
+      "id": "or-0238",
+      "jurisdiction": "us-or",
+      "label": "Page 321",
+      "sequence": 239,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-322",
+      "id": "or-0239",
+      "jurisdiction": "us-or",
+      "label": "Page 322",
+      "sequence": 240,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-323",
+      "id": "or-0240",
+      "jurisdiction": "us-or",
+      "label": "Page 323",
+      "sequence": 241,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-324",
+      "id": "or-0241",
+      "jurisdiction": "us-or",
+      "label": "Page 324",
+      "sequence": 242,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-326",
+      "id": "or-0242",
+      "jurisdiction": "us-or",
+      "label": "Page 326",
+      "sequence": 243,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-327",
+      "id": "or-0243",
+      "jurisdiction": "us-or",
+      "label": "Page 327",
+      "sequence": 244,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-329",
+      "id": "or-0244",
+      "jurisdiction": "us-or",
+      "label": "Page 329",
+      "sequence": 245,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-331",
+      "id": "or-0245",
+      "jurisdiction": "us-or",
+      "label": "Page 331",
+      "sequence": 246,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-334",
+      "id": "or-0246",
+      "jurisdiction": "us-or",
+      "label": "Page 334",
+      "sequence": 247,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-335",
+      "id": "or-0247",
+      "jurisdiction": "us-or",
+      "label": "Page 335",
+      "sequence": 248,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-336",
+      "id": "or-0248",
+      "jurisdiction": "us-or",
+      "label": "Page 336",
+      "sequence": 249,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-337",
+      "id": "or-0249",
+      "jurisdiction": "us-or",
+      "label": "Page 337",
+      "sequence": 250,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-338",
+      "id": "or-0250",
+      "jurisdiction": "us-or",
+      "label": "Page 338",
+      "sequence": 251,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-339",
+      "id": "or-0251",
+      "jurisdiction": "us-or",
+      "label": "Page 339",
+      "sequence": 252,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-341",
+      "id": "or-0252",
+      "jurisdiction": "us-or",
+      "label": "Page 341",
+      "sequence": 253,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-342",
+      "id": "or-0253",
+      "jurisdiction": "us-or",
+      "label": "Page 342",
+      "sequence": 254,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-344",
+      "id": "or-0254",
+      "jurisdiction": "us-or",
+      "label": "Page 344",
+      "sequence": 255,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-347",
+      "id": "or-0255",
+      "jurisdiction": "us-or",
+      "label": "Page 347",
+      "sequence": 256,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-348",
+      "id": "or-0256",
+      "jurisdiction": "us-or",
+      "label": "Page 348",
+      "sequence": 257,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-351",
+      "id": "or-0257",
+      "jurisdiction": "us-or",
+      "label": "Page 351",
+      "sequence": 258,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-352",
+      "id": "or-0258",
+      "jurisdiction": "us-or",
+      "label": "Page 352",
+      "sequence": 259,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-355",
+      "id": "or-0259",
+      "jurisdiction": "us-or",
+      "label": "Page 355",
+      "sequence": 260,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-356",
+      "id": "or-0260",
+      "jurisdiction": "us-or",
+      "label": "Page 356",
+      "sequence": 261,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-357",
+      "id": "or-0261",
+      "jurisdiction": "us-or",
+      "label": "Page 357",
+      "sequence": 262,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-358",
+      "id": "or-0262",
+      "jurisdiction": "us-or",
+      "label": "Page 358",
+      "sequence": 263,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-360",
+      "id": "or-0263",
+      "jurisdiction": "us-or",
+      "label": "Page 360",
+      "sequence": 264,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-361",
+      "id": "or-0264",
+      "jurisdiction": "us-or",
+      "label": "Page 361",
+      "sequence": 265,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-363",
+      "id": "or-0265",
+      "jurisdiction": "us-or",
+      "label": "Page 363",
+      "sequence": 266,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-364",
+      "id": "or-0266",
+      "jurisdiction": "us-or",
+      "label": "Page 364",
+      "sequence": 267,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-368",
+      "id": "or-0267",
+      "jurisdiction": "us-or",
+      "label": "Page 368",
+      "sequence": 268,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-370",
+      "id": "or-0268",
+      "jurisdiction": "us-or",
+      "label": "Page 370",
+      "sequence": 269,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-371",
+      "id": "or-0269",
+      "jurisdiction": "us-or",
+      "label": "Page 371",
+      "sequence": 270,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-372",
+      "id": "or-0270",
+      "jurisdiction": "us-or",
+      "label": "Page 372",
+      "sequence": 271,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-373",
+      "id": "or-0271",
+      "jurisdiction": "us-or",
+      "label": "Page 373",
+      "sequence": 272,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-374",
+      "id": "or-0272",
+      "jurisdiction": "us-or",
+      "label": "Page 374",
+      "sequence": 273,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-375",
+      "id": "or-0273",
+      "jurisdiction": "us-or",
+      "label": "Page 375",
+      "sequence": 274,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-376",
+      "id": "or-0274",
+      "jurisdiction": "us-or",
+      "label": "Page 376",
+      "sequence": 275,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-378",
+      "id": "or-0275",
+      "jurisdiction": "us-or",
+      "label": "Page 378",
+      "sequence": 276,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-380",
+      "id": "or-0276",
+      "jurisdiction": "us-or",
+      "label": "Page 380",
+      "sequence": 277,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-381",
+      "id": "or-0277",
+      "jurisdiction": "us-or",
+      "label": "Page 381",
+      "sequence": 278,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-382",
+      "id": "or-0278",
+      "jurisdiction": "us-or",
+      "label": "Page 382",
+      "sequence": 279,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-384",
+      "id": "or-0279",
+      "jurisdiction": "us-or",
+      "label": "Page 384",
+      "sequence": 280,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-385",
+      "id": "or-0280",
+      "jurisdiction": "us-or",
+      "label": "Page 385",
+      "sequence": 281,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-387",
+      "id": "or-0281",
+      "jurisdiction": "us-or",
+      "label": "Page 387",
+      "sequence": 282,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-391",
+      "id": "or-0282",
+      "jurisdiction": "us-or",
+      "label": "Page 391",
+      "sequence": 283,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-393",
+      "id": "or-0283",
+      "jurisdiction": "us-or",
+      "label": "Page 393",
+      "sequence": 284,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-394",
+      "id": "or-0284",
+      "jurisdiction": "us-or",
+      "label": "Page 394",
+      "sequence": 285,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-397",
+      "id": "or-0285",
+      "jurisdiction": "us-or",
+      "label": "Page 397",
+      "sequence": 286,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-398",
+      "id": "or-0286",
+      "jurisdiction": "us-or",
+      "label": "Page 398",
+      "sequence": 287,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-399",
+      "id": "or-0287",
+      "jurisdiction": "us-or",
+      "label": "Page 399",
+      "sequence": 288,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-400",
+      "id": "or-0288",
+      "jurisdiction": "us-or",
+      "label": "Page 400",
+      "sequence": 289,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-401",
+      "id": "or-0289",
+      "jurisdiction": "us-or",
+      "label": "Page 401",
+      "sequence": 290,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-402",
+      "id": "or-0290",
+      "jurisdiction": "us-or",
+      "label": "Page 402",
+      "sequence": 291,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-404",
+      "id": "or-0291",
+      "jurisdiction": "us-or",
+      "label": "Page 404",
+      "sequence": 292,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-405",
+      "id": "or-0292",
+      "jurisdiction": "us-or",
+      "label": "Page 405",
+      "sequence": 293,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-406",
+      "id": "or-0293",
+      "jurisdiction": "us-or",
+      "label": "Page 406",
+      "sequence": 294,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-407",
+      "id": "or-0294",
+      "jurisdiction": "us-or",
+      "label": "Page 407",
+      "sequence": 295,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-408",
+      "id": "or-0295",
+      "jurisdiction": "us-or",
+      "label": "Page 408",
+      "sequence": 296,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-409",
+      "id": "or-0296",
+      "jurisdiction": "us-or",
+      "label": "Page 409",
+      "sequence": 297,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-411",
+      "id": "or-0297",
+      "jurisdiction": "us-or",
+      "label": "Page 411",
+      "sequence": 298,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-412",
+      "id": "or-0298",
+      "jurisdiction": "us-or",
+      "label": "Page 412",
+      "sequence": 299,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-418",
+      "id": "or-0299",
+      "jurisdiction": "us-or",
+      "label": "Page 418",
+      "sequence": 300,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-419",
+      "id": "or-0300",
+      "jurisdiction": "us-or",
+      "label": "Page 419",
+      "sequence": 301,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-420",
+      "id": "or-0301",
+      "jurisdiction": "us-or",
+      "label": "Page 420",
+      "sequence": 302,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-421",
+      "id": "or-0302",
+      "jurisdiction": "us-or",
+      "label": "Page 421",
+      "sequence": 303,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-422",
+      "id": "or-0303",
+      "jurisdiction": "us-or",
+      "label": "Page 422",
+      "sequence": 304,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-423",
+      "id": "or-0304",
+      "jurisdiction": "us-or",
+      "label": "Page 423",
+      "sequence": 305,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-424",
+      "id": "or-0305",
+      "jurisdiction": "us-or",
+      "label": "Page 424",
+      "sequence": 306,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-427",
+      "id": "or-0306",
+      "jurisdiction": "us-or",
+      "label": "Page 427",
+      "sequence": 307,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-43",
+      "id": "or-0307",
+      "jurisdiction": "us-or",
+      "label": "Page 43",
+      "sequence": 308,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-435",
+      "id": "or-0308",
+      "jurisdiction": "us-or",
+      "label": "Page 435",
+      "sequence": 309,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-437",
+      "id": "or-0309",
+      "jurisdiction": "us-or",
+      "label": "Page 437",
+      "sequence": 310,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-451",
+      "id": "or-0310",
+      "jurisdiction": "us-or",
+      "label": "Page 451",
+      "sequence": 311,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-457",
+      "id": "or-0311",
+      "jurisdiction": "us-or",
+      "label": "Page 457",
+      "sequence": 312,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-460",
+      "id": "or-0312",
+      "jurisdiction": "us-or",
+      "label": "Page 460",
+      "sequence": 313,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-461",
+      "id": "or-0313",
+      "jurisdiction": "us-or",
+      "label": "Page 461",
+      "sequence": 314,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-462",
+      "id": "or-0314",
+      "jurisdiction": "us-or",
+      "label": "Page 462",
+      "sequence": 315,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-463",
+      "id": "or-0315",
+      "jurisdiction": "us-or",
+      "label": "Page 463",
+      "sequence": 316,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-464",
+      "id": "or-0316",
+      "jurisdiction": "us-or",
+      "label": "Page 464",
+      "sequence": 317,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-465",
+      "id": "or-0317",
+      "jurisdiction": "us-or",
+      "label": "Page 465",
+      "sequence": 318,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-466",
+      "id": "or-0318",
+      "jurisdiction": "us-or",
+      "label": "Page 466",
+      "sequence": 319,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-467",
+      "id": "or-0319",
+      "jurisdiction": "us-or",
+      "label": "Page 467",
+      "sequence": 320,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-468",
+      "id": "or-0320",
+      "jurisdiction": "us-or",
+      "label": "Page 468",
+      "sequence": 321,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-469",
+      "id": "or-0321",
+      "jurisdiction": "us-or",
+      "label": "Page 469",
+      "sequence": 322,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-47",
+      "id": "or-0322",
+      "jurisdiction": "us-or",
+      "label": "Page 47",
+      "sequence": 323,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-470",
+      "id": "or-0323",
+      "jurisdiction": "us-or",
+      "label": "Page 470",
+      "sequence": 324,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-471",
+      "id": "or-0324",
+      "jurisdiction": "us-or",
+      "label": "Page 471",
+      "sequence": 325,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-472",
+      "id": "or-0325",
+      "jurisdiction": "us-or",
+      "label": "Page 472",
+      "sequence": 326,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-473",
+      "id": "or-0326",
+      "jurisdiction": "us-or",
+      "label": "Page 473",
+      "sequence": 327,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-474",
+      "id": "or-0327",
+      "jurisdiction": "us-or",
+      "label": "Page 474",
+      "sequence": 328,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-475",
+      "id": "or-0328",
+      "jurisdiction": "us-or",
+      "label": "Page 475",
+      "sequence": 329,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-476",
+      "id": "or-0329",
+      "jurisdiction": "us-or",
+      "label": "Page 476",
+      "sequence": 330,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-484",
+      "id": "or-0330",
+      "jurisdiction": "us-or",
+      "label": "Page 484",
+      "sequence": 331,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-485",
+      "id": "or-0331",
+      "jurisdiction": "us-or",
+      "label": "Page 485",
+      "sequence": 332,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-487",
+      "id": "or-0332",
+      "jurisdiction": "us-or",
+      "label": "Page 487",
+      "sequence": 333,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-488",
+      "id": "or-0333",
+      "jurisdiction": "us-or",
+      "label": "Page 488",
+      "sequence": 334,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-490",
+      "id": "or-0334",
+      "jurisdiction": "us-or",
+      "label": "Page 490",
+      "sequence": 335,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-491",
+      "id": "or-0335",
+      "jurisdiction": "us-or",
+      "label": "Page 491",
+      "sequence": 336,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-493",
+      "id": "or-0336",
+      "jurisdiction": "us-or",
+      "label": "Page 493",
+      "sequence": 337,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-497",
+      "id": "or-0337",
+      "jurisdiction": "us-or",
+      "label": "Page 497",
+      "sequence": 338,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-498",
+      "id": "or-0338",
+      "jurisdiction": "us-or",
+      "label": "Page 498",
+      "sequence": 339,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-499",
+      "id": "or-0339",
+      "jurisdiction": "us-or",
+      "label": "Page 499",
+      "sequence": 340,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-5",
+      "id": "or-0340",
+      "jurisdiction": "us-or",
+      "label": "Page 5",
+      "sequence": 341,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-500",
+      "id": "or-0341",
+      "jurisdiction": "us-or",
+      "label": "Page 500",
+      "sequence": 342,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-501",
+      "id": "or-0342",
+      "jurisdiction": "us-or",
+      "label": "Page 501",
+      "sequence": 343,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-502",
+      "id": "or-0343",
+      "jurisdiction": "us-or",
+      "label": "Page 502",
+      "sequence": 344,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-503",
+      "id": "or-0344",
+      "jurisdiction": "us-or",
+      "label": "Page 503",
+      "sequence": 345,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-517",
+      "id": "or-0345",
+      "jurisdiction": "us-or",
+      "label": "Page 517",
+      "sequence": 346,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-52",
+      "id": "or-0346",
+      "jurisdiction": "us-or",
+      "label": "Page 52",
+      "sequence": 347,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-526",
+      "id": "or-0347",
+      "jurisdiction": "us-or",
+      "label": "Page 526",
+      "sequence": 348,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-537",
+      "id": "or-0348",
+      "jurisdiction": "us-or",
+      "label": "Page 537",
+      "sequence": 349,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-538",
+      "id": "or-0349",
+      "jurisdiction": "us-or",
+      "label": "Page 538",
+      "sequence": 350,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-539",
+      "id": "or-0350",
+      "jurisdiction": "us-or",
+      "label": "Page 539",
+      "sequence": 351,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-54",
+      "id": "or-0351",
+      "jurisdiction": "us-or",
+      "label": "Page 54",
+      "sequence": 352,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-543",
+      "id": "or-0352",
+      "jurisdiction": "us-or",
+      "label": "Page 543",
+      "sequence": 353,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-546",
+      "id": "or-0353",
+      "jurisdiction": "us-or",
+      "label": "Page 546",
+      "sequence": 354,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-568",
+      "id": "or-0354",
+      "jurisdiction": "us-or",
+      "label": "Page 568",
+      "sequence": 355,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-578",
+      "id": "or-0355",
+      "jurisdiction": "us-or",
+      "label": "Page 578",
+      "sequence": 356,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-579",
+      "id": "or-0356",
+      "jurisdiction": "us-or",
+      "label": "Page 579",
+      "sequence": 357,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-580",
+      "id": "or-0357",
+      "jurisdiction": "us-or",
+      "label": "Page 580",
+      "sequence": 358,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-583",
+      "id": "or-0358",
+      "jurisdiction": "us-or",
+      "label": "Page 583",
+      "sequence": 359,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-584",
+      "id": "or-0359",
+      "jurisdiction": "us-or",
+      "label": "Page 584",
+      "sequence": 360,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-585",
+      "id": "or-0360",
+      "jurisdiction": "us-or",
+      "label": "Page 585",
+      "sequence": 361,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-586",
+      "id": "or-0361",
+      "jurisdiction": "us-or",
+      "label": "Page 586",
+      "sequence": 362,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-588",
+      "id": "or-0362",
+      "jurisdiction": "us-or",
+      "label": "Page 588",
+      "sequence": 363,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-589",
+      "id": "or-0363",
+      "jurisdiction": "us-or",
+      "label": "Page 589",
+      "sequence": 364,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-59",
+      "id": "or-0364",
+      "jurisdiction": "us-or",
+      "label": "Page 59",
+      "sequence": 365,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-590",
+      "id": "or-0365",
+      "jurisdiction": "us-or",
+      "label": "Page 590",
+      "sequence": 366,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-594",
+      "id": "or-0366",
+      "jurisdiction": "us-or",
+      "label": "Page 594",
+      "sequence": 367,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-595",
+      "id": "or-0367",
+      "jurisdiction": "us-or",
+      "label": "Page 595",
+      "sequence": 368,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-6",
+      "id": "or-0368",
+      "jurisdiction": "us-or",
+      "label": "Page 6",
+      "sequence": 369,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-600",
+      "id": "or-0369",
+      "jurisdiction": "us-or",
+      "label": "Page 600",
+      "sequence": 370,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-601",
+      "id": "or-0370",
+      "jurisdiction": "us-or",
+      "label": "Page 601",
+      "sequence": 371,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-606",
+      "id": "or-0371",
+      "jurisdiction": "us-or",
+      "label": "Page 606",
+      "sequence": 372,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-608",
+      "id": "or-0372",
+      "jurisdiction": "us-or",
+      "label": "Page 608",
+      "sequence": 373,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-609",
+      "id": "or-0373",
+      "jurisdiction": "us-or",
+      "label": "Page 609",
+      "sequence": 374,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-61",
+      "id": "or-0374",
+      "jurisdiction": "us-or",
+      "label": "Page 61",
+      "sequence": 375,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-611",
+      "id": "or-0375",
+      "jurisdiction": "us-or",
+      "label": "Page 611",
+      "sequence": 376,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-613",
+      "id": "or-0376",
+      "jurisdiction": "us-or",
+      "label": "Page 613",
+      "sequence": 377,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-616",
+      "id": "or-0377",
+      "jurisdiction": "us-or",
+      "label": "Page 616",
+      "sequence": 378,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-617",
+      "id": "or-0378",
+      "jurisdiction": "us-or",
+      "label": "Page 617",
+      "sequence": 379,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-62",
+      "id": "or-0379",
+      "jurisdiction": "us-or",
+      "label": "Page 62",
+      "sequence": 380,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-620",
+      "id": "or-0380",
+      "jurisdiction": "us-or",
+      "label": "Page 620",
+      "sequence": 381,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-621",
+      "id": "or-0381",
+      "jurisdiction": "us-or",
+      "label": "Page 621",
+      "sequence": 382,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-624",
+      "id": "or-0382",
+      "jurisdiction": "us-or",
+      "label": "Page 624",
+      "sequence": 383,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-627",
+      "id": "or-0383",
+      "jurisdiction": "us-or",
+      "label": "Page 627",
+      "sequence": 384,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-630",
+      "id": "or-0384",
+      "jurisdiction": "us-or",
+      "label": "Page 630",
+      "sequence": 385,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-631",
+      "id": "or-0385",
+      "jurisdiction": "us-or",
+      "label": "Page 631",
+      "sequence": 386,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-634",
+      "id": "or-0386",
+      "jurisdiction": "us-or",
+      "label": "Page 634",
+      "sequence": 387,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-639",
+      "id": "or-0387",
+      "jurisdiction": "us-or",
+      "label": "Page 639",
+      "sequence": 388,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-640",
+      "id": "or-0388",
+      "jurisdiction": "us-or",
+      "label": "Page 640",
+      "sequence": 389,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-644",
+      "id": "or-0389",
+      "jurisdiction": "us-or",
+      "label": "Page 644",
+      "sequence": 390,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-646",
+      "id": "or-0390",
+      "jurisdiction": "us-or",
+      "label": "Page 646",
+      "sequence": 391,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-647",
+      "id": "or-0391",
+      "jurisdiction": "us-or",
+      "label": "Page 647",
+      "sequence": 392,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-648",
+      "id": "or-0392",
+      "jurisdiction": "us-or",
+      "label": "Page 648",
+      "sequence": 393,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-649",
+      "id": "or-0393",
+      "jurisdiction": "us-or",
+      "label": "Page 649",
+      "sequence": 394,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-650",
+      "id": "or-0394",
+      "jurisdiction": "us-or",
+      "label": "Page 650",
+      "sequence": 395,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-651",
+      "id": "or-0395",
+      "jurisdiction": "us-or",
+      "label": "Page 651",
+      "sequence": 396,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-652",
+      "id": "or-0396",
+      "jurisdiction": "us-or",
+      "label": "Page 652",
+      "sequence": 397,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-653",
+      "id": "or-0397",
+      "jurisdiction": "us-or",
+      "label": "Page 653",
+      "sequence": 398,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-654",
+      "id": "or-0398",
+      "jurisdiction": "us-or",
+      "label": "Page 654",
+      "sequence": 399,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-659",
+      "id": "or-0399",
+      "jurisdiction": "us-or",
+      "label": "Page 659",
+      "sequence": 400,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-660",
+      "id": "or-0400",
+      "jurisdiction": "us-or",
+      "label": "Page 660",
+      "sequence": 401,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-661",
+      "id": "or-0401",
+      "jurisdiction": "us-or",
+      "label": "Page 661",
+      "sequence": 402,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-663",
+      "id": "or-0402",
+      "jurisdiction": "us-or",
+      "label": "Page 663",
+      "sequence": 403,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-665",
+      "id": "or-0403",
+      "jurisdiction": "us-or",
+      "label": "Page 665",
+      "sequence": 404,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-666",
+      "id": "or-0404",
+      "jurisdiction": "us-or",
+      "label": "Page 666",
+      "sequence": 405,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-667",
+      "id": "or-0405",
+      "jurisdiction": "us-or",
+      "label": "Page 667",
+      "sequence": 406,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-668",
+      "id": "or-0406",
+      "jurisdiction": "us-or",
+      "label": "Page 668",
+      "sequence": 407,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-669",
+      "id": "or-0407",
+      "jurisdiction": "us-or",
+      "label": "Page 669",
+      "sequence": 408,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-670",
+      "id": "or-0408",
+      "jurisdiction": "us-or",
+      "label": "Page 670",
+      "sequence": 409,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-671",
+      "id": "or-0409",
+      "jurisdiction": "us-or",
+      "label": "Page 671",
+      "sequence": 410,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-672",
+      "id": "or-0410",
+      "jurisdiction": "us-or",
+      "label": "Page 672",
+      "sequence": 411,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-673",
+      "id": "or-0411",
+      "jurisdiction": "us-or",
+      "label": "Page 673",
+      "sequence": 412,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-674",
+      "id": "or-0412",
+      "jurisdiction": "us-or",
+      "label": "Page 674",
+      "sequence": 413,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-675",
+      "id": "or-0413",
+      "jurisdiction": "us-or",
+      "label": "Page 675",
+      "sequence": 414,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-676",
+      "id": "or-0414",
+      "jurisdiction": "us-or",
+      "label": "Page 676",
+      "sequence": 415,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-677",
+      "id": "or-0415",
+      "jurisdiction": "us-or",
+      "label": "Page 677",
+      "sequence": 416,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-678",
+      "id": "or-0416",
+      "jurisdiction": "us-or",
+      "label": "Page 678",
+      "sequence": 417,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-679",
+      "id": "or-0417",
+      "jurisdiction": "us-or",
+      "label": "Page 679",
+      "sequence": 418,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-68",
+      "id": "or-0418",
+      "jurisdiction": "us-or",
+      "label": "Page 68",
+      "sequence": 419,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-680",
+      "id": "or-0419",
+      "jurisdiction": "us-or",
+      "label": "Page 680",
+      "sequence": 420,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-681",
+      "id": "or-0420",
+      "jurisdiction": "us-or",
+      "label": "Page 681",
+      "sequence": 421,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-682",
+      "id": "or-0421",
+      "jurisdiction": "us-or",
+      "label": "Page 682",
+      "sequence": 422,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-683",
+      "id": "or-0422",
+      "jurisdiction": "us-or",
+      "label": "Page 683",
+      "sequence": 423,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-684",
+      "id": "or-0423",
+      "jurisdiction": "us-or",
+      "label": "Page 684",
+      "sequence": 424,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-685",
+      "id": "or-0424",
+      "jurisdiction": "us-or",
+      "label": "Page 685",
+      "sequence": 425,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-686",
+      "id": "or-0425",
+      "jurisdiction": "us-or",
+      "label": "Page 686",
+      "sequence": 426,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-687",
+      "id": "or-0426",
+      "jurisdiction": "us-or",
+      "label": "Page 687",
+      "sequence": 427,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-688",
+      "id": "or-0427",
+      "jurisdiction": "us-or",
+      "label": "Page 688",
+      "sequence": 428,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-689",
+      "id": "or-0428",
+      "jurisdiction": "us-or",
+      "label": "Page 689",
+      "sequence": 429,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-690",
+      "id": "or-0429",
+      "jurisdiction": "us-or",
+      "label": "Page 690",
+      "sequence": 430,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-693",
+      "id": "or-0430",
+      "jurisdiction": "us-or",
+      "label": "Page 693",
+      "sequence": 431,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-694",
+      "id": "or-0431",
+      "jurisdiction": "us-or",
+      "label": "Page 694",
+      "sequence": 432,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-695",
+      "id": "or-0432",
+      "jurisdiction": "us-or",
+      "label": "Page 695",
+      "sequence": 433,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-697",
+      "id": "or-0433",
+      "jurisdiction": "us-or",
+      "label": "Page 697",
+      "sequence": 434,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-698",
+      "id": "or-0434",
+      "jurisdiction": "us-or",
+      "label": "Page 698",
+      "sequence": 435,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-699",
+      "id": "or-0435",
+      "jurisdiction": "us-or",
+      "label": "Page 699",
+      "sequence": 436,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-7",
+      "id": "or-0436",
+      "jurisdiction": "us-or",
+      "label": "Page 7",
+      "sequence": 437,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-700",
+      "id": "or-0437",
+      "jurisdiction": "us-or",
+      "label": "Page 700",
+      "sequence": 438,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-701",
+      "id": "or-0438",
+      "jurisdiction": "us-or",
+      "label": "Page 701",
+      "sequence": 439,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-708",
+      "id": "or-0439",
+      "jurisdiction": "us-or",
+      "label": "Page 708",
+      "sequence": 440,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-709",
+      "id": "or-0440",
+      "jurisdiction": "us-or",
+      "label": "Page 709",
+      "sequence": 441,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-711",
+      "id": "or-0441",
+      "jurisdiction": "us-or",
+      "label": "Page 711",
+      "sequence": 442,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-727",
+      "id": "or-0442",
+      "jurisdiction": "us-or",
+      "label": "Page 727",
+      "sequence": 443,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-728",
+      "id": "or-0443",
+      "jurisdiction": "us-or",
+      "label": "Page 728",
+      "sequence": 444,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-729",
+      "id": "or-0444",
+      "jurisdiction": "us-or",
+      "label": "Page 729",
+      "sequence": 445,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-730",
+      "id": "or-0445",
+      "jurisdiction": "us-or",
+      "label": "Page 730",
+      "sequence": 446,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-731",
+      "id": "or-0446",
+      "jurisdiction": "us-or",
+      "label": "Page 731",
+      "sequence": 447,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-732",
+      "id": "or-0447",
+      "jurisdiction": "us-or",
+      "label": "Page 732",
+      "sequence": 448,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-733",
+      "id": "or-0448",
+      "jurisdiction": "us-or",
+      "label": "Page 733",
+      "sequence": 449,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-735",
+      "id": "or-0449",
+      "jurisdiction": "us-or",
+      "label": "Page 735",
+      "sequence": 450,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-736",
+      "id": "or-0450",
+      "jurisdiction": "us-or",
+      "label": "Page 736",
+      "sequence": 451,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-737",
+      "id": "or-0451",
+      "jurisdiction": "us-or",
+      "label": "Page 737",
+      "sequence": 452,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-738",
+      "id": "or-0452",
+      "jurisdiction": "us-or",
+      "label": "Page 738",
+      "sequence": 453,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-740",
+      "id": "or-0453",
+      "jurisdiction": "us-or",
+      "label": "Page 740",
+      "sequence": 454,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-741",
+      "id": "or-0454",
+      "jurisdiction": "us-or",
+      "label": "Page 741",
+      "sequence": 455,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-742",
+      "id": "or-0455",
+      "jurisdiction": "us-or",
+      "label": "Page 742",
+      "sequence": 456,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-743",
+      "id": "or-0456",
+      "jurisdiction": "us-or",
+      "label": "Page 743",
+      "sequence": 457,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-744",
+      "id": "or-0457",
+      "jurisdiction": "us-or",
+      "label": "Page 744",
+      "sequence": 458,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-75",
+      "id": "or-0458",
+      "jurisdiction": "us-or",
+      "label": "Page 75",
+      "sequence": 459,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-750",
+      "id": "or-0459",
+      "jurisdiction": "us-or",
+      "label": "Page 750",
+      "sequence": 460,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-751",
+      "id": "or-0460",
+      "jurisdiction": "us-or",
+      "label": "Page 751",
+      "sequence": 461,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-752",
+      "id": "or-0461",
+      "jurisdiction": "us-or",
+      "label": "Page 752",
+      "sequence": 462,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-754",
+      "id": "or-0462",
+      "jurisdiction": "us-or",
+      "label": "Page 754",
+      "sequence": 463,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-755",
+      "id": "or-0463",
+      "jurisdiction": "us-or",
+      "label": "Page 755",
+      "sequence": 464,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-756",
+      "id": "or-0464",
+      "jurisdiction": "us-or",
+      "label": "Page 756",
+      "sequence": 465,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-757",
+      "id": "or-0465",
+      "jurisdiction": "us-or",
+      "label": "Page 757",
+      "sequence": 466,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-759",
+      "id": "or-0466",
+      "jurisdiction": "us-or",
+      "label": "Page 759",
+      "sequence": 467,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-765",
+      "id": "or-0467",
+      "jurisdiction": "us-or",
+      "label": "Page 765",
+      "sequence": 468,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-768",
+      "id": "or-0468",
+      "jurisdiction": "us-or",
+      "label": "Page 768",
+      "sequence": 469,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-769",
+      "id": "or-0469",
+      "jurisdiction": "us-or",
+      "label": "Page 769",
+      "sequence": 470,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-771",
+      "id": "or-0470",
+      "jurisdiction": "us-or",
+      "label": "Page 771",
+      "sequence": 471,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-785",
+      "id": "or-0471",
+      "jurisdiction": "us-or",
+      "label": "Page 785",
+      "sequence": 472,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-80",
+      "id": "or-0472",
+      "jurisdiction": "us-or",
+      "label": "Page 80",
+      "sequence": 473,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-800",
+      "id": "or-0473",
+      "jurisdiction": "us-or",
+      "label": "Page 800",
+      "sequence": 474,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-801",
+      "id": "or-0474",
+      "jurisdiction": "us-or",
+      "label": "Page 801",
+      "sequence": 475,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-807",
+      "id": "or-0475",
+      "jurisdiction": "us-or",
+      "label": "Page 807",
+      "sequence": 476,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-81",
+      "id": "or-0476",
+      "jurisdiction": "us-or",
+      "label": "Page 81",
+      "sequence": 477,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-810",
+      "id": "or-0477",
+      "jurisdiction": "us-or",
+      "label": "Page 810",
+      "sequence": 478,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-813",
+      "id": "or-0478",
+      "jurisdiction": "us-or",
+      "label": "Page 813",
+      "sequence": 479,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-823",
+      "id": "or-0479",
+      "jurisdiction": "us-or",
+      "label": "Page 823",
+      "sequence": 480,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-83",
+      "id": "or-0480",
+      "jurisdiction": "us-or",
+      "label": "Page 83",
+      "sequence": 481,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-842",
+      "id": "or-0481",
+      "jurisdiction": "us-or",
+      "label": "Page 842",
+      "sequence": 482,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-843",
+      "id": "or-0482",
+      "jurisdiction": "us-or",
+      "label": "Page 843",
+      "sequence": 483,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-860",
+      "id": "or-0483",
+      "jurisdiction": "us-or",
+      "label": "Page 860",
+      "sequence": 484,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-88",
+      "id": "or-0484",
+      "jurisdiction": "us-or",
+      "label": "Page 88",
+      "sequence": 485,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-89",
+      "id": "or-0485",
+      "jurisdiction": "us-or",
+      "label": "Page 89",
+      "sequence": 486,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-9",
+      "id": "or-0486",
+      "jurisdiction": "us-or",
+      "label": "Page 9",
+      "sequence": 487,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-90",
+      "id": "or-0487",
+      "jurisdiction": "us-or",
+      "label": "Page 90",
+      "sequence": 488,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-904",
+      "id": "or-0488",
+      "jurisdiction": "us-or",
+      "label": "Page 904",
+      "sequence": 489,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-917",
+      "id": "or-0489",
+      "jurisdiction": "us-or",
+      "label": "Page 917",
+      "sequence": 490,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-93",
+      "id": "or-0490",
+      "jurisdiction": "us-or",
+      "label": "Page 93",
+      "sequence": 491,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-932",
+      "id": "or-0491",
+      "jurisdiction": "us-or",
+      "label": "Page 932",
+      "sequence": 492,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-934",
+      "id": "or-0492",
+      "jurisdiction": "us-or",
+      "label": "Page 934",
+      "sequence": 493,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-935",
+      "id": "or-0493",
+      "jurisdiction": "us-or",
+      "label": "Page 935",
+      "sequence": 494,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-936",
+      "id": "or-0494",
+      "jurisdiction": "us-or",
+      "label": "Page 936",
+      "sequence": 495,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-937",
+      "id": "or-0495",
+      "jurisdiction": "us-or",
+      "label": "Page 937",
+      "sequence": 496,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-938",
+      "id": "or-0496",
+      "jurisdiction": "us-or",
+      "label": "Page 938",
+      "sequence": 497,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-939",
+      "id": "or-0497",
+      "jurisdiction": "us-or",
+      "label": "Page 939",
+      "sequence": 498,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-94",
+      "id": "or-0498",
+      "jurisdiction": "us-or",
+      "label": "Page 94",
+      "sequence": 499,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-940",
+      "id": "or-0499",
+      "jurisdiction": "us-or",
+      "label": "Page 940",
+      "sequence": 500,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-941",
+      "id": "or-0500",
+      "jurisdiction": "us-or",
+      "label": "Page 941",
+      "sequence": 501,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-942",
+      "id": "or-0501",
+      "jurisdiction": "us-or",
+      "label": "Page 942",
+      "sequence": 502,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-943",
+      "id": "or-0502",
+      "jurisdiction": "us-or",
+      "label": "Page 943",
+      "sequence": 503,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-944",
+      "id": "or-0503",
+      "jurisdiction": "us-or",
+      "label": "Page 944",
+      "sequence": 504,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-945",
+      "id": "or-0504",
+      "jurisdiction": "us-or",
+      "label": "Page 945",
+      "sequence": 505,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-946",
+      "id": "or-0505",
+      "jurisdiction": "us-or",
+      "label": "Page 946",
+      "sequence": 506,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-947",
+      "id": "or-0506",
+      "jurisdiction": "us-or",
+      "label": "Page 947",
+      "sequence": 507,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-948",
+      "id": "or-0507",
+      "jurisdiction": "us-or",
+      "label": "Page 948",
+      "sequence": 508,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-95",
+      "id": "or-0508",
+      "jurisdiction": "us-or",
+      "label": "Page 95",
+      "sequence": 509,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-950",
+      "id": "or-0509",
+      "jurisdiction": "us-or",
+      "label": "Page 950",
+      "sequence": 510,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-951",
+      "id": "or-0510",
+      "jurisdiction": "us-or",
+      "label": "Page 951",
+      "sequence": 511,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-952",
+      "id": "or-0511",
+      "jurisdiction": "us-or",
+      "label": "Page 952",
+      "sequence": 512,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-953",
+      "id": "or-0512",
+      "jurisdiction": "us-or",
+      "label": "Page 953",
+      "sequence": 513,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-957",
+      "id": "or-0513",
+      "jurisdiction": "us-or",
+      "label": "Page 957",
+      "sequence": 514,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-959",
+      "id": "or-0514",
+      "jurisdiction": "us-or",
+      "label": "Page 959",
+      "sequence": 515,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-96",
+      "id": "or-0515",
+      "jurisdiction": "us-or",
+      "label": "Page 96",
+      "sequence": 516,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-960",
+      "id": "or-0516",
+      "jurisdiction": "us-or",
+      "label": "Page 960",
+      "sequence": 517,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-961",
+      "id": "or-0517",
+      "jurisdiction": "us-or",
+      "label": "Page 961",
+      "sequence": 518,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-962",
+      "id": "or-0518",
+      "jurisdiction": "us-or",
+      "label": "Page 962",
+      "sequence": 519,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-964",
+      "id": "or-0519",
+      "jurisdiction": "us-or",
+      "label": "Page 964",
+      "sequence": 520,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-965",
+      "id": "or-0520",
+      "jurisdiction": "us-or",
+      "label": "Page 965",
+      "sequence": 521,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-966",
+      "id": "or-0521",
+      "jurisdiction": "us-or",
+      "label": "Page 966",
+      "sequence": 522,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-967",
+      "id": "or-0522",
+      "jurisdiction": "us-or",
+      "label": "Page 967",
+      "sequence": 523,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-968",
+      "id": "or-0523",
+      "jurisdiction": "us-or",
+      "label": "Page 968",
+      "sequence": 524,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-969",
+      "id": "or-0524",
+      "jurisdiction": "us-or",
+      "label": "Page 969",
+      "sequence": 525,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-97",
+      "id": "or-0525",
+      "jurisdiction": "us-or",
+      "label": "Page 97",
+      "sequence": 526,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-970",
+      "id": "or-0526",
+      "jurisdiction": "us-or",
+      "label": "Page 970",
+      "sequence": 527,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-972",
+      "id": "or-0527",
+      "jurisdiction": "us-or",
+      "label": "Page 972",
+      "sequence": 528,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-981",
+      "id": "or-0528",
+      "jurisdiction": "us-or",
+      "label": "Page 981",
+      "sequence": 529,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-982",
+      "id": "or-0529",
+      "jurisdiction": "us-or",
+      "label": "Page 982",
+      "sequence": 530,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-or/manual/odhs/open/page-995",
+      "id": "or-0530",
+      "jurisdiction": "us-or",
+      "label": "Page 995",
+      "sequence": 531,
+      "source_kind": "page",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/100-general-information-and-provisions-100-general-information-and-provisions-htm",
+      "id": "ut-0002",
+      "jurisdiction": "us-ut",
+      "label": "All Programs",
+      "sequence": 532,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/100-general-information-and-provisions-105-customer-rights-htm",
+      "id": "ut-0003",
+      "jurisdiction": "us-ut",
+      "label": "All Programs",
+      "sequence": 533,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/100-general-information-and-provisions-106-customer-responsibilities-htm",
+      "id": "ut-0004",
+      "jurisdiction": "us-ut",
+      "label": "All Programs",
+      "sequence": 534,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/100-general-information-and-provisions-110-4-releasing-information-to-sources-other-than-the-custome",
+      "id": "ut-0005",
+      "jurisdiction": "us-ut",
+      "label": "All Programs",
+      "sequence": 535,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/100-general-information-and-provisions-110-5b-who-has-access-to-income-match-data-htm",
+      "id": "ut-0006",
+      "jurisdiction": "us-ut",
+      "label": "All Programs",
+      "sequence": 536,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/100-general-information-and-provisions-115-complaints-htm",
+      "id": "ut-0007",
+      "jurisdiction": "us-ut",
+      "label": "Additional Considerations for Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 537,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/100-general-information-and-provisions-125-1-requesting-the-fair-hearing-htm",
+      "id": "ut-0008",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: May 1, 2025",
+      "sequence": 538,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/100-general-information-and-provisions-125-8-issuance-of-assistance-through-the-fair-hearing-process",
+      "id": "ut-0009",
+      "jurisdiction": "us-ut",
+      "label": "Program Specific Requirements",
+      "sequence": 539,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-200-general-program-requirements-htm",
+      "id": "ut-0010",
+      "jurisdiction": "us-ut",
+      "label": "Main sub-topics in this section:",
+      "sequence": 540,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-205-1b-transitional-fep-cash-assistance-tca-and-extended-servic",
+      "id": "ut-0011",
+      "jurisdiction": "us-ut",
+      "label": "Transitional Cash Assistance (TCA)",
+      "sequence": 541,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-207-snap-general-information-htm",
+      "id": "ut-0012",
+      "jurisdiction": "us-ut",
+      "label": "207 SNAP - General Information",
+      "sequence": 542,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-215-2-eligible-non-citizen-status-htm",
+      "id": "ut-0013",
+      "jurisdiction": "us-ut",
+      "label": "SNAP and GA",
+      "sequence": 543,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-215-2a-eligible-non-citizen-status-fep-fep-tp-aa-ea-htm",
+      "id": "ut-0014",
+      "jurisdiction": "us-ut",
+      "label": "See Also:",
+      "sequence": 544,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-215-2b-eligible-non-citizen-status-snap-tanf-non-fep-and-tanf-n",
+      "id": "ut-0015",
+      "jurisdiction": "us-ut",
+      "label": "Qualified and Eligible Non-citizens",
+      "sequence": 545,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-215-2c-eligible-non-citizen-status-rca-htm",
+      "id": "ut-0016",
+      "jurisdiction": "us-ut",
+      "label": "See Also:",
+      "sequence": 546,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-215-2d-eligible-non-citizens-status-snap-htm",
+      "id": "ut-0017",
+      "jurisdiction": "us-ut",
+      "label": "215-2D Eligible Non-citizens Status - SNAP",
+      "sequence": 547,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-215-3-ineligible-non-citizen-status-htm",
+      "id": "ut-0018",
+      "jurisdiction": "us-ut",
+      "label": "All Programs",
+      "sequence": 548,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-215-us-citizenship-and-non-citizen-status-requirements-htm",
+      "id": "ut-0019",
+      "jurisdiction": "us-ut",
+      "label": "All Programs",
+      "sequence": 549,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-216-utah-residency-htm",
+      "id": "ut-0020",
+      "jurisdiction": "us-ut",
+      "label": "All programs",
+      "sequence": 550,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-217-1-social-security-number-requirements-for-all-financial-pro",
+      "id": "ut-0021",
+      "jurisdiction": "us-ut",
+      "label": "217-1 Social Security Number Requirements for all Financial Programs and SNAP",
+      "sequence": 551,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-217-1a-submitting-a-correct-ssn-htm",
+      "id": "ut-0022",
+      "jurisdiction": "us-ut",
+      "label": "Financial and Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 552,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-217-1b-refusal-to-provide-a-correct-ssn-htm",
+      "id": "ut-0023",
+      "jurisdiction": "us-ut",
+      "label": "Financial and Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 553,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-217-1c-good-cause-for-not-applying-for-the-ssn-card-htm",
+      "id": "ut-0024",
+      "jurisdiction": "us-ut",
+      "label": "Financial and Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 554,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-217-social-security-number-ssn-requirements-htm",
+      "id": "ut-0025",
+      "jurisdiction": "us-ut",
+      "label": "Main sub-topics in this section:",
+      "sequence": 555,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-230-1-household-members-defined-snap-htm",
+      "id": "ut-0026",
+      "jurisdiction": "us-ut",
+      "label": "230-1 Household Members Defined - SNAP",
+      "sequence": 556,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-230-2-determining-who-lives-together-snap-htm",
+      "id": "ut-0027",
+      "jurisdiction": "us-ut",
+      "label": "230-2 Determining Who Lives Together - SNAP",
+      "sequence": 557,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-230-3-household-concept-custody-snap-htm",
+      "id": "ut-0028",
+      "jurisdiction": "us-ut",
+      "label": "230-3 Household Concept/Custody - SNAP",
+      "sequence": 558,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-230-household-composition-snap-htm",
+      "id": "ut-0029",
+      "jurisdiction": "us-ut",
+      "label": "230 Household Composition - SNAP",
+      "sequence": 559,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-250-269-additional-household-situations-htm",
+      "id": "ut-0030",
+      "jurisdiction": "us-ut",
+      "label": "Main sub-topics in this section:",
+      "sequence": 560,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-251-ineligible-household-members-htm",
+      "id": "ut-0031",
+      "jurisdiction": "us-ut",
+      "label": "Additional SNAP Considerations",
+      "sequence": 561,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-252-disqualified-household-members-htm",
+      "id": "ut-0032",
+      "jurisdiction": "us-ut",
+      "label": "Additional Supplemental Nutrition Assistance Program (SNAP) Considerations",
+      "sequence": 562,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-253-non-household-members-htm",
+      "id": "ut-0033",
+      "jurisdiction": "us-ut",
+      "label": "Additional Supplemental Nutrition Assistance Program (SNAP) Considerations",
+      "sequence": 563,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-254-qualified-elderly-and-disabled-household-members-snap-htm",
+      "id": "ut-0034",
+      "jurisdiction": "us-ut",
+      "label": "254 Qualified Elderly and Disabled Household Members - SNAP",
+      "sequence": 564,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-255-3-residents-of-institutions-snap-htm",
+      "id": "ut-0035",
+      "jurisdiction": "us-ut",
+      "label": "255-3 Residents of Institutions - SNAP",
+      "sequence": 565,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-255-3a-institutions-snap-htm",
+      "id": "ut-0036",
+      "jurisdiction": "us-ut",
+      "label": "255-3A Institutions - SNAP",
+      "sequence": 566,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-255-3b-authorized-representatives-for-residents-of-institutions",
+      "id": "ut-0037",
+      "jurisdiction": "us-ut",
+      "label": "255-3B Authorized Representatives for Residents of Institutions - SNAP",
+      "sequence": 567,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-255-3c-approved-arcs-htm",
+      "id": "ut-0038",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: January 1, 2026",
+      "sequence": 568,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-255-3d-approved-glas-htm",
+      "id": "ut-0039",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: July 1, 2025",
+      "sequence": 569,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-255-residents-of-institutions-htm",
+      "id": "ut-0040",
+      "jurisdiction": "us-ut",
+      "label": "Sub-topics in this section:",
+      "sequence": 570,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-256-communal-dining-facilities-and-meal-delivery-service-snap-h",
+      "id": "ut-0041",
+      "jurisdiction": "us-ut",
+      "label": "256 Communal Dining Facilities and Meal Delivery Service \u2013 SNAP",
+      "sequence": 571,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-257-students-in-institutions-of-higher-learning-food-snap-htm",
+      "id": "ut-0042",
+      "jurisdiction": "us-ut",
+      "label": "257 Students in Institutions of Higher Learning \u2013 SNAP",
+      "sequence": 572,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-258-strikers-htm",
+      "id": "ut-0043",
+      "jurisdiction": "us-ut",
+      "label": "Additional Considerations for Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 573,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-259-boarders-snap-htm",
+      "id": "ut-0044",
+      "jurisdiction": "us-ut",
+      "label": "259 Boarders \u2013 SNAP",
+      "sequence": 574,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-260-eligible-non-citizens-with-sponsors-htm",
+      "id": "ut-0045",
+      "jurisdiction": "us-ut",
+      "label": "Exemptions for All Programs",
+      "sequence": 575,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-261-1-categorically-eligible-snap-households-defined-htm",
+      "id": "ut-0046",
+      "jurisdiction": "us-ut",
+      "label": "261-1 Categorically Eligible SNAP Households Defined",
+      "sequence": 576,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-261-2-exceptions-to-categorically-eligible-snap-households-htm",
+      "id": "ut-0047",
+      "jurisdiction": "us-ut",
+      "label": "261-2 Exceptions to Categorically Eligible SNAP Households",
+      "sequence": 577,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-261-3-categorically-asset-eligible-snap-individuals-htm",
+      "id": "ut-0048",
+      "jurisdiction": "us-ut",
+      "label": "261-3 Categorically Asset Eligible SNAP Individuals",
+      "sequence": 578,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-261-categorically-eligible-snap-households-htm",
+      "id": "ut-0049",
+      "jurisdiction": "us-ut",
+      "label": "261 Categorically Eligible SNAP Households",
+      "sequence": 579,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-262-head-of-household-snap-htm",
+      "id": "ut-0050",
+      "jurisdiction": "us-ut",
+      "label": "262 Head of Household - SNAP",
+      "sequence": 580,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-263-authorized-representatives-htm",
+      "id": "ut-0051",
+      "jurisdiction": "us-ut",
+      "label": "All Programs",
+      "sequence": 581,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-264-duplicate-participation-htm",
+      "id": "ut-0052",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 582,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-265-recipients-of-food-distribution-programs-on-indian-reservat",
+      "id": "ut-0053",
+      "jurisdiction": "us-ut",
+      "label": "265 Recipients of Food Distribution Programs on Indian Reservations \u2013 SNAP",
+      "sequence": 583,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-266-fleeing-felons-and-violators-of-probation-or-parole-htm",
+      "id": "ut-0054",
+      "jurisdiction": "us-ut",
+      "label": "Additional SNAP Considerations",
+      "sequence": 584,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/200-program-eligibility-requirements-270-nesting-htm",
+      "id": "ut-0055",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP) and Employment Support Child Care (ESCC)",
+      "sequence": 585,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/300-participation-requirements-300-participation-requirements-htm",
+      "id": "ut-0056",
+      "jurisdiction": "us-ut",
+      "label": "300 Participation Requirements",
+      "sequence": 586,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/300-participation-requirements-321-5-consequences-of-non-participation-or-non-compliance-fep-htm",
+      "id": "ut-0057",
+      "jurisdiction": "us-ut",
+      "label": "Additional Mini-Simplified Supplemental Nutrition Assistance Program (MSSNAP) Considerations",
+      "sequence": 587,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/300-participation-requirements-340-snap-participation-requirements-htm",
+      "id": "ut-0058",
+      "jurisdiction": "us-ut",
+      "label": "340 SNAP Participation Requirements",
+      "sequence": 588,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/300-participation-requirements-341-2-abawd-participation-requirements-htm",
+      "id": "ut-0059",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: July 1, 2025",
+      "sequence": 589,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/300-participation-requirements-341-3-abawd-determining-countable-months-htm",
+      "id": "ut-0060",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: April 1, 2024",
+      "sequence": 590,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/300-participation-requirements-341-5-abawd-regaining-eligibility-htm",
+      "id": "ut-0061",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: August 1, 2022",
+      "sequence": 591,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/300-participation-requirements-341-6-abawd-one-time-extension-htm",
+      "id": "ut-0062",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: August 1, 2022",
+      "sequence": 592,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/300-participation-requirements-341-abawd-time-limits-htm",
+      "id": "ut-0063",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: November 1, 2025",
+      "sequence": 593,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/300-participation-requirements-342-1-snap-work-requirements-exemptions-htm",
+      "id": "ut-0064",
+      "jurisdiction": "us-ut",
+      "label": "342-1 SNAP Work Requirements - Exemptions",
+      "sequence": 594,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/300-participation-requirements-342-1a-snap-work-requirements-federal-exemptions-htm",
+      "id": "ut-0065",
+      "jurisdiction": "us-ut",
+      "label": "342-1A SNAP Work Requirements - Federal Exemptions",
+      "sequence": 595,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/300-participation-requirements-342-1b-snap-eandt-state-exemptions-htm",
+      "id": "ut-0066",
+      "jurisdiction": "us-ut",
+      "label": "342-1B SNAP E&T - State Exemptions",
+      "sequence": 596,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/300-participation-requirements-342-2-snap-employment-and-training-participation-requirements-htm",
+      "id": "ut-0067",
+      "jurisdiction": "us-ut",
+      "label": "342-2 SNAP Employment and Training Participation Requirements",
+      "sequence": 597,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/300-participation-requirements-342-2a-snap-eandt-participation-activities-htm",
+      "id": "ut-0068",
+      "jurisdiction": "us-ut",
+      "label": "342-2A SNAP E&T Participation Activities",
+      "sequence": 598,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/300-participation-requirements-342-2b-snap-good-cause-for-not-participating-in-eandt-activities-htm",
+      "id": "ut-0069",
+      "jurisdiction": "us-ut",
+      "label": "342-2B SNAP Good Cause for Not Participating in E&T Activities",
+      "sequence": 599,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/300-participation-requirements-342-3-voluntary-reduction-of-work-hours-snap-htm",
+      "id": "ut-0070",
+      "jurisdiction": "us-ut",
+      "label": "342-3 Voluntary Reduction of Work Hours - SNAP",
+      "sequence": 600,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/300-participation-requirements-342-3a-determination-of-voluntary-reduction-in-hours-snap-htm",
+      "id": "ut-0071",
+      "jurisdiction": "us-ut",
+      "label": "342-3A Determination of Voluntary Reduction in Hours - SNAP",
+      "sequence": 601,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/300-participation-requirements-342-4-voluntary-quit-snap-htm",
+      "id": "ut-0072",
+      "jurisdiction": "us-ut",
+      "label": "342-4 Voluntary Quit - SNAP",
+      "sequence": 602,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/300-participation-requirements-342-4a-determination-of-voluntary-quit-snap-htm",
+      "id": "ut-0073",
+      "jurisdiction": "us-ut",
+      "label": "342-4A Determination of Voluntary Quit - SNAP",
+      "sequence": 603,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/300-participation-requirements-342-4b-good-cause-for-voluntary-quit-snap-htm",
+      "id": "ut-0074",
+      "jurisdiction": "us-ut",
+      "label": "342-4B Good Cause for Voluntary Quit - SNAP",
+      "sequence": 604,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/300-participation-requirements-342-5-snap-work-requirements-sanctions-for-non-compliance-htm",
+      "id": "ut-0075",
+      "jurisdiction": "us-ut",
+      "label": "342-5 SNAP Work Requirements - Sanctions for Non-Compliance",
+      "sequence": 605,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/300-participation-requirements-342-5a-snap-work-requirements-disqualification-periods-htm",
+      "id": "ut-0076",
+      "jurisdiction": "us-ut",
+      "label": "342-5A SNAP Work Requirements - Disqualification Periods",
+      "sequence": 606,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/300-participation-requirements-342-5b-snap-work-requirements-imposing-the-sanction-for-non-complianc",
+      "id": "ut-0077",
+      "jurisdiction": "us-ut",
+      "label": "342-5B SNAP Work Requirements - Imposing the Sanction for Non-compliance",
+      "sequence": 607,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/300-participation-requirements-342-5c-snap-work-requirements-problem-solving-period-htm",
+      "id": "ut-0078",
+      "jurisdiction": "us-ut",
+      "label": "342-5C SNAP Work Requirements - Problem Solving Period",
+      "sequence": 608,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/300-participation-requirements-342-5d-snap-work-requirements-terminating-the-sanction-prior-to-the-m",
+      "id": "ut-0079",
+      "jurisdiction": "us-ut",
+      "label": "342-5D SNAP Work Requirements - Terminating the Sanction Prior to the Minimum Disqualification Period",
+      "sequence": 609,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/300-participation-requirements-342-5e-snap-work-requirements-releasing-the-sanction-after-the-minimu",
+      "id": "ut-0080",
+      "jurisdiction": "us-ut",
+      "label": "342-5E SNAP Work Requirements - Releasing the Sanction after the Minimum Sanction Period",
+      "sequence": 610,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/300-participation-requirements-342-5f-snap-work-requirements-restoring-snap-when-a-sanction-was-impo",
+      "id": "ut-0081",
+      "jurisdiction": "us-ut",
+      "label": "342-5F SNAP Work Requirements - Restoring SNAP When a Sanction was Imposed in Error",
+      "sequence": 611,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/300-participation-requirements-342-snap-work-requirements-htm",
+      "id": "ut-0082",
+      "jurisdiction": "us-ut",
+      "label": "342 SNAP Work Requirements",
+      "sequence": 612,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-400-income-standards-htm",
+      "id": "ut-0083",
+      "jurisdiction": "us-ut",
+      "label": "Main sub-topics in this section:",
+      "sequence": 613,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-402-1-income-of-disqualified-household-members-snap-htm",
+      "id": "ut-0084",
+      "jurisdiction": "us-ut",
+      "label": "402-1 Income of Disqualified Household Members - SNAP",
+      "sequence": 614,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-402-2-income-of-ineligible-household-members-snap-htm",
+      "id": "ut-0085",
+      "jurisdiction": "us-ut",
+      "label": "402-2 Income of Ineligible Household Members - SNAP",
+      "sequence": 615,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-402-3-income-of-non-household-members-snap-htm",
+      "id": "ut-0086",
+      "jurisdiction": "us-ut",
+      "label": "402-3 Income of Non-Household Members - SNAP",
+      "sequence": 616,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-402-4-income-of-the-sponsor-of-an-eligible-non-citizen-snap-htm",
+      "id": "ut-0087",
+      "jurisdiction": "us-ut",
+      "label": "402-4 Income of the Sponsor of an Eligible Non-Citizen - SNAP",
+      "sequence": 617,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-402-5-income-of-migrant-or-seasonal-farmworkers-snap-htm",
+      "id": "ut-0088",
+      "jurisdiction": "us-ut",
+      "label": "402-5 Income of Migrant or Seasonal Farmworkers - SNAP",
+      "sequence": 618,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-402-whose-income-to-count-snap-htm",
+      "id": "ut-0089",
+      "jurisdiction": "us-ut",
+      "label": "402 Whose Income to Count - SNAP",
+      "sequence": 619,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-410-income-limits-htm",
+      "id": "ut-0090",
+      "jurisdiction": "us-ut",
+      "label": "All Programs",
+      "sequence": 620,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-425-1-diversion-payments-htm",
+      "id": "ut-0091",
+      "jurisdiction": "us-ut",
+      "label": "SNAP",
+      "sequence": 621,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-425-11-supplemental-security-income-ssi-htm",
+      "id": "ut-0092",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 622,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-425-12-foster-care-and-guardianship-payments-htm",
+      "id": "ut-0093",
+      "jurisdiction": "us-ut",
+      "label": "SNAP",
+      "sequence": 623,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-425-13-adoption-assistance-payments-for-children-with-special-needs-htm",
+      "id": "ut-0094",
+      "jurisdiction": "us-ut",
+      "label": "SNAP and Employment Support Child Care",
+      "sequence": 624,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-425-14-refugee-resettlement-payments-htm",
+      "id": "ut-0095",
+      "jurisdiction": "us-ut",
+      "label": "SNAP",
+      "sequence": 625,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-425-2-financial-assistance-payments-htm",
+      "id": "ut-0096",
+      "jurisdiction": "us-ut",
+      "label": "SNAP",
+      "sequence": 626,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-425-20-child-support-and-alimony-payments-htm",
+      "id": "ut-0097",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 627,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-425-22-cash-contributions-htm",
+      "id": "ut-0098",
+      "jurisdiction": "us-ut",
+      "label": "All Programs",
+      "sequence": 628,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-425-24-sales-contracts-htm",
+      "id": "ut-0099",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 629,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-425-32-donation-payments-htm",
+      "id": "ut-0100",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 630,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-425-42-disability-workers-compensation-htm",
+      "id": "ut-0101",
+      "jurisdiction": "us-ut",
+      "label": "All Programs",
+      "sequence": 631,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-425-unearned-income-htm",
+      "id": "ut-0102",
+      "jurisdiction": "us-ut",
+      "label": "SNAP Only",
+      "sequence": 632,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-426-1-wages-and-salaries-htm",
+      "id": "ut-0103",
+      "jurisdiction": "us-ut",
+      "label": "SNAP",
+      "sequence": 633,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-426-4-severance-termination-pay-htm",
+      "id": "ut-0104",
+      "jurisdiction": "us-ut",
+      "label": "Additional SNAP Considerations",
+      "sequence": 634,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-426-8d-determining-allowable-self-employment-business-expenses-htm",
+      "id": "ut-0105",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: August 1, 2024",
+      "sequence": 635,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-426-8f-offsetting-the-losses-of-a-self-employed-farmer-htm",
+      "id": "ut-0106",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP) only",
+      "sequence": 636,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-426-8g-income-from-boarders-htm",
+      "id": "ut-0107",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: November 1, 2009",
+      "sequence": 637,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-426-8h-income-from-roomers-htm",
+      "id": "ut-0108",
+      "jurisdiction": "us-ut",
+      "label": "P olicy Effective: July 1, 2022",
+      "sequence": 638,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-427-11-tax-refunds-earned-income-tax-credit-eitc-and-american-opportunity-tax-c",
+      "id": "ut-0109",
+      "jurisdiction": "us-ut",
+      "label": "SNAP, Financial, and Child Care",
+      "sequence": 639,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-427-13-tribal-income-htm",
+      "id": "ut-0110",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 640,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-427-14-food-programs-government-funded-htm",
+      "id": "ut-0111",
+      "jurisdiction": "us-ut",
+      "label": "All Programs",
+      "sequence": 641,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-427-2-state-funded-child-care-subsidies-htm",
+      "id": "ut-0112",
+      "jurisdiction": "us-ut",
+      "label": "Financial and Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 642,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-428-1-in-kind-benefits-htm",
+      "id": "ut-0113",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP) and Employment Support Child Care",
+      "sequence": 643,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-428-10-military-income-and-allowances-htm",
+      "id": "ut-0114",
+      "jurisdiction": "us-ut",
+      "label": "Financial, Child Care and SNAP",
+      "sequence": 644,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-428-11-chafee-program-income-htm",
+      "id": "ut-0115",
+      "jurisdiction": "us-ut",
+      "label": "SNAP",
+      "sequence": 645,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-428-4-lump-sum-income-htm",
+      "id": "ut-0116",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: March 1, 2026",
+      "sequence": 646,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-428-5-reimbursements-htm",
+      "id": "ut-0117",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 647,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-428-6-trust-fund-payments-htm",
+      "id": "ut-0118",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 648,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-428-7-training-payments-and-allowances-htm",
+      "id": "ut-0119",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: December 1, 2018",
+      "sequence": 649,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-428-8-service-program-payments-htm",
+      "id": "ut-0120",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: July 1, 2007",
+      "sequence": 650,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-440-income-disregards-htm",
+      "id": "ut-0121",
+      "jurisdiction": "us-ut",
+      "label": "All Programs",
+      "sequence": 651,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-442-1-earned-income-disregard-snap-htm",
+      "id": "ut-0122",
+      "jurisdiction": "us-ut",
+      "label": "442-1 Earned Income Disregard - SNAP",
+      "sequence": 652,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-442-2-standard-deduction-snap-htm",
+      "id": "ut-0123",
+      "jurisdiction": "us-ut",
+      "label": "442-2 Standard Deduction - SNAP",
+      "sequence": 653,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-442-3-dependent-care-expenses-snap-htm",
+      "id": "ut-0124",
+      "jurisdiction": "us-ut",
+      "label": "442-3 Dependent Care Expenses - SNAP",
+      "sequence": 654,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-442-4-excess-medical-deduction-for-the-elderly-and-disabled-snap-htm",
+      "id": "ut-0125",
+      "jurisdiction": "us-ut",
+      "label": "442-4 Excess Medical Deduction for the Elderly and Disabled - SNAP",
+      "sequence": 655,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-442-5-child-support-paid-deduction-snap-htm",
+      "id": "ut-0126",
+      "jurisdiction": "us-ut",
+      "label": "442-5 Child Support Paid Deduction - SNAP",
+      "sequence": 656,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-442-6-shelter-cost-deduction-snap-htm",
+      "id": "ut-0127",
+      "jurisdiction": "us-ut",
+      "label": "442-6 Shelter Cost Deduction - SNAP",
+      "sequence": 657,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-442-7-homeless-stand-ded-snap-htm",
+      "id": "ut-0128",
+      "jurisdiction": "us-ut",
+      "label": "442-7 Homeless Standard Deduction - SNAP",
+      "sequence": 658,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-442-income-disregards-snap-htm",
+      "id": "ut-0129",
+      "jurisdiction": "us-ut",
+      "label": "442 Income Disregards - SNAP",
+      "sequence": 659,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/400-income-standards-460-quarterly-wage-data-qwd-htm",
+      "id": "ut-0130",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 660,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-500-asset-standards-htm",
+      "id": "ut-0131",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP) and Financial",
+      "sequence": 661,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-505-definition-of-assets-htm",
+      "id": "ut-0132",
+      "jurisdiction": "us-ut",
+      "label": "Financial and Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 662,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-510-asset-limits-htm",
+      "id": "ut-0133",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: October 1, 2025",
+      "sequence": 663,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-515-how-to-count-the-value-of-assets-htm",
+      "id": "ut-0134",
+      "jurisdiction": "us-ut",
+      "label": "Financial and Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 664,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-516-assigning-cash-value-to-financial-accounts-htm",
+      "id": "ut-0135",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 665,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-517-cryptocurrency-htm",
+      "id": "ut-0136",
+      "jurisdiction": "us-ut",
+      "label": "Financial and Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 666,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-520-availability-of-assets-htm",
+      "id": "ut-0137",
+      "jurisdiction": "us-ut",
+      "label": "Financial and Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 667,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-521-joint-accounts-htm",
+      "id": "ut-0138",
+      "jurisdiction": "us-ut",
+      "label": "Financial and Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 668,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-522-joint-ownership-htm",
+      "id": "ut-0139",
+      "jurisdiction": "us-ut",
+      "label": "Financial and Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 669,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-523-transfer-of-title-htm",
+      "id": "ut-0140",
+      "jurisdiction": "us-ut",
+      "label": "Financial and Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 670,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-524-divorce-decrees-htm",
+      "id": "ut-0141",
+      "jurisdiction": "us-ut",
+      "label": "Financial and Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 671,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-530-1-home-and-surrounding-property-htm",
+      "id": "ut-0142",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 672,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-530-10-household-goods-htm",
+      "id": "ut-0143",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 673,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-530-11-assets-for-burial-arrangements-htm",
+      "id": "ut-0144",
+      "jurisdiction": "us-ut",
+      "label": "Burials Plots",
+      "sequence": 674,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-530-12-life-insurance-htm",
+      "id": "ut-0145",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 675,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-530-13-life-estates-htm",
+      "id": "ut-0146",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 676,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-530-15-pension-retirement-401k-plans-htm",
+      "id": "ut-0147",
+      "jurisdiction": "us-ut",
+      "label": "Financial and Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 677,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-530-16-pass-accounts-htm",
+      "id": "ut-0148",
+      "jurisdiction": "us-ut",
+      "label": "Financial and Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 678,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-530-18-individual-development-accounts-ida-htm",
+      "id": "ut-0149",
+      "jurisdiction": "us-ut",
+      "label": "Financial and Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 679,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-530-2-other-real-property-not-lived-in-htm",
+      "id": "ut-0150",
+      "jurisdiction": "us-ut",
+      "label": "Financial and Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 680,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-530-20-assets-the-household-cannot-sell-for-significant-return-htm",
+      "id": "ut-0151",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 681,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-530-21-livestock-htm",
+      "id": "ut-0152",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 682,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-530-3-lands-held-in-trust-htm",
+      "id": "ut-0153",
+      "jurisdiction": "us-ut",
+      "label": "Financial and Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 683,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-530-30-income-producing-property-and-work-related-equipment-htm",
+      "id": "ut-0154",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 684,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-530-31-farm-land-and-farm-equipment-htm",
+      "id": "ut-0155",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 685,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-530-32-financial-assets-used-for-se-htm",
+      "id": "ut-0156",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 686,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-530-33-portion-of-personal-or-real-property-necessary-for-maintenance-or-use-of-an-income",
+      "id": "ut-0157",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 687,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-530-40-assets-of-battered-women-and-children-living-in-shelters-htm",
+      "id": "ut-0158",
+      "jurisdiction": "us-ut",
+      "label": "Financial and Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 688,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-530-41-assets-of-an-ssi-recipient-htm",
+      "id": "ut-0159",
+      "jurisdiction": "us-ut",
+      "label": "Financial and Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 689,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-530-42-assets-of-a-fep-recipient-htm",
+      "id": "ut-0160",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 690,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-530-50-government-payments-for-restoration-of-home-damaged-in-a-disaster-htm",
+      "id": "ut-0161",
+      "jurisdiction": "us-ut",
+      "label": "Financial and Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 691,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-530-51-insurance-settlements-for-destroyed-property-htm",
+      "id": "ut-0162",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 692,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-530-52-prorated-income-htm",
+      "id": "ut-0163",
+      "jurisdiction": "us-ut",
+      "label": "Financial and Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 693,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-530-53-bona-fide-loans-htm",
+      "id": "ut-0164",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 694,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-530-54-excluded-funds-combined-with-non-excluded-funds-htm",
+      "id": "ut-0165",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 695,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-530-55-tribal-lands-and-per-capita-payments-made-to-tribal-members-htm",
+      "id": "ut-0166",
+      "jurisdiction": "us-ut",
+      "label": "Financial and Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 696,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-530-56-payments-from-federal-programs-and-public-laws-htm",
+      "id": "ut-0167",
+      "jurisdiction": "us-ut",
+      "label": "Financial and Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 697,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-535-transfer-of-assets-htm",
+      "id": "ut-0168",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 698,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-540-conversion-of-assets-htm",
+      "id": "ut-0169",
+      "jurisdiction": "us-ut",
+      "label": "Financial and Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 699,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-545-1-ineligible-household-members-htm",
+      "id": "ut-0170",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 700,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-545-2-disqualified-household-members-htm",
+      "id": "ut-0171",
+      "jurisdiction": "us-ut",
+      "label": "Financial and Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 701,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-550-assets-of-the-sponsor-of-an-eligible-non-citizen-htm",
+      "id": "ut-0172",
+      "jurisdiction": "us-ut",
+      "label": "Financial and Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 702,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-555-trusts-htm",
+      "id": "ut-0173",
+      "jurisdiction": "us-ut",
+      "label": "Financial and Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 703,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/500-assets-560-sales-contracts-and-proceeds-from-sales-contracts-htm",
+      "id": "ut-0174",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 704,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/600-issuances-and-payments-600-eligibility-issuance-amount-and-payment-determination-htm",
+      "id": "ut-0175",
+      "jurisdiction": "us-ut",
+      "label": "Main sub-topics in this section:",
+      "sequence": 705,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/600-issuances-and-payments-605-prospective-eligibility-and-budgeting-htm",
+      "id": "ut-0176",
+      "jurisdiction": "us-ut",
+      "label": "Changes in Prospective Eligibility and Budgeting",
+      "sequence": 706,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/600-issuances-and-payments-610-3-issuance-determination-financial-htm",
+      "id": "ut-0177",
+      "jurisdiction": "us-ut",
+      "label": "Combined Initial Assistance",
+      "sequence": 707,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/600-issuances-and-payments-615-1-asset-test-snap-htm",
+      "id": "ut-0178",
+      "jurisdiction": "us-ut",
+      "label": "615-1 Asset Test - SNAP",
+      "sequence": 708,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/600-issuances-and-payments-615-2-income-tests-snap-htm",
+      "id": "ut-0179",
+      "jurisdiction": "us-ut",
+      "label": "615-2 Income Tests - SNAP",
+      "sequence": 709,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/600-issuances-and-payments-615-3-issuance-determination-snap-htm",
+      "id": "ut-0180",
+      "jurisdiction": "us-ut",
+      "label": "615-3 Issuance Determination - SNAP",
+      "sequence": 710,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/600-issuances-and-payments-615-eligibility-tests-and-issuance-determination-snap-htm",
+      "id": "ut-0181",
+      "jurisdiction": "us-ut",
+      "label": "615 Eligibility Tests and Issuance Determination - SNAP",
+      "sequence": 711,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/600-issuances-and-payments-625-7-who-may-not-be-paid-as-a-child-care-provider-htm",
+      "id": "ut-0182",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: July 1, 2025",
+      "sequence": 712,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/600-issuances-and-payments-640-forms-of-payment-htm",
+      "id": "ut-0183",
+      "jurisdiction": "us-ut",
+      "label": "SNAP",
+      "sequence": 713,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/600-issuances-and-payments-641-1-types-of-ebt-accounts-and-access-methods-htm",
+      "id": "ut-0184",
+      "jurisdiction": "us-ut",
+      "label": "Cash Account",
+      "sequence": 714,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/600-issuances-and-payments-641-3a-accessing-ebt-account-information-htm",
+      "id": "ut-0185",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: May 20, 2026",
+      "sequence": 715,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/600-issuances-and-payments-641-3b-replacing-ebt-cards-and-otc-cards-htm",
+      "id": "ut-0186",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: May 20, 2026",
+      "sequence": 716,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/600-issuances-and-payments-641-3d-reissuing-a-utah-horizon-card-and-over-the-counter-issuance-otc-ht",
+      "id": "ut-0187",
+      "jurisdiction": "us-ut",
+      "label": "SNAP Returns",
+      "sequence": 717,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/600-issuances-and-payments-641-4-issuance-of-assistance-through-the-utah-horizon-system-htm",
+      "id": "ut-0188",
+      "jurisdiction": "us-ut",
+      "label": "Daily Issuance",
+      "sequence": 718,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/600-issuances-and-payments-641-5-cancelling-or-withdrawing-an-ebt-payment-htm",
+      "id": "ut-0189",
+      "jurisdiction": "us-ut",
+      "label": "Canceling an EBT Payment",
+      "sequence": 719,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/600-issuances-and-payments-641-6-households-moving-to-another-state-htm",
+      "id": "ut-0190",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: May 20, 2026",
+      "sequence": 720,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/600-issuances-and-payments-641-9-unused-snap-and-financial-cash-ebt-benefits-htm",
+      "id": "ut-0191",
+      "jurisdiction": "us-ut",
+      "label": "641-9 Unused SNAP and Financial/Cash EBT Benefits",
+      "sequence": 721,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/600-issuances-and-payments-641-utah-horizon-electronic-benefit-transfer-ebt-system-htm",
+      "id": "ut-0192",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: May 20, 2026",
+      "sequence": 722,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/600-issuances-and-payments-650-destruction-of-food-purchased-with-snap-assistance-htm",
+      "id": "ut-0193",
+      "jurisdiction": "us-ut",
+      "label": "650 Destruction of Food Purchased with SNAP Assistance",
+      "sequence": 723,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/600-issuances-and-payments-660-3-suspension-or-cancellation-of-benefits-htm",
+      "id": "ut-0194",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: April 1, 2004",
+      "sequence": 724,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/600-issuances-and-payments-660-6-determining-benefit-level-for-eligible-households-during-a-reductio",
+      "id": "ut-0195",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: April 1, 2004",
+      "sequence": 725,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/600-issuances-and-payments-660-7-expedited-service-during-a-reduction-suspension-or-cancellation-of-",
+      "id": "ut-0196",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: April 1, 2004",
+      "sequence": 726,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/600-issuances-and-payments-660-federal-reduction-suspension-or-cancellation-of-snap-benefits-htm",
+      "id": "ut-0197",
+      "jurisdiction": "us-ut",
+      "label": "660 Federal Reduction, Suspension or Cancellation of SNAP Benefits",
+      "sequence": 727,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-700-eligibility-processes-and-case-maintenance-htm",
+      "id": "ut-0198",
+      "jurisdiction": "us-ut",
+      "label": "M ain sub-topics in this section:",
+      "sequence": 728,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-705-1-initial-contact-with-the-local-employment-center-",
+      "id": "ut-0199",
+      "jurisdiction": "us-ut",
+      "label": "Additional SNAP Considerations",
+      "sequence": 729,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-705-2-filing-an-application-htm",
+      "id": "ut-0200",
+      "jurisdiction": "us-ut",
+      "label": "Additional SNAP Considerations",
+      "sequence": 730,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-705-3-customer-information-htm",
+      "id": "ut-0201",
+      "jurisdiction": "us-ut",
+      "label": "All Programs",
+      "sequence": 731,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-705-application-htm",
+      "id": "ut-0202",
+      "jurisdiction": "us-ut",
+      "label": "All Programs",
+      "sequence": 732,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-710-1-interview-type-for-snap-htm",
+      "id": "ut-0203",
+      "jurisdiction": "us-ut",
+      "label": "710-1 Interview Type for SNAP",
+      "sequence": 733,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-710-3-completing-interviews-htm",
+      "id": "ut-0204",
+      "jurisdiction": "us-ut",
+      "label": "SNAP",
+      "sequence": 734,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-710-interviews-htm",
+      "id": "ut-0205",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 735,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-715-1-application-processing-time-requirements-htm",
+      "id": "ut-0206",
+      "jurisdiction": "us-ut",
+      "label": "Expedited Processing",
+      "sequence": 736,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-715-2-month-of-application-htm",
+      "id": "ut-0207",
+      "jurisdiction": "us-ut",
+      "label": "All Programs",
+      "sequence": 737,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-715-3-benefit-effective-dates-htm",
+      "id": "ut-0208",
+      "jurisdiction": "us-ut",
+      "label": "Additional SNAP Considerations",
+      "sequence": 738,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-715-5-refusal-to-cooperate-with-quality-control-snap-ht",
+      "id": "ut-0209",
+      "jurisdiction": "us-ut",
+      "label": "715-5 Refusal to Cooperate with Quality Control \u2013 SNAP",
+      "sequence": 739,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-715-6-denying-the-application-htm",
+      "id": "ut-0210",
+      "jurisdiction": "us-ut",
+      "label": "Additional Supplemental Nutrition Assistance Program (SNAP) Considerations",
+      "sequence": 740,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-715-8a-determining-cause-of-the-delay-htm",
+      "id": "ut-0211",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 741,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-715-processing-the-application-htm",
+      "id": "ut-0212",
+      "jurisdiction": "us-ut",
+      "label": "Main sub-topics in this section:",
+      "sequence": 742,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-720-11-snap-disqualifications-htm",
+      "id": "ut-0213",
+      "jurisdiction": "us-ut",
+      "label": "720-11 SNAP Disqualifications",
+      "sequence": 743,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-720-2-required-verifications-snap-htm",
+      "id": "ut-0214",
+      "jurisdiction": "us-ut",
+      "label": "720-2 Required Verifications - SNAP",
+      "sequence": 744,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-720-5-verifying-identity-htm",
+      "id": "ut-0215",
+      "jurisdiction": "us-ut",
+      "label": "Additional Considerations for Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 745,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-720-6-verifying-social-security-numbers-htm",
+      "id": "ut-0216",
+      "jurisdiction": "us-ut",
+      "label": "All Programs",
+      "sequence": 746,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-720-9-income-match-data-htm",
+      "id": "ut-0217",
+      "jurisdiction": "us-ut",
+      "label": "All Programs",
+      "sequence": 747,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-720-verification-requirements-htm",
+      "id": "ut-0218",
+      "jurisdiction": "us-ut",
+      "label": "Additional Financial and Supplemental Nutrition Assistance Program (SNAP) Considerations",
+      "sequence": 748,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-730-eligibility-period-htm",
+      "id": "ut-0219",
+      "jurisdiction": "us-ut",
+      "label": "SNAP",
+      "sequence": 749,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-735-2-review-due-dates-and-time-frames-htm",
+      "id": "ut-0220",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 750,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-735-2a-reviews-completed-on-time-htm",
+      "id": "ut-0221",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: December 1, 2013",
+      "sequence": 751,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-735-2b-reviews-not-completed-on-time-htm",
+      "id": "ut-0222",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: June 1, 2023",
+      "sequence": 752,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-735-3-when-an-eligible-household-completes-its-review-h",
+      "id": "ut-0223",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: December 1, 2013",
+      "sequence": 753,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-735-eligibility-reviews-htm",
+      "id": "ut-0224",
+      "jurisdiction": "us-ut",
+      "label": "All Programs",
+      "sequence": 754,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-745-reopening-cases-without-a-new-application-htm",
+      "id": "ut-0225",
+      "jurisdiction": "us-ut",
+      "label": "Review Closures",
+      "sequence": 755,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-750-1-customer-responsibility-to-report-changes-htm",
+      "id": "ut-0226",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 756,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-750-2-changes-that-must-be-reported-htm",
+      "id": "ut-0227",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 757,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-750-4-change-processing-standards-10-10-10-and-10-10-1-",
+      "id": "ut-0228",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 758,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-750-5a-effective-date-of-changes-that-cause-assistance-",
+      "id": "ut-0229",
+      "jurisdiction": "us-ut",
+      "label": "All Programs",
+      "sequence": 759,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-750-5b-effective-date-of-changes-that-cause-assistance-",
+      "id": "ut-0230",
+      "jurisdiction": "us-ut",
+      "label": "All Programs",
+      "sequence": 760,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-750-6-agency-action-on-reported-changes-htm",
+      "id": "ut-0231",
+      "jurisdiction": "us-ut",
+      "label": "Sub-topics in this section:",
+      "sequence": 761,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-750-6a-adding-a-new-household-member-htm",
+      "id": "ut-0232",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective Date: July 1, 2023",
+      "sequence": 762,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-750-6c-increase-in-income-starting-a-job-htm",
+      "id": "ut-0233",
+      "jurisdiction": "us-ut",
+      "label": "All Programs",
+      "sequence": 763,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-750-6d-decrease-in-income-termination-of-a-job-htm",
+      "id": "ut-0234",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 764,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-750-6e-change-of-address-htm",
+      "id": "ut-0235",
+      "jurisdiction": "us-ut",
+      "label": "All Programs",
+      "sequence": 765,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-750-6f-change-to-shelter-costs-snap-only-htm",
+      "id": "ut-0236",
+      "jurisdiction": "us-ut",
+      "label": "750-6F Change to Shelter Costs \u2013 SNAP Only",
+      "sequence": 766,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-750-6g-change-in-expenses-htm",
+      "id": "ut-0237",
+      "jurisdiction": "us-ut",
+      "label": "Additional SNAP Considerations",
+      "sequence": 767,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-750-6h-mass-changes-htm",
+      "id": "ut-0238",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: April 1, 2004",
+      "sequence": 768,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-750-6i-action-on-reported-changes-to-fin-and-med-progra",
+      "id": "ut-0239",
+      "jurisdiction": "us-ut",
+      "label": "750-6I Action on Reported Changes to Financial and Medical Programs in a SNAP Household",
+      "sequence": 769,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-750-6l-changes-to-snap-bens-based-on-failure-to-comply-",
+      "id": "ut-0240",
+      "jurisdiction": "us-ut",
+      "label": "750-6L Changes to SNAP Benefits Based on Failure to Comply with Financial Requirements",
+      "sequence": 770,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-770-1-advance-notice-of-adverse-action-htm",
+      "id": "ut-0241",
+      "jurisdiction": "us-ut",
+      "label": "Additional Considerations for Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 771,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-770-2-exceptions-to-advance-notice-htm",
+      "id": "ut-0242",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP) Only",
+      "sequence": 772,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-770-3-when-no-notice-is-required-snap-htm",
+      "id": "ut-0243",
+      "jurisdiction": "us-ut",
+      "label": "770-3 When No Notice is Required \u2013 SNAP",
+      "sequence": 773,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-770-notification-htm",
+      "id": "ut-0244",
+      "jurisdiction": "us-ut",
+      "label": "Sub-topics in this section:",
+      "sequence": 774,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-775-1-application-process-for-expedited-snap-htm",
+      "id": "ut-0245",
+      "jurisdiction": "us-ut",
+      "label": "775-1 Application Process for Expedited SNAP",
+      "sequence": 775,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-775-2-interviews-for-expedited-snap-htm",
+      "id": "ut-0246",
+      "jurisdiction": "us-ut",
+      "label": "775-2 Interviews for Expedited SNAP",
+      "sequence": 776,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-775-3-expedited-snap-timeframes-htm",
+      "id": "ut-0247",
+      "jurisdiction": "us-ut",
+      "label": "775-3 Expedited SNAP Timeframes",
+      "sequence": 777,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-775-4-special-processing-for-expedited-snap-htm",
+      "id": "ut-0248",
+      "jurisdiction": "us-ut",
+      "label": "775-4 Special Processing for Expedited SNAP",
+      "sequence": 778,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-775-5-verifications-for-expedited-snap-htm",
+      "id": "ut-0249",
+      "jurisdiction": "us-ut",
+      "label": "775-5 Verifications for Expedited SNAP",
+      "sequence": 779,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/700-eligibility-process-and-case-maintenance-775-expedited-snap-requirements-htm",
+      "id": "ut-0250",
+      "jurisdiction": "us-ut",
+      "label": "775 Expedited SNAP Requirements",
+      "sequence": 780,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-800-overpayments-and-underpayments-htm",
+      "id": "ut-0251",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: February 1, 2024",
+      "sequence": 781,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-805-2-retained-child-support-debt-htm",
+      "id": "ut-0252",
+      "jurisdiction": "us-ut",
+      "label": "Additional Supplemental Nutrition Assistance Program (SNAP) Considerations",
+      "sequence": 782,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-815-1-calculating-overpayments-htm",
+      "id": "ut-0253",
+      "jurisdiction": "us-ut",
+      "label": "Additional Supplemental Nutrition Assistance Program (SNAP) Considerations",
+      "sequence": 783,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-815-2-determining-the-first-month-of-an-overpayment-htm",
+      "id": "ut-0254",
+      "jurisdiction": "us-ut",
+      "label": "All Programs",
+      "sequence": 784,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-815-3-calculating-overpayments-with-wage-match-data-htm",
+      "id": "ut-0255",
+      "jurisdiction": "us-ut",
+      "label": "See Also:",
+      "sequence": 785,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-815-4-incomplete-claims-htm",
+      "id": "ut-0256",
+      "jurisdiction": "us-ut",
+      "label": "See Also:",
+      "sequence": 786,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-815-5-snap-trafficking-overpayment-calculation-htm",
+      "id": "ut-0257",
+      "jurisdiction": "us-ut",
+      "label": "815-5 SNAP Trafficking Overpayment Calculation",
+      "sequence": 787,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-815-6-overpayment-thresholds-htm",
+      "id": "ut-0258",
+      "jurisdiction": "us-ut",
+      "label": "Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 788,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-815-7-waiving-adjudication-of-small-overpayments-htm",
+      "id": "ut-0259",
+      "jurisdiction": "us-ut",
+      "label": "See Also:",
+      "sequence": 789,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-815-overpayment-calculation-htm",
+      "id": "ut-0260",
+      "jurisdiction": "us-ut",
+      "label": "Sub-topics in this section:",
+      "sequence": 790,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-820-1-determining-responsible-parties-htm",
+      "id": "ut-0261",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: April 1, 2004",
+      "sequence": 791,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-820-10-compromising-overpayments-htm",
+      "id": "ut-0262",
+      "jurisdiction": "us-ut",
+      "label": "All Programs",
+      "sequence": 792,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-820-7-issuing-an-order-htm",
+      "id": "ut-0263",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: March 1, 2024",
+      "sequence": 793,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-825-1-intentional-program-violation-htm",
+      "id": "ut-0264",
+      "jurisdiction": "us-ut",
+      "label": "Additional Supplemental Nutrition Assistance Program (SNAP) Considerations",
+      "sequence": 794,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-825-10-edrs-electronic-disqualified-recipient-system-htm",
+      "id": "ut-0265",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: June 1, 2024",
+      "sequence": 795,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-825-11-applying-intentional-program-violation-and-fraud-penalties",
+      "id": "ut-0266",
+      "jurisdiction": "us-ut",
+      "label": "Financial and Supplemental Nutrition Assistance Program (SNAP)",
+      "sequence": 796,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-825-2-fraud-fault-htm",
+      "id": "ut-0267",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: May 6, 2026",
+      "sequence": 797,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-825-3-snap-trafficking-htm",
+      "id": "ut-0268",
+      "jurisdiction": "us-ut",
+      "label": "825-3 SNAP Trafficking",
+      "sequence": 798,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-825-6-intentional-program-violation-fraud-fault-penalties-htm",
+      "id": "ut-0269",
+      "jurisdiction": "us-ut",
+      "label": "Additional Supplemental Nutrition Assistance Program (SNAP) Disqualification Penalties:",
+      "sequence": 799,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-825-7-determining-disqualification-offense-number-and-time-period",
+      "id": "ut-0270",
+      "jurisdiction": "us-ut",
+      "label": "Additional SNAP Considerations",
+      "sequence": 800,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-825-8-criminal-prosecution-ipv-fraud-htm",
+      "id": "ut-0271",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: May 6, 2026",
+      "sequence": 801,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-825-9-permanent-verification-file-ipv-fraud-htm",
+      "id": "ut-0272",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: June 1, 2024",
+      "sequence": 802,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-825-intentional-program-violation-fraud-fault-htm",
+      "id": "ut-0273",
+      "jurisdiction": "us-ut",
+      "label": "Sub-topics in this section:",
+      "sequence": 803,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-830-1-methods-of-collection-htm",
+      "id": "ut-0274",
+      "jurisdiction": "us-ut",
+      "label": "Sub-topics in this section:",
+      "sequence": 804,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-830-1a-benefit-reduction-recoupment-htm",
+      "id": "ut-0275",
+      "jurisdiction": "us-ut",
+      "label": "SNAP",
+      "sequence": 805,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-830-1b-ebt-withdrawal-htm",
+      "id": "ut-0276",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: June 1, 2024",
+      "sequence": 806,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-830-1c-offsetting-an-overpayment-with-restored-benefits-htm",
+      "id": "ut-0277",
+      "jurisdiction": "us-ut",
+      "label": "Other Sub-topics in this section:",
+      "sequence": 807,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-830-1d-repayment-agreements-htm",
+      "id": "ut-0278",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: June 1, 2024",
+      "sequence": 808,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-830-1e-wage-assignments-htm",
+      "id": "ut-0279",
+      "jurisdiction": "us-ut",
+      "label": "Other Sub-topics in this section:",
+      "sequence": 809,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-830-1g-direct-billing-htm",
+      "id": "ut-0280",
+      "jurisdiction": "us-ut",
+      "label": "Other Sub-topics in this section:",
+      "sequence": 810,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-830-1h-garnishment-htm",
+      "id": "ut-0281",
+      "jurisdiction": "us-ut",
+      "label": "Other Sub-topics in this section:",
+      "sequence": 811,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-830-1i-state-tax-refund-offsets-htm",
+      "id": "ut-0282",
+      "jurisdiction": "us-ut",
+      "label": "Other Sub-topics in this section:",
+      "sequence": 812,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-830-1j-vehicle-execution-htm",
+      "id": "ut-0283",
+      "jurisdiction": "us-ut",
+      "label": "Other Sub-topics in this section:",
+      "sequence": 813,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-830-1k-real-property-liens-htm",
+      "id": "ut-0284",
+      "jurisdiction": "us-ut",
+      "label": "Other Sub-topics in this section:",
+      "sequence": 814,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-830-1l-treasury-offset-program-referral-snap-only-htm",
+      "id": "ut-0285",
+      "jurisdiction": "us-ut",
+      "label": "830-1L Treasury Offset Program (TOP) Referral - SNAP/SNAP Trafficking Debts Only",
+      "sequence": 815,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-830-1m-unemployment-compensation-offset-htm",
+      "id": "ut-0286",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: June 1, 2006",
+      "sequence": 816,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-830-2-posting-collections-htm",
+      "id": "ut-0287",
+      "jurisdiction": "us-ut",
+      "label": "Required Posting to a Specified Obligation or Debt",
+      "sequence": 817,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/800-overpayments-and-underpayments-830-7-account-management-htm",
+      "id": "ut-0288",
+      "jurisdiction": "us-ut",
+      "label": "All Programs",
+      "sequence": 818,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/900-disaster-snap-900-disaster-snap-htm",
+      "id": "ut-0289",
+      "jurisdiction": "us-ut",
+      "label": "900 Disaster SNAP",
+      "sequence": 819,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/900-disaster-snap-901-application-and-interview-htm",
+      "id": "ut-0290",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: April 1, 2009",
+      "sequence": 820,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/900-disaster-snap-902-household-eligibility-requirements-htm",
+      "id": "ut-0291",
+      "jurisdiction": "us-ut",
+      "label": "Household Composition",
+      "sequence": 821,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/900-disaster-snap-903-program-requirements-htm",
+      "id": "ut-0292",
+      "jurisdiction": "us-ut",
+      "label": "Intentional Program Violation (IPV)",
+      "sequence": 822,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/900-disaster-snap-904-income-test-and-benefit-amount-htm",
+      "id": "ut-0293",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: April 1, 2009",
+      "sequence": 823,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/900-disaster-snap-906-special-cases-htm",
+      "id": "ut-0294",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: April 1, 2009",
+      "sequence": 824,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/900-disaster-snap-907-eligibility-and-participation-in-other-snap-htm",
+      "id": "ut-0295",
+      "jurisdiction": "us-ut",
+      "label": "907 Eligibility and Participation in Other SNAP",
+      "sequence": 825,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/900-disaster-snap-909-definitions-htm",
+      "id": "ut-0296",
+      "jurisdiction": "us-ut",
+      "label": "Policy Effective: April 1, 2009",
+      "sequence": 826,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/tables-appendicies-and-charts-tables-appendicies-and-charts-table-2-snap-monthly-income-limits-and-m",
+      "id": "ut-0297",
+      "jurisdiction": "us-ut",
+      "label": "Table 2 - SNAP Monthly Income Limits and Maximum Assistance Amounts",
+      "sequence": 827,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/tables-appendicies-and-charts-tables-appendicies-and-charts-table-9-disaster-snap-monthly-income-lim",
+      "id": "ut-0298",
+      "jurisdiction": "us-ut",
+      "label": "Table 9 - Disaster SNAP Monthly Income Limits and Maximum Assistance",
+      "sequence": 828,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/welcome-welcome-htm",
+      "id": "ut-0299",
+      "jurisdiction": "us-ut",
+      "label": "Welcome",
+      "sequence": 829,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/dws/eligibility-manual/what-s-new-htm",
+      "id": "ut-0300",
+      "jurisdiction": "us-ut",
+      "label": "What's new In Child Care, Financial and SNAP Eligibility Policy",
+      "sequence": 830,
+      "source_kind": "topic",
+      "status": "pending"
+    },
+    {
+      "attempt": 1,
+      "citation": "us-ut/manual/recovery/release-scope-us-ut-manual-2026-05-27-ut-manuals",
+      "id": "ut-0301",
+      "jurisdiction": "us-ut",
+      "label": "Welcome",
+      "sequence": 831,
+      "source_kind": "topic",
+      "status": "pending"
+    }
+  ],
+  "pause_reason": "Awaiting a green, independently reviewed exact RuleSpec protected-branch tip.",
+  "queue_id": "us-snap-or-ut-2026-07",
+  "release": {
+    "content_sha256": "cb275c76c4f07f8ad37470a32296bb1763e5db853d152697524ab07021b6d544",
+    "manifest_sha256": "be18ff3f1557f4e30a1520e519e4d14b31c01122534ca1690294729bb7029691",
+    "name": "us-rulespec-2026-07-24-snap-cms-pit-union"
+  },
+  "schema": "axiom-encode/signed-encoding-queue/v1",
+  "state": "paused"
+}

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -11,6 +11,8 @@ from pathlib import Path, PurePosixPath
 
 COUNTRY_PATTERN = re.compile(r"[a-z]{2}")
 COMMIT_PATTERN = re.compile(r"[0-9a-f]{40}")
+DIGEST_PATTERN = re.compile(r"[0-9a-f]{64}")
+QUEUE_TRACKING_PATTERN = re.compile(r"[a-z0-9][a-z0-9-]{0,63}")
 MANIFEST_ROOT = PurePosixPath(".axiom/encoding-manifests")
 RULESPEC_ATOMIC_ROOTS = frozenset(
     {"legislation", "policies", "regulations", "statutes"}
@@ -38,6 +40,35 @@ def validate_country(value: str) -> str:
     if COUNTRY_PATTERN.fullmatch(value) is None:
         raise ValueError("country must be a two-letter lowercase country code")
     return value
+
+
+def validate_queue_tracking(
+    queue_id: str,
+    queue_item_id: str,
+    queue_manifest_sha256: str,
+    queue_item_generation_sha256: str,
+) -> str:
+    """Require complete, shell-safe queue tracking metadata or no metadata."""
+
+    values = (
+        queue_id,
+        queue_item_id,
+        queue_manifest_sha256,
+        queue_item_generation_sha256,
+    )
+    if not any(values):
+        return "ad-hoc"
+    if not all(values):
+        raise ValueError("queue tracking fields must be supplied together")
+    if QUEUE_TRACKING_PATTERN.fullmatch(queue_id) is None:
+        raise ValueError("queue_id is malformed")
+    if QUEUE_TRACKING_PATTERN.fullmatch(queue_item_id) is None:
+        raise ValueError("queue_item_id is malformed")
+    if DIGEST_PATTERN.fullmatch(queue_manifest_sha256) is None:
+        raise ValueError("queue_manifest_sha256 is malformed")
+    if DIGEST_PATTERN.fullmatch(queue_item_generation_sha256) is None:
+        raise ValueError("queue_item_generation_sha256 is malformed")
+    return "tracked"
 
 
 def branch_name(country: str, run_id: str, run_attempt: str) -> str:
@@ -106,18 +137,12 @@ def _require_remote_branch_tip(
 ) -> None:
     try:
         branch_ref = (
-            _git(repo, "rev-parse", f"refs/remotes/origin/{branch}")
-            .decode()
-            .strip()
+            _git(repo, "rev-parse", f"refs/remotes/origin/{branch}").decode().strip()
         )
     except subprocess.CalledProcessError as exc:
-        raise ValueError(
-            f"pull request base branch is unavailable: {branch}"
-        ) from exc
+        raise ValueError(f"pull request base branch is unavailable: {branch}") from exc
     if branch_ref != requested_ref:
-        raise ValueError(
-            "rulespec ref is not the exact pull request base branch tip"
-        )
+        raise ValueError("rulespec ref is not the exact pull request base branch tip")
 
 
 def _citation_rulespec_path(citation: str) -> tuple[str, PurePosixPath]:
@@ -339,6 +364,11 @@ def main() -> None:
     subparsers = parser.add_subparsers(dest="command", required=True)
     country_parser = subparsers.add_parser("validate-country")
     country_parser.add_argument("country")
+    queue_parser = subparsers.add_parser("validate-queue-tracking")
+    queue_parser.add_argument("queue_id")
+    queue_parser.add_argument("queue_item_id")
+    queue_parser.add_argument("queue_manifest_sha256")
+    queue_parser.add_argument("queue_item_generation_sha256")
     branch_parser = subparsers.add_parser("branch-name")
     branch_parser.add_argument("country")
     branch_parser.add_argument("run_id")
@@ -359,6 +389,15 @@ def main() -> None:
     try:
         if args.command == "validate-country":
             print(validate_country(args.country))
+        elif args.command == "validate-queue-tracking":
+            print(
+                validate_queue_tracking(
+                    args.queue_id,
+                    args.queue_item_id,
+                    args.queue_manifest_sha256,
+                    args.queue_item_generation_sha256,
+                )
+            )
         elif args.command == "branch-name":
             print(branch_name(args.country, args.run_id, args.run_attempt))
         elif args.command == "validate-rulespec-base":

--- a/scripts/prepare_signed_queue.py
+++ b/scripts/prepare_signed_queue.py
@@ -1,0 +1,2282 @@
+#!/usr/bin/env python3
+"""Build, validate, and select bounded protected encoding queue tranches."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "axiom-encode/signed-encoding-queue/v1"
+ACTIVATION_CHANGED_FILES = (
+    "data/encoding-queues/us-snap-or-ut-2026-07.json",
+    "pyproject.toml",
+    "src/axiom_encode/__init__.py",
+    "uv.lock",
+)
+QUEUE_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
+ITEM_ID_PATTERN = re.compile(r"^(?:or|ut)-[0-9]{4}$")
+RELEASE_NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{0,127}$")
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+DIGEST_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+BLOCK_SUFFIX_PATTERN = re.compile(r"/block-[0-9]+$")
+SNAP_PATTERN = re.compile(r"SNAP", re.IGNORECASE)
+ALLOWED_STATUSES = frozenset(
+    {
+        "blocked",
+        "completed",
+        "no-executable-rule",
+        "pending",
+        "retryable",
+    }
+)
+SELECTABLE_STATUSES = frozenset({"pending", "retryable"})
+TERMINAL_STATUSES = frozenset({"blocked", "completed", "no-executable-rule"})
+MAX_BATCH_SIZE = 4
+EXPECTED_COUNTS = {"total": 831, "us-or": 530, "us-ut": 301}
+RULESPEC_PR_PATTERN = re.compile(
+    r"^https://github\.com/TheAxiomFoundation/rulespec-us/pull/[0-9]+$"
+)
+QUEUE_ISSUE_COMMENT_PATTERN = re.compile(
+    r"^https://github\.com/TheAxiomFoundation/axiom-encode/issues/"
+    r"1257#issuecomment-[0-9]+$"
+)
+FINALIZER_RUN_PATTERN = re.compile(
+    r"^https://github\.com/TheAxiomFoundation/axiom-encode/actions/runs/[0-9]+$"
+)
+TARGET_RUN_MARKER_PATTERN = re.compile(
+    r"(?:^|\n)Axiom Encode run: "
+    r"(https://github\.com/TheAxiomFoundation/axiom-encode/actions/runs/[0-9]+)"
+    r"(?:\n|$)"
+)
+PRIORITY_CITATIONS = (
+    "us-ut/manual/dws/eligibility-manual/"
+    "tables-appendicies-and-charts-tables-appendicies-and-charts-table-2-"
+    "snap-monthly-income-limits-and-m/block-2",
+    "us-or/manual/odhs/open/page-272",
+    "us-or/manual/odhs/open/page-273",
+    "us-or/manual/odhs/open/page-274",
+)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("queue manifest must be a JSON object")
+    return payload
+
+
+def _load_jsonl(paths: list[Path]) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for path in paths:
+        with path.open(encoding="utf-8") as stream:
+            for line_number, line in enumerate(stream, start=1):
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    raise ValueError(
+                        f"malformed corpus JSONL at {path}:{line_number}"
+                    ) from exc
+                if not isinstance(record, dict):
+                    raise ValueError(
+                        f"corpus JSONL row is not an object at {path}:{line_number}"
+                    )
+                records.append(record)
+    return records
+
+
+def _has_snap_marker(record: dict[str, Any]) -> bool:
+    text = " ".join(
+        str(record.get(field) or "") for field in ("body", "heading", "citation_label")
+    )
+    return SNAP_PATTERN.search(text) is not None
+
+
+def _record_label(record: dict[str, Any]) -> str:
+    for field in ("heading", "citation_label", "citation_path"):
+        value = record.get(field)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    raise ValueError("corpus record has no usable label")
+
+
+def _require_sha(value: object, label: str) -> str:
+    if not isinstance(value, str) or SHA_PATTERN.fullmatch(value) is None:
+        raise ValueError(f"{label} must be a full lowercase commit SHA")
+    return value
+
+
+def _require_digest(value: object, label: str) -> str:
+    if not isinstance(value, str) or DIGEST_PATTERN.fullmatch(value) is None:
+        raise ValueError(f"{label} must be a lowercase SHA-256 digest")
+    return value
+
+
+def _json_sha256(payload: object) -> str:
+    canonical = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _git(corpus_root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(corpus_root), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _verify_corpus_provenance(
+    corpus_root: Path,
+    *,
+    corpus_ref: str,
+    release_name: str,
+    source_paths: list[Path],
+) -> str:
+    """Verify queue inputs come from the exact clean released corpus commit."""
+
+    if RELEASE_NAME_PATTERN.fullmatch(release_name) is None:
+        raise ValueError("release_name is malformed")
+    try:
+        head = _git(corpus_root, "rev-parse", "HEAD")
+        checkout_status = _git(corpus_root, "status", "--porcelain")
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise ValueError("corpus_root must be a readable Git checkout") from exc
+    if head != corpus_ref:
+        raise ValueError(f"corpus checkout HEAD {head} does not match {corpus_ref}")
+    if checkout_status:
+        raise ValueError("corpus checkout is not clean")
+
+    manifest_path = corpus_root / "manifests/releases" / f"{release_name}.json"
+    release = _load_json(manifest_path)
+    if release.get("name") != release_name:
+        raise ValueError("corpus release manifest name does not match release_name")
+    scopes = release.get("scopes")
+    if not isinstance(scopes, list):
+        raise ValueError("corpus release manifest scopes are missing")
+    provisions = corpus_root / "data/corpus/provisions"
+    required_scopes = set()
+    for source_path in source_paths:
+        try:
+            relative = source_path.relative_to(provisions)
+        except ValueError as exc:
+            raise ValueError("queue source is outside canonical provisions") from exc
+        if len(relative.parts) != 3 or relative.suffix != ".jsonl":
+            raise ValueError(f"queue source path is malformed: {relative}")
+        required_scopes.add((relative.parts[0], relative.parts[1], relative.stem))
+    available_scopes = {
+        (
+            scope.get("jurisdiction"),
+            scope.get("document_class"),
+            scope.get("version"),
+        )
+        for scope in scopes
+        if isinstance(scope, dict)
+    }
+    missing = required_scopes - available_scopes
+    if missing:
+        raise ValueError(
+            "corpus release manifest is missing SNAP manual scopes: "
+            + ", ".join("/".join(scope) for scope in sorted(missing))
+        )
+    return hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+
+
+def _verify_signed_release_binding(
+    corpus_root: Path,
+    rulespec_root: Path,
+    *,
+    corpus_ref: str,
+    rulespec_ref: str,
+    release_name: str,
+    release_content_sha256: str,
+    release_object_path: Path,
+    release_public_key_path: Path,
+    source_paths: list[Path],
+) -> None:
+    """Authenticate the release and bind it to RuleSpec and local source bytes."""
+
+    try:
+        rulespec_head = _git(rulespec_root, "rev-parse", "HEAD")
+        rulespec_status = _git(rulespec_root, "status", "--porcelain")
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise ValueError("rulespec_root must be a readable Git checkout") from exc
+    if rulespec_head != rulespec_ref:
+        raise ValueError(
+            f"RuleSpec checkout HEAD {rulespec_head} does not match {rulespec_ref}"
+        )
+    if rulespec_status:
+        raise ValueError("RuleSpec checkout is not clean")
+
+    try:
+        from scripts.materialize_corpus_release import load_release_pin
+    except ModuleNotFoundError:
+        from materialize_corpus_release import load_release_pin
+
+    pinned_name, pinned_sha = load_release_pin(rulespec_root / ".axiom/toolchain.toml")
+    if (pinned_name, pinned_sha) != (release_name, release_content_sha256):
+        raise ValueError("RuleSpec toolchain release pin does not match the queue")
+
+    try:
+        release_object = _load_json(release_object_path)
+        public_keys = tuple(
+            line.strip()
+            for line in release_public_key_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        )
+    except OSError as exc:
+        raise ValueError("signed release verification inputs are unavailable") from exc
+    if not public_keys:
+        raise ValueError("release public key file is empty")
+
+    from axiom_encode.corpus_release import (
+        CorpusReleaseObjectError,
+        verify_release_object,
+    )
+
+    try:
+        verified = verify_release_object(release_object, public_key=public_keys)
+    except CorpusReleaseObjectError as exc:
+        raise ValueError(f"signed release object is invalid: {exc}") from exc
+    if (
+        verified.name != release_name
+        or verified.content_sha256 != release_content_sha256
+    ):
+        raise ValueError("signed release identity does not match the queue")
+    content = release_object.get("content")
+    git = content.get("git") if isinstance(content, dict) else None
+    if not isinstance(git, dict) or git.get("commit") != corpus_ref:
+        raise ValueError("signed release Git provenance does not match corpus_ref")
+
+    artifacts = {artifact.path: artifact for artifact in verified.artifacts}
+    for source_path in source_paths:
+        relative = source_path.relative_to(corpus_root).as_posix()
+        artifact = artifacts.get(relative)
+        if artifact is None:
+            raise ValueError(f"signed release omits queue source artifact: {relative}")
+        if hashlib.sha256(source_path.read_bytes()).hexdigest() != artifact.sha256:
+            raise ValueError(
+                f"queue source digest differs from signed release: {relative}"
+            )
+
+
+def build_snap_queue(
+    corpus_root: Path,
+    rulespec_root: Path,
+    *,
+    corpus_ref: str,
+    rulespec_ref: str,
+    rules_engine_ref: str,
+    release_name: str,
+    release_content_sha256: str,
+    release_object_path: Path,
+    release_public_key_path: Path,
+    state: str,
+    pause_reason: str | None,
+) -> dict[str, Any]:
+    """Build the reviewed Oregon and Utah SNAP source-unit inventory."""
+
+    _require_sha(corpus_ref, "corpus_ref")
+    _require_sha(rulespec_ref, "rulespec_ref")
+    _require_sha(rules_engine_ref, "rules_engine_ref")
+    _require_digest(release_content_sha256, "release_content_sha256")
+    provisions = corpus_root / "data/corpus/provisions"
+    or_paths = sorted((provisions / "us-or/manual").glob("*.jsonl"))
+    ut_paths = sorted((provisions / "us-ut/manual").glob("*.jsonl"))
+    source_paths = or_paths + ut_paths
+    release_manifest_sha256 = _verify_corpus_provenance(
+        corpus_root,
+        corpus_ref=corpus_ref,
+        release_name=release_name,
+        source_paths=source_paths,
+    )
+    _verify_signed_release_binding(
+        corpus_root,
+        rulespec_root,
+        corpus_ref=corpus_ref,
+        rulespec_ref=rulespec_ref,
+        release_name=release_name,
+        release_content_sha256=release_content_sha256,
+        release_object_path=release_object_path,
+        release_public_key_path=release_public_key_path,
+        source_paths=source_paths,
+    )
+    or_records = _load_jsonl(or_paths)
+    ut_records = _load_jsonl(ut_paths)
+    if not or_records or not ut_records:
+        raise ValueError("Oregon and Utah manual corpus records are required")
+
+    candidates: dict[str, tuple[str, str]] = {}
+    for record in or_records:
+        citation = record.get("citation_path")
+        if not isinstance(citation, str):
+            raise ValueError("Oregon corpus record has no citation_path")
+        if record.get("kind") == "document" or _has_snap_marker(record):
+            candidates[citation] = (
+                "document" if record.get("kind") == "document" else "page",
+                _record_label(record),
+            )
+
+    for record in ut_records:
+        citation = record.get("citation_path")
+        if not isinstance(citation, str):
+            raise ValueError("Utah corpus record has no citation_path")
+        if not _has_snap_marker(record):
+            continue
+        topic = BLOCK_SUFFIX_PATTERN.sub("", citation)
+        candidates.setdefault(topic, ("topic", _record_label(record)))
+
+    exact_block = PRIORITY_CITATIONS[0]
+    exact_record = next(
+        (record for record in ut_records if record.get("citation_path") == exact_block),
+        None,
+    )
+    if exact_record is None:
+        raise ValueError(f"priority corpus block is unavailable: {exact_block}")
+    candidates[exact_block] = ("block", _record_label(exact_record))
+
+    priority = list(PRIORITY_CITATIONS)
+    missing_priority = [citation for citation in priority if citation not in candidates]
+    if missing_priority:
+        raise ValueError(
+            "priority citations are unavailable: " + ", ".join(missing_priority)
+        )
+    remaining = sorted(set(candidates) - set(priority))
+    ordered_citations = priority + remaining
+
+    counters = {"us-or": 0, "us-ut": 0}
+    items: list[dict[str, Any]] = []
+    for sequence, citation in enumerate(ordered_citations, start=1):
+        jurisdiction = citation.split("/", 1)[0]
+        if jurisdiction not in counters:
+            raise ValueError(f"unexpected queue jurisdiction: {jurisdiction}")
+        counters[jurisdiction] += 1
+        prefix = "or" if jurisdiction == "us-or" else "ut"
+        source_kind, label = candidates[citation]
+        items.append(
+            {
+                "attempt": 1,
+                "citation": citation,
+                "id": f"{prefix}-{counters[jurisdiction]:04d}",
+                "jurisdiction": jurisdiction,
+                "label": label,
+                "sequence": sequence,
+                "source_kind": source_kind,
+                "status": "pending",
+            }
+        )
+
+    counts = {"total": len(items), **counters}
+    if counts != EXPECTED_COUNTS:
+        raise ValueError(
+            f"SNAP queue inventory drifted: expected {EXPECTED_COUNTS}, got {counts}"
+        )
+
+    payload = {
+        "schema": SCHEMA,
+        "queue_id": "us-snap-or-ut-2026-07",
+        "state": state,
+        "description": (
+            "Conservative Oregon and Utah SNAP manual source-unit inventory. "
+            "Each item requires an explicit encoder disposition."
+        ),
+        "issue": 1257,
+        "release": {
+            "content_sha256": release_content_sha256,
+            "manifest_sha256": release_manifest_sha256,
+            "name": release_name,
+        },
+        "dispatch": {
+            "corpus_ref": corpus_ref,
+            "country": "us",
+            "max_batch_size": MAX_BATCH_SIZE,
+            "open_pr": True,
+            "pr_base_branch": "hard-cut/canonical-layout-us",
+            "rules_engine_ref": rules_engine_ref,
+            "rulespec_ref": rulespec_ref,
+        },
+        "expected_counts": EXPECTED_COUNTS,
+        "items": items,
+    }
+    if pause_reason is not None:
+        payload["pause_reason"] = pause_reason
+    validate_queue(payload)
+    return payload
+
+
+def validate_queue(payload: dict[str, Any]) -> None:
+    """Validate the complete queue and immutable dispatch trust boundary."""
+
+    if payload.get("schema") != SCHEMA:
+        raise ValueError(f"queue schema must be {SCHEMA}")
+    queue_id = payload.get("queue_id")
+    if not isinstance(queue_id, str) or QUEUE_ID_PATTERN.fullmatch(queue_id) is None:
+        raise ValueError("queue_id is malformed")
+    issue = payload.get("issue")
+    if not isinstance(issue, int) or isinstance(issue, bool) or issue <= 0:
+        raise ValueError("queue issue must be a positive integer")
+    state = payload.get("state")
+    if state not in {"active", "paused"}:
+        raise ValueError("queue state must be active or paused")
+    pause_reason = payload.get("pause_reason")
+    if state == "paused":
+        if not isinstance(pause_reason, str) or not pause_reason.strip():
+            raise ValueError("paused queue requires a pause_reason")
+    elif pause_reason is not None:
+        raise ValueError("active queue must not have a pause_reason")
+    activation = payload.get("activation")
+    suspension = payload.get("suspension")
+    if state == "paused":
+        if activation is not None:
+            raise ValueError("paused queue must not have activation evidence")
+        if suspension is not None:
+            if (
+                not isinstance(suspension, dict)
+                or set(suspension) != {"active_queue_sha256", "schema"}
+                or suspension.get("schema")
+                != "axiom-encode/signed-encoding-queue-suspension/v1"
+            ):
+                raise ValueError("paused queue suspension evidence is malformed")
+            _require_digest(
+                suspension.get("active_queue_sha256"),
+                "suspension active_queue_sha256",
+            )
+    else:
+        if suspension is not None:
+            raise ValueError("active queue must not have suspension evidence")
+        expected_activation_fields = {
+            "check_runs_sha256",
+            "finalizer_head_sha",
+            "finalizer_run_attempt",
+            "finalizer_run_url",
+            "previous_queue_object_sha256",
+            "pull_requests_sha256",
+            "rulespec_ref",
+            "schema",
+            "workflow_runs_sha256",
+        }
+        if (
+            not isinstance(activation, dict)
+            or set(activation) != expected_activation_fields
+            or activation.get("schema")
+            != "axiom-encode/signed-encoding-queue-activation/v1"
+            or activation.get("rulespec_ref")
+            != (
+                payload.get("dispatch", {}).get("rulespec_ref")
+                if isinstance(payload.get("dispatch"), dict)
+                else None
+            )
+            or not isinstance(activation.get("finalizer_run_url"), str)
+            or FINALIZER_RUN_PATTERN.fullmatch(activation["finalizer_run_url"]) is None
+            or activation.get("finalizer_run_attempt") != 1
+        ):
+            raise ValueError("active queue requires valid finalization evidence")
+        _require_sha(activation.get("finalizer_head_sha"), "finalizer_head_sha")
+        for field in (
+            "check_runs_sha256",
+            "previous_queue_object_sha256",
+            "pull_requests_sha256",
+            "workflow_runs_sha256",
+        ):
+            _require_digest(activation.get(field), field)
+
+    release = payload.get("release")
+    if not isinstance(release, dict):
+        raise ValueError("queue release binding is missing")
+    if not isinstance(release.get("name"), str) or not release["name"].strip():
+        raise ValueError("queue release name is missing")
+    if RELEASE_NAME_PATTERN.fullmatch(release["name"]) is None:
+        raise ValueError("queue release name is malformed")
+    _require_digest(release.get("content_sha256"), "release content_sha256")
+    _require_digest(release.get("manifest_sha256"), "release manifest_sha256")
+
+    dispatch = payload.get("dispatch")
+    if not isinstance(dispatch, dict):
+        raise ValueError("queue dispatch binding is missing")
+    if dispatch.get("country") != "us":
+        raise ValueError("SNAP queue country must be us")
+    if dispatch.get("pr_base_branch") != "hard-cut/canonical-layout-us":
+        raise ValueError("SNAP queue PR base branch is not approved")
+    if dispatch.get("open_pr") is not True:
+        raise ValueError("SNAP queue must publish draft pull requests")
+    if dispatch.get("max_batch_size") != MAX_BATCH_SIZE:
+        raise ValueError(f"SNAP queue max_batch_size must be {MAX_BATCH_SIZE}")
+    for key in ("corpus_ref", "rules_engine_ref", "rulespec_ref"):
+        _require_sha(dispatch.get(key), key)
+
+    expected_counts = payload.get("expected_counts")
+    if expected_counts != EXPECTED_COUNTS:
+        raise ValueError(f"SNAP queue expected_counts must be {EXPECTED_COUNTS}")
+    items = payload.get("items")
+    if not isinstance(items, list):
+        raise ValueError("queue items must be a list")
+    if len(items) != EXPECTED_COUNTS["total"]:
+        raise ValueError("queue item count does not match expected_counts")
+
+    seen_ids: set[str] = set()
+    seen_citations: set[str] = set()
+    counts = {"total": len(items), "us-or": 0, "us-ut": 0}
+    for expected_sequence, item in enumerate(items, start=1):
+        if not isinstance(item, dict):
+            raise ValueError("queue item must be an object")
+        item_id = item.get("id")
+        if not isinstance(item_id, str) or ITEM_ID_PATTERN.fullmatch(item_id) is None:
+            raise ValueError("queue item id is malformed")
+        if item_id in seen_ids:
+            raise ValueError(f"duplicate queue item id: {item_id}")
+        seen_ids.add(item_id)
+        citation = item.get("citation")
+        jurisdiction = item.get("jurisdiction")
+        if jurisdiction not in ("us-or", "us-ut"):
+            raise ValueError(f"queue item jurisdiction is invalid: {item_id}")
+        if (
+            not isinstance(citation, str)
+            or not citation.startswith(f"{jurisdiction}/manual/")
+            or any(character.isspace() for character in citation)
+        ):
+            raise ValueError(f"queue item citation is invalid: {item_id}")
+        if citation in seen_citations:
+            raise ValueError(f"duplicate queue citation: {citation}")
+        seen_citations.add(citation)
+        counts[jurisdiction] += 1
+        if item.get("sequence") != expected_sequence:
+            raise ValueError(f"queue item sequence is invalid: {item_id}")
+        attempt = item.get("attempt")
+        if not isinstance(attempt, int) or isinstance(attempt, bool) or attempt <= 0:
+            raise ValueError(f"queue item attempt is invalid: {item_id}")
+        if item.get("status") not in ALLOWED_STATUSES:
+            raise ValueError(f"queue item status is invalid: {item_id}")
+        status = item["status"]
+        evidence = item.get("evidence")
+        if status not in TERMINAL_STATUSES and evidence is not None:
+            raise ValueError(
+                f"nonterminal queue item must not have evidence: {item_id}"
+            )
+        if status in TERMINAL_STATUSES:
+            if not isinstance(evidence, dict):
+                raise ValueError(
+                    f"terminal queue item requires durable evidence: {item_id}"
+                )
+            url = evidence.get("url")
+            if status == "completed":
+                if (
+                    evidence.get("type") != "merged-rulespec-pr"
+                    or not isinstance(url, str)
+                    or RULESPEC_PR_PATTERN.fullmatch(url) is None
+                ):
+                    raise ValueError(
+                        f"completed queue item requires a merged RuleSpec PR: {item_id}"
+                    )
+                _require_sha(
+                    evidence.get("merge_commit"),
+                    f"{item_id} evidence merge_commit",
+                )
+                _require_digest(
+                    evidence.get("generation_sha256"),
+                    f"{item_id} evidence generation_sha256",
+                )
+                _require_digest(
+                    evidence.get("applied_manifest_sha256"),
+                    f"{item_id} evidence applied_manifest_sha256",
+                )
+                _require_digest(
+                    evidence.get("artifact_metadata_sha256"),
+                    f"{item_id} evidence artifact_metadata_sha256",
+                )
+                _require_sha(
+                    evidence.get("rulespec_pr_head_sha"),
+                    f"{item_id} evidence rulespec_pr_head_sha",
+                )
+                _require_sha(
+                    evidence.get("target_run_head_sha"),
+                    f"{item_id} evidence target_run_head_sha",
+                )
+                target_run_url = evidence.get("target_run_url")
+                target_run_attempt = evidence.get("target_run_attempt")
+                applied_manifest_path = evidence.get("applied_manifest_path")
+                if (
+                    not isinstance(target_run_url, str)
+                    or FINALIZER_RUN_PATTERN.fullmatch(target_run_url) is None
+                    or target_run_attempt != 1
+                    or not isinstance(applied_manifest_path, str)
+                    or not applied_manifest_path.startswith(
+                        ".axiom/encoding-manifests/"
+                    )
+                    or Path(applied_manifest_path).is_absolute()
+                    or ".." in Path(applied_manifest_path).parts
+                ):
+                    raise ValueError(
+                        f"completed queue item evidence is malformed: {item_id}"
+                    )
+            else:
+                note = evidence.get("note")
+                if (
+                    evidence.get("type") != "issue-comment"
+                    or not isinstance(url, str)
+                    or QUEUE_ISSUE_COMMENT_PATTERN.fullmatch(url) is None
+                    or not isinstance(note, str)
+                    or not note.strip()
+                ):
+                    raise ValueError(
+                        f"{status} queue item requires an issue comment and note: "
+                        f"{item_id}"
+                    )
+        if item.get("source_kind") not in {"block", "document", "page", "topic"}:
+            raise ValueError(f"queue item source_kind is invalid: {item_id}")
+        if not isinstance(item.get("label"), str) or not item["label"].strip():
+            raise ValueError(f"queue item label is missing: {item_id}")
+    if counts != EXPECTED_COUNTS:
+        raise ValueError(
+            f"queue jurisdiction counts drifted: expected {EXPECTED_COUNTS}, "
+            f"got {counts}"
+        )
+    if tuple(item["citation"] for item in items[:4]) != PRIORITY_CITATIONS:
+        raise ValueError("queue priority tranche has drifted")
+
+
+def queue_file_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def queue_object_file_sha256(payload: dict[str, Any]) -> str:
+    serialized = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def dispatch_queue_sha256(payload: dict[str, Any]) -> str:
+    """Return the exact active queue digest that authorized target runs."""
+
+    if payload.get("state") == "active":
+        return queue_object_file_sha256(payload)
+    suspension = payload.get("suspension")
+    if not isinstance(suspension, dict):
+        raise ValueError("paused queue lacks active dispatch digest evidence")
+    return _require_digest(
+        suspension.get("active_queue_sha256"),
+        "suspension active_queue_sha256",
+    )
+
+
+def item_generation_sha256(
+    payload: dict[str, Any],
+    item: dict[str, Any],
+) -> str:
+    """Return the stable trust identity for one queue item attempt."""
+
+    generation = {
+        "attempt": item["attempt"],
+        "citation": item["citation"],
+        "dispatch": payload["dispatch"],
+        "item_id": item["id"],
+        "queue_id": payload["queue_id"],
+        "release": payload["release"],
+    }
+    canonical = json.dumps(
+        generation,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _selection_payload(
+    payload: dict[str, Any],
+    items: list[dict[str, Any]],
+) -> dict[str, Any]:
+    selected_items = []
+    for item in items:
+        selected = copy.deepcopy(item)
+        selected["generation_sha256"] = item_generation_sha256(payload, item)
+        selected_items.append(selected)
+    selection = {
+        "dispatch": payload["dispatch"],
+        "issue": payload["issue"],
+        "items": selected_items,
+        "queue_id": payload["queue_id"],
+        "schema": SCHEMA,
+        "state": payload["state"],
+    }
+    if payload.get("pause_reason") is not None:
+        selection["pause_reason"] = payload["pause_reason"]
+    return selection
+
+
+def selectable_items(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return the full ordered candidate pool for history-aware selection."""
+
+    validate_queue(payload)
+    items = (
+        [item for item in payload["items"] if item["status"] in SELECTABLE_STATUSES]
+        if payload["state"] == "active"
+        else []
+    )
+    return _selection_payload(payload, items)
+
+
+def select_items(
+    payload: dict[str, Any],
+    *,
+    item_ids: str,
+    limit: int,
+) -> dict[str, Any]:
+    """Select an explicit or leading bounded tranche from a valid queue."""
+
+    validate_queue(payload)
+    if limit < 1 or limit > MAX_BATCH_SIZE:
+        raise ValueError(f"limit must be between 1 and {MAX_BATCH_SIZE}")
+    requested = [
+        value.strip() for value in re.split(r"[,\n]", item_ids) if value.strip()
+    ]
+    if len(requested) != len(set(requested)):
+        raise ValueError("item_ids contains duplicates")
+    by_id = {item["id"]: item for item in payload["items"]}
+    unknown = [item_id for item_id in requested if item_id not in by_id]
+    if unknown:
+        raise ValueError("unknown queue item ids: " + ", ".join(unknown))
+    if requested:
+        if payload["state"] != "active":
+            raise ValueError("queue is paused")
+        if len(requested) > limit:
+            raise ValueError("explicit item_ids exceed the requested limit")
+        selected = [by_id[item_id] for item_id in requested]
+    else:
+        selected = (
+            [
+                item
+                for item in payload["items"]
+                if item["status"] in SELECTABLE_STATUSES
+            ][:limit]
+            if payload["state"] == "active"
+            else []
+        )
+    blocked = [
+        item["id"] for item in selected if item["status"] not in SELECTABLE_STATUSES
+    ]
+    if blocked:
+        raise ValueError("queue items are not selectable: " + ", ".join(blocked))
+    return _selection_payload(payload, selected)
+
+
+def validate_tracked_dispatch(
+    path: Path,
+    *,
+    queue_id: str,
+    item_id: str,
+    manifest_sha256: str,
+    item_generation_sha256_value: str,
+    citation: str,
+    country: str,
+    rulespec_ref: str,
+    pr_base_branch: str,
+    corpus_ref: str,
+    rules_engine_ref: str,
+    open_pr: bool,
+) -> None:
+    """Bind targeted workflow inputs to one exact committed queue item."""
+
+    payload = _load_json(path)
+    validate_queue(payload)
+    if payload["queue_id"] != queue_id:
+        raise ValueError("tracked dispatch queue_id does not match the manifest")
+    if queue_file_sha256(path) != manifest_sha256:
+        raise ValueError("tracked dispatch queue manifest digest does not match")
+    matches = [item for item in payload["items"] if item["id"] == item_id]
+    if len(matches) != 1:
+        raise ValueError("tracked dispatch queue item is unavailable")
+    item = matches[0]
+    if item["citation"] != citation:
+        raise ValueError("tracked dispatch citation does not match the queue item")
+    if item["status"] not in SELECTABLE_STATUSES:
+        raise ValueError("tracked dispatch queue item is not selectable")
+    if payload["state"] != "active":
+        raise ValueError("tracked dispatch queue is paused")
+    if item_generation_sha256(payload, item) != item_generation_sha256_value:
+        raise ValueError("tracked dispatch queue item generation does not match")
+    dispatch = payload["dispatch"]
+    expected = {
+        "country": country,
+        "rulespec_ref": rulespec_ref,
+        "pr_base_branch": pr_base_branch,
+        "corpus_ref": corpus_ref,
+        "rules_engine_ref": rules_engine_ref,
+        "open_pr": open_pr,
+    }
+    mismatches = [key for key, value in expected.items() if dispatch.get(key) != value]
+    if mismatches:
+        raise ValueError(
+            "tracked dispatch trust inputs do not match the queue: "
+            + ", ".join(mismatches)
+        )
+
+
+def validate_release_pin(
+    queue_path: Path,
+    *,
+    toolchain_path: Path,
+    manifest_sha256: str,
+) -> None:
+    """Bind the runtime RuleSpec toolchain pin to the exact tracked queue."""
+
+    payload = _load_json(queue_path)
+    validate_queue(payload)
+    if queue_file_sha256(queue_path) != manifest_sha256:
+        raise ValueError("runtime queue manifest digest does not match")
+    try:
+        from scripts.materialize_corpus_release import load_release_pin
+    except ModuleNotFoundError:
+        from materialize_corpus_release import load_release_pin
+
+    release_name, release_sha = load_release_pin(toolchain_path)
+    release = payload["release"]
+    if (release_name, release_sha) != (
+        release["name"],
+        release["content_sha256"],
+    ):
+        raise ValueError("runtime RuleSpec corpus release pin does not match the queue")
+
+
+def verify_activation_evidence(
+    queue_path: Path,
+    *,
+    previous_queue_path: Path,
+    expected_base_sha: str,
+    finalized_queue_path: Path,
+    check_runs: object,
+    pull_requests: object,
+    workflow_runs: object,
+    finalizer_run: object,
+    finalizer_jobs: object,
+    require_success: bool,
+) -> None:
+    """Authenticate an active queue against one finalizer run and its artifact."""
+
+    queue = _load_json(queue_path)
+    previous_queue = _load_json(previous_queue_path)
+    finalized = _load_json(finalized_queue_path)
+    validate_queue(queue)
+    validate_queue(previous_queue)
+    if (
+        queue["state"] != "active"
+        or queue != finalized
+        or queue_path.read_bytes() != finalized_queue_path.read_bytes()
+    ):
+        raise ValueError("active queue differs from the finalizer artifact")
+    if previous_queue["state"] != "paused":
+        raise ValueError("activation base queue must be paused")
+    activation = queue["activation"]
+    _require_sha(expected_base_sha, "expected_base_sha")
+    if activation["finalizer_head_sha"] != expected_base_sha:
+        raise ValueError("activation finalizer head does not match the pull request base")
+    if activation["previous_queue_object_sha256"] != _json_sha256(previous_queue):
+        raise ValueError("activation base queue digest does not match")
+    if activation["check_runs_sha256"] != _json_sha256(check_runs):
+        raise ValueError("activation check run evidence digest does not match")
+    if activation["pull_requests_sha256"] != _json_sha256(pull_requests):
+        raise ValueError("activation pull request evidence digest does not match")
+    if activation["workflow_runs_sha256"] != _json_sha256(workflow_runs):
+        raise ValueError("activation workflow run evidence digest does not match")
+    _validate_green_check_runs(check_runs)
+    if not isinstance(finalizer_run, dict):
+        raise ValueError("finalizer run evidence must be an object")
+    expected_run = {
+        "event": "workflow_dispatch",
+        "head_branch": "main",
+        "head_sha": activation["finalizer_head_sha"],
+        "html_url": activation["finalizer_run_url"],
+        "path": ".github/workflows/finalize-signed-snap-queue.yml",
+    }
+    mismatches = [
+        field
+        for field, expected in expected_run.items()
+        if finalizer_run.get(field) != expected
+    ]
+    if mismatches:
+        raise ValueError(
+            "activation finalizer run identity does not match: " + ", ".join(mismatches)
+        )
+    _verify_attempt_one_job(
+        finalizer_run,
+        finalizer_jobs,
+        expected_name="Finalize protected SNAP queue tranche",
+        label="activation finalizer",
+        require_success=require_success,
+    )
+
+
+def verify_activation_commit(
+    queue_path: Path,
+    *,
+    provenance: object,
+    pull_request: object,
+    current_base_sha: str,
+    current_head_sha: str,
+    current_tree_sha: str,
+    current_changed_files: object,
+) -> None:
+    """Bind an activation PR to the exact finalizer-created commit and tree."""
+
+    _require_sha(current_base_sha, "current_base_sha")
+    _require_sha(current_head_sha, "current_head_sha")
+    _require_sha(current_tree_sha, "current_tree_sha")
+    if not isinstance(provenance, dict):
+        raise ValueError("activation commit provenance must be an object")
+    expected_fields = {
+        "base_sha",
+        "changed_files",
+        "head_sha",
+        "queue_path",
+        "queue_sha256",
+        "repository",
+        "schema",
+        "tree_sha",
+    }
+    if (
+        set(provenance) != expected_fields
+        or provenance.get("schema")
+        != "axiom-encode/snap-queue-activation-commit/v1"
+        or provenance.get("repository") != "TheAxiomFoundation/axiom-encode"
+        or provenance.get("queue_path") != ACTIVATION_CHANGED_FILES[0]
+        or provenance.get("queue_sha256") != queue_file_sha256(queue_path)
+        or provenance.get("base_sha") != current_base_sha
+        or provenance.get("head_sha") != current_head_sha
+        or provenance.get("tree_sha") != current_tree_sha
+        or provenance.get("changed_files") != list(ACTIVATION_CHANGED_FILES)
+        or current_changed_files != list(ACTIVATION_CHANGED_FILES)
+    ):
+        raise ValueError("activation commit or changed-file inventory does not match")
+    if not isinstance(pull_request, dict):
+        raise ValueError("activation pull request must be an object")
+    base = pull_request.get("base")
+    head = pull_request.get("head")
+    head_repo = head.get("repo") if isinstance(head, dict) else None
+    if (
+        pull_request.get("state") != "open"
+        or not isinstance(base, dict)
+        or base.get("ref") != "main"
+        or base.get("sha") != current_base_sha
+        or not isinstance(head, dict)
+        or head.get("sha") != current_head_sha
+        or not isinstance(head_repo, dict)
+        or head_repo.get("full_name") != "TheAxiomFoundation/axiom-encode"
+    ):
+        raise ValueError("activation pull request identity does not match")
+
+
+def verify_merge_authorization(
+    queue_path: Path,
+    *,
+    authorization: object,
+    merge_run: object,
+    merge_jobs: object,
+    pull_request: object,
+    current_head_sha: str,
+    queue_change_sha: str,
+) -> None:
+    """Authenticate the trusted workflow that merged an active queue."""
+
+    queue = _load_json(queue_path)
+    validate_queue(queue)
+    if queue["state"] != "active":
+        raise ValueError("merge authorization is only valid for an active queue")
+    _require_sha(current_head_sha, "current_head_sha")
+    _require_sha(queue_change_sha, "queue_change_sha")
+    if not isinstance(authorization, dict):
+        raise ValueError("merge authorization must be an object")
+    expected_fields = {
+        "activation_pr_head_sha",
+        "activation_pr_number",
+        "merge_commit",
+        "merge_workflow_run_id",
+        "merge_workflow_run_attempt",
+        "merge_workflow_run_url",
+        "queue_path",
+        "queue_sha256",
+        "repository",
+        "schema",
+    }
+    if (
+        set(authorization) != expected_fields
+        or authorization.get("schema")
+        != "axiom-encode/snap-queue-merge-authorization/v1"
+        or authorization.get("repository") != "TheAxiomFoundation/axiom-encode"
+        or authorization.get("queue_path")
+        != "data/encoding-queues/us-snap-or-ut-2026-07.json"
+        or authorization.get("queue_sha256") != queue_file_sha256(queue_path)
+        or authorization.get("merge_workflow_run_attempt") != 1
+    ):
+        raise ValueError("merge authorization does not match the active queue")
+    _require_sha(authorization.get("activation_pr_head_sha"), "activation_pr_head_sha")
+    _require_sha(authorization.get("merge_commit"), "merge_commit")
+    run_id = authorization.get("merge_workflow_run_id")
+    pr_number = authorization.get("activation_pr_number")
+    if (
+        not isinstance(run_id, int)
+        or isinstance(run_id, bool)
+        or run_id <= 0
+        or not isinstance(pr_number, int)
+        or isinstance(pr_number, bool)
+        or pr_number <= 0
+    ):
+        raise ValueError("merge authorization identifiers are malformed")
+    expected_run_url = (
+        "https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/"
+        f"{run_id}"
+    )
+    if authorization.get("merge_workflow_run_url") != expected_run_url:
+        raise ValueError("merge authorization workflow URL is malformed")
+    if not isinstance(merge_run, dict):
+        raise ValueError("merge workflow run evidence must be an object")
+    expected_run = {
+        "event": "workflow_dispatch",
+        "head_branch": "main",
+        "html_url": expected_run_url,
+        "path": ".github/workflows/merge-snap-queue-activation.yml",
+    }
+    if any(merge_run.get(field) != value for field, value in expected_run.items()):
+        raise ValueError("merge workflow run identity or conclusion does not match")
+    _verify_attempt_one_job(
+        merge_run,
+        merge_jobs,
+        expected_name="Merge reviewed SNAP queue activation",
+        label="activation merge",
+        require_success=True,
+    )
+    if not isinstance(pull_request, dict):
+        raise ValueError("activation pull request evidence must be an object")
+    base = pull_request.get("base")
+    head = pull_request.get("head")
+    head_repo = head.get("repo") if isinstance(head, dict) else None
+    merged_by = pull_request.get("merged_by")
+    if (
+        pull_request.get("number") != pr_number
+        or pull_request.get("state") != "closed"
+        or pull_request.get("merged_at") is None
+        or pull_request.get("merge_commit_sha") != authorization["merge_commit"]
+        or not isinstance(base, dict)
+        or base.get("ref") != "main"
+        or not isinstance(head, dict)
+        or head.get("sha") != authorization["activation_pr_head_sha"]
+        or not isinstance(head_repo, dict)
+        or head_repo.get("full_name") != "TheAxiomFoundation/axiom-encode"
+        or not isinstance(merged_by, dict)
+        or merged_by.get("login") != "github-actions[bot]"
+    ):
+        raise ValueError("activation pull request was not merged by the trusted workflow")
+    if queue_change_sha != authorization["merge_commit"]:
+        raise ValueError("active queue was changed outside its authorized merge commit")
+
+
+def verify_paused_transition(
+    queue_path: Path,
+    *,
+    previous_queue_path: Path,
+) -> None:
+    """Reject manual completion and terminal-evidence rewrites in paused PRs."""
+
+    queue = _load_json(queue_path)
+    previous = _load_json(previous_queue_path)
+    validate_queue(queue)
+    validate_queue(previous)
+    if queue["state"] != "paused":
+        raise ValueError("paused transition verification requires a paused queue")
+    for field in (
+        "description",
+        "dispatch",
+        "expected_counts",
+        "issue",
+        "queue_id",
+        "release",
+        "schema",
+    ):
+        if queue[field] != previous[field]:
+            raise ValueError(f"paused queue transition changed trusted field {field}")
+    if previous["state"] == "paused" and queue.get("suspension") != previous.get(
+        "suspension"
+    ):
+        raise ValueError("paused queue transition changed suspension evidence")
+    previous_items = {item["id"]: item for item in previous["items"]}
+    current_items = {item["id"]: item for item in queue["items"]}
+    if set(previous_items) != set(current_items):
+        raise ValueError("paused queue transition changed the item inventory")
+    immutable_fields = (
+        "citation",
+        "id",
+        "jurisdiction",
+        "label",
+        "sequence",
+        "source_kind",
+    )
+    for item_id, current in current_items.items():
+        prior = previous_items[item_id]
+        if any(current[field] != prior[field] for field in immutable_fields):
+            raise ValueError(f"paused queue transition rewrote item {item_id}")
+        if current["status"] == "completed" and prior["status"] != "completed":
+            raise ValueError(
+                f"paused queue transition cannot complete item {item_id}"
+            )
+        if prior["status"] in TERMINAL_STATUSES and current != prior:
+            raise ValueError(
+                f"paused queue transition rewrote terminal item {item_id}"
+            )
+        if current["attempt"] < prior["attempt"]:
+            raise ValueError(
+                f"paused queue transition decreased attempt for item {item_id}"
+            )
+        if current["attempt"] > prior["attempt"] + 1:
+            raise ValueError(
+                f"paused queue transition skipped an attempt for item {item_id}"
+            )
+        if current["attempt"] == prior["attempt"] + 1 and current["status"] != "retryable":
+            raise ValueError(
+                f"paused queue transition changed attempt without retrying {item_id}"
+            )
+        if (
+            current["status"] == "retryable"
+            and current != prior
+            and current["attempt"] != prior["attempt"] + 1
+        ):
+            raise ValueError(
+                f"paused queue transition retried {item_id} without a new attempt"
+            )
+    if previous["state"] == "active":
+        expected = pause_queue(
+            previous,
+            reason=queue["pause_reason"],
+            active_queue_sha256=queue_file_sha256(previous_queue_path),
+        )
+        if queue != expected:
+            raise ValueError("active queue pause transition changed queue items or trust")
+
+
+def _flatten_pull_requests(payload: object) -> list[dict[str, Any]]:
+    if not isinstance(payload, list):
+        raise ValueError("pull request history must be a JSON array")
+    flattened: list[dict[str, Any]] = []
+    for page in payload:
+        values = page if isinstance(page, list) else [page]
+        for value in values:
+            if not isinstance(value, dict):
+                raise ValueError("pull request history contains a non-object")
+            flattened.append(value)
+    return flattened
+
+
+def _flatten_workflow_runs(payload: object) -> list[dict[str, Any]]:
+    if not isinstance(payload, list):
+        raise ValueError("workflow run history must be a JSON array")
+    flattened: list[dict[str, Any]] = []
+    for page in payload:
+        if not isinstance(page, dict):
+            raise ValueError("workflow run history page must be an object")
+        runs = page.get("workflow_runs")
+        if not isinstance(runs, list):
+            raise ValueError("workflow run history page has no workflow_runs")
+        for run in runs:
+            if not isinstance(run, dict):
+                raise ValueError("workflow run history contains a non-object")
+            flattened.append(run)
+    return flattened
+
+
+def _flatten_workflow_jobs(payload: object) -> list[dict[str, Any]]:
+    pages = payload if isinstance(payload, list) else [payload]
+    flattened: list[dict[str, Any]] = []
+    for page in pages:
+        if not isinstance(page, dict):
+            raise ValueError("workflow job history page must be an object")
+        jobs = page.get("jobs")
+        if not isinstance(jobs, list):
+            raise ValueError("workflow job history page has no jobs")
+        for job in jobs:
+            if not isinstance(job, dict):
+                raise ValueError("workflow job history contains a non-object")
+            flattened.append(job)
+    return flattened
+
+
+def _verify_attempt_one_job(
+    run: dict[str, Any],
+    jobs_payload: object,
+    *,
+    expected_name: str,
+    label: str,
+    require_success: bool,
+) -> None:
+    run_attempt = run.get("run_attempt")
+    if (
+        not isinstance(run_attempt, int)
+        or isinstance(run_attempt, bool)
+        or run_attempt < 1
+    ):
+        raise ValueError(f"{label} run attempt is malformed")
+    status = run.get("status")
+    conclusion = run.get("conclusion")
+    if require_success:
+        if status != "completed" or conclusion != "success":
+            raise ValueError(f"{label} run has not completed successfully")
+    elif status not in {"in_progress", "completed"} or (
+        status == "completed" and conclusion != "success"
+    ):
+        raise ValueError(f"{label} run is not successful or in progress")
+
+    jobs = [
+        job
+        for job in _flatten_workflow_jobs(jobs_payload)
+        if job.get("name") == expected_name
+    ]
+    by_attempt: dict[int, list[dict[str, Any]]] = {}
+    for job in jobs:
+        attempt = job.get("run_attempt")
+        if isinstance(attempt, int) and not isinstance(attempt, bool):
+            by_attempt.setdefault(attempt, []).append(job)
+    if set(by_attempt) != set(range(1, run_attempt + 1)) or any(
+        len(values) != 1 for values in by_attempt.values()
+    ):
+        raise ValueError(f"{label} job history is incomplete")
+    first = by_attempt[1][0]
+    first_success = first.get("status") == "completed" and first.get(
+        "conclusion"
+    ) == "success"
+    first_in_progress = (
+        not require_success
+        and run_attempt == 1
+        and first.get("status") == "in_progress"
+        and first.get("conclusion") is None
+    )
+    if not first_success and not first_in_progress:
+        raise ValueError(f"{label} attempt 1 was not successful or in progress")
+    if any(
+        job.get("status") != "completed" or job.get("conclusion") != "skipped"
+        for attempt, values in by_attempt.items()
+        if attempt > 1
+        for job in values
+    ):
+        raise ValueError(f"{label} later attempt executed the protected job")
+
+
+def _validate_green_check_runs(payload: object) -> None:
+    if not isinstance(payload, list):
+        raise ValueError("RuleSpec check run evidence must be a JSON array")
+    checks: list[dict[str, Any]] = []
+    for page in payload:
+        if not isinstance(page, dict) or not isinstance(page.get("check_runs"), list):
+            raise ValueError("RuleSpec check run evidence page is malformed")
+        for check in page["check_runs"]:
+            if not isinstance(check, dict):
+                raise ValueError("RuleSpec check run evidence contains a non-object")
+            checks.append(check)
+    if not checks:
+        raise ValueError("RuleSpec tip has no check run evidence")
+    unacceptable = [
+        str(check.get("name") or "unknown")
+        for check in checks
+        if check.get("status") != "completed"
+        or check.get("conclusion") not in {"neutral", "skipped", "success"}
+    ]
+    if unacceptable:
+        raise ValueError(
+            "RuleSpec tip does not have green check runs: " + ", ".join(unacceptable)
+        )
+
+
+def reconcile_candidates(
+    selection: dict[str, Any],
+    *,
+    pull_requests: object,
+    workflow_runs: object,
+) -> dict[str, Any]:
+    """Reconcile selectable items against durable PR state and run recovery state."""
+
+    queue_id = selection.get("queue_id")
+    items = selection.get("items")
+    if not isinstance(queue_id, str) or QUEUE_ID_PATTERN.fullmatch(queue_id) is None:
+        raise ValueError("selection queue_id is malformed")
+    if not isinstance(items, list):
+        raise ValueError("selection items must be a list")
+    prs = _flatten_pull_requests(pull_requests)
+    runs = _flatten_workflow_runs(workflow_runs)
+    reconciled: list[dict[str, Any]] = []
+
+    for item in items:
+        if not isinstance(item, dict):
+            raise ValueError("selection item must be an object")
+        item_id = item.get("id")
+        if not isinstance(item_id, str) or ITEM_ID_PATTERN.fullmatch(item_id) is None:
+            raise ValueError("selection item id is malformed")
+        generation_sha256 = _require_digest(
+            item.get("generation_sha256"),
+            f"{item_id} generation_sha256",
+        )
+        pr_marker = f"Queue item: `{queue_id}/{item_id}`"
+        pr_identity_markers = (
+            pr_marker,
+            f"Citation: `{item['citation']}`",
+            f"Base commit: `{selection['dispatch']['rulespec_ref']}`",
+            f"Base branch: `{selection['dispatch']['pr_base_branch']}`",
+            f"Queue generation SHA-256: `{generation_sha256}`",
+        )
+        run_marker = f"[{queue_id}:{item_id}:{generation_sha256}]"
+        matching_prs = []
+        for pr in prs:
+            base = pr.get("base")
+            head = pr.get("head")
+            head_repo = head.get("repo") if isinstance(head, dict) else None
+            body = str(pr.get("body") or "")
+            if (
+                all(marker in body for marker in pr_identity_markers)
+                and isinstance(base, dict)
+                and base.get("ref") == selection["dispatch"]["pr_base_branch"]
+                and isinstance(head_repo, dict)
+                and head_repo.get("full_name") == "TheAxiomFoundation/rulespec-us"
+            ):
+                matching_prs.append(pr)
+        matching_prs.sort(key=lambda pr: str(pr.get("updated_at") or ""), reverse=True)
+        merged_pr = None
+        untrusted_merged_pr = None
+        target_run = None
+        for pr in matching_prs:
+            if pr.get("merged_at") is None:
+                continue
+            untrusted_merged_pr = untrusted_merged_pr or pr
+            match = TARGET_RUN_MARKER_PATTERN.search(str(pr.get("body") or ""))
+            run_url = match.group(1) if match is not None else None
+            candidate_run = next(
+                (run for run in runs if run.get("html_url") == run_url),
+                None,
+            )
+            actor = (
+                candidate_run.get("actor")
+                if isinstance(candidate_run, dict)
+                else None
+            )
+            if (
+                isinstance(candidate_run, dict)
+                and candidate_run.get("status") == "completed"
+                and candidate_run.get("conclusion") == "success"
+                and candidate_run.get("event") == "workflow_dispatch"
+                and candidate_run.get("head_branch") == "main"
+                and isinstance(candidate_run.get("run_attempt"), int)
+                and not isinstance(candidate_run.get("run_attempt"), bool)
+                and candidate_run["run_attempt"] >= 1
+                and candidate_run.get("path")
+                == ".github/workflows/targeted-signed-reencode.yml"
+                and isinstance(actor, dict)
+                and actor.get("login") == "github-actions[bot]"
+                and run_marker
+                in str(candidate_run.get("display_title") or "")
+            ):
+                merged_pr = pr
+                target_run = candidate_run
+                break
+        open_pr = next(
+            (pr for pr in matching_prs if pr.get("state") == "open"),
+            None,
+        )
+
+        decision = copy.deepcopy(item)
+        if merged_pr is not None:
+            decision.update(
+                {
+                    "dispatchable": False,
+                    "reason": "merged-rulespec-pr",
+                    "history_url": merged_pr.get("html_url"),
+                    "target_run_url": target_run.get("html_url"),
+                }
+            )
+            reconciled.append(decision)
+            continue
+        if untrusted_merged_pr is not None:
+            decision.update(
+                {
+                    "dispatchable": False,
+                    "reason": "untrusted-merged-rulespec-pr",
+                    "history_url": untrusted_merged_pr.get("html_url"),
+                }
+            )
+            reconciled.append(decision)
+            continue
+        if open_pr is not None:
+            decision.update(
+                {
+                    "dispatchable": False,
+                    "reason": "open-rulespec-pr",
+                    "history_url": open_pr.get("html_url"),
+                }
+            )
+            reconciled.append(decision)
+            continue
+        if matching_prs:
+            decision.update(
+                {
+                    "dispatchable": False,
+                    "reason": "closed-unmerged-rulespec-pr",
+                    "history_url": matching_prs[0].get("html_url"),
+                }
+            )
+            reconciled.append(decision)
+            continue
+
+        matching_runs = [
+            run for run in runs if run_marker in str(run.get("display_title") or "")
+        ]
+        matching_runs.sort(
+            key=lambda run: str(run.get("created_at") or ""),
+            reverse=True,
+        )
+        latest_run = matching_runs[0] if matching_runs else None
+        if latest_run is not None:
+            run_url = latest_run.get("html_url")
+            status = latest_run.get("status")
+            conclusion = latest_run.get("conclusion")
+            if status != "completed" or conclusion is None:
+                decision.update(
+                    {
+                        "dispatchable": False,
+                        "reason": "active-workflow-run",
+                        "history_url": run_url,
+                    }
+                )
+                reconciled.append(decision)
+                continue
+            if conclusion == "success":
+                decision.update(
+                    {
+                        "dispatchable": False,
+                        "reason": "successful-run-without-durable-pr",
+                        "history_url": run_url,
+                    }
+                )
+                reconciled.append(decision)
+                continue
+            if conclusion != "success":
+                decision.update(
+                    {
+                        "dispatchable": False,
+                        "reason": f"failed-workflow-run:{conclusion}",
+                        "history_url": run_url,
+                    }
+                )
+                reconciled.append(decision)
+                continue
+
+        decision.update(
+            {
+                "dispatchable": True,
+                "reason": "new",
+                "history_url": None,
+            }
+        )
+        reconciled.append(decision)
+
+    return {
+        **{key: value for key, value in selection.items() if key != "items"},
+        "items": reconciled,
+    }
+
+
+def finalization_target_plan(
+    payload: dict[str, Any],
+    *,
+    pull_requests: object,
+    workflow_runs: object,
+) -> dict[str, Any]:
+    """Return newly merged queue items whose target artifacts must be fetched."""
+
+    validate_queue(payload)
+    if payload["state"] != "paused":
+        raise ValueError("target evidence planning requires a paused queue")
+    selectable = [
+        item for item in payload["items"] if item["status"] in SELECTABLE_STATUSES
+    ]
+    reconciled = reconcile_candidates(
+        _selection_payload(payload, selectable),
+        pull_requests=pull_requests,
+        workflow_runs=workflow_runs,
+    )
+    return {
+        "queue_id": payload["queue_id"],
+        "items": [
+            {
+                "id": item["id"],
+                "pull_request_url": item["history_url"],
+                "target_run_url": item["target_run_url"],
+            }
+            for item in reconciled["items"]
+            if item["reason"] == "merged-rulespec-pr"
+        ],
+        "schema": "axiom-encode/finalization-target-plan/v1",
+    }
+
+
+def _verify_target_evidence(
+    *,
+    payload: dict[str, Any],
+    item: dict[str, Any],
+    decision: dict[str, Any],
+    pull_request: dict[str, Any],
+    rulespec_root: Path,
+    evidence: object,
+) -> dict[str, Any]:
+    if not isinstance(evidence, dict) or set(evidence) != {
+        "apply_manifests",
+        "jobs",
+        "metadata",
+        "pull_request",
+        "run",
+    }:
+        raise ValueError(f"{item['id']} target evidence is malformed")
+    run = evidence["run"]
+    jobs = evidence["jobs"]
+    metadata = evidence["metadata"]
+    artifact_pr = evidence["pull_request"]
+    inventory = evidence["apply_manifests"]
+    if not all(
+        isinstance(value, dict)
+        for value in (run, metadata, artifact_pr, inventory)
+    ):
+        raise ValueError(f"{item['id']} target evidence contains a non-object")
+    actor = run.get("actor")
+    expected_run_url = decision["target_run_url"]
+    if (
+        run.get("status") != "completed"
+        or run.get("conclusion") != "success"
+        or run.get("event") != "workflow_dispatch"
+        or run.get("head_branch") != "main"
+        or run.get("html_url") != expected_run_url
+        or run.get("path") != ".github/workflows/targeted-signed-reencode.yml"
+        or not isinstance(actor, dict)
+        or actor.get("login") != "github-actions[bot]"
+    ):
+        raise ValueError(f"{item['id']} target run is not trusted and successful")
+    _verify_attempt_one_job(
+        run,
+        jobs,
+        expected_name="Queue protected signed RuleSpec re-encode",
+        label=f"{item['id']} target",
+        require_success=True,
+    )
+    run_id = run.get("id")
+    if not isinstance(run_id, int) or isinstance(run_id, bool) or run_id <= 0:
+        raise ValueError(f"{item['id']} target run id is malformed")
+    expected_metadata = {
+        "citation": item["citation"],
+        "encoder_commit": run.get("head_sha"),
+        "pr_base_branch": payload["dispatch"]["pr_base_branch"],
+        "queue_id": payload["queue_id"],
+        "queue_item_generation_sha256": decision["generation_sha256"],
+        "queue_item_id": item["id"],
+        "queue_manifest_sha256": dispatch_queue_sha256(payload),
+        "rulespec_base": payload["dispatch"]["rulespec_ref"],
+        "schema": "axiom-encode/targeted-reencode-artifact/v1",
+        "workflow_run_attempt": 1,
+        "workflow_run_id": str(run_id),
+    }
+    mismatches = [
+        field
+        for field, expected in expected_metadata.items()
+        if metadata.get(field) != expected
+    ]
+    if mismatches:
+        raise ValueError(
+            f"{item['id']} target artifact metadata does not match: "
+            + ", ".join(mismatches)
+        )
+    pr_head = pull_request.get("head")
+    artifact_pr_head = artifact_pr.get("head")
+    if (
+        artifact_pr.get("number") != pull_request.get("number")
+        or artifact_pr.get("html_url") != pull_request.get("html_url")
+        or not isinstance(pr_head, dict)
+        or not isinstance(artifact_pr_head, dict)
+        or artifact_pr_head.get("sha") != pr_head.get("sha")
+    ):
+        raise ValueError(f"{item['id']} target artifact PR identity does not match")
+    inventory_items = inventory.get("items")
+    if (
+        inventory.get("schema") != "axiom-encode/applied-manifest-inventory/v1"
+        or not isinstance(inventory_items, list)
+    ):
+        raise ValueError(f"{item['id']} applied manifest inventory is malformed")
+    matches = [
+        value
+        for value in inventory_items
+        if isinstance(value, dict) and value.get("citation") == item["citation"]
+    ]
+    if len(matches) != 1:
+        raise ValueError(
+            f"{item['id']} target artifact lacks one applied manifest"
+        )
+    applied = matches[0]
+    relative_path = applied.get("path")
+    digest = _require_digest(
+        applied.get("sha256"),
+        f"{item['id']} applied manifest sha256",
+    )
+    if (
+        not isinstance(relative_path, str)
+        or not relative_path.startswith(".axiom/encoding-manifests/")
+        or Path(relative_path).is_absolute()
+        or ".." in Path(relative_path).parts
+    ):
+        raise ValueError(f"{item['id']} applied manifest path is unsafe")
+    manifest_path = rulespec_root / relative_path
+    if (
+        not manifest_path.is_file()
+        or hashlib.sha256(manifest_path.read_bytes()).hexdigest() != digest
+    ):
+        raise ValueError(
+            f"{item['id']} merged RuleSpec tree lacks the signed applied manifest"
+        )
+    return {
+        "applied_manifest_path": relative_path,
+        "applied_manifest_sha256": digest,
+        "artifact_metadata_sha256": _json_sha256(metadata),
+        "rulespec_pr_head_sha": _require_sha(
+            pr_head.get("sha"),
+            f"{item['id']} RuleSpec PR head",
+        ),
+        "target_run_head_sha": _require_sha(
+            run.get("head_sha"),
+            f"{item['id']} target run head",
+        ),
+        "target_run_attempt": 1,
+        "target_run_url": expected_run_url,
+    }
+
+
+def finalize_and_repin(
+    payload: dict[str, Any],
+    *,
+    rulespec_root: Path,
+    check_runs: object,
+    pull_requests: object,
+    workflow_runs: object,
+    target_evidence: object,
+    new_rulespec_ref: str,
+    finalizer_head_sha: str,
+    finalizer_run_url: str,
+    finalizer_run_attempt: int = 1,
+    reviewed_rulespec_refs: frozenset[tuple[str, str]] | None = None,
+) -> dict[str, Any]:
+    """Finalize a quiet tranche and advance the queue to one reviewed base tip."""
+
+    validate_queue(payload)
+    if payload["state"] != "paused":
+        raise ValueError("finalize-repin requires a paused queue")
+    _require_sha(new_rulespec_ref, "new_rulespec_ref")
+    _require_sha(finalizer_head_sha, "finalizer_head_sha")
+    if FINALIZER_RUN_PATTERN.fullmatch(finalizer_run_url) is None:
+        raise ValueError("finalizer_run_url is malformed")
+    if finalizer_run_attempt != 1:
+        raise ValueError("finalizer_run_attempt must be 1")
+    _validate_green_check_runs(check_runs)
+    previous_queue_object_sha256 = _json_sha256(payload)
+    if new_rulespec_ref == payload["dispatch"]["rulespec_ref"]:
+        raise ValueError("new_rulespec_ref must advance the queue base")
+    if reviewed_rulespec_refs is None:
+        try:
+            from scripts.prepare_signed_backfill import REVIEWED_RULESPEC_REFS
+        except ModuleNotFoundError:
+            from prepare_signed_backfill import REVIEWED_RULESPEC_REFS
+
+        reviewed_rulespec_refs = REVIEWED_RULESPEC_REFS
+    country = payload["dispatch"]["country"]
+    if (country, new_rulespec_ref) not in reviewed_rulespec_refs:
+        raise ValueError(
+            "new_rulespec_ref is not independently reviewed and allowlisted"
+        )
+    try:
+        checkout_head = _git(rulespec_root, "rev-parse", "HEAD")
+        checkout_status = _git(rulespec_root, "status", "--porcelain")
+        remote_tip = _git(
+            rulespec_root,
+            "rev-parse",
+            f"refs/remotes/origin/{payload['dispatch']['pr_base_branch']}",
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise ValueError(
+            "finalize-repin requires an exact RuleSpec branch checkout"
+        ) from exc
+    if checkout_head != new_rulespec_ref or remote_tip != new_rulespec_ref:
+        raise ValueError(
+            "new_rulespec_ref is not the exact checked-out remote branch tip"
+        )
+    if checkout_status:
+        raise ValueError("finalize-repin RuleSpec checkout is not clean")
+    old_rulespec_ref = payload["dispatch"]["rulespec_ref"]
+    try:
+        _git(
+            rulespec_root,
+            "merge-base",
+            "--is-ancestor",
+            old_rulespec_ref,
+            new_rulespec_ref,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise ValueError(
+            "new RuleSpec base does not contain the prior queue base"
+        ) from exc
+    try:
+        from scripts.materialize_corpus_release import load_release_pin
+    except ModuleNotFoundError:
+        from materialize_corpus_release import load_release_pin
+
+    pinned_release = load_release_pin(rulespec_root / ".axiom/toolchain.toml")
+    release = payload["release"]
+    if pinned_release != (release["name"], release["content_sha256"]):
+        raise ValueError("new RuleSpec base changed the queue corpus release pin")
+    prs = _flatten_pull_requests(pull_requests)
+    runs = _flatten_workflow_runs(workflow_runs)
+    queue_prefix = f"Queue item: `{payload['queue_id']}/"
+    trusted_queue_prs = []
+    for pr in prs:
+        base = pr.get("base")
+        head = pr.get("head")
+        head_repo = head.get("repo") if isinstance(head, dict) else None
+        if (
+            queue_prefix in str(pr.get("body") or "")
+            and isinstance(base, dict)
+            and base.get("ref") == payload["dispatch"]["pr_base_branch"]
+            and isinstance(head_repo, dict)
+            and head_repo.get("full_name") == "TheAxiomFoundation/rulespec-us"
+        ):
+            trusted_queue_prs.append(pr)
+    open_prs = [pr for pr in trusted_queue_prs if pr.get("state") == "open"]
+    if open_prs:
+        urls = ", ".join(str(pr.get("html_url") or "unknown") for pr in open_prs)
+        raise ValueError(f"cannot repin while queue pull requests are open: {urls}")
+
+    run_prefix = f"[{payload['queue_id']}:"
+    active_runs = [
+        run
+        for run in runs
+        if run_prefix in str(run.get("display_title") or "")
+        and (run.get("status") != "completed" or run.get("conclusion") is None)
+    ]
+    if active_runs:
+        urls = ", ".join(str(run.get("html_url") or "unknown") for run in active_runs)
+        raise ValueError(f"cannot repin while queue workflow runs are active: {urls}")
+
+    prs_by_url = {
+        pr.get("html_url"): pr
+        for pr in trusted_queue_prs
+        if isinstance(pr.get("html_url"), str)
+    }
+    for item in payload["items"]:
+        if item["status"] != "completed":
+            continue
+        evidence = item["evidence"]
+        pr_url = evidence["url"]
+        pr = prs_by_url.get(pr_url)
+        body = str(pr.get("body") or "") if isinstance(pr, dict) else ""
+        expected_markers = (
+            f"Queue item: `{payload['queue_id']}/{item['id']}`",
+            f"Citation: `{item['citation']}`",
+            (
+                "Queue generation SHA-256: "
+                f"`{evidence['generation_sha256']}`"
+            ),
+            f"Axiom Encode run: {evidence['target_run_url']}",
+        )
+        pr_head = pr.get("head") if isinstance(pr, dict) else None
+        if (
+            not isinstance(pr, dict)
+            or pr.get("state") != "closed"
+            or pr.get("merged_at") is None
+            or pr.get("merge_commit_sha") != evidence["merge_commit"]
+            or not isinstance(pr_head, dict)
+            or pr_head.get("sha") != evidence["rulespec_pr_head_sha"]
+            or not all(marker in body for marker in expected_markers)
+        ):
+            raise ValueError(
+                f"completed queue item {item['id']} lacks a verified merged RuleSpec PR"
+            )
+        try:
+            _git(
+                rulespec_root,
+                "merge-base",
+                "--is-ancestor",
+                evidence["merge_commit"],
+                new_rulespec_ref,
+            )
+        except subprocess.CalledProcessError as exc:
+            raise ValueError(
+                f"new RuleSpec base omits completed queue item {item['id']}"
+            ) from exc
+        manifest_path = rulespec_root / evidence["applied_manifest_path"]
+        if (
+            not manifest_path.is_file()
+            or hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+            != evidence["applied_manifest_sha256"]
+        ):
+            raise ValueError(
+                f"completed queue item {item['id']} lacks its applied manifest"
+            )
+
+    selectable = [
+        item for item in payload["items"] if item["status"] in SELECTABLE_STATUSES
+    ]
+    selection = _selection_payload(payload, selectable)
+    reconciled = reconcile_candidates(
+        selection,
+        pull_requests=pull_requests,
+        workflow_runs=workflow_runs,
+    )
+    unresolved = [
+        item
+        for item in reconciled["items"]
+        if item["reason"] not in {"merged-rulespec-pr", "new"}
+    ]
+    if unresolved:
+        details = ", ".join(f"{item['id']}={item['reason']}" for item in unresolved)
+        raise ValueError("queue dispositions are required before repinning: " + details)
+
+    updated = copy.deepcopy(payload)
+    if not isinstance(target_evidence, dict):
+        raise ValueError("target evidence must be an object")
+    by_id = {item["id"]: item for item in updated["items"]}
+    for decision in reconciled["items"]:
+        if decision["reason"] != "merged-rulespec-pr":
+            continue
+        pr_url = decision.get("history_url")
+        pr = prs_by_url.get(pr_url)
+        merge_commit = pr.get("merge_commit_sha") if isinstance(pr, dict) else None
+        _require_sha(merge_commit, f"{decision['id']} merged PR commit")
+        try:
+            _git(
+                rulespec_root,
+                "merge-base",
+                "--is-ancestor",
+                merge_commit,
+                new_rulespec_ref,
+            )
+        except subprocess.CalledProcessError as exc:
+            raise ValueError(
+                f"new RuleSpec base omits merged queue item {decision['id']}"
+            ) from exc
+        authenticated = _verify_target_evidence(
+            payload=payload,
+            item=by_id[decision["id"]],
+            decision=decision,
+            pull_request=pr,
+            rulespec_root=rulespec_root,
+            evidence=target_evidence.get(decision["id"]),
+        )
+        item = by_id[decision["id"]]
+        item["status"] = "completed"
+        item["evidence"] = {
+            **authenticated,
+            "generation_sha256": decision["generation_sha256"],
+            "merge_commit": merge_commit,
+            "type": "merged-rulespec-pr",
+            "url": pr_url,
+        }
+
+    updated["dispatch"]["rulespec_ref"] = new_rulespec_ref
+    updated["state"] = "active"
+    updated.pop("pause_reason", None)
+    updated.pop("suspension", None)
+    updated["activation"] = {
+        "check_runs_sha256": _json_sha256(check_runs),
+        "finalizer_head_sha": finalizer_head_sha,
+        "finalizer_run_attempt": finalizer_run_attempt,
+        "finalizer_run_url": finalizer_run_url,
+        "previous_queue_object_sha256": previous_queue_object_sha256,
+        "pull_requests_sha256": _json_sha256(pull_requests),
+        "rulespec_ref": new_rulespec_ref,
+        "schema": "axiom-encode/signed-encoding-queue-activation/v1",
+        "workflow_runs_sha256": _json_sha256(workflow_runs),
+    }
+    validate_queue(updated)
+    return updated
+
+
+def record_disposition(
+    payload: dict[str, Any],
+    *,
+    item_id: str,
+    status: str,
+    evidence_url: str | None,
+    note: str | None,
+) -> dict[str, Any]:
+    """Return a queue manifest with one reviewable durable item disposition."""
+
+    validate_queue(payload)
+    if status not in {"blocked", "no-executable-rule", "retryable"}:
+        raise ValueError(
+            "disposition status must be blocked, no-executable-rule, or retryable"
+        )
+    updated = copy.deepcopy(payload)
+    matches = [item for item in updated["items"] if item["id"] == item_id]
+    if len(matches) != 1:
+        raise ValueError("disposition queue item is unavailable")
+    item = matches[0]
+    item["status"] = status
+    item.pop("evidence", None)
+    if status in {"blocked", "no-executable-rule"}:
+        item["evidence"] = {
+            "note": note,
+            "type": "issue-comment",
+            "url": evidence_url,
+        }
+    elif status == "retryable":
+        item["attempt"] += 1
+    validate_queue(updated)
+    return updated
+
+
+def pause_queue(
+    payload: dict[str, Any],
+    *,
+    reason: str,
+    active_queue_sha256: str,
+) -> dict[str, Any]:
+    """Return a reviewable fail-closed transition after dispatching one tranche."""
+
+    validate_queue(payload)
+    if payload["state"] != "active":
+        raise ValueError("only an active queue can be paused")
+    if not reason.strip():
+        raise ValueError("pause reason must not be empty")
+    _require_digest(active_queue_sha256, "active_queue_sha256")
+    updated = copy.deepcopy(payload)
+    updated["state"] = "paused"
+    updated["pause_reason"] = reason.strip()
+    updated.pop("activation", None)
+    updated["suspension"] = {
+        "active_queue_sha256": active_queue_sha256,
+        "schema": "axiom-encode/signed-encoding-queue-suspension/v1",
+    }
+    validate_queue(updated)
+    return updated
+
+
+def _write_json(payload: dict[str, Any]) -> None:
+    json.dump(payload, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    build = subparsers.add_parser("build-snap")
+    build.add_argument("corpus_root", type=Path)
+    build.add_argument("rulespec_root", type=Path)
+    build.add_argument("--corpus-ref", required=True)
+    build.add_argument("--rulespec-ref", required=True)
+    build.add_argument("--rules-engine-ref", required=True)
+    build.add_argument("--release-name", required=True)
+    build.add_argument("--release-content-sha256", required=True)
+    build.add_argument("--release-object", type=Path, required=True)
+    build.add_argument("--release-public-key", type=Path, required=True)
+    build.add_argument("--state", choices=("active", "paused"), required=True)
+    build.add_argument("--pause-reason")
+
+    validate = subparsers.add_parser("validate")
+    validate.add_argument("queue", type=Path)
+
+    select = subparsers.add_parser("select")
+    select.add_argument("queue", type=Path)
+    select.add_argument("--item-ids", default="")
+    select.add_argument("--limit", type=int, default=1)
+
+    candidates = subparsers.add_parser("candidates")
+    candidates.add_argument("queue", type=Path)
+
+    reconcile = subparsers.add_parser("reconcile")
+    reconcile.add_argument("selection", type=Path)
+    reconcile.add_argument("--pull-requests", type=Path, required=True)
+    reconcile.add_argument("--workflow-runs", type=Path, required=True)
+
+    target_plan = subparsers.add_parser("finalization-target-plan")
+    target_plan.add_argument("queue", type=Path)
+    target_plan.add_argument("--pull-requests", type=Path, required=True)
+    target_plan.add_argument("--workflow-runs", type=Path, required=True)
+
+    disposition = subparsers.add_parser("record-disposition")
+    disposition.add_argument("queue", type=Path)
+    disposition.add_argument("--item-id", required=True)
+    disposition.add_argument(
+        "--status",
+        choices=("blocked", "no-executable-rule", "retryable"),
+        required=True,
+    )
+    disposition.add_argument("--evidence-url")
+    disposition.add_argument("--note")
+
+    pause = subparsers.add_parser("pause")
+    pause.add_argument("queue", type=Path)
+    pause.add_argument("--reason", required=True)
+
+    repin = subparsers.add_parser("finalize-repin")
+    repin.add_argument("queue", type=Path)
+    repin.add_argument("rulespec_root", type=Path)
+    repin.add_argument("--check-runs", type=Path, required=True)
+    repin.add_argument("--pull-requests", type=Path, required=True)
+    repin.add_argument("--workflow-runs", type=Path, required=True)
+    repin.add_argument("--target-evidence", type=Path, required=True)
+    repin.add_argument("--new-rulespec-ref", required=True)
+    repin.add_argument("--finalizer-head-sha", required=True)
+    repin.add_argument("--finalizer-run-url", required=True)
+
+    tracked = subparsers.add_parser("validate-dispatch")
+    tracked.add_argument("queue", type=Path)
+    tracked.add_argument("--queue-id", required=True)
+    tracked.add_argument("--item-id", required=True)
+    tracked.add_argument("--manifest-sha256", required=True)
+    tracked.add_argument("--item-generation-sha256", required=True)
+    tracked.add_argument("--citation", required=True)
+    tracked.add_argument("--country", required=True)
+    tracked.add_argument("--rulespec-ref", required=True)
+    tracked.add_argument("--pr-base-branch", required=True)
+    tracked.add_argument("--corpus-ref", required=True)
+    tracked.add_argument("--rules-engine-ref", required=True)
+    tracked.add_argument("--open-pr", choices=("true", "false"), required=True)
+
+    digest = subparsers.add_parser("sha256")
+    digest.add_argument("queue", type=Path)
+
+    release_pin = subparsers.add_parser("validate-release-pin")
+    release_pin.add_argument("queue", type=Path)
+    release_pin.add_argument("--toolchain", type=Path, required=True)
+    release_pin.add_argument("--manifest-sha256", required=True)
+
+    activation = subparsers.add_parser("verify-activation")
+    activation.add_argument("queue", type=Path)
+    activation.add_argument("--previous-queue", type=Path, required=True)
+    activation.add_argument("--expected-base-sha", required=True)
+    activation.add_argument("--finalized-queue", type=Path, required=True)
+    activation.add_argument("--check-runs", type=Path, required=True)
+    activation.add_argument("--pull-requests", type=Path, required=True)
+    activation.add_argument("--workflow-runs", type=Path, required=True)
+    activation.add_argument("--finalizer-run", type=Path, required=True)
+    activation.add_argument("--finalizer-jobs", type=Path, required=True)
+    activation.add_argument(
+        "--require-success",
+        choices=("true", "false"),
+        required=True,
+    )
+
+    activation_commit = subparsers.add_parser("verify-activation-commit")
+    activation_commit.add_argument("queue", type=Path)
+    activation_commit.add_argument("--provenance", type=Path, required=True)
+    activation_commit.add_argument("--pull-request", type=Path, required=True)
+    activation_commit.add_argument("--current-base-sha", required=True)
+    activation_commit.add_argument("--current-head-sha", required=True)
+    activation_commit.add_argument("--current-tree-sha", required=True)
+    activation_commit.add_argument("--current-changed-files", type=Path, required=True)
+
+    authorization = subparsers.add_parser("verify-merge-authorization")
+    authorization.add_argument("queue", type=Path)
+    authorization.add_argument("--authorization", type=Path, required=True)
+    authorization.add_argument("--merge-run", type=Path, required=True)
+    authorization.add_argument("--merge-jobs", type=Path, required=True)
+    authorization.add_argument("--pull-request", type=Path, required=True)
+    authorization.add_argument("--current-head-sha", required=True)
+    authorization.add_argument("--queue-change-sha", required=True)
+
+    transition = subparsers.add_parser("verify-paused-transition")
+    transition.add_argument("queue", type=Path)
+    transition.add_argument("--previous-queue", type=Path, required=True)
+
+    args = parser.parse_args()
+    try:
+        if args.command == "build-snap":
+            _write_json(
+                build_snap_queue(
+                    args.corpus_root,
+                    args.rulespec_root,
+                    corpus_ref=args.corpus_ref,
+                    rulespec_ref=args.rulespec_ref,
+                    rules_engine_ref=args.rules_engine_ref,
+                    release_name=args.release_name,
+                    release_content_sha256=args.release_content_sha256,
+                    release_object_path=args.release_object,
+                    release_public_key_path=args.release_public_key,
+                    state=args.state,
+                    pause_reason=args.pause_reason,
+                )
+            )
+        elif args.command == "validate":
+            validate_queue(_load_json(args.queue))
+            print("valid")
+        elif args.command == "select":
+            _write_json(
+                select_items(
+                    _load_json(args.queue),
+                    item_ids=args.item_ids,
+                    limit=args.limit,
+                )
+            )
+        elif args.command == "candidates":
+            _write_json(selectable_items(_load_json(args.queue)))
+        elif args.command == "reconcile":
+            _write_json(
+                reconcile_candidates(
+                    _load_json(args.selection),
+                    pull_requests=json.loads(
+                        args.pull_requests.read_text(encoding="utf-8")
+                    ),
+                    workflow_runs=json.loads(
+                        args.workflow_runs.read_text(encoding="utf-8")
+                    ),
+                )
+            )
+        elif args.command == "finalization-target-plan":
+            _write_json(
+                finalization_target_plan(
+                    _load_json(args.queue),
+                    pull_requests=json.loads(
+                        args.pull_requests.read_text(encoding="utf-8")
+                    ),
+                    workflow_runs=json.loads(
+                        args.workflow_runs.read_text(encoding="utf-8")
+                    ),
+                )
+            )
+        elif args.command == "record-disposition":
+            _write_json(
+                record_disposition(
+                    _load_json(args.queue),
+                    item_id=args.item_id,
+                    status=args.status,
+                    evidence_url=args.evidence_url,
+                    note=args.note,
+                )
+            )
+        elif args.command == "pause":
+            _write_json(
+                pause_queue(
+                    _load_json(args.queue),
+                    reason=args.reason,
+                    active_queue_sha256=queue_file_sha256(args.queue),
+                )
+            )
+        elif args.command == "finalize-repin":
+            _write_json(
+                finalize_and_repin(
+                    _load_json(args.queue),
+                    rulespec_root=args.rulespec_root,
+                    check_runs=json.loads(args.check_runs.read_text(encoding="utf-8")),
+                    pull_requests=json.loads(
+                        args.pull_requests.read_text(encoding="utf-8")
+                    ),
+                    workflow_runs=json.loads(
+                        args.workflow_runs.read_text(encoding="utf-8")
+                    ),
+                    target_evidence=json.loads(
+                        args.target_evidence.read_text(encoding="utf-8")
+                    ),
+                    new_rulespec_ref=args.new_rulespec_ref,
+                    finalizer_head_sha=args.finalizer_head_sha,
+                    finalizer_run_url=args.finalizer_run_url,
+                )
+            )
+        elif args.command == "validate-dispatch":
+            validate_tracked_dispatch(
+                args.queue,
+                queue_id=args.queue_id,
+                item_id=args.item_id,
+                manifest_sha256=args.manifest_sha256,
+                item_generation_sha256_value=args.item_generation_sha256,
+                citation=args.citation,
+                country=args.country,
+                rulespec_ref=args.rulespec_ref,
+                pr_base_branch=args.pr_base_branch,
+                corpus_ref=args.corpus_ref,
+                rules_engine_ref=args.rules_engine_ref,
+                open_pr=args.open_pr == "true",
+            )
+            print("valid")
+        elif args.command == "sha256":
+            print(queue_file_sha256(args.queue))
+        elif args.command == "validate-release-pin":
+            validate_release_pin(
+                args.queue,
+                toolchain_path=args.toolchain,
+                manifest_sha256=args.manifest_sha256,
+            )
+            print("valid")
+        elif args.command == "verify-activation":
+            verify_activation_evidence(
+                args.queue,
+                previous_queue_path=args.previous_queue,
+                expected_base_sha=args.expected_base_sha,
+                finalized_queue_path=args.finalized_queue,
+                check_runs=json.loads(args.check_runs.read_text(encoding="utf-8")),
+                pull_requests=json.loads(
+                    args.pull_requests.read_text(encoding="utf-8")
+                ),
+                workflow_runs=json.loads(
+                    args.workflow_runs.read_text(encoding="utf-8")
+                ),
+                finalizer_run=json.loads(
+                    args.finalizer_run.read_text(encoding="utf-8")
+                ),
+                finalizer_jobs=json.loads(
+                    args.finalizer_jobs.read_text(encoding="utf-8")
+                ),
+                require_success=args.require_success == "true",
+            )
+            print("valid")
+        elif args.command == "verify-merge-authorization":
+            verify_merge_authorization(
+                args.queue,
+                authorization=json.loads(
+                    args.authorization.read_text(encoding="utf-8")
+                ),
+                merge_run=json.loads(args.merge_run.read_text(encoding="utf-8")),
+                merge_jobs=json.loads(args.merge_jobs.read_text(encoding="utf-8")),
+                pull_request=json.loads(
+                    args.pull_request.read_text(encoding="utf-8")
+                ),
+                current_head_sha=args.current_head_sha,
+                queue_change_sha=args.queue_change_sha,
+            )
+            print("valid")
+        elif args.command == "verify-activation-commit":
+            verify_activation_commit(
+                args.queue,
+                provenance=json.loads(args.provenance.read_text(encoding="utf-8")),
+                pull_request=json.loads(
+                    args.pull_request.read_text(encoding="utf-8")
+                ),
+                current_base_sha=args.current_base_sha,
+                current_head_sha=args.current_head_sha,
+                current_tree_sha=args.current_tree_sha,
+                current_changed_files=json.loads(
+                    args.current_changed_files.read_text(encoding="utf-8")
+                ),
+            )
+            print("valid")
+        elif args.command == "verify-paused-transition":
+            verify_paused_transition(
+                args.queue,
+                previous_queue_path=args.previous_queue,
+            )
+            print("valid")
+    except (
+        OSError,
+        ValueError,
+        json.JSONDecodeError,
+        subprocess.CalledProcessError,
+    ) as exc:
+        raise SystemExit(str(exc)) from exc
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/release_object_fixtures.py
+++ b/tests/release_object_fixtures.py
@@ -42,6 +42,8 @@ def write_test_release_object(
     corpus_root: Path,
     name: str,
     scopes: list[tuple[str, str, str]],
+    *,
+    git_commit: str = "a" * 40,
 ) -> str:
     """Write a production-shaped signed release object and return its identity."""
 
@@ -143,7 +145,7 @@ def write_test_release_object(
         "selector_sha256": _canonical_sha256(selector),
         "corpus_base": "data/corpus",
         "git": {
-            "commit": "a" * 40,
+            "commit": git_commit,
             "committed_at": "2026-07-10T00:00:00Z",
         },
         "r2": {"bucket": "axiom-corpus", "addressing": "sha256"},

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -13,6 +13,7 @@ from scripts.prepare_signed_backfill import (
     stage_authorized_changes,
     validate_country,
     validate_dependent_cascade,
+    validate_queue_tracking,
     validate_rulespec_base,
 )
 
@@ -89,6 +90,40 @@ def _write_module(
 def test_validate_country_rejects_adversarial_values(country: str) -> None:
     with pytest.raises(ValueError, match="two-letter lowercase"):
         validate_country(country)
+
+
+def test_validate_queue_tracking_accepts_complete_or_empty_metadata() -> None:
+    assert validate_queue_tracking("", "", "", "") == "ad-hoc"
+    assert (
+        validate_queue_tracking(
+            "us-snap-or-ut-2026-07",
+            "ut-0001",
+            "a" * 64,
+            "b" * 64,
+        )
+        == "tracked"
+    )
+
+
+@pytest.mark.parametrize(
+    ("queue_id", "item_id", "digest", "generation", "message"),
+    [
+        ("queue", "", "a" * 64, "b" * 64, "supplied together"),
+        ("queue/unsafe", "ut-0001", "a" * 64, "b" * 64, "queue_id"),
+        ("queue", "ut/0001", "a" * 64, "b" * 64, "queue_item_id"),
+        ("queue", "ut-0001", "abc", "b" * 64, "queue_manifest_sha256"),
+        ("queue", "ut-0001", "a" * 64, "abc", "queue_item_generation"),
+    ],
+)
+def test_validate_queue_tracking_rejects_incomplete_or_unsafe_metadata(
+    queue_id: str,
+    item_id: str,
+    digest: str,
+    generation: str,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        validate_queue_tracking(queue_id, item_id, digest, generation)
 
 
 def test_stage_authorized_changes_stages_only_manifest_and_applied_files(

--- a/tests/test_signed_snap_queue.py
+++ b/tests/test_signed_snap_queue.py
@@ -1,0 +1,1736 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.prepare_signed_queue import (
+    ACTIVATION_CHANGED_FILES,
+    EXPECTED_COUNTS,
+    PRIORITY_CITATIONS,
+    _json_sha256,
+    _verify_corpus_provenance,
+    _verify_signed_release_binding,
+    dispatch_queue_sha256,
+    finalization_target_plan,
+    finalize_and_repin,
+    item_generation_sha256,
+    pause_queue,
+    queue_file_sha256,
+    queue_object_file_sha256,
+    reconcile_candidates,
+    record_disposition,
+    select_items,
+    selectable_items,
+    validate_queue,
+    validate_release_pin,
+    validate_tracked_dispatch,
+    verify_activation_commit,
+    verify_activation_evidence,
+    verify_merge_authorization,
+    verify_paused_transition,
+)
+from tests.release_object_fixtures import (
+    TEST_RELEASE_PUBLIC_KEY,
+    write_test_release_object,
+)
+
+ROOT = Path(__file__).parents[1]
+QUEUE_PATH = ROOT / "data/encoding-queues/us-snap-or-ut-2026-07.json"
+
+
+def _queue(*, active: bool = True) -> dict:
+    payload = json.loads(QUEUE_PATH.read_text(encoding="utf-8"))
+    if active:
+        payload["state"] = "active"
+        payload.pop("pause_reason", None)
+        payload["activation"] = {
+            "check_runs_sha256": "0" * 64,
+            "finalizer_head_sha": "a" * 40,
+            "finalizer_run_attempt": 1,
+            "finalizer_run_url": (
+                "https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/1"
+            ),
+            "previous_queue_object_sha256": "1" * 64,
+            "pull_requests_sha256": "2" * 64,
+            "rulespec_ref": payload["dispatch"]["rulespec_ref"],
+            "schema": "axiom-encode/signed-encoding-queue-activation/v1",
+            "workflow_runs_sha256": "3" * 64,
+        }
+    return payload
+
+
+def test_committed_snap_queue_is_complete_and_valid() -> None:
+    payload = _queue(active=False)
+
+    validate_queue(payload)
+
+    assert payload["expected_counts"] == EXPECTED_COUNTS
+    assert tuple(item["citation"] for item in payload["items"][:4]) == (
+        PRIORITY_CITATIONS
+    )
+    assert len(queue_file_sha256(QUEUE_PATH)) == 64
+    assert payload["state"] in {"active", "paused"}
+    assert payload["release"]["manifest_sha256"] == (
+        "be18ff3f1557f4e30a1520e519e4d14b31c01122534ca1690294729bb7029691"
+    )
+
+
+def test_select_snap_queue_defaults_to_bounded_priority_tranche() -> None:
+    selection = select_items(_queue(), item_ids="", limit=4)
+
+    assert [item["id"] for item in selection["items"]] == [
+        "ut-0001",
+        "or-0001",
+        "or-0002",
+        "or-0003",
+    ]
+    assert selection["dispatch"]["max_batch_size"] == 4
+    assert selection["issue"] == 1257
+
+
+def test_paused_snap_queue_is_not_dispatchable() -> None:
+    payload = _queue(active=False)
+
+    assert selectable_items(payload)["items"] == []
+    assert select_items(payload, item_ids="", limit=4)["items"] == []
+    with pytest.raises(ValueError, match="paused"):
+        select_items(payload, item_ids="ut-0001", limit=1)
+
+    bypass = copy.deepcopy(payload)
+    bypass["state"] = "active"
+    bypass.pop("pause_reason")
+    with pytest.raises(ValueError, match="finalization evidence"):
+        validate_queue(bypass)
+
+
+def test_active_snap_queue_can_be_paused_fail_closed() -> None:
+    active = _queue()
+    active_digest = queue_object_file_sha256(active)
+    paused = pause_queue(
+        active,
+        reason="Tranche dispatched; awaiting finalization.",
+        active_queue_sha256=active_digest,
+    )
+
+    assert paused["state"] == "paused"
+    assert paused["pause_reason"] == "Tranche dispatched; awaiting finalization."
+    assert "activation" not in paused
+    assert paused["suspension"] == {
+        "active_queue_sha256": active_digest,
+        "schema": "axiom-encode/signed-encoding-queue-suspension/v1",
+    }
+    assert dispatch_queue_sha256(paused) == active_digest
+    assert selectable_items(paused)["items"] == []
+
+
+def test_pause_transition_preserves_exact_noncanonical_active_file_digest(
+    tmp_path: Path,
+) -> None:
+    active = _queue()
+    previous = tmp_path / "active.json"
+    previous.write_text(json.dumps(active, separators=(",", ":")), encoding="utf-8")
+    active_digest = queue_file_sha256(previous)
+    assert active_digest != queue_object_file_sha256(active)
+    paused = pause_queue(
+        active,
+        reason="Tranche dispatched; awaiting finalization.",
+        active_queue_sha256=active_digest,
+    )
+    current = tmp_path / "paused.json"
+    current.write_text(
+        json.dumps(paused, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    verify_paused_transition(current, previous_queue_path=previous)
+    assert paused["suspension"]["active_queue_sha256"] == active_digest
+
+
+def test_paused_transition_rejects_manual_completion(tmp_path: Path) -> None:
+    previous_payload = _queue(active=False)
+    current_payload = copy.deepcopy(previous_payload)
+    current_payload["items"][0]["status"] = "completed"
+    current_payload["items"][0]["evidence"] = {
+        "applied_manifest_path": ".axiom/encoding-manifests/test.json",
+        "applied_manifest_sha256": "c" * 64,
+        "artifact_metadata_sha256": "d" * 64,
+        "generation_sha256": "b" * 64,
+        "merge_commit": "a" * 40,
+        "rulespec_pr_head_sha": "e" * 40,
+        "target_run_head_sha": "f" * 40,
+        "target_run_attempt": 1,
+        "target_run_url": (
+            "https://github.com/TheAxiomFoundation/"
+            "axiom-encode/actions/runs/1"
+        ),
+        "type": "merged-rulespec-pr",
+        "url": "https://github.com/TheAxiomFoundation/rulespec-us/pull/1",
+    }
+    previous = tmp_path / "previous.json"
+    current = tmp_path / "current.json"
+    previous.write_text(json.dumps(previous_payload), encoding="utf-8")
+    current.write_text(json.dumps(current_payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="cannot complete"):
+        verify_paused_transition(current, previous_queue_path=previous)
+
+
+def test_selectable_snap_queue_returns_history_scan_pool() -> None:
+    candidates = selectable_items(_queue())
+
+    assert len(candidates["items"]) == 831
+    assert candidates["items"][0]["id"] == "ut-0001"
+    assert candidates["items"][-1]["id"] == "ut-0301"
+
+
+def test_completed_snap_queue_returns_empty_successful_selection() -> None:
+    payload = _queue()
+    for item in payload["items"]:
+        item["status"] = "blocked"
+        item["evidence"] = {
+            "note": "Durable terminal test disposition.",
+            "type": "issue-comment",
+            "url": (
+                "https://github.com/TheAxiomFoundation/axiom-encode/issues/"
+                "1257#issuecomment-123"
+            ),
+        }
+
+    assert selectable_items(payload)["items"] == []
+    assert select_items(payload, item_ids="", limit=4)["items"] == []
+
+
+def test_select_snap_queue_preserves_explicit_item_order() -> None:
+    selection = select_items(
+        _queue(),
+        item_ids="or-0002,ut-0001",
+        limit=2,
+    )
+
+    assert [item["id"] for item in selection["items"]] == [
+        "or-0002",
+        "ut-0001",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("item_ids", "limit", "message"),
+    [
+        ("", 5, "between 1 and 4"),
+        ("missing-0001", 1, "unknown queue item"),
+        ("ut-0001,ut-0001", 2, "duplicates"),
+        ("ut-0001,or-0001", 1, "exceed"),
+    ],
+)
+def test_select_snap_queue_rejects_invalid_tranches(
+    item_ids: str,
+    limit: int,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        select_items(_queue(), item_ids=item_ids, limit=limit)
+
+
+def test_validate_snap_queue_rejects_count_and_priority_drift() -> None:
+    count_drift = copy.deepcopy(_queue())
+    count_drift["items"].pop()
+    with pytest.raises(ValueError, match="count"):
+        validate_queue(count_drift)
+
+    priority_drift = copy.deepcopy(_queue())
+    priority_drift["items"][0]["citation"] = "us-ut/manual/other"
+    with pytest.raises(ValueError, match="priority tranche"):
+        validate_queue(priority_drift)
+
+
+def test_select_snap_queue_rejects_nonselectable_item() -> None:
+    payload = record_disposition(
+        _queue(),
+        item_id="ut-0001",
+        status="blocked",
+        evidence_url=(
+            "https://github.com/TheAxiomFoundation/axiom-encode/issues/"
+            "1257#issuecomment-123"
+        ),
+        note="The source is blocked pending a readable capture.",
+    )
+
+    with pytest.raises(ValueError, match="not selectable"):
+        select_items(payload, item_ids="ut-0001", limit=1)
+
+
+def test_terminal_snap_queue_dispositions_require_durable_evidence() -> None:
+    payload = _queue()
+    payload["items"][0]["status"] = "completed"
+    with pytest.raises(ValueError, match="durable evidence"):
+        validate_queue(payload)
+
+    with pytest.raises(ValueError, match="must be blocked"):
+        record_disposition(
+            _queue(),
+            item_id="ut-0001",
+            status="completed",
+            evidence_url=(
+                "https://github.com/TheAxiomFoundation/rulespec-us/pull/123"
+            ),
+            note=None,
+        )
+
+    no_rule = record_disposition(
+        _queue(),
+        item_id="ut-0001",
+        status="no-executable-rule",
+        evidence_url=(
+            "https://github.com/TheAxiomFoundation/axiom-encode/issues/"
+            "1257#issuecomment-123"
+        ),
+        note="The source unit contains only navigation text.",
+    )
+    assert no_rule["items"][0]["evidence"]["type"] == "issue-comment"
+
+
+def _run_history(
+    item_id: str,
+    *,
+    status: str,
+    conclusion: str | None,
+    payload: dict | None = None,
+) -> list:
+    selectable_payload = copy.deepcopy(payload or _queue())
+    selectable_payload["state"] = "active"
+    selectable_payload.pop("pause_reason", None)
+    selectable_payload.pop("suspension", None)
+    selectable_payload["activation"] = copy.deepcopy(_queue()["activation"])
+    selectable_payload["activation"]["rulespec_ref"] = selectable_payload["dispatch"][
+        "rulespec_ref"
+    ]
+    selection = select_items(selectable_payload, item_ids=item_id, limit=1)
+    generation = selection["items"][0]["generation_sha256"]
+    return [
+        {
+            "workflow_runs": [
+                {
+                    "actor": {"login": "github-actions[bot]"},
+                    "conclusion": conclusion,
+                    "created_at": "2026-07-24T12:00:00Z",
+                    "display_title": (
+                        "Targeted signed RuleSpec re-encode "
+                        f"[us-snap-or-ut-2026-07:{item_id}:{generation}] citation"
+                    ),
+                    "event": "workflow_dispatch",
+                    "head_branch": "main",
+                    "head_sha": "c" * 40,
+                    "html_url": (
+                        "https://github.com/TheAxiomFoundation/"
+                        "axiom-encode/actions/runs/1"
+                    ),
+                    "id": 1,
+                    "path": ".github/workflows/targeted-signed-reencode.yml",
+                    "run_attempt": 1,
+                    "status": status,
+                }
+            ]
+        }
+    ]
+
+
+def _pr_history(
+    item_id: str,
+    *,
+    state: str,
+    merged: bool,
+    generation_sha256: str | None = None,
+    citation: str | None = None,
+    base_commit: str | None = None,
+    merge_commit_sha: str | None = None,
+    payload: dict | None = None,
+) -> list:
+    selectable_payload = copy.deepcopy(payload or _queue())
+    selectable_payload["state"] = "active"
+    selectable_payload.pop("pause_reason", None)
+    selectable_payload.pop("suspension", None)
+    selectable_payload["activation"] = copy.deepcopy(_queue()["activation"])
+    selectable_payload["activation"]["rulespec_ref"] = selectable_payload["dispatch"][
+        "rulespec_ref"
+    ]
+    selection = select_items(selectable_payload, item_ids=item_id, limit=1)
+    item = selection["items"][0]
+    dispatch = selection["dispatch"]
+    generation_sha256 = generation_sha256 or item["generation_sha256"]
+    citation = citation or item["citation"]
+    base_commit = base_commit or dispatch["rulespec_ref"]
+    return [
+        [
+            {
+                "base": {"ref": "hard-cut/canonical-layout-us"},
+                "body": (
+                    "Generated PR\n\n"
+                    f"Citation: `{citation}`\n"
+                    f"Base commit: `{base_commit}`\n"
+                    "Base branch: `hard-cut/canonical-layout-us`\n"
+                    f"Queue item: `us-snap-or-ut-2026-07/{item_id}`\n"
+                    f"Queue generation SHA-256: `{generation_sha256}`\n"
+                    "Axiom Encode run: https://github.com/"
+                    "TheAxiomFoundation/axiom-encode/actions/runs/1"
+                ),
+                "head": {
+                    "repo": {"full_name": "TheAxiomFoundation/rulespec-us"},
+                    "sha": "d" * 40,
+                },
+                "html_url": "https://github.com/TheAxiomFoundation/rulespec-us/pull/1",
+                "merged_at": "2026-07-24T13:00:00Z" if merged else None,
+                "merge_commit_sha": (merge_commit_sha or "b" * 40 if merged else None),
+                "number": 1,
+                "state": state,
+                "updated_at": "2026-07-24T13:00:00Z",
+            }
+        ]
+    ]
+
+
+def test_reconcile_queue_treats_merged_or_open_pr_as_durable_state() -> None:
+    selection = select_items(_queue(), item_ids="", limit=2)
+    prs = _pr_history("ut-0001", state="closed", merged=True)
+    prs[0].extend(_pr_history("or-0001", state="open", merged=False)[0])
+
+    result = reconcile_candidates(
+        selection,
+        pull_requests=prs,
+        workflow_runs=_run_history(
+            "ut-0001",
+            status="completed",
+            conclusion="success",
+        ),
+    )
+
+    assert [item["reason"] for item in result["items"]] == [
+        "merged-rulespec-pr",
+        "open-rulespec-pr",
+    ]
+    assert not any(item["dispatchable"] for item in result["items"])
+
+
+def test_reconcile_queue_does_not_treat_successful_run_as_completion() -> None:
+    selection = select_items(_queue(), item_ids="ut-0001", limit=1)
+
+    result = reconcile_candidates(
+        selection,
+        pull_requests=[],
+        workflow_runs=_run_history(
+            "ut-0001",
+            status="completed",
+            conclusion="success",
+        ),
+    )
+
+    assert result["items"][0]["reason"] == "successful-run-without-durable-pr"
+    assert result["items"][0]["dispatchable"] is False
+
+
+def test_reconcile_queue_does_not_trust_merged_pr_body_without_target_run() -> None:
+    selection = select_items(_queue(), item_ids="ut-0001", limit=1)
+
+    result = reconcile_candidates(
+        selection,
+        pull_requests=_pr_history("ut-0001", state="closed", merged=True),
+        workflow_runs=[],
+    )
+
+    assert result["items"][0]["reason"] == "untrusted-merged-rulespec-pr"
+    assert result["items"][0]["dispatchable"] is False
+
+
+def test_reconcile_queue_preserves_attempt_one_target_after_skipped_rerun() -> None:
+    selection = select_items(_queue(), item_ids="ut-0001", limit=1)
+    runs = _run_history(
+        "ut-0001",
+        status="completed",
+        conclusion="success",
+    )
+    runs[0]["workflow_runs"][0]["run_attempt"] = 2
+
+    result = reconcile_candidates(
+        selection,
+        pull_requests=_pr_history("ut-0001", state="closed", merged=True),
+        workflow_runs=runs,
+    )
+
+    assert result["items"][0]["reason"] == "merged-rulespec-pr"
+    assert result["items"][0]["dispatchable"] is False
+
+
+def test_reconcile_queue_ignores_matching_marker_from_untrusted_fork() -> None:
+    selection = select_items(_queue(), item_ids="ut-0001", limit=1)
+    prs = _pr_history("ut-0001", state="open", merged=False)
+    prs[0][0]["head"]["repo"]["full_name"] = "external/fork"
+
+    result = reconcile_candidates(
+        selection,
+        pull_requests=prs,
+        workflow_runs=[],
+    )
+
+    assert result["items"][0]["dispatchable"] is True
+    assert result["items"][0]["reason"] == "new"
+
+
+@pytest.mark.parametrize(
+    "pr_kwargs",
+    [
+        {"generation_sha256": "0" * 64},
+        {"citation": "us-ut/manual/stale-citation"},
+        {"base_commit": "0" * 40},
+    ],
+)
+def test_reconcile_queue_ignores_stale_pr_identity(pr_kwargs: dict) -> None:
+    selection = select_items(_queue(), item_ids="ut-0001", limit=1)
+
+    result = reconcile_candidates(
+        selection,
+        pull_requests=_pr_history(
+            "ut-0001",
+            state="closed",
+            merged=True,
+            **pr_kwargs,
+        ),
+        workflow_runs=[],
+    )
+
+    assert result["items"][0]["dispatchable"] is True
+    assert result["items"][0]["reason"] == "new"
+
+
+def test_retryable_disposition_creates_new_item_generation() -> None:
+    original = select_items(_queue(), item_ids="ut-0001", limit=1)
+    retried_queue = record_disposition(
+        _queue(),
+        item_id="ut-0001",
+        status="retryable",
+        evidence_url=None,
+        note=None,
+    )
+    retried = select_items(retried_queue, item_ids="ut-0001", limit=1)
+
+    assert retried["items"][0]["attempt"] == 2
+    assert (
+        retried["items"][0]["generation_sha256"]
+        != original["items"][0]["generation_sha256"]
+    )
+    result = reconcile_candidates(
+        retried,
+        pull_requests=_pr_history("ut-0001", state="closed", merged=True),
+        workflow_runs=[],
+    )
+    assert result["items"][0]["dispatchable"] is True
+
+
+def _repin_fixture(tmp_path: Path) -> tuple[dict, Path, str, str]:
+    payload = _queue()
+    rulespec = tmp_path / "rulespec"
+    toolchain = rulespec / ".axiom/toolchain.toml"
+    toolchain.parent.mkdir(parents=True)
+    release = payload["release"]
+    toolchain.write_text(
+        "[toolchain]\n"
+        f'axiom_corpus_release = "{release["name"]}"\n'
+        "axiom_corpus_release_content_sha256 = "
+        f'"{release["content_sha256"]}"\n',
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init", "-q", rulespec], check=True)
+    subprocess.run(["git", "-C", rulespec, "add", "."], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            rulespec,
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-qm",
+            "old base",
+        ],
+        check=True,
+    )
+    old_ref = subprocess.check_output(
+        ["git", "-C", rulespec, "rev-parse", "HEAD"],
+        text=True,
+    ).strip()
+    (rulespec / "next.txt").write_text("next base\n", encoding="utf-8")
+    manifest = rulespec / ".axiom/encoding-manifests/test.json"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text('{"signed": true}\n', encoding="utf-8")
+    subprocess.run(["git", "-C", rulespec, "add", "."], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            rulespec,
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-qm",
+            "new base",
+        ],
+        check=True,
+    )
+    new_ref = subprocess.check_output(
+        ["git", "-C", rulespec, "rev-parse", "HEAD"],
+        text=True,
+    ).strip()
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            rulespec,
+            "update-ref",
+            "refs/remotes/origin/hard-cut/canonical-layout-us",
+            new_ref,
+        ],
+        check=True,
+    )
+    payload["dispatch"]["rulespec_ref"] = old_ref
+    payload["activation"]["rulespec_ref"] = old_ref
+    validate_queue(payload)
+    payload = pause_queue(
+        payload,
+        reason="Tranche dispatched; awaiting finalization.",
+        active_queue_sha256=queue_object_file_sha256(payload),
+    )
+    return payload, rulespec, old_ref, new_ref
+
+
+def _finalizer_evidence() -> dict:
+    return {
+        "check_runs": [
+            {
+                "check_runs": [
+                    {
+                        "conclusion": "success",
+                        "name": "validate",
+                        "status": "completed",
+                    }
+                ]
+            }
+        ],
+        "finalizer_head_sha": "a" * 40,
+        "finalizer_run_url": (
+            "https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/1"
+        ),
+        "target_evidence": {},
+    }
+
+
+def _target_evidence(payload: dict, rulespec: Path, item_id: str) -> dict:
+    item = next(value for value in payload["items"] if value["id"] == item_id)
+    manifest_path = ".axiom/encoding-manifests/test.json"
+    manifest_digest = hashlib.sha256(
+        (rulespec / manifest_path).read_bytes()
+    ).hexdigest()
+    run_url = (
+        "https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/1"
+    )
+    return {
+        item_id: {
+            "apply_manifests": {
+                "items": [
+                    {
+                        "citation": item["citation"],
+                        "path": manifest_path,
+                        "sha256": manifest_digest,
+                    }
+                ],
+                "schema": "axiom-encode/applied-manifest-inventory/v1",
+            },
+            "jobs": {
+                "jobs": [
+                    {
+                        "conclusion": "success",
+                        "name": "Queue protected signed RuleSpec re-encode",
+                        "run_attempt": 1,
+                        "status": "completed",
+                    }
+                ]
+            },
+            "metadata": {
+                "citation": item["citation"],
+                "encoder_commit": "c" * 40,
+                "pr_base_branch": payload["dispatch"]["pr_base_branch"],
+                "queue_id": payload["queue_id"],
+                "queue_item_generation_sha256": item_generation_sha256(
+                    payload, item
+                ),
+                "queue_item_id": item_id,
+                "queue_manifest_sha256": dispatch_queue_sha256(payload),
+                "rulespec_base": payload["dispatch"]["rulespec_ref"],
+                "schema": "axiom-encode/targeted-reencode-artifact/v1",
+                "workflow_run_attempt": 1,
+                "workflow_run_id": "1",
+            },
+            "pull_request": {
+                "head": {"sha": "d" * 40},
+                "html_url": (
+                    "https://github.com/TheAxiomFoundation/rulespec-us/pull/1"
+                ),
+                "number": 1,
+            },
+            "run": {
+                "actor": {"login": "github-actions[bot]"},
+                "conclusion": "success",
+                "event": "workflow_dispatch",
+                "head_branch": "main",
+                "head_sha": "c" * 40,
+                "html_url": run_url,
+                "id": 1,
+                "path": ".github/workflows/targeted-signed-reencode.yml",
+                "run_attempt": 1,
+                "status": "completed",
+            },
+        }
+    }
+
+
+def test_finalize_repin_activates_quiet_queue_and_records_merged_pr(
+    tmp_path: Path,
+) -> None:
+    payload, rulespec, _, new_ref = _repin_fixture(tmp_path)
+    evidence = _finalizer_evidence()
+    evidence["target_evidence"] = _target_evidence(payload, rulespec, "ut-0001")
+    assert evidence["target_evidence"]["ut-0001"]["metadata"][
+        "queue_manifest_sha256"
+    ] == payload["suspension"]["active_queue_sha256"]
+    updated = finalize_and_repin(
+        payload,
+        rulespec_root=rulespec,
+        pull_requests=_pr_history(
+            "ut-0001",
+            state="closed",
+            merged=True,
+            merge_commit_sha=new_ref,
+            payload=payload,
+        ),
+        workflow_runs=_run_history(
+            "ut-0001",
+            status="completed",
+            conclusion="success",
+            payload=payload,
+        ),
+        new_rulespec_ref=new_ref,
+        reviewed_rulespec_refs=frozenset({("us", new_ref)}),
+        **evidence,
+    )
+
+    assert updated["state"] == "active"
+    assert "pause_reason" not in updated
+    assert "suspension" not in updated
+    assert updated["dispatch"]["rulespec_ref"] == new_ref
+    assert updated["items"][0]["status"] == "completed"
+    assert updated["items"][0]["evidence"]["merge_commit"] == new_ref
+
+
+def test_finalize_repin_accepts_attempt_one_target_after_skipped_rerun(
+    tmp_path: Path,
+) -> None:
+    payload, rulespec, _, new_ref = _repin_fixture(tmp_path)
+    evidence = _finalizer_evidence()
+    target_evidence = _target_evidence(payload, rulespec, "ut-0001")
+    target = target_evidence["ut-0001"]
+    target["run"]["run_attempt"] = 2
+    target["jobs"]["jobs"].append(
+        {
+            "conclusion": "skipped",
+            "name": "Queue protected signed RuleSpec re-encode",
+            "run_attempt": 2,
+            "status": "completed",
+        }
+    )
+    evidence["target_evidence"] = target_evidence
+
+    updated = finalize_and_repin(
+        payload,
+        rulespec_root=rulespec,
+        pull_requests=_pr_history(
+            "ut-0001",
+            state="closed",
+            merged=True,
+            merge_commit_sha=new_ref,
+            payload=payload,
+        ),
+        workflow_runs=_run_history(
+            "ut-0001",
+            status="completed",
+            conclusion="success",
+            payload=payload,
+        ),
+        new_rulespec_ref=new_ref,
+        reviewed_rulespec_refs=frozenset({("us", new_ref)}),
+        **evidence,
+    )
+
+    assert updated["items"][0]["evidence"]["target_run_attempt"] == 1
+    target["jobs"]["jobs"][1]["conclusion"] = "success"
+    with pytest.raises(ValueError, match="later attempt executed"):
+        finalize_and_repin(
+            payload,
+            rulespec_root=rulespec,
+            pull_requests=_pr_history(
+                "ut-0001",
+                state="closed",
+                merged=True,
+                merge_commit_sha=new_ref,
+                payload=payload,
+            ),
+            workflow_runs=_run_history(
+                "ut-0001",
+                status="completed",
+                conclusion="success",
+                payload=payload,
+            ),
+            new_rulespec_ref=new_ref,
+            reviewed_rulespec_refs=frozenset({("us", new_ref)}),
+            **evidence,
+        )
+
+
+def test_finalization_plan_and_repin_require_exact_target_artifact(
+    tmp_path: Path,
+) -> None:
+    payload, rulespec, _, new_ref = _repin_fixture(tmp_path)
+    pull_requests = _pr_history(
+        "ut-0001",
+        state="closed",
+        merged=True,
+        merge_commit_sha=new_ref,
+        payload=payload,
+    )
+    workflow_runs = _run_history(
+        "ut-0001",
+        status="completed",
+        conclusion="success",
+        payload=payload,
+    )
+    plan = finalization_target_plan(
+        payload,
+        pull_requests=pull_requests,
+        workflow_runs=workflow_runs,
+    )
+    assert plan["items"] == [
+        {
+            "id": "ut-0001",
+            "pull_request_url": (
+                "https://github.com/TheAxiomFoundation/rulespec-us/pull/1"
+            ),
+            "target_run_url": (
+                "https://github.com/TheAxiomFoundation/"
+                "axiom-encode/actions/runs/1"
+            ),
+        }
+    ]
+
+    evidence = _finalizer_evidence()
+    evidence["target_evidence"] = _target_evidence(payload, rulespec, "ut-0001")
+    evidence["target_evidence"]["ut-0001"]["apply_manifests"]["items"][0][
+        "sha256"
+    ] = "0" * 64
+    with pytest.raises(
+        ValueError,
+        match="merged RuleSpec tree lacks the signed applied manifest",
+    ):
+        finalize_and_repin(
+            payload,
+            rulespec_root=rulespec,
+            pull_requests=pull_requests,
+            workflow_runs=workflow_runs,
+            new_rulespec_ref=new_ref,
+            reviewed_rulespec_refs=frozenset({("us", new_ref)}),
+            **evidence,
+        )
+
+
+def test_finalize_repin_revalidates_existing_completed_items(tmp_path: Path) -> None:
+    payload, rulespec, _, new_ref = _repin_fixture(tmp_path)
+    pull_requests = _pr_history(
+        "ut-0001",
+        state="closed",
+        merged=True,
+        merge_commit_sha=new_ref,
+        payload=payload,
+    )
+    target = _target_evidence(payload, rulespec, "ut-0001")["ut-0001"]
+    applied = target["apply_manifests"]["items"][0]
+    payload["items"][0]["status"] = "completed"
+    payload["items"][0]["evidence"] = {
+        "applied_manifest_path": applied["path"],
+        "applied_manifest_sha256": applied["sha256"],
+        "artifact_metadata_sha256": _json_sha256(target["metadata"]),
+        "generation_sha256": item_generation_sha256(payload, payload["items"][0]),
+        "merge_commit": new_ref,
+        "rulespec_pr_head_sha": "d" * 40,
+        "target_run_head_sha": "c" * 40,
+        "target_run_attempt": 1,
+        "target_run_url": (
+            "https://github.com/TheAxiomFoundation/"
+            "axiom-encode/actions/runs/1"
+        ),
+        "type": "merged-rulespec-pr",
+        "url": "https://github.com/TheAxiomFoundation/rulespec-us/pull/1",
+    }
+
+    updated = finalize_and_repin(
+        payload,
+        rulespec_root=rulespec,
+        pull_requests=pull_requests,
+        workflow_runs=[],
+        new_rulespec_ref=new_ref,
+        reviewed_rulespec_refs=frozenset({("us", new_ref)}),
+        **_finalizer_evidence(),
+    )
+    assert updated["items"][0]["status"] == "completed"
+
+    pull_requests[0][0]["merge_commit_sha"] = "f" * 40
+    with pytest.raises(ValueError, match="verified merged RuleSpec PR"):
+        finalize_and_repin(
+            payload,
+            rulespec_root=rulespec,
+            pull_requests=pull_requests,
+            workflow_runs=[],
+            new_rulespec_ref=new_ref,
+            reviewed_rulespec_refs=frozenset({("us", new_ref)}),
+            **_finalizer_evidence(),
+        )
+
+
+def test_verify_activation_commit_rejects_amendment_or_extra_file(
+    tmp_path: Path,
+) -> None:
+    queue = tmp_path / "queue.json"
+    queue.write_text(
+        json.dumps(_queue(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    base_sha = "a" * 40
+    head_sha = "b" * 40
+    tree_sha = "c" * 40
+    changed_files = list(ACTIVATION_CHANGED_FILES)
+    provenance = {
+        "base_sha": base_sha,
+        "changed_files": changed_files,
+        "head_sha": head_sha,
+        "queue_path": ACTIVATION_CHANGED_FILES[0],
+        "queue_sha256": queue_file_sha256(queue),
+        "repository": "TheAxiomFoundation/axiom-encode",
+        "schema": "axiom-encode/snap-queue-activation-commit/v1",
+        "tree_sha": tree_sha,
+    }
+    pull_request = {
+        "base": {"ref": "main", "sha": base_sha},
+        "head": {
+            "repo": {"full_name": "TheAxiomFoundation/axiom-encode"},
+            "sha": head_sha,
+        },
+        "state": "open",
+    }
+
+    verify_activation_commit(
+        queue,
+        provenance=provenance,
+        pull_request=pull_request,
+        current_base_sha=base_sha,
+        current_head_sha=head_sha,
+        current_tree_sha=tree_sha,
+        current_changed_files=changed_files,
+    )
+
+    with pytest.raises(ValueError, match="commit or changed-file inventory"):
+        verify_activation_commit(
+            queue,
+            provenance=provenance,
+            pull_request=pull_request,
+            current_base_sha=base_sha,
+            current_head_sha="d" * 40,
+            current_tree_sha=tree_sha,
+            current_changed_files=changed_files,
+        )
+    with pytest.raises(ValueError, match="commit or changed-file inventory"):
+        verify_activation_commit(
+            queue,
+            provenance=provenance,
+            pull_request=pull_request,
+            current_base_sha=base_sha,
+            current_head_sha=head_sha,
+            current_tree_sha=tree_sha,
+            current_changed_files=[*changed_files, ".github/workflows/pwn.yml"],
+        )
+
+
+def test_verify_activation_evidence_authenticates_run_and_artifact(
+    tmp_path: Path,
+) -> None:
+    payload, rulespec, _, new_ref = _repin_fixture(tmp_path)
+    evidence = _finalizer_evidence()
+    pull_requests = []
+    workflow_runs = []
+    updated = finalize_and_repin(
+        payload,
+        rulespec_root=rulespec,
+        pull_requests=pull_requests,
+        workflow_runs=workflow_runs,
+        new_rulespec_ref=new_ref,
+        reviewed_rulespec_refs=frozenset({("us", new_ref)}),
+        **evidence,
+    )
+    queue = tmp_path / "queue.json"
+    previous = tmp_path / "previous.json"
+    finalized = tmp_path / "finalized.json"
+    previous.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    serialized = json.dumps(updated, indent=2, sort_keys=True) + "\n"
+    queue.write_text(serialized, encoding="utf-8")
+    finalized.write_text(serialized, encoding="utf-8")
+    finalizer_run = {
+        "conclusion": "success",
+        "event": "workflow_dispatch",
+        "head_branch": "main",
+        "head_sha": "a" * 40,
+        "html_url": (
+            "https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/1"
+        ),
+        "path": ".github/workflows/finalize-signed-snap-queue.yml",
+        "run_attempt": 1,
+        "status": "completed",
+    }
+    finalizer_jobs = {
+        "jobs": [
+            {
+                "conclusion": "success",
+                "name": "Finalize protected SNAP queue tranche",
+                "run_attempt": 1,
+                "status": "completed",
+            }
+        ]
+    }
+
+    verify_activation_evidence(
+        queue,
+        previous_queue_path=previous,
+        expected_base_sha="a" * 40,
+        finalized_queue_path=finalized,
+        check_runs=evidence["check_runs"],
+        pull_requests=pull_requests,
+        workflow_runs=workflow_runs,
+        finalizer_run=finalizer_run,
+        finalizer_jobs=finalizer_jobs,
+        require_success=True,
+    )
+
+    finalizer_run["run_attempt"] = 2
+    finalizer_jobs["jobs"].append(
+        {
+            "conclusion": "skipped",
+            "name": "Finalize protected SNAP queue tranche",
+            "run_attempt": 2,
+            "status": "completed",
+        }
+    )
+    verify_activation_evidence(
+        queue,
+        previous_queue_path=previous,
+        expected_base_sha="a" * 40,
+        finalized_queue_path=finalized,
+        check_runs=evidence["check_runs"],
+        pull_requests=pull_requests,
+        workflow_runs=workflow_runs,
+        finalizer_run=finalizer_run,
+        finalizer_jobs=finalizer_jobs,
+        require_success=True,
+    )
+    finalizer_jobs["jobs"][1]["conclusion"] = "success"
+    with pytest.raises(ValueError, match="later attempt executed"):
+        verify_activation_evidence(
+            queue,
+            previous_queue_path=previous,
+            expected_base_sha="a" * 40,
+            finalized_queue_path=finalized,
+            check_runs=evidence["check_runs"],
+            pull_requests=pull_requests,
+            workflow_runs=workflow_runs,
+            finalizer_run=finalizer_run,
+            finalizer_jobs=finalizer_jobs,
+            require_success=True,
+        )
+    finalizer_run["run_attempt"] = 1
+    finalizer_jobs["jobs"].pop()
+
+    finalized.write_text(json.dumps(updated), encoding="utf-8")
+    with pytest.raises(ValueError, match="differs from the finalizer artifact"):
+        verify_activation_evidence(
+            queue,
+            previous_queue_path=previous,
+            expected_base_sha="a" * 40,
+            finalized_queue_path=finalized,
+            check_runs=evidence["check_runs"],
+            pull_requests=pull_requests,
+            workflow_runs=workflow_runs,
+            finalizer_run=finalizer_run,
+            finalizer_jobs=finalizer_jobs,
+            require_success=True,
+        )
+    finalized.write_text(serialized, encoding="utf-8")
+
+    finalizer_run["head_sha"] = "b" * 40
+    with pytest.raises(ValueError, match="identity does not match"):
+        verify_activation_evidence(
+            queue,
+            previous_queue_path=previous,
+            expected_base_sha="a" * 40,
+            finalized_queue_path=finalized,
+            check_runs=evidence["check_runs"],
+            pull_requests=pull_requests,
+            workflow_runs=workflow_runs,
+            finalizer_run=finalizer_run,
+            finalizer_jobs=finalizer_jobs,
+            require_success=True,
+        )
+
+    finalizer_run["head_sha"] = "a" * 40
+    stale_previous = copy.deepcopy(payload)
+    stale_previous["items"][0]["attempt"] = 2
+    previous.write_text(
+        json.dumps(stale_previous, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="base queue digest"):
+        verify_activation_evidence(
+            queue,
+            previous_queue_path=previous,
+            expected_base_sha="a" * 40,
+            finalized_queue_path=finalized,
+            check_runs=evidence["check_runs"],
+            pull_requests=pull_requests,
+            workflow_runs=workflow_runs,
+            finalizer_run=finalizer_run,
+            finalizer_jobs=finalizer_jobs,
+            require_success=True,
+        )
+
+
+def test_verify_merge_authorization_rejects_direct_activation_merge(
+    tmp_path: Path,
+) -> None:
+    queue = tmp_path / "queue.json"
+    queue.write_text(
+        json.dumps(_queue(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    run_id = 9
+    merge_commit = "b" * 40
+    pr_head = "a" * 40
+    run_url = (
+        "https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/"
+        f"{run_id}"
+    )
+    authorization = {
+        "activation_pr_head_sha": pr_head,
+        "activation_pr_number": 123,
+        "merge_commit": merge_commit,
+        "merge_workflow_run_id": run_id,
+        "merge_workflow_run_attempt": 1,
+        "merge_workflow_run_url": run_url,
+        "queue_path": "data/encoding-queues/us-snap-or-ut-2026-07.json",
+        "queue_sha256": queue_file_sha256(queue),
+        "repository": "TheAxiomFoundation/axiom-encode",
+        "schema": "axiom-encode/snap-queue-merge-authorization/v1",
+    }
+    merge_run = {
+        "conclusion": "success",
+        "event": "workflow_dispatch",
+        "head_branch": "main",
+        "html_url": run_url,
+        "path": ".github/workflows/merge-snap-queue-activation.yml",
+        "run_attempt": 1,
+        "status": "completed",
+    }
+    merge_jobs = {
+        "jobs": [
+            {
+                "conclusion": "success",
+                "name": "Merge reviewed SNAP queue activation",
+                "run_attempt": 1,
+                "status": "completed",
+            }
+        ]
+    }
+    pull_request = {
+        "base": {"ref": "main"},
+        "head": {
+            "repo": {"full_name": "TheAxiomFoundation/axiom-encode"},
+            "sha": pr_head,
+        },
+        "merge_commit_sha": merge_commit,
+        "merged_at": "2026-07-24T13:00:00Z",
+        "merged_by": {"login": "github-actions[bot]"},
+        "number": 123,
+        "state": "closed",
+    }
+
+    verify_merge_authorization(
+        queue,
+        authorization=authorization,
+        merge_run=merge_run,
+        merge_jobs=merge_jobs,
+        pull_request=pull_request,
+        current_head_sha="c" * 40,
+        queue_change_sha=merge_commit,
+    )
+
+    merge_run["run_attempt"] = 2
+    merge_jobs["jobs"].append(
+        {
+            "conclusion": "skipped",
+            "name": "Merge reviewed SNAP queue activation",
+            "run_attempt": 2,
+            "status": "completed",
+        }
+    )
+    verify_merge_authorization(
+        queue,
+        authorization=authorization,
+        merge_run=merge_run,
+        merge_jobs=merge_jobs,
+        pull_request=pull_request,
+        current_head_sha="c" * 40,
+        queue_change_sha=merge_commit,
+    )
+    merge_jobs["jobs"][1]["conclusion"] = "success"
+    with pytest.raises(ValueError, match="later attempt executed"):
+        verify_merge_authorization(
+            queue,
+            authorization=authorization,
+            merge_run=merge_run,
+            merge_jobs=merge_jobs,
+            pull_request=pull_request,
+            current_head_sha="c" * 40,
+            queue_change_sha=merge_commit,
+        )
+    merge_run["run_attempt"] = 1
+    merge_jobs["jobs"].pop()
+
+    pull_request["merged_by"]["login"] = "maintainer"
+    with pytest.raises(ValueError, match="trusted workflow"):
+        verify_merge_authorization(
+            queue,
+            authorization=authorization,
+            merge_run=merge_run,
+            merge_jobs=merge_jobs,
+            pull_request=pull_request,
+            current_head_sha="c" * 40,
+            queue_change_sha=merge_commit,
+        )
+
+
+def test_finalize_repin_refuses_open_pr_or_active_run(tmp_path: Path) -> None:
+    payload, rulespec, _, new_ref = _repin_fixture(tmp_path)
+    with pytest.raises(ValueError, match="pull requests are open"):
+        finalize_and_repin(
+            payload,
+            rulespec_root=rulespec,
+            pull_requests=_pr_history(
+                "ut-0001",
+                state="open",
+                merged=False,
+                payload=payload,
+            ),
+            workflow_runs=[],
+            new_rulespec_ref=new_ref,
+            reviewed_rulespec_refs=frozenset({("us", new_ref)}),
+            **_finalizer_evidence(),
+        )
+
+    with pytest.raises(ValueError, match="workflow runs are active"):
+        finalize_and_repin(
+            payload,
+            rulespec_root=rulespec,
+            pull_requests=[],
+            workflow_runs=_run_history(
+                "ut-0001",
+                status="in_progress",
+                conclusion=None,
+                payload=payload,
+            ),
+            new_rulespec_ref=new_ref,
+            reviewed_rulespec_refs=frozenset({("us", new_ref)}),
+            **_finalizer_evidence(),
+        )
+
+
+def test_finalize_repin_requires_reviewed_allowlisted_base(tmp_path: Path) -> None:
+    payload, rulespec, _, new_ref = _repin_fixture(tmp_path)
+    with pytest.raises(ValueError, match="reviewed and allowlisted"):
+        finalize_and_repin(
+            payload,
+            rulespec_root=rulespec,
+            pull_requests=[],
+            workflow_runs=[],
+            new_rulespec_ref=new_ref,
+            reviewed_rulespec_refs=frozenset(),
+            **_finalizer_evidence(),
+        )
+
+
+def test_finalize_repin_requires_green_rulespec_checks(tmp_path: Path) -> None:
+    payload, rulespec, _, new_ref = _repin_fixture(tmp_path)
+    evidence = _finalizer_evidence()
+    evidence["check_runs"][0]["check_runs"][0]["conclusion"] = "failure"
+    with pytest.raises(ValueError, match="green check runs"):
+        finalize_and_repin(
+            payload,
+            rulespec_root=rulespec,
+            pull_requests=[],
+            workflow_runs=[],
+            new_rulespec_ref=new_ref,
+            reviewed_rulespec_refs=frozenset({("us", new_ref)}),
+            **evidence,
+        )
+
+
+def test_finalize_repin_requires_paused_exact_remote_tip(tmp_path: Path) -> None:
+    payload, rulespec, old_ref, new_ref = _repin_fixture(tmp_path)
+    active = copy.deepcopy(payload)
+    active["state"] = "active"
+    active.pop("pause_reason", None)
+    active.pop("suspension", None)
+    active["activation"] = copy.deepcopy(_queue()["activation"])
+    active["activation"]["rulespec_ref"] = old_ref
+    with pytest.raises(ValueError, match="requires a paused queue"):
+        finalize_and_repin(
+            active,
+            rulespec_root=rulespec,
+            pull_requests=[],
+            workflow_runs=[],
+            new_rulespec_ref=new_ref,
+            reviewed_rulespec_refs=frozenset({("us", new_ref)}),
+            **_finalizer_evidence(),
+        )
+
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            rulespec,
+            "update-ref",
+            "refs/remotes/origin/hard-cut/canonical-layout-us",
+            old_ref,
+        ],
+        check=True,
+    )
+    with pytest.raises(ValueError, match="exact checked-out remote branch tip"):
+        finalize_and_repin(
+            payload,
+            rulespec_root=rulespec,
+            pull_requests=[],
+            workflow_runs=[],
+            new_rulespec_ref=new_ref,
+            reviewed_rulespec_refs=frozenset({("us", new_ref)}),
+            **_finalizer_evidence(),
+        )
+
+
+def test_finalize_repin_requires_failed_run_disposition(tmp_path: Path) -> None:
+    payload, rulespec, _, new_ref = _repin_fixture(tmp_path)
+    with pytest.raises(ValueError, match="dispositions are required"):
+        finalize_and_repin(
+            payload,
+            rulespec_root=rulespec,
+            pull_requests=[],
+            workflow_runs=_run_history(
+                "ut-0001",
+                status="completed",
+                conclusion="failure",
+                payload=payload,
+            ),
+            new_rulespec_ref=new_ref,
+            reviewed_rulespec_refs=frozenset({("us", new_ref)}),
+            **_finalizer_evidence(),
+        )
+
+
+def test_verify_corpus_provenance_rejects_wrong_head_and_checkout_dirt(
+    tmp_path: Path,
+) -> None:
+    release_name = "test-release"
+    release_dir = tmp_path / "manifests/releases"
+    release_dir.mkdir(parents=True)
+    provisions = tmp_path / "data/corpus/provisions"
+    source_paths = [
+        provisions / "us-or/manual/2026-07-16-or-programs-eligibility-notebook.jsonl",
+        provisions
+        / "us-ut/manual/2026-05-27-ut-manuals-r2026-07-15-self-contained.jsonl",
+        provisions / "us-ut/manual/2026-07-13-recovery.jsonl",
+    ]
+    for source_path in source_paths:
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        source_path.write_text("{}\n", encoding="utf-8")
+    release = {
+        "name": release_name,
+        "scopes": [
+            {
+                "document_class": "manual",
+                "jurisdiction": "us-or",
+                "version": "2026-07-16-or-programs-eligibility-notebook",
+            },
+            {
+                "document_class": "manual",
+                "jurisdiction": "us-ut",
+                "version": "2026-05-27-ut-manuals-r2026-07-15-self-contained",
+            },
+            {
+                "document_class": "manual",
+                "jurisdiction": "us-ut",
+                "version": "2026-07-13-recovery",
+            },
+        ],
+    }
+    manifest = release_dir / f"{release_name}.json"
+    manifest.write_text(json.dumps(release), encoding="utf-8")
+    subprocess.run(["git", "init", "-q", tmp_path], check=True)
+    subprocess.run(["git", "-C", tmp_path, "add", "."], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            tmp_path,
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-qm",
+            "fixture",
+        ],
+        check=True,
+    )
+    head = subprocess.check_output(
+        ["git", "-C", tmp_path, "rev-parse", "HEAD"],
+        text=True,
+    ).strip()
+
+    assert (
+        len(
+            _verify_corpus_provenance(
+                tmp_path,
+                corpus_ref=head,
+                release_name=release_name,
+                source_paths=source_paths,
+            )
+        )
+        == 64
+    )
+    with pytest.raises(ValueError, match="does not match"):
+        _verify_corpus_provenance(
+            tmp_path,
+            corpus_ref="a" * 40,
+            release_name=release_name,
+            source_paths=source_paths,
+        )
+
+    manifest.write_text(
+        json.dumps({**release, "description": "dirty"}), encoding="utf-8"
+    )
+    with pytest.raises(ValueError, match="not clean"):
+        _verify_corpus_provenance(
+            tmp_path,
+            corpus_ref=head,
+            release_name=release_name,
+            source_paths=source_paths,
+        )
+
+    manifest.write_text(
+        json.dumps({**release, "name": "wrong-release"}), encoding="utf-8"
+    )
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            tmp_path,
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-qam",
+            "wrong release",
+        ],
+        check=True,
+    )
+    wrong_release_head = subprocess.check_output(
+        ["git", "-C", tmp_path, "rev-parse", "HEAD"],
+        text=True,
+    ).strip()
+    with pytest.raises(ValueError, match="name does not match"):
+        _verify_corpus_provenance(
+            tmp_path,
+            corpus_ref=wrong_release_head,
+            release_name=release_name,
+            source_paths=source_paths,
+        )
+
+    missing_recovery = {
+        **release,
+        "scopes": [
+            scope
+            for scope in release["scopes"]
+            if scope["version"] != "2026-07-13-recovery"
+        ],
+    }
+    manifest.write_text(json.dumps(missing_recovery), encoding="utf-8")
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            tmp_path,
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-qam",
+            "missing recovery scope",
+        ],
+        check=True,
+    )
+    missing_scope_head = subprocess.check_output(
+        ["git", "-C", tmp_path, "rev-parse", "HEAD"],
+        text=True,
+    ).strip()
+    with pytest.raises(ValueError, match="2026-07-13-recovery"):
+        _verify_corpus_provenance(
+            tmp_path,
+            corpus_ref=missing_scope_head,
+            release_name=release_name,
+            source_paths=source_paths,
+        )
+
+
+def test_verify_signed_release_binding_authenticates_sources_and_toolchain(
+    tmp_path: Path,
+) -> None:
+    corpus = tmp_path / "corpus"
+    scopes = [
+        ("us-or", "manual", "or-manual"),
+        ("us-ut", "manual", "ut-manual"),
+        ("us-ut", "manual", "ut-recovery"),
+    ]
+    source_paths = []
+    for jurisdiction, document_class, version in scopes:
+        source_path = (
+            corpus
+            / "data/corpus/provisions"
+            / jurisdiction
+            / document_class
+            / f"{version}.jsonl"
+        )
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        source_path.write_text('{"citation_path":"fixture"}\n', encoding="utf-8")
+        source_paths.append(source_path)
+    subprocess.run(["git", "init", "-q", corpus], check=True)
+    subprocess.run(["git", "-C", corpus, "add", "."], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            corpus,
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-qm",
+            "corpus",
+        ],
+        check=True,
+    )
+    corpus_ref = subprocess.check_output(
+        ["git", "-C", corpus, "rev-parse", "HEAD"],
+        text=True,
+    ).strip()
+    release_name = "test-signed-release"
+    release_sha = write_test_release_object(
+        corpus,
+        release_name,
+        scopes,
+        git_commit=corpus_ref,
+    )
+    release_object = corpus / "releases" / release_name / f"{release_sha}.json"
+    public_key = tmp_path / "release-public-key"
+    public_key.write_text(TEST_RELEASE_PUBLIC_KEY + "\n", encoding="utf-8")
+
+    rulespec = tmp_path / "rulespec"
+    toolchain = rulespec / ".axiom/toolchain.toml"
+    toolchain.parent.mkdir(parents=True)
+    toolchain.write_text(
+        "[toolchain]\n"
+        f'axiom_corpus_release = "{release_name}"\n'
+        f'axiom_corpus_release_content_sha256 = "{release_sha}"\n',
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init", "-q", rulespec], check=True)
+    subprocess.run(["git", "-C", rulespec, "add", "."], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            rulespec,
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-qm",
+            "rulespec",
+        ],
+        check=True,
+    )
+    rulespec_ref = subprocess.check_output(
+        ["git", "-C", rulespec, "rev-parse", "HEAD"],
+        text=True,
+    ).strip()
+
+    _verify_signed_release_binding(
+        corpus,
+        rulespec,
+        corpus_ref=corpus_ref,
+        rulespec_ref=rulespec_ref,
+        release_name=release_name,
+        release_content_sha256=release_sha,
+        release_object_path=release_object,
+        release_public_key_path=public_key,
+        source_paths=source_paths,
+    )
+
+    source_paths[0].write_text('{"citation_path":"tampered"}\n', encoding="utf-8")
+    with pytest.raises(ValueError, match="differs from signed release"):
+        _verify_signed_release_binding(
+            corpus,
+            rulespec,
+            corpus_ref=corpus_ref,
+            rulespec_ref=rulespec_ref,
+            release_name=release_name,
+            release_content_sha256=release_sha,
+            release_object_path=release_object,
+            release_public_key_path=public_key,
+            source_paths=source_paths,
+        )
+
+
+def _tracked_dispatch_kwargs(path: Path) -> dict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    dispatch = payload["dispatch"]
+    selected = select_items(payload, item_ids="ut-0001", limit=1)["items"][0]
+    return {
+        "queue_id": payload["queue_id"],
+        "item_id": "ut-0001",
+        "manifest_sha256": queue_file_sha256(path),
+        "item_generation_sha256_value": selected["generation_sha256"],
+        "citation": payload["items"][0]["citation"],
+        "country": dispatch["country"],
+        "rulespec_ref": dispatch["rulespec_ref"],
+        "pr_base_branch": dispatch["pr_base_branch"],
+        "corpus_ref": dispatch["corpus_ref"],
+        "rules_engine_ref": dispatch["rules_engine_ref"],
+        "open_pr": dispatch["open_pr"],
+    }
+
+
+def test_validate_runtime_release_pin_matches_exact_queue(
+    tmp_path: Path,
+) -> None:
+    payload = _queue()
+    release = payload["release"]
+    toolchain = tmp_path / "toolchain.toml"
+    toolchain.write_text(
+        "[toolchain]\n"
+        f'axiom_corpus_release = "{release["name"]}"\n'
+        "axiom_corpus_release_content_sha256 = "
+        f'"{release["content_sha256"]}"\n',
+        encoding="utf-8",
+    )
+
+    validate_release_pin(
+        QUEUE_PATH,
+        toolchain_path=toolchain,
+        manifest_sha256=queue_file_sha256(QUEUE_PATH),
+    )
+
+    toolchain.write_text(
+        "[toolchain]\n"
+        'axiom_corpus_release = "stale-release"\n'
+        f'axiom_corpus_release_content_sha256 = "{"0" * 64}"\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="does not match"):
+        validate_release_pin(
+            QUEUE_PATH,
+            toolchain_path=toolchain,
+            manifest_sha256=queue_file_sha256(QUEUE_PATH),
+        )
+
+
+def test_validate_tracked_dispatch_binds_exact_manifest_item_and_refs(
+    tmp_path: Path,
+) -> None:
+    active_queue = tmp_path / "queue.json"
+    active_queue.write_text(
+        json.dumps(_queue(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    validate_tracked_dispatch(
+        active_queue,
+        **_tracked_dispatch_kwargs(active_queue),
+    )
+
+
+def test_validate_tracked_dispatch_rejects_paused_queue() -> None:
+    with pytest.raises(ValueError, match="paused"):
+        validate_tracked_dispatch(
+            QUEUE_PATH,
+            **_tracked_dispatch_kwargs(QUEUE_PATH),
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("manifest_sha256", "a" * 64, "digest"),
+        ("item_generation_sha256_value", "a" * 64, "generation"),
+        ("citation", "us-ut/manual/other", "citation"),
+        ("rulespec_ref", "a" * 40, "trust inputs"),
+        ("open_pr", False, "trust inputs"),
+    ],
+)
+def test_validate_tracked_dispatch_rejects_spoofed_provenance(
+    tmp_path: Path,
+    field: str,
+    value: str | bool,
+    message: str,
+) -> None:
+    active_queue = tmp_path / "queue.json"
+    active_queue.write_text(
+        json.dumps(_queue(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    kwargs = _tracked_dispatch_kwargs(active_queue)
+    kwargs[field] = value
+
+    with pytest.raises(ValueError, match=message):
+        validate_tracked_dispatch(active_queue, **kwargs)

--- a/tests/test_signed_snap_queue.py
+++ b/tests/test_signed_snap_queue.py
@@ -165,8 +165,7 @@ def test_paused_transition_rejects_manual_completion(tmp_path: Path) -> None:
         "target_run_head_sha": "f" * 40,
         "target_run_attempt": 1,
         "target_run_url": (
-            "https://github.com/TheAxiomFoundation/"
-            "axiom-encode/actions/runs/1"
+            "https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/1"
         ),
         "type": "merged-rulespec-pr",
         "url": "https://github.com/TheAxiomFoundation/rulespec-us/pull/1",
@@ -275,9 +274,7 @@ def test_terminal_snap_queue_dispositions_require_durable_evidence() -> None:
             _queue(),
             item_id="ut-0001",
             status="completed",
-            evidence_url=(
-                "https://github.com/TheAxiomFoundation/rulespec-us/pull/123"
-            ),
+            evidence_url=("https://github.com/TheAxiomFoundation/rulespec-us/pull/123"),
             note=None,
         )
 
@@ -636,9 +633,7 @@ def _target_evidence(payload: dict, rulespec: Path, item_id: str) -> dict:
     manifest_digest = hashlib.sha256(
         (rulespec / manifest_path).read_bytes()
     ).hexdigest()
-    run_url = (
-        "https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/1"
-    )
+    run_url = "https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/1"
     return {
         item_id: {
             "apply_manifests": {
@@ -666,9 +661,7 @@ def _target_evidence(payload: dict, rulespec: Path, item_id: str) -> dict:
                 "encoder_commit": "c" * 40,
                 "pr_base_branch": payload["dispatch"]["pr_base_branch"],
                 "queue_id": payload["queue_id"],
-                "queue_item_generation_sha256": item_generation_sha256(
-                    payload, item
-                ),
+                "queue_item_generation_sha256": item_generation_sha256(payload, item),
                 "queue_item_id": item_id,
                 "queue_manifest_sha256": dispatch_queue_sha256(payload),
                 "rulespec_base": payload["dispatch"]["rulespec_ref"],
@@ -705,9 +698,10 @@ def test_finalize_repin_activates_quiet_queue_and_records_merged_pr(
     payload, rulespec, _, new_ref = _repin_fixture(tmp_path)
     evidence = _finalizer_evidence()
     evidence["target_evidence"] = _target_evidence(payload, rulespec, "ut-0001")
-    assert evidence["target_evidence"]["ut-0001"]["metadata"][
-        "queue_manifest_sha256"
-    ] == payload["suspension"]["active_queue_sha256"]
+    assert (
+        evidence["target_evidence"]["ut-0001"]["metadata"]["queue_manifest_sha256"]
+        == payload["suspension"]["active_queue_sha256"]
+    )
     updated = finalize_and_repin(
         payload,
         rulespec_root=rulespec,
@@ -830,17 +824,16 @@ def test_finalization_plan_and_repin_require_exact_target_artifact(
                 "https://github.com/TheAxiomFoundation/rulespec-us/pull/1"
             ),
             "target_run_url": (
-                "https://github.com/TheAxiomFoundation/"
-                "axiom-encode/actions/runs/1"
+                "https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/1"
             ),
         }
     ]
 
     evidence = _finalizer_evidence()
     evidence["target_evidence"] = _target_evidence(payload, rulespec, "ut-0001")
-    evidence["target_evidence"]["ut-0001"]["apply_manifests"]["items"][0][
-        "sha256"
-    ] = "0" * 64
+    evidence["target_evidence"]["ut-0001"]["apply_manifests"]["items"][0]["sha256"] = (
+        "0" * 64
+    )
     with pytest.raises(
         ValueError,
         match="merged RuleSpec tree lacks the signed applied manifest",
@@ -878,8 +871,7 @@ def test_finalize_repin_revalidates_existing_completed_items(tmp_path: Path) -> 
         "target_run_head_sha": "c" * 40,
         "target_run_attempt": 1,
         "target_run_url": (
-            "https://github.com/TheAxiomFoundation/"
-            "axiom-encode/actions/runs/1"
+            "https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/1"
         ),
         "type": "merged-rulespec-pr",
         "url": "https://github.com/TheAxiomFoundation/rulespec-us/pull/1",
@@ -1137,8 +1129,7 @@ def test_verify_merge_authorization_rejects_direct_activation_merge(
     merge_commit = "b" * 40
     pr_head = "a" * 40
     run_url = (
-        "https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/"
-        f"{run_id}"
+        f"https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/{run_id}"
     )
     authorization = {
         "activation_pr_head_sha": pr_head,

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1862,8 +1862,9 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "prepare_signed_queue.py" in country_step["run"]
     assert "validate-dispatch" in country_step["run"]
     assert "QUEUE_DISPATCHER_RUN_ID" in country_step["env"]
-    assert "queue target must be created by an authenticated dispatcher" in (
-        country_step["run"]
+    assert (
+        "queue target must be created by an authenticated dispatcher"
+        in (country_step["run"])
     )
     assert 'GITHUB_RUN_ATTEMPT" != "1"' in country_step["run"]
     assert "dispatch-signed-snap-queue.yml" in country_step["run"]
@@ -1871,9 +1872,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "jobs?filter=all&per_page=100" in country_step["run"]
     assert "Dispatch protected SNAP queue" in country_step["run"]
     assert '.conclusion == "skipped"' in country_step["run"]
-    assert "snap-queue-reconciliation-$QUEUE_DISPATCHER_RUN_ID" in (
-        country_step["run"]
-    )
+    assert "snap-queue-reconciliation-$QUEUE_DISPATCHER_RUN_ID" in (country_step["run"])
     assert "snap-queue-plan.json" in country_step["run"]
     assert "dispatched-run-records.jsonl" in country_step["run"]
     assert "workflow_run_id == $run_id" in country_step["run"]
@@ -2325,9 +2324,7 @@ def test_snap_queue_activation_checks_and_merge_revalidate_live_state() -> None:
         step["if"] == "${{ steps.transition.outputs.initial == 'true' }}"
         for step in initial_checkouts
     )
-    assert {
-        step["with"]["repository"] for step in initial_checkouts
-    } == {
+    assert {step["with"]["repository"] for step in initial_checkouts} == {
         "TheAxiomFoundation/axiom-corpus",
         "TheAxiomFoundation/rulespec-us",
         "TheAxiomFoundation/axiom-rules-engine",
@@ -2338,9 +2335,10 @@ def test_snap_queue_activation_checks_and_merge_revalidate_live_state() -> None:
         if step.get("name") == "Regenerate and authenticate initial queue"
     )
     provenance_command = provenance["run"]
-    assert "AXIOM_CORPUS_RELEASE_PUBLIC_KEY" in provenance["env"][
-        "CORPUS_RELEASE_PUBLIC_KEY"
-    ]
+    assert (
+        "AXIOM_CORPUS_RELEASE_PUBLIC_KEY"
+        in provenance["env"]["CORPUS_RELEASE_PUBLIC_KEY"]
+    )
     assert "release_objects?select=release_object" in provenance_command
     assert "build-snap initial-axiom-corpus initial-rulespec-us" in provenance_command
     assert "--state paused" in provenance_command
@@ -2368,8 +2366,7 @@ def test_snap_queue_activation_checks_and_merge_revalidate_live_state() -> None:
     command = next(
         step["run"]
         for step in steps
-        if step.get("name")
-        == "Revalidate evidence and merge against live RuleSpec tip"
+        if step.get("name") == "Revalidate evidence and merge against live RuleSpec tip"
     )
     assert "--require-success true" in command
     assert "verify-activation-commit" in command
@@ -2390,7 +2387,9 @@ def test_snap_queue_activation_checks_and_merge_revalidate_live_state() -> None:
         for step in steps
         if step.get("name") == "Upload trusted queue merge authorization"
     )
-    assert "snap-queue-merge-authorization-${{ github.run_id }}" == upload["with"]["name"]
+    assert (
+        "snap-queue-merge-authorization-${{ github.run_id }}" == upload["with"]["name"]
+    )
     assert upload["with"]["retention-days"] == 90
 
 
@@ -2504,7 +2503,7 @@ def test_targeted_artifact_packages_signed_review_context(tmp_path: Path) -> Non
     marker = (
         "python - \\\n"
         '  "$artifact/context-manifest.json" \\\n'
-        '  "$artifact/apply-manifests.json" <<\'PY\'\n'
+        "  \"$artifact/apply-manifests.json\" <<'PY'\n"
     )
     script = package_command.split(marker, 1)[1].split(
         '\nPY\npython - "$artifact/metadata.json"', 1
@@ -2625,7 +2624,7 @@ def test_targeted_artifact_enforces_target_and_dependent_context_lanes(
     marker = (
         "python - \\\n"
         '  "$artifact/context-manifest.json" \\\n'
-        '  "$artifact/apply-manifests.json" <<\'PY\'\n'
+        "  \"$artifact/apply-manifests.json\" <<'PY'\n"
     )
     script = package_command.split(marker, 1)[1].split(
         '\nPY\npython - "$artifact/metadata.json"', 1

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1820,7 +1820,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     )
     trigger = workflow.get("on", workflow.get(True))
     assert set(trigger) == {"workflow_dispatch"}
-    assert workflow["permissions"] == {"contents": "read"}
+    assert workflow["permissions"] == {"actions": "read", "contents": "read"}
     inputs = trigger["workflow_dispatch"]["inputs"]
     assert "allowlisted reviewed SHA" in inputs["rulespec_ref"]["description"]
     assert "artifact-only" in inputs["rulespec_ref"]["description"]
@@ -1836,16 +1836,51 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert inputs["pr_base_branch"]["default"] == "main"
     assert inputs["dependent_citation"]["required"] is False
     assert inputs["dependent_review_finding"]["required"] is False
+    assert inputs["queue_id"]["required"] is False
+    assert inputs["queue_item_id"]["required"] is False
+    assert inputs["queue_manifest_sha256"]["required"] is False
+    assert inputs["queue_item_generation_sha256"]["required"] is False
+    assert inputs["queue_dispatcher_run_id"]["required"] is False
+    assert "[${{ inputs.queue_id || 'adhoc' }}:" in workflow["run-name"]
 
     job = workflow["jobs"]["encode"]
+    assert job["name"] == "Queue protected signed RuleSpec re-encode"
     assert job["environment"] == "production-signing"
     assert "github.ref == 'refs/heads/main'" in job["if"]
+    assert "github.actor == 'github-actions[bot]'" in job["if"]
+    assert "github.run_attempt == 1" in job["if"]
     steps = job["steps"]
     country_step = next(
         step for step in steps if step.get("name") == "Validate country routing input"
     )
     assert "prepare_signed_backfill.py" in country_step["run"]
     assert 'validate-country "$COUNTRY"' in country_step["run"]
+    assert "validate-queue-tracking" in country_step["run"]
+    assert '"$QUEUE_ID" "$QUEUE_ITEM_ID"' in country_step["run"]
+    assert '"$QUEUE_MANIFEST_SHA256"' in country_step["run"]
+    assert '"$QUEUE_ITEM_GENERATION_SHA256"' in country_step["run"]
+    assert "prepare_signed_queue.py" in country_step["run"]
+    assert "validate-dispatch" in country_step["run"]
+    assert "QUEUE_DISPATCHER_RUN_ID" in country_step["env"]
+    assert "queue target must be created by an authenticated dispatcher" in (
+        country_step["run"]
+    )
+    assert 'GITHUB_RUN_ATTEMPT" != "1"' in country_step["run"]
+    assert "dispatch-signed-snap-queue.yml" in country_step["run"]
+    assert ".run_attempt >= 1" in country_step["run"]
+    assert "jobs?filter=all&per_page=100" in country_step["run"]
+    assert "Dispatch protected SNAP queue" in country_step["run"]
+    assert '.conclusion == "skipped"' in country_step["run"]
+    assert "snap-queue-reconciliation-$QUEUE_DISPATCHER_RUN_ID" in (
+        country_step["run"]
+    )
+    assert "snap-queue-plan.json" in country_step["run"]
+    assert "dispatched-run-records.jsonl" in country_step["run"]
+    assert "workflow_run_id == $run_id" in country_step["run"]
+    assert "workflow_run_attempt == 1" in country_step["run"]
+    assert (
+        '"axiom-encode/data/encoding-queues/${QUEUE_ID}.json"' in (country_step["run"])
+    )
     assert steps.index(country_step) < next(
         index
         for index, step in enumerate(steps)
@@ -1884,11 +1919,15 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         "SUPABASE_URL": "https://swocpijqqahhuwtuahwc.supabase.co",
         "SUPABASE_ANON_KEY": "${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY }}",
         "RULESPEC_CHECKOUT": "rulespec-${{ inputs.country }}",
+        "QUEUE_ID": "${{ inputs.queue_id }}",
+        "QUEUE_MANIFEST_SHA256": "${{ inputs.queue_manifest_sha256 }}",
     }
     release_command = release_step["run"]
     assert "materialize_corpus_release.py" in release_command
     assert "$RULESPEC_CHECKOUT/.axiom/toolchain.toml" in release_command
     assert 'pin --toolchain "$toolchain"' in release_command
+    assert "validate-release-pin" in release_command
+    assert '--manifest-sha256 "$QUEUE_MANIFEST_SHA256"' in release_command
     assert 'mktemp "$RUNNER_TEMP/' in release_command
     assert "/rest/v1/release_objects?select=release_object" in release_command
     assert "content_sha256=eq.${release_sha}&limit=2" in release_command
@@ -1998,6 +2037,15 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert 'finding.get("sha256")' in package_command
     assert '"dependent-context-manifest.json"' in package_command
     assert '"pr_base_branch": os.environ["PR_BASE_BRANCH"]' in package_command
+    assert '"queue_id": os.environ.get("QUEUE_ID") or None' in package_command
+    assert '"queue_item_id": os.environ.get("QUEUE_ITEM_ID") or None' in (
+        package_command
+    )
+    assert '"queue_item_generation_sha256": (' in package_command
+    assert '"queue_manifest_sha256": (' in package_command
+    assert '"workflow_run_attempt": int(os.environ["GITHUB_RUN_ATTEMPT"])' in (
+        package_command
+    )
 
     guard_step = next(
         step for step in steps if step.get("name") == "Verify generated provenance"
@@ -2032,6 +2080,9 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "gh api --method POST" in publish_command
     assert '-f base="$PR_BASE_BRANCH"' in publish_command
     assert "-F draft=true" in publish_command
+    assert "Queue item:" in publish_command
+    assert "Queue generation SHA-256:" in publish_command
+    assert "Queue manifest SHA-256:" in publish_command
     assert "'.base.ref == $branch and .base.sha == $sha'" in publish_command
     assert "pulls/${pr_number}" in publish_command
     assert "-f state=closed" in publish_command
@@ -2056,6 +2107,291 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         step for step in steps if step.get("name") == "Upload signed re-encode artifact"
     )
     assert steps.index(checksum_step) + 1 == steps.index(upload_step)
+
+
+def test_signed_snap_queue_dispatcher_is_bounded_and_idempotent() -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/dispatch-signed-snap-queue.yml").read_text()
+    )
+    trigger = workflow.get("on", workflow.get(True))
+    assert set(trigger) == {"workflow_dispatch"}
+    inputs = trigger["workflow_dispatch"]["inputs"]
+    assert inputs["dispatch"]["type"] == "boolean"
+    assert inputs["dispatch"]["default"] is False
+    assert inputs["limit"]["options"] == ["1", "2", "3", "4"]
+    assert workflow["permissions"] == {
+        "actions": "write",
+        "contents": "read",
+        "issues": "write",
+    }
+    assert workflow["concurrency"] == {
+        "group": "dispatch-signed-snap-queue",
+        "cancel-in-progress": False,
+    }
+
+    job = workflow["jobs"]["dispatch"]
+    assert job["name"] == "Dispatch protected SNAP queue"
+    assert "github.ref == 'refs/heads/main'" in job["if"]
+    assert "github.run_attempt == 1" in job["if"]
+    assert "environment" not in job
+    steps = job["steps"]
+    checkout = steps[0]
+    assert checkout["with"]["persist-credentials"] is False
+    assert checkout["with"]["fetch-depth"] == 0
+
+    selection = next(
+        step
+        for step in steps
+        if step.get("name") == "Select and validate bounded queue tranche"
+    )
+    selection_command = selection["run"]
+    assert 'test "$(git rev-parse HEAD)" = "$GITHUB_SHA"' in selection_command
+    assert "prepare_signed_queue.py validate" in selection_command
+    assert "activation_merge_run_id" in inputs
+    assert "verify-merge-authorization" in selection_command
+    assert '--merge-jobs "$RUNNER_TEMP/activation-merge-jobs.json"' in (
+        selection_command
+    )
+    assert "snap-queue-merge-authorization-$ACTIVATION_MERGE_RUN_ID" in (
+        selection_command
+    )
+    assert "git log --first-parent" in selection_command
+    assert "commits/$rulespec_ref/check-runs?per_page=100" in selection_command
+    assert "prepare_signed_queue.py select" in selection_command
+    assert '--item-ids "$ITEM_IDS" --limit "$LIMIT"' in selection_command
+    assert "prepare_signed_queue.py candidates" in selection_command
+    assert 'if [ -n "$ITEM_IDS" ]' not in selection_command
+    assert "prepare_signed_queue.py sha256" in selection_command
+
+    dispatch = next(
+        step
+        for step in steps
+        if step.get("name") == "Plan or dispatch idempotent protected runs"
+    )
+    assert "if" not in dispatch
+    assert dispatch["env"]["DO_DISPATCH"] == "${{ inputs.dispatch }}"
+    assert dispatch["env"]["GH_TOKEN"] == "${{ github.token }}"
+    command = dispatch["run"]
+    assert "rulespec-us/pulls?state=all" in command
+    assert "prepare_signed_queue.py reconcile" in command
+    assert "retry_failed" not in inputs
+    assert "--retry-failed" not in command
+    assert "snap-queue-reconciled.json" in command
+    assert "the current tranche must be finalized" in command
+    assert "any(.items[]; .dispatchable == false)" in command
+    assert "targeted-signed-reencode.yml/dispatches" not in command
+    assert "actions/workflows/$workflow/dispatches" in command
+    assert 'ref: "main"' in command
+    assert 'open_pr: "true"' in command
+    assert "queue_item_generation_sha256" in command
+    assert "queue_manifest_sha256" in command
+    assert "queue_dispatcher_run_id: $dispatcher_run_id" in command
+    assert command.index(
+        'queue_id="$(jq -r \'.queue_id\' "$candidates")"'
+    ) < command.index('> "$selection"')
+    assert 'if [ "$selected_count" -ge "$LIMIT" ]' in command
+    assert "signed-encoding-queue-plan/v1" in command
+    assert 'if [ "$DO_DISPATCH" = "true" ]' in command
+    assert "X-GitHub-Api-Version: 2026-03-10" in command
+    assert "workflow_run_id" in command
+    assert "workflow_run_attempt: 1" in command
+    assert "dispatched-run-records.jsonl" in command
+    assert "sleep 5" not in command
+    assert 'gh issue comment "$issue"' in command
+
+    upload = next(
+        step
+        for step in steps
+        if step.get("name") == "Upload queue reconciliation record"
+    )
+    assert upload["with"]["retention-days"] == 90
+    assert upload["with"]["if-no-files-found"] == "warn"
+    assert "snap-queue-seed.json" in upload["with"]["path"]
+    assert "snap-queue-reconciled.json" in upload["with"]["path"]
+    assert "snap-queue-plan.json" in upload["with"]["path"]
+    assert "dispatched-run-records.jsonl" in upload["with"]["path"]
+
+
+def test_signed_snap_queue_finalizer_uses_live_fail_closed_evidence() -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/finalize-signed-snap-queue.yml").read_text()
+    )
+    trigger = workflow.get("on", workflow.get(True))
+    assert set(trigger) == {"workflow_dispatch"}
+    assert workflow["permissions"] == {
+        "actions": "read",
+        "contents": "write",
+        "pull-requests": "write",
+    }
+    assert workflow["concurrency"] == {
+        "group": "finalize-signed-snap-queue",
+        "cancel-in-progress": False,
+    }
+    job = workflow["jobs"]["finalize"]
+    assert job["name"] == "Finalize protected SNAP queue tranche"
+    assert "github.run_attempt == 1" in job["if"]
+    assert "github.ref == 'refs/heads/main'" in job["if"]
+    steps = job["steps"]
+    checkouts = [
+        step for step in steps if step.get("uses", "").startswith("actions/checkout@")
+    ]
+    assert len(checkouts) == 2
+    assert all(step["with"]["persist-credentials"] is False for step in checkouts)
+    assert all(step["with"]["fetch-depth"] == 0 for step in checkouts)
+
+    evidence = next(
+        step for step in steps if step.get("name") == "Fetch live finalization evidence"
+    )
+    command = evidence["run"]
+    assert 'test "$(jq -r \'.state\' "$queue")" = "paused"' in command
+    assert "git/ref/heads/hard-cut/canonical-layout-us" in command
+    assert "commits/$NEW_RULESPEC_REF/check-runs?per_page=100" in command
+    assert '.status == "completed"' in command
+    assert 'IN("success", "neutral", "skipped")' in command
+    assert "rulespec-us/pulls?state=all" in command
+    assert "targeted-signed-reencode.yml/runs" in command
+    assert "finalize-repin" in command
+    assert "finalization-target-plan" in command
+    assert "targeted-reencode-$run_id" in command
+    assert "jobs?filter=all&per_page=100" in command
+    assert "--slurpfile jobs" in command
+    assert "sha256sum -c SHA256SUMS" in command
+    assert '--target-evidence "$RUNNER_TEMP/target-evidence.json"' in command
+    assert '"$queue" rulespec-us' in command
+    assert '--check-runs "$RUNNER_TEMP/rulespec-check-runs.json"' in command
+    assert '--finalizer-head-sha "$GITHUB_SHA"' in command
+    assert "--finalizer-run-url" in command
+    assert command.count("\"$branch_ref\" --jq '.object.sha'") == 2
+
+    activation = next(
+        step
+        for step in steps
+        if step.get("name") == "Create exact queue activation commit"
+    )
+    activation_command = activation["run"]
+    assert "uv version --bump patch" in activation_command
+    assert "uv lock --offline" in activation_command
+    assert 'test "$(git rev-parse refs/remotes/origin/main)" = "$GITHUB_SHA"' in (
+        activation_command
+    )
+    assert "activation-commit.json" in activation_command
+    assert "activation-changed-files.json" in activation_command
+    assert "HEAD^{tree}" in activation_command
+    upload = next(
+        step for step in steps if step.get("name") == "Upload finalization evidence"
+    )
+    assert "activation-commit.json" in upload["with"]["path"]
+    assert steps.index(activation) < steps.index(upload)
+
+    publish = next(
+        step
+        for step in steps
+        if step.get("name") == "Open reviewed queue activation pull request"
+    )
+    publish_command = publish["run"]
+    assert "gh api --method POST" in publish_command
+    assert "-F draft=true" in publish_command
+    assert "required independent review-fix cycle" in publish_command
+    assert steps.index(upload) < steps.index(publish)
+
+
+def test_snap_queue_activation_checks_and_merge_revalidate_live_state() -> None:
+    validate = yaml.safe_load(
+        (ROOT / ".github/workflows/validate-snap-queue-activation.yml").read_text()
+    )
+    trigger = validate.get("on", validate.get(True))
+    assert set(trigger) == {"pull_request"}
+    assert validate["permissions"] == {"actions": "read", "contents": "read"}
+    validate_command = validate["jobs"]["validate"]["steps"][1]["run"]
+    assert "verify-activation" in validate_command
+    assert "verify-paused-transition" in validate_command
+    assert '--previous-queue "$previous_queue"' in validate_command
+    assert '--expected-base-sha "$BASE_SHA"' in validate_command
+    assert "--require-success false" in validate_command
+    assert "verify-activation-commit" in validate_command
+    assert '--finalizer-jobs "$RUNNER_TEMP/finalizer-jobs.json"' in validate_command
+    assert "snap-queue-finalization-$run_id" in validate_command
+    assert "git/ref/heads/hard-cut/canonical-layout-us" in validate_command
+    assert 'echo "initial=$initial" >> "$GITHUB_OUTPUT"' in validate_command
+
+    steps = validate["jobs"]["validate"]["steps"]
+    initial_checkouts = [
+        step
+        for step in steps
+        if step.get("name", "").startswith("Checkout exact queue")
+    ]
+    assert len(initial_checkouts) == 3
+    assert all(
+        step["if"] == "${{ steps.transition.outputs.initial == 'true' }}"
+        for step in initial_checkouts
+    )
+    assert {
+        step["with"]["repository"] for step in initial_checkouts
+    } == {
+        "TheAxiomFoundation/axiom-corpus",
+        "TheAxiomFoundation/rulespec-us",
+        "TheAxiomFoundation/axiom-rules-engine",
+    }
+    provenance = next(
+        step
+        for step in steps
+        if step.get("name") == "Regenerate and authenticate initial queue"
+    )
+    provenance_command = provenance["run"]
+    assert "AXIOM_CORPUS_RELEASE_PUBLIC_KEY" in provenance["env"][
+        "CORPUS_RELEASE_PUBLIC_KEY"
+    ]
+    assert "release_objects?select=release_object" in provenance_command
+    assert "build-snap initial-axiom-corpus initial-rulespec-us" in provenance_command
+    assert "--state paused" in provenance_command
+    assert "cmp --silent" in provenance_command
+
+    merge = yaml.safe_load(
+        (ROOT / ".github/workflows/merge-snap-queue-activation.yml").read_text()
+    )
+    trigger = merge.get("on", merge.get(True))
+    assert set(trigger) == {"workflow_dispatch"}
+    assert merge["permissions"] == {
+        "actions": "read",
+        "contents": "write",
+        "pull-requests": "write",
+    }
+    assert "github.ref == 'refs/heads/main'" in merge["jobs"]["merge"]["if"]
+    assert "github.run_attempt == 1" in merge["jobs"]["merge"]["if"]
+    assert merge["jobs"]["merge"]["name"] == "Merge reviewed SNAP queue activation"
+    steps = merge["jobs"]["merge"]["steps"]
+    checkout = next(
+        step for step in steps if step.get("uses", "").startswith("actions/checkout@")
+    )
+    assert checkout["with"]["ref"] == "${{ steps.pull.outputs.base_sha }}"
+    assert checkout["with"]["persist-credentials"] is False
+    command = next(
+        step["run"]
+        for step in steps
+        if step.get("name")
+        == "Revalidate evidence and merge against live RuleSpec tip"
+    )
+    assert "--require-success true" in command
+    assert "verify-activation-commit" in command
+    assert 'test "$(git rev-parse HEAD)" = "$BASE_SHA"' in command
+    assert 'git fetch --no-tags origin "$HEAD_SHA"' in command
+    assert "--current-changed-files" in command
+    assert '--finalizer-jobs "$RUNNER_TEMP/finalizer-jobs.json"' in command
+    assert "merge_workflow_run_attempt: 1" in command
+    assert "commits/$HEAD_SHA/check-runs?per_page=100" in command
+    assert "commits/$rulespec_ref/check-runs?per_page=100" in command
+    assert '--previous-queue "$RUNNER_TEMP/previous-snap-queue.json"' in command
+    assert '--expected-base-sha "$BASE_SHA"' in command
+    assert "git/ref/heads/hard-cut/canonical-layout-us" in command
+    assert '--match-head-commit "$HEAD_SHA"' in command
+    assert "git log --first-parent" in command
+    upload = next(
+        step
+        for step in steps
+        if step.get("name") == "Upload trusted queue merge authorization"
+    )
+    assert "snap-queue-merge-authorization-${{ github.run_id }}" == upload["with"]["name"]
+    assert upload["with"]["retention-days"] == 90
 
 
 def test_targeted_signed_reencode_orders_target_and_dependent(tmp_path: Path) -> None:
@@ -2165,7 +2501,11 @@ def test_targeted_artifact_packages_signed_review_context(tmp_path: Path) -> Non
         for step in workflow["jobs"]["encode"]["steps"]
         if step.get("name") == "Package exact generated changes"
     )["run"]
-    marker = "python - \"$artifact/context-manifest.json\" <<'PY'\n"
+    marker = (
+        "python - \\\n"
+        '  "$artifact/context-manifest.json" \\\n'
+        '  "$artifact/apply-manifests.json" <<\'PY\'\n'
+    )
     script = package_command.split(marker, 1)[1].split(
         '\nPY\npython - "$artifact/metadata.json"', 1
     )[0]
@@ -2212,9 +2552,10 @@ def test_targeted_artifact_packages_signed_review_context(tmp_path: Path) -> Non
     applied_path.write_text(json.dumps(applied_manifest))
 
     packaged_context = tmp_path / "artifact" / "context-manifest.json"
+    packaged_inventory = tmp_path / "artifact" / "apply-manifests.json"
     packaged_context.parent.mkdir()
     completed = subprocess.run(
-        [sys.executable, "-", str(packaged_context)],
+        [sys.executable, "-", str(packaged_context), str(packaged_inventory)],
         cwd=tmp_path,
         input=script,
         check=False,
@@ -2231,6 +2572,15 @@ def test_targeted_artifact_packages_signed_review_context(tmp_path: Path) -> Non
 
     assert completed.returncode == 0, completed.stderr
     assert packaged_context.read_bytes() == context_bytes
+    inventory = json.loads(packaged_inventory.read_text())
+    assert inventory["schema"] == "axiom-encode/applied-manifest-inventory/v1"
+    assert inventory["items"] == [
+        {
+            "citation": citation,
+            "path": applied_path.relative_to(rulespec).as_posix(),
+            "sha256": hashlib.sha256(applied_path.read_bytes()).hexdigest(),
+        }
+    ]
 
 
 @pytest.mark.parametrize(
@@ -2272,7 +2622,11 @@ def test_targeted_artifact_enforces_target_and_dependent_context_lanes(
         for step in workflow["jobs"]["encode"]["steps"]
         if step.get("name") == "Package exact generated changes"
     )["run"]
-    marker = "python - \"$artifact/context-manifest.json\" <<'PY'\n"
+    marker = (
+        "python - \\\n"
+        '  "$artifact/context-manifest.json" \\\n'
+        '  "$artifact/apply-manifests.json" <<\'PY\'\n'
+    )
     script = package_command.split(marker, 1)[1].split(
         '\nPY\npython - "$artifact/metadata.json"', 1
     )[0]
@@ -2353,8 +2707,9 @@ def test_targeted_artifact_enforces_target_and_dependent_context_lanes(
     artifact = tmp_path / "artifact"
     artifact.mkdir()
     packaged_target = artifact / "context-manifest.json"
+    packaged_inventory = artifact / "apply-manifests.json"
     completed = subprocess.run(
-        [sys.executable, "-", str(packaged_target)],
+        [sys.executable, "-", str(packaged_target), str(packaged_inventory)],
         cwd=tmp_path,
         input=script,
         check=False,


### PR DESCRIPTION
## Summary

- add an exact, paused 831-source-unit SNAP queue for Oregon (530) and Utah (301) from corpus release `us-rulespec-2026-07-24-snap-cms-pit-union`
- add protected finalization, activation validation/merge, and bounded dispatch workflows with attempt-one and immutable-evidence enforcement
- harden targeted signed re-encoding and backfill evidence verification against reruns, amended commits, raw-byte digest mismatches, and PR-controlled verification

Closes #1257.

## Provenance

- corpus release commit: `0fd35bfb`
- corpus release tag commit: `cb275c76`
- RuleSpec corpus pin: TheAxiomFoundation/rulespec#1051
- queue starts paused; no source unit can dispatch before protected finalization and exact activation merge

## Review cycle

Independent review/fix cycles covered queue persistence, retry semantics, activation authorization, attempt binding, byte-exact digests, immutable finalizer evidence, and trusted-base activation verification. Final independent review reported no actionable findings after the fixes.

## Validation

- `uv run --active ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run --active pytest` (`4864 passed, 119 skipped`)
- all 79 workflow Bash `run:` blocks parsed with `bash -n`
- `git diff origin/main --check`