### PR TITLE
Pin Texas Wyoming and Colorado income-tax oracle mappings

### DIFF
--- a/changelog.d/tx-wy-co-2026-oracle-pin.changed.md
+++ b/changelog.d/tx-wy-co-2026-oracle-pin.changed.md
@@ -1,0 +1,1 @@
+Pin axiom-oracles to the reviewed Texas, Wyoming, and Colorado tax-year-2026 individual-income-tax classifications so encoder coverage resolves all 13 Texas, 12 Wyoming, and 13 Colorado outputs exactly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1373"
+version = "0.2.1374"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@2c58e4409c8238ebbb241c8032d1add378f8e42c",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@157a07185fad0d1277e501fad034560d269f72d4",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1373"
+__version__ = "0.2.1374"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1373"
+version = "0.2.1374"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=2c58e4409c8238ebbb241c8032d1add378f8e42c" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=157a07185fad0d1277e501fad034560d269f72d4" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=2c58e4409c8238ebbb241c8032d1add378f8e42c#2c58e4409c8238ebbb241c8032d1add378f8e42c" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=157a07185fad0d1277e501fad034560d269f72d4#157a07185fad0d1277e501fad034560d269f72d4" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- bump axiom-encode from 0.2.1373 to 0.2.1374
- pin axiom-oracles to reviewed and merged Texas, Wyoming, and Colorado oracle commit `157a07185fad0d1277e501fad034560d269f72d4`
- refresh the lockfile without unrelated dependency drift
- add the required changelog fragment

This unblocks exact oracle coverage for 13 Texas, 12 Wyoming, and 13 Colorado tax-year-2026 individual-income-tax outputs.

## Exact mapping verification

- Texas: 13 exact `tax` / `not_comparable` / `P4` mappings with rationales
- Wyoming: 12 exact `tax` / `not_comparable` / `P4` mappings with rationales
- Colorado: 13 exact `tax` / `not_comparable` / `P4` mappings with rationales
- packaged registry validation: clean
- installed `direct_url.json` commit: exact `157a07185fad0d1277e501fad034560d269f72d4`

## Validation

- version-affecting-change guard: passed
- focused PolicyEngine coverage/classifier/pending suite: 459 passed
- `uv run --python 3.13 ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run --python 3.13 python -m compileall -q src/axiom_encode scripts`
- `uv run --python 3.13 towncrier check`
- full suite: 5015 passed, 119 skipped
- `git diff --check`
- credential-pattern scan: clean

## Review cycle

Independent no-edit review of exact base `caebbda1a190181ef8184ed7aaffedb3789202a3` through exact head `20dbb32861b2cd3d49a0b81b340956a5f510ec44` was CLEAN with no actionable findings. It verified the exact four-file scope, synchronized 0.2.1374 version metadata, exact oracle pin and installed revision, rendered changelog, clean tree/diff, and credential safety.
