### PR TITLE
Add protected all-state SNAP encoding queue

### DIFF
--- a/.github/workflows/dispatch-signed-snap-queue.yml
+++ b/.github/workflows/dispatch-signed-snap-queue.yml
@@ -1,9 +1,17 @@
 name: Dispatch protected SNAP queue
-run-name: "SNAP queue dispatch=${{ inputs.dispatch }} items=${{ inputs.item_ids || 'next' }} limit=${{ inputs.limit }}"
+run-name: "SNAP queue=${{ inputs.queue_id }} dispatch=${{ inputs.dispatch }} items=${{ inputs.item_ids || 'next' }} limit=${{ inputs.limit }}"
 
 on:
   workflow_dispatch:
     inputs:
+      queue_id:
+        description: Durable protected SNAP queue identifier
+        required: true
+        default: us-snap-or-ut-2026-07
+        type: choice
+        options:
+          - us-snap-or-ut-2026-07
+          - us-snap-all-states-2026-07
       item_ids:
         description: Optional comma-separated queue item IDs; defaults to the next items
         required: false
@@ -62,11 +70,20 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           ITEM_IDS: ${{ inputs.item_ids }}
           LIMIT: ${{ inputs.limit }}
+          QUEUE_ID: ${{ inputs.queue_id }}
         run: |
           set -euo pipefail
           test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
-          queue="data/encoding-queues/us-snap-or-ut-2026-07.json"
+          queue="data/encoding-queues/${QUEUE_ID}.json"
+          test -f "$queue"
           python3 scripts/prepare_signed_queue.py validate "$queue"
+          legacy_queue="data/encoding-queues/us-snap-or-ut-2026-07.json"
+          all_state_queue="data/encoding-queues/us-snap-all-states-2026-07.json"
+          if [ "$QUEUE_ID" = "us-snap-all-states-2026-07" ]; then
+            test "$(jq -r '.state' "$legacy_queue")" != "active"
+          elif [ -f "$all_state_queue" ]; then
+            test "$(jq -r '.state' "$all_state_queue")" != "active"
+          fi
           if [ "$(jq -r '.state' "$queue")" = "active" ]; then
             if [[ ! "$ACTIVATION_MERGE_RUN_ID" =~ ^[0-9]+$ ]]; then
               echo "active queue requires activation_merge_run_id" >&2

--- a/.github/workflows/finalize-signed-snap-queue.yml
+++ b/.github/workflows/finalize-signed-snap-queue.yml
@@ -1,9 +1,17 @@
 name: Finalize protected SNAP queue tranche
-run-name: "Finalize SNAP queue at ${{ inputs.new_rulespec_ref }}"
+run-name: "Finalize SNAP queue=${{ inputs.queue_id }} at ${{ inputs.new_rulespec_ref }}"
 
 on:
   workflow_dispatch:
     inputs:
+      queue_id:
+        description: Durable protected SNAP queue identifier
+        required: true
+        default: us-snap-or-ut-2026-07
+        type: choice
+        options:
+          - us-snap-or-ut-2026-07
+          - us-snap-all-states-2026-07
       new_rulespec_ref:
         description: Independently reviewed and allowlisted current RuleSpec branch tip
         required: true
@@ -54,6 +62,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           NEW_RULESPEC_REF: ${{ inputs.new_rulespec_ref }}
+          QUEUE_ID: ${{ inputs.queue_id }}
         run: |
           set -euo pipefail
           test "$GITHUB_RUN_ATTEMPT" = "1"
@@ -63,9 +72,18 @@ jobs:
           fi
           test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
           test "$(git -C rulespec-us rev-parse HEAD)" = "$NEW_RULESPEC_REF"
-          queue="data/encoding-queues/us-snap-or-ut-2026-07.json"
+          queue="data/encoding-queues/${QUEUE_ID}.json"
+          test -f "$queue"
           python3 scripts/prepare_signed_queue.py validate "$queue"
           test "$(jq -r '.state' "$queue")" = "paused"
+          legacy_queue="data/encoding-queues/us-snap-or-ut-2026-07.json"
+          all_state_queue="data/encoding-queues/us-snap-all-states-2026-07.json"
+          if [ "$QUEUE_ID" = "us-snap-all-states-2026-07" ]; then
+            test "$(jq -r '.state' "$legacy_queue")" != "active"
+          elif [ -f "$all_state_queue" ]; then
+            echo "legacy SNAP queue is permanently superseded" >&2
+            exit 1
+          fi
 
           api_version="2026-03-10"
           branch_ref="repos/TheAxiomFoundation/rulespec-us/git/ref/heads/hard-cut/canonical-layout-us"
@@ -186,9 +204,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           NEW_RULESPEC_REF: ${{ inputs.new_rulespec_ref }}
+          QUEUE_ID: ${{ inputs.queue_id }}
         run: |
           set -euo pipefail
-          queue="data/encoding-queues/us-snap-or-ut-2026-07.json"
+          queue="data/encoding-queues/${QUEUE_ID}.json"
           cp "$RUNNER_TEMP/finalized-snap-queue.json" "$queue"
           old_version="$(uv version --short)"
           new_version="$(uv version --bump patch --short --no-sync)"
@@ -224,9 +243,9 @@ jobs:
           git diff --name-only "$GITHUB_SHA" "$head_sha" \
             | jq -R -s 'split("\n") | map(select(length > 0))' \
             > "$RUNNER_TEMP/activation-changed-files.json"
-          jq -e '
+          jq -e --arg queue "$queue" '
             . == [
-              "data/encoding-queues/us-snap-or-ut-2026-07.json",
+              $queue,
               "pyproject.toml",
               "src/axiom_encode/__init__.py",
               "uv.lock"
@@ -236,6 +255,7 @@ jobs:
           jq -n \
             --arg base_sha "$GITHUB_SHA" \
             --arg head_sha "$head_sha" \
+            --arg queue_path "$queue" \
             --arg queue_sha256 "$queue_sha256" \
             --arg repository "$GITHUB_REPOSITORY" \
             --arg tree_sha "$tree_sha" \
@@ -246,7 +266,7 @@ jobs:
               base_sha: $base_sha,
               head_sha: $head_sha,
               tree_sha: $tree_sha,
-              queue_path: "data/encoding-queues/us-snap-or-ut-2026-07.json",
+              queue_path: $queue_path,
               queue_sha256: $queue_sha256,
               changed_files: $changed_files[0]
             }' > "$RUNNER_TEMP/activation-commit.json"

--- a/.github/workflows/merge-snap-queue-activation.yml
+++ b/.github/workflows/merge-snap-queue-activation.yml
@@ -1,9 +1,17 @@
 name: Merge reviewed SNAP queue activation
-run-name: "Merge SNAP queue activation PR #${{ inputs.pull_request_number }}"
+run-name: "Merge SNAP queue=${{ inputs.queue_id }} activation PR #${{ inputs.pull_request_number }}"
 
 on:
   workflow_dispatch:
     inputs:
+      queue_id:
+        description: Durable protected SNAP queue identifier
+        required: true
+        default: us-snap-or-ut-2026-07
+        type: choice
+        options:
+          - us-snap-or-ut-2026-07
+          - us-snap-all-states-2026-07
       pull_request_number:
         description: Reviewed, ready, green SNAP queue activation pull request
         required: true
@@ -72,16 +80,26 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ steps.pull.outputs.head_sha }}
           PULL_REQUEST_NUMBER: ${{ inputs.pull_request_number }}
+          QUEUE_ID: ${{ inputs.queue_id }}
         run: |
           set -euo pipefail
           test "$(git rev-parse HEAD)" = "$BASE_SHA"
           git fetch --no-tags origin "$HEAD_SHA"
           test "$(git rev-parse FETCH_HEAD)" = "$HEAD_SHA"
           test "$(git rev-parse "${HEAD_SHA}^")" = "$BASE_SHA"
-          queue="data/encoding-queues/us-snap-or-ut-2026-07.json"
+          queue="data/encoding-queues/${QUEUE_ID}.json"
           candidate_queue="$RUNNER_TEMP/candidate-snap-queue.json"
           git show "$HEAD_SHA:$queue" > "$candidate_queue"
           python3 scripts/prepare_signed_queue.py validate "$candidate_queue"
+          legacy_queue="data/encoding-queues/us-snap-or-ut-2026-07.json"
+          all_state_queue="data/encoding-queues/us-snap-all-states-2026-07.json"
+          if [ "$QUEUE_ID" = "us-snap-all-states-2026-07" ]; then
+            test "$(git show "$BASE_SHA:$legacy_queue" | jq -r '.state')" != \
+              "active"
+          elif git cat-file -e "$BASE_SHA:$all_state_queue" 2> /dev/null; then
+            echo "legacy SNAP queue is permanently superseded" >&2
+            exit 1
+          fi
           test "$(jq -r '.state' "$candidate_queue")" = "active"
 
           run_url="$(jq -r '.activation.finalizer_run_url' "$candidate_queue")"
@@ -210,6 +228,7 @@ jobs:
           jq -n \
             --arg head_sha "$HEAD_SHA" \
             --arg merge_commit "$merge_commit" \
+            --arg queue_path "$queue" \
             --arg queue_sha256 "$queue_sha256" \
             --arg repository "$GITHUB_REPOSITORY" \
             --arg run_url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
@@ -218,7 +237,7 @@ jobs:
             '{
               schema: "axiom-encode/snap-queue-merge-authorization/v1",
               repository: $repository,
-              queue_path: "data/encoding-queues/us-snap-or-ut-2026-07.json",
+              queue_path: $queue_path,
               queue_sha256: $queue_sha256,
               activation_pr_number: $pr_number,
               activation_pr_head_sha: $head_sha,

--- a/.github/workflows/prepare-all-state-snap-queue.yml
+++ b/.github/workflows/prepare-all-state-snap-queue.yml
@@ -1,0 +1,125 @@
+name: Prepare protected all-state SNAP queue
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: prepare-all-state-snap-queue
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch'
+        && github.ref == 'refs/heads/main'
+        && github.run_attempt == 1
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      CORPUS_REF: 0fd35bfbda98836c406ec539a492c4e661c6695d
+      RELEASE_NAME: us-rulespec-2026-07-24-snap-cms-pit-union
+      RELEASE_SHA: cb275c76c4f07f8ad37470a32296bb1763e5db853d152697524ab07021b6d544
+      RULES_ENGINE_REF: 05eac9d2f89dabe5c6673176260762cef3a58f47
+      RULESPEC_REF: 8f224620540f9e285428ec839d094835396f7d99
+      SUPABASE_URL: https://swocpijqqahhuwtuahwc.supabase.co
+    steps:
+      - name: Checkout immutable encoder main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Checkout pinned corpus
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: TheAxiomFoundation/axiom-corpus
+          ref: ${{ env.CORPUS_REF }}
+          path: pinned-corpus
+          persist-credentials: false
+
+      - name: Checkout pinned RuleSpec
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: TheAxiomFoundation/rulespec-us
+          ref: ${{ env.RULESPEC_REF }}
+          path: pinned-rulespec
+          persist-credentials: false
+
+      - name: Install encoder
+        uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc # v7.2.0
+        with:
+          version: "0.9.26"
+
+      - name: Build authenticated paused queue
+        env:
+          CORPUS_READ_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          CORPUS_RELEASE_PUBLIC_KEY: ${{ vars.AXIOM_CORPUS_RELEASE_PUBLIC_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "$CORPUS_READ_KEY"
+          test -n "$CORPUS_RELEASE_PUBLIC_KEY"
+          uv sync --frozen --python 3.13
+
+          response="$RUNNER_TEMP/corpus-release-response.json"
+          release_object="$RUNNER_TEMP/corpus-release-object.json"
+          release_public_key="$RUNNER_TEMP/corpus-release-public-key"
+          queue="data/encoding-queues/us-snap-all-states-2026-07.json"
+          url="${SUPABASE_URL%/}/rest/v1/release_objects?select=release_object&release_name=eq.${RELEASE_NAME}&content_sha256=eq.${RELEASE_SHA}&limit=2"
+          curl --fail --silent --show-error \
+            --header "apikey: $CORPUS_READ_KEY" \
+            --header "Authorization: Bearer $CORPUS_READ_KEY" \
+            --header "Accept-Profile: corpus" \
+            --output "$response" "$url"
+          jq -e 'if length == 1 then .[0].release_object else
+            error("expected exactly one signed corpus release object") end' \
+            "$response" > "$release_object"
+          printf '%s\n' "$CORPUS_RELEASE_PUBLIC_KEY" > "$release_public_key"
+
+          uv run --frozen --python 3.13 python scripts/prepare_signed_queue.py \
+            build-snap-all-states pinned-corpus pinned-rulespec \
+            --corpus-ref "$CORPUS_REF" \
+            --rulespec-ref "$RULESPEC_REF" \
+            --rules-engine-ref "$RULES_ENGINE_REF" \
+            --release-name "$RELEASE_NAME" \
+            --release-content-sha256 "$RELEASE_SHA" \
+            --release-object "$release_object" \
+            --release-public-key "$release_public_key" \
+            --state paused \
+            --pause-reason \
+              "Awaiting a green, independently reviewed exact RuleSpec protected-branch tip." \
+            > "$queue"
+          uv run --frozen --python 3.13 python scripts/prepare_signed_queue.py \
+            validate "$queue"
+
+          {
+            echo "### All-state SNAP queue"
+            echo
+            echo "Items: $(jq '.expected_counts.total' "$queue")"
+            echo "Jurisdictions: $(jq '.expected_counts | keys - [\"total\"] | length' "$queue")"
+            echo "Queue SHA-256: $(sha256sum "$queue" | cut -d' ' -f1)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open durable queue pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          branch="queue/all-state-snap-${GITHUB_RUN_ID}"
+          queue="data/encoding-queues/us-snap-all-states-2026-07.json"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add "$queue"
+          git commit -m "Add durable all-state SNAP encoding queue"
+          git push origin "$branch"
+          gh pr create \
+            --draft \
+            --base main \
+            --head "$branch" \
+            --title "Add durable all-state SNAP encoding queue" \
+            --body "Creates the authenticated, paused 50-state-plus-DC SNAP queue tracked by #1287. The queue is generated from the pinned signed corpus release and remains paused until the protected RuleSpec branch is green and independently reviewed."

--- a/.github/workflows/validate-snap-queue-activation.yml
+++ b/.github/workflows/validate-snap-queue-activation.yml
@@ -4,8 +4,12 @@ on:
   pull_request:
     paths:
       - data/encoding-queues/us-snap-or-ut-2026-07.json
+      - data/encoding-queues/us-snap-all-states-2026-07.json
       - scripts/prepare_signed_queue.py
       - .github/workflows/finalize-signed-snap-queue.yml
+      - .github/workflows/merge-snap-queue-activation.yml
+      - .github/workflows/dispatch-signed-snap-queue.yml
+      - .github/workflows/prepare-all-state-snap-queue.yml
       - .github/workflows/validate-snap-queue-activation.yml
 
 permissions:
@@ -33,7 +37,20 @@ jobs:
         run: |
           set -euo pipefail
           test "$(git rev-parse HEAD)" = "$HEAD_SHA"
-          queue="data/encoding-queues/us-snap-or-ut-2026-07.json"
+          mapfile -t changed_queues < <(
+            git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- \
+              data/encoding-queues/us-snap-or-ut-2026-07.json \
+              data/encoding-queues/us-snap-all-states-2026-07.json
+          )
+          if [ "${#changed_queues[@]}" -eq 1 ]; then
+            queue="${changed_queues[0]}"
+          elif [ "${#changed_queues[@]}" -eq 0 ]; then
+            queue="data/encoding-queues/us-snap-or-ut-2026-07.json"
+          else
+            echo "activation PR must modify at most one SNAP queue" >&2
+            exit 1
+          fi
+          echo "queue_path=$queue" >> "$GITHUB_OUTPUT"
           python3 scripts/prepare_signed_queue.py validate "$queue"
           previous_queue="$RUNNER_TEMP/previous-snap-queue.json"
           initial=false
@@ -47,8 +64,23 @@ jobs:
           else
             initial=true
           fi
+          queue_id="$(jq -r '.queue_id' "$queue")"
+          if [ "$(jq -r '.state' "$queue")" = "active" ]; then
+            legacy_queue="data/encoding-queues/us-snap-or-ut-2026-07.json"
+            all_state_queue="data/encoding-queues/us-snap-all-states-2026-07.json"
+            if [ "$queue_id" = "us-snap-all-states-2026-07" ]; then
+              if git cat-file -e "$BASE_SHA:$legacy_queue" 2> /dev/null; then
+                test "$(git show "$BASE_SHA:$legacy_queue" | jq -r '.state')" != \
+                  "active"
+              fi
+            elif git cat-file -e "$BASE_SHA:$all_state_queue" 2> /dev/null; then
+              echo "legacy SNAP queue is permanently superseded" >&2
+              exit 1
+            fi
+          fi
           echo "initial=$initial" >> "$GITHUB_OUTPUT"
           if [ "$initial" = "true" ]; then
+            printf 'queue_id=%s\n' "$queue_id" >> "$GITHUB_OUTPUT"
             for field in corpus_ref rules_engine_ref rulespec_ref; do
               printf '%s=%s\n' "$field" \
                 "$(jq -r --arg field "$field" '.dispatch[$field]' "$queue")" \
@@ -172,6 +204,7 @@ jobs:
         if: ${{ steps.transition.outputs.initial == 'true' }}
         env:
           CORPUS_RELEASE_PUBLIC_KEY: ${{ vars.AXIOM_CORPUS_RELEASE_PUBLIC_KEY }}
+          QUEUE_PATH: ${{ steps.transition.outputs.queue_path }}
           RELEASE_NAME: ${{ steps.transition.outputs.release_name }}
           RELEASE_SHA: ${{ steps.transition.outputs.release_sha }}
           SUPABASE_ANON_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
@@ -204,8 +237,17 @@ jobs:
             "$response" > "$release_object"
           printf '%s\n' "$CORPUS_RELEASE_PUBLIC_KEY" > "$release_public_key"
 
+          queue_id="${{ steps.transition.outputs.queue_id }}"
+          if [ "$queue_id" = "us-snap-all-states-2026-07" ]; then
+            build_command=build-snap-all-states
+          elif [ "$queue_id" = "us-snap-or-ut-2026-07" ]; then
+            build_command=build-snap
+          else
+            echo "unsupported initial SNAP queue: $queue_id" >&2
+            exit 1
+          fi
           uv run --frozen --python 3.13 python scripts/prepare_signed_queue.py \
-            build-snap initial-axiom-corpus initial-rulespec-us \
+            "$build_command" initial-axiom-corpus initial-rulespec-us \
             --corpus-ref "${{ steps.transition.outputs.corpus_ref }}" \
             --rulespec-ref "${{ steps.transition.outputs.rulespec_ref }}" \
             --rules-engine-ref "${{ steps.transition.outputs.rules_engine_ref }}" \
@@ -218,4 +260,4 @@ jobs:
               "Awaiting a green, independently reviewed exact RuleSpec protected-branch tip." \
             > "$generated_queue"
           cmp --silent \
-            data/encoding-queues/us-snap-or-ut-2026-07.json "$generated_queue"
+            "$QUEUE_PATH" "$generated_queue"

--- a/changelog.d/all-state-snap-queue.added.md
+++ b/changelog.d/all-state-snap-queue.added.md
@@ -1,0 +1,2 @@
+Add a signed, durable SNAP queue profile and protected workflow routing for all
+50 states and the District of Columbia.

--- a/scripts/prepare_signed_queue.py
+++ b/scripts/prepare_signed_queue.py
@@ -13,6 +13,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 SCHEMA = "axiom-encode/signed-encoding-queue/v1"
 ACTIVATION_CHANGED_FILES = (
     "data/encoding-queues/us-snap-or-ut-2026-07.json",
@@ -21,7 +23,7 @@ ACTIVATION_CHANGED_FILES = (
     "uv.lock",
 )
 QUEUE_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
-ITEM_ID_PATTERN = re.compile(r"^(?:or|ut)-[0-9]{4}$")
+ITEM_ID_PATTERN = re.compile(r"^[a-z]{2}-[0-9]{4,5}$")
 RELEASE_NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{0,127}$")
 SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 DIGEST_PATTERN = re.compile(r"^[0-9a-f]{64}$")
@@ -40,12 +42,62 @@ SELECTABLE_STATUSES = frozenset({"pending", "retryable"})
 TERMINAL_STATUSES = frozenset({"blocked", "completed", "no-executable-rule"})
 MAX_BATCH_SIZE = 4
 EXPECTED_COUNTS = {"total": 831, "us-or": 530, "us-ut": 301}
+ALL_STATE_EXPECTED_COUNTS = {
+    "total": 17784,
+    "us-ak": 239,
+    "us-al": 17,
+    "us-ar": 8,
+    "us-az": 7,
+    "us-ca": 15,
+    "us-co": 302,
+    "us-ct": 279,
+    "us-dc": 349,
+    "us-de": 264,
+    "us-fl": 48,
+    "us-ga": 100,
+    "us-hi": 20,
+    "us-ia": 12,
+    "us-id": 70,
+    "us-il": 4750,
+    "us-in": 483,
+    "us-ks": 255,
+    "us-ky": 2,
+    "us-la": 346,
+    "us-ma": 9,
+    "us-md": 51,
+    "us-me": 2,
+    "us-mi": 196,
+    "us-mn": 1353,
+    "us-mo": 515,
+    "us-ms": 384,
+    "us-mt": 83,
+    "us-nc": 79,
+    "us-nd": 67,
+    "us-ne": 5,
+    "us-nh": 1,
+    "us-nj": 265,
+    "us-nm": 28,
+    "us-nv": 51,
+    "us-ny": 17,
+    "us-oh": 82,
+    "us-ok": 87,
+    "us-or": 1322,
+    "us-pa": 297,
+    "us-ri": 272,
+    "us-sc": 459,
+    "us-sd": 339,
+    "us-tn": 27,
+    "us-tx": 11,
+    "us-ut": 655,
+    "us-va": 677,
+    "us-vt": 32,
+    "us-wa": 200,
+    "us-wi": 372,
+    "us-wv": 2276,
+    "us-wy": 4,
+}
 RULESPEC_PR_PATTERN = re.compile(
     r"^https://github\.com/TheAxiomFoundation/rulespec-us/pull/[0-9]+$"
-)
-QUEUE_ISSUE_COMMENT_PATTERN = re.compile(
-    r"^https://github\.com/TheAxiomFoundation/axiom-encode/issues/"
-    r"1257#issuecomment-[0-9]+$"
 )
 FINALIZER_RUN_PATTERN = re.compile(
     r"^https://github\.com/TheAxiomFoundation/axiom-encode/actions/runs/[0-9]+$"
@@ -63,6 +115,51 @@ PRIORITY_CITATIONS = (
     "us-or/manual/odhs/open/page-273",
     "us-or/manual/odhs/open/page-274",
 )
+ALL_STATE_QUEUE_ID = "us-snap-all-states-2026-07"
+ALL_STATE_QUEUE_ISSUE = 1287
+ALL_STATE_INVENTORY_PATH = "manifests/state-snap-manual-agent-queue.yaml"
+ALL_STATE_INVENTORY_SHA256 = (
+    "23b32cef7957d56b171abe51ed63de6cf22c6c29475ba7a2190b3da4692422b6"
+)
+ALL_STATE_SCOPE_ALIASES = {
+    (
+        "us-ma",
+        "regulation",
+        "2026-07-17-ma-dta-snap-regulations",
+    ): (
+        "us-ma",
+        "regulation",
+        "2026-07-24-ma-dta-regulations-snap-current-union",
+    ),
+}
+
+
+def _queue_profile(queue_id: str) -> dict[str, Any]:
+    if queue_id == "us-snap-or-ut-2026-07":
+        return {
+            "activation_path": "data/encoding-queues/us-snap-or-ut-2026-07.json",
+            "expected_counts": EXPECTED_COUNTS,
+            "issue": 1257,
+            "inventory": None,
+            "item_width": 4,
+            "priority_citations": PRIORITY_CITATIONS,
+            "supersedes": None,
+        }
+    if queue_id == ALL_STATE_QUEUE_ID:
+        return {
+            "activation_path": f"data/encoding-queues/{ALL_STATE_QUEUE_ID}.json",
+            "expected_counts": ALL_STATE_EXPECTED_COUNTS,
+            "issue": ALL_STATE_QUEUE_ISSUE,
+            "inventory": {
+                "jurisdictions": 51,
+                "path": ALL_STATE_INVENTORY_PATH,
+                "sha256": ALL_STATE_INVENTORY_SHA256,
+            },
+            "item_width": 5,
+            "priority_citations": (),
+            "supersedes": ["us-snap-or-ut-2026-07"],
+        }
+    raise ValueError(f"unsupported protected SNAP queue: {queue_id}")
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -104,6 +201,66 @@ def _record_label(record: dict[str, Any]) -> str:
         if isinstance(value, str) and value.strip():
             return value.strip()
     raise ValueError("corpus record has no usable label")
+
+
+def _logical_source_units(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Select one stable encoder target per logical source unit."""
+
+    by_kind: dict[str, list[dict[str, Any]]] = {}
+    for record in records:
+        kind = record.get("kind")
+        citation = record.get("citation_path")
+        if not isinstance(kind, str) or not isinstance(citation, str):
+            raise ValueError("SNAP scope record lacks kind or citation_path")
+        by_kind.setdefault(kind, []).append(record)
+
+    documents = by_kind.get("document", [])
+    if len(documents) > 1:
+        selected = documents
+    else:
+        selected = []
+        for kind in ("page", "section", "rule", "sheet"):
+            if by_kind.get(kind):
+                selected = by_kind[kind]
+                break
+        if not selected and documents:
+            selected = documents
+        if not selected:
+            citations = {
+                record["citation_path"]
+                for record in records
+                if isinstance(record.get("citation_path"), str)
+            }
+            selected = [
+                record
+                for record in records
+                if not any(
+                    other.startswith(f"{record['citation_path']}/")
+                    for other in citations
+                    if other != record["citation_path"]
+                )
+            ]
+
+    if any(
+        any(character.isspace() for character in record["citation_path"])
+        for record in selected
+    ):
+        if not documents:
+            raise ValueError(
+                "logical source-unit citations contain whitespace and have no "
+                "document fallback"
+            )
+        selected = documents
+
+    return sorted(
+        selected,
+        key=lambda record: (
+            record.get("ordinal")
+            if isinstance(record.get("ordinal"), int)
+            else sys.maxsize,
+            record["citation_path"],
+        ),
+    )
 
 
 def _require_sha(value: object, label: str) -> str:
@@ -416,6 +573,197 @@ def build_snap_queue(
     return payload
 
 
+def build_all_state_snap_queue(
+    corpus_root: Path,
+    rulespec_root: Path,
+    *,
+    corpus_ref: str,
+    rulespec_ref: str,
+    rules_engine_ref: str,
+    release_name: str,
+    release_content_sha256: str,
+    release_object_path: Path,
+    release_public_key_path: Path,
+    state: str,
+    pause_reason: str | None,
+) -> dict[str, Any]:
+    """Build the signed all-state SNAP logical source-unit inventory."""
+
+    _require_sha(corpus_ref, "corpus_ref")
+    _require_sha(rulespec_ref, "rulespec_ref")
+    _require_sha(rules_engine_ref, "rules_engine_ref")
+    _require_digest(release_content_sha256, "release_content_sha256")
+
+    inventory_path = corpus_root / ALL_STATE_INVENTORY_PATH
+    try:
+        inventory = yaml.safe_load(inventory_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        raise ValueError("state SNAP source inventory is unavailable") from exc
+    if not isinstance(inventory, dict) or inventory.get("program") != "SNAP":
+        raise ValueError("state SNAP source inventory has the wrong program")
+    states = inventory.get("states")
+    if not isinstance(states, list) or len(states) != 51:
+        raise ValueError("state SNAP source inventory must contain 51 jurisdictions")
+
+    release_path = (
+        corpus_root / "manifests/releases" / f"{release_name}.json"
+    )
+    release = _load_json(release_path)
+    release_scopes = release.get("scopes")
+    if not isinstance(release_scopes, list):
+        raise ValueError("corpus release manifest scopes are missing")
+    available_scopes = {
+        (
+            scope.get("jurisdiction"),
+            scope.get("document_class"),
+            scope.get("version"),
+        )
+        for scope in release_scopes
+        if isinstance(scope, dict)
+    }
+
+    provisions = corpus_root / "data/corpus/provisions"
+    source_paths: list[Path] = []
+    state_sources: list[tuple[str, Path]] = []
+    seen_jurisdictions: set[str] = set()
+    for entry in states:
+        if not isinstance(entry, dict):
+            raise ValueError("state SNAP source inventory entry is malformed")
+        jurisdiction = entry.get("jurisdiction")
+        if (
+            not isinstance(jurisdiction, str)
+            or re.fullmatch(r"us-[a-z]{2}", jurisdiction) is None
+            or jurisdiction in seen_jurisdictions
+        ):
+            raise ValueError("state SNAP source inventory jurisdiction is invalid")
+        seen_jurisdictions.add(jurisdiction)
+        if entry.get("queue_status") != "published_current":
+            raise ValueError(
+                f"state SNAP source is not published_current: {jurisdiction}"
+            )
+        for scope_field in ("target_scope", "supporting_scope"):
+            scope = entry.get(scope_field)
+            if scope is None:
+                continue
+            if not isinstance(scope, dict):
+                raise ValueError(
+                    f"{jurisdiction} {scope_field} is malformed"
+                )
+            scope_key = (
+                scope.get("jurisdiction"),
+                scope.get("document_class"),
+                scope.get("version"),
+            )
+            resolved_scope = ALL_STATE_SCOPE_ALIASES.get(scope_key, scope_key)
+            if resolved_scope not in available_scopes:
+                raise ValueError(
+                    "state SNAP scope is absent from signed release: "
+                    + "/".join(str(value) for value in scope_key)
+                )
+            path = (
+                provisions
+                / str(resolved_scope[0])
+                / str(resolved_scope[1])
+                / f"{resolved_scope[2]}.jsonl"
+            )
+            source_paths.append(path)
+            state_sources.append((jurisdiction, path))
+
+    if len(seen_jurisdictions) != 51:
+        raise ValueError("state SNAP source inventory has duplicate jurisdictions")
+
+    release_manifest_sha256 = _verify_corpus_provenance(
+        corpus_root,
+        corpus_ref=corpus_ref,
+        release_name=release_name,
+        source_paths=source_paths,
+    )
+    _verify_signed_release_binding(
+        corpus_root,
+        rulespec_root,
+        corpus_ref=corpus_ref,
+        rulespec_ref=rulespec_ref,
+        release_name=release_name,
+        release_content_sha256=release_content_sha256,
+        release_object_path=release_object_path,
+        release_public_key_path=release_public_key_path,
+        source_paths=source_paths,
+    )
+
+    candidates: list[tuple[str, dict[str, Any]]] = []
+    seen_citations: set[str] = set()
+    for jurisdiction, source_path in state_sources:
+        records = _load_jsonl([source_path])
+        for record in _logical_source_units(records):
+            citation = record["citation_path"]
+            if citation in seen_citations:
+                raise ValueError(f"duplicate all-state SNAP citation: {citation}")
+            seen_citations.add(citation)
+            candidates.append((jurisdiction, record))
+
+    candidates.sort(key=lambda candidate: (candidate[0], candidate[1]["citation_path"]))
+    counters = {jurisdiction: 0 for jurisdiction in sorted(seen_jurisdictions)}
+    items: list[dict[str, Any]] = []
+    for sequence, (jurisdiction, record) in enumerate(candidates, start=1):
+        counters[jurisdiction] += 1
+        items.append(
+            {
+                "attempt": 1,
+                "citation": record["citation_path"],
+                "id": f"{jurisdiction[3:]}-{counters[jurisdiction]:05d}",
+                "jurisdiction": jurisdiction,
+                "label": _record_label(record),
+                "sequence": sequence,
+                "source_kind": record["kind"],
+                "status": "pending",
+            }
+        )
+
+    counts = {"total": len(items), **counters}
+    if counts != ALL_STATE_EXPECTED_COUNTS:
+        raise ValueError(
+            "all-state SNAP inventory drifted: "
+            f"expected {ALL_STATE_EXPECTED_COUNTS}, got {counts}"
+        )
+
+    payload = {
+        "schema": SCHEMA,
+        "queue_id": ALL_STATE_QUEUE_ID,
+        "state": state,
+        "description": (
+            "All-state SNAP logical source-unit inventory for the 50 states and "
+            "District of Columbia. Every item requires an encoder disposition."
+        ),
+        "issue": ALL_STATE_QUEUE_ISSUE,
+        "supersedes": ["us-snap-or-ut-2026-07"],
+        "inventory": {
+            "jurisdictions": 51,
+            "path": ALL_STATE_INVENTORY_PATH,
+            "sha256": hashlib.sha256(inventory_path.read_bytes()).hexdigest(),
+        },
+        "release": {
+            "content_sha256": release_content_sha256,
+            "manifest_sha256": release_manifest_sha256,
+            "name": release_name,
+        },
+        "dispatch": {
+            "corpus_ref": corpus_ref,
+            "country": "us",
+            "max_batch_size": MAX_BATCH_SIZE,
+            "open_pr": True,
+            "pr_base_branch": "hard-cut/canonical-layout-us",
+            "rules_engine_ref": rules_engine_ref,
+            "rulespec_ref": rulespec_ref,
+        },
+        "expected_counts": ALL_STATE_EXPECTED_COUNTS,
+        "items": items,
+    }
+    if pause_reason is not None:
+        payload["pause_reason"] = pause_reason
+    validate_queue(payload)
+    return payload
+
+
 def validate_queue(payload: dict[str, Any]) -> None:
     """Validate the complete queue and immutable dispatch trust boundary."""
 
@@ -424,9 +772,22 @@ def validate_queue(payload: dict[str, Any]) -> None:
     queue_id = payload.get("queue_id")
     if not isinstance(queue_id, str) or QUEUE_ID_PATTERN.fullmatch(queue_id) is None:
         raise ValueError("queue_id is malformed")
+    profile = _queue_profile(queue_id)
     issue = payload.get("issue")
     if not isinstance(issue, int) or isinstance(issue, bool) or issue <= 0:
         raise ValueError("queue issue must be a positive integer")
+    if issue != profile["issue"]:
+        raise ValueError(f"queue issue must be {profile['issue']}")
+    if payload.get("supersedes") != profile["supersedes"]:
+        if profile["supersedes"] is None and "supersedes" not in payload:
+            pass
+        else:
+            raise ValueError("queue supersession binding is invalid")
+    if payload.get("inventory") != profile["inventory"]:
+        if profile["inventory"] is None and "inventory" not in payload:
+            pass
+        else:
+            raise ValueError("queue inventory binding is invalid")
     state = payload.get("state")
     if state not in {"active", "paused"}:
         raise ValueError("queue state must be active or paused")
@@ -517,33 +878,40 @@ def validate_queue(payload: dict[str, Any]) -> None:
         _require_sha(dispatch.get(key), key)
 
     expected_counts = payload.get("expected_counts")
-    if expected_counts != EXPECTED_COUNTS:
-        raise ValueError(f"SNAP queue expected_counts must be {EXPECTED_COUNTS}")
+    profile_counts = profile["expected_counts"]
+    if expected_counts != profile_counts:
+        raise ValueError(f"SNAP queue expected_counts must be {profile_counts}")
     items = payload.get("items")
     if not isinstance(items, list):
         raise ValueError("queue items must be a list")
-    if len(items) != EXPECTED_COUNTS["total"]:
+    if len(items) != profile_counts["total"]:
         raise ValueError("queue item count does not match expected_counts")
 
     seen_ids: set[str] = set()
     seen_citations: set[str] = set()
-    counts = {"total": len(items), "us-or": 0, "us-ut": 0}
+    jurisdictions = set(profile_counts) - {"total"}
+    counts = {"total": len(items), **dict.fromkeys(sorted(jurisdictions), 0)}
     for expected_sequence, item in enumerate(items, start=1):
         if not isinstance(item, dict):
             raise ValueError("queue item must be an object")
         item_id = item.get("id")
         if not isinstance(item_id, str) or ITEM_ID_PATTERN.fullmatch(item_id) is None:
             raise ValueError("queue item id is malformed")
+        jurisdiction = item.get("jurisdiction")
+        expected_item_pattern = re.compile(
+            rf"^{str(jurisdiction)[3:]}-[0-9]{{{profile['item_width']}}}$"
+        )
+        if expected_item_pattern.fullmatch(item_id) is None:
+            raise ValueError(f"queue item id does not match jurisdiction: {item_id}")
         if item_id in seen_ids:
             raise ValueError(f"duplicate queue item id: {item_id}")
         seen_ids.add(item_id)
         citation = item.get("citation")
-        jurisdiction = item.get("jurisdiction")
-        if jurisdiction not in ("us-or", "us-ut"):
+        if jurisdiction not in jurisdictions:
             raise ValueError(f"queue item jurisdiction is invalid: {item_id}")
         if (
             not isinstance(citation, str)
-            or not citation.startswith(f"{jurisdiction}/manual/")
+            or not citation.startswith(f"{jurisdiction}/")
             or any(character.isspace() for character in citation)
         ):
             raise ValueError(f"queue item citation is invalid: {item_id}")
@@ -622,10 +990,14 @@ def validate_queue(payload: dict[str, Any]) -> None:
                     )
             else:
                 note = evidence.get("note")
+                issue_comment_pattern = re.compile(
+                    r"^https://github\.com/TheAxiomFoundation/axiom-encode/issues/"
+                    rf"{issue}#issuecomment-[0-9]+$"
+                )
                 if (
                     evidence.get("type") != "issue-comment"
                     or not isinstance(url, str)
-                    or QUEUE_ISSUE_COMMENT_PATTERN.fullmatch(url) is None
+                    or issue_comment_pattern.fullmatch(url) is None
                     or not isinstance(note, str)
                     or not note.strip()
                 ):
@@ -633,16 +1005,24 @@ def validate_queue(payload: dict[str, Any]) -> None:
                         f"{status} queue item requires an issue comment and note: "
                         f"{item_id}"
                     )
-        if item.get("source_kind") not in {"block", "document", "page", "topic"}:
+        if (
+            not isinstance(item.get("source_kind"), str)
+            or re.fullmatch(r"[a-z][a-z0-9_-]{0,31}", item["source_kind"]) is None
+        ):
             raise ValueError(f"queue item source_kind is invalid: {item_id}")
         if not isinstance(item.get("label"), str) or not item["label"].strip():
             raise ValueError(f"queue item label is missing: {item_id}")
-    if counts != EXPECTED_COUNTS:
+    if counts != profile_counts:
         raise ValueError(
-            f"queue jurisdiction counts drifted: expected {EXPECTED_COUNTS}, "
+            f"queue jurisdiction counts drifted: expected {profile_counts}, "
             f"got {counts}"
         )
-    if tuple(item["citation"] for item in items[:4]) != PRIORITY_CITATIONS:
+    priority_citations = profile["priority_citations"]
+    if (
+        priority_citations
+        and tuple(item["citation"] for item in items[: len(priority_citations)])
+        != priority_citations
+    ):
         raise ValueError("queue priority tranche has drifted")
 
 
@@ -931,6 +1311,14 @@ def verify_activation_commit(
     _require_sha(current_base_sha, "current_base_sha")
     _require_sha(current_head_sha, "current_head_sha")
     _require_sha(current_tree_sha, "current_tree_sha")
+    queue = _load_json(queue_path)
+    profile = _queue_profile(queue["queue_id"])
+    activation_changed_files = (
+        profile["activation_path"],
+        "pyproject.toml",
+        "src/axiom_encode/__init__.py",
+        "uv.lock",
+    )
     if not isinstance(provenance, dict):
         raise ValueError("activation commit provenance must be an object")
     expected_fields = {
@@ -948,13 +1336,13 @@ def verify_activation_commit(
         or provenance.get("schema")
         != "axiom-encode/snap-queue-activation-commit/v1"
         or provenance.get("repository") != "TheAxiomFoundation/axiom-encode"
-        or provenance.get("queue_path") != ACTIVATION_CHANGED_FILES[0]
+        or provenance.get("queue_path") != activation_changed_files[0]
         or provenance.get("queue_sha256") != queue_file_sha256(queue_path)
         or provenance.get("base_sha") != current_base_sha
         or provenance.get("head_sha") != current_head_sha
         or provenance.get("tree_sha") != current_tree_sha
-        or provenance.get("changed_files") != list(ACTIVATION_CHANGED_FILES)
-        or current_changed_files != list(ACTIVATION_CHANGED_FILES)
+        or provenance.get("changed_files") != list(activation_changed_files)
+        or current_changed_files != list(activation_changed_files)
     ):
         raise ValueError("activation commit or changed-file inventory does not match")
     if not isinstance(pull_request, dict):
@@ -989,6 +1377,7 @@ def verify_merge_authorization(
 
     queue = _load_json(queue_path)
     validate_queue(queue)
+    profile = _queue_profile(queue["queue_id"])
     if queue["state"] != "active":
         raise ValueError("merge authorization is only valid for an active queue")
     _require_sha(current_head_sha, "current_head_sha")
@@ -1012,8 +1401,7 @@ def verify_merge_authorization(
         or authorization.get("schema")
         != "axiom-encode/snap-queue-merge-authorization/v1"
         or authorization.get("repository") != "TheAxiomFoundation/axiom-encode"
-        or authorization.get("queue_path")
-        != "data/encoding-queues/us-snap-or-ut-2026-07.json"
+        or authorization.get("queue_path") != profile["activation_path"]
         or authorization.get("queue_sha256") != queue_file_sha256(queue_path)
         or authorization.get("merge_workflow_run_attempt") != 1
     ):
@@ -1986,6 +2374,19 @@ def main() -> None:
     build.add_argument("--state", choices=("active", "paused"), required=True)
     build.add_argument("--pause-reason")
 
+    build_all = subparsers.add_parser("build-snap-all-states")
+    build_all.add_argument("corpus_root", type=Path)
+    build_all.add_argument("rulespec_root", type=Path)
+    build_all.add_argument("--corpus-ref", required=True)
+    build_all.add_argument("--rulespec-ref", required=True)
+    build_all.add_argument("--rules-engine-ref", required=True)
+    build_all.add_argument("--release-name", required=True)
+    build_all.add_argument("--release-content-sha256", required=True)
+    build_all.add_argument("--release-object", type=Path, required=True)
+    build_all.add_argument("--release-public-key", type=Path, required=True)
+    build_all.add_argument("--state", choices=("active", "paused"), required=True)
+    build_all.add_argument("--pause-reason")
+
     validate = subparsers.add_parser("validate")
     validate.add_argument("queue", type=Path)
 
@@ -2098,6 +2499,22 @@ def main() -> None:
         if args.command == "build-snap":
             _write_json(
                 build_snap_queue(
+                    args.corpus_root,
+                    args.rulespec_root,
+                    corpus_ref=args.corpus_ref,
+                    rulespec_ref=args.rulespec_ref,
+                    rules_engine_ref=args.rules_engine_ref,
+                    release_name=args.release_name,
+                    release_content_sha256=args.release_content_sha256,
+                    release_object_path=args.release_object,
+                    release_public_key_path=args.release_public_key,
+                    state=args.state,
+                    pause_reason=args.pause_reason,
+                )
+            )
+        elif args.command == "build-snap-all-states":
+            _write_json(
+                build_all_state_snap_queue(
                     args.corpus_root,
                     args.rulespec_root,
                     corpus_ref=args.corpus_ref,

--- a/tests/test_all_state_snap_queue.py
+++ b/tests/test_all_state_snap_queue.py
@@ -1,0 +1,464 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+import scripts.prepare_signed_queue as signed_queue
+from scripts.prepare_signed_queue import (
+    ALL_STATE_EXPECTED_COUNTS,
+    ALL_STATE_INVENTORY_PATH,
+    ALL_STATE_INVENTORY_SHA256,
+    ALL_STATE_QUEUE_ID,
+    _logical_source_units,
+    _queue_profile,
+    build_all_state_snap_queue,
+    validate_queue,
+    verify_activation_commit,
+    verify_merge_authorization,
+)
+
+ROOT = Path(__file__).parents[1]
+
+
+def _all_state_queue() -> dict:
+    items = []
+    sequence = 0
+    for jurisdiction, count in ALL_STATE_EXPECTED_COUNTS.items():
+        if jurisdiction == "total":
+            continue
+        for index in range(1, count + 1):
+            sequence += 1
+            items.append(
+                {
+                    "attempt": 1,
+                    "citation": (f"{jurisdiction}/manual/snap/source-{index:05d}"),
+                    "id": f"{jurisdiction[3:]}-{index:05d}",
+                    "jurisdiction": jurisdiction,
+                    "label": f"{jurisdiction} source {index}",
+                    "sequence": sequence,
+                    "source_kind": "document",
+                    "status": "pending",
+                }
+            )
+    return {
+        "schema": "axiom-encode/signed-encoding-queue/v1",
+        "queue_id": ALL_STATE_QUEUE_ID,
+        "state": "paused",
+        "pause_reason": "Awaiting protected activation.",
+        "description": "Test all-state queue.",
+        "issue": 1287,
+        "supersedes": ["us-snap-or-ut-2026-07"],
+        "inventory": {
+            "jurisdictions": 51,
+            "path": ALL_STATE_INVENTORY_PATH,
+            "sha256": ALL_STATE_INVENTORY_SHA256,
+        },
+        "release": {
+            "content_sha256": "a" * 64,
+            "manifest_sha256": "b" * 64,
+            "name": "test-all-state-snap-release",
+        },
+        "dispatch": {
+            "corpus_ref": "a" * 40,
+            "country": "us",
+            "max_batch_size": 4,
+            "open_pr": True,
+            "pr_base_branch": "hard-cut/canonical-layout-us",
+            "rules_engine_ref": "b" * 40,
+            "rulespec_ref": "c" * 40,
+        },
+        "expected_counts": ALL_STATE_EXPECTED_COUNTS,
+        "items": items,
+    }
+
+
+def test_all_state_profile_covers_50_states_and_dc() -> None:
+    profile = _queue_profile(ALL_STATE_QUEUE_ID)
+    jurisdictions = set(profile["expected_counts"]) - {"total"}
+
+    assert len(jurisdictions) == 51
+    assert profile["expected_counts"]["total"] == sum(
+        profile["expected_counts"][jurisdiction] for jurisdiction in jurisdictions
+    )
+    assert profile["issue"] == 1287
+    assert profile["item_width"] == 5
+
+
+def test_all_state_queue_accepts_five_digit_state_items() -> None:
+    validate_queue(_all_state_queue())
+
+
+def test_all_state_builder_is_deterministic_and_resolves_ma_alias(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    corpus_root = tmp_path / "corpus"
+    rulespec_root = tmp_path / "rulespec"
+    rulespec_root.mkdir()
+    jurisdictions = sorted(set(ALL_STATE_EXPECTED_COUNTS) - {"total"})
+    expected_counts = {
+        "total": len(jurisdictions),
+        **dict.fromkeys(jurisdictions, 1),
+    }
+    monkeypatch.setattr(
+        signed_queue,
+        "ALL_STATE_EXPECTED_COUNTS",
+        expected_counts,
+    )
+
+    states = []
+    release_scopes = []
+    expected_paths = []
+    for jurisdiction in jurisdictions:
+        inventory_version = f"test-{jurisdiction}-snap"
+        release_version = inventory_version
+        if jurisdiction == "us-ma":
+            inventory_version = "2026-07-17-ma-dta-snap-regulations"
+            release_version = "2026-07-24-ma-dta-regulations-snap-current-union"
+        states.append(
+            {
+                "jurisdiction": jurisdiction,
+                "queue_status": "published_current",
+                "target_scope": {
+                    "jurisdiction": jurisdiction,
+                    "document_class": "regulation",
+                    "version": inventory_version,
+                },
+            }
+        )
+        release_scopes.append(
+            {
+                "jurisdiction": jurisdiction,
+                "document_class": "regulation",
+                "version": release_version,
+            }
+        )
+        source_path = (
+            corpus_root
+            / "data/corpus/provisions"
+            / jurisdiction
+            / "regulation"
+            / f"{release_version}.jsonl"
+        )
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        source_path.write_text(
+            json.dumps(
+                {
+                    "citation_label": f"{jurisdiction} SNAP",
+                    "citation_path": f"{jurisdiction}/regulation/snap",
+                    "kind": "document",
+                    "ordinal": 1,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        expected_paths.append(source_path)
+
+    inventory_path = corpus_root / ALL_STATE_INVENTORY_PATH
+    inventory_path.parent.mkdir(parents=True)
+    inventory_path.write_text(
+        yaml.safe_dump({"program": "SNAP", "states": states}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        signed_queue,
+        "ALL_STATE_INVENTORY_SHA256",
+        hashlib.sha256(inventory_path.read_bytes()).hexdigest(),
+    )
+    release_name = "test-all-state-snap-release"
+    release_path = corpus_root / "manifests/releases" / f"{release_name}.json"
+    release_path.parent.mkdir(parents=True)
+    release_path.write_text(
+        json.dumps({"scopes": release_scopes}),
+        encoding="utf-8",
+    )
+
+    verified_paths = []
+    monkeypatch.setattr(
+        signed_queue,
+        "_verify_corpus_provenance",
+        lambda *args, **kwargs: "d" * 64,
+    )
+
+    def record_signed_binding(*args: object, **kwargs: object) -> None:
+        verified_paths.extend(kwargs["source_paths"])
+
+    monkeypatch.setattr(
+        signed_queue,
+        "_verify_signed_release_binding",
+        record_signed_binding,
+    )
+    arguments = {
+        "corpus_ref": "a" * 40,
+        "rulespec_ref": "b" * 40,
+        "rules_engine_ref": "c" * 40,
+        "release_name": release_name,
+        "release_content_sha256": "e" * 64,
+        "release_object_path": tmp_path / "release-object.json",
+        "release_public_key_path": tmp_path / "release-public-key",
+        "state": "paused",
+        "pause_reason": "Awaiting protected activation.",
+    }
+
+    first = build_all_state_snap_queue(
+        corpus_root,
+        rulespec_root,
+        **arguments,
+    )
+    second = build_all_state_snap_queue(
+        corpus_root,
+        rulespec_root,
+        **arguments,
+    )
+
+    assert first == second
+    assert len(first["items"]) == 51
+    assert first["items"][0]["id"] == "ak-00001"
+    assert first["items"][-1]["id"] == "wy-00001"
+    assert set(verified_paths) == set(expected_paths)
+    assert any(
+        path.name == "2026-07-24-ma-dta-regulations-snap-current-union.jsonl"
+        for path in verified_paths
+    )
+
+
+def test_logical_source_units_prefer_document_topics() -> None:
+    records = [
+        {
+            "citation_path": "us-ut/manual/topic-a",
+            "citation_label": "Topic A",
+            "kind": "document",
+            "ordinal": 1,
+        },
+        {
+            "citation_path": "us-ut/manual/topic-a/block-1",
+            "citation_label": "Topic A block",
+            "kind": "block",
+            "ordinal": 2,
+        },
+        {
+            "citation_path": "us-ut/manual/topic-b",
+            "citation_label": "Topic B",
+            "kind": "document",
+            "ordinal": 3,
+        },
+    ]
+
+    assert [record["citation_path"] for record in _logical_source_units(records)] == [
+        "us-ut/manual/topic-a",
+        "us-ut/manual/topic-b",
+    ]
+
+
+def test_logical_source_units_select_rules_from_code_hierarchy() -> None:
+    records = [
+        {
+            "citation_path": "us-oh/regulation",
+            "citation_label": "Collection",
+            "kind": "collection",
+            "ordinal": 1,
+        },
+        {
+            "citation_path": "us-oh/regulation/chapter-1",
+            "citation_label": "Chapter",
+            "kind": "chapter",
+            "ordinal": 2,
+        },
+        {
+            "citation_path": "us-oh/regulation/chapter-1/rule-1",
+            "citation_label": "Rule",
+            "kind": "rule",
+            "ordinal": 3,
+        },
+    ]
+
+    assert [record["citation_path"] for record in _logical_source_units(records)] == [
+        "us-oh/regulation/chapter-1/rule-1"
+    ]
+
+
+def test_logical_source_units_fall_back_from_unsafe_section_citations() -> None:
+    records = [
+        {
+            "citation_path": "us-nh/regulation/he-w-700",
+            "citation_label": "He-W 700",
+            "kind": "document",
+            "ordinal": 1,
+        },
+        {
+            "citation_path": "us-nh/regulation/he-w-700/He-W 701.01",
+            "citation_label": "He-W 701.01",
+            "kind": "section",
+            "ordinal": 2,
+        },
+    ]
+
+    assert [record["citation_path"] for record in _logical_source_units(records)] == [
+        "us-nh/regulation/he-w-700"
+    ]
+
+
+def test_protected_workflows_route_the_selected_queue_id() -> None:
+    for filename in (
+        "dispatch-signed-snap-queue.yml",
+        "finalize-signed-snap-queue.yml",
+        "merge-snap-queue-activation.yml",
+    ):
+        workflow = (ROOT / ".github/workflows" / filename).read_text(encoding="utf-8")
+        assert "us-snap-all-states-2026-07" in workflow
+        assert 'queue="data/encoding-queues/${QUEUE_ID}.json"' in workflow
+
+
+def test_protected_workflows_enforce_one_way_all_state_cutover() -> None:
+    validation = (
+        ROOT / ".github/workflows/validate-snap-queue-activation.yml"
+    ).read_text(encoding="utf-8")
+    finalizer = (ROOT / ".github/workflows/finalize-signed-snap-queue.yml").read_text(
+        encoding="utf-8"
+    )
+    merger = (ROOT / ".github/workflows/merge-snap-queue-activation.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "'data/encoding-queues/us-snap-*.json'" not in validation
+    assert "QUEUE_PATH: ${{ steps.transition.outputs.queue_path }}" in validation
+    assert '"${{ steps.transition.outputs.queue_path }}"' not in validation
+    for workflow in (validation, finalizer, merger):
+        assert "legacy SNAP queue is permanently superseded" in workflow
+
+
+def test_all_state_activation_and_merge_authorization_bind_queue_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queue_path = tmp_path / f"{ALL_STATE_QUEUE_ID}.json"
+    queue_path.write_text(
+        json.dumps({"queue_id": ALL_STATE_QUEUE_ID, "state": "active"}) + "\n",
+        encoding="utf-8",
+    )
+    queue_sha = hashlib.sha256(queue_path.read_bytes()).hexdigest()
+    activation_path = f"data/encoding-queues/{ALL_STATE_QUEUE_ID}.json"
+    changed_files = [
+        activation_path,
+        "pyproject.toml",
+        "src/axiom_encode/__init__.py",
+        "uv.lock",
+    ]
+    provenance = {
+        "base_sha": "a" * 40,
+        "changed_files": changed_files,
+        "head_sha": "b" * 40,
+        "queue_path": activation_path,
+        "queue_sha256": queue_sha,
+        "repository": "TheAxiomFoundation/axiom-encode",
+        "schema": "axiom-encode/snap-queue-activation-commit/v1",
+        "tree_sha": "c" * 40,
+    }
+    pull_request = {
+        "state": "open",
+        "base": {"ref": "main", "sha": "a" * 40},
+        "head": {
+            "sha": "b" * 40,
+            "repo": {"full_name": "TheAxiomFoundation/axiom-encode"},
+        },
+    }
+    verify_activation_commit(
+        queue_path,
+        provenance=provenance,
+        pull_request=pull_request,
+        current_base_sha="a" * 40,
+        current_head_sha="b" * 40,
+        current_tree_sha="c" * 40,
+        current_changed_files=changed_files,
+    )
+
+    monkeypatch.setattr(signed_queue, "validate_queue", lambda payload: None)
+    run_id = 123
+    run_url = (
+        f"https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/{run_id}"
+    )
+    authorization = {
+        "activation_pr_head_sha": "b" * 40,
+        "activation_pr_number": 17,
+        "merge_commit": "d" * 40,
+        "merge_workflow_run_id": run_id,
+        "merge_workflow_run_attempt": 1,
+        "merge_workflow_run_url": run_url,
+        "queue_path": activation_path,
+        "queue_sha256": queue_sha,
+        "repository": "TheAxiomFoundation/axiom-encode",
+        "schema": "axiom-encode/snap-queue-merge-authorization/v1",
+    }
+    merge_run = {
+        "event": "workflow_dispatch",
+        "head_branch": "main",
+        "html_url": run_url,
+        "path": ".github/workflows/merge-snap-queue-activation.yml",
+        "run_attempt": 1,
+        "status": "completed",
+        "conclusion": "success",
+    }
+    merge_jobs = {
+        "jobs": [
+            {
+                "name": "Merge reviewed SNAP queue activation",
+                "run_attempt": 1,
+                "status": "completed",
+                "conclusion": "success",
+            }
+        ]
+    }
+    merged_pull_request = {
+        "number": 17,
+        "state": "closed",
+        "merged_at": "2026-07-26T00:00:00Z",
+        "merge_commit_sha": "d" * 40,
+        "base": {"ref": "main"},
+        "head": {
+            "sha": "b" * 40,
+            "repo": {"full_name": "TheAxiomFoundation/axiom-encode"},
+        },
+        "merged_by": {"login": "github-actions[bot]"},
+    }
+    verify_merge_authorization(
+        queue_path,
+        authorization=authorization,
+        merge_run=merge_run,
+        merge_jobs=merge_jobs,
+        pull_request=merged_pull_request,
+        current_head_sha="e" * 40,
+        queue_change_sha="d" * 40,
+    )
+
+    tampered = copy.deepcopy(authorization)
+    tampered["queue_path"] = "data/encoding-queues/us-snap-or-ut-2026-07.json"
+    with pytest.raises(
+        ValueError,
+        match="merge authorization does not match",
+    ):
+        verify_merge_authorization(
+            queue_path,
+            authorization=tampered,
+            merge_run=merge_run,
+            merge_jobs=merge_jobs,
+            pull_request=merged_pull_request,
+            current_head_sha="e" * 40,
+            queue_change_sha="d" * 40,
+        )
+
+
+def test_all_state_preparation_uses_authenticated_release_builder() -> None:
+    workflow = (ROOT / ".github/workflows/prepare-all-state-snap-queue.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "build-snap-all-states" in workflow
+    assert "AXIOM_CORPUS_RELEASE_PUBLIC_KEY" in workflow
+    assert "NEXT_PUBLIC_SUPABASE_ANON_KEY" in workflow
+    assert "--state paused" in workflow

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2340,7 +2340,12 @@ def test_snap_queue_activation_checks_and_merge_revalidate_live_state() -> None:
         in provenance["env"]["CORPUS_RELEASE_PUBLIC_KEY"]
     )
     assert "release_objects?select=release_object" in provenance_command
-    assert "build-snap initial-axiom-corpus initial-rulespec-us" in provenance_command
+    assert "build_command=build-snap-all-states" in provenance_command
+    assert "build_command=build-snap" in provenance_command
+    assert '"$build_command" initial-axiom-corpus initial-rulespec-us' in (
+        provenance_command
+    )
+    assert "unsupported initial SNAP queue" in provenance_command
     assert "--state paused" in provenance_command
     assert "cmp --silent" in provenance_command
 


### PR DESCRIPTION
Closes #1287.

## Summary
- derives a durable 17,784-item SNAP queue for all 50 states and DC from the pinned signed corpus inventory
- generalizes protected dispatch, activation, finalization, and merge workflows to select the legacy OR/UT or all-state queue
- adds one-way supersession so the all-state queue cannot race or regress to legacy OR/UT dispatch
- adds a protected main-only workflow that authenticates the signed corpus release and opens the generated queue as a paused draft PR

## Trust pins
- corpus: `0fd35bfbda98836c406ec539a492c4e661c6695d`
- release: `us-rulespec-2026-07-24-snap-cms-pit-union` / `cb275c76c4f07f8ad37470a32296bb1763e5db853d152697524ab07021b6d544`
- RuleSpec: `8f224620540f9e285428ec839d094835396f7d99`
- rules engine: `05eac9d2f89dabe5c6673176260762cef3a58f47`
- source inventory SHA-256: `23b32cef7957d56b171abe51ed63de6cf22c6c29475ba7a2190b3da4692422b6`

## Review cycle
- independent cycle 1 found unsafe PR-controlled queue path interpolation, incomplete supersession enforcement, and missing behavioral coverage
- all findings fixed with exact path allowlisting/env transport, one-way validation/finalization/merge guards, and builder/authorization tests
- independent cycle 2 found no actionable correctness, security, or test findings

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest` (`5364 passed, 119 skipped`)
- focused signed SNAP suite (`73 passed, 51 skipped`)
- `git diff --check`