### PR TITLE
ci: make the signed apply manifest a required stage in signed-apply-reusable

### DIFF
--- a/.github/workflows/signed-apply-reusable.yml
+++ b/.github/workflows/signed-apply-reusable.yml
@@ -435,9 +435,14 @@ jobs:
           # generation bug/compromise cannot smuggle an executable surface (e.g.
           # a workflow file) into the signed branch.
           jurs="$(cd "$genroot" && ls -d */ 2>/dev/null | grep -E '^[a-z]{2}(-[a-z0-9-]+)*/' | tr -d '/')"
-          allow=()
+          manifest_dir=".axiom/encoding-manifests"
+          if [ ! -d "$genroot/$manifest_dir" ]; then
+            echo "::error::required signed apply manifest directory missing: $manifest_dir"
+            exit 1
+          fi
+          allow=("$manifest_dir")
           for j in $jurs; do allow+=("$j"); done
-          for p in .axiom/encoding-manifests docs data/coverage \
+          for p in docs data/coverage \
                    known-validation-gaps.yaml known-missing-money-atoms.yaml \
                    oracle-coverage-pending.yaml; do
             [ -e "$genroot/$p" ] && allow+=("$p")
@@ -625,10 +630,10 @@ jobs:
           # on a pathspec that matches nothing (e.g. a mirror with no docs/),
           # staging NOTHING and masking it under `|| true` — so add the
           # jurisdiction glob (always present post-gate: the tracked .gitkeep
-          # under each content root matches it) plus only the optional meta
-          # paths that actually exist.
-          add_paths=(':(glob)*/**')
-          for p in .axiom/encoding-manifests docs data/coverage \
+          # under each content root matches it), the required encoding manifest,
+          # plus only the optional meta paths that actually exist.
+          add_paths=(':(glob)*/**' '.axiom/encoding-manifests')
+          for p in docs data/coverage \
                    known-validation-gaps.yaml known-missing-money-atoms.yaml \
                    oracle-coverage-pending.yaml; do
             [ -e "$p" ] && add_paths+=("$p")


### PR DESCRIPTION
## What

`.axiom/encoding-manifests` is a **required** output of a signed-apply run, but both gates in `signed-apply-reusable.yml` treated it as optional (appended only under `[ -e ]`):

- **Producer allowlist** (~L438): a generation that emitted no manifest just copied less into the artifact.
- **Push/staging** (~L630): `git add` succeeded, the nonempty-diff check passed on the jurisdiction YAML alone, and `open_pr` opened a *signed* PR carrying content with **no signed manifest**.

`origin/main` has no manifest directory to backfill from, so the omission isn't recoverable downstream. The required `guard-generated` check would red such a PR, but the signed PR itself would still be incomplete — defeating the purpose of the signed-apply leg.

## Fix

Both sites fail closed:
- producer **errors explicitly** when the manifest directory is absent (clearer than a silent short-copy);
- staging includes `.axiom/encoding-manifests` **unconditionally** — `git add` on a missing required path errors "pathspec did not match", which is the desired behavior.

Only the genuinely optional meta paths (`docs`, `data/coverage`, the gap YAMLs) stay existence-gated.

## Why here

This ports the fix from **rulespec-de#21** to the shared reusable workflow. Since `7e851ba` the country repos are thin callers of this file, so the defect applied to **every** country repo, not just DE.

## Verification

- Found by cross-family adversarial review (sol) on the rulespec-de inline copy; independently re-derived here against this file.
- All extracted shell blocks pass `bash -n`; ShellCheck/actionlint produce **no new findings** vs unmodified `origin/main`.
- Preserved: both independent allowlist gates, symlink refusal, `.github`/`scripts`/`_axiom` exclusion, non-`-A` staging, no auto-merge, context-bound signer.
- Scope: **one file, two hunks**. No pins, no CODEOWNERS, no unrelated content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
