### PR TITLE
Accept complete legal numeric proof spans

### DIFF
--- a/changelog.d/proof-legal-numeric-spans.fixed.md
+++ b/changelog.d/proof-legal-numeric-spans.fixed.md
@@ -1,0 +1,1 @@
+Allow complete parenthesized effective dates and comma-delimited legal citations as proof evidence without weakening partial numeric-token checks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1371"
+version = "0.2.1372"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1370"
+version = "0.2.1371"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1370"
+__version__ = "0.2.1371"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1371"
+__version__ = "0.2.1372"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/proof_validator.py
+++ b/src/axiom_encode/harness/proof_validator.py
@@ -719,7 +719,7 @@ def _left_context_continues_numeric_token(before: str) -> bool:
     if not connectors or not left or not left[-1].isdecimal():
         return False
     return bool(
-        not separated_from_evidence
+        (not separated_from_evidence and not connector_preceded_by_space)
         or any(_is_spaced_numeric_connector(character) for character in connectors)
         or (
             connector_preceded_by_space
@@ -743,7 +743,7 @@ def _right_context_continues_numeric_token(after: str) -> bool:
     if not connectors or not right or not right[0].isdecimal():
         return False
     return bool(
-        not separated_from_evidence
+        (not separated_from_evidence and not connector_followed_by_space)
         or any(_is_spaced_numeric_connector(character) for character in connectors)
         or (
             connector_followed_by_space
@@ -761,12 +761,27 @@ def _span_omits_accounting_parentheses(
     before: str,
     after: str,
 ) -> bool:
+    if _is_numeric_date_label(evidence_text):
+        return False
     left = before.rstrip()
     while left and _is_currency_marker(left[-1]):
         left = left[:-1].rstrip()
     omitted_closing = after.lstrip().startswith(")")
     carried_closing = evidence_text.rstrip().endswith(")")
     return bool(left.endswith("(") and (omitted_closing or carried_closing))
+
+
+def _is_numeric_date_label(text: str) -> bool:
+    """Recognize a complete date-only legal effective-period label."""
+
+    date = r"\d{1,4}/\d{1,2}/\d{1,4}"
+    return bool(
+        re.fullmatch(
+            rf"\s*{date}(?:\s*(?:-|[\u2010-\u2015]|to)\s*{date})?\s*",
+            text,
+            flags=re.IGNORECASE,
+        )
+    )
 
 
 def _span_omits_trailing_accounting_sign(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -9569,6 +9569,17 @@ def test_rulespec_proof_validator_ignores_source_line_wrapping():
         ("The official amount is 50‐.", "50", "50"),
         ("The official amount is 50\u200b-.", "50", "50"),
         ("The official amount is ١50 dollars.", "50 dollars", "50"),
+        (
+            "The official amount is ($50 dollars effective 01/01/19).",
+            "50 dollars effective 01/01/19",
+            "50",
+        ),
+        (
+            "The official amount is 100/50 dollars effective 01/01/19.",
+            "50 dollars effective 01/01/19",
+            "50",
+        ),
+        ("The official amount is 100/01/01/19.", "01/01/19", "2019"),
     ],
 )
 def test_rulespec_proof_validator_rejects_partial_numeric_evidence(
@@ -9633,6 +9644,57 @@ def test_rulespec_proof_validator_accepts_complete_connected_numeric_evidence(
     result = validate_rulespec_proofs(
         content,
         source_texts={"us/guidance/example/page-1": evidence},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+@pytest.mark.parametrize(
+    "evidence",
+    [
+        "01/01/19 - 12/31/19",
+        "10/01/10 \u201312/31/10",
+        "12/01/15 \u201301/31/16",
+    ],
+)
+def test_rulespec_proof_validator_accepts_parenthesized_effective_dates(
+    evidence: str,
+):
+    content = (
+        _corpus_checked_proof_content()
+        .replace("The official amount is $298.", repr(evidence))
+        .replace("$298", repr(evidence))
+        .replace("formula: '298'", "formula: '2019'")
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={
+            "us/guidance/example/page-1": f"REVISION 47 ({evidence})"
+        },
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_accepts_complete_numeric_legal_citation():
+    evidence = "through the application of sections 457.10"
+    content = (
+        _corpus_checked_proof_content()
+        .replace("The official amount is $298.", repr(evidence))
+        .replace("$298", repr(evidence))
+        .replace("formula: '298'", "formula: '457'")
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={
+            "us/guidance/example/page-1": (
+                f"{evidence}, 457.350(b)(2), 457.622(c)(5), and 457.626(a)(3)"
+            )
+        },
     )
 
     assert result.passed is True

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -9670,9 +9670,7 @@ def test_rulespec_proof_validator_accepts_parenthesized_effective_dates(
 
     result = validate_rulespec_proofs(
         content,
-        source_texts={
-            "us/guidance/example/page-1": f"REVISION 47 ({evidence})"
-        },
+        source_texts={"us/guidance/example/page-1": f"REVISION 47 ({evidence})"},
     )
 
     assert result.passed is True

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1370"
+version = "0.2.1371"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1371"
+version = "0.2.1372"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- accept complete parenthesized effective-date ranges as proof evidence
- treat whitespace-delimited commas in legal citation lists as evidence boundaries
- preserve rejection of partial accounting values, ratios, decimals, thousands separators, and embedded slash tokens
- release as `axiom-encode` 0.2.1372

## Hard-cut failures addressed
- five Arizona proof excerpts ending in complete parenthesized effective-date ranges
- Minnesota and Oklahoma proof excerpts ending before the next comma-delimited legal citation

## Review cycle
- independent review found the initial date exception was too broad; narrowed it to exact date/date-range labels and added accounting coverage
- follow-up review found an embedded slash-token edge case; added the regression and tightened the date matcher
- final independent re-review after merging current `main`: no actionable findings

## Checks
- `uv run --active ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run --active pytest -q` (`5001 passed, 119 skipped`)
- focused proof-validator suite (`89 passed`) and direct boundary assertions (`7 passed`)
- `uv lock --check`
- `git diff --check`