### PR TITLE
Pin Alaska income-tax oracle mappings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1369"
+version = "0.2.1370"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@7f1741128bd3a7c06c305061644fa5e0f0f9c1a1",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@6f4a48a8859917cf7e0a880489858e41855a77d9",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1369"
+__version__ = "0.2.1370"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1369"
+version = "0.2.1370"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=7f1741128bd3a7c06c305061644fa5e0f0f9c1a1" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=6f4a48a8859917cf7e0a880489858e41855a77d9" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=7f1741128bd3a7c06c305061644fa5e0f0f9c1a1#7f1741128bd3a7c06c305061644fa5e0f0f9c1a1" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=6f4a48a8859917cf7e0a880489858e41855a77d9#6f4a48a8859917cf7e0a880489858e41855a77d9" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary
- bump axiom-encode from 0.2.1369 to 0.2.1370
- pin axiom-oracles to merged Alaska mapping commit `6f4a48a8859917cf7e0a880489858e41855a77d9`
- refresh the lockfile without unrelated dependency drift

This unblocks the RuleSpec changed-file oracle coverage gate for the 21 Alaska TY2026 resident income-tax outputs.

## Validation
- `uv lock --check`
- frozen sync and installed VCS `direct_url.json` commit verified exact
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- focused classifier/coverage: 504 passed, 992 deselected
- full suite: 4994 passed, 119 skipped

## Review cycle
Independent review CLEAN at exact head `fd4e4f506875b08acdda4c6b483362f02d2212fc`; exact three-file delta, version/pin/lock provenance and secret scan verified.