### PR TITLE
Pin Kansas income-tax oracle mappings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1353"
+version = "0.2.1354"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@06945b5d06435fe79234a38a0ee980dd3acea173",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@7f1741128bd3a7c06c305061644fa5e0f0f9c1a1",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1353"
+__version__ = "0.2.1354"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1353"
+version = "0.2.1354"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=06945b5d06435fe79234a38a0ee980dd3acea173" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=7f1741128bd3a7c06c305061644fa5e0f0f9c1a1" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=06945b5d06435fe79234a38a0ee980dd3acea173#06945b5d06435fe79234a38a0ee980dd3acea173" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=7f1741128bd3a7c06c305061644fa5e0f0f9c1a1#7f1741128bd3a7c06c305061644fa5e0f0f9c1a1" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- bump axiom-encode from 0.2.1353 to 0.2.1354
- advance the axiom-oracles dependency from 06945b5d to merged Kansas oracle SHA 7f174112
- refresh uv.lock with no dependency drift beyond the intended version and oracle revision

## Validation

- Ruff: passed
- compileall: passed
- full pytest: 4864 passed, 119 skipped
- uv lock --check: passed
- exact three-file scope and diff check: passed
- credential-shape scan: clean

## Review cycle

Independent read-only review of exact head 140e0a24 over exact main 079abbff was CLEAN with no actionable findings. It verified version/pin consistency, lock integrity, oracle reachability, secret safety, and that the protected pinned encoder checkout remains untouched at 3869d66d.