### PR TITLE
Pin Michigan income-tax oracle mappings

### DIFF
--- a/changelog.d/mi-2026-oracle-pin.changed.md
+++ b/changelog.d/mi-2026-oracle-pin.changed.md
@@ -1,0 +1,1 @@
+Pin axiom-oracles to the reviewed Michigan tax-year-2026 full-year-resident income-tax source-hold classifications, preserving the federal AGI diagnostic while keeping source-readiness predicates and fail-closed State liability sentinels out of PolicyEngine value comparisons.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1382"
+version = "0.2.1383"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@3033eed72c451f15f6df92c93073e39f5c921a03",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@343e9fae8a76e02c55c4e072c500b72a80656ef4",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1382"
+__version__ = "0.2.1383"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1382"
+version = "0.2.1383"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=3033eed72c451f15f6df92c93073e39f5c921a03" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=343e9fae8a76e02c55c4e072c500b72a80656ef4" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=3033eed72c451f15f6df92c93073e39f5c921a03#3033eed72c451f15f6df92c93073e39f5c921a03" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=343e9fae8a76e02c55c4e072c500b72a80656ef4#343e9fae8a76e02c55c4e072c500b72a80656ef4" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- pin `axiom-oracles` to merged Michigan resident-income-tax mapping commit `343e9fae8a76e02c55c4e072c500b72a80656ef4`
- bump `axiom-encode` from `0.2.1382` to `0.2.1383` consistently and regenerate `uv.lock`
- add the Michigan 2026 oracle-pin changelog fragment

## Validation

- upstream oracle post-merge CI run `30188622027`: terminal `SUCCESS`
- `uv run --python 3.13 ruff check pyproject.toml src/axiom_encode scripts tests`
- `.venv/bin/python -m compileall -q src/axiom_encode scripts`
- focused ECPS tax oracle suite: `78 passed, 23 skipped`
- version provenance regression: `1 passed`
- full suite: `5354 passed, 119 skipped`
- `git diff --check`
- independent review cycle: no actionable findings; exact installed oracle provenance, version/lock consistency, scope, and changelog verified

## Notes

Python 3.13 was selected explicitly because the unconstrained local `uv` default selected Python 3.14, where the locked `pyroaring==1.0.3` dependency does not build on macOS. The repository-supported Python 3.13 environment is green.