### PR TITLE
Skip advisory reviewers in persisted-row revalidation; add opus-5 EncodeBench runner

### DIFF
--- a/benchmarks/encodebench_uk_v1.yaml
+++ b/benchmarks/encodebench_uk_v1.yaml
@@ -37,6 +37,7 @@ runners:
   - gpt-5.5=codex:gpt-5.5
   - luna=codex:gpt-5.6-luna
   - fable=claude:claude-fable-5
+  - opus-5=claude:claude-opus-5
 mode: cold
 # Rate gates are pinned to 0.0: a capability suite reports rates through
 # eval-board instead of gating bulk-readiness, and the manifest loader

--- a/changelog.d/1189-encodebench-opus5-runner.changed.md
+++ b/changelog.d/1189-encodebench-opus5-runner.changed.md
@@ -1,0 +1,1 @@
+EncodeBench UK v1 adds an opus-5 runner (claude:claude-opus-5).

--- a/changelog.d/1189-revalidation-reviewer-determinism.fixed.md
+++ b/changelog.d/1189-revalidation-reviewer-determinism.fixed.md
@@ -1,0 +1,1 @@
+Persisted-row revalidation at eval-suite finalize, resume, and archive now skips advisory reviewers and compares only deterministic validator outputs, so suites with live generalist reviewers can finalize instead of failing on nondeterministic review scores.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1379"
+version = "0.2.1380"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1379"
+__version__ = "0.2.1380"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3751,6 +3751,31 @@ def _validate_persisted_eval_suite_case_group(
     return [results_by_runner[runner.name] for runner in parsed_runners]
 
 
+_REVIEWER_DEPENDENT_METRIC_FIELDS = (
+    "generalist_review_pass",
+    "generalist_review_score",
+    "generalist_review_issues",
+    "generalist_review_prompt_sha256",
+)
+
+
+def _reviewer_independent_metrics(
+    metrics: EvalArtifactMetrics | None,
+) -> dict[str, object] | None:
+    """Project metrics onto reviewer-independent fields for revalidation.
+
+    Generalist review is advisory and model-generated, so recomputing it
+    yields different output for the same artifact; persisted-row integrity
+    checks must compare only the deterministic validator outputs.
+    """
+    if metrics is None:
+        return None
+    payload = asdict(metrics)
+    for field_name in _REVIEWER_DEPENDENT_METRIC_FIELDS:
+        payload.pop(field_name, None)
+    return payload
+
+
 def _revalidate_persisted_eval_suite_case_results(
     case: EvalSuiteCase,
     results: Sequence[EvalResult],
@@ -3761,7 +3786,13 @@ def _revalidate_persisted_eval_suite_case_results(
     policyengine_runtime: PolicyEngineRuntime | None,
     rulespec_dependency_roots: Sequence[Path],
 ) -> None:
-    """Recompute persisted verdicts from exact artifacts before admitting them."""
+    """Recompute persisted deterministic verdicts before admitting rows.
+
+    Reviewers are skipped: generalist review is advisory and nondeterministic,
+    so persisted reviewer outcomes are carried forward as recorded while the
+    deterministic validators (compile, CI, grounding, oracle) must reproduce
+    exactly from the bound artifacts.
+    """
 
     identifier = case.corpus_citation_path or case.citation or ""
     source_unit = resolve_corpus_source_unit(identifier, corpus_release)
@@ -3782,7 +3813,7 @@ def _revalidate_persisted_eval_suite_case_results(
                 oracle=case.oracle,
                 policyengine_runtime=policyengine_runtime,
                 policyengine_rule_hint=case.policyengine_rule_hint,
-                skip_reviewers=False,
+                skip_reviewers=True,
                 source_metadata=source_metadata,
                 source_citation_path=source_citation_path,
                 rulespec_dependency_roots=rulespec_dependency_roots,
@@ -3803,12 +3834,8 @@ def _revalidate_persisted_eval_suite_case_results(
             if result.output_file
             else None
         )
-        persisted_metrics = (
-            asdict(result.metrics) if result.metrics is not None else None
-        )
-        recomputed_metrics = (
-            asdict(fresh_metrics) if fresh_metrics is not None else None
-        )
+        persisted_metrics = _reviewer_independent_metrics(result.metrics)
+        recomputed_metrics = _reviewer_independent_metrics(fresh_metrics)
         if (
             result.success is not fresh_success
             or persisted_metrics != recomputed_metrics

--- a/tests/test_eval_board.py
+++ b/tests/test_eval_board.py
@@ -1319,4 +1319,11 @@ def test_capability_manifest_locks_shape():
     # The roster is subscription-billed backends only.
     backends = {spec.split("=", 1)[-1].split(":", 1)[0] for spec in manifest.runners}
     assert backends == {"codex", "claude"}
-    assert len(manifest.runners) == len(set(manifest.runners)) == 5
+    assert manifest.runners == [
+        "terra=codex:gpt-5.6-terra",
+        "sol=codex:gpt-5.6-sol",
+        "gpt-5.5=codex:gpt-5.5",
+        "luna=codex:gpt-5.6-luna",
+        "fable=claude:claude-fable-5",
+        "opus-5=claude:claude-opus-5",
+    ]

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -9,6 +9,7 @@ import uuid
 from dataclasses import replace
 from datetime import date
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
@@ -21,6 +22,7 @@ from axiom_encode.corpus_resolver import (
     LocalCorpusRelease,
     resolve_scoped_local_corpus_source,
 )
+from axiom_encode.harness import evals as evals_module
 from axiom_encode.harness import validator_pipeline
 from axiom_encode.harness.dependency_stubs import UnsafeRulespecContextPath
 from axiom_encode.harness.encoding_db import TokenUsage
@@ -13279,10 +13281,16 @@ cases:
                 resume_existing=True,
             )
 
-    def test_run_eval_suite_resume_reruns_reviewer_for_complete_revalidation(
+    def test_run_eval_suite_resume_revalidates_without_rerunning_reviewer(
         self,
         tmp_path,
     ):
+        """Resume recomputes deterministic verdicts; advisory review is not rerun.
+
+        Generalist review is model-generated and nondeterministic, so a resume
+        that rerun it could never reproduce the persisted output byte-for-byte
+        and every legitimate resume of a reviewed suite would be refused.
+        """
         manifest, corpus_release, output_root, axiom_rules_path = (
             _complete_test_eval_suite(tmp_path)
         )
@@ -13301,7 +13309,7 @@ cases:
         self.persisted_result_revalidation.assert_called_once()
         assert (
             self.persisted_result_revalidation.call_args.kwargs["skip_reviewers"]
-            is False
+            is True
         )
 
     def test_revalidation_admission_authenticates_without_old_verdict_equality(
@@ -13343,25 +13351,8 @@ cases:
         assert completed == {1}
         self.persisted_result_revalidation.assert_not_called()
 
-    @pytest.mark.parametrize(
-        "metrics_mutation",
-        [
-            {
-                "generalist_review_pass": False,
-                "generalist_review_score": 1.0,
-            },
-            {"policyengine_pass": True},
-        ],
-        ids=["generalist-review", "policyengine-oracle"],
-    )
-    def test_run_eval_suite_resume_rejects_fully_rehashed_verdict_mutation(
-        self,
-        tmp_path,
-        metrics_mutation,
-    ):
-        manifest, corpus_release, output_root, axiom_rules_path = (
-            _complete_test_eval_suite(tmp_path)
-        )
+    def _mutate_and_rehash_first_row(self, output_root, metrics_mutation):
+        """Mutate persisted metrics with full verdict re-sign and rehash."""
         ledger_path = output_root / "suite-results.jsonl"
         row = json.loads(ledger_path.read_text())
         result_payload = row["result"]
@@ -13383,12 +13374,18 @@ cases:
         row["result"] = _bind_eval_result_payload(result_payload)
         ledger_path.write_text(json.dumps(row, sort_keys=True) + "\n")
 
-        expected_error = (
-            "PolicyEngine evidence without its runtime identity"
-            if "policyengine_pass" in metrics_mutation
-            else "fresh validation of the bound artifact"
+    def test_run_eval_suite_resume_rejects_fully_rehashed_verdict_mutation(
+        self,
+        tmp_path,
+    ):
+        manifest, corpus_release, output_root, axiom_rules_path = (
+            _complete_test_eval_suite(tmp_path)
         )
-        with pytest.raises(ValueError, match=expected_error):
+        self._mutate_and_rehash_first_row(output_root, {"policyengine_pass": True})
+
+        with pytest.raises(
+            ValueError, match="PolicyEngine evidence without its runtime identity"
+        ):
             run_eval_suite(
                 manifest=manifest,
                 output_root=output_root,
@@ -13397,13 +13394,46 @@ cases:
                 corpus_release=corpus_release,
                 resume_existing=True,
             )
-        if "policyengine_pass" in metrics_mutation:
-            self.persisted_result_revalidation.assert_not_called()
-        else:
-            assert (
-                self.persisted_result_revalidation.call_args.kwargs["skip_reviewers"]
-                is False
-            )
+        self.persisted_result_revalidation.assert_not_called()
+
+    def test_run_eval_suite_resume_admits_resigned_advisory_review_mutation(
+        self,
+        tmp_path,
+    ):
+        """A key-holding mutation of advisory review fields is admitted.
+
+        Recompute-equality cannot police the generalist reviewer: it is
+        nondeterministic, so rerunning it rejects every legitimate resume
+        (the failure this contract replaces). Advisory review integrity is
+        signature-bound instead; this attacker re-signs with the live broker
+        key, which no deterministic check can distinguish from a real run.
+        Deterministic gate fields stay recompute-verified regardless.
+        """
+        manifest, corpus_release, output_root, axiom_rules_path = (
+            _complete_test_eval_suite(tmp_path)
+        )
+        self._mutate_and_rehash_first_row(
+            output_root,
+            {"generalist_review_pass": False, "generalist_review_score": 1.0},
+        )
+        self.persisted_result_revalidation.reset_mock()
+
+        results = run_eval_suite(
+            manifest=manifest,
+            output_root=output_root,
+            axiom_rules_path=axiom_rules_path,
+            policy_repo_path=tmp_path / "rulespec-us",
+            corpus_release=corpus_release,
+            resume_existing=True,
+        )
+
+        assert len(results) == 1
+        assert results[0].metrics.generalist_review_pass is False
+        assert results[0].metrics.generalist_review_score == 1.0
+        assert (
+            self.persisted_result_revalidation.call_args.kwargs["skip_reviewers"]
+            is True
+        )
 
     def test_run_eval_suite_resume_rejects_fully_rehashed_cost_laundering(
         self,
@@ -17250,3 +17280,118 @@ def test_summarize_validation_failures_deduplicates_caps_and_counts_before_cap()
     assert sum(summary["validation_failure_counts"].values()) == 42
     assert summary["validation_failure_counts"][f"compile:{'x' * 60}"] == 1
     assert all(len(item["detail"]) <= 240 for item in summary["validation_failures"])
+
+
+def _revalidation_metrics(**overrides) -> EvalArtifactMetrics:
+    base = dict(
+        compile_pass=True,
+        compile_issues=[],
+        ci_pass=True,
+        ci_issues=[],
+        embedded_source_present=True,
+        grounded_numeric_count=3,
+        ungrounded_numeric_count=0,
+        grounding=[GroundingMetric(line=4, raw="20", value=20.0, grounded=True)],
+        source_numeric_occurrence_count=3,
+        covered_source_numeric_occurrence_count=3,
+        missing_source_numeric_occurrence_count=0,
+        numeric_occurrence_issues=[],
+        generalist_review_pass=True,
+        generalist_review_score=8.5,
+        generalist_review_issues=["style nit"],
+        generalist_review_prompt_sha256="a" * 64,
+    )
+    base.update(overrides)
+    return EvalArtifactMetrics(**base)
+
+
+def _revalidation_result(metrics: EvalArtifactMetrics) -> evals_module.EvalResult:
+    return evals_module.EvalResult(
+        citation="uk/statute/ukpga/1994/23/2",
+        runner="fable",
+        backend="claude",
+        model="claude-fable-5",
+        mode="cold",
+        output_file="artifact.yaml",
+        trace_file="trace.json",
+        context_manifest_file="context.json",
+        generated_output_sha256="b" * 64,
+        trace_sha256="c" * 64,
+        context_manifest_sha256="d" * 64,
+        duration_ms=1000,
+        success=True,
+        error=None,
+        input_tokens=10,
+        output_tokens=20,
+        cache_read_tokens=0,
+        cache_creation_tokens=0,
+        reasoning_output_tokens=0,
+        estimated_cost_usd=None,
+        actual_cost_usd=1.0,
+        retrieved_files=[],
+        unexpected_accesses=[],
+        metrics=metrics,
+    )
+
+
+def _run_case_revalidation(persisted: EvalArtifactMetrics, fresh: EvalArtifactMetrics):
+    case = evals_module.EvalSuiteCase(
+        kind="source",
+        name="vat_standard_rate",
+        mode="cold",
+        corpus_citation_path="uk/statute/ukpga/1994/23/2",
+    )
+    source_unit = SimpleNamespace(body="The rate of VAT is 20 percent.")
+    with (
+        patch.object(
+            evals_module, "resolve_corpus_source_unit", return_value=source_unit
+        ),
+        patch.object(
+            evals_module, "_source_metadata_with_attestation", return_value={}
+        ),
+        patch.object(
+            evals_module,
+            "_source_metadata_citation_path",
+            return_value="uk/statute/ukpga/1994/23/2",
+        ),
+        patch.object(
+            evals_module, "evaluate_artifact", return_value=fresh
+        ) as evaluate_mock,
+    ):
+        evals_module._revalidate_persisted_eval_suite_case_results(
+            case,
+            [_revalidation_result(persisted)],
+            policy_repo_root=Path("/nonexistent/policy"),
+            axiom_rules_path=Path("/nonexistent/engine"),
+            corpus_release=SimpleNamespace(),
+            policyengine_runtime=None,
+            rulespec_dependency_roots=(),
+        )
+    return evaluate_mock
+
+
+def test_persisted_revalidation_ignores_reviewer_outcomes():
+    """Advisory reviewer output is nondeterministic; it must not gate resume."""
+    persisted = _revalidation_metrics()
+    fresh = _revalidation_metrics(
+        generalist_review_pass=None,
+        generalist_review_score=None,
+        generalist_review_issues=[],
+        generalist_review_prompt_sha256=None,
+    )
+    evaluate_mock = _run_case_revalidation(persisted, fresh)
+    assert evaluate_mock.call_args.kwargs["skip_reviewers"] is True
+
+
+def test_persisted_revalidation_still_rejects_deterministic_drift():
+    persisted = _revalidation_metrics()
+    fresh = _revalidation_metrics(
+        ci_pass=False,
+        ci_issues=["fixture failed"],
+        generalist_review_pass=None,
+        generalist_review_score=None,
+        generalist_review_issues=[],
+        generalist_review_prompt_sha256=None,
+    )
+    with pytest.raises(ValueError, match="do not match fresh validation"):
+        _run_case_revalidation(persisted, fresh)

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -13396,6 +13396,41 @@ cases:
             )
         self.persisted_result_revalidation.assert_not_called()
 
+    def test_run_eval_suite_resume_rejects_fully_rehashed_deterministic_mutation(
+        self,
+        tmp_path,
+    ):
+        """Deterministic metric drift is refused by recompute, not hydration.
+
+        The mutation survives every hydration-layer guard (verdict re-signed,
+        hashes rebound, no runtime-identity coupling), so the refusal must
+        come from the deterministic revalidation comparison itself.
+        """
+        manifest, corpus_release, output_root, axiom_rules_path = (
+            _complete_test_eval_suite(tmp_path)
+        )
+        row = json.loads((output_root / "suite-results.jsonl").read_text())
+        original_count = row["result"]["metrics"]["grounded_numeric_count"]
+        self._mutate_and_rehash_first_row(
+            output_root, {"grounded_numeric_count": original_count + 4}
+        )
+        self.persisted_result_revalidation.reset_mock()
+
+        with pytest.raises(ValueError, match="fresh validation of the bound artifact"):
+            run_eval_suite(
+                manifest=manifest,
+                output_root=output_root,
+                axiom_rules_path=axiom_rules_path,
+                policy_repo_path=tmp_path / "rulespec-us",
+                corpus_release=corpus_release,
+                resume_existing=True,
+            )
+        self.persisted_result_revalidation.assert_called_once()
+        assert (
+            self.persisted_result_revalidation.call_args.kwargs["skip_reviewers"]
+            is True
+        )
+
     def test_run_eval_suite_resume_admits_resigned_advisory_review_mutation(
         self,
         tmp_path,
@@ -17305,22 +17340,28 @@ def _revalidation_metrics(**overrides) -> EvalArtifactMetrics:
     return EvalArtifactMetrics(**base)
 
 
-def _revalidation_result(metrics: EvalArtifactMetrics) -> evals_module.EvalResult:
+def _revalidation_result(
+    metrics: EvalArtifactMetrics | None,
+    *,
+    output_file: str = "artifact.yaml",
+    success: bool = True,
+    error: str | None = None,
+) -> evals_module.EvalResult:
     return evals_module.EvalResult(
         citation="uk/statute/ukpga/1994/23/2",
         runner="fable",
         backend="claude",
         model="claude-fable-5",
         mode="cold",
-        output_file="artifact.yaml",
+        output_file=output_file,
         trace_file="trace.json",
         context_manifest_file="context.json",
         generated_output_sha256="b" * 64,
         trace_sha256="c" * 64,
         context_manifest_sha256="d" * 64,
         duration_ms=1000,
-        success=True,
-        error=None,
+        success=success,
+        error=error,
         input_tokens=10,
         output_tokens=20,
         cache_read_tokens=0,
@@ -17334,7 +17375,11 @@ def _revalidation_result(metrics: EvalArtifactMetrics) -> evals_module.EvalResul
     )
 
 
-def _run_case_revalidation(persisted: EvalArtifactMetrics, fresh: EvalArtifactMetrics):
+def _run_case_revalidation(
+    persisted: EvalArtifactMetrics | None,
+    fresh: EvalArtifactMetrics | None,
+    **result_overrides,
+):
     case = evals_module.EvalSuiteCase(
         kind="source",
         name="vat_standard_rate",
@@ -17360,7 +17405,7 @@ def _run_case_revalidation(persisted: EvalArtifactMetrics, fresh: EvalArtifactMe
     ):
         evals_module._revalidate_persisted_eval_suite_case_results(
             case,
-            [_revalidation_result(persisted)],
+            [_revalidation_result(persisted, **result_overrides)],
             policy_repo_root=Path("/nonexistent/policy"),
             axiom_rules_path=Path("/nonexistent/engine"),
             corpus_release=SimpleNamespace(),
@@ -17383,15 +17428,36 @@ def test_persisted_revalidation_ignores_reviewer_outcomes():
     assert evaluate_mock.call_args.kwargs["skip_reviewers"] is True
 
 
-def test_persisted_revalidation_still_rejects_deterministic_drift():
-    persisted = _revalidation_metrics()
-    fresh = _revalidation_metrics(
-        ci_pass=False,
-        ci_issues=["fixture failed"],
+@pytest.mark.parametrize(
+    "persisted_overrides,fresh_overrides",
+    [
+        ({}, {"ci_pass": False, "ci_issues": ["fixture failed"]}),
+        (
+            {"policyengine_pass": True, "policyengine_score": 0.97},
+            {"policyengine_pass": False, "policyengine_score": 0.41},
+        ),
+    ],
+    ids=["ci", "policyengine-oracle"],
+)
+def test_persisted_revalidation_still_rejects_deterministic_drift(
+    persisted_overrides, fresh_overrides
+):
+    """Deterministic validator fields — oracle included — stay recompute-bound."""
+    reviewer_blank = dict(
         generalist_review_pass=None,
         generalist_review_score=None,
         generalist_review_issues=[],
         generalist_review_prompt_sha256=None,
     )
+    persisted = _revalidation_metrics(**persisted_overrides)
+    fresh = _revalidation_metrics(**reviewer_blank, **fresh_overrides)
     with pytest.raises(ValueError, match="do not match fresh validation"):
         _run_case_revalidation(persisted, fresh)
+
+
+def test_persisted_revalidation_admits_unvalidated_rows_without_reviewer_calls():
+    """A row with no bound artifact (no output, metrics=None) resumes cleanly."""
+    evaluate_mock = _run_case_revalidation(
+        None, None, output_file="", success=False, error="encode failed"
+    )
+    evaluate_mock.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1379"
+version = "0.2.1380"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Defect

`_revalidate_persisted_eval_suite_case_results` re-ran the full validator stack with `skip_reviewers=False` and required bitwise metric equality against persisted rows. The generalist reviewer is model-generated and nondeterministic, so any suite whose reviewer actually ran could never pass this check: eval-suite **finalize** (post-run verified-artifact build), **resume**, and **archive** all refused with "persisted success, error, or metrics do not match fresh validation of the bound artifact".

Production evidence: EncodeBench UK v1 fable runner (rig run 3ff8e583, encoder 0.2.1333) completed 16/16 cases at 2026-07-24T19:59Z, then finalization refused on case 1 ~99s later — one reviewer re-run's worth of work. The defect was latent until #1239 made claude reviewer calls actually work; before that, reviewer failures were deterministic ("Not logged in" both times → identical metrics), so revalidation always matched.

## Contract change

Persisted-row revalidation now:
- calls `evaluate_artifact(..., skip_reviewers=True)`;
- compares only reviewer-independent metric fields (new `_reviewer_independent_metrics` projection over `generalist_review_pass/score/issues/prompt_sha256`);
- carries persisted advisory reviewer outcomes forward as recorded.

Deterministic gate fields (compile, CI, grounding, numeric occurrence, oracle) remain recompute-verified — `success`/`error` were already reviewer-independent via `_eval_artifact_validation_error`.

**Security boundary, stated honestly:** recompute-equality cannot police a nondeterministic judge. Advisory review integrity is signature-bound: a key-less attacker is still caught by verdict signature verification; an attacker holding the live signing broker key can mutate advisory fields undetected (they could equally sign a fresh fake review — no deterministic check distinguishes them). Deterministic gate columns — the headline board numbers — stay recompute-verified against the bound artifacts in every case.

## Tests

- `test_persisted_revalidation_ignores_reviewer_outcomes` — reproduces the production failure (fresh reviewer output differs → must admit); asserts `skip_reviewers=True`.
- `test_persisted_revalidation_still_rejects_deterministic_drift` — CI flip still refused.
- `test_run_eval_suite_resume_reruns_reviewer_for_complete_revalidation` → renamed `..._revalidates_without_rerunning_reviewer`, assertion inverted to the new contract.
- `test_run_eval_suite_resume_rejects_fully_rehashed_verdict_mutation` — de-parametrized; the PolicyEngine-oracle mutation case (deterministic) still rejects.
- New `test_run_eval_suite_resume_admits_resigned_advisory_review_mutation` — documents the signature-bound boundary for advisory fields with a broker-holding attacker.

## Also

- EncodeBench UK v1 adds an `opus-5=claude:claude-opus-5` runner (roster change only; runner sets fold freely under the eval-board comparability contract).
- Version 0.2.1380; changelog entries under #1189.

## Checks

- `uv run pytest tests/test_evals.py` — 617 passed
- Repo focused battery (`-k "rulespec or EncoderPrompt"`) — 1230 passed
- `test_current_encoder_affecting_changes_are_behind_version_bump` — passed on HEAD
- `ruff check` + `ruff format --check` + `compileall` — clean

Review cycle: independent Sol (gpt-5.6-sol, ultra) review to follow on this PR per repo PR discipline; merge only on cross-family agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
