### PR TITLE
Typed numeric occurrences with rate-context grounding (#1279) + de-DE locale profile

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1380"
+version = "0.2.1381"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1380"
+__version__ = "0.2.1381"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -28908,19 +28908,12 @@ def _closest_exact_source_excerpt(
         return _safe_wrapped_direct_source_match(source, direct_match)
 
     query_tokens = _proof_excerpt_match_tokens(query)
-    query_numbers = set(
-        extract_numbers_from_text(query, profile=numeric_profile)
-    )
-    if (
-        _has_malformed_profiled_numeric_envelope(
-            query,
-            profile=numeric_profile,
-        )
-        or (
-            numeric_profile != "legacy"
-            and re.search(r"\d", query)
-            and not query_numbers
-        )
+    query_numbers = set(extract_numbers_from_text(query, profile=numeric_profile))
+    if _has_malformed_profiled_numeric_envelope(
+        query,
+        profile=numeric_profile,
+    ) or (
+        numeric_profile != "legacy" and re.search(r"\d", query) and not query_numbers
     ):
         return None
     scored: list[tuple[float, _SourceExcerptCandidate]] = []

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -221,9 +221,11 @@ from .harness.validator_pipeline import (
     _canonical_rulespec_target,
     _extract_source_verification_text,
     _filing_status_rule_source_context,
+    _has_malformed_profiled_numeric_envelope,
     _is_executable_rulespec_rule,
     _matching_delegated_setting_rule_names,
     _normalize_rulespec_dependency_roots,
+    _numeric_profile_for_citation_path,
     _parse_rulespec_target,
     _resolve_rulespec_target_file,
     _rule_versions_are_constant_false,
@@ -23098,7 +23100,10 @@ def _try_repair_generated_source_child_corpus_paths_for_apply(
     )
     if not child_source_text:
         return []
-    source_occurrences = extract_typed_numeric_occurrences_from_text(child_source_text)
+    source_occurrences = extract_typed_numeric_occurrences_from_text(
+        child_source_text,
+        profile=_numeric_profile_for_citation_path(child_corpus_path),
+    )
     if not all(
         numeric_value_is_grounded(float(value), source_occurrences)
         for value in literals
@@ -23800,8 +23805,14 @@ def _grounded_formula_literal_for_scalar_expression(
                 continue
             excerpt = source.get("excerpt")
             if isinstance(excerpt, str):
+                citation_path = source.get("corpus_citation_path")
                 source_occurrences.extend(
-                    extract_typed_numeric_occurrences_from_text(excerpt)
+                    extract_typed_numeric_occurrences_from_text(
+                        excerpt,
+                        profile=_numeric_profile_for_citation_path(
+                            citation_path if isinstance(citation_path, str) else None
+                        ),
+                    )
                 )
     if not source_occurrences or not numeric_value_is_grounded(
         value, source_occurrences
@@ -28722,7 +28733,11 @@ def _try_repair_generated_nonexact_proof_excerpts_for_apply(
             if not isinstance(excerpt, str) or not excerpt.strip():
                 continue
             source_text = embedded_source_text
-            corpus_citation_path = str(source.get("corpus_citation_path") or "").strip()
+            raw_citation_path = source.get("corpus_citation_path")
+            corpus_citation_path = str(raw_citation_path or "").strip()
+            numeric_profile = _numeric_profile_for_citation_path(
+                raw_citation_path if isinstance(raw_citation_path, str) else None
+            )
             if corpus_release is not None and corpus_citation_path:
                 if corpus_citation_path not in cited_source_texts:
                     cited_source_texts[corpus_citation_path] = (
@@ -28750,6 +28765,7 @@ def _try_repair_generated_nonexact_proof_excerpts_for_apply(
                 exact_excerpt = _closest_exact_source_excerpt(
                     source_text=source_text,
                     excerpt=excerpt,
+                    numeric_profile=numeric_profile,
                 )
             if exact_excerpt is None or exact_excerpt == excerpt:
                 continue
@@ -28835,7 +28851,12 @@ def _install_generated_yaml_payload(rules_file: Path, payload: dict) -> bool:
     return True
 
 
-def _closest_exact_source_excerpt(*, source_text: str, excerpt: str) -> str | None:
+def _closest_exact_source_excerpt(
+    *,
+    source_text: str,
+    excerpt: str,
+    numeric_profile: str = "legacy",
+) -> str | None:
     source = str(source_text)
     query = re.sub(r"\s+", " ", str(excerpt)).strip()
     if not source or not query:
@@ -28849,6 +28870,7 @@ def _closest_exact_source_excerpt(*, source_text: str, excerpt: str) -> str | No
                 candidate := _closest_exact_source_excerpt(
                     source_text=segment,
                     excerpt=excerpt,
+                    numeric_profile=numeric_profile,
                 )
             )
         }
@@ -28886,13 +28908,32 @@ def _closest_exact_source_excerpt(*, source_text: str, excerpt: str) -> str | No
         return _safe_wrapped_direct_source_match(source, direct_match)
 
     query_tokens = _proof_excerpt_match_tokens(query)
-    query_numbers = set(extract_numbers_from_text(query))
+    query_numbers = set(
+        extract_numbers_from_text(query, profile=numeric_profile)
+    )
+    if (
+        _has_malformed_profiled_numeric_envelope(
+            query,
+            profile=numeric_profile,
+        )
+        or (
+            numeric_profile != "legacy"
+            and re.search(r"\d", query)
+            and not query_numbers
+        )
+    ):
+        return None
     scored: list[tuple[float, _SourceExcerptCandidate]] = []
     for candidate in candidates:
         normalized_candidate = re.sub(r"\s+", " ", candidate.text).strip()
         candidate_tokens = _proof_excerpt_match_tokens(candidate.text)
         shared_tokens = query_tokens & candidate_tokens
-        candidate_numbers = set(extract_numbers_from_text(candidate.text))
+        candidate_numbers = set(
+            extract_numbers_from_text(
+                candidate.text,
+                profile=numeric_profile,
+            )
+        )
         shared_numbers = query_numbers & candidate_numbers
         if query_numbers and not shared_numbers:
             continue

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -237,6 +237,7 @@ from .harness.validator_pipeline import (
     _rulespec_target_is_descendant_of,
     extract_embedded_source_text,
     extract_numbers_from_text,
+    extract_typed_numeric_occurrences_from_text,
     find_interval_table_reencoding_candidates,
     find_structured_scale_parameter_issue_records,
     find_tax_filing_status_local_input_issues,
@@ -23097,9 +23098,10 @@ def _try_repair_generated_source_child_corpus_paths_for_apply(
     )
     if not child_source_text:
         return []
-    source_numbers = extract_numbers_from_text(child_source_text)
+    source_occurrences = extract_typed_numeric_occurrences_from_text(child_source_text)
     if not all(
-        numeric_value_is_grounded(float(value), source_numbers) for value in literals
+        numeric_value_is_grounded(float(value), source_occurrences)
+        for value in literals
     ):
         return []
 
@@ -23786,7 +23788,7 @@ def _grounded_formula_literal_for_scalar_expression(
     value = _simple_fraction_expression_value(expression)
     if value is None:
         return None
-    source_numbers: set[float] = set()
+    source_occurrences = []
     proof = rule.get("metadata", {}).get("proof")
     atoms = proof.get("atoms") if isinstance(proof, dict) else None
     if isinstance(atoms, list):
@@ -23798,8 +23800,12 @@ def _grounded_formula_literal_for_scalar_expression(
                 continue
             excerpt = source.get("excerpt")
             if isinstance(excerpt, str):
-                source_numbers.update(extract_numbers_from_text(excerpt))
-    if not source_numbers or not numeric_value_is_grounded(value, source_numbers):
+                source_occurrences.extend(
+                    extract_typed_numeric_occurrences_from_text(excerpt)
+                )
+    if not source_occurrences or not numeric_value_is_grounded(
+        value, source_occurrences
+    ):
         return None
     return _format_grounded_scalar_formula_literal(value)
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -6374,11 +6374,9 @@ def _evaluate_artifact_in_scope(
                 )
 
     content = rulespec_file.read_text()
-    numeric_proof_source_texts = (
-        pipeline._numeric_source_texts_for_rulespec_content(
-            content,
-            source_texts=None,
-        )
+    numeric_proof_source_texts = pipeline._numeric_source_texts_for_rulespec_content(
+        content,
+        source_texts=None,
     )
     embedded_source = extract_embedded_source_text(content)
     numeric_source_text = extract_numeric_grounding_source_text(content)
@@ -6397,9 +6395,7 @@ def _evaluate_artifact_in_scope(
                 numeric_source_citation_path = _module_numeric_citation_path(
                     numeric_payload
                 )
-    numeric_profile = _numeric_profile_for_citation_path(
-        numeric_source_citation_path
-    )
+    numeric_profile = _numeric_profile_for_citation_path(numeric_source_citation_path)
     half_up_helper_count = min(
         source_backed_half_up_rounding_helper_count(content, source_text),
         source_backed_half_up_rounding_helper_count(
@@ -6439,9 +6435,7 @@ def _evaluate_artifact_in_scope(
     semantic_source_occurrence_coverage = Counter[float]()
     if half_up_helper_count:
         semantic_source_occurrence_coverage[5.0] = half_up_helper_count
-    source_is_table = _source_text_looks_like_table(
-        numeric_validation_source_text
-    )
+    source_is_table = _source_text_looks_like_table(numeric_validation_source_text)
     inline_table_formula_occurrences = (
         _inline_table_formula_numeric_occurrences(content)
         if source_is_table

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -100,18 +100,20 @@ from .validator_pipeline import (
     ValidatorPipeline,
     _authoritative_corpus_scope,
     _authoritative_rulespec_dependency_scope,
+    _module_numeric_citation_path,
     _normalize_rulespec_dependency_roots,
+    _numeric_profile_for_citation_path,
     _parse_rulespec_target,
     _resolve_rulespec_target_file,
     _source_text_looks_like_table,
-    evaluate_numeric_grounding_values,
+    evaluate_numeric_grounding_values_scoped,
     extract_embedded_source_text,
     extract_named_scalar_occurrences,
     extract_numeric_grounding_source_text,
     extract_numeric_occurrences_from_text,
     extract_typed_numeric_inventory_occurrences_from_text,
     find_deferred_output_issues,
-    find_ungrounded_numeric_issues,
+    find_ungrounded_numeric_issues_scoped,
     find_unused_import_issues,
     find_unused_modifier_parameter_issues,
     normalize_source_backed_half_up_rounding_occurrence_text,
@@ -640,70 +642,6 @@ def _is_empty_nonassertable_artifact(content: str) -> bool:
         else str(payload.get("status", "")).strip()
     )
     return status in {"deferred", "entity_not_supported"} and not payload.get("rules")
-
-
-def _extract_proof_source_excerpt_text(content: str) -> str:
-    """Return source excerpts from proof atoms for numeric grounding."""
-    with contextlib.suppress(ValueError, TypeError, yaml.YAMLError):
-        payload = yaml.safe_load(content)
-        if not isinstance(payload, dict):
-            return ""
-        rules = payload.get("rules")
-        if not isinstance(rules, list):
-            return ""
-        excerpts: list[str] = []
-        for rule in rules:
-            if not isinstance(rule, dict):
-                continue
-            metadata = rule.get("metadata")
-            if not isinstance(metadata, dict):
-                continue
-            proof = metadata.get("proof")
-            if not isinstance(proof, dict):
-                continue
-            atoms = proof.get("atoms")
-            if not isinstance(atoms, list):
-                continue
-            for atom in atoms:
-                if not isinstance(atom, dict):
-                    continue
-                source = atom.get("source")
-                if not isinstance(source, dict):
-                    continue
-                excerpt = source.get("excerpt")
-                if isinstance(excerpt, str) and excerpt.strip():
-                    excerpts.append(excerpt.strip())
-        return "\n".join(excerpts)
-    return ""
-
-
-def _has_parameter_table_proof_atom(content: str) -> bool:
-    """Return true when a RuleSpec artifact grounds values in a source table."""
-    with contextlib.suppress(ValueError, TypeError, yaml.YAMLError):
-        payload = yaml.safe_load(content)
-        if not isinstance(payload, dict):
-            return False
-        rules = payload.get("rules")
-        if not isinstance(rules, list):
-            return False
-        for rule in rules:
-            if not isinstance(rule, dict):
-                continue
-            metadata = rule.get("metadata")
-            if not isinstance(metadata, dict):
-                continue
-            proof = metadata.get("proof")
-            if not isinstance(proof, dict):
-                continue
-            atoms = proof.get("atoms")
-            if not isinstance(atoms, list):
-                continue
-            if any(
-                isinstance(atom, dict) and atom.get("kind") == "parameter_table"
-                for atom in atoms
-            ):
-                return True
-    return False
 
 
 @dataclass(frozen=True)
@@ -6436,21 +6374,31 @@ def _evaluate_artifact_in_scope(
                 )
 
     content = rulespec_file.read_text()
+    numeric_proof_source_texts = (
+        pipeline._numeric_source_texts_for_rulespec_content(
+            content,
+            source_texts=None,
+        )
+    )
     embedded_source = extract_embedded_source_text(content)
-    proof_excerpt_text = _extract_proof_source_excerpt_text(content)
     numeric_source_text = extract_numeric_grounding_source_text(content)
     if not numeric_source_text and source_text:
         numeric_source_text = source_text
-    numeric_validation_source_text = embedded_source or numeric_source_text
-    numeric_grounding_validation_source_text = numeric_validation_source_text
-    if source_text and _has_parameter_table_proof_atom(content):
-        numeric_grounding_validation_source_text = "\n".join(
-            part for part in (source_text, numeric_validation_source_text) if part
-        )
-    numeric_grounding_source_text = "\n".join(
-        part
-        for part in (numeric_grounding_validation_source_text, proof_excerpt_text)
-        if part
+    # Source-recall metrics retain their long-standing operating-slice scope,
+    # but generated literals are grounded only in authoritative source text and
+    # separately parsed proof evidence below — never in module.summary.
+    numeric_validation_source_text = embedded_source or numeric_source_text or ""
+    grounding_module_source_text = source_text or numeric_source_text or ""
+    numeric_source_citation_path = source_citation_path
+    if numeric_source_citation_path is None:
+        with contextlib.suppress(ValueError, TypeError, yaml.YAMLError):
+            numeric_payload = yaml.safe_load(content)
+            if isinstance(numeric_payload, dict):
+                numeric_source_citation_path = _module_numeric_citation_path(
+                    numeric_payload
+                )
+    numeric_profile = _numeric_profile_for_citation_path(
+        numeric_source_citation_path
     )
     half_up_helper_count = min(
         source_backed_half_up_rounding_helper_count(content, source_text),
@@ -6464,7 +6412,8 @@ def _evaluate_artifact_in_scope(
     )
     typed_source_numeric_occurrences = (
         extract_typed_numeric_inventory_occurrences_from_text(
-            counted_numeric_source_text
+            counted_numeric_source_text,
+            profile=numeric_profile,
         )
     )
     source_numeric_occurrences = Counter(
@@ -6491,7 +6440,7 @@ def _evaluate_artifact_in_scope(
     if half_up_helper_count:
         semantic_source_occurrence_coverage[5.0] = half_up_helper_count
     source_is_table = _source_text_looks_like_table(
-        numeric_grounding_validation_source_text or ""
+        numeric_validation_source_text
     )
     inline_table_formula_occurrences = (
         _inline_table_formula_numeric_occurrences(content)
@@ -6500,10 +6449,13 @@ def _evaluate_artifact_in_scope(
     )
 
     grounding_metrics: list[GroundingMetric] = []
-    for line, raw, value, grounded in evaluate_numeric_grounding_values(
+    for line, raw, value, grounded in evaluate_numeric_grounding_values_scoped(
         content,
-        numeric_grounding_source_text,
+        module_source_text=grounding_module_source_text,
+        module_citation_path=numeric_source_citation_path,
+        proof_source_texts=numeric_proof_source_texts,
         authoritative_source_text=source_text,
+        require_body_bound_proof_evidence=False,
     ):
         grounding_metrics.append(
             GroundingMetric(
@@ -6541,10 +6493,12 @@ def _evaluate_artifact_in_scope(
                 f"but only {covered_count} named scalar definition(s) with that value were found."
             )
 
-    ungrounded_numeric_issues = find_ungrounded_numeric_issues(
+    ungrounded_numeric_issues = find_ungrounded_numeric_issues_scoped(
         content,
-        numeric_grounding_source_text,
-        authoritative_source_text=source_text,
+        module_source_text=grounding_module_source_text,
+        module_citation_path=numeric_source_citation_path,
+        proof_source_texts=numeric_proof_source_texts,
+        require_body_bound_proof_evidence=False,
     )
     admin_agency_aggregate_issues = find_admin_agency_aggregate_entity_issues(
         content,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -95,6 +95,7 @@ from .policyengine_runtime import (
 )
 from .pricing import estimate_usage_cost_usd
 from .validator_pipeline import (
+    NumericOccurrence,
     ValidationResult,
     ValidatorPipeline,
     _authoritative_corpus_scope,
@@ -108,6 +109,7 @@ from .validator_pipeline import (
     extract_named_scalar_occurrences,
     extract_numeric_grounding_source_text,
     extract_numeric_occurrences_from_text,
+    extract_typed_numeric_inventory_occurrences_from_text,
     find_deferred_output_issues,
     find_ungrounded_numeric_issues,
     find_unused_import_issues,
@@ -279,7 +281,7 @@ def _is_rulespec_local_identifier(value: str | None) -> bool:
 
 def _matching_numeric_occurrence_count(
     occurrences: Counter[float],
-    value: float,
+    source_occurrences: Sequence[NumericOccurrence],
 ) -> int:
     """Return whether a named scalar covers the source value.
 
@@ -288,7 +290,7 @@ def _matching_numeric_occurrence_count(
     """
     return int(
         any(
-            numeric_value_is_grounded(occurrence_value, {value})
+            numeric_value_is_grounded(occurrence_value, source_occurrences)
             for occurrence_value in occurrences
         )
     )
@@ -6460,11 +6462,22 @@ def _evaluate_artifact_in_scope(
         numeric_validation_source_text or "",
         suppress_source_backed_half_up_increment=bool(half_up_helper_count),
     )
-    source_numeric_occurrences = Counter(
-        extract_numeric_occurrences_from_text(counted_numeric_source_text)
+    typed_source_numeric_occurrences = (
+        extract_typed_numeric_inventory_occurrences_from_text(
+            counted_numeric_source_text
+        )
     )
+    source_numeric_occurrences = Counter(
+        occurrence.value for occurrence in typed_source_numeric_occurrences
+    )
+    source_occurrences_by_value: dict[float, list[NumericOccurrence]] = defaultdict(
+        list
+    )
+    for occurrence in typed_source_numeric_occurrences:
+        source_occurrences_by_value[occurrence.value].append(occurrence)
     if _is_empty_nonassertable_artifact(content):
         source_numeric_occurrences = Counter()
+        source_occurrences_by_value = defaultdict(list)
     named_scalar_occurrences = Counter(
         item.value for item in extract_named_scalar_occurrences(content)
     )
@@ -6507,7 +6520,10 @@ def _evaluate_artifact_in_scope(
     for value, expected_count in sorted(source_numeric_occurrences.items()):
         covered_count = (
             expected_count
-            if _matching_numeric_occurrence_count(named_scalar_occurrences, value)
+            if _matching_numeric_occurrence_count(
+                named_scalar_occurrences,
+                source_occurrences_by_value[value],
+            )
             else 0
         )
         covered_count = max(

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -29,6 +29,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import unicodedata
 from calendar import monthrange
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -5764,13 +5765,42 @@ def _locale_sign_is_unary(text: str, sign_index: int) -> bool:
     )
 
 
-def _iter_locale_numeric_envelopes(text: str) -> Iterator[tuple[int, int]]:
+def _de_glued_sentence_marker_end(text: str, dot_index: int) -> int | None:
+    """Return the end of a juris ``.3Die``-style marker prefix, if present."""
+    if dot_index >= len(text) or text[dot_index] != ".":
+        return None
+
+    marker_end = dot_index + 1
+    digit_count = 0
+    while marker_end < len(text) and digit_count < 2 and text[marker_end].isdecimal():
+        marker_end += 1
+        digit_count += 1
+
+    if (
+        digit_count > 0
+        and marker_end < len(text)
+        and unicodedata.category(text[marker_end]) == "Lu"
+    ):
+        return marker_end
+    return None
+
+
+def _iter_locale_numeric_envelopes(
+    text: str,
+    *,
+    profile: str,
+) -> Iterator[tuple[int, int]]:
     """Reserve each complete numeric-looking span before locale validation."""
     occupied_until = 0
     for digit_match in re.finditer(r"\d", text):
         digit_start = digit_match.start()
         if digit_start < occupied_until:
             continue
+        if profile == "de-DE" and digit_start > 0 and text[digit_start - 1] == ".":
+            marker_end = _de_glued_sentence_marker_end(text, digit_start - 1)
+            if marker_end is not None:
+                occupied_until = marker_end
+                continue
 
         start = digit_start
         while start > 0 and text[start - 1] in ".,":
@@ -5791,12 +5821,18 @@ def _iter_locale_numeric_envelopes(text: str) -> Iterator[tuple[int, int]]:
 
         index = digit_start
         exponent_seen = False
+        reserved_until = 0
         while index < len(text):
             char = text[index]
             if char.isdigit():
                 index += 1
                 continue
             if char in ".,":
+                if profile == "de-DE" and char == ".":
+                    marker_end = _de_glued_sentence_marker_end(text, index)
+                    if marker_end is not None:
+                        reserved_until = marker_end
+                        break
                 separator_end = index
                 while separator_end < len(text) and text[separator_end] in ".,":
                     separator_end += 1
@@ -5826,7 +5862,7 @@ def _iter_locale_numeric_envelopes(text: str) -> Iterator[tuple[int, int]]:
                 continue
             break
 
-        occupied_until = index
+        occupied_until = max(index, reserved_until)
         yield start, index
 
 
@@ -5935,7 +5971,7 @@ def _has_malformed_profiled_numeric_envelope(
         _locale_numeric_envelope_has_token_boundaries(cleaned, span)
         and _parse_locale_numeric_envelope(cleaned[span[0] : span[1]], profile)
         is None
-        for span in _iter_locale_numeric_envelopes(cleaned)
+        for span in _iter_locale_numeric_envelopes(cleaned, profile=profile)
     )
 
 
@@ -5950,7 +5986,7 @@ def _tokenize_profiled_numeric_occurrences(
     collector = _LegacyNumericCollector(text)
     occurrences: list[NumericOccurrence] = []
 
-    for span in _iter_locale_numeric_envelopes(cleaned):
+    for span in _iter_locale_numeric_envelopes(cleaned, profile=profile):
         if not _locale_numeric_envelope_has_token_boundaries(cleaned, span):
             continue
         value = _parse_locale_numeric_envelope(cleaned[span[0] : span[1]], profile)

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -36,6 +36,7 @@ from contextvars import ContextVar
 from dataclasses import dataclass, field
 from datetime import date
 from decimal import Decimal, InvalidOperation
+from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any, Iterable, Iterator, Mapping, Optional, Sequence
 
@@ -1642,6 +1643,26 @@ _PERCENT_MARKER_AFTER_NUMBER_PATTERN = re.compile(
     r"\s*(?:%|\bp\.?\s*c\.?\b)",
     re.IGNORECASE,
 )
+_LOCAL_RATE_CONTEXT_AFTER_NUMBER_PATTERN = re.compile(
+    r"[ \t]*(?:"
+    r"%|"
+    r"\bp\.?[ \t]*c\.?\b|"
+    r"\bpercent\b|"
+    r"\bper[ \t-]+cent(?:um)?\b|"
+    r"\bProzent\b|"
+    r"\bvom[ \t]+Hundert\b"
+    r")",
+    re.IGNORECASE,
+)
+_TABLE_RATE_HEADER_PATTERN = re.compile(
+    r"(?:"
+    r"\bpercent(?:age)?\b|"
+    r"\bper[ \t-]+cent(?:um)?\b|"
+    r"\bProzent\b|"
+    r"\bvom[ \t]+Hundert\b"
+    r")",
+    re.IGNORECASE,
+)
 _VEHICLE_TAX_FISCAL_POWER_TABLE_CELL_PATTERN = re.compile(
     r"\b(?P<cv>[5-9]|1\d|20)\s+"
     r"(?=(?:\d{1,3}[.\u00a0\u202f]\d{3},\d{2}|\d{2,3}[,.]\d{2})"
@@ -1718,6 +1739,24 @@ _DATE_DECOMPOSITION_CUE_TOKENS = {
     "start",
     "end",
 }
+
+
+@dataclass(frozen=True)
+class NumericOccurrence:
+    """One normalized numeric candidate anchored to its exact source token."""
+
+    value: float
+    start: int
+    end: int
+    raw: str
+    has_rate_context: bool = False
+    source_value: float | None = None
+    requires_rate_context: bool = False
+
+    @property
+    def span(self) -> tuple[int, int]:
+        """Return the half-open source span for this occurrence."""
+        return self.start, self.end
 
 
 @dataclass(frozen=True)
@@ -3730,7 +3769,7 @@ def _call_body_contains_any(
         search_start = call_start + 1
 
 
-def extract_numbers_from_text(text: str) -> set[float]:
+def _extract_legacy_grounding_values(text: str) -> set[float]:
     """Extract numeric values from embedded statute text."""
     implied_cents_matches = _iter_form_implied_cents_matches(text)
     original_text = _FORM_IMPLIED_CENTS_PATTERN.sub(
@@ -4783,11 +4822,11 @@ def _strip_superseded_bracketed_numeric_text(match: re.Match[str]) -> str:
     return " "
 
 
-def _extract_collapsed_schedule_row_occurrences(
+def _iter_collapsed_schedule_row_occurrences(
     text: str,
-) -> tuple[list[float], str]:
-    """Extract schedule row values once per contiguous value block and remove row lines."""
-    occurrences: list[float] = []
+) -> tuple[list[tuple[tuple[int, int], float]], str]:
+    """Return schedule row values with input spans and remove their row lines."""
+    occurrences: list[tuple[tuple[int, int], float]] = []
     retained_lines: list[str] = []
     current_heading: str | None = None
     last_value_by_block: dict[str, float] = {}
@@ -4796,8 +4835,11 @@ def _extract_collapsed_schedule_row_occurrences(
     current_ungrouped_block: str | None = None
     pending_split_block_key: str | None = None
 
-    for line in text.splitlines():
+    line_offset = 0
+    for line_with_ending in text.splitlines(keepends=True):
+        line = line_with_ending.rstrip("\r\n")
         stripped = line.strip()
+        stripped_offset = line_offset + len(line) - len(line.lstrip())
         if pending_split_block_key is not None:
             split_value_match = _SCHEDULE_SPLIT_VALUE_PATTERN.fullmatch(stripped)
             if split_value_match:
@@ -4807,10 +4849,20 @@ def _extract_collapsed_schedule_row_occurrences(
                         last_value_by_block.get(pending_split_block_key) != value
                         and value not in seen_values
                     ):
-                        occurrences.append(value)
+                        span = split_value_match.span(1)
+                        occurrences.append(
+                            (
+                                (
+                                    stripped_offset + span[0],
+                                    stripped_offset + span[1],
+                                ),
+                                value,
+                            )
+                        )
                         last_value_by_block[pending_split_block_key] = value
                         seen_values.add(value)
                 pending_split_block_key = None
+                line_offset += len(line_with_ending)
                 continue
             pending_split_block_key = None
 
@@ -4818,6 +4870,7 @@ def _extract_collapsed_schedule_row_occurrences(
             current_heading = stripped
             current_ungrouped_block = None
             retained_lines.append(line)
+            line_offset += len(line_with_ending)
             continue
 
         split_key_match = _SCHEDULE_SPLIT_ROW_KEY_PATTERN.fullmatch(stripped)
@@ -4825,7 +4878,16 @@ def _extract_collapsed_schedule_row_occurrences(
             with contextlib.suppress(ValueError):
                 key_value = float(split_key_match.group(1).replace(",", ""))
                 if key_value not in seen_values:
-                    occurrences.append(key_value)
+                    span = split_key_match.span(1)
+                    occurrences.append(
+                        (
+                            (
+                                stripped_offset + span[0],
+                                stripped_offset + span[1],
+                            ),
+                            key_value,
+                        )
+                    )
                     seen_values.add(key_value)
             if current_heading is not None:
                 pending_split_block_key = current_heading
@@ -4834,6 +4896,7 @@ def _extract_collapsed_schedule_row_occurrences(
                     ungrouped_block += 1
                     current_ungrouped_block = f"__ungrouped_{ungrouped_block}"
                 pending_split_block_key = current_ungrouped_block
+            line_offset += len(line_with_ending)
             continue
 
         row_match = (
@@ -4856,34 +4919,59 @@ def _extract_collapsed_schedule_row_occurrences(
                     last_value_by_block.get(block_key) != value
                     and value not in seen_values
                 ):
-                    occurrences.append(value)
+                    span = row_match.span(1)
+                    occurrences.append(
+                        (
+                            (
+                                stripped_offset + span[0],
+                                stripped_offset + span[1],
+                            ),
+                            value,
+                        )
+                    )
                     last_value_by_block[block_key] = value
                     seen_values.add(value)
+            line_offset += len(line_with_ending)
             continue
 
         if stripped:
             current_heading = None
             current_ungrouped_block = None
         retained_lines.append(line)
+        line_offset += len(line_with_ending)
 
     return occurrences, "\n".join(retained_lines)
 
 
-def _extract_two_line_table_value_occurrences(text: str) -> list[float]:
-    """Extract values from official tables that alternate row key and value lines."""
-    occurrences: list[float] = []
+def _extract_collapsed_schedule_row_occurrences(
+    text: str,
+) -> tuple[list[float], str]:
+    """Extract schedule row values once per contiguous value block and remove row lines."""
+    occurrences, retained = _iter_collapsed_schedule_row_occurrences(text)
+    return [value for _, value in occurrences], retained
+
+
+def _iter_two_line_table_value_occurrences(
+    text: str,
+) -> list[tuple[tuple[int, int], float]]:
+    """Return values and exact input spans from alternating official table rows."""
+    occurrences: list[tuple[tuple[int, int], float]] = []
     table_context_active = False
     pending_table_key = False
+    line_offset = 0
 
-    for line in text.splitlines():
+    for line_with_ending in text.splitlines(keepends=True):
+        line = line_with_ending.rstrip("\r\n")
         stripped = line.strip().strip(_STRUCTURAL_SOURCE_QUOTE_CHARS).strip()
         if not stripped:
             table_context_active = False
             pending_table_key = False
+            line_offset += len(line_with_ending)
             continue
         if _SOURCE_SUBDIVISION_LINE_PATTERN.match(stripped):
             table_context_active = False
             pending_table_key = False
+            line_offset += len(line_with_ending)
             continue
         if _TWO_LINE_TABLE_CONTEXT_PATTERN.search(stripped):
             table_context_active = True
@@ -4892,21 +4980,40 @@ def _extract_two_line_table_value_occurrences(text: str) -> list[float]:
             value_match = _SCHEDULE_SPLIT_VALUE_PATTERN.fullmatch(stripped)
             if value_match:
                 with contextlib.suppress(ValueError):
-                    occurrences.append(float(value_match.group(1).replace(",", "")))
+                    raw = value_match.group(1)
+                    relative_start = line.rfind(raw)
+                    if relative_start >= 0:
+                        occurrences.append(
+                            (
+                                (
+                                    line_offset + relative_start,
+                                    line_offset + relative_start + len(raw),
+                                ),
+                                float(raw.replace(",", "")),
+                            )
+                        )
                 pending_table_key = False
+                line_offset += len(line_with_ending)
                 continue
             pending_table_key = False
 
         if table_context_active and _TWO_LINE_TABLE_ROW_KEY_PATTERN.fullmatch(stripped):
             pending_table_key = True
+            line_offset += len(line_with_ending)
             continue
 
         pending_table_key = False
+        line_offset += len(line_with_ending)
 
     return occurrences
 
 
-def extract_numeric_occurrences_from_text(text: str) -> list[float]:
+def _extract_two_line_table_value_occurrences(text: str) -> list[float]:
+    """Extract values from official tables that alternate row key and value lines."""
+    return [value for _, value in _iter_two_line_table_value_occurrences(text)]
+
+
+def _extract_legacy_inventory_values(text: str) -> list[float]:
     """Extract substantive numeric occurrences from source text, preserving repeats."""
     implied_cents_matches = _iter_form_implied_cents_matches(text)
     raw_text = _FORM_IMPLIED_CENTS_PATTERN.sub(
@@ -5102,6 +5209,1122 @@ def extract_numeric_occurrences_from_text(text: str) -> list[float]:
     return normalized
 
 
+@dataclass(frozen=True)
+class _NumericTokenization:
+    """Typed legacy emission streams used by both public extraction adapters."""
+
+    grounding: tuple[NumericOccurrence, ...]
+    inventory: tuple[NumericOccurrence, ...]
+
+
+def _numeric_occurrence_has_local_rate_context(
+    text: str,
+    span: tuple[int, int],
+) -> bool:
+    """Return whether adjacent or same-column evidence marks this as a rate."""
+    _, end = span
+    return bool(
+        _LOCAL_RATE_CONTEXT_AFTER_NUMBER_PATTERN.match(text, end)
+        or _numeric_occurrence_has_rate_table_header(text, span)
+    )
+
+
+def _numeric_occurrence_has_rate_table_header(
+    text: str,
+    span: tuple[int, int],
+) -> bool:
+    """Recognize a percentage header for the occurrence's pipe-table column."""
+    start, _ = span
+    line_start = text.rfind("\n", 0, start) + 1
+    line_end = text.find("\n", start)
+    if line_end < 0:
+        line_end = len(text)
+    line = text[line_start:line_end]
+    if "|" not in line:
+        return False
+
+    relative_start = start - line_start
+    column = line[:relative_start].count("|")
+    if line.lstrip().startswith("|"):
+        column -= 1
+    if column < 0:
+        return False
+
+    previous_lines = text[:line_start].splitlines()
+    for previous_line in reversed(previous_lines):
+        if "|" not in previous_line:
+            break
+        cells = previous_line.strip().strip("|").split("|")
+        if column < len(cells) and _TABLE_RATE_HEADER_PATTERN.search(cells[column]):
+            return True
+    return False
+
+
+def _pipe_table_rate_cell_spans(text: str) -> tuple[tuple[int, int], ...]:
+    """Index cells whose pipe-table column has an explicit percentage header."""
+    rate_cells: list[tuple[int, int]] = []
+    rate_columns: set[int] = set()
+    line_offset = 0
+    for line_with_ending in text.splitlines(keepends=True):
+        line = line_with_ending.rstrip("\r\n")
+        if "|" not in line:
+            rate_columns.clear()
+            line_offset += len(line_with_ending)
+            continue
+
+        boundaries = [
+            -1,
+            *(match.start() for match in re.finditer(r"\|", line)),
+            len(line),
+        ]
+        cells = [
+            (boundaries[index] + 1, boundaries[index + 1])
+            for index in range(len(boundaries) - 1)
+        ]
+        if line.lstrip().startswith("|") and cells:
+            cells = cells[1:]
+        if line.rstrip().endswith("|") and cells:
+            cells = cells[:-1]
+
+        for column, (start, end) in enumerate(cells):
+            if _TABLE_RATE_HEADER_PATTERN.search(line[start:end]):
+                rate_columns.add(column)
+        for column in rate_columns:
+            if column >= len(cells):
+                continue
+            start, end = cells[column]
+            rate_cells.append((line_offset + start, line_offset + end))
+        line_offset += len(line_with_ending)
+    return tuple(rate_cells)
+
+
+def _source_span_for_parsed_numeric_span(
+    source_text: str,
+    parsed_text: str,
+    span: tuple[int, int],
+) -> tuple[int, int]:
+    """Map a parsed-buffer span back to an exact source substring when possible."""
+    if parsed_text is source_text:
+        return span
+    raw = parsed_text[span[0] : span[1]]
+    if not raw:
+        return 0, len(source_text)
+    starts = [match.start() for match in re.finditer(re.escape(raw), source_text)]
+    if not starts:
+        return 0, len(source_text)
+    expected = (
+        round(span[0] * len(source_text) / len(parsed_text)) if parsed_text else 0
+    )
+    start = min(starts, key=lambda candidate: abs(candidate - expected))
+    return start, start + len(raw)
+
+
+def _numeric_occurrence_from_parsed_span(
+    source_text: str,
+    parsed_text: str,
+    span: tuple[int, int],
+    value: float,
+    *,
+    source_value: float | None = None,
+    force_rate_context: bool = False,
+) -> NumericOccurrence:
+    source_span = _source_span_for_parsed_numeric_span(source_text, parsed_text, span)
+    start, end = source_span
+    return NumericOccurrence(
+        value=value,
+        start=start,
+        end=end,
+        raw=source_text[start:end],
+        has_rate_context=force_rate_context
+        or _numeric_occurrence_has_local_rate_context(source_text, source_span),
+        source_value=value if source_value is None else source_value,
+    )
+
+
+def _fallback_numeric_occurrence(text: str, value: float) -> NumericOccurrence:
+    """Anchor derived semantic candidates to their complete source evidence item."""
+    return NumericOccurrence(
+        value=value,
+        start=0,
+        end=len(text),
+        raw=text,
+        has_rate_context=False,
+        source_value=value,
+    )
+
+
+def _legacy_surface_numeric_occurrences(text: str) -> list[NumericOccurrence]:
+    """Return exact-span surface candidates used to type legacy numeric values."""
+    raw_text = _FORM_IMPLIED_CENTS_PATTERN.sub(
+        lambda match: " " * len(match.group(0)),
+        text,
+    )
+    cleaned = _clean_source_text_for_numeric_extraction(raw_text)
+    _, cleaned = _extract_collapsed_schedule_row_occurrences(cleaned)
+    occurrences: list[NumericOccurrence] = []
+
+    for span, value in _iter_direct_percentage_rate_matches(raw_text):
+        occurrences.append(
+            _numeric_occurrence_from_parsed_span(
+                text,
+                raw_text,
+                span,
+                value,
+                source_value=value * 100,
+                force_rate_context=True,
+            )
+        )
+
+    for span, value in _iter_raw_european_money_value_matches(cleaned):
+        occurrences.append(
+            _numeric_occurrence_from_parsed_span(text, cleaned, span, value)
+        )
+    for span, value in _iter_belgian_numeric_range_endpoint_matches(cleaned):
+        occurrences.append(
+            _numeric_occurrence_from_parsed_span(text, cleaned, span, value)
+        )
+    for span, value in _iter_normalized_special_numeric_matches(cleaned):
+        raw = cleaned[span[0] : span[1]]
+        has_rate_context = bool(
+            re.search(
+                r"(?:%|\bp\.?[ \t]*c\.?\b|\bpercent\b|"
+                r"\bper[ \t-]+cent(?:um)?\b|\bProzent\b|"
+                r"\bvom[ \t]+Hundert\b)",
+                raw,
+                re.IGNORECASE,
+            )
+        )
+        occurrences.append(
+            _numeric_occurrence_from_parsed_span(
+                text,
+                cleaned,
+                span,
+                value,
+                source_value=value * 100 if has_rate_context else value,
+                force_rate_context=has_rate_context,
+            )
+        )
+    for span, value in _iter_standalone_fraction_word_matches(cleaned):
+        occurrences.append(
+            _numeric_occurrence_from_parsed_span(text, cleaned, span, value)
+        )
+    for span, value in _iter_word_quantity_fraction_matches(cleaned):
+        occurrences.append(
+            _numeric_occurrence_from_parsed_span(text, cleaned, span, value)
+        )
+    for span, value in _iter_ordinal_word_number_matches(cleaned):
+        occurrences.append(
+            _numeric_occurrence_from_parsed_span(text, cleaned, span, value)
+        )
+    for span, value in _iter_cardinal_word_number_matches(cleaned):
+        occurrences.append(
+            _numeric_occurrence_from_parsed_span(text, cleaned, span, value)
+        )
+    for span, value in _iter_french_cardinal_phrase_matches(cleaned):
+        occurrences.append(
+            _numeric_occurrence_from_parsed_span(text, cleaned, span, value)
+        )
+    for span, value in _iter_dutch_cardinal_phrase_matches(cleaned):
+        occurrences.append(
+            _numeric_occurrence_from_parsed_span(text, cleaned, span, value)
+        )
+    for span, value, raw_value in _iter_digit_scale_number_matches(cleaned):
+        occurrences.append(
+            _numeric_occurrence_from_parsed_span(text, cleaned, span, value)
+        )
+        occurrences.append(
+            _numeric_occurrence_from_parsed_span(text, cleaned, span, raw_value)
+        )
+
+    for pattern, normalize in (
+        (
+            SPACED_EUROPEAN_DECIMAL_MONEY_PATTERN,
+            _normalize_european_decimal_number,
+        ),
+        (EUROPEAN_DECIMAL_NUMBER_PATTERN, _normalize_european_decimal_number),
+        (
+            EUROPEAN_LEADING_ZERO_DECIMAL_NUMBER_PATTERN,
+            _normalize_european_decimal_number,
+        ),
+        (EUROPEAN_THOUSANDS_NUMBER_PATTERN, _normalize_grouped_thousands_number),
+        (
+            EUROPEAN_DOT_THOUSANDS_NUMBER_PATTERN,
+            _normalize_grouped_thousands_number,
+        ),
+    ):
+        for match in pattern.finditer(cleaned):
+            span = match.span(1)
+            with contextlib.suppress(ValueError):
+                value = float(normalize(match.group(1)))
+                occurrences.append(
+                    _numeric_occurrence_from_parsed_span(
+                        text,
+                        cleaned,
+                        span,
+                        value,
+                    )
+                )
+                if pattern is EUROPEAN_DOT_THOUSANDS_NUMBER_PATTERN and re.fullmatch(
+                    r"-?[1-9]\d{0,2}\.\d{3}", match.group(1)
+                ):
+                    occurrences.append(
+                        _numeric_occurrence_from_parsed_span(
+                            text,
+                            cleaned,
+                            span,
+                            float(match.group(1)),
+                        )
+                    )
+
+    for match in SOURCE_TEXT_NUMBER_PATTERN.finditer(cleaned):
+        span = match.span(1)
+        with contextlib.suppress(ValueError):
+            value = float(match.group(1).replace(",", ""))
+            occurrences.append(
+                _numeric_occurrence_from_parsed_span(
+                    text,
+                    cleaned,
+                    span,
+                    value,
+                )
+            )
+    for match in _ORDINAL_NUMBER_PATTERN.finditer(cleaned):
+        with contextlib.suppress(ValueError):
+            occurrences.append(
+                _numeric_occurrence_from_parsed_span(
+                    text,
+                    cleaned,
+                    match.span(1),
+                    float(match.group(1)),
+                )
+            )
+    for glyph, value in _UNICODE_FRACTION_VALUES.items():
+        for match in re.finditer(re.escape(glyph), cleaned):
+            occurrences.append(
+                _numeric_occurrence_from_parsed_span(
+                    text,
+                    cleaned,
+                    match.span(),
+                    value,
+                )
+            )
+    return occurrences
+
+
+@dataclass(frozen=True)
+class _NumericTextView:
+    """A parsed text buffer with character provenance in the source item."""
+
+    source: str
+    text: str
+    source_offsets: tuple[int | None, ...]
+
+    @classmethod
+    def identity(cls, source: str) -> "_NumericTextView":
+        return cls(source, source, tuple(range(len(source))))
+
+    @classmethod
+    def aligned(cls, source: str, parsed: str) -> "_NumericTextView":
+        if parsed == source:
+            return cls.identity(source)
+        offsets: list[int | None] = [None] * len(parsed)
+        matcher = SequenceMatcher(a=source, b=parsed)
+        for (
+            operation,
+            source_start,
+            _,
+            parsed_start,
+            parsed_end,
+        ) in matcher.get_opcodes():
+            if operation != "equal":
+                continue
+            for index in range(parsed_start, parsed_end):
+                offsets[index] = source_start + index - parsed_start
+        return cls(source, parsed, tuple(offsets))
+
+    def source_span(self, span: tuple[int, int]) -> tuple[int, int]:
+        """Map a parsed span to the exact source interval that supplied it."""
+        start, end = span
+        mapped = [
+            offset for offset in self.source_offsets[start:end] if offset is not None
+        ]
+        if mapped:
+            return min(mapped), max(mapped) + 1
+
+        raw = self.text[start:end]
+        candidates = [
+            match.span() for match in re.finditer(re.escape(raw), self.source)
+        ]
+        if not candidates:
+            raise ValueError(f"Numeric token has no source span: {raw!r}")
+
+        left_anchor = next(
+            (
+                offset
+                for offset in reversed(self.source_offsets[:start])
+                if offset is not None
+            ),
+            None,
+        )
+        right_anchor = next(
+            (offset for offset in self.source_offsets[end:] if offset is not None),
+            None,
+        )
+        bounded = [
+            candidate
+            for candidate in candidates
+            if (left_anchor is None or candidate[0] > left_anchor)
+            and (right_anchor is None or candidate[1] <= right_anchor)
+        ]
+        if len(bounded) == 1:
+            return bounded[0]
+        if bounded:
+            candidates = bounded
+        expected = left_anchor + 1 if left_anchor is not None else 0
+        return min(candidates, key=lambda candidate: abs(candidate[0] - expected))
+
+
+@dataclass
+class _LegacyNumericCollector:
+    """Collect exact typed emissions for both legacy public projections."""
+
+    source: str
+    grounding: list[NumericOccurrence] = field(default_factory=list)
+    inventory: list[NumericOccurrence] = field(default_factory=list)
+    rate_table_cell_spans: tuple[tuple[int, int], ...] = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.rate_table_cell_spans = _pipe_table_rate_cell_spans(self.source)
+
+    def occurrence(
+        self,
+        view: _NumericTextView,
+        span: tuple[int, int],
+        value: float,
+        *,
+        source_value: float | None = None,
+        force_rate_context: bool = False,
+        requires_rate_context: bool = False,
+    ) -> NumericOccurrence:
+        source_span = view.source_span(span)
+        start, end = source_span
+        has_table_rate_context = any(
+            start >= cell_start and end <= cell_end
+            for cell_start, cell_end in self.rate_table_cell_spans
+        )
+        return NumericOccurrence(
+            value=value,
+            start=start,
+            end=end,
+            raw=self.source[start:end],
+            has_rate_context=force_rate_context
+            or bool(_LOCAL_RATE_CONTEXT_AFTER_NUMBER_PATTERN.match(self.source, end))
+            or has_table_rate_context,
+            source_value=value if source_value is None else source_value,
+            requires_rate_context=requires_rate_context,
+        )
+
+    def add_grounding(
+        self,
+        view: _NumericTextView,
+        span: tuple[int, int],
+        value: float,
+        **kwargs: Any,
+    ) -> None:
+        self.grounding.append(self.occurrence(view, span, value, **kwargs))
+
+    def add_inventory(
+        self,
+        view: _NumericTextView,
+        span: tuple[int, int],
+        value: float,
+        **kwargs: Any,
+    ) -> None:
+        self.inventory.append(self.occurrence(view, span, value, **kwargs))
+
+
+def _occurrence_value_matches(left: float, right: float) -> bool:
+    return math.isclose(
+        left,
+        right,
+        rel_tol=0,
+        abs_tol=NUMERIC_GROUNDING_ABS_TOLERANCE,
+    )
+
+
+def _tokenize_numeric_occurrences_from_text(
+    text: str,
+    *,
+    profile: str = "legacy",
+) -> _NumericTokenization:
+    """Tokenize once into typed grounding and source-inventory emission streams."""
+    if profile != "legacy":
+        raise ValueError(f"Unsupported numeric profile: {profile}")
+
+    collector = _LegacyNumericCollector(text)
+    source_view = _NumericTextView.identity(text)
+    implied_cents_matches = _iter_form_implied_cents_matches(text)
+    raw_text = _FORM_IMPLIED_CENTS_PATTERN.sub(
+        lambda match: " " * len(match.group(0)),
+        text,
+    )
+    raw_view = _NumericTextView.aligned(text, raw_text)
+    two_line_table_matches = _iter_two_line_table_value_occurrences(text)
+    cleaned_before_schedule = _clean_source_text_for_numeric_extraction(raw_text)
+    cleaned_before_schedule_view = _NumericTextView.aligned(
+        text,
+        cleaned_before_schedule,
+    )
+    schedule_matches, cleaned = _iter_collapsed_schedule_row_occurrences(
+        cleaned_before_schedule
+    )
+    cleaned_view = (
+        cleaned_before_schedule_view
+        if cleaned == cleaned_before_schedule
+        else _NumericTextView.aligned(text, cleaned)
+    )
+
+    def add_both(
+        view: _NumericTextView,
+        span: tuple[int, int],
+        value: float,
+        **kwargs: Any,
+    ) -> None:
+        collector.add_grounding(view, span, value, **kwargs)
+        collector.add_inventory(view, span, value, **kwargs)
+
+    def unique_matches(
+        matches: Iterable[tuple[tuple[int, int], float]],
+    ) -> list[tuple[tuple[int, int], float]]:
+        first_span_by_value: dict[float, tuple[int, int]] = {}
+        values: set[float] = set()
+        for span, value in matches:
+            values.add(value)
+            first_span_by_value.setdefault(value, span)
+        return [(first_span_by_value[value], value) for value in values]
+
+    for span, value in two_line_table_matches:
+        add_both(source_view, span, value)
+    for span, value in schedule_matches:
+        add_both(cleaned_before_schedule_view, span, value)
+    for span, value in implied_cents_matches:
+        add_both(source_view, span, value)
+
+    grounding_spans: list[tuple[int, int]] = []
+    inventory_spans: list[tuple[int, int]] = []
+
+    range_matches = _iter_belgian_numeric_range_endpoint_matches(cleaned)
+    for span, value in range_matches:
+        add_both(cleaned_view, span, value)
+        grounding_spans.append(span)
+        inventory_spans.append(span)
+
+    for match in re.finditer(
+        r"\b(?:age|aged)\s+(\d{1,3})(?=\b)",
+        raw_text,
+        re.IGNORECASE,
+    ):
+        with contextlib.suppress(ValueError):
+            collector.add_grounding(
+                raw_view,
+                match.span(1),
+                float(match.group(1)),
+            )
+
+    raw_money_matches = _iter_raw_european_money_value_matches(raw_text)
+    for span, value in raw_money_matches:
+        collector.add_grounding(raw_view, span, value)
+
+    cleaned_money_values: list[float] = []
+    for span, value in _iter_raw_european_money_value_matches(cleaned):
+        collector.add_grounding(cleaned_view, span, value)
+        grounding_spans.append(span)
+        if _span_overlaps(span, inventory_spans):
+            continue
+        collector.add_inventory(cleaned_view, span, value)
+        cleaned_money_values.append(value)
+        inventory_spans.append(span)
+    for span, value in raw_money_matches:
+        if any(
+            math.isclose(
+                value,
+                cleaned_value,
+                rel_tol=0,
+                abs_tol=NUMERIC_GROUNDING_ABS_TOLERANCE,
+            )
+            for cleaned_value in cleaned_money_values
+        ):
+            continue
+        collector.add_inventory(raw_view, span, value)
+
+    direct_percentage_rate_matches = _iter_direct_percentage_rate_matches(raw_text)
+    for span, value in direct_percentage_rate_matches:
+        collector.add_grounding(
+            raw_view,
+            span,
+            value,
+            source_value=value * 100,
+            force_rate_context=True,
+            requires_rate_context=True,
+        )
+    for span, value in unique_matches(direct_percentage_rate_matches):
+        collector.add_inventory(
+            raw_view,
+            span,
+            value,
+            source_value=value * 100,
+            force_rate_context=True,
+            requires_rate_context=True,
+        )
+
+    week_matches: list[tuple[tuple[int, int], float]] = []
+    for match in _WEEK_DURATION_PATTERN.finditer(raw_text):
+        value = _parse_belgian_numeric_phrase(match.group("number"))
+        if value is not None:
+            week_matches.append((match.span(), value * 7))
+    for match in _ORDINAL_WEEK_DURATION_PATTERN.finditer(raw_text):
+        normalized = re.sub(r"\s+", " ", match.group("number").strip().lower())
+        value = _FRENCH_ORDINAL_PHRASE_VALUES.get(normalized)
+        if value is not None:
+            week_matches.append((match.span(), value * 7))
+    for span, value in unique_matches(week_matches):
+        add_both(raw_view, span, value)
+
+    year_matches: list[tuple[tuple[int, int], float]] = []
+    for match in _YEAR_DURATION_PATTERN.finditer(raw_text):
+        value = _parse_belgian_numeric_phrase(match.group("number"))
+        if value is not None:
+            year_matches.append((match.span(), value * 12))
+    for span, value in unique_matches(year_matches):
+        add_both(raw_view, span, value)
+
+    dotted_year_matches: list[tuple[tuple[int, int], float]] = []
+    for match in _DOTTED_DATE_PATTERN.finditer(raw_text):
+        with contextlib.suppress(ValueError):
+            dotted_year_matches.append((match.span("year"), float(match.group("year"))))
+    for span, value in unique_matches(dotted_year_matches):
+        add_both(raw_view, span, value)
+
+    centime_match = _CENTIME_UNIT_PATTERN.search(raw_text)
+    if centime_match:
+        add_both(raw_view, centime_match.span(), 100.0)
+    annual_match = _ANNUAL_CONTEXT_PATTERN.search(raw_text)
+    if annual_match:
+        collector.add_grounding(raw_view, annual_match.span(), 12.0)
+
+    form_fraction_spans: list[tuple[int, int]] = []
+    for match in (
+        *_FORM_ARITHMETIC_FRACTION_PATTERN.finditer(raw_text),
+        *_STANDALONE_FORM_FRACTION_PATTERN.finditer(raw_text),
+    ):
+        with contextlib.suppress(ValueError, ZeroDivisionError):
+            denominator = float(match.group("denominator"))
+            add_both(
+                raw_view,
+                match.span(),
+                float(match.group("numerator")) / denominator,
+            )
+            form_fraction_spans.append(match.span())
+    for match in _FORM_ARITHMETIC_OPERAND_PATTERN.finditer(raw_text):
+        if _span_overlaps(match.span(), form_fraction_spans):
+            continue
+        with contextlib.suppress(ValueError):
+            source_value = float(match.group("number").replace(",", ""))
+            is_rate = bool(match.group("percent"))
+            value = source_value / 100 if is_rate else source_value
+            add_both(
+                raw_view,
+                match.span(),
+                value,
+                source_value=source_value,
+                force_rate_context=is_rate,
+                requires_rate_context=is_rate,
+            )
+
+    for match in _CONTEXTUAL_ASCII_FRACTION_PATTERN.finditer(raw_text):
+        with contextlib.suppress(ValueError, ZeroDivisionError):
+            whole = float(match.group("whole") or 0)
+            numerator = float(match.group("numerator"))
+            denominator = float(match.group("denominator"))
+            add_both(
+                raw_view,
+                match.span(),
+                whole + numerator / denominator,
+            )
+
+    month_range_matches: list[tuple[tuple[int, int], float]] = []
+    for match in _SMALL_MONTH_RANGE_PATTERN.finditer(raw_text):
+        start = int(match.group("start"))
+        end = int(match.group("end"))
+        preceding_context = raw_text[max(0, match.start() - 500) : match.start()]
+        row_context = raw_text[match.start() : match.end() + 80]
+        if (
+            0 <= start <= end <= 24
+            and re.search(
+                r"\bmonthly\s+proration\s+table\b",
+                preceding_context,
+                re.IGNORECASE,
+            )
+            and re.search(r"\bline\s+[A-E]\b", row_context, re.IGNORECASE)
+        ):
+            month_range_matches.extend(
+                (match.span(), float(value)) for value in range(start, end + 1)
+            )
+    for span, value in month_range_matches:
+        add_both(raw_view, span, value)
+
+    vehicle_matches: list[tuple[tuple[int, int], float]] = []
+    lowered_raw_text = raw_text.lower()
+    for match in _VEHICLE_TAX_FISCAL_POWER_TABLE_CELL_PATTERN.finditer(raw_text):
+        context = lowered_raw_text[max(0, match.start() - 2000) : match.start()]
+        if not re.search(
+            r"\b(?:chevaux\s+fiscaux|fiscale\s+paardenkracht|aantal\s+pk|cv)\b",
+            context,
+        ):
+            continue
+        with contextlib.suppress(ValueError):
+            vehicle_matches.append((match.span("cv"), float(match.group("cv"))))
+    for span, value in unique_matches(vehicle_matches):
+        collector.add_grounding(raw_view, span, value)
+
+    for match in GLUED_UNIT_NUMBER_PATTERN.finditer(cleaned):
+        with contextlib.suppress(ValueError):
+            collector.add_grounding(
+                cleaned_view,
+                match.span(),
+                float(match.group("number").replace(",", "")),
+            )
+            grounding_spans.append(match.span())
+
+    for match in CENTS_VALUE_NUMBER_PATTERN.finditer(cleaned):
+        span = match.span()
+        if _span_overlaps(span, grounding_spans):
+            continue
+        with contextlib.suppress(ValueError):
+            value = float(match.group("number").replace(",", ""))
+            collector.add_grounding(cleaned_view, span, value)
+            collector.add_grounding(cleaned_view, span, value / 100)
+            grounding_spans.append(span)
+
+    special_matches = list(_iter_normalized_special_numeric_matches(cleaned))
+    rate_marker_pattern = re.compile(
+        r"(?:%|\bp\.?[ \t]*c\.?\b|\bpercent\b|"
+        r"\bper[ \t-]+cent(?:um)?\b|\bProzent\b|"
+        r"\bvom[ \t]+Hundert\b)",
+        re.IGNORECASE,
+    )
+    for span, value in special_matches:
+        raw = cleaned[span[0] : span[1]]
+        is_rate = bool(rate_marker_pattern.search(raw))
+        kwargs = {
+            "source_value": value * 100 if is_rate else value,
+            "force_rate_context": is_rate,
+            "requires_rate_context": is_rate,
+        }
+        if not _span_overlaps(span, grounding_spans):
+            collector.add_grounding(cleaned_view, span, value, **kwargs)
+            grounding_spans.append(span)
+        if not _span_overlaps(span, inventory_spans):
+            collector.add_inventory(cleaned_view, span, value, **kwargs)
+            inventory_spans.append(span)
+
+    for match in re.finditer(
+        r"(-?[\d,]+)\s+(\d+)\s*/\s*(\d+)"
+        r"(?:\s+|-)(?:percent|per\s*cent(?:um)?)",
+        cleaned,
+        re.IGNORECASE,
+    ):
+        for group_index in (1, 2, 3):
+            with contextlib.suppress(ValueError):
+                collector.add_grounding(
+                    cleaned_view,
+                    match.span(group_index),
+                    float(match.group(group_index).replace(",", "")),
+                )
+
+    percentage_number = (
+        r"-?(?:\d{1,3}(?:[.\u00a0\u202f ]\d{3})+|\d+)"
+        r"(?:,\d{1,4})?"
+    )
+    range_separator = (
+        "(?:and|to|through|thru|et|\\u00e0|a|tot|bis|en|[-\\u2010-\\u2015])"
+    )
+    for match in re.finditer(
+        rf"\b({percentage_number})\s+{range_separator}\s+({percentage_number})"
+        r"\s*(?:%|\bp\.?\s*c\.?\b|\b(?:percent|per\s*cent(?:um)?)\b)",
+        cleaned,
+        re.IGNORECASE,
+    ):
+        for group_index in (1, 2):
+            raw = _normalize_european_decimal_number(match.group(group_index))
+            with contextlib.suppress(ValueError):
+                source_value = float(raw)
+                collector.add_grounding(
+                    cleaned_view,
+                    match.span(group_index),
+                    source_value / 100,
+                    source_value=source_value,
+                    force_rate_context=True,
+                    requires_rate_context=True,
+                )
+
+    for match in re.finditer(
+        r"(?:^|(?<=[\s(\[,+\-−*/\"'`“”‘’]))"
+        r"(-?(?:\d{1,3}(?:[.\u00a0\u202f ]\d{3})+|\d+),\d{1,4})"
+        r"\s*(?:%|\bp\.?\s*c\.?\b|\b(?:percent|per\s*cent(?:um)?)\b)",
+        cleaned,
+        re.IGNORECASE,
+    ):
+        raw = _normalize_european_decimal_number(match.group(1))
+        with contextlib.suppress(ValueError):
+            source_value = float(raw)
+            collector.add_grounding(
+                cleaned_view,
+                match.span(1),
+                source_value / 100,
+                source_value=source_value,
+                force_rate_context=True,
+                requires_rate_context=True,
+            )
+            collector.add_grounding(
+                cleaned_view,
+                match.span(1),
+                source_value,
+                force_rate_context=True,
+            )
+
+    percentage_context_number_matches = list(
+        SOURCE_TEXT_NUMBER_PATTERN.finditer(cleaned)
+    )
+    for match in percentage_context_number_matches:
+        raw = match.group(1).replace(",", "")
+        with contextlib.suppress(ValueError):
+            source_value = float(raw)
+            if source_value <= 1:
+                continue
+            context = cleaned[max(0, match.start() - 500) : match.end() + 80].lower()
+            if not re.search(r"\bpercent(?:age|ages)?\b", context):
+                continue
+            collector.add_grounding(
+                cleaned_view,
+                match.span(1),
+                source_value / 100,
+                source_value=source_value,
+                requires_rate_context=True,
+            )
+            if source_value >= 100 and re.search(
+                r"\b(?:percent\s+of\s+(?:the\s+)?poverty\s+line|"
+                r"percent\s+of\s+(?:the\s+)?federal\s+poverty\s+"
+                r"(?:line|level)|fpl|income\s+tier)\b",
+                context,
+            ):
+                collector.add_grounding(
+                    cleaned_view,
+                    match.span(1),
+                    source_value,
+                )
+
+    word_quantity_matches = list(_iter_word_quantity_fraction_matches(cleaned))
+    for span, value in word_quantity_matches:
+        if _span_overlaps(span, grounding_spans):
+            continue
+        collector.add_grounding(cleaned_view, span, value)
+        grounding_spans.append(span)
+
+    standalone_fraction_matches = list(_iter_standalone_fraction_word_matches(cleaned))
+    for span, value in standalone_fraction_matches:
+        if not _span_overlaps(span, grounding_spans):
+            collector.add_grounding(cleaned_view, span, value)
+            grounding_spans.append(span)
+        if not _span_overlaps(span, inventory_spans):
+            collector.add_inventory(cleaned_view, span, value)
+            inventory_spans.append(span)
+
+    ordinal_word_matches = _iter_ordinal_word_number_matches(cleaned)
+    for span, value in ordinal_word_matches:
+        if _span_overlaps(span, grounding_spans):
+            continue
+        collector.add_grounding(cleaned_view, span, value)
+        grounding_spans.append(span)
+
+    compound_cardinal_matches = _iter_cardinal_word_number_matches(
+        cleaned,
+        compound_only=True,
+    )
+    for span, value in compound_cardinal_matches:
+        if _span_overlaps(span, grounding_spans):
+            continue
+        collector.add_grounding(cleaned_view, span, value)
+        grounding_spans.append(span)
+
+    digit_scale_matches = _iter_digit_scale_number_matches(cleaned)
+    for span, value, raw_value in digit_scale_matches:
+        if _span_overlaps(span, grounding_spans):
+            continue
+        collector.add_grounding(cleaned_view, span, value)
+        collector.add_grounding(cleaned_view, span, raw_value)
+        grounding_spans.append(span)
+
+    french_cardinal_matches = _iter_french_cardinal_phrase_matches(cleaned)
+    for span, value in french_cardinal_matches:
+        if _span_overlaps(span, grounding_spans):
+            continue
+        collector.add_grounding(cleaned_view, span, value)
+        grounding_spans.append(span)
+
+    dutch_cardinal_matches = _iter_dutch_cardinal_phrase_matches(cleaned)
+    for span, value in dutch_cardinal_matches:
+        if _span_overlaps(span, grounding_spans):
+            continue
+        collector.add_grounding(cleaned_view, span, value)
+        grounding_spans.append(span)
+
+    cardinal_matches = _iter_cardinal_word_number_matches(cleaned)
+    for span, value in cardinal_matches:
+        if _span_overlaps(span, grounding_spans):
+            continue
+        collector.add_grounding(cleaned_view, span, value)
+        grounding_spans.append(span)
+
+    for pattern, normalize, include_grounding, include_inventory in (
+        (
+            SPACED_EUROPEAN_DECIMAL_MONEY_PATTERN,
+            _normalize_european_decimal_number,
+            True,
+            True,
+        ),
+        (
+            EUROPEAN_DECIMAL_NUMBER_PATTERN,
+            _normalize_european_decimal_number,
+            True,
+            True,
+        ),
+        (
+            EUROPEAN_LEADING_ZERO_DECIMAL_NUMBER_PATTERN,
+            _normalize_european_decimal_number,
+            True,
+            False,
+        ),
+    ):
+        for match in pattern.finditer(cleaned):
+            span = match.span(1)
+            with contextlib.suppress(ValueError):
+                value = float(normalize(match.group(1)))
+                if include_grounding:
+                    collector.add_grounding(cleaned_view, span, value)
+                    grounding_spans.append(span)
+                if include_inventory and not _span_overlaps(span, inventory_spans):
+                    collector.add_inventory(cleaned_view, span, value)
+                    inventory_spans.append(span)
+
+    for match in EUROPEAN_THOUSANDS_NUMBER_PATTERN.finditer(cleaned):
+        span = match.span(1)
+        with contextlib.suppress(ValueError):
+            value = float(_normalize_grouped_thousands_number(match.group(1)))
+            if not _span_overlaps(span, grounding_spans):
+                collector.add_grounding(cleaned_view, span, value)
+                grounding_spans.append(span)
+            if not _span_overlaps(span, inventory_spans):
+                collector.add_inventory(cleaned_view, span, value)
+                inventory_spans.append(span)
+
+    for span, value, _ in digit_scale_matches:
+        if _span_overlaps(span, inventory_spans):
+            continue
+        if value not in GROUNDING_ALLOWED_VALUES:
+            collector.add_inventory(cleaned_view, span, value)
+        inventory_spans.append(span)
+
+    for match in EUROPEAN_DOT_THOUSANDS_NUMBER_PATTERN.finditer(cleaned):
+        span = match.span(1)
+        if _span_overlaps(span, grounding_spans):
+            continue
+        if _number_span_is_immediately_followed_by_percent_marker(cleaned, span):
+            grounding_spans.append(span)
+            continue
+        with contextlib.suppress(ValueError):
+            collector.add_grounding(
+                cleaned_view,
+                span,
+                float(_normalize_grouped_thousands_number(match.group(1))),
+            )
+            grounding_spans.append(span)
+        if re.fullmatch(r"-?[1-9]\d{0,2}\.\d{3}", match.group(1)):
+            with contextlib.suppress(ValueError):
+                collector.add_grounding(
+                    cleaned_view,
+                    span,
+                    float(match.group(1)),
+                )
+
+    for match in percentage_context_number_matches:
+        span = match.span(1)
+        raw = match.group(1).replace(",", "")
+        with contextlib.suppress(ValueError):
+            value = float(raw)
+            if not _span_overlaps(span, grounding_spans):
+                if not _number_span_is_immediately_followed_by_percent_marker(
+                    cleaned,
+                    span,
+                ) and not _has_captured_percentage_rate(
+                    direct_percentage_rate_matches,
+                    value,
+                    span=span,
+                ):
+                    collector.add_grounding(cleaned_view, span, value)
+            if _span_overlaps(span, inventory_spans):
+                continue
+            if _number_span_is_immediately_followed_by_percent_marker(cleaned, span):
+                continue
+            if value.is_integer() and 1900 <= value <= 2100:
+                continue
+            if _has_captured_percentage_rate(
+                direct_percentage_rate_matches,
+                value,
+                span=span,
+            ):
+                continue
+            grouped_value = _parse_belgian_numeric_phrase(match.group(1))
+            if (
+                grouped_value is not None
+                and not math.isclose(
+                    grouped_value,
+                    value,
+                    rel_tol=0,
+                    abs_tol=NUMERIC_GROUNDING_ABS_TOLERANCE,
+                )
+                and any(
+                    math.isclose(
+                        grouped_value,
+                        occurrence.value,
+                        rel_tol=0,
+                        abs_tol=NUMERIC_GROUNDING_ABS_TOLERANCE,
+                    )
+                    for occurrence in collector.inventory
+                )
+            ):
+                continue
+            collector.add_inventory(cleaned_view, span, value)
+
+    for match in _ORDINAL_NUMBER_PATTERN.finditer(cleaned):
+        with contextlib.suppress(ValueError):
+            value = float(match.group(1))
+            collector.add_grounding(cleaned_view, match.span(1), value)
+            if value.is_integer() and 1900 <= value <= 2100:
+                continue
+            if _ordinal_is_calendar_day_reference(cleaned, match.end(), value):
+                continue
+            collector.add_inventory(cleaned_view, match.span(1), value)
+
+    for span, value in ordinal_word_matches:
+        if _span_overlaps(span, inventory_spans):
+            continue
+        if value not in GROUNDING_ALLOWED_VALUES:
+            collector.add_inventory(cleaned_view, span, value)
+        inventory_spans.append(span)
+
+    for glyph, value in _UNICODE_FRACTION_VALUES.items():
+        for match in re.finditer(re.escape(glyph), cleaned):
+            collector.add_grounding(cleaned_view, match.span(), value)
+            collector.add_inventory(cleaned_view, match.span(), value)
+
+    for span, value in compound_cardinal_matches:
+        if _span_overlaps(span, inventory_spans):
+            continue
+        if value not in GROUNDING_ALLOWED_VALUES:
+            collector.add_inventory(cleaned_view, span, value)
+        inventory_spans.append(span)
+
+    for matches in (
+        french_cardinal_matches,
+        dutch_cardinal_matches,
+        cardinal_matches,
+    ):
+        for span, value in matches:
+            if _span_overlaps(span, inventory_spans):
+                continue
+            if value not in GROUNDING_ALLOWED_VALUES:
+                collector.add_inventory(cleaned_view, span, value)
+            inventory_spans.append(span)
+
+    text_lower = cleaned.lower()
+    for match in _CARDINAL_WORD_PATTERN.finditer(text_lower):
+        if _span_overlaps(match.span(1), grounding_spans):
+            continue
+        collector.add_grounding(
+            cleaned_view,
+            match.span(1),
+            _CARDINAL_WORD_VALUES[match.group(1)],
+        )
+        grounding_spans.append(match.span(1))
+
+    occurrence_counts = Counter(occurrence.value for occurrence in collector.inventory)
+    normalized_inventory = tuple(
+        occurrence
+        for occurrence in collector.inventory
+        if not (
+            occurrence.value <= 1
+            and round(occurrence.value * 100, 9) in occurrence_counts
+        )
+    )
+    return _NumericTokenization(
+        grounding=tuple(collector.grounding),
+        inventory=normalized_inventory,
+    )
+
+
+def extract_typed_numeric_occurrences_from_text(
+    text: str,
+    *,
+    profile: str = "legacy",
+) -> list[NumericOccurrence]:
+    """Extract typed numeric grounding candidates with exact source metadata."""
+    return list(
+        _tokenize_numeric_occurrences_from_text(text, profile=profile).grounding
+    )
+
+
+def extract_typed_numeric_inventory_occurrences_from_text(
+    text: str,
+    *,
+    profile: str = "legacy",
+) -> list[NumericOccurrence]:
+    """Extract the ordered typed source-recall occurrence stream."""
+    return list(
+        _tokenize_numeric_occurrences_from_text(text, profile=profile).inventory
+    )
+
+
+def extract_numbers_from_text(
+    text: str,
+    *,
+    profile: str = "legacy",
+) -> set[float]:
+    """Extract numeric values from embedded statute text."""
+    return {
+        occurrence.value
+        for occurrence in _tokenize_numeric_occurrences_from_text(
+            text,
+            profile=profile,
+        ).grounding
+    }
+
+
+def extract_numeric_occurrences_from_text(
+    text: str,
+    *,
+    profile: str = "legacy",
+) -> list[float]:
+    """Extract substantive numeric occurrences from source text, preserving repeats."""
+    return [
+        occurrence.value
+        for occurrence in _tokenize_numeric_occurrences_from_text(
+            text,
+            profile=profile,
+        ).inventory
+    ]
+
+
 def extract_named_scalar_occurrences(content: str) -> list[NamedScalarOccurrence]:
     """Extract direct named scalar definitions from a RuleSpec file."""
     with contextlib.suppress(yaml.YAMLError, TypeError, ValueError):
@@ -5213,10 +6436,10 @@ def _decimal_place_scale_values_from_source(source: str) -> set[float]:
 
 def _numeric_value_grounded_in_source(
     value: float,
-    source_numbers: set[float],
+    source_occurrences: Sequence[NumericOccurrence],
     decimal_place_scale_values: set[float],
 ) -> bool:
-    if numeric_value_is_grounded(value, source_numbers):
+    if numeric_value_is_grounded(value, source_occurrences):
         return True
     return any(
         math.isclose(
@@ -5233,18 +6456,18 @@ def _ungrounded_from_values(
     grounding_values: Sequence[tuple[int, str, float]],
     source: str,
     *,
-    source_numbers: set[float] | None = None,
+    source_occurrences: Sequence[NumericOccurrence] | None = None,
     decimal_place_scale_values: set[float] | None = None,
 ) -> list[str]:
     """Report values not grounded in ``source`` (which must be pre-stripped)."""
-    if source_numbers is None:
-        source_numbers = extract_numbers_from_text(source)
+    if source_occurrences is None:
+        source_occurrences = _tokenize_numeric_occurrences_from_text(source).grounding
     if decimal_place_scale_values is None:
         decimal_place_scale_values = _decimal_place_scale_values_from_source(source)
     issues: list[str] = []
     for _, raw, value in grounding_values:
         if _numeric_value_grounded_in_source(
-            value, source_numbers, decimal_place_scale_values
+            value, source_occurrences, decimal_place_scale_values
         ):
             continue
         display = raw if raw == f"{value:g}" else f"{raw} ({value:g})"
@@ -5283,7 +6506,9 @@ def evaluate_numeric_grounding_values(
         if isinstance(rules, list):
             selector_table_keys = _rulespec_index_selector_keys(rules)
             decisions: list[tuple[int, str, float, bool]] = []
-            source_indexes: dict[str, tuple[set[float], set[float]]] = {}
+            source_indexes: dict[
+                str, tuple[tuple[NumericOccurrence, ...], set[float]]
+            ] = {}
             for rule in rules:
                 anchored_values = _rule_grounding_values_by_path(
                     rule, selector_table_keys=selector_table_keys
@@ -5312,7 +6537,9 @@ def evaluate_numeric_grounding_values(
                     source_index = source_indexes.get(grounding_source)
                     if source_index is None:
                         source_index = (
-                            extract_numbers_from_text(grounding_source),
+                            _tokenize_numeric_occurrences_from_text(
+                                grounding_source
+                            ).grounding,
                             _decimal_place_scale_values_from_source(grounding_source),
                         )
                         source_indexes[grounding_source] = source_index
@@ -5329,7 +6556,7 @@ def evaluate_numeric_grounding_values(
             if len(decisions) == len(grounding_values):
                 return decisions
 
-    source_numbers = extract_numbers_from_text(source_text)
+    source_occurrences = _tokenize_numeric_occurrences_from_text(source_text).grounding
     decimal_place_scale_values = _decimal_place_scale_values_from_source(source_text)
     return [
         (
@@ -5337,7 +6564,7 @@ def evaluate_numeric_grounding_values(
             raw,
             value,
             _numeric_value_grounded_in_source(
-                value, source_numbers, decimal_place_scale_values
+                value, source_occurrences, decimal_place_scale_values
             ),
         )
         for line, raw, value in grounding_values
@@ -6704,7 +7931,9 @@ def repair_source_table_open_ended_bound_sentinels(
         if source_text is not None
         else (extract_numeric_grounding_source_text(content) or "").strip()
     )
-    source_numbers = extract_numbers_from_text(source) if source else set()
+    source_occurrences = (
+        extract_typed_numeric_occurrences_from_text(source) if source else []
+    )
     changed_rules: set[str] = set()
 
     for rule in rules:
@@ -6733,7 +7962,10 @@ def repair_source_table_open_ended_bound_sentinels(
             if numeric is None:
                 continue
             _raw, value = numeric
-            if not _is_generated_open_ended_bound_sentinel(value, source_numbers):
+            if not _is_generated_open_ended_bound_sentinel(
+                value,
+                source_occurrences,
+            ):
                 continue
             del values[max_key]
             changed_rules.add(rule_name or "<unknown>")
@@ -7819,11 +9051,11 @@ def _max_structural_integer_table_key(values: dict[Any, Any]) -> Any | None:
 
 def _is_generated_open_ended_bound_sentinel(
     value: float,
-    source_numbers: set[float],
+    source_occurrences: Sequence[NumericOccurrence],
 ) -> bool:
     if abs(value) < 1_000_000:
         return False
-    if source_numbers and numeric_value_is_grounded(value, source_numbers):
+    if source_occurrences and numeric_value_is_grounded(value, source_occurrences):
         return False
     return True
 
@@ -19643,7 +20875,10 @@ def _source_text_contains_numeric_value_equivalent(text: str, value: Any) -> boo
     numeric = _numeric_rule_value(value)
     if numeric is None:
         return False
-    return numeric_value_is_grounded(numeric[1], extract_numbers_from_text(text))
+    return numeric_value_is_grounded(
+        numeric[1],
+        extract_typed_numeric_occurrences_from_text(text),
+    )
 
 
 def _source_text_contains_table_value_multiset(
@@ -20652,21 +21887,37 @@ def _embedded_integer_scale_selector(formula: str) -> str | None:
     return None
 
 
-def numeric_value_is_grounded(value: float, source_numbers: set[float]) -> bool:
-    """Return true when a generated number is present in extracted source numbers."""
-    for source_value in source_numbers:
+def numeric_value_is_grounded(
+    value: float,
+    source_occurrences: Iterable[NumericOccurrence],
+) -> bool:
+    """Return whether a generated value is grounded by typed source evidence.
+
+    Percentage scaling requires an occurrence whose own context supplies rate
+    evidence; an unrelated integer can never authorize the conversion.
+    """
+    for occurrence in source_occurrences:
+        source_value = occurrence.value
         if math.isclose(
             value,
             source_value,
             rel_tol=0,
             abs_tol=NUMERIC_GROUNDING_ABS_TOLERANCE,
+        ) and not (
+            occurrence.requires_rate_context and not occurrence.has_rate_context
         ):
             return True
-        if 0 < abs(value) <= 1 and math.isclose(
-            value * 100,
-            source_value,
-            rel_tol=0,
-            abs_tol=NUMERIC_GROUNDING_ABS_TOLERANCE,
+        if (
+            occurrence.has_rate_context
+            and 0 < abs(value) <= 1
+            and math.isclose(
+                value * 100,
+                occurrence.source_value
+                if occurrence.source_value is not None
+                else source_value,
+                rel_tol=0,
+                abs_tol=NUMERIC_GROUNDING_ABS_TOLERANCE,
+            )
         ):
             return True
     return False

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -2692,11 +2692,21 @@ def _rule_grounding_values_by_path(
     return out
 
 
-def _rule_atom_evidence_by_path(
+@dataclass(frozen=True)
+class _NumericEvidenceItem:
+    """One source fragment and the citation identity that selects its profile."""
+
+    citation_path: str | None
+    text: str
+
+
+def _rule_atom_numeric_evidence_items_by_path(
     rule: Any,
     proof_source_texts: Mapping[str, str | None] | None = None,
-) -> dict[str, str]:
-    """Map each proof atom's anchor ``path`` to that atom's grounding evidence.
+    *,
+    require_body_bound_evidence: bool = True,
+) -> dict[str, tuple[_NumericEvidenceItem, ...]]:
+    """Map each proof anchor to separately profileable numeric evidence items.
 
     Evidence is excerpt-first: the atom's excerpt/quote/table cells — the
     encoder's chosen, excerpt-verified text for the value at that exact path.
@@ -2705,10 +2715,11 @@ def _rule_atom_evidence_by_path(
     module-source semantics while keeping the boundary per anchored atom: an
     unrelated atom in the same rule can launder nothing, because neither its
     excerpt nor its cited provision is consulted for another path's literal.
+    Fragments retain their own citation and are never joined before tokenization.
     (Follow-up ratchet: require excerpts on numeric-bearing atoms.)
     """
-    by_path: dict[str, list[str]] = {}
-    cited_by_path: dict[str, list[str]] = {}
+    by_path: dict[str, list[_NumericEvidenceItem]] = {}
+    cited_by_path: dict[str, list[tuple[str, str]]] = {}
     explicit_evidence_paths: set[str] = set()
     if not isinstance(rule, dict):
         return {}
@@ -2728,7 +2739,13 @@ def _rule_atom_evidence_by_path(
         source = atom.get("source")
         if not path or not isinstance(source, dict):
             continue
-        citation_path = str(source.get("corpus_citation_path") or "").strip()
+        raw_citation_path = source.get("corpus_citation_path")
+        citation_identity = (
+            raw_citation_path if isinstance(raw_citation_path, str) else None
+        )
+        citation_path = (
+            citation_identity.strip() if citation_identity is not None else ""
+        )
         resolved_text = (
             proof_source_texts.get(citation_path)
             if proof_source_texts is not None and citation_path
@@ -2741,7 +2758,8 @@ def _rule_atom_evidence_by_path(
                 continue
             explicit_evidence_paths.add(path)
             excerpt_is_body_bound = (
-                proof_source_texts is None
+                not require_body_bound_evidence
+                or proof_source_texts is None
                 or not citation_path
                 or (
                     resolved_text is not None
@@ -2749,7 +2767,9 @@ def _rule_atom_evidence_by_path(
                 )
             )
             if excerpt_is_body_bound:
-                fragments.append(text.strip())
+                fragments.append(
+                    _NumericEvidenceItem(citation_identity, text.strip())
+                )
         table = source.get("table")
         if isinstance(table, dict):
             for cell in table.values():
@@ -2757,7 +2777,8 @@ def _rule_atom_evidence_by_path(
                     explicit_evidence_paths.add(path)
                     text = str(cell).strip()
                     cell_is_body_bound = (
-                        proof_source_texts is None
+                        not require_body_bound_evidence
+                        or proof_source_texts is None
                         or not citation_path
                         or (
                             resolved_text is not None
@@ -2767,25 +2788,41 @@ def _rule_atom_evidence_by_path(
                         )
                     )
                     if cell_is_body_bound:
-                        fragments.append(text)
+                        fragments.append(_NumericEvidenceItem(citation_identity, text))
         if citation_path:
-            cited_by_path.setdefault(path, []).append(citation_path)
-    evidence: dict[str, str] = {}
+            cited_by_path.setdefault(path, []).append(
+                (citation_path, citation_identity or citation_path)
+            )
+    evidence: dict[str, tuple[_NumericEvidenceItem, ...]] = {}
     for path, fragments in by_path.items():
         if fragments:
-            evidence[path] = "\n".join(fragments)
+            evidence[path] = tuple(fragments)
             continue
         if path in explicit_evidence_paths:
-            evidence[path] = ""
+            evidence[path] = ()
             continue
-        resolved: list[str] = []
+        resolved: list[_NumericEvidenceItem] = []
         if proof_source_texts is not None:
-            for citation_path in cited_by_path.get(path, []):
+            for citation_path, citation_identity in cited_by_path.get(path, []):
                 text = proof_source_texts.get(citation_path)
                 if text:
-                    resolved.append(text)
-        evidence[path] = "\n".join(resolved)
+                    resolved.append(_NumericEvidenceItem(citation_identity, text))
+        evidence[path] = tuple(resolved)
     return evidence
+
+
+def _rule_atom_evidence_by_path(
+    rule: Any,
+    proof_source_texts: Mapping[str, str | None] | None = None,
+) -> dict[str, str]:
+    """Return the legacy joined view used by non-numeric evidence consumers."""
+    return {
+        path: "\n".join(item.text for item in items)
+        for path, items in _rule_atom_numeric_evidence_items_by_path(
+            rule,
+            proof_source_texts,
+        ).items()
+    }
 
 
 def _source_evidence_fragment_is_body_bound(
@@ -5211,7 +5248,7 @@ def _extract_legacy_inventory_values(text: str) -> list[float]:
 
 @dataclass(frozen=True)
 class _NumericTokenization:
-    """Typed legacy emission streams used by both public extraction adapters."""
+    """Typed emission streams used by both public extraction adapters."""
 
     grounding: tuple[NumericOccurrence, ...]
     inventory: tuple[NumericOccurrence, ...]
@@ -5643,6 +5680,299 @@ class _LegacyNumericCollector:
         self.inventory.append(self.occurrence(view, span, value, **kwargs))
 
 
+_NUMERIC_EXTRACTION_PROFILES = frozenset({"legacy", "en-US", "en-GB", "de-DE"})
+_LOCALE_NUMERIC_GROUPING_SPACES = " \u00a0\u202f"
+_LOCALE_UNARY_SIGNS = "+-\u2013\u2212"
+_LOCALE_UNARY_PREFIXES = frozenset(
+    "([{=:;,+*/|<>!%^&~?"
+    "\u2022"  # bullet
+    "\u00b7"  # middle dot
+    "\u00d7"  # multiplication sign
+    "\u00f7"  # division sign
+    "\u2219"  # bullet operator
+    "\u2260"  # not equal
+    "\u2264"  # less than or equal
+    "\u2265"  # greater than or equal
+)
+_GERMAN_LEXICAL_SCALE_VALUES = {
+    "Einhundertzwanzigstel": 120.0,
+    "Dreihundertsechzigstel": 360.0,
+    "Vierhundertfünfzigstel": 450.0,
+    "Vierundzwanzigstel": 24.0,
+    "Hundertzwanzigstel": 120.0,
+    "Fünfundsiebzigstel": 75.0,
+    "Dreihundertstel": 300.0,
+    "Sechshundertstel": 600.0,
+    "Zehntausendstel": 10_000.0,
+    "Vierzehntel": 14.0,
+    "Fünfzehntel": 15.0,
+    "Neunzehntel": 19.0,
+    "Dreizehntel": 13.0,
+    "Tausendstel": 1_000.0,
+    "Hundertstel": 100.0,
+    "Dreißigstel": 30.0,
+    "Fünfzigstel": 50.0,
+    "Zwanzigstel": 20.0,
+    "Zwölftel": 12.0,
+    "Siebtel": 7.0,
+    "Sechstel": 6.0,
+    "Fünftel": 5.0,
+    "Viertel": 4.0,
+    "Drittel": 3.0,
+    "Zehntel": 10.0,
+    "Achtel": 8.0,
+}
+_GERMAN_LEXICAL_SCALE_VALUES_CASEFOLD = {
+    word.casefold(): value for word, value in _GERMAN_LEXICAL_SCALE_VALUES.items()
+}
+_GERMAN_LEXICAL_SCALE_PATTERN = re.compile(
+    r"(?<!\w)(?P<denominator>"
+    + "|".join(
+        re.escape(word)
+        for word in sorted(_GERMAN_LEXICAL_SCALE_VALUES, key=len, reverse=True)
+    )
+    + r")(?:n)?(?!\w)",
+    re.IGNORECASE,
+)
+
+
+def _numeric_profile_for_citation_path(citation_path: str | None) -> str:
+    """Select a locale only from a canonical evidence citation path."""
+    if not isinstance(citation_path, str) or not citation_path:
+        return "legacy"
+    try:
+        canonical = require_canonical_corpus_citation_path(citation_path)
+    except (InvalidCorpusCitationError, TypeError, ValueError):
+        return "legacy"
+    return "de-DE" if canonical.startswith("de/") else "legacy"
+
+
+def _locale_sign_is_unary(text: str, sign_index: int) -> bool:
+    prefix_index = sign_index - 1
+    while (
+        prefix_index >= 0
+        and text[prefix_index] in _LOCALE_NUMERIC_GROUPING_SPACES
+    ):
+        prefix_index -= 1
+    if prefix_index < 0:
+        return True
+    prefix = text[prefix_index]
+    return (
+        prefix.isspace()
+        or prefix in _LOCALE_UNARY_PREFIXES
+        or prefix in _LOCALE_UNARY_SIGNS
+    )
+
+
+def _iter_locale_numeric_envelopes(text: str) -> Iterator[tuple[int, int]]:
+    """Reserve each complete numeric-looking span before locale validation."""
+    occupied_until = 0
+    for digit_match in re.finditer(r"\d", text):
+        digit_start = digit_match.start()
+        if digit_start < occupied_until:
+            continue
+
+        start = digit_start
+        while start > 0 and text[start - 1] in ".,":
+            start -= 1
+        whitespace_start = start
+        while (
+            whitespace_start > 0
+            and text[whitespace_start - 1] in _LOCALE_NUMERIC_GROUPING_SPACES
+        ):
+            whitespace_start -= 1
+        sign_index = whitespace_start - 1
+        if (
+            sign_index >= 0
+            and text[sign_index] in _LOCALE_UNARY_SIGNS
+            and _locale_sign_is_unary(text, sign_index)
+        ):
+            start = sign_index
+
+        index = digit_start
+        exponent_seen = False
+        while index < len(text):
+            char = text[index]
+            if char.isdigit():
+                index += 1
+                continue
+            if char in ".,":
+                separator_end = index
+                while separator_end < len(text) and text[separator_end] in ".,":
+                    separator_end += 1
+                if (
+                    separator_end < len(text)
+                    and text[separator_end].isdigit()
+                ):
+                    index = separator_end
+                    continue
+                break
+            if char in _LOCALE_NUMERIC_GROUPING_SPACES:
+                next_index = index
+                while (
+                    next_index < len(text)
+                    and text[next_index] in _LOCALE_NUMERIC_GROUPING_SPACES
+                ):
+                    next_index += 1
+                if next_index < len(text) and text[next_index].isdigit():
+                    index = next_index
+                    continue
+                break
+            if char in "Ee" and not exponent_seen:
+                exponent_seen = True
+                index += 1
+                while index < len(text) and text[index] in _LOCALE_UNARY_SIGNS:
+                    index += 1
+                continue
+            break
+
+        occupied_until = index
+        yield start, index
+
+
+def _valid_grouped_integer(
+    raw: str,
+    *,
+    allowed_separators: str,
+) -> tuple[bool, str]:
+    separators = {char for char in raw if char in allowed_separators}
+    if not separators:
+        return raw.isdigit(), raw
+    if len(separators) != 1:
+        return False, ""
+    separator = next(iter(separators))
+    groups = raw.split(separator)
+    if (
+        not groups
+        or not groups[0].isdigit()
+        or not 1 <= len(groups[0]) <= 3
+        or (len(groups[0]) > 1 and groups[0].startswith("0"))
+        or any(len(group) != 3 or not group.isdigit() for group in groups[1:])
+    ):
+        return False, ""
+    return True, "".join(groups)
+
+
+def _parse_locale_numeric_envelope(raw: str, profile: str) -> float | None:
+    stripped = raw.strip(_LOCALE_NUMERIC_GROUPING_SPACES)
+    sign = 1.0
+    if stripped and stripped[0] in _LOCALE_UNARY_SIGNS:
+        if stripped[0] in "-\u2013\u2212":
+            sign = -1.0
+        stripped = stripped[1:].lstrip(_LOCALE_NUMERIC_GROUPING_SPACES)
+    if not stripped:
+        return None
+
+    scientific = re.fullmatch(
+        r"(?P<mantissa>.+?)(?P<exponent>[Ee][+\-\u2013\u2212]?\d+)?",
+        stripped,
+    )
+    if scientific is None:
+        return None
+    mantissa = scientific.group("mantissa")
+    exponent = (
+        scientific.group("exponent") or ""
+    ).replace("\u2013", "-").replace("\u2212", "-")
+
+    if profile == "de-DE":
+        if mantissa.count(",") > 1:
+            return None
+        integer, comma, fraction = mantissa.partition(",")
+        if comma and (not fraction or not fraction.isdigit()):
+            return None
+        valid, normalized_integer = _valid_grouped_integer(
+            integer,
+            allowed_separators="." + _LOCALE_NUMERIC_GROUPING_SPACES,
+        )
+        if not valid:
+            return None
+        normalized = normalized_integer + (f".{fraction}" if comma else "") + exponent
+    else:
+        if mantissa.count(".") > 1:
+            return None
+        integer, dot, fraction = mantissa.partition(".")
+        if dot and (not fraction or not fraction.isdigit()):
+            return None
+        valid, normalized_integer = _valid_grouped_integer(
+            integer,
+            allowed_separators=",",
+        )
+        if not valid:
+            return None
+        normalized = normalized_integer + (f".{fraction}" if dot else "") + exponent
+
+    with contextlib.suppress(ValueError, OverflowError):
+        value = sign * float(normalized)
+        if math.isfinite(value):
+            return value
+    return None
+
+
+def _locale_numeric_envelope_has_token_boundaries(
+    text: str,
+    span: tuple[int, int],
+) -> bool:
+    before = text[span[0] - 1] if span[0] > 0 else ""
+    after = text[span[1]] if span[1] < len(text) else ""
+    return not (
+        (before and (before.isalnum() or before == "_"))
+        or (after and (after.isalnum() or after == "_"))
+    )
+
+
+def _has_malformed_profiled_numeric_envelope(
+    text: str,
+    *,
+    profile: str,
+) -> bool:
+    """Return whether strict-profile text contains an unparseable full span."""
+    if profile == "legacy":
+        return False
+    if profile not in _NUMERIC_EXTRACTION_PROFILES:
+        raise ValueError(f"Unsupported numeric profile: {profile}")
+    cleaned = _clean_source_text_for_numeric_extraction(text)
+    return any(
+        _locale_numeric_envelope_has_token_boundaries(cleaned, span)
+        and _parse_locale_numeric_envelope(cleaned[span[0] : span[1]], profile)
+        is None
+        for span in _iter_locale_numeric_envelopes(cleaned)
+    )
+
+
+def _tokenize_profiled_numeric_occurrences(
+    text: str,
+    *,
+    profile: str,
+) -> _NumericTokenization:
+    """Tokenize strict locale-aware numeric envelopes without suffix fallback."""
+    cleaned = _clean_source_text_for_numeric_extraction(text)
+    view = _NumericTextView.aligned(text, cleaned)
+    collector = _LegacyNumericCollector(text)
+    occurrences: list[NumericOccurrence] = []
+
+    for span in _iter_locale_numeric_envelopes(cleaned):
+        if not _locale_numeric_envelope_has_token_boundaries(cleaned, span):
+            continue
+        value = _parse_locale_numeric_envelope(cleaned[span[0] : span[1]], profile)
+        if value is None:
+            continue
+        occurrences.append(collector.occurrence(view, span, value))
+
+    if profile == "de-DE":
+        for match in _GERMAN_LEXICAL_SCALE_PATTERN.finditer(cleaned):
+            value = _GERMAN_LEXICAL_SCALE_VALUES_CASEFOLD.get(
+                match.group("denominator").casefold()
+            )
+            if value is not None:
+                occurrences.append(collector.occurrence(view, match.span(), value))
+
+    occurrences.sort(key=lambda occurrence: (occurrence.start, occurrence.end))
+    return _NumericTokenization(
+        grounding=tuple(occurrences),
+        inventory=tuple(occurrences),
+    )
+
+
 def _occurrence_value_matches(left: float, right: float) -> bool:
     return math.isclose(
         left,
@@ -5658,8 +5988,10 @@ def _tokenize_numeric_occurrences_from_text(
     profile: str = "legacy",
 ) -> _NumericTokenization:
     """Tokenize once into typed grounding and source-inventory emission streams."""
-    if profile != "legacy":
+    if profile not in _NUMERIC_EXTRACTION_PROFILES:
         raise ValueError(f"Unsupported numeric profile: {profile}")
+    if profile != "legacy":
+        return _tokenize_profiled_numeric_occurrences(text, profile=profile)
 
     collector = _LegacyNumericCollector(text)
     source_view = _NumericTextView.identity(text)
@@ -6434,6 +6766,73 @@ def _decimal_place_scale_values_from_source(source: str) -> set[float]:
     return values
 
 
+def _module_numeric_citation_path(payload: Mapping[str, Any]) -> str | None:
+    """Return the exact, unnormalized module citation identity when present."""
+    citation_path: str | None = None
+    module = payload.get("module")
+    source_verification = (
+        module.get("source_verification") if isinstance(module, dict) else None
+    )
+    if isinstance(source_verification, dict):
+        raw_citation_path = source_verification.get("corpus_citation_path")
+        if isinstance(raw_citation_path, str):
+            citation_path = raw_citation_path
+    return citation_path
+
+
+def _module_numeric_evidence_item(
+    payload: Mapping[str, Any],
+    module_source: str,
+    *,
+    citation_path: str | None = None,
+) -> _NumericEvidenceItem | None:
+    """Attach the module source to its exact persisted citation identity."""
+    if not module_source:
+        return None
+    if citation_path is None:
+        citation_path = _module_numeric_citation_path(payload)
+    return _NumericEvidenceItem(citation_path, module_source)
+
+
+def _numeric_evidence_index(
+    evidence_items: Sequence[_NumericEvidenceItem],
+    *,
+    suppress_ambiguous_half_up_terms: bool = False,
+    cache: dict[
+        tuple[str, str],
+        tuple[tuple[NumericOccurrence, ...], frozenset[float]],
+    ]
+    | None = None,
+) -> tuple[tuple[NumericOccurrence, ...], set[float]]:
+    """Parse each evidence item under its own profile, then union the indexes."""
+    occurrences: list[NumericOccurrence] = []
+    decimal_place_scale_values: set[float] = set()
+    for item in evidence_items:
+        source = (
+            _strip_ambiguous_half_up_terms(item.text)
+            if suppress_ambiguous_half_up_terms
+            else item.text
+        )
+        if not source:
+            continue
+        profile = _numeric_profile_for_citation_path(item.citation_path)
+        cache_key = (profile, source)
+        source_index = cache.get(cache_key) if cache is not None else None
+        if source_index is None:
+            source_index = (
+                _tokenize_numeric_occurrences_from_text(
+                    source,
+                    profile=profile,
+                ).grounding,
+                frozenset(_decimal_place_scale_values_from_source(source)),
+            )
+            if cache is not None:
+                cache[cache_key] = source_index
+        occurrences.extend(source_index[0])
+        decimal_place_scale_values.update(source_index[1])
+    return tuple(occurrences), decimal_place_scale_values
+
+
 def _numeric_value_grounded_in_source(
     value: float,
     source_occurrences: Sequence[NumericOccurrence],
@@ -6483,18 +6882,22 @@ def evaluate_numeric_grounding_values(
     source_text: str,
     *,
     authoritative_source_text: str | None = None,
+    source_citation_path: str | None = None,
 ) -> list[tuple[int, str, float, bool]]:
     """Return a grounding decision for every generated numeric literal.
 
     ``source_text`` may include excerpt-verified proof evidence used for ordinary
     literal matching. Semantic rounding support is intentionally restricted to
     ``authoritative_source_text`` when supplied, so inline excerpts cannot grant
-    the half-up helper exemption.
+    the half-up helper exemption. A single annotated source is parsed under the
+    profile selected by its exact canonical citation; unannotated text remains
+    legacy.
     """
     grounding_values = extract_grounding_values(content)
     if not grounding_values:
         return []
 
+    source_profile = _numeric_profile_for_citation_path(source_citation_path)
     authoritative_source = (
         source_text
         if authoritative_source_text is None
@@ -6502,12 +6905,17 @@ def evaluate_numeric_grounding_values(
     )
     with contextlib.suppress(yaml.YAMLError, TypeError, ValueError):
         payload = yaml.safe_load(content)
+        if isinstance(payload, dict) and source_citation_path is None:
+            source_profile = _numeric_profile_for_citation_path(
+                _module_numeric_citation_path(payload)
+            )
         rules = payload.get("rules") if isinstance(payload, dict) else None
         if isinstance(rules, list):
             selector_table_keys = _rulespec_index_selector_keys(rules)
             decisions: list[tuple[int, str, float, bool]] = []
             source_indexes: dict[
-                str, tuple[tuple[NumericOccurrence, ...], set[float]]
+                tuple[str, str],
+                tuple[tuple[NumericOccurrence, ...], set[float]],
             ] = {}
             for rule in rules:
                 anchored_values = _rule_grounding_values_by_path(
@@ -6534,15 +6942,17 @@ def evaluate_numeric_grounding_values(
                         if _is_half_up_rounding_helper_scalar(rule_name, value)
                         else source_text
                     )
-                    source_index = source_indexes.get(grounding_source)
+                    source_index_key = (source_profile, grounding_source)
+                    source_index = source_indexes.get(source_index_key)
                     if source_index is None:
                         source_index = (
                             _tokenize_numeric_occurrences_from_text(
-                                grounding_source
+                                grounding_source,
+                                profile=source_profile,
                             ).grounding,
                             _decimal_place_scale_values_from_source(grounding_source),
                         )
-                        source_indexes[grounding_source] = source_index
+                        source_indexes[source_index_key] = source_index
                     decisions.append(
                         (
                             1,
@@ -6556,7 +6966,10 @@ def evaluate_numeric_grounding_values(
             if len(decisions) == len(grounding_values):
                 return decisions
 
-    source_occurrences = _tokenize_numeric_occurrences_from_text(source_text).grounding
+    source_occurrences = _tokenize_numeric_occurrences_from_text(
+        source_text,
+        profile=source_profile,
+    ).grounding
     decimal_place_scale_values = _decimal_place_scale_values_from_source(source_text)
     return [
         (
@@ -6576,6 +6989,7 @@ def find_ungrounded_numeric_issues(
     source_text: str | None = None,
     *,
     authoritative_source_text: str | None = None,
+    source_citation_path: str | None = None,
 ) -> list[str]:
     """Return issues for generated numeric literals absent from source text."""
     grounding_values = extract_grounding_values(content)
@@ -6598,6 +7012,7 @@ def find_ungrounded_numeric_issues(
         content,
         source,
         authoritative_source_text=authoritative_source_text,
+        source_citation_path=source_citation_path,
     ):
         if grounded:
             continue
@@ -6609,11 +7024,151 @@ def find_ungrounded_numeric_issues(
     return issues
 
 
+def evaluate_numeric_grounding_values_scoped(
+    content: str,
+    *,
+    module_source_text: str | None,
+    module_citation_path: str | None = None,
+    proof_source_texts: Mapping[str, str | None] | None = None,
+    authoritative_source_text: str | None = None,
+    require_body_bound_proof_evidence: bool = True,
+) -> list[tuple[int, str, float, bool]]:
+    """Evaluate anchored literals against separately profiled evidence items."""
+    grounding_values = extract_grounding_values(content)
+    if not grounding_values:
+        return []
+
+    module_source = (module_source_text or "").strip()
+    try:
+        payload = yaml.safe_load(content)
+    except (yaml.YAMLError, ValueError):
+        payload = None
+    if (
+        not isinstance(payload, dict)
+        or payload.get("format") != "rulespec/v1"
+        or not isinstance(payload.get("rules"), list)
+    ):
+        return evaluate_numeric_grounding_values(
+            content,
+            module_source,
+            authoritative_source_text=authoritative_source_text,
+            source_citation_path=module_citation_path,
+        )
+
+    module_evidence = _module_numeric_evidence_item(
+        payload,
+        module_source,
+        citation_path=module_citation_path,
+    )
+    evidence_items_by_rule = [
+        _rule_atom_numeric_evidence_items_by_path(
+            rule,
+            proof_source_texts,
+            require_body_bound_evidence=require_body_bound_proof_evidence,
+        )
+        for rule in payload["rules"]
+    ]
+    selector_table_keys = _rulespec_index_selector_keys(payload["rules"])
+    evidence_index_cache: dict[
+        tuple[str, str],
+        tuple[tuple[NumericOccurrence, ...], frozenset[float]],
+    ] = {}
+    decisions: list[tuple[int, str, float, bool]] = []
+    for rule, evidence_items_by_path in zip(
+        payload["rules"],
+        evidence_items_by_rule,
+        strict=True,
+    ):
+        anchored_values = _rule_grounding_values_by_path(
+            rule,
+            selector_table_keys=selector_table_keys,
+        )
+        if not anchored_values:
+            continue
+        verified_source_pairs_by_path = _rule_verified_source_excerpt_pairs_by_path(
+            rule,
+            proof_source_texts,
+        )
+        rule_name = (
+            str(rule.get("name") or "").strip() if isinstance(rule, dict) else ""
+        )
+        for anchor_path, raw, value in anchored_values:
+            direct_half_up_helper = _is_direct_half_up_rounding_helper_value(
+                rule,
+                anchor_path,
+                value,
+            )
+            module_supports_rounding = bool(module_source) and (
+                _is_source_backed_half_up_rounding_helper(
+                    rule_name,
+                    value,
+                    module_source,
+                )
+            )
+            source_evidence = verified_source_pairs_by_path.get(anchor_path, ())
+            atom_supports_rounding = any(
+                (
+                    excerpt is None
+                    or _is_source_backed_half_up_rounding_helper(
+                        rule_name,
+                        value,
+                        excerpt,
+                    )
+                )
+                and _is_source_backed_half_up_rounding_helper(
+                    rule_name,
+                    value,
+                    resolved_source,
+                )
+                for excerpt, resolved_source in source_evidence
+            )
+            if direct_half_up_helper and (
+                module_supports_rounding or atom_supports_rounding
+            ):
+                decisions.append((1, raw, value, True))
+                continue
+
+            evidence_items = (
+                ([module_evidence] if module_evidence is not None else [])
+                + list(evidence_items_by_path.get(anchor_path, ()))
+            )
+            source_occurrences, decimal_place_scale_values = _numeric_evidence_index(
+                evidence_items,
+                suppress_ambiguous_half_up_terms=(
+                    _is_half_up_rounding_helper_scalar(rule_name, value)
+                ),
+                cache=evidence_index_cache,
+            )
+            decisions.append(
+                (
+                    1,
+                    raw,
+                    value,
+                    _numeric_value_grounded_in_source(
+                        value,
+                        source_occurrences,
+                        decimal_place_scale_values,
+                    ),
+                )
+            )
+
+    if len(decisions) == len(grounding_values):
+        return decisions
+    return evaluate_numeric_grounding_values(
+        content,
+        module_source,
+        authoritative_source_text=authoritative_source_text,
+        source_citation_path=module_citation_path,
+    )
+
+
 def find_ungrounded_numeric_issues_scoped(
     content: str,
     *,
     module_source_text: str | None,
+    module_citation_path: str | None = None,
     proof_source_texts: Mapping[str, str | None] | None = None,
+    require_body_bound_proof_evidence: bool = True,
 ) -> list[str]:
     """Ground each rule's literals against the provisions that rule actually cites.
 
@@ -6636,13 +7191,30 @@ def find_ungrounded_numeric_issues_scoped(
         or payload.get("format") != "rulespec/v1"
         or not isinstance(payload.get("rules"), list)
     ):
-        return find_ungrounded_numeric_issues(content, source_text=module_source_text)
+        return find_ungrounded_numeric_issues(
+            content,
+            source_text=module_source_text,
+            source_citation_path=module_citation_path,
+        )
 
     if not extract_grounding_values(content):
         return []
-    any_evidence = bool(module_source) or any(
-        any(_rule_atom_evidence_by_path(rule, proof_source_texts).values())
+    module_evidence = _module_numeric_evidence_item(
+        payload,
+        module_source,
+        citation_path=module_citation_path,
+    )
+    evidence_items_by_rule = [
+        _rule_atom_numeric_evidence_items_by_path(
+            rule,
+            proof_source_texts,
+            require_body_bound_evidence=require_body_bound_proof_evidence,
+        )
         for rule in payload["rules"]
+    ]
+    any_evidence = module_evidence is not None or any(
+        any(items for items in evidence_by_path.values())
+        for evidence_by_path in evidence_items_by_rule
     )
     if not any_evidence:
         return [
@@ -6651,67 +7223,28 @@ def find_ungrounded_numeric_issues_scoped(
             "`module.summary` is not accepted as source text for numeric grounding."
         ]
 
-    selector_table_keys = _rulespec_index_selector_keys(payload["rules"])
     seen: set[str] = set()
     issues: list[str] = []
-    for rule in payload["rules"]:
-        anchored_values = _rule_grounding_values_by_path(
-            rule, selector_table_keys=selector_table_keys
-        )
-        if not anchored_values:
+    # Bind each literal to only the proof atom at its exact RuleSpec path plus
+    # the designated module source. The evaluator parses each source fragment
+    # under its own citation-selected profile before unioning typed indexes.
+    for _line, raw, value, grounded in evaluate_numeric_grounding_values_scoped(
+        content,
+        module_source_text=module_source,
+        module_citation_path=module_citation_path,
+        proof_source_texts=proof_source_texts,
+        require_body_bound_proof_evidence=require_body_bound_proof_evidence,
+    ):
+        if grounded:
             continue
-        # Bind each literal to ONLY the proof atom anchored to that literal's
-        # exact path (versions[i].formula / versions[i].values), plus the single
-        # designated module source. Grounding against just that atom's
-        # excerpt-verified evidence — not every atom in the rule, and not the
-        # full text of cited provisions — is the tightest correct semantics: an
-        # unrelated atom in the same rule (e.g. a note) cannot launder a
-        # fabricated value that merely appears in its own excerpt. Module-source
-        # retention matches the pre-existing single-source check (no regression).
-        evidence_by_path = _rule_atom_evidence_by_path(rule, proof_source_texts)
-        verified_source_pairs_by_path = _rule_verified_source_excerpt_pairs_by_path(
-            rule, proof_source_texts
+        display = raw if raw == f"{value:g}" else f"{raw} ({value:g})"
+        issue = (
+            "Ungrounded generated numeric literal: "
+            f"{display} does not appear as a substantive numeric value in the source text."
         )
-        rule_name = (
-            str(rule.get("name") or "").strip() if isinstance(rule, dict) else ""
-        )
-        for anchor_path, raw, value in anchored_values:
-            direct_half_up_helper = _is_direct_half_up_rounding_helper_value(
-                rule, anchor_path, value
-            )
-            texts = [module_source, evidence_by_path.get(anchor_path, "")]
-            combined = "\n".join(text for text in texts if text).strip()
-            source_evidence = verified_source_pairs_by_path.get(anchor_path, ())
-            module_supports_rounding = bool(module_source) and (
-                _is_source_backed_half_up_rounding_helper(
-                    rule_name, value, module_source
-                )
-            )
-            atom_supports_rounding = any(
-                (
-                    excerpt is None
-                    or _is_source_backed_half_up_rounding_helper(
-                        rule_name, value, excerpt
-                    )
-                )
-                and _is_source_backed_half_up_rounding_helper(
-                    rule_name, value, resolved_source
-                )
-                for excerpt, resolved_source in source_evidence
-            )
-            if direct_half_up_helper and (
-                module_supports_rounding or atom_supports_rounding
-            ):
-                continue
-            grounding_source = (
-                _strip_ambiguous_half_up_terms(combined)
-                if _is_half_up_rounding_helper_scalar(rule_name, value)
-                else combined
-            )
-            for issue in _ungrounded_from_values([(1, raw, value)], grounding_source):
-                if issue not in seen:
-                    seen.add(issue)
-                    issues.append(issue)
+        if issue not in seen:
+            seen.add(issue)
+            issues.append(issue)
     return issues
 
 
@@ -7931,8 +8464,13 @@ def repair_source_table_open_ended_bound_sentinels(
         if source_text is not None
         else (extract_numeric_grounding_source_text(content) or "").strip()
     )
+    profile = _numeric_profile_for_citation_path(
+        _module_numeric_citation_path(payload)
+    )
     source_occurrences = (
-        extract_typed_numeric_occurrences_from_text(source) if source else []
+        extract_typed_numeric_occurrences_from_text(source, profile=profile)
+        if source
+        else []
     )
     changed_rules: set[str] = set()
 
@@ -20755,11 +21293,19 @@ def _find_source_text_value_issues(
     expected_value: Any,
 ) -> list[str]:
     """Check expected values are present in the ingested source page text."""
+    numeric_profile = _numeric_profile_for_citation_path(source_label)
     normalized_text = _normalize_source_verification_text(source_text)
     if isinstance(expected_value, dict):
         issues: list[str] = []
+        profiled_numeric_cells: list[tuple[str, Any]] = []
         for raw_key, expected_cell in expected_value.items():
             cell_key = str(raw_key)
+            if (
+                numeric_profile != "legacy"
+                and _numeric_rule_value(expected_cell) is not None
+            ):
+                profiled_numeric_cells.append((cell_key, expected_cell))
+                continue
             if not _source_text_contains_indexed_value(
                 normalized_text,
                 index=cell_key,
@@ -20770,17 +21316,50 @@ def _find_source_text_value_issues(
                     f"`{source_label}` does not contain `{value_name}[{cell_key}]` = "
                     f"{_format_verification_value(expected_cell)}."
                 )
-        if issues and _source_text_contains_table_value_multiset(
-            normalized_text,
-            expected_value.values(),
+        if (
+            numeric_profile == "legacy"
+            and issues
+            and _source_text_contains_table_value_multiset(
+                normalized_text,
+                expected_value.values(),
+            )
         ):
             return []
+        if profiled_numeric_cells and not (
+            _source_text_contains_profiled_table_value_multiset(
+                source_text,
+                (cell for _, cell in profiled_numeric_cells),
+                profile=numeric_profile,
+            )
+        ):
+            issues.extend(
+                "Source verification value missing: "
+                f"`{source_label}` does not contain `{value_name}[{cell_key}]` = "
+                f"{_format_verification_value(expected_cell)}."
+                for cell_key, expected_cell in profiled_numeric_cells
+            )
         return issues
 
-    if _source_text_contains_scalar_value(
-        normalized_text,
-        expected_value,
-    ) or _source_text_contains_numeric_value_equivalent(source_text, expected_value):
+    expected_is_numeric = _numeric_rule_value(expected_value) is not None
+    if numeric_profile != "legacy" and expected_is_numeric:
+        value_is_present = _source_text_contains_numeric_value_equivalent(
+            source_text,
+            expected_value,
+            profile=numeric_profile,
+        )
+    else:
+        value_is_present = _source_text_contains_scalar_value(
+            normalized_text,
+            expected_value,
+        ) or (
+            expected_is_numeric
+            and _source_text_contains_numeric_value_equivalent(
+                source_text,
+                expected_value,
+                profile=numeric_profile,
+            )
+        )
+    if value_is_present:
         return []
     return [
         "Source verification value missing: "
@@ -20871,13 +21450,18 @@ def _source_text_contains_scalar_value(text: str, value: Any) -> bool:
     )
 
 
-def _source_text_contains_numeric_value_equivalent(text: str, value: Any) -> bool:
+def _source_text_contains_numeric_value_equivalent(
+    text: str,
+    value: Any,
+    *,
+    profile: str = "legacy",
+) -> bool:
     numeric = _numeric_rule_value(value)
     if numeric is None:
         return False
     return numeric_value_is_grounded(
         numeric[1],
-        extract_typed_numeric_occurrences_from_text(text),
+        extract_typed_numeric_occurrences_from_text(text, profile=profile),
     )
 
 
@@ -20899,6 +21483,57 @@ def _source_text_contains_table_value_multiset(
         )
         >= expected_count
         for value_texts_key, expected_count in expected_counts.items()
+    )
+
+
+def _source_text_contains_profiled_table_value_multiset(
+    text: str,
+    values: Iterable[Any],
+    *,
+    profile: str,
+) -> bool:
+    """Match locale-parsed table values without reusing source occurrences."""
+    expected_values: list[float] = []
+    for value in values:
+        numeric = _numeric_rule_value(value)
+        if numeric is None:
+            return False
+        expected_values.append(numeric[1])
+
+    source_occurrences = extract_typed_numeric_occurrences_from_text(
+        text,
+        profile=profile,
+    )
+    candidate_indexes = [
+        [
+            occurrence_index
+            for occurrence_index, occurrence in enumerate(source_occurrences)
+            if numeric_value_is_grounded(expected, (occurrence,))
+        ]
+        for expected in expected_values
+    ]
+    if any(not candidates for candidates in candidate_indexes):
+        return False
+
+    matched_expected_by_occurrence: dict[int, int] = {}
+
+    def assign(expected_index: int, visited: set[int]) -> bool:
+        for occurrence_index in candidate_indexes[expected_index]:
+            if occurrence_index in visited:
+                continue
+            visited.add(occurrence_index)
+            previous = matched_expected_by_occurrence.get(occurrence_index)
+            if previous is None or assign(previous, visited):
+                matched_expected_by_occurrence[occurrence_index] = expected_index
+                return True
+        return False
+
+    return all(
+        assign(expected_index, set())
+        for expected_index in sorted(
+            range(len(expected_values)),
+            key=lambda index: len(candidate_indexes[index]),
+        )
     )
 
 
@@ -24057,7 +24692,9 @@ class ValidatorPipeline:
         if self.source_text is not None:
             issues.extend(
                 find_ungrounded_numeric_issues(
-                    content, source_text=validation_source_text
+                    content,
+                    source_text=validation_source_text,
+                    source_citation_path=self.source_citation_path,
                 )
             )
         else:
@@ -24065,6 +24702,7 @@ class ValidatorPipeline:
                 find_ungrounded_numeric_issues_scoped(
                     content,
                     module_source_text=validation_source_text,
+                    module_citation_path=self.source_citation_path,
                     proof_source_texts=numeric_source_texts,
                 )
             )

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -2768,9 +2768,7 @@ def _rule_atom_numeric_evidence_items_by_path(
                 )
             )
             if excerpt_is_body_bound:
-                fragments.append(
-                    _NumericEvidenceItem(citation_identity, text.strip())
-                )
+                fragments.append(_NumericEvidenceItem(citation_identity, text.strip()))
         table = source.get("table")
         if isinstance(table, dict):
             for cell in table.values():
@@ -5750,10 +5748,7 @@ def _numeric_profile_for_citation_path(citation_path: str | None) -> str:
 
 def _locale_sign_is_unary(text: str, sign_index: int) -> bool:
     prefix_index = sign_index - 1
-    while (
-        prefix_index >= 0
-        and text[prefix_index] in _LOCALE_NUMERIC_GROUPING_SPACES
-    ):
+    while prefix_index >= 0 and text[prefix_index] in _LOCALE_NUMERIC_GROUPING_SPACES:
         prefix_index -= 1
     if prefix_index < 0:
         return True
@@ -5836,10 +5831,7 @@ def _iter_locale_numeric_envelopes(
                 separator_end = index
                 while separator_end < len(text) and text[separator_end] in ".,":
                     separator_end += 1
-                if (
-                    separator_end < len(text)
-                    and text[separator_end].isdigit()
-                ):
+                if separator_end < len(text) and text[separator_end].isdigit():
                     index = separator_end
                     continue
                 break
@@ -5907,8 +5899,10 @@ def _parse_locale_numeric_envelope(raw: str, profile: str) -> float | None:
         return None
     mantissa = scientific.group("mantissa")
     exponent = (
-        scientific.group("exponent") or ""
-    ).replace("\u2013", "-").replace("\u2212", "-")
+        (scientific.group("exponent") or "")
+        .replace("\u2013", "-")
+        .replace("\u2212", "-")
+    )
 
     if profile == "de-DE":
         if mantissa.count(",") > 1:
@@ -5969,8 +5963,7 @@ def _has_malformed_profiled_numeric_envelope(
     cleaned = _clean_source_text_for_numeric_extraction(text)
     return any(
         _locale_numeric_envelope_has_token_boundaries(cleaned, span)
-        and _parse_locale_numeric_envelope(cleaned[span[0] : span[1]], profile)
-        is None
+        and _parse_locale_numeric_envelope(cleaned[span[0] : span[1]], profile) is None
         for span in _iter_locale_numeric_envelopes(cleaned, profile=profile)
     )
 
@@ -7165,9 +7158,8 @@ def evaluate_numeric_grounding_values_scoped(
                 continue
 
             evidence_items = (
-                ([module_evidence] if module_evidence is not None else [])
-                + list(evidence_items_by_path.get(anchor_path, ()))
-            )
+                [module_evidence] if module_evidence is not None else []
+            ) + list(evidence_items_by_path.get(anchor_path, ()))
             source_occurrences, decimal_place_scale_values = _numeric_evidence_index(
                 evidence_items,
                 suppress_ambiguous_half_up_terms=(
@@ -8500,9 +8492,7 @@ def repair_source_table_open_ended_bound_sentinels(
         if source_text is not None
         else (extract_numeric_grounding_source_text(content) or "").strip()
     )
-    profile = _numeric_profile_for_citation_path(
-        _module_numeric_citation_path(payload)
-    )
+    profile = _numeric_profile_for_citation_path(_module_numeric_citation_path(payload))
     source_occurrences = (
         extract_typed_numeric_occurrences_from_text(source, profile=profile)
         if source

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -75,6 +75,7 @@ from axiom_encode.cli import (
     _find_rulespec_dependents,
     _generated_result_source_metadata,
     _git_changed_files,
+    _grounded_formula_literal_for_scalar_expression,
     _has_zero_output_test,
     _hoist_nested_test_tables,
     _import_base_to_repo_file,
@@ -7185,6 +7186,41 @@ def test_closest_exact_source_excerpt_rejects_unrelated_numeric_text():
     assert repaired is None
 
 
+def test_closest_exact_source_excerpt_uses_de_numeric_profile():
+    source_text = (
+        "Der Betrag ist laut Tabelle 34,87 Euro.\n\n"
+        "Der maßgebliche Betrag ist laut Gesetz 1 034,87 Euro."
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="Der Betrag ist laut Tabelle 1 034,87 Euro.",
+        numeric_profile="de-DE",
+    )
+
+    assert repaired == "Der maßgebliche Betrag ist laut Gesetz 1 034,87 Euro."
+
+
+def test_closest_exact_source_excerpt_rejects_malformed_de_numeric_span():
+    repaired = _closest_exact_source_excerpt(
+        source_text="Der Betrag ist laut Tabelle 1 234,56 Euro.",
+        excerpt="Der Betrag ist laut Tabelle 1,234.56 Euro.",
+        numeric_profile="de-DE",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_rejects_malformed_de_span_with_valid_number():
+    repaired = _closest_exact_source_excerpt(
+        source_text="Absatz 2: Der maßgebliche Betrag ist 1 234,56 Euro.",
+        excerpt="Absatz 2: Der maßgebliche Betrag ist 1,234.56 Euro.",
+        numeric_profile="de-DE",
+    )
+
+    assert repaired is None
+
+
 def test_repair_generated_undeclared_money_unit(tmp_path):
     output_root = tmp_path / "out"
     rules_file = output_root / "model" / "policies" / "benefit.yaml"
@@ -7259,6 +7295,53 @@ rules:
     assert payload["rules"][0]["metadata"]["proof"]["atoms"][0]["source"] == {
         "corpus_citation_path": "ca/policy/example",
         "excerpt": "$533 with 2 children",
+    }
+
+
+def test_repair_generated_nonexact_proof_excerpt_uses_atom_numeric_profile(tmp_path):
+    output_root = tmp_path / "out"
+    rules_file = output_root / "model" / "policies" / "benefit.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+module:
+  summary: |-
+    Der Betrag ist laut Tabelle 34,87 Euro.
+
+    Der maßgebliche Betrag ist laut Gesetz 1 034,87 Euro.
+rules:
+- name: german_amount
+  kind: parameter
+  dtype: Money
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: de/statute/example/1
+          excerpt: Der Betrag ist laut Tabelle 1 034,87 Euro.
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 1034.87
+"""
+    )
+    result = SimpleNamespace(output_file=str(rules_file))
+
+    repaired = _try_repair_generated_nonexact_proof_excerpts_for_apply(
+        result,
+        output_root=output_root,
+        issues=[
+            "Proof source evidence not found: rule `german_amount` "
+            "proof atom 0 `source.excerpt` does not appear in `de/statute/example/1`."
+        ],
+    )
+
+    assert repaired == ["german_amount[0]"]
+    payload = yaml.safe_load(rules_file.read_text())
+    assert payload["rules"][0]["metadata"]["proof"]["atoms"][0]["source"] == {
+        "corpus_citation_path": "de/statute/example/1",
+        "excerpt": "Der maßgebliche Betrag ist laut Gesetz 1 034,87 Euro.",
     }
 
 
@@ -15328,6 +15411,38 @@ rules:
         assert (
             derived["versions"][0]["formula"]
             == "applicable_income_limitation_rate_scalar_limit"
+        )
+
+    def test_fraction_collapse_uses_proof_excerpt_citation_numeric_profile(self):
+        def rule(citation_path):
+            return {
+                "metadata": {
+                    "proof": {
+                        "atoms": [
+                            {
+                                "source": {
+                                    "corpus_citation_path": citation_path,
+                                    "excerpt": "Der Betrag ist 1 034,87 Punkte.",
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+
+        assert (
+            _grounded_formula_literal_for_scalar_expression(
+                rule("de/statute/estg/32a"),
+                "103487 / 100",
+            )
+            == "1034.87"
+        )
+        assert (
+            _grounded_formula_literal_for_scalar_expression(
+                rule("xx/statute/act/1"),
+                "103487 / 100",
+            )
+            is None
         )
 
     def test_embedded_scalar_literal_repair_reuses_existing_scalar_parameter(

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -6451,7 +6451,7 @@ rules: []
         assert metrics.source_numeric_occurrence_count == 0
         assert metrics.numeric_occurrence_issues == []
 
-    def test_generated_numeric_grounding_uses_embedded_operating_excerpt(
+    def test_generated_numeric_grounding_uses_authoritative_module_source(
         self, tmp_path
     ):
         source_text = (
@@ -6502,9 +6502,175 @@ rules:
                 local_corpus_release=corpus_release,
             )
 
+        assert metrics.ci_pass
+        assert metrics.grounded_numeric_count == 1
+        assert metrics.ungrounded_numeric_count == 0
+
+    def test_generated_numeric_grounding_never_uses_module_summary(self, tmp_path):
+        source_text = (
+            "(a) Households in which each member receives qualifying public "
+            "assistance shall be eligible."
+        )
+        corpus_release = _write_test_corpus_provision(
+            tmp_path,
+            citation_path="us/statute/7/2014",
+            body=source_text,
+        )
+        rulespec_file = tmp_path / "statutes" / "7" / "2014" / "a.yaml"
+        rulespec_file.parent.mkdir(parents=True)
+        rulespec_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/7/2014
+  summary: The unrelated standard deduction is $144.
+rules:
+  - name: unrelated_standard_deduction_amount
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 144
+"""
+        )
+
+        compile_result = ValidationResult("compile", True, issues=[])
+        ci_result = ValidationResult("ci", True, issues=[])
+
+        with (
+            patch.object(
+                ValidatorPipeline,
+                "_run_compile_check",
+                return_value=compile_result,
+            ),
+            patch.object(ValidatorPipeline, "_run_ci", return_value=ci_result),
+        ):
+            metrics = evaluate_artifact(
+                rulespec_file=rulespec_file,
+                policy_repo_root=_canonical_rulespec_content_root(tmp_path, "us"),
+                axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+                source_text=source_text,
+                local_corpus_release=corpus_release,
+            )
+
         assert not metrics.ci_pass
         assert metrics.ungrounded_numeric_count == 1
         assert any("144" in issue for issue in metrics.ci_issues)
+
+    def test_numeric_grounding_uses_de_profile_from_source_citation(self, tmp_path):
+        source_text = "Der Betrag beläuft sich auf 1 034,87 Punkte."
+        citation_path = "de/statute/estg/32a"
+        corpus_release = _write_test_corpus_provision(
+            tmp_path,
+            citation_path=citation_path,
+            body=source_text,
+        )
+        rulespec_file = tmp_path / "statutes" / "estg" / "32a.yaml"
+        rulespec_file.parent.mkdir(parents=True)
+        rulespec_file.write_text(
+            f"""format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: {citation_path}
+rules:
+  - name: german_amount
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 1034.87
+"""
+        )
+
+        compile_result = ValidationResult("compile", True, issues=[])
+        ci_result = ValidationResult("ci", True, issues=[])
+
+        with (
+            patch.object(
+                ValidatorPipeline,
+                "_run_compile_check",
+                return_value=compile_result,
+            ),
+            patch.object(ValidatorPipeline, "_run_ci", return_value=ci_result),
+        ):
+            metrics = evaluate_artifact(
+                rulespec_file=rulespec_file,
+                policy_repo_root=_canonical_rulespec_content_root(tmp_path, "de"),
+                axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+                source_text=source_text,
+                source_citation_path=citation_path,
+                local_corpus_release=corpus_release,
+            )
+
+        assert metrics.ci_pass
+        assert metrics.grounded_numeric_count == 1
+        assert metrics.ungrounded_numeric_count == 0
+        assert metrics.source_numeric_occurrence_count == 1
+        assert metrics.missing_source_numeric_occurrence_count == 0
+
+    def test_numeric_grounding_uses_citation_only_de_proof_source(self, tmp_path):
+        module_citation = "de/statute/example/1"
+        proof_citation = "de/statute/example/2"
+        module_source = "Der Haupttext enthält keinen maßgeblichen Betrag."
+        proof_source = "Der maßgebliche Betrag ist 1 034,87 Punkte."
+        corpus_release = _write_test_corpus_release(
+            tmp_path,
+            [
+                {"citation_path": module_citation, "body": module_source},
+                {"citation_path": proof_citation, "body": proof_source},
+            ],
+        )
+        rulespec_file = tmp_path / "statutes" / "example" / "1.yaml"
+        rulespec_file.parent.mkdir(parents=True)
+        rulespec_file.write_text(
+            f"""format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: {module_citation}
+rules:
+  - name: german_amount
+    kind: parameter
+    dtype: Money
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: {proof_citation}
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 1034.87
+"""
+        )
+
+        with (
+            patch.object(
+                ValidatorPipeline,
+                "_run_compile_check",
+                return_value=ValidationResult("compile", True, issues=[]),
+            ),
+            patch.object(
+                ValidatorPipeline,
+                "_run_ci",
+                return_value=ValidationResult("ci", True, issues=[]),
+            ),
+        ):
+            metrics = evaluate_artifact(
+                rulespec_file=rulespec_file,
+                policy_repo_root=_canonical_rulespec_content_root(tmp_path, "de"),
+                axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+                source_text=module_source,
+                source_citation_path=module_citation,
+                local_corpus_release=corpus_release,
+                skip_reviewers=True,
+            )
+
+        assert metrics.ci_pass
+        assert metrics.grounded_numeric_count == 1
+        assert metrics.ungrounded_numeric_count == 0
 
     def test_generated_numeric_grounding_uses_proof_excerpts_with_compact_summary(
         self, tmp_path

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -7752,6 +7752,275 @@ def test_numeric_extraction_reads_single_dot_group_as_decimal_too():
     assert 12345678.0 not in multi_pct
 
 
+_GERMAN_SECTION_32A_FORMULA_TEXT = (
+    ":(914,51 \u2022 y + 1 400) \u2022 y;\n"
+    ":(173,10 \u2022 z + 2 397) \u2022 z + 1 034,87;\n"
+    ":0,42 \u2022 x \u2013 11 135,63;\n"
+    ":0,45 \u2022 x \u2013 19 470,38."
+)
+_GERMAN_SECTION_32A_VALUES = (
+    914.51,
+    1400.0,
+    173.10,
+    2397.0,
+    1034.87,
+    0.42,
+    11135.63,
+    0.45,
+    19470.38,
+)
+_GERMAN_SECTION_32A_RAWS = (
+    "914,51",
+    "1 400",
+    "173,10",
+    "2 397",
+    "1 034,87",
+    "0,42",
+    "11 135,63",
+    "0,45",
+    "19 470,38",
+)
+
+
+def test_de_numeric_profile_extracts_released_section_32a_coefficients_exactly():
+    expected = set(_GERMAN_SECTION_32A_VALUES)
+
+    assert (
+        extract_numbers_from_text(
+            _GERMAN_SECTION_32A_FORMULA_TEXT,
+            profile="de-DE",
+        )
+        == expected
+    )
+    assert extract_numeric_occurrences_from_text(
+        _GERMAN_SECTION_32A_FORMULA_TEXT,
+        profile="de-DE",
+    ) == list(_GERMAN_SECTION_32A_VALUES)
+
+
+def test_de_numeric_profile_preserves_section_32a_raw_spans():
+    occurrences = extract_typed_numeric_occurrences_from_text(
+        _GERMAN_SECTION_32A_FORMULA_TEXT,
+        profile="de-DE",
+    )
+
+    assert [(item.value, item.raw) for item in occurrences] == list(
+        zip(_GERMAN_SECTION_32A_VALUES, _GERMAN_SECTION_32A_RAWS, strict=True)
+    )
+    assert all(
+        item.raw == _GERMAN_SECTION_32A_FORMULA_TEXT[item.start : item.end]
+        for item in occurrences
+    )
+
+
+@pytest.mark.parametrize(
+    ("profile", "source_text", "expected"),
+    (
+        ("legacy", "1,234.56", {1234.56}),
+        ("legacy", "1.234,56", {1234.56}),
+        ("legacy", "1 234,56", {1.0, 234.56}),
+        ("en-US", "1,234.56", {1234.56}),
+        ("en-US", "1.234,56", set()),
+        ("en-US", "1 234,56", set()),
+        ("en-GB", "1,234.56", {1234.56}),
+        ("en-GB", "1.234,56", set()),
+        ("en-GB", "1 234,56", set()),
+        ("de-DE", "1,234.56", set()),
+        ("de-DE", "1.234,56", {1234.56}),
+        ("de-DE", "1 234,56", {1234.56}),
+    ),
+)
+def test_numeric_profile_convention_matrix(profile, source_text, expected):
+    assert extract_numbers_from_text(source_text, profile=profile) == expected
+    assert (
+        set(extract_numeric_occurrences_from_text(source_text, profile=profile))
+        == expected
+    )
+
+
+def test_legacy_profile_keeps_uk_single_dot_dual_read():
+    source_text = "1.075 if the relevant dwelling is in valuation band E"
+    expected = {1.075, 1075.0}
+
+    assert extract_numbers_from_text(source_text) == expected
+    assert extract_numbers_from_text(source_text, profile="legacy") == expected
+
+
+@pytest.mark.parametrize(
+    "source_text",
+    (
+        "10 000",
+        "10\u00a0000",
+        "10\u202f000",
+        "10.000",
+    ),
+)
+def test_de_numeric_profile_accepts_supported_grouping_separators(source_text):
+    assert extract_numbers_from_text(source_text, profile="de-DE") == {10000.0}
+    assert extract_numeric_occurrences_from_text(
+        source_text,
+        profile="de-DE",
+    ) == [10000.0]
+
+
+@pytest.mark.parametrize(
+    ("source_text", "expected"),
+    (
+        ("10 000", 10000.0),
+        ("100 000", 100000.0),
+    ),
+)
+def test_de_numeric_profile_accepts_wogg_group_widths(source_text, expected):
+    assert extract_numbers_from_text(source_text, profile="de-DE") == {expected}
+
+
+@pytest.mark.parametrize(
+    "source_text",
+    (
+        ",42",
+        "1,,234",
+        "1 34,87",
+        "1 0034,87",
+        "1 034,,87",
+        "12.34,56",
+        "1,234.56",
+        "4,797E-4,5",
+        "4,797E--4",
+        "4,797E\u2212-4",
+        "4,797E\u2013\u20134",
+        "1E2.3",
+    ),
+)
+def test_de_numeric_profile_reserves_malformed_spans_without_suffixes(source_text):
+    assert extract_numbers_from_text(source_text, profile="de-DE") == set()
+    assert (
+        extract_numeric_occurrences_from_text(source_text, profile="de-DE") == []
+    )
+
+
+@pytest.mark.parametrize(
+    "source_text",
+    (
+        "4,797E-4",
+        "4,797E\u22124",
+        "4,797E\u20134",
+    ),
+)
+def test_de_numeric_profile_reads_wogg_comma_scientific_notation(source_text):
+    assert extract_numbers_from_text(source_text, profile="de-DE") == {0.0004797}
+    assert extract_numeric_occurrences_from_text(
+        source_text,
+        profile="de-DE",
+    ) == [0.0004797]
+
+
+@pytest.mark.parametrize("operator", ("\u2219", "\u00b7", "\u2022", "\u00d7"))
+def test_de_numeric_profile_accepts_multiplication_boundaries(operator):
+    source_text = f"x{operator}914,51"
+    occurrences = extract_typed_numeric_occurrences_from_text(
+        source_text,
+        profile="de-DE",
+    )
+
+    assert [(item.value, item.raw) for item in occurrences] == [(914.51, "914,51")]
+
+
+def test_de_numeric_profile_accepts_released_wogg_dot_operator_orientation():
+    source_text = "z4 = 1,15 \u2219 z3"
+
+    assert extract_numbers_from_text(source_text, profile="de-DE") == {1.15}
+    assert extract_numeric_occurrences_from_text(
+        source_text,
+        profile="de-DE",
+    ) == [1.15]
+
+
+def test_de_numeric_profile_accepts_punctuation_boundaries():
+    source_text = "(914,51);0,42:1 400"
+
+    assert extract_numbers_from_text(source_text, profile="de-DE") == {
+        914.51,
+        0.42,
+        1400.0,
+    }
+
+
+@pytest.mark.parametrize(
+    ("source_text", "expected"),
+    (
+        ("\u2013 1,000E-2", -0.01),
+        ("| \u2013 1,000E-2", -0.01),
+        ("\u22120,42", -0.42),
+        ("(\u2013 1 034,87)", -1034.87),
+        ("x \u2264 \u22120,42", -0.42),
+        ("x < \u2013 1 000", -1000.0),
+        ("x > -5", -5.0),
+        ("x \u00f7 \u22122", -2.0),
+        ("x \u2212 \u22120,42", -0.42),
+    ),
+)
+def test_de_numeric_profile_reads_unicode_unary_minus(source_text, expected):
+    assert extract_numbers_from_text(source_text, profile="de-DE") == {expected}
+    assert extract_numeric_occurrences_from_text(
+        source_text,
+        profile="de-DE",
+    ) == [expected]
+
+
+def test_de_numeric_profile_keeps_expression_subtraction_binary():
+    source_text = (
+        "0,42 \u2219 x \u2013 11 135,63; "
+        "0,45 \u00b7 x \u2212 19 470,38"
+    )
+
+    assert extract_numbers_from_text(source_text, profile="de-DE") == {
+        0.42,
+        11135.63,
+        0.45,
+        19470.38,
+    }
+
+
+@pytest.mark.parametrize(
+    ("source_text", "expected"),
+    (
+        ("42 Prozent", True),
+        ("42 Tage", False),
+    ),
+)
+def test_de_numeric_profile_types_local_rate_context(source_text, expected):
+    occurrences = extract_typed_numeric_occurrences_from_text(
+        source_text,
+        profile="de-DE",
+    )
+
+    assert numeric_value_is_grounded(0.42, occurrences) is expected
+
+
+@pytest.mark.parametrize(
+    ("source_text", "expected"),
+    (
+        ("Achtel", 8.0),
+        ("Vierundzwanzigstel", 24.0),
+        ("Hundertstel", 100.0),
+        ("Dreihundertsechzigstel", 360.0),
+        ("Tausendstel", 1000.0),
+        ("Zehntausendstel", 10000.0),
+        ("Sechsteln", 6.0),
+        ("Zwanzigsteln", 20.0),
+    ),
+)
+def test_de_numeric_profile_reads_german_lexical_denominators(
+    source_text,
+    expected,
+):
+    assert extract_numbers_from_text(source_text, profile="de-DE") == {expected}
+    assert extract_numeric_occurrences_from_text(
+        source_text,
+        profile="de-DE",
+    ) == [expected]
+
+
 def test_numeric_extraction_handles_uganda_shilling_suffix():
     # Ugandan prints glue a "/=" (or plain "=") shilling suffix to amounts
     # ("Exceeding 100,000= but not exceeding 200,000= 5,000=" in the Local
@@ -30562,6 +30831,449 @@ def test_grounding_binds_each_literal_to_its_own_anchored_atom():
         },
     )
     assert any("450" in issue for issue in issues), issues
+
+
+@pytest.mark.parametrize(
+    ("module_block", "expects_grounded"),
+    (
+        (
+            """
+            module:
+              source_verification:
+                corpus_citation_path: de/statute/estg/32a
+            """,
+            True,
+        ),
+        (
+            """
+            module:
+              source_verification:
+                corpus_citation_path: xx/statute/act/32a
+            """,
+            False,
+        ),
+        ("", False),
+    ),
+)
+def test_scoped_numeric_profile_is_selected_from_module_citation(
+    module_block,
+    expects_grounded,
+):
+    rules_block = textwrap.dedent(
+        """
+        rules:
+          - name: german_amount
+            kind: parameter
+            dtype: Money
+            versions:
+              - effective_from: '2025-01-01'
+                formula: '1034.87'
+        """
+    ).strip()
+    content = "\n".join(
+        part
+        for part in (
+            "format: rulespec/v1",
+            textwrap.dedent(module_block).strip(),
+            rules_block,
+        )
+        if part
+    )
+
+    issues = find_ungrounded_numeric_issues_scoped(
+        content,
+        module_source_text="Der Betrag beläuft sich auf 1 034,87 Punkte.",
+    )
+
+    if expects_grounded:
+        assert issues == []
+    else:
+        assert any("1034.87" in issue for issue in issues), issues
+
+
+def test_single_source_grounding_selects_profile_from_module_citation():
+    content = textwrap.dedent(
+        """
+        format: rulespec/v1
+        module:
+          source_verification:
+            corpus_citation_path: de/statute/estg/32a
+        rules:
+          - name: german_amount
+            kind: parameter
+            dtype: Money
+            versions:
+              - effective_from: '2025-01-01'
+                formula: '1034.87'
+        """
+    ).strip()
+
+    assert (
+        find_ungrounded_numeric_issues(
+            content,
+            source_text="Der Betrag beläuft sich auf 1 034,87 Punkte.",
+        )
+        == []
+    )
+
+
+@pytest.mark.parametrize(
+    ("citation_path", "expects_grounded"),
+    (
+        ("de/statute/estg/32a", True),
+        ("xx/statute/act/32a", False),
+    ),
+)
+def test_scoped_numeric_profile_is_selected_from_atom_citation(
+    citation_path,
+    expects_grounded,
+):
+    source_text = "Der Betrag beläuft sich auf 1 034,87 Punkte."
+    content = textwrap.dedent(
+        f"""
+        format: rulespec/v1
+        rules:
+          - name: german_amount
+            kind: parameter
+            dtype: Money
+            metadata:
+              proof:
+                atoms:
+                  - path: versions[0].formula
+                    kind: amount
+                    source:
+                      corpus_citation_path: {citation_path}
+                      excerpt: {source_text}
+            versions:
+              - effective_from: '2025-01-01'
+                formula: '1034.87'
+        """
+    ).strip()
+
+    issues = find_ungrounded_numeric_issues_scoped(
+        content,
+        module_source_text="",
+        proof_source_texts={citation_path: source_text},
+    )
+
+    if expects_grounded:
+        assert issues == []
+    else:
+        assert any("1034.87" in issue for issue in issues), issues
+
+
+def test_scoped_numeric_profiles_parse_each_anchored_evidence_item_before_union():
+    german_source = "Der deutsche Betrag ist 1 034,87 Punkte."
+    english_source = "The other amount is 1,234.56 dollars."
+    content = textwrap.dedent(
+        f"""
+        format: rulespec/v1
+        rules:
+          - name: mixed_locale_sum
+            kind: parameter
+            dtype: Money
+            metadata:
+              proof:
+                atoms:
+                  - path: versions[0].formula
+                    kind: amount
+                    source:
+                      corpus_citation_path: de/statute/estg/32a
+                      excerpt: {german_source}
+                  - path: versions[0].formula
+                    kind: amount
+                    source:
+                      corpus_citation_path: xx/statute/act/2
+                      excerpt: {english_source}
+            versions:
+              - effective_from: '2025-01-01'
+                formula: '1034.87 + 1234.56'
+        """
+    ).strip()
+
+    assert (
+        find_ungrounded_numeric_issues_scoped(
+            content,
+            module_source_text="",
+            proof_source_texts={
+                "de/statute/estg/32a": german_source,
+                "xx/statute/act/2": english_source,
+            },
+        )
+        == []
+    )
+
+
+def test_scoped_numeric_profiles_do_not_leak_across_anchored_evidence_items():
+    german_source = "Der deutsche Betrag ist 2 000 Punkte."
+    legacy_source = "The legacy record prints 1 034,87."
+    content = textwrap.dedent(
+        f"""
+        format: rulespec/v1
+        rules:
+          - name: mixed_locale_sum
+            kind: parameter
+            dtype: Money
+            metadata:
+              proof:
+                atoms:
+                  - path: versions[0].formula
+                    kind: amount
+                    source:
+                      corpus_citation_path: de/statute/estg/32a
+                      excerpt: {german_source}
+                  - path: versions[0].formula
+                    kind: amount
+                    source:
+                      corpus_citation_path: xx/statute/act/2
+                      excerpt: {legacy_source}
+            versions:
+              - effective_from: '2025-01-01'
+                formula: '2000 + 1034.87'
+        """
+    ).strip()
+
+    issues = find_ungrounded_numeric_issues_scoped(
+        content,
+        module_source_text="",
+        proof_source_texts={
+            "de/statute/estg/32a": german_source,
+            "xx/statute/act/2": legacy_source,
+        },
+    )
+
+    assert not any("2000" in issue for issue in issues), issues
+    assert any("1034.87" in issue for issue in issues), issues
+
+
+def test_scoped_locale_evidence_stays_bound_to_exact_atom_anchor():
+    source_text = "Der deutsche Betrag ist 1 034,87 Punkte."
+    content = textwrap.dedent(
+        f"""
+        format: rulespec/v1
+        rules:
+          - name: german_amount
+            kind: parameter
+            dtype: Money
+            metadata:
+              note: supporting note
+              proof:
+                atoms:
+                  - path: metadata.note
+                    kind: note
+                    source:
+                      corpus_citation_path: de/statute/estg/32a
+                      excerpt: {source_text}
+            versions:
+              - effective_from: '2025-01-01'
+                formula: '1034.87'
+        """
+    ).strip()
+
+    issues = find_ungrounded_numeric_issues_scoped(
+        content,
+        module_source_text="",
+        proof_source_texts={"de/statute/estg/32a": source_text},
+    )
+
+    assert any("1034.87" in issue for issue in issues), issues
+
+
+@pytest.mark.parametrize(
+    ("citation_path", "expects_grounded"),
+    (
+        ("de/statute/wogg/anlage", True),
+        ("xx/statute/act/annex", False),
+    ),
+)
+def test_scoped_de_profile_grounds_german_lexical_denominator(
+    citation_path,
+    expects_grounded,
+):
+    source_text = "Das Ergebnis ist auf ein Zehntausendstel genau zu berechnen."
+    content = textwrap.dedent(
+        f"""
+        format: rulespec/v1
+        rules:
+          - name: calculation_scale
+            kind: parameter
+            dtype: Decimal
+            metadata:
+              proof:
+                atoms:
+                  - path: versions[0].formula
+                    kind: parameter
+                    source:
+                      corpus_citation_path: {citation_path}
+                      excerpt: {source_text}
+            versions:
+              - effective_from: '2025-01-01'
+                formula: '10000'
+        """
+    ).strip()
+
+    issues = find_ungrounded_numeric_issues_scoped(
+        content,
+        module_source_text="",
+        proof_source_texts={citation_path: source_text},
+    )
+
+    if expects_grounded:
+        assert issues == []
+    else:
+        assert any("10000" in issue for issue in issues), issues
+
+
+def test_source_verification_uses_de_profile_for_scalar_and_table_values():
+    citation_path = "de/statute/estg/32a"
+    content = textwrap.dedent(
+        f"""
+        format: rulespec/v1
+        module:
+          source_verification:
+            corpus_citation_path: {citation_path}
+            values:
+              german_amount: 1034.87
+              german_table:
+                1: 11135.63
+                2: 19470.38
+        rules:
+          - name: german_amount
+            kind: parameter
+            dtype: Money
+            versions:
+              - effective_from: '2026-01-01'
+                formula: '1034.87'
+          - name: german_table
+            kind: parameter
+            dtype: Money
+            indexed_by: band
+            versions:
+              - effective_from: '2026-01-01'
+                values:
+                  1: 11135.63
+                  2: 19470.38
+        """
+    ).strip()
+    source_text = (
+        "Der Betrag ist 1 034,87 Euro.\n"
+        "1 | 11 135,63\n"
+        "2 | 19 470,38"
+    )
+
+    assert (
+        find_source_verification_issues(
+            content,
+            source_texts={citation_path: source_text},
+        )
+        == []
+    )
+
+
+def test_source_verification_de_profile_rejects_us_numeric_spans():
+    citation_path = "de/statute/example/1"
+    content = textwrap.dedent(
+        f"""
+        format: rulespec/v1
+        module:
+          source_verification:
+            corpus_citation_path: {citation_path}
+            values:
+              german_amount: 1234.56
+              german_table:
+                1: 1234.56
+                2: 2345.67
+        rules:
+          - name: german_amount
+            kind: parameter
+            dtype: Money
+            versions:
+              - effective_from: '2026-01-01'
+                formula: '1234.56'
+          - name: german_table
+            kind: parameter
+            dtype: Money
+            indexed_by: band
+            versions:
+              - effective_from: '2026-01-01'
+                values:
+                  1: 1234.56
+                  2: 2345.67
+        """
+    ).strip()
+    source_text = (
+        "Der Betrag ist 1,234.56 Euro.\n"
+        "1 | 1,234.56\n"
+        "2 | 2,345.67"
+    )
+
+    issues = find_source_verification_issues(
+        content,
+        source_texts={citation_path: source_text},
+    )
+
+    assert any("`german_amount`" in issue for issue in issues), issues
+    assert any("`german_table[1]`" in issue for issue in issues), issues
+    assert any("`german_table[2]`" in issue for issue in issues), issues
+
+
+def test_source_verification_de_profile_requires_rate_context():
+    citation_path = "de/statute/example/1"
+    content = textwrap.dedent(
+        f"""
+        format: rulespec/v1
+        module:
+          source_verification:
+            corpus_citation_path: {citation_path}
+            values:
+              german_rate: 0.42
+        rules:
+          - name: german_rate
+            kind: parameter
+            dtype: Rate
+            versions:
+              - effective_from: '2026-01-01'
+                formula: '0.42'
+        """
+    ).strip()
+
+    issues = find_source_verification_issues(
+        content,
+        source_texts={citation_path: "Die Frist beträgt 42 Tage."},
+    )
+
+    assert any("`german_rate`" in issue for issue in issues), issues
+
+
+def test_open_ended_bound_repair_uses_module_numeric_profile():
+    content = textwrap.dedent(
+        """
+        format: rulespec/v1
+        module:
+          source_verification:
+            corpus_citation_path: de/statute/example/1
+        rules:
+          - name: benefit_upper_bound
+            kind: parameter
+            dtype: Money
+            indexed_by: band
+            versions:
+              - effective_from: '2026-01-01'
+                values:
+                  0: 500000
+                  1: 1000000
+        """
+    ).strip()
+
+    repaired, changed = (
+        validator_pipeline.repair_source_table_open_ended_bound_sentinels(
+            content,
+            source_text="Der Grenzwert beträgt 1 000 000 Punkte.",
+        )
+    )
+
+    assert repaired == content
+    assert changed == []
 
 
 def test_scoped_grounding_uses_resolved_source_for_half_up_helper():

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -34,6 +34,7 @@ from axiom_encode.harness.proof_validator import (
     validate_rulespec_proofs,
 )
 from axiom_encode.harness.validator_pipeline import (
+    NumericOccurrence,
     OracleSubprocessResult,
     _corpus_citation_to_normalized_target,
     _extract_json_object,
@@ -48,6 +49,7 @@ from axiom_encode.harness.validator_pipeline import (
     extract_named_scalar_occurrences,
     extract_numbers_from_text,
     extract_numeric_occurrences_from_text,
+    extract_typed_numeric_occurrences_from_text,
     find_aggregate_exception_predicate_issues,
     find_anaphoric_scope_omission_issues,
     find_broad_application_passthrough_issues,
@@ -116,6 +118,7 @@ from axiom_encode.harness.validator_pipeline import (
     find_upstream_placement_issues,
     find_versioned_derived_formula_issues,
     find_zero_branch_test_coverage_issues,
+    numeric_value_is_grounded,
     repair_copied_cross_reference_summary,
     repair_nonnegative_amount_reductions,
     repair_source_table_band_scalar_parameters,
@@ -7087,6 +7090,166 @@ rules:
     )
 
 
+@pytest.mark.parametrize(
+    ("generated_literal", "source_text"),
+    (
+        ("0.42", "The released formula fragment is :0,42."),
+        ("0.30", "The deadline is 30 Tage."),
+        ("0.18", "Children under age 18 qualify."),
+        ("0.18", "Die Altersgrenze beträgt 18 Jahre."),
+        ("0.20", "See § 20 for the governing rule."),
+    ),
+)
+def test_numeric_grounding_rejects_x100_without_local_rate_context(
+    generated_literal,
+    source_text,
+):
+    content = f"""format: rulespec/v1
+rules:
+  - name: demonstrated_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2025-01-01'
+        formula: '{generated_literal}'
+"""
+
+    issues = find_ungrounded_numeric_issues(content, source_text=source_text)
+
+    assert any(generated_literal in issue for issue in issues), issues
+
+
+@pytest.mark.parametrize(
+    "source_text",
+    (
+        "The applicable rate is 42 %.",
+        "Der anzuwendende Satz beträgt 42 Prozent.",
+        "The applicable rate is 42 percent.",
+        "The applicable rate is 42 per cent.",
+        "Der anzuwendende Satz beträgt 42 vom Hundert.",
+    ),
+)
+def test_numeric_grounding_accepts_x100_with_local_rate_context(source_text):
+    content = """format: rulespec/v1
+rules:
+  - name: demonstrated_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2025-01-01'
+        formula: '0.42'
+"""
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+
+
+@pytest.mark.parametrize(
+    ("source_text", "expected_value", "has_rate_context"),
+    (
+        ("The released formula fragment is :0,42.", 42.0, False),
+        ("The applicable rate is 42 %.", 0.42, True),
+        ("Der anzuwendende Satz beträgt 42 Prozent.", 42.0, True),
+        ("The deadline is 30 Tage.", 30.0, False),
+    ),
+)
+def test_typed_numeric_occurrences_preserve_source_spans_and_rate_context(
+    source_text,
+    expected_value,
+    has_rate_context,
+):
+    occurrences = extract_typed_numeric_occurrences_from_text(source_text)
+    occurrence = next(
+        item
+        for item in occurrences
+        if math.isclose(item.value, expected_value, rel_tol=0, abs_tol=1e-9)
+    )
+
+    assert isinstance(occurrence, NumericOccurrence)
+    assert occurrence.raw == source_text[occurrence.start : occurrence.end]
+    assert occurrence.has_rate_context is has_rate_context
+
+
+def test_typed_numeric_occurrences_preserve_exact_legacy_float_emissions():
+    source_text = "Applicable percentage 18.1 and literal 0.181"
+
+    numbers = extract_numbers_from_text(source_text)
+
+    assert numbers == {18.1, 18.1 / 100, 0.181}
+    assert 18.1 / 100 != 0.181
+    assert extract_numbers_from_text("0.0000000004%") == {4e-12}
+
+
+def test_typed_numeric_occurrences_map_repeated_cleaned_values_exactly():
+    source_text = "Section 42\nRate 42 Prozent"
+
+    occurrences = extract_typed_numeric_occurrences_from_text(source_text)
+    occurrence = next(item for item in occurrences if item.has_rate_context)
+    expected_start = source_text.index("42 Prozent")
+
+    assert occurrence.span == (expected_start, expected_start + 2)
+    assert occurrence.raw == "42"
+    assert numeric_value_is_grounded(0.42, occurrences)
+
+
+def test_typed_derived_numeric_occurrence_has_exact_phrase_span():
+    source_text = "The period is for 2 weeks."
+
+    occurrence = next(
+        item
+        for item in extract_typed_numeric_occurrences_from_text(source_text)
+        if item.value == 14
+    )
+    expected_start = source_text.index("2 weeks")
+
+    assert occurrence.span == (expected_start, expected_start + len("2 weeks"))
+    assert occurrence.raw == "2 weeks"
+
+
+@pytest.mark.parametrize(
+    "source_text",
+    (
+        "The applicable percentage is described elsewhere. The deadline is 42 Tage.",
+        "The applicable percentage is described elsewhere. Children age 42 qualify.",
+        "20 percent 42 days",
+    ),
+)
+def test_numeric_grounding_rejects_nonlocal_or_consumed_rate_context(source_text):
+    content = """format: rulespec/v1
+rules:
+  - name: demonstrated_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2025-01-01'
+        formula: '0.42'
+"""
+
+    issues = find_ungrounded_numeric_issues(content, source_text=source_text)
+
+    assert any("0.42" in issue for issue in issues), issues
+
+
+def test_typed_numeric_occurrences_carry_pipe_table_percentage_column_context():
+    source_text = (
+        "Ratio | Applicable percentage\n| At least | Section 3201(b) |\n| 2.5 | 4.9 |"
+    )
+
+    occurrences = extract_typed_numeric_occurrences_from_text(source_text)
+    percentage = next(
+        item
+        for item in occurrences
+        if math.isclose(item.value, 4.9, rel_tol=0, abs_tol=1e-9)
+    )
+    ratio_bound = next(
+        item
+        for item in occurrences
+        if math.isclose(item.value, 2.5, rel_tol=0, abs_tol=1e-9)
+    )
+
+    assert percentage.has_rate_context
+    assert not ratio_bound.has_rate_context
+
+
 def test_rulespec_grounding_accepts_dotted_fractional_percentage_rates():
     content = """format: rulespec/v1
 module:
@@ -8376,20 +8539,35 @@ rules:
 {values}
 """
     source_text = " ".join(f"The value is {value}." for value in range(100, 200))
-    calls = 0
-    original = validator_pipeline.extract_numbers_from_text
+    tokenizer_calls = 0
+    cleaner_calls = 0
+    original_tokenizer = validator_pipeline._tokenize_numeric_occurrences_from_text
+    original_cleaner = validator_pipeline._clean_source_text_for_numeric_extraction
 
-    def counting_extract_numbers(text):
-        nonlocal calls
-        calls += 1
-        return original(text)
+    def counting_tokenize(text, *, profile="legacy"):
+        nonlocal tokenizer_calls
+        tokenizer_calls += 1
+        return original_tokenizer(text, profile=profile)
+
+    def counting_cleaner(text):
+        nonlocal cleaner_calls
+        cleaner_calls += 1
+        return original_cleaner(text)
 
     monkeypatch.setattr(
-        validator_pipeline, "extract_numbers_from_text", counting_extract_numbers
+        validator_pipeline,
+        "_tokenize_numeric_occurrences_from_text",
+        counting_tokenize,
+    )
+    monkeypatch.setattr(
+        validator_pipeline,
+        "_clean_source_text_for_numeric_extraction",
+        counting_cleaner,
     )
 
     assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
-    assert calls == 1
+    assert tokenizer_calls == 1
+    assert cleaner_calls == 1
 
 
 def test_rulespec_grounding_rejects_half_up_exemption_for_helper_value_table():
@@ -8843,9 +9021,9 @@ rules:
 """
 
     source_text = (
-        "The credit percentage and the phaseout percentage are determined as "
-        "follows. The no-children row appears later in the table at 7.65. "
-        "The one-child row is 34."
+        "Qualifying children | Applicable percentage\n"
+        "| None | 7.65 |\n"
+        "| One | 34 |"
     )
 
     assert find_ungrounded_numeric_issues(content, source_text=source_text) == []

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -7758,6 +7758,20 @@ _GERMAN_SECTION_32A_FORMULA_TEXT = (
     ":0,42 \u2022 x \u2013 11 135,63;\n"
     ":0,45 \u2022 x \u2013 19 470,38."
 )
+_GERMAN_SECTION_32A_RELEASED_BODY = """(1) 1Die tarifliche Einkommensteuer bemisst sich nach dem auf volle Euro abgerundeten zu versteuernden Einkommen. 2Sie beträgt ab dem Veranlagungszeitraum 2026 vorbehaltlich der §§ 32b, 32d, 34, 34a, 34b und 34c jeweils in Euro für zu versteuernde Einkommen
+1. bis 12 348 Euro (Grundfreibetrag):0;
+2. von 12 349 Euro bis 17 799 Euro:(914,51 • y + 1 400) • y;
+3. von 17 800 Euro bis 69 878 Euro:(173,10 • z + 2 397) • z + 1 034,87;
+4. von 69 879 Euro bis 277 825 Euro:0,42 • x – 11 135,63;
+5. von 277 826 Euro an:0,45 • x – 19 470,38.3Die Größe „y“ ist ein Zehntausendstel des den Grundfreibetrag übersteigenden Teils des auf einen vollen Euro-Betrag abgerundeten zu versteuernden Einkommens. 4Die Größe „z“ ist ein Zehntausendstel des 17 799 Euro übersteigenden Teils des auf einen vollen Euro-Betrag abgerundeten zu versteuernden Einkommens. 5Die Größe „x“ ist das auf einen vollen Euro-Betrag abgerundete zu versteuernde Einkommen. 6Der sich ergebende Steuerbetrag ist auf den nächsten vollen Euro-Betrag abzurunden.
+(2) bis (4) (weggefallen)
+(5) Bei Ehegatten, die nach den §§ 26, 26b zusammen zur Einkommensteuer veranlagt werden, beträgt die tarifliche Einkommensteuer vorbehaltlich der §§ 32b, 32d, 34, 34a, 34b und 34c das Zweifache des Steuerbetrags, der sich für die Hälfte ihres gemeinsam zu versteuernden Einkommens nach Absatz 1 ergibt (Splitting-Verfahren).
+(6) 1Das Verfahren nach Absatz 5 ist auch anzuwenden zur Berechnung der tariflichen Einkommensteuer für das zu versteuernde Einkommen
+1. bei einem verwitweten Steuerpflichtigen für den Veranlagungszeitraum, der dem Kalenderjahr folgt, in dem der Ehegatte verstorben ist, wenn der Steuerpflichtige und sein verstorbener Ehegatte im Zeitpunkt seines Todes die Voraussetzungen des § 26 Absatz 1 Satz 1 erfüllt haben,
+2. bei einem Steuerpflichtigen, dessen Ehe in dem Kalenderjahr, in dem er sein Einkommen bezogen hat, aufgelöst worden ist, wenn in diesem Kalenderjahr
+a) der Steuerpflichtige und sein bisheriger Ehegatte die Voraussetzungen des § 26 Absatz 1 Satz 1 erfüllt haben,
+b) der bisherige Ehegatte wieder geheiratet hat und
+c) der bisherige Ehegatte und dessen neuer Ehegatte ebenfalls die Voraussetzungen des § 26 Absatz 1 Satz 1 erfüllen.2Voraussetzung für die Anwendung des Satzes 1 ist, dass der Steuerpflichtige nicht nach den §§ 26, 26a einzeln zur Einkommensteuer veranlagt wird."""
 _GERMAN_SECTION_32A_VALUES = (
     914.51,
     1400.0,
@@ -7796,6 +7810,53 @@ def test_de_numeric_profile_extracts_released_section_32a_coefficients_exactly()
         _GERMAN_SECTION_32A_FORMULA_TEXT,
         profile="de-DE",
     ) == list(_GERMAN_SECTION_32A_VALUES)
+
+
+def test_de_numeric_profile_extracts_full_released_section_32a_body():
+    assert (
+        hashlib.sha256(_GERMAN_SECTION_32A_RELEASED_BODY.encode()).hexdigest()
+        == "1d821a8b21e6fb634be7ec38ea3e380d314843d735703b20baf4609c4f2c2c50"
+    )
+
+    numbers = extract_numbers_from_text(
+        _GERMAN_SECTION_32A_RELEASED_BODY,
+        profile="de-DE",
+    )
+
+    assert set(_GERMAN_SECTION_32A_VALUES) <= numbers
+    assert {34.87, 135.63, 470.38}.isdisjoint(numbers)
+
+
+def test_de_numeric_profile_terminates_at_released_juris_sentence_marker():
+    source_text = (
+        "von 277 826 Euro an:0,45 • x – 19 470,38.3Die Größe „y“ ist ein "
+        "Zehntausendstel"
+    )
+
+    occurrences = extract_typed_numeric_occurrences_from_text(
+        source_text,
+        profile="de-DE",
+    )
+
+    assert [(item.value, item.raw) for item in occurrences] == [
+        (277826.0, "277 826"),
+        (0.45, "0,45"),
+        (19470.38, "19 470,38"),
+        (10000.0, "Zehntausendstel"),
+    ]
+    assert {3.0, 38.3, 470.38}.isdisjoint({item.value for item in occurrences})
+
+
+def test_de_numeric_profile_ignores_released_juris_marker_after_word():
+    source_text = "von insgesamt 102 Euro.2Der Pauschbetrag"
+
+    assert extract_numbers_from_text(source_text, profile="de-DE") == {102.0}
+
+
+def test_de_numeric_profile_handles_two_digit_unicode_sentence_marker():
+    source_text = "Der Betrag ist 19 470,38.12Über dem Grenzwert"
+
+    assert extract_numbers_from_text(source_text, profile="de-DE") == {19470.38}
 
 
 def test_de_numeric_profile_preserves_section_32a_raw_spans():
@@ -7889,6 +7950,8 @@ def test_de_numeric_profile_accepts_wogg_group_widths(source_text, expected):
         "4,797E\u2212-4",
         "4,797E\u2013\u20134",
         "1E2.3",
+        "19 470,38.123Die",
+        "19 470,38.3die",
     ),
 )
 def test_de_numeric_profile_reserves_malformed_spans_without_suffixes(source_text):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -7956,9 +7956,7 @@ def test_de_numeric_profile_accepts_wogg_group_widths(source_text, expected):
 )
 def test_de_numeric_profile_reserves_malformed_spans_without_suffixes(source_text):
     assert extract_numbers_from_text(source_text, profile="de-DE") == set()
-    assert (
-        extract_numeric_occurrences_from_text(source_text, profile="de-DE") == []
-    )
+    assert extract_numeric_occurrences_from_text(source_text, profile="de-DE") == []
 
 
 @pytest.mark.parametrize(
@@ -8031,10 +8029,7 @@ def test_de_numeric_profile_reads_unicode_unary_minus(source_text, expected):
 
 
 def test_de_numeric_profile_keeps_expression_subtraction_binary():
-    source_text = (
-        "0,42 \u2219 x \u2013 11 135,63; "
-        "0,45 \u00b7 x \u2212 19 470,38"
-    )
+    source_text = "0,42 \u2219 x \u2013 11 135,63; 0,45 \u00b7 x \u2212 19 470,38"
 
     assert extract_numbers_from_text(source_text, profile="de-DE") == {
         0.42,
@@ -9353,9 +9348,7 @@ rules:
 """
 
     source_text = (
-        "Qualifying children | Applicable percentage\n"
-        "| None | 7.65 |\n"
-        "| One | 34 |"
+        "Qualifying children | Applicable percentage\n| None | 7.65 |\n| One | 34 |"
     )
 
     assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
@@ -31218,11 +31211,7 @@ def test_source_verification_uses_de_profile_for_scalar_and_table_values():
                   2: 19470.38
         """
     ).strip()
-    source_text = (
-        "Der Betrag ist 1 034,87 Euro.\n"
-        "1 | 11 135,63\n"
-        "2 | 19 470,38"
-    )
+    source_text = "Der Betrag ist 1 034,87 Euro.\n1 | 11 135,63\n2 | 19 470,38"
 
     assert (
         find_source_verification_issues(
@@ -31264,11 +31253,7 @@ def test_source_verification_de_profile_rejects_us_numeric_spans():
                   2: 2345.67
         """
     ).strip()
-    source_text = (
-        "Der Betrag ist 1,234.56 Euro.\n"
-        "1 | 1,234.56\n"
-        "2 | 2,345.67"
-    )
+    source_text = "Der Betrag ist 1,234.56 Euro.\n1 | 1,234.56\n2 | 2,345.67"
 
     issues = find_source_verification_issues(
         content,

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1380"
+version = "0.2.1381"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
Fixes #1279. Unblocks full-provision encoding for the DE lane (rulespec-de#1 program).

## Commit 1 — typed occurrences + the #1279 fix

The numeric extractor now returns **typed occurrences** (value, span, raw text, rate context) instead of bare floats, and `numeric_value_is_grounded` accepts the `value×100` percentage interpretation **only when the matched source occurrence carries explicit rate context** (`%`, `Prozent`, `vom Hundert`, `per cent`). The false-pass class is dead: a generated `0.42` no longer grounds against a bare `42` — or an age `18`, a `30 Tage` period, or a `§ 20` section number (regression tests pin all of these, plus the positive cases).

## Commits 2–3 — de-DE numeric locale profile

Per-evidence-item locale profiles (`legacy` default everywhere; `de-DE` selected by canonical `de/...` citation path) — texts are parsed **per item** and candidate sets unioned after, never concatenated across locales. The German grammar handles: ordinary-space/NBSP/NNBSP/dot grouping, decimal commas, comma scientific notation (`4,797E-4`), multiplication glyph boundaries (`·`/`•`/`×`/`∙`), unary en-dash/minus, colon boundaries (`:0,42`), German lexical scales (*Zehntausendstel* → 10000, with sibling and dative-plural forms), and **glued juris sentence markers** (`19 470,38.3Die Größe…` — the `.3D` is a sentence number, not a decimal continuation; caught by running acceptance against the real released corpus body rather than fixtures). Complete-span reservation: `1 034,87` can never fragment to `{1, 34.87}`; malformed forms yield no suffix candidates.

## Verification

- **Acceptance on the real released §32a body** (de-rulespec-2026-07-21): all nine tariff tokens extract exactly — `{914.51, 1400, 173.10, 2397, 1034.87, 0.42, 11135.63, 0.45, 19470.38}` — with fragments `{34.87, 135.63, 470.38}` absent. Independently re-run by the reviewing agent against the released bundle, not just the test fixtures.
- **Hard contracts green**: UK `1.075` dual-read (pinned test), #1127 literal-to-atom anchoring, waiver fingerprint proof contract.
- **Legacy is behavior-identical**: verified against a clean `origin/main` worktree on a cross-jurisdiction battery (US percent/thousands, UK multiplier, bare integers) — byte-identical outputs.
- Full suite: 5,162 passed / 15 failed / 50 errors vs baseline 5,050 / 14 / 50 — the +1 failure was the version-provenance check, resolved by the version bump commit; remaining failures/errors reproduce on unmodified main (environmental).
- Both extraction paths (`extract_numbers_from_text`, `extract_numeric_occurrences_from_text`) share the occurrence-aware tokenizer, so they cannot disagree.

## Design constraints honored

No proof-excerpt normalization or synthesis; `module.summary` stays excluded from grounding; no waivers; proof validation stays in repository CI; no global punctuation normalization (`1,234.56` vs `1.234,56` stay locale-disambiguated).

Built cross-family (sol implements, Claude independently verifies each claim against the tree and the released corpus). Design: the defensive audit on rulespec-de#1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
