### PR TITLE
Pin Kansas income-tax oracle mappings

### DIFF
--- a/changelog.d/ks-2026-oracle-pin.changed.md
+++ b/changelog.d/ks-2026-oracle-pin.changed.md
@@ -1,0 +1,1 @@
+Pin axiom-oracles to the reviewed Kansas tax-year-2026 individual-income-tax classification, including the supported refundable-credit stage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1374"
+version = "0.2.1375"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@157a07185fad0d1277e501fad034560d269f72d4",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@7c0efc7ab5f320038e7bb36bfa292cdd73a713a9",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1374"
+__version__ = "0.2.1375"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1374"
+version = "0.2.1375"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=157a07185fad0d1277e501fad034560d269f72d4" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=7c0efc7ab5f320038e7bb36bfa292cdd73a713a9" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=157a07185fad0d1277e501fad034560d269f72d4#157a07185fad0d1277e501fad034560d269f72d4" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=7c0efc7ab5f320038e7bb36bfa292cdd73a713a9#7c0efc7ab5f320038e7bb36bfa292cdd73a713a9" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- bump axiom-encode from `0.2.1374` to `0.2.1375`
- pin axiom-oracles to the reviewed Kansas oracle merge `7c0efc7ab5f320038e7bb36bfa292cdd73a713a9`
- refresh the lockfile without unrelated dependency drift
- add the required Kansas changelog fragment
- leave reusable-workflow and legacy RuleSpec validator surfaces unchanged

This exposes the reviewed Kansas tax-year-2026 individual-income-tax classification, including the supported refundable-credit stage, to the encoder runtime.

## Dependency evidence

- oracle PR: TheAxiomFoundation/axiom-oracles#348
- true merge: `7c0efc7ab5f320038e7bb36bfa292cdd73a713a9`
- merge parents: `157a07185fad0d1277e501fad034560d269f72d4` + `bbbc7f677bf4791a43b52d5cb2009881c007f79e`
- post-merge main CI: run `30136313749`, both `test` and `gettsim-live` succeeded
- installed `axiom-oracles` `direct_url.json`: exact commit `7c0efc7ab5f320038e7bb36bfa292cdd73a713a9`

## Validation

- focused PolicyEngine coverage/classifier/pending suite: 459 passed
- version metadata and encoder-affecting version guards: passed
- `uv run --python 3.13 ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run --python 3.13 ruff format --check src/ tests/`
- `uv run --python 3.13 python -m compileall -q src/axiom_encode scripts`
- `uv run --python 3.13 towncrier check`
- towncrier draft render includes the Kansas fragment
- full suite: 5015 passed, 119 skipped
- `git diff --check`
- credential-pattern scan: clean

## Review cycle

Independent no-edit review of exact base `f7ae2c418565921c66f98a5f99eca17b1c26720f` through exact head `394d9ce3d62640258f7a0e30b43ae826143f40d6` was CLEAN with no actionable findings. It verified the unchanged current base and merge-base, clean tree, exact four-file `7+/6-` release diff, synchronized `0.2.1375` metadata and lockfile, exact postgreen oracle pin, changelog wording, unchanged workflow/legacy-validator surfaces, diff check, focused version/oracle tests, and installed oracle commit identity.
