### PR TITLE
Inherit parent-document identifiers for provision-level amendment discovery

### DIFF
--- a/changelog.d/provision-amendment-inheritance.fixed.md
+++ b/changelog.d/provision-amendment-inheritance.fixed.md
@@ -1,0 +1,5 @@
+Provision-level corpus targets now inherit their parent document's identifiers
+for amendment discovery when both rows share a non-empty source path and version.
+This preserves document-level behavior while preventing cross-document leakage.
+
+Closes #1275.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1378"
+version = "0.2.1379"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1378"
+__version__ = "0.2.1379"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -1606,6 +1606,7 @@ def _target_document_identifiers(
     row: _corpus_resolver.ActiveCorpusBodyRow | None,
     *,
     target_citation_path: str,
+    parent_document_row: _corpus_resolver.ActiveCorpusBodyRow | None = None,
 ) -> _AmendmentTargetIdentifiers:
     exact_structured = {_normalized_relation_text(target_citation_path)}
     structured_phrases: set[tuple[str, ...]] = set()
@@ -1630,8 +1631,15 @@ def _target_document_identifiers(
         ):
             structured_phrases.add(tokens)
 
-    if row is not None:
-        exact_structured.add(_normalized_relation_text(row.row.citation_path))
+    identifier_rows = tuple(
+        identifier_row
+        for identifier_row in (row, parent_document_row)
+        if identifier_row is not None
+    )
+    for identifier_row in identifier_rows:
+        exact_structured.add(
+            _normalized_relation_text(identifier_row.row.citation_path)
+        )
     citation_segments = target_citation_path.split("/")[2:]
     for index, segment in enumerate(citation_segments):
         segment_tokens = _normalized_tokens(segment)
@@ -1653,9 +1661,9 @@ def _target_document_identifiers(
             add_structured(f"{segment}/{citation_segments[index + 1]}")
         else:
             add_name(segment)
-    if row is not None:
+    for identifier_row in identifier_rows:
         for key in ("title", "title_short", "title_alternative"):
-            for value in _metadata_scalar_values(row.metadata.get(key)):
+            for value in _metadata_scalar_values(identifier_row.metadata.get(key)):
                 add_name(value)
                 if key == "title":
                     title_without_parenthetical = re.sub(
@@ -1664,7 +1672,7 @@ def _target_document_identifiers(
                     short_title_tokens = _normalized_tokens(title_without_parenthetical)
                     if short_title_tokens[:2] == ("bek", "af"):
                         add_name(" ".join(short_title_tokens[2:]))
-        for key, value in row.metadata.items():
+        for key, value in identifier_row.metadata.items():
             normalized_key = key.casefold().replace("-", "_")
             is_eli_identifier = _is_eli_key(normalized_key)
             if is_eli_identifier or (
@@ -1672,8 +1680,8 @@ def _target_document_identifiers(
             ):
                 for scalar in _metadata_scalar_values(value):
                     add_structured(scalar, force_phrase=is_eli_identifier)
-        if row.heading:
-            add_name(row.heading)
+        if identifier_row.heading:
+            add_name(identifier_row.heading)
     return _AmendmentTargetIdentifiers(
         exact_structured=frozenset(exact_structured),
         structured_phrases=frozenset(structured_phrases),
@@ -1741,13 +1749,16 @@ def _discover_amendment_documents(
     rows: Sequence[_corpus_resolver.ActiveCorpusBodyRow],
     *,
     target_row: _corpus_resolver.ActiveCorpusBodyRow | None,
+    parent_document_row: _corpus_resolver.ActiveCorpusBodyRow | None,
     target_citation_path: str,
     target_source_path: str | None,
     version: str,
 ) -> tuple[CorpusAmendmentDocument, ...]:
     target_document_key = target_source_path or target_citation_path
     target_identifiers = _target_document_identifiers(
-        target_row, target_citation_path=target_citation_path
+        target_row,
+        target_citation_path=target_citation_path,
+        parent_document_row=parent_document_row,
     )
     marked_rows = [
         row
@@ -5288,6 +5299,30 @@ def prepare_eval_workspace(
     )
 
 
+def _shallowest_active_source_path_row(
+    rows: Sequence[_corpus_resolver.ActiveCorpusBodyRow],
+    *,
+    source_path: str | None,
+    version: str,
+) -> _corpus_resolver.ActiveCorpusBodyRow | None:
+    """Select a document root only within one non-empty source and version."""
+
+    if not source_path:
+        return None
+    return min(
+        (
+            row
+            for row in rows
+            if row.row.source_path == source_path and row.row.version == version
+        ),
+        key=lambda row: (
+            len(row.row.citation_path.split("/")),
+            row.row.citation_path,
+        ),
+        default=None,
+    )
+
+
 def resolve_corpus_source_unit(
     identifier: str,
     release: _corpus_resolver.LocalCorpusRelease,
@@ -5326,20 +5361,20 @@ def resolve_corpus_source_unit(
             None,
         )
         if target_row is None and resolved.row.source_path:
-            source_path_matches = (
-                item
-                for item in active_rows
-                if item.row.source_path == resolved.row.source_path
-                and item.row.version == resolved.row.version
+            target_row = _shallowest_active_source_path_row(
+                active_rows,
+                source_path=resolved.row.source_path,
+                version=resolved.row.version,
             )
-            target_row = min(
-                source_path_matches,
-                key=lambda item: (
-                    len(item.row.citation_path.split("/")),
-                    item.row.citation_path,
-                ),
-                default=None,
-            )
+        parent_document_row = _shallowest_active_source_path_row(
+            active_rows,
+            source_path=resolved.row.source_path,
+            version=resolved.row.version,
+        )
+        if parent_document_row is None or len(resolved.citation_path.split("/")) <= len(
+            parent_document_row.row.citation_path.split("/")
+        ):
+            parent_document_row = None
         return CorpusSourceUnit(
             requested=resolved.requested,
             citation_path=resolved.citation_path,
@@ -5353,6 +5388,7 @@ def resolve_corpus_source_unit(
             amendment_documents=_discover_amendment_documents(
                 active_rows,
                 target_row=target_row,
+                parent_document_row=parent_document_row,
                 target_citation_path=resolved.citation_path,
                 target_source_path=resolved.row.source_path,
                 version=resolved.row.version,

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -15,6 +15,7 @@ import pytest
 import requests
 import yaml
 
+from axiom_encode import corpus_resolver
 from axiom_encode.corpus_resolver import (
     InvalidCorpusCitationError,
     LocalCorpusRelease,
@@ -81,6 +82,7 @@ from axiom_encode.harness.evals import (
     _run_codex_prompt_eval,
     _secure_eval_read,
     _select_cross_section_context_files,
+    _shallowest_active_source_path_row,
     _slugify,
     _source_identifier_to_relative_rulespec_path,
     _source_metadata_citation_path,
@@ -766,6 +768,193 @@ def test_target_source_document_is_not_its_own_amendment_context(tmp_path):
                 "body": "Embedded amendment history.",
                 "source_path": "sources/dk/benefit-act.txt",
                 "metadata": {"amends": "dk/statute/benefit/section-1"},
+            },
+        ],
+    )
+
+    source_unit = resolve_corpus_source_unit("dk/statute/benefit/section-1", release)
+
+    assert source_unit.amendment_documents == ()
+
+
+def test_provision_inherits_document_identifiers_for_de_amendment_discovery(tmp_path):
+    target_path = "de/statute/estg"
+    target_source_path = "sources/de/statute/estg/BJNR010050934.xml"
+    stefe_path = "de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1"
+    stefe_metadata = {
+        "amendment_targets": [target_path, f"{target_path}/32"],
+        "amends": (
+            "Einkommensteuergesetz (EStG), in der Fassung der Bekanntmachung "
+            "vom 8. Oktober 2009 (BGBl. I S. 3366, 3862)"
+        ),
+        "document_type": "Änderungsgesetz (amendment act)",
+        "title": (
+            "Gesetz zur Fortentwicklung des Steuerrechts und zur Anpassung des "
+            "Einkommensteuertarifs (Steuerfortentwicklungsgesetz – SteFeG) "
+            "(BGBl. 2024 I Nr. 449)"
+        ),
+        "source_note": "Official electronic Bundesgesetzblatt PDF.",
+    }
+    release = _write_test_corpus_release(
+        tmp_path,
+        [
+            {
+                "citation_path": target_path,
+                "body": "Einkommensteuergesetz",
+                "source_path": target_source_path,
+                "heading": "Einkommensteuergesetz",
+                "metadata": {
+                    "ausfertigung_datum": "1934-10-16",
+                    "jurabk": "EStG",
+                    "law_metadata": {
+                        "jurabk": "EStG",
+                        "langtitel": "Einkommensteuergesetz",
+                    },
+                    "law_slug": "estg",
+                    "law_title": "Einkommensteuergesetz (EStG)",
+                    "legal_authority_url": ("https://www.gesetze-im-internet.de/estg/"),
+                },
+            },
+            {
+                "citation_path": f"{target_path}/3",
+                "body": "§ 3 Steuerfreie Einnahmen",
+                "source_path": target_source_path,
+                "heading": "§ 3",
+                "metadata": {},
+            },
+            {
+                "citation_path": stefe_path,
+                "body": "Artikel 1 ändert das Einkommensteuergesetz.",
+                "source_path": "sources/de/statute/stefeg/regelungstext.pdf",
+                "expression_date": "2024-12-23",
+                "metadata": stefe_metadata,
+            },
+        ],
+    )
+
+    provision = resolve_corpus_source_unit(f"{target_path}/3", release)
+    document = resolve_corpus_source_unit(target_path, release)
+
+    assert [item.citation_path for item in provision.amendment_documents] == [
+        stefe_path
+    ]
+    assert (
+        provision.amendment_documents[0].metadata["source_note"].startswith("Official")
+    )
+    assert provision.amendment_documents == document.amendment_documents
+
+
+def test_provision_identifier_inheritance_does_not_cross_source_documents(tmp_path):
+    release = _write_test_corpus_release(
+        tmp_path,
+        [
+            {
+                "citation_path": "de/statute/act-a",
+                "source_path": "sources/de/act-a.xml",
+                "metadata": {"title": "Alpha Family Benefits Act"},
+            },
+            {
+                "citation_path": "de/statute/act-a/3",
+                "body": "Act A provision.",
+                "source_path": "sources/de/act-a.xml",
+                "metadata": {},
+            },
+            {
+                "citation_path": "de/statute/act-b",
+                "source_path": "sources/de/act-b.xml",
+                "metadata": {"title": "Beta Housing Support Act"},
+            },
+            {
+                "citation_path": "de/statute/act-b/amendment",
+                "body": "Act B amendment.",
+                "source_path": "sources/de/act-b-amendment.xml",
+                "metadata": {
+                    "document_type": "amendment act",
+                    "amends": "Beta Housing Support Act",
+                },
+            },
+        ],
+    )
+
+    assert (
+        resolve_corpus_source_unit("de/statute/act-a/3", release).amendment_documents
+        == ()
+    )
+    # Active release rows require source_path, so exercise the resolver's
+    # fail-closed boundary against populated candidate rows through its selector.
+    candidate_rows = tuple(
+        corpus_resolver.iter_active_local_corpus_rows(
+            release, jurisdiction="de", document_class="statute"
+        )
+    )
+    assert candidate_rows
+    assert (
+        _shallowest_active_source_path_row(
+            candidate_rows, source_path=None, version=_TEST_CORPUS_VERSION
+        )
+        is None
+    )
+
+
+def test_provision_inherits_parent_metadata_identifiers(tmp_path):
+    source_path = "sources/de/family-benefit.xml"
+    release = _write_test_corpus_release(
+        tmp_path,
+        [
+            {
+                "citation_path": "de/statute/family-benefit",
+                "source_path": source_path,
+                "metadata": {"title": "German Family Benefit Act"},
+            },
+            {
+                "citation_path": "de/statute/family-benefit/3",
+                "body": "Provision text.",
+                "source_path": source_path,
+                "metadata": {},
+            },
+            {
+                "citation_path": "de/statute/amendment-2026",
+                "body": "Amendment text.",
+                "source_path": "sources/de/amendment-2026.xml",
+                "metadata": {
+                    "document_type": "amendment act",
+                    "amends": "Amendment of the German Family Benefit Act",
+                },
+            },
+        ],
+    )
+
+    source_unit = resolve_corpus_source_unit("de/statute/family-benefit/3", release)
+
+    assert [item.citation_path for item in source_unit.amendment_documents] == [
+        "de/statute/amendment-2026"
+    ]
+
+
+def test_provision_inheritance_preserves_same_document_amendment_exclusion(tmp_path):
+    source_path = "sources/dk/benefit-act.txt"
+    release = _write_test_corpus_release(
+        tmp_path,
+        [
+            {
+                "citation_path": "dk/statute/benefit",
+                "source_path": source_path,
+                "metadata": {"title": "Danish Family Benefit Act"},
+            },
+            {
+                "citation_path": "dk/statute/benefit/section-1",
+                "body": "The divisor is 12.",
+                "source_path": source_path,
+                "metadata": {},
+            },
+            {
+                "citation_path": "dk/statute/benefit/amendment-note",
+                "body": "Embedded amendment history.",
+                "source_path": source_path,
+                "metadata": {
+                    "document_type": "amendment act",
+                    "amends": "Danish Family Benefit Act",
+                },
             },
         ],
     )

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1378"
+version = "0.2.1379"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
Closes #1275. Follow-up to #1139/#1140 from the standing DE recall probe.

Amendment discovery worked at document level but returned zero for provision-level targets — the primary encode granularity. On the signed `de-rulespec-2026-07-21` release, `de/statute/estg` found the SteFeG amendment while `de/statute/estg/3` — the exact section SteFeG amends — found nothing: the § row carries no identifier-bearing metadata, and a path like `estg/3` derives no usable identifiers, so the relation matcher was vacuously false.

## Fix

Provision-level targets now inherit their parent document's identifiers, fail-closed: the parent is the shallowest active row sharing the target's non-empty `source_path` and version (the same selection rule #1140 introduced for the target-row fallback, reused not duplicated); identifiers are the union of provision-local and parent-derived (metadata, headings, citation paths). No inheritance without a shared source path; document-level targets get no parent row and keep byte-identical behavior; the same-document self-exclusion in discovery stays source-keyed.

Probe finding recorded for the record: the DE document-level match fires through the ingest's structured `amendment_targets` field (literal `de/statute/estg`) — none of the prose metadata fields (`jurabk`, `law_title`, …) participate in identifier derivation today. Inheritance transfers exactly that durable structured identifier to provisions.

## Verification

Live acceptance on real signed releases: `de/statute/estg/3` → 1 amendment (SteFeG) with curated metadata; `de/statute/estg` → unchanged; dk `…/boerne-og-ungeydelsesloven` → unchanged (2 docs, newest-first). New tests: the DE case, metadata/path union, cross-document leakage guard, `source_path`-None fail-closed, self-exclusion under inheritance. Full `tests/test_evals.py`: 615 passed. Ratchet 3/3 at 0.2.1379.

Gate note: the worker's commit left `__init__.py` at 0.2.1378 (its "ratchet passed" claim was wrong — caught in unmasked verification after my own `| grep` pipeline briefly masked the failing exit); corrected before this PR was opened.

Build: gpt-5.6-sol worker; Fable review + gate; clean-context audit before merge.
