### PR TITLE
Pin Maryland income-tax oracle mappings

### DIFF
--- a/changelog.d/md-2026-oracle-pin.changed.md
+++ b/changelog.d/md-2026-oracle-pin.changed.md
@@ -1,0 +1,1 @@
+Pin axiom-oracles to the reviewed Maryland tax-year-2026 full-year-resident State income-tax source-hold classifications, keeping the preserved federal-return diagnostic, typed source-readiness predicates, and fail-closed State liability sentinels out of PolicyEngine value comparisons.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1377"
+version = "0.2.1378"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@f92adb1e2f488d7494544dfac678558eefa84885",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@3033eed72c451f15f6df92c93073e39f5c921a03",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1377"
+__version__ = "0.2.1378"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1377"
+version = "0.2.1378"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=f92adb1e2f488d7494544dfac678558eefa84885" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=3033eed72c451f15f6df92c93073e39f5c921a03" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=f92adb1e2f488d7494544dfac678558eefa84885#f92adb1e2f488d7494544dfac678558eefa84885" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=3033eed72c451f15f6df92c93073e39f5c921a03#3033eed72c451f15f6df92c93073e39f5c921a03" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- bump axiom-encode from 0.2.1377 to 0.2.1378
- pin axiom-oracles to reviewed post-green Maryland oracle merge `3033eed72c451f15f6df92c93073e39f5c921a03`
- add a precise Maryland TY2026 source-held State income-tax changelog entry

This is the normal four-file release/dependency update only. It does not modify the legacy RuleSpec validator, RuleSpec toolchain pins, or shared workflow surfaces.

## Review cycle

Independent no-edit review completed CLEAN with no actionable findings on exact base `af50eb32b8ff33667e3ea22d478a8b81ddb781d5` and exact head `27249a1d856fa8be338305e2cad6d295bb53285c`. Review reverified the exact four-file `7+ / 6-` scope, clean tree, clean diff, consistent 0.2.1378 metadata, exact installed axiom-oracles direct URL commit, and 15 focused tests. The reviewed diff is unchanged.

## Checks

- `uv sync --locked --extra dev`: passed
- `uv lock --check`: passed
- installed encoder version, oracle commit, and all 14 Maryland exact tax / not_comparable / P4 mappings: passed
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`: passed
- `python -m compileall -q src/axiom_encode scripts`: passed
- final full suite: 5015 passed, 119 skipped
- package sdist and wheel build: passed
- `git diff --check`: passed
- independent focused suite: 15 passed