### PR TITLE
Accept OCR legal proof boundaries

### DIFF
--- a/changelog.d/proof-ocr-legal-boundaries.fixed.md
+++ b/changelog.d/proof-ocr-legal-boundaries.fixed.md
@@ -1,0 +1,1 @@
+Accept complete proof excerpts after fused OCR footnote markers and inside parenthesized legal prose without weakening accounting-number boundaries.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1372"
+version = "0.2.1373"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1372"
+__version__ = "0.2.1373"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/proof_validator.py
+++ b/src/axiom_encode/harness/proof_validator.py
@@ -587,7 +587,16 @@ def _source_evidence_span_is_bounded(
 
     before = source_text[:start]
     after = source_text[end:]
-    if before and (before[-1].isalnum() or before[-1] == "_"):
+    if (
+        before
+        and (before[-1].isalnum() or before[-1] == "_")
+        and not (
+            _span_starts_after_fused_footnote_marker(
+                evidence_text=evidence_text,
+                before=before,
+            )
+        )
+    ):
         return False
     if after and (after[0].isalnum() or after[0] == "_"):
         return False
@@ -761,14 +770,18 @@ def _span_omits_accounting_parentheses(
     before: str,
     after: str,
 ) -> bool:
-    if _is_numeric_date_label(evidence_text):
-        return False
     left = before.rstrip()
     while left and _is_currency_marker(left[-1]):
         left = left[:-1].rstrip()
-    omitted_closing = after.lstrip().startswith(")")
     carried_closing = evidence_text.rstrip().endswith(")")
-    return bool(left.endswith("(") and (omitted_closing or carried_closing))
+    if carried_closing:
+        return left.endswith("(")
+    if _is_numeric_date_label(evidence_text) or _is_substantive_numeric_prose(
+        evidence_text
+    ):
+        return False
+    omitted_closing = after.lstrip().startswith(")")
+    return bool(left.endswith("(") and omitted_closing)
 
 
 def _is_numeric_date_label(text: str) -> bool:
@@ -779,6 +792,53 @@ def _is_numeric_date_label(text: str) -> bool:
         re.fullmatch(
             rf"\s*{date}(?:\s*(?:-|[\u2010-\u2015]|to)\s*{date})?\s*",
             text,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _span_starts_after_fused_footnote_marker(
+    *,
+    evidence_text: str,
+    before: str,
+) -> bool:
+    """Recognize OCR text that fuses a one-digit footnote to sentence prose."""
+
+    text = evidence_text.lstrip()
+    lead = re.match(r"[^\W\d_]+", text)
+    words = re.findall(r"[^\W\d_]+", text)
+    left_context = before[:-1].rstrip()
+    follows_document_boundary = bool(
+        re.search(r"\$\d[\d,]*(?:\.\d+)?$", left_context)
+        or left_context.endswith((".", "!", "?"))
+    )
+    return bool(
+        lead
+        and lead.group(0) == "The"
+        and len(words) >= 4
+        and len(before) >= 2
+        and before[-1] in "123456789"
+        and before[-2].isspace()
+        and left_context
+        and follows_document_boundary
+    )
+
+
+def _is_substantive_numeric_prose(text: str) -> bool:
+    """Distinguish a parenthesized legal clause from accounting notation."""
+
+    normalized = re.sub(r"\s+", " ", text).strip()
+    return bool(
+        re.fullmatch(
+            r"\d+(?:\.\d+)?%\s+of\s+\w+\s+meals\s+(?:a|per)\s+"
+            r"(?:day|week|month|year)",
+            normalized,
+            flags=re.IGNORECASE,
+        )
+        or re.fullmatch(
+            r"\d+\s+(?:days?|weeks?|months?|years?)\s+or\s+the\s+period\s+"
+            r"for\s+which\b.+",
+            normalized,
             flags=re.IGNORECASE,
         )
     )

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -9700,6 +9700,140 @@ def test_rulespec_proof_validator_accepts_complete_numeric_legal_citation():
 
 
 @pytest.mark.parametrize(
+    ("prefix", "marker"),
+    [
+        ("Annual limits $146,836", "1"),
+        ("The FPL guidelines are subject to change.", "2"),
+        ("This threshold is established by CAPS.", "3"),
+    ],
+)
+def test_rulespec_proof_validator_accepts_fused_ocr_footnote_marker(
+    prefix: str,
+    marker: str,
+):
+    evidence = (
+        "The threshold for families in the very low-income priority group is "
+        "50% of the federal poverty level (FPL) guidelines"
+    )
+    content = (
+        _corpus_checked_proof_content()
+        .replace("The official amount is $298.", repr(evidence))
+        .replace("$298", repr(evidence))
+        .replace("formula: '298'", "formula: '0.50'")
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us/guidance/example/page-1": f"{prefix} {marker}{evidence}"},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+@pytest.mark.parametrize(
+    ("source_text", "evidence"),
+    [
+        (
+            "Section 1The allowance is for all eligible families.",
+            "The allowance is for all eligible families",
+        ),
+        (
+            "Ratio 1For every 2 units during the year.",
+            "For every 2 units during the year",
+        ),
+        (
+            "Section 1ABC allowance is 50 percent.",
+            "ABC allowance is 50 percent",
+        ),
+        (
+            "Section 1.2 3The allowance is for all eligible families.",
+            "The allowance is for all eligible families",
+        ),
+        (
+            "Ratio 3:1 2The allowance is for all eligible families.",
+            "The allowance is for all eligible families",
+        ),
+    ],
+)
+def test_rulespec_proof_validator_rejects_partial_alphanumeric_identifier(
+    source_text: str,
+    evidence: str,
+):
+    content = (
+        _corpus_checked_proof_content()
+        .replace("The official amount is $298.", repr(evidence))
+        .replace("$298", repr(evidence))
+        .replace("formula: '298'", "formula: '0.50'")
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us/guidance/example/page-1": source_text},
+    )
+
+    assert result.passed is False
+    assert any("Proof source evidence not found" in issue for issue in result.issues)
+
+
+@pytest.mark.parametrize(
+    "evidence",
+    [
+        "50% of three meals a day",
+        "24 months or the period for which the person was called to active duty",
+    ],
+)
+def test_rulespec_proof_validator_accepts_parenthesized_numeric_legal_prose(
+    evidence: str,
+):
+    content = (
+        _corpus_checked_proof_content()
+        .replace("The official amount is $298.", repr(evidence))
+        .replace("$298", repr(evidence))
+        .replace("formula: '298'", "formula: '50'")
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us/guidance/example/page-1": f"Rule text ({evidence}) applies."},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+@pytest.mark.parametrize(
+    "evidence",
+    [
+        "$50 of total assets for the current period",
+        "1:50 of total assets for the current period",
+        "$50 of total assets for the current period)",
+        "24 months or the period for which the person was called to active duty)",
+    ],
+)
+def test_rulespec_proof_validator_rejects_parenthesized_accounting_prose(
+    evidence: str,
+):
+    source_evidence = evidence.rstrip(")")
+    content = (
+        _corpus_checked_proof_content()
+        .replace("The official amount is $298.", repr(evidence))
+        .replace("$298", repr(evidence))
+        .replace("formula: '298'", "formula: '50'")
+    )
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={
+            "us/guidance/example/page-1": f"Statement ({source_evidence}) filed."
+        },
+    )
+
+    assert result.passed is False
+    assert any("Proof source evidence not found" in issue for issue in result.issues)
+
+
+@pytest.mark.parametrize(
     "source_text",
     [
         "(1) 50 dollars is allowed.",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1372"
+version = "0.2.1373"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- accept complete legal proof excerpts after observed fused OCR footnote markers
- accept the two parenthesized Florida legal-clause shapes without weakening accounting boundaries
- reject carried closing parentheses, arbitrary numeric/alphanumeric joins, currency prose, and ratios
- release encoder 0.2.1373

## Hard-cut validation
- the 15 proof failures repaired by 0.2.1372 remain unchanged
- exact corpus replay passes for all 3 remaining hard-cut files: two Florida clauses and the Georgia CAPS OCR footnotes
- focused proof-validator suite: 117 passed
- full encoder suite: 5015 passed, 119 skipped

## Review cycle
- independent review found broad accounting/ratio and fused-marker exceptions; both were narrowed and regression-tested
- second review found hierarchical identifier and carried-closing edge cases; both were fixed and regression-tested
- final independent review: no actionable findings

## Checks
- `uv run --active ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run --active ruff format --check src tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run --active pytest -q`
- `uv lock --check`
- `git diff --check`
