### PR TITLE
Pin Kentucky and Idaho income-tax oracle mappings

### DIFF
--- a/changelog.d/ky-id-2026-oracle-pin.changed.md
+++ b/changelog.d/ky-id-2026-oracle-pin.changed.md
@@ -1,0 +1,1 @@
+Pin axiom-oracles to the reviewed Kentucky and Idaho tax-year-2026 full-year-resident source-hold classifications, keeping their source-readiness predicates and fail-closed sentinel outputs out of PolicyEngine value comparisons.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1375"
+version = "0.2.1376"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@7c0efc7ab5f320038e7bb36bfa292cdd73a713a9",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@92c19428f8bbf3cab2f6e9f43210c24c40fe251b",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1375"
+__version__ = "0.2.1376"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1375"
+version = "0.2.1376"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=7c0efc7ab5f320038e7bb36bfa292cdd73a713a9" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=92c19428f8bbf3cab2f6e9f43210c24c40fe251b" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=7c0efc7ab5f320038e7bb36bfa292cdd73a713a9#7c0efc7ab5f320038e7bb36bfa292cdd73a713a9" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=92c19428f8bbf3cab2f6e9f43210c24c40fe251b#92c19428f8bbf3cab2f6e9f43210c24c40fe251b" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- bump axiom-encode from `0.2.1375` to `0.2.1376`
- pin axiom-oracles to combined reviewed Kentucky+Idaho main `92c19428f8bbf3cab2f6e9f43210c24c40fe251b`
- refresh the lockfile without unrelated dependency drift
- add a precise Kentucky/Idaho source-hold changelog fragment
- leave reusable-workflow and legacy RuleSpec validator/toolchain surfaces unchanged

This exposes the reviewed tax-year-2026 full-year-resident source-readiness classifications for both states to the encoder runtime. It keeps their source-hold predicates and fail-closed sentinel outputs out of PolicyEngine value comparisons.

## Dependency evidence

- oracle PRs: TheAxiomFoundation/axiom-oracles#349 and TheAxiomFoundation/axiom-oracles#350
- combined postgreen oracle main: `92c19428f8bbf3cab2f6e9f43210c24c40fe251b`
- final merge parents: `6521a2f8d6748bb9ec9c22b5a1502feebe69918d` + `6aad3a151f3a1fdb2ccd7666fce5b2f492e0cd91`
- post-merge oracle main CI: run `30138052672`; both `test` and `gettsim-live` succeeded
- installed `axiom-oracles` `direct_url.json`: exact commit `92c19428f8bbf3cab2f6e9f43210c24c40fe251b`
- installed registry: 15 Kentucky plus 15 Idaho mappings, all exact tax / not_comparable / P4

## Validation

- focused version/oracle suite: 15 passed
- corrected provenance and canonical-checkout representative retry: 3 passed
- `uv lock --check`
- `uv run --frozen ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run --frozen ruff format --check src/ tests/`: 125 files already formatted
- `python -m compileall -q src/axiom_encode scripts` under the reused Python 3.13 environment
- `uv run --frozen towncrier check`
- towncrier draft render includes the Kentucky/Idaho fragment
- full suite: 5015 passed, 119 skipped
- `git diff --check`
- credential-pattern scan: clean

## Review cycle

Independent no-edit review of exact base `cfda96e7ae27c75f784324290dea76999ce3ad71` through exact head `182cd0c410700859ea7065cf76f6019a9e5d4296` completed CLEAN with no actionable findings. It verified unchanged encoder origin/main and merge-base, a clean exact four-file `7+/6-` release diff, synchronized `0.2.1376` metadata and lockfile, the exact combined postgreen oracle pin, precise changelog wording, unchanged workflow and legacy-validator/toolchain surfaces, diff check, 15 focused version/oracle tests, and installed oracle commit identity.