### PR TITLE
Pin Massachusetts 2026 income-tax oracle mappings

### DIFF
--- a/changelog.d/ma-2026-oracle-pin.changed.md
+++ b/changelog.d/ma-2026-oracle-pin.changed.md
@@ -1,0 +1,1 @@
+Pin axiom-oracles to the reviewed Massachusetts tax-year-2026 full-year-resident source-hold classifications, keeping the federal boundary, typed source-readiness predicates, and fail-closed liability sentinels out of PolicyEngine value comparisons.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1376"
+version = "0.2.1377"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@92c19428f8bbf3cab2f6e9f43210c24c40fe251b",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@f92adb1e2f488d7494544dfac678558eefa84885",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1376"
+__version__ = "0.2.1377"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1376"
+version = "0.2.1377"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=92c19428f8bbf3cab2f6e9f43210c24c40fe251b" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=f92adb1e2f488d7494544dfac678558eefa84885" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=92c19428f8bbf3cab2f6e9f43210c24c40fe251b#92c19428f8bbf3cab2f6e9f43210c24c40fe251b" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=f92adb1e2f488d7494544dfac678558eefa84885#f92adb1e2f488d7494544dfac678558eefa84885" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- bump axiom-encode from 0.2.1376 to 0.2.1377
- pin axiom-oracles to reviewed Massachusetts tax-year-2026 merge f92adb1e2f488d7494544dfac678558eefa84885
- record the source-hold boundary for the 16 Massachusetts full-year-resident P4 tax/not_comparable mappings

## Scope

Exact reviewed range: fbfc8e6b073978a6428e3f36e95c4847328f5f5d..5bb5a9a084cea3d9f608c306262d3dd6eabd47c6

Only the normal four release/pin files change: pyproject.toml, src/axiom_encode/__init__.py, uv.lock, and changelog.d/ma-2026-oracle-pin.changed.md. Legacy RuleSpec validator, toolchain, and workflow surfaces are unchanged.

## Review cycle

Independent no-edit review completed cleanly after implementation. The reviewer verified the unchanged current origin/main and merge base, exact four-file 7 insertion/6 deletion diff, synchronized 0.2.1377 metadata and lock, exact postgreen Massachusetts oracle pin, precise changelog, absence of legacy validator/workflow changes, diff-check, 15 focused version/oracle tests, and installed direct_url commit identity. No actionable findings remain.

## Validation

- uv lock --check
- uv run --frozen ruff check pyproject.toml src/axiom_encode scripts tests
- uv run --frozen ruff format --check src/ tests/
- .venv/bin/python -m compileall -q src/axiom_encode scripts
- uv run --frozen towncrier check
- focused version, pin, provenance, and registry tests: 15 passed
- full suite: 5015 passed, 119 skipped, 12 dependency deprecation warnings
- git diff --check
- changed-file credential-pattern scan: 0 findings
- installed axiom-encode: 0.2.1377
- installed axiom-oracles direct_url commit: f92adb1e2f488d7494544dfac678558eefa84885
- installed Massachusetts registry: 16 exact P4 tax/not_comparable mappings

## Merge hold

Do not merge until explicit maintainer GO. Fresh PR CI and current-base status must remain green.