### PR TITLE
Add opt-in require-complete-source-unit mode (full-provision encoding gate)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1383"
+version = "0.2.1384"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1383"
+__version__ = "0.2.1384"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -47918,6 +47918,7 @@ def _cmd_eval_suite_revalidate_with_signer(args, evidence_signing_key):
             source_metadata=source_metadata,
             source_citation_path=source_citation_path,
             rulespec_dependency_roots=manifest.rulespec_dependency_roots,
+            require_complete_source_unit=case.require_complete_source_unit,
         )
         validation_error = _eval_artifact_validation_error(
             result.metrics,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -623,6 +623,18 @@ def _add_rulespec_dependency_root_argument(parser: argparse.ArgumentParser) -> N
     )
 
 
+def _add_complete_source_unit_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--require-complete-source-unit",
+        action="store_true",
+        default=False,
+        help=(
+            "Require complete encoding or precise typed deferral of the "
+            "authoritative corpus source unit (default: off)"
+        ),
+    )
+
+
 def _add_policyengine_runtime_root_argument(
     parser: argparse.ArgumentParser,
 ) -> None:
@@ -904,6 +916,7 @@ def main():
         action="store_true",
         help="Fail oracle validation when oracle coverage reports unclassified legal IDs",
     )
+    _add_complete_source_unit_argument(validate_parser)
     _add_rulespec_dependency_root_argument(validate_parser)
 
     validation_waivers_parser = subparsers.add_parser(
@@ -1989,6 +2002,7 @@ def main():
             "re-encoded in the same change set before final repository validation."
         ),
     )
+    _add_complete_source_unit_argument(encode_parser)
     _add_rulespec_dependency_root_argument(encode_parser)
 
     # eval command - run deterministic model comparisons on one or more citations
@@ -2046,6 +2060,7 @@ def main():
         action="store_true",
         help="Emit machine-readable JSON summary",
     )
+    _add_complete_source_unit_argument(eval_parser)
     _add_rulespec_dependency_root_argument(eval_parser)
 
     eval_source_parser = subparsers.add_parser(
@@ -2112,6 +2127,7 @@ def main():
         default=None,
         help="Canonical rule name to use as the PolicyEngine oracle target for this source slice",
     )
+    _add_complete_source_unit_argument(eval_source_parser)
     _add_rulespec_dependency_root_argument(eval_source_parser)
 
     eval_suite_parser = subparsers.add_parser(
@@ -2669,6 +2685,9 @@ def _cmd_validate_with_resolution_cache(args):
                 policyengine_runtime=policyengine_runtime,
                 local_corpus_release=corpus_release,
                 rulespec_dependency_roots=_rulespec_dependency_roots_from_args(args),
+                require_complete_source_unit=(
+                    getattr(args, "require_complete_source_unit", False) is True
+                ),
             )
             pipelines[roots] = pipeline
             policyengine_runtimes[roots] = policyengine_runtime
@@ -19692,6 +19711,9 @@ def _run_encode_attempt(
             local_corpus_release=corpus_release,
             validate_dependents=validate_dependents,
             rulespec_dependency_roots=rulespec_dependency_roots,
+            require_complete_source_unit=(
+                getattr(args, "require_complete_source_unit", False) is True
+            ),
         )
 
     skip_reviewers = bool(getattr(args, "skip_reviewers", False))
@@ -19713,6 +19735,9 @@ def _run_encode_attempt(
         skip_reviewers=skip_reviewers,
         policyengine_rule_hint=policyengine_rule_hint,
         rulespec_dependency_roots=rulespec_dependency_roots,
+        require_complete_source_unit=(
+            getattr(args, "require_complete_source_unit", False) is True
+        ),
     )
 
     result = results[0]
@@ -42351,6 +42376,7 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
     local_corpus_release: LocalCorpusRelease,
     validate_dependents: bool = True,
     rulespec_dependency_roots: Sequence[Path] = (),
+    require_complete_source_unit: bool = False,
 ) -> tuple[bool, list[str], dict[Path, str]]:
     """Validate generated artifacts in a temporary policy-repo overlay."""
     setattr(result, _APPLY_VALIDATION_SNAPSHOT_ATTR, None)
@@ -42466,6 +42492,7 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
             local_corpus_release=local_corpus_release,
             rulespec_dependency_roots=staged_dependency_roots,
             source_metadata=source_metadata,
+            require_complete_source_unit=require_complete_source_unit,
         )
         dependents = (
             _find_rulespec_dependents(overlay_content_root, relative_output)
@@ -42935,6 +42962,7 @@ def _run_generated_encoding_overlay_validation(
     local_corpus_release: LocalCorpusRelease,
     validate_dependents: bool = True,
     rulespec_dependency_roots: Sequence[Path] = (),
+    require_complete_source_unit: bool = False,
 ) -> tuple[bool, list[str], dict[Path, str]]:
     """Dispatch a release-bound overlay run through the patchable test seam."""
 
@@ -42946,6 +42974,7 @@ def _run_generated_encoding_overlay_validation(
         local_corpus_release=local_corpus_release,
         validate_dependents=validate_dependents,
         rulespec_dependency_roots=rulespec_dependency_roots,
+        require_complete_source_unit=require_complete_source_unit,
     )
 
 
@@ -46667,6 +46696,9 @@ def cmd_eval(args):
         mode=args.mode,
         extra_context_paths=[Path(path) for path in args.allow_context],
         rulespec_dependency_roots=rulespec_dependency_roots,
+        require_complete_source_unit=(
+            getattr(args, "require_complete_source_unit", False) is True
+        ),
     )
 
     if args.json:
@@ -46745,6 +46777,9 @@ def cmd_eval_source(args):
         extra_context_paths=[Path(path) for path in args.allow_context],
         policyengine_rule_hint=args.policyengine_rule_hint,
         rulespec_dependency_roots=rulespec_dependency_roots,
+        require_complete_source_unit=(
+            getattr(args, "require_complete_source_unit", False) is True
+        ),
     )
 
     if args.json:

--- a/src/axiom_encode/harness/backends.py
+++ b/src/axiom_encode/harness/backends.py
@@ -40,6 +40,7 @@ class EncoderRequest:
     corpus_citation_path: str | None = None
     model: str = DEFAULT_CLI_MODEL
     timeout: int = 300
+    require_complete_source_unit: bool = False
 
 
 @dataclass
@@ -153,6 +154,7 @@ class ClaudeCodeBackend(EncoderBackend):
             request.citation,
             str(request.output_path),
             corpus_citation_path=request.corpus_citation_path,
+            require_complete_source_unit=request.require_complete_source_unit,
         )
         prompt += f"\n\nSource Text:\n{request.source_text}\n"
 
@@ -342,6 +344,7 @@ class CodexCLIBackend(EncoderBackend):
             request.citation,
             str(request.output_path),
             corpus_citation_path=request.corpus_citation_path,
+            require_complete_source_unit=request.require_complete_source_unit,
         )
         prompt += f"\n\nSource Text:\n{request.source_text}\n"
 
@@ -558,6 +561,7 @@ class AgentSDKBackend(EncoderBackend):
                 request.citation,
                 str(request.output_path),
                 corpus_citation_path=request.corpus_citation_path,
+                require_complete_source_unit=request.require_complete_source_unit,
             )
             prompt += f"\n\nSource Text:\n{request.source_text}\n"
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -6892,7 +6892,12 @@ def _evaluate_artifact_in_scope(
     if half_up_helper_count:
         semantic_source_occurrence_coverage[5.0] = half_up_helper_count
     source_is_table = _source_text_looks_like_table(
-        numeric_recall_source_text or ""
+        (
+            numeric_recall_source_text
+            if require_complete_source_unit
+            else numeric_grounding_validation_source_text
+        )
+        or ""
     )
     inline_table_formula_occurrences = (
         _inline_table_formula_numeric_occurrences(content)

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -6825,9 +6825,10 @@ def _evaluate_artifact_in_scope(
         if require_complete_source_unit
         else numeric_validation_source_text
     )
-    grounding_module_source_text = (
-        evaluation_source_text or numeric_source_text or ""
-    )
+    # Complete-source recall deliberately inventories the whole authoritative
+    # unit.  Generated-number grounding remains scoped exactly as it is in the
+    # default lane so an unrelated sibling branch cannot legitimize a literal.
+    grounding_module_source_text = source_text or numeric_source_text or ""
     numeric_source_citation_path = source_citation_path
     if numeric_source_citation_path is None:
         with contextlib.suppress(ValueError, TypeError, yaml.YAMLError):
@@ -6838,7 +6839,7 @@ def _evaluate_artifact_in_scope(
                 )
     numeric_profile = _numeric_profile_for_citation_path(numeric_source_citation_path)
     half_up_helper_count = min(
-        source_backed_half_up_rounding_helper_count(content, evaluation_source_text),
+        source_backed_half_up_rounding_helper_count(content, source_text),
         source_backed_half_up_rounding_helper_count(
             content, numeric_validation_source_text or ""
         ),
@@ -6890,7 +6891,9 @@ def _evaluate_artifact_in_scope(
     semantic_source_occurrence_coverage = Counter[float]()
     if half_up_helper_count:
         semantic_source_occurrence_coverage[5.0] = half_up_helper_count
-    source_is_table = _source_text_looks_like_table(numeric_recall_source_text)
+    source_is_table = _source_text_looks_like_table(
+        numeric_recall_source_text or ""
+    )
     inline_table_formula_occurrences = (
         _inline_table_formula_numeric_occurrences(content)
         if source_is_table
@@ -6903,7 +6906,7 @@ def _evaluate_artifact_in_scope(
         module_source_text=grounding_module_source_text,
         module_citation_path=numeric_source_citation_path,
         proof_source_texts=numeric_proof_source_texts,
-        authoritative_source_text=evaluation_source_text,
+        authoritative_source_text=source_text,
         require_body_bound_proof_evidence=False,
     ):
         grounding_metrics.append(
@@ -6951,7 +6954,7 @@ def _evaluate_artifact_in_scope(
     )
     admin_agency_aggregate_issues = find_admin_agency_aggregate_entity_issues(
         content,
-        evaluation_source_text,
+        source_text,
     )
     policyengine_hint_upstream_issues = _policyengine_hint_upstream_composition_issues(
         content,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -6650,6 +6650,44 @@ def evaluate_artifact(
         )
 
 
+def _module_corpus_citation_path(content: str) -> str | None:
+    """Return the artifact's exact corpus source locator, when present."""
+
+    try:
+        payload = yaml.safe_load(content)
+    except (yaml.YAMLError, TypeError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    module = payload.get("module")
+    if not isinstance(module, dict):
+        return None
+    source_verification = module.get("source_verification")
+    if not isinstance(source_verification, dict):
+        return None
+    citation_path = source_verification.get("corpus_citation_path")
+    if not isinstance(citation_path, str) or not citation_path.strip():
+        return None
+    return _corpus_resolver.require_canonical_corpus_citation_path(citation_path)
+
+
+def _complete_source_unit_eval_text(
+    content: str,
+    *,
+    local_corpus_release: _corpus_resolver.LocalCorpusRelease,
+    source_citation_path: str | None,
+) -> str:
+    """Resolve strict eval accounting text from the bound corpus release."""
+
+    citation_path = source_citation_path or _module_corpus_citation_path(content)
+    if citation_path is None:
+        return ""
+    return _corpus_resolver.resolve_local_corpus_source(
+        citation_path,
+        local_corpus_release,
+    ).body
+
+
 def _evaluate_artifact_in_scope(
     rulespec_file: Path,
     policy_repo_root: Path,
@@ -6761,6 +6799,15 @@ def _evaluate_artifact_in_scope(
                 )
 
     content = rulespec_file.read_text()
+    evaluation_source_text = (
+        _complete_source_unit_eval_text(
+            content,
+            local_corpus_release=local_corpus_release,
+            source_citation_path=source_citation_path,
+        )
+        if require_complete_source_unit
+        else source_text
+    )
     numeric_proof_source_texts = pipeline._numeric_source_texts_for_rulespec_content(
         content,
         source_texts=None,
@@ -6774,11 +6821,13 @@ def _evaluate_artifact_in_scope(
     # separately parsed proof evidence below — never in module.summary.
     numeric_validation_source_text = embedded_source or numeric_source_text or ""
     numeric_recall_source_text = (
-        authoritative_numeric_recall_text(source_text)
+        authoritative_numeric_recall_text(evaluation_source_text)
         if require_complete_source_unit
         else numeric_validation_source_text
     )
-    grounding_module_source_text = source_text or numeric_source_text or ""
+    grounding_module_source_text = (
+        evaluation_source_text or numeric_source_text or ""
+    )
     numeric_source_citation_path = source_citation_path
     if numeric_source_citation_path is None:
         with contextlib.suppress(ValueError, TypeError, yaml.YAMLError):
@@ -6789,7 +6838,7 @@ def _evaluate_artifact_in_scope(
                 )
     numeric_profile = _numeric_profile_for_citation_path(numeric_source_citation_path)
     half_up_helper_count = min(
-        source_backed_half_up_rounding_helper_count(content, source_text),
+        source_backed_half_up_rounding_helper_count(content, evaluation_source_text),
         source_backed_half_up_rounding_helper_count(
             content, numeric_validation_source_text or ""
         ),
@@ -6841,7 +6890,7 @@ def _evaluate_artifact_in_scope(
     semantic_source_occurrence_coverage = Counter[float]()
     if half_up_helper_count:
         semantic_source_occurrence_coverage[5.0] = half_up_helper_count
-    source_is_table = _source_text_looks_like_table(numeric_validation_source_text)
+    source_is_table = _source_text_looks_like_table(numeric_recall_source_text)
     inline_table_formula_occurrences = (
         _inline_table_formula_numeric_occurrences(content)
         if source_is_table
@@ -6854,7 +6903,7 @@ def _evaluate_artifact_in_scope(
         module_source_text=grounding_module_source_text,
         module_citation_path=numeric_source_citation_path,
         proof_source_texts=numeric_proof_source_texts,
-        authoritative_source_text=source_text,
+        authoritative_source_text=evaluation_source_text,
         require_body_bound_proof_evidence=False,
     ):
         grounding_metrics.append(
@@ -6902,7 +6951,7 @@ def _evaluate_artifact_in_scope(
     )
     admin_agency_aggregate_issues = find_admin_agency_aggregate_entity_issues(
         content,
-        source_text,
+        evaluation_source_text,
     )
     policyengine_hint_upstream_issues = _policyengine_hint_upstream_composition_issues(
         content,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -1010,12 +1010,12 @@ def _validate_eval_result_artifact_binding(
 
     if not isinstance(payload.get("success"), bool):
         raise ValueError(f"{artifact_name} success must be a boolean")
-    if "require_complete_source_unit" in payload and type(
-        payload["require_complete_source_unit"]
-    ) is not bool:
+    if (
+        "require_complete_source_unit" in payload
+        and type(payload["require_complete_source_unit"]) is not bool
+    ):
         raise ValueError(
-            f"{artifact_name} has invalid boolean field "
-            "'require_complete_source_unit'"
+            f"{artifact_name} has invalid boolean field 'require_complete_source_unit'"
         )
     for field_name in (
         "duration_ms",
@@ -3543,10 +3543,7 @@ def _validate_new_eval_suite_case_results(
                 f"Eval suite case '{case.name}' returned runner '{result.runner}' "
                 f"with mode '{result.mode}' instead of '{case.mode}'"
             )
-        if (
-            result.require_complete_source_unit
-            is not case.require_complete_source_unit
-        ):
+        if result.require_complete_source_unit is not case.require_complete_source_unit:
             raise ValueError(
                 f"Eval suite case '{case.name}' returned runner '{result.runner}' "
                 "with a different complete-source-unit mode"
@@ -3985,10 +3982,7 @@ def _validate_persisted_eval_suite_case_group(
                 "Cannot resume eval suite: suite-results.jsonl row uses a "
                 f"different mode for case '{case.name}' runner '{runner_name}'"
             )
-        if (
-            result.require_complete_source_unit
-            is not case.require_complete_source_unit
-        ):
+        if result.require_complete_source_unit is not case.require_complete_source_unit:
             raise ValueError(
                 "Cannot resume eval suite: suite-results.jsonl row uses a "
                 "different complete-source-unit mode for case "

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -98,6 +98,10 @@ from .policyengine_runtime import (
     PolicyEngineRuntimeError,
 )
 from .pricing import estimate_usage_cost_usd
+from .source_completeness import (
+    authoritative_numeric_recall_text,
+    collect_artifact_numeric_values,
+)
 from .validator_pipeline import (
     NumericOccurrence,
     ValidationResult,
@@ -967,9 +971,12 @@ class EvalResult:
     admission: dict[str, object] | None = None
     verdict_file: str = ""
     verdict_sha256: str | None = None
+    require_complete_source_unit: bool = False
 
     def to_dict(self) -> dict:
         data = asdict(self)
+        if not self.require_complete_source_unit:
+            data.pop("require_complete_source_unit", None)
         if self.metrics is not None:
             data["metrics"] = asdict(self.metrics)
         return _bind_eval_result_payload(data)
@@ -1344,9 +1351,11 @@ def run_model_eval(
     policyengine_rule_hint: str | None = None,
     rulespec_dependency_roots: Sequence[Path] = (),
     review_findings_paths: list[Path] | None = None,
+    require_complete_source_unit: bool = False,
 ) -> list[EvalResult]:
     """Run a deterministic comparison over one or more citations."""
     _validate_eval_oracle_runtime(oracle, policyengine_runtime, policy_path)
+    include_tests = include_tests or require_complete_source_unit
     results: list[EvalResult] = []
     runners = [parse_runner_spec(spec) for spec in runner_specs]
     resolved_sources = [
@@ -1375,6 +1384,7 @@ def run_model_eval(
                         source_unit=source_unit,
                         rulespec_dependency_roots=rulespec_dependency_roots,
                         review_findings_paths=review_findings_paths or [],
+                        require_complete_source_unit=require_complete_source_unit,
                     )
                 )
 
@@ -1396,6 +1406,7 @@ def run_source_eval(
     skip_reviewers: bool = False,
     rulespec_dependency_roots: Sequence[Path] = (),
     review_findings_paths: list[Path] | None = None,
+    require_complete_source_unit: bool = False,
 ) -> list[EvalResult]:
     """Run a deterministic comparison over one corpus-backed source unit."""
     _validate_eval_oracle_runtime(oracle, policyengine_runtime, policy_path)
@@ -1433,6 +1444,7 @@ def run_source_eval(
                     local_corpus_release=local_corpus_release,
                     rulespec_dependency_roots=rulespec_dependency_roots,
                     review_findings_paths=review_findings_paths or [],
+                    require_complete_source_unit=require_complete_source_unit,
                 )
             )
 
@@ -4853,6 +4865,9 @@ def _eval_result_from_payload(
         success=payload["success"],
         error=payload.get("error"),
         generation_prompt_sha256=payload.get("generation_prompt_sha256"),
+        require_complete_source_unit=(
+            payload.get("require_complete_source_unit", False) is True
+        ),
         input_tokens=int(payload.get("input_tokens", 0) or 0),
         output_tokens=int(payload.get("output_tokens", 0) or 0),
         cache_read_tokens=int(payload.get("cache_read_tokens", 0) or 0),
@@ -6601,6 +6616,7 @@ def evaluate_artifact(
     source_metadata: dict[str, object] | None = None,
     source_citation_path: str | None = None,
     rulespec_dependency_roots: Sequence[Path] = (),
+    require_complete_source_unit: bool = False,
 ) -> EvalArtifactMetrics:
     """Evaluate an artifact inside one exact named corpus release."""
 
@@ -6630,6 +6646,7 @@ def evaluate_artifact(
             local_corpus_release=local_corpus_release,
             source_citation_path=source_citation_path,
             rulespec_dependency_roots=rulespec_dependency_roots,
+            require_complete_source_unit=require_complete_source_unit,
         )
 
 
@@ -6646,6 +6663,7 @@ def _evaluate_artifact_in_scope(
     source_metadata: dict[str, object] | None = None,
     source_citation_path: str | None = None,
     rulespec_dependency_roots: Sequence[Path] = (),
+    require_complete_source_unit: bool = False,
 ) -> EvalArtifactMetrics:
     """Evaluate one RuleSpec artifact with deterministic checks plus optional oracles."""
     with _rulespec_validation_target(
@@ -6675,6 +6693,7 @@ def _evaluate_artifact_in_scope(
             source_citation_path=source_citation_path,
             rulespec_dependency_roots=validation_dependency_roots,
             validation_staging_root=validation_staging_root,
+            require_complete_source_unit=require_complete_source_unit,
         )
         compile_result = pipeline._run_compile_check(validation_file)
         ci_result = pipeline._run_ci(validation_file)
@@ -6754,6 +6773,11 @@ def _evaluate_artifact_in_scope(
     # but generated literals are grounded only in authoritative source text and
     # separately parsed proof evidence below — never in module.summary.
     numeric_validation_source_text = embedded_source or numeric_source_text or ""
+    numeric_recall_source_text = (
+        authoritative_numeric_recall_text(source_text)
+        if require_complete_source_unit
+        else numeric_validation_source_text
+    )
     grounding_module_source_text = source_text or numeric_source_text or ""
     numeric_source_citation_path = source_citation_path
     if numeric_source_citation_path is None:
@@ -6771,7 +6795,7 @@ def _evaluate_artifact_in_scope(
         ),
     )
     counted_numeric_source_text = _numeric_occurrence_source_text(
-        numeric_validation_source_text or "",
+        numeric_recall_source_text or "",
         suppress_source_backed_half_up_increment=bool(half_up_helper_count),
     )
     typed_source_numeric_occurrences = (
@@ -6791,15 +6815,29 @@ def _evaluate_artifact_in_scope(
     if _is_empty_nonassertable_artifact(content):
         source_numeric_occurrences = Counter()
         source_occurrences_by_value = defaultdict(list)
-    named_scalar_occurrences = Counter(
-        item.value for item in extract_named_scalar_occurrences(content)
+    imported_named_scalar_occurrences = _imported_named_scalar_occurrences(
+        content,
+        policy_repo_root,
     )
-    named_scalar_occurrences.update(_numeric_concept_name_occurrences(content))
-    named_scalar_occurrences.update(_verification_value_numeric_occurrences(content))
-    named_scalar_occurrences.update(_deferred_output_numeric_occurrences(content))
-    named_scalar_occurrences.update(
-        _imported_named_scalar_occurrences(content, policy_repo_root)
-    )
+    if require_complete_source_unit:
+        named_scalar_occurrences = Counter(
+            collect_artifact_numeric_values(
+                content,
+                extract_named_scalars=extract_named_scalar_occurrences,
+                extract_numeric_occurrences=extract_numeric_occurrences_from_text,
+                additional_values=imported_named_scalar_occurrences,
+            )
+        )
+    else:
+        named_scalar_occurrences = Counter(
+            item.value for item in extract_named_scalar_occurrences(content)
+        )
+        named_scalar_occurrences.update(_numeric_concept_name_occurrences(content))
+        named_scalar_occurrences.update(
+            _verification_value_numeric_occurrences(content)
+        )
+        named_scalar_occurrences.update(_deferred_output_numeric_occurrences(content))
+        named_scalar_occurrences.update(imported_named_scalar_occurrences)
     semantic_source_occurrence_coverage = Counter[float]()
     if half_up_helper_count:
         semantic_source_occurrence_coverage[5.0] = half_up_helper_count
@@ -6945,6 +6983,7 @@ def _evaluate_generated_artifact_with_repairs(
     source_metadata: dict[str, object] | None = None,
     source_citation_path: str | None = None,
     rulespec_dependency_roots: Sequence[Path] = (),
+    require_complete_source_unit: bool = False,
 ) -> EvalArtifactMetrics | None:
     metrics = evaluate_artifact(
         rulespec_file=rulespec_file,
@@ -6959,6 +6998,7 @@ def _evaluate_generated_artifact_with_repairs(
         local_corpus_release=local_corpus_release,
         source_citation_path=source_citation_path,
         rulespec_dependency_roots=rulespec_dependency_roots,
+        require_complete_source_unit=require_complete_source_unit,
     )
     if metrics is None:
         return None
@@ -6984,6 +7024,7 @@ def _evaluate_generated_artifact_with_repairs(
         local_corpus_release=local_corpus_release,
         source_citation_path=source_citation_path,
         rulespec_dependency_roots=rulespec_dependency_roots,
+        require_complete_source_unit=require_complete_source_unit,
     )
 
 
@@ -7663,7 +7704,9 @@ def _run_single_eval(
     source_unit: CorpusSourceUnit | None = None,
     rulespec_dependency_roots: Sequence[Path] = (),
     review_findings_paths: list[Path] | None = None,
+    require_complete_source_unit: bool = False,
 ) -> EvalResult:
+    include_tests = include_tests or require_complete_source_unit
     if source_unit is None:
         source_unit = resolve_corpus_source_unit(citation, corpus_release)
     _validate_corpus_source_unit(
@@ -7718,6 +7761,7 @@ def _run_single_eval(
         include_tests=include_tests,
         runner_backend=runner.backend,
         policyengine_rule_hint=policyengine_rule_hint,
+        require_complete_source_unit=require_complete_source_unit,
     )
     generation_prompt_sha256 = _sha256_text(prompt)
     output_file = _contained_eval_output_file(output_root, runner.name, relative_output)
@@ -7769,6 +7813,7 @@ def _run_single_eval(
                 source_metadata_payload
             ),
             rulespec_dependency_roots=rulespec_dependency_roots,
+            require_complete_source_unit=require_complete_source_unit,
         )
     validation_error = _eval_artifact_validation_error(
         metrics,
@@ -7834,6 +7879,7 @@ def _run_single_eval(
         **outcome,
         retry_count=retry_count,
         source_attestation=_source_metadata_attestation(source_metadata_payload),
+        require_complete_source_unit=require_complete_source_unit,
     )
     emit_eval_result(result, response.trace)
     return result
@@ -7905,6 +7951,7 @@ def _run_single_source_eval(
     skip_reviewers: bool = False,
     rulespec_dependency_roots: Sequence[Path] = (),
     review_findings_paths: list[Path] | None = None,
+    require_complete_source_unit: bool = False,
 ) -> EvalResult:
     """Run one eval on a corpus-backed source unit rather than a USC citation."""
     workspace = prepare_eval_workspace(
@@ -7936,6 +7983,7 @@ def _run_single_source_eval(
         include_tests=True,
         runner_backend=runner.backend,
         policyengine_rule_hint=policyengine_rule_hint,
+        require_complete_source_unit=require_complete_source_unit,
     )
     generation_prompt_sha256 = _sha256_text(prompt)
     output_file = _contained_eval_output_file(output_root, runner.name, relative_output)
@@ -7989,6 +8037,7 @@ def _run_single_source_eval(
                 source_metadata_payload
             ),
             rulespec_dependency_roots=rulespec_dependency_roots,
+            require_complete_source_unit=require_complete_source_unit,
         )
     validation_error = _eval_artifact_validation_error(
         metrics,
@@ -8052,6 +8101,7 @@ def _run_single_source_eval(
         **outcome,
         retry_count=retry_count,
         source_attestation=_source_metadata_attestation(source_metadata_payload),
+        require_complete_source_unit=require_complete_source_unit,
     )
     emit_eval_result(result, response.trace)
     return result
@@ -8574,6 +8624,7 @@ def _build_rulespec_eval_prompt(
     runner_backend: str,
     policyengine_rule_hint: str | None,
     include_corpus_context_injection: bool = True,
+    require_complete_source_unit: bool = False,
 ) -> str:
     """Build the RuleSpec authoring prompt used by current evals."""
     source_text = workspace.source_text_file.read_text()
@@ -9096,6 +9147,30 @@ Preferred principal output:
 """
 
     mandatory_review_findings_section = _format_mandatory_review_findings(workspace)
+    complete_source_unit_section = ""
+    if require_complete_source_unit:
+        complete_source_unit_section = """
+Complete-source-unit mode is enabled for this request:
+- Treat the entire authoritative `./source.txt` body as the completeness
+  inventory. `module.summary` is only a concise reviewer orientation and
+  contributes nothing to completeness accounting.
+- Every explicit computation stated in the source unit must have a principal
+  `kind: derived` or `kind: derived_relation` output. Naming its constants as
+  parameters without encoding the stated formula is invalid.
+- Encode every structural paragraph and list branch, including Absatz markers
+  such as `(1)` and `(2)`, `Abs. 5`, numbered items such as `1.` and `1a.`, and
+  Satz enumerations. If a branch cannot be encoded, use a precise typed
+  deferral that names the exact branch and its missing dependency or citation;
+  never omit it silently. Put the structural branch in the deferred output
+  path (for example, `de:statutes/estg/32a/6#surviving_spouse_tariff`) and list
+  exact missing RuleSpec targets under `blocked_by`.
+- Companion tests must cover every source-stated formula branch, boundary,
+  exception, and rounding rule. When a formula branch cannot be identified
+  from a numeric selector input, add an exact canonical source branch under
+  the executing case's `covers` list (for example,
+  `covers: [de/statute/estg/32a/1/2]`).
+- A genuinely scalar-only source unit may remain parameter-only.
+"""
 
     return f"""You are participating in an encoding eval for {citation}.
 
@@ -9115,7 +9190,7 @@ Primary legal authority:
 {inline_source}
 {source_metadata_section}{provision_metadata_section}{amendment_section}{context_section}{missing_cited_source_section}{mandatory_review_findings_section}
 {backend_section}
-{canonical_concept_section}
+{canonical_concept_section}{complete_source_unit_section}
 RuleSpec requirements:
 - The RuleSpec file must begin with `format: rulespec/v1`.
 - Include `module.summary: |-` with a concise exact audit excerpt, not the full source text when the source is more than a short paragraph. Corpus-backed validation reads the authoritative source from `corpus.provisions`; use the summary only to orient reviewers to the encoded provisions.
@@ -9932,6 +10007,7 @@ def _build_eval_prompt(
     runner_backend: str = "codex",
     policyengine_rule_hint: str | None = None,
     include_corpus_context_injection: bool = True,
+    require_complete_source_unit: bool = False,
 ) -> str:
     """Build a prompt-only eval request with explicit provenance rules."""
     return _build_rulespec_eval_prompt(
@@ -9945,6 +10021,7 @@ def _build_eval_prompt(
         runner_backend=runner_backend,
         policyengine_rule_hint=policyengine_rule_hint,
         include_corpus_context_injection=include_corpus_context_injection,
+        require_complete_source_unit=require_complete_source_unit,
     )
 
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -6890,10 +6890,22 @@ def _evaluate_artifact_in_scope(
                     numeric_payload
                 )
     numeric_profile = _numeric_profile_for_citation_path(numeric_source_citation_path)
+    half_up_recall_source_text = (
+        evaluation_source_text
+        if require_complete_source_unit
+        else numeric_validation_source_text
+    )
+    half_up_authoritative_source_text = (
+        evaluation_source_text if require_complete_source_unit else source_text
+    )
     half_up_helper_count = min(
-        source_backed_half_up_rounding_helper_count(content, source_text),
         source_backed_half_up_rounding_helper_count(
-            content, numeric_validation_source_text or ""
+            content,
+            half_up_authoritative_source_text,
+        ),
+        source_backed_half_up_rounding_helper_count(
+            content,
+            half_up_recall_source_text or "",
         ),
     )
     counted_numeric_source_text = _numeric_occurrence_source_text(

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -6949,7 +6949,7 @@ def _evaluate_artifact_in_scope(
         (
             numeric_recall_source_text
             if require_complete_source_unit
-            else numeric_grounding_validation_source_text
+            else numeric_validation_source_text
         )
         or ""
     )

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -6926,8 +6926,10 @@ def _evaluate_artifact_in_scope(
             collect_artifact_numeric_values(
                 content,
                 extract_named_scalars=extract_named_scalar_occurrences,
-                extract_numeric_occurrences=extract_numeric_occurrences_from_text,
-                additional_values=imported_named_scalar_occurrences,
+                additional_values=_strict_imported_named_scalar_occurrences(
+                    content,
+                    policy_repo_root,
+                ),
             )
         )
     else:
@@ -7324,6 +7326,29 @@ def _imported_named_scalar_occurrences(
                     for item in extract_named_scalar_occurrences(imported_content)
                 )
                 occurrences.update(_numeric_concept_name_occurrences(imported_content))
+            break
+    return occurrences
+
+
+def _strict_imported_named_scalar_occurrences(
+    content: str,
+    policy_repo_root: Path,
+) -> Counter[float]:
+    """Count only direct scalar definitions for explicitly imported symbols."""
+
+    occurrences: Counter[float] = Counter()
+    for import_target in _extract_import_targets(content):
+        if "#" not in import_target:
+            continue
+        imported_symbol = import_target.rsplit("#", 1)[1]
+        for path in _candidate_import_rule_files(import_target, policy_repo_root):
+            with contextlib.suppress(OSError):
+                imported_content = path.read_text()
+                occurrences.update(
+                    item.value
+                    for item in extract_named_scalar_occurrences(imported_content)
+                    if item.name.split("[", 1)[0] == imported_symbol
+                )
             break
     return occurrences
 
@@ -9273,11 +9298,10 @@ Complete-source-unit mode is enabled for this request:
   never omit it silently. Put the structural branch in the deferred output
   path (for example, `de:statutes/estg/32a/6#surviving_spouse_tariff`) and list
   exact missing RuleSpec targets under `blocked_by`.
-- Companion tests must cover every source-stated formula branch, boundary,
-  exception, and rounding rule. When a formula branch cannot be identified
-  from a numeric selector input, add an exact canonical source branch under
-  the executing case's `covers` list (for example,
-  `covers: [de/statute/estg/32a/1/2]`).
+- Companion tests must execute every source-stated formula branch, boundary,
+  exception, and rounding rule with assertions on the affected principal
+  output. Each branch needs distinct runtime evidence; descriptive test
+  metadata is not coverage evidence.
 - A genuinely scalar-only source unit may remain parameter-only.
 """
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -9308,8 +9308,10 @@ Complete-source-unit mode is enabled for this request:
   Satz enumerations. If a branch cannot be encoded, use a precise typed
   deferral that names the exact branch and its missing dependency or citation;
   never omit it silently. Put the structural branch in the deferred output
-  path (for example, `de:statutes/estg/32a/6#surviving_spouse_tariff`) and list
-  exact missing RuleSpec targets under `blocked_by`.
+  path (for example, `de:statutes/estg/32a/6#surviving_spouse_tariff`). Include
+  `blocked_by` only for known exact RuleSpec targets with a `#rule_fragment`;
+  otherwise omit `blocked_by` and name the exact missing legal dependency or
+  citation in `reason`. Never guess a blocker target.
 - Companion tests must execute every source-stated formula branch, boundary,
   exception, and rounding rule with assertions on the affected principal
   output. Each branch needs distinct runtime evidence; descriptive test

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -1010,6 +1010,13 @@ def _validate_eval_result_artifact_binding(
 
     if not isinstance(payload.get("success"), bool):
         raise ValueError(f"{artifact_name} success must be a boolean")
+    if "require_complete_source_unit" in payload and type(
+        payload["require_complete_source_unit"]
+    ) is not bool:
+        raise ValueError(
+            f"{artifact_name} has invalid boolean field "
+            "'require_complete_source_unit'"
+        )
     for field_name in (
         "duration_ms",
         "input_tokens",
@@ -1226,6 +1233,7 @@ class EvalSuiteCase:
     corpus_citation_path: str | None = None
     policyengine_rule_hint: str | None = None
     oracle: EvalOracleMode = "none"
+    require_complete_source_unit: bool = False
 
 
 @dataclass
@@ -2076,6 +2084,7 @@ _EVAL_SUITE_CASE_KEYS = frozenset(
         "corpus_citation_path",
         "policyengine_rule_hint",
         "oracle",
+        "require_complete_source_unit",
         "source_id",
         "source_file",
         "metadata_file",
@@ -2309,6 +2318,15 @@ def load_eval_suite_manifest(path: Path) -> EvalSuiteManifest:
                     f"Eval suite case #{index} field '{field_name}' must be a "
                     "canonical nonempty string"
                 )
+        require_complete_source_unit = item.get(
+            "require_complete_source_unit",
+            False,
+        )
+        if type(require_complete_source_unit) is not bool:
+            raise ValueError(
+                f"Eval suite case #{index} field "
+                "'require_complete_source_unit' must be a boolean"
+            )
         case = EvalSuiteCase(
             kind=kind,
             name=name,
@@ -2328,6 +2346,7 @@ def load_eval_suite_manifest(path: Path) -> EvalSuiteManifest:
                 else None
             ),
             oracle=item.get("oracle", "none"),
+            require_complete_source_unit=require_complete_source_unit,
         )
         _validate_eval_suite_case(case, index)
         cases.append(case)
@@ -2561,6 +2580,9 @@ def _run_eval_suite_with_signer(
                                     rulespec_dependency_roots=(
                                         manifest.rulespec_dependency_roots
                                     ),
+                                    require_complete_source_unit=(
+                                        case.require_complete_source_unit
+                                    ),
                                 )
                             elif case.kind == "source":
                                 if (
@@ -2583,6 +2605,9 @@ def _run_eval_suite_with_signer(
                                     policyengine_rule_hint=case.policyengine_rule_hint,
                                     rulespec_dependency_roots=(
                                         manifest.rulespec_dependency_roots
+                                    ),
+                                    require_complete_source_unit=(
+                                        case.require_complete_source_unit
                                     ),
                                 )
                             else:
@@ -2945,7 +2970,7 @@ def _validate_signed_eval_result_verdict_evidence(
 def _canonical_eval_suite_case_payload(case: EvalSuiteCase) -> dict[str, object]:
     """Return every case field that can affect generation or validation."""
 
-    return {
+    payload: dict[str, object] = {
         "kind": case.kind,
         "name": case.name,
         "mode": case.mode,
@@ -2955,6 +2980,9 @@ def _canonical_eval_suite_case_payload(case: EvalSuiteCase) -> dict[str, object]
         "policyengine_rule_hint": case.policyengine_rule_hint,
         "oracle": case.oracle,
     }
+    if case.require_complete_source_unit:
+        payload["require_complete_source_unit"] = True
+    return payload
 
 
 def _eval_suite_case_identities(
@@ -3515,6 +3543,14 @@ def _validate_new_eval_suite_case_results(
                 f"Eval suite case '{case.name}' returned runner '{result.runner}' "
                 f"with mode '{result.mode}' instead of '{case.mode}'"
             )
+        if (
+            result.require_complete_source_unit
+            is not case.require_complete_source_unit
+        ):
+            raise ValueError(
+                f"Eval suite case '{case.name}' returned runner '{result.runner}' "
+                "with a different complete-source-unit mode"
+            )
         if result.citation != expected_citation:
             raise ValueError(
                 f"Eval suite case '{case.name}' returned citation "
@@ -3949,6 +3985,15 @@ def _validate_persisted_eval_suite_case_group(
                 "Cannot resume eval suite: suite-results.jsonl row uses a "
                 f"different mode for case '{case.name}' runner '{runner_name}'"
             )
+        if (
+            result.require_complete_source_unit
+            is not case.require_complete_source_unit
+        ):
+            raise ValueError(
+                "Cannot resume eval suite: suite-results.jsonl row uses a "
+                "different complete-source-unit mode for case "
+                f"'{case.name}' runner '{runner_name}'"
+            )
         _validate_eval_result_artifacts(
             result,
             output_root,
@@ -4049,6 +4094,7 @@ def _revalidate_persisted_eval_suite_case_results(
                 source_metadata=source_metadata,
                 source_citation_path=source_citation_path,
                 rulespec_dependency_roots=rulespec_dependency_roots,
+                require_complete_source_unit=case.require_complete_source_unit,
             )
         fresh_success = bool(
             fresh_metrics is not None
@@ -4951,6 +4997,7 @@ def _suite_case_failure_results(
             source_attestation=(
                 dict(source_attestation) if source_attestation is not None else None
             ),
+            require_complete_source_unit=case.require_complete_source_unit,
         )
         for runner in runners
     ]
@@ -5245,6 +5292,11 @@ def _resolve_manifest_path(base_dir: Path, value: object) -> Path:
 
 def _validate_eval_suite_case(case: EvalSuiteCase, index: int) -> None:
     """Validate one suite case after parsing."""
+    if type(case.require_complete_source_unit) is not bool:
+        raise ValueError(
+            f"Eval suite case #{index} field "
+            "'require_complete_source_unit' must be a boolean"
+        )
     if case.oracle not in {"none", "policyengine"}:
         raise ValueError(
             f"Eval suite case #{index} has unsupported oracle '{case.oracle}'"

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -160,10 +160,19 @@ _COMPUTATION_LANGUAGE = re.compile(
     r"geteilt\s+durch|durch\s+(?:\d+|[a-zäöüß]+)\s+geteilt|"
     r"multipliziert\s+mit|"
     r"mit\s+(?:(?:dem|einem)\s+faktor\s+)?"
+    r"(?:von\s+)?"
     r"(?:\d+(?:[.,]\d+)?|[a-zäöüß]+)\s+zu\s+"
     r"(?:multiplizieren|vervielfachen)|"
+    r"durch\s+multiplikation\s+mit\s+"
+    r"(?:(?:(?:dem|einem)\s+)?faktor\s+)?(?:von\s+)?"
+    r"(?:\d+(?:[.,]\d+)?|[a-zäöüß]+)\s+zu\s+ermitteln|"
     r"unter\s+anwendung\s+(?:des|eines)\s+faktors?\s+"
     r"(?:\d+(?:[.,]\d+)?|[a-zäöüß]+)\s+zu\s+ermitteln|"
+    r"(?:ist|sind)\s+zu\s+(?:verdoppeln|verdreifachen|vervierfachen)|"
+    r"durch\s+(?:\d+(?:[.,]\d+)?|[a-zäöüß]+)\s+zu\s+teilen|"
+    r"um\s+(?:\d+(?:[.,]\d+)?|[a-zäöüß]+)\s+zu\s+"
+    r"(?:erhöhen|vermindern|kürzen|vermehren)|"
+    r"aus\s+[^.;]{1,100}\s+zu\s+(?:summieren|addieren)|"
     r"\bmal\s+(?:\d+(?:[.,]\d+)?|"
     r"ein(?:s|e[nsrm]?)?|zwei|drei|vier|fünf|sechs|sieben|acht|neun|zehn)|"
     r"(?:wird|werden)\s+(?:verdoppelt|verdreifacht|vervierfacht)|"
@@ -1977,11 +1986,13 @@ def _formula_operation_kinds(text: str) -> set[str]:
     operation_patterns = {
         "add": (
             r"(?:\+|\bsumme\b|\bsum\s+of\b|\bzuzüglich\b|"
+            r"\b(?:summieren|addieren)\b|"
             r"\berhöh\w*\s+(?:sich\s+)?um\b)"
         ),
         "subtract": (
             r"(?:\s[−–-]\s|\bunterschied\b|\bdifferenz\b|"
             r"\bdifference\s+between\b|\babzüglich\b|"
+            r"\b(?:vermindern|kürzen)\b|"
             r"\b(?:vermindert|gekürzt|mindert|kürzt)\w*\s+"
             r"(?:sich\s+)?um\b)"
         ),
@@ -1992,7 +2003,8 @@ def _formula_operation_kinds(text: str) -> set[str]:
             r"\b(?:doppelte|zweifache|dreifache|twice)\b)"
         ),
         "divide": (
-            r"(?:/|\bgeteilt\b|\bdivided\b|\bhälfte\b|\bhalf\s+of\b)"
+            r"(?:/|\bgeteilt\b|\bteilen\b|\bdivided\b|"
+            r"\bhälfte\b|\bhalf\s+of\b)"
         ),
     }
     operations.update(
@@ -2070,7 +2082,11 @@ def _source_describes_doubling(text: str) -> bool:
 
 def _source_named_multiplier(text: str) -> float | None:
     patterns = (
-        (2.0, r"\b(?:doppelte|zweifache|verdoppelt|twice|double[ds]?)\b"),
+        (
+            2.0,
+            r"\b(?:doppelte|zweifache|verdoppelt|verdoppeln|"
+            r"twice|double[ds]?)\b",
+        ),
         (3.0, r"\b(?:dreifache|verdreifacht|threefold|triple[ds]?)\b"),
         (4.0, r"\b(?:vierfache|vervierfacht|fourfold|quadruple[ds]?)\b"),
         (5.0, r"\b(?:fünffache|fivefold)\b"),

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -237,7 +237,8 @@ _COMPUTATION_LANGUAGE = re.compile(
     r"\d+(?:[.,]\d+)?\s*-?fach(?:e[nsrm]?)?|"
     r"(?:vermindert|erhöht|gekürzt|vermehrt)\s+um|"
     r"(?:erhöht|mindert|vermindert|kürzt|vermehrt)\s+sich\s+um|"
-    r"(?:abzüglich|zuzüglich)|prozent\s+(?:des|der|von)|"
+    r"(?:abzüglich|zuzüglich|plus|minus)|"
+    r"(?:prozent|\d+(?:[.,]\d+)?\s*%)\s+(?:des|der|von|of)|"
     r"\d+(?:[.,]\d+)?\s+(?:vom\s+hundert|v\.?\s*h\.?)\s+"
     r"(?:des|der|von)|"
     r"splitting-verfahren|verfahren\s+nach\s+absatz|"
@@ -2339,14 +2340,14 @@ def _formula_operation_kinds(text: str) -> set[str]:
     lowered_text = text.lower()
     operation_patterns = {
         "add": (
-            r"(?:\+|\bsumme\b|\bsum\s+of\b|\bzuzüglich\b|"
+            r"(?:\+|\bplus\b|\bsumme\b|\bsum\s+of\b|\bzuzüglich\b|"
             r"\b(?:summieren|addieren)\b|"
             r"\berhöh\w*\s+(?:sich\s+)?um\b|"
             r"\bum\s+(?:\d+(?:[.,]\d+)?|[a-zäöüß]+)\s+zu\s+"
             r"(?:erhöhen|vermehren)\b)"
         ),
         "subtract": (
-            r"(?:\s[−–-]\s|\bunterschied\b|\bdifferenz\b|"
+            r"(?:\s[−–-]\s|\bminus\b|\bunterschied\b|\bdifferenz\b|"
             r"\bdifference\s+between\b|\babzüglich\b|"
             r"\b(?:vermindern|kürzen)\b|"
             r"\b(?:vermindert|gekürzt|mindert|kürzt)\w*\s+"
@@ -2355,7 +2356,8 @@ def _formula_operation_kinds(text: str) -> set[str]:
             r"(?:vermindern|kürzen)\b)"
         ),
         "multiply": (
-            r"(?:[*×·•∗∙]|\bprodukt\b|\bproduct\s+of\b|"
+            r"(?:[*×·•∗∙]|\d+(?:[.,]\d+)?\s*%\s+(?:des|der|von|of)\b|"
+            r"\bprodukt\b|\bproduct\s+of\b|"
             r"\b(?:multiplied|multiply|multiplication|multipliziert|"
             r"multiplizieren|multiplikation)\b|\bvervielfach\w*\b|\bmal\b|"
             r"\b(?:verfünf|versechs|versieben|veracht|verneun|verzehn)"
@@ -4637,7 +4639,8 @@ def _formula_interval_from_text(
 ) -> _NumericInterval | None:
     lowered = text.lower()
     keyword = re.search(
-        r"\b(?:zwischen|between|von(?!\s+(?:höchstens|mindestens))|"
+        r"\b(?:zwischen|between|von\s+mehr\s+als|"
+        r"von(?!\s+(?:höchstens|mindestens))|"
         r"from|unter|less\s+than|below|"
         r"bis|up\s+to|höchstens|nicht\s+mehr\s+als|"
         r"at\s+most|über|more\s+than|above|ab|at\s+least|mindestens)\b",
@@ -4681,7 +4684,10 @@ def _formula_interval_from_text(
         lowered_range,
     ):
         return _NumericInterval(None, False, occurrences[0], True)
-    if re.match(r"(?:über|more\s+than|above)\b", lowered_range):
+    if re.match(
+        r"(?:über|more\s+than|above|von\s+mehr\s+als)\b",
+        lowered_range,
+    ):
         return _NumericInterval(occurrences[0], False, None, False)
     if re.match(
         r"(?:von|ab|from|at\s+least|mindestens)\b",

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -4510,12 +4510,32 @@ def _rounding_source_formula_branches(
         )
     if not _rounding_text_refers_to_result(rounding_branch.text):
         return ()
-    return tuple(
+    preceding = tuple(
         branch
         for branch in formula_branches
         if branch.end <= rounding_branch.start
         and _same_top_level_source_path(branch.path, rounding_branch.path)
     )
+    if not preceding:
+        return ()
+    if re.match(
+        r"\s*der\s+sich\s+ergebende\s+steuerbetrag\b",
+        _strip_source_clause_marker(rounding_branch.text),
+        flags=re.IGNORECASE,
+    ):
+        interval_branches = tuple(
+            branch
+            for branch in preceding
+            if re.search(
+                r"\b(?:bis|von|ab|unter|über|between|from|through|"
+                r"up\s+to|above|below)\b",
+                branch.text.split(":", 1)[0],
+                flags=re.IGNORECASE,
+            )
+        )
+        if interval_branches:
+            return interval_branches
+    return (max(preceding, key=lambda branch: branch.end),)
 
 
 def _unwitnessed_exception_branches(
@@ -5397,13 +5417,7 @@ def _rounding_stage_subject_matches(
     operand_subject: tuple[str, ...],
     output_subject: tuple[str, ...],
 ) -> bool:
-    if not operand_subject:
-        return False
-    shorter, longer = sorted(
-        (operand_subject, output_subject),
-        key=len,
-    )
-    return longer[: len(shorter)] == shorter
+    return bool(operand_subject) and operand_subject == output_subject
 
 
 def _rounding_stage_subject(identifier: str) -> tuple[str, ...]:
@@ -5429,11 +5443,14 @@ def _rounding_stage_subject(identifier: str) -> tuple[str, ...]:
         "nearest",
         "final",
     }
-    return tuple(
+    subject = tuple(
         token
         for token in re.findall(r"[A-Za-z0-9]+", normalized.lower())
         if token not in stage_tokens
     )
+    if len(subject) > 1 and subject[-1] in {"amount", "value", "result"}:
+        return subject[:-1]
+    return subject
 
 
 def _balanced_call_operands(text: str, function_name: str) -> Iterable[str]:

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -583,6 +583,25 @@ def _rule_coverage(
 
 
 def _rule_source_excerpts(rule: dict[str, Any]) -> Iterable[tuple[str, str]]:
+    return tuple(
+        (citation_path, excerpt)
+        for _path, citation_path, excerpt in _rule_source_excerpt_atoms(rule)
+    )
+
+
+def _rule_formula_source_excerpts(
+    rule: dict[str, Any],
+) -> Iterable[tuple[str, str]]:
+    return tuple(
+        (citation_path, excerpt)
+        for path, citation_path, excerpt in _rule_source_excerpt_atoms(rule)
+        if re.fullmatch(r"versions(?:\[\d+\])?\.formula", path)
+    )
+
+
+def _rule_source_excerpt_atoms(
+    rule: dict[str, Any],
+) -> Iterable[tuple[str, str, str]]:
     metadata = rule.get("metadata")
     proof = metadata.get("proof") if isinstance(metadata, dict) else None
     if not isinstance(proof, dict):
@@ -590,17 +609,18 @@ def _rule_source_excerpts(rule: dict[str, Any]) -> Iterable[tuple[str, str]]:
     atoms = proof.get("atoms") if isinstance(proof, dict) else None
     if not isinstance(atoms, list):
         return ()
-    excerpts: list[tuple[str, str]] = []
+    excerpts: list[tuple[str, str, str]] = []
     for atom in atoms:
         source = atom.get("source") if isinstance(atom, dict) else None
+        path = str(atom.get("path") or "").strip() if isinstance(atom, dict) else ""
         excerpt = source.get("excerpt") if isinstance(source, dict) else None
         citation_path = (
             str(source.get("corpus_citation_path") or "").strip()
             if isinstance(source, dict)
             else ""
         )
-        if isinstance(excerpt, str) and excerpt.strip() and citation_path:
-            excerpts.append((citation_path, excerpt.strip()))
+        if isinstance(excerpt, str) and excerpt.strip() and citation_path and path:
+            excerpts.append((path, citation_path, excerpt.strip()))
     return excerpts
 
 
@@ -632,7 +652,7 @@ def _principal_formula_clause_rules(
             clause_rules[clause] = path_rules
             continue
         clause_text = _normalized_formula_clause_text(clause.text)
-        rounding_direction = _rounding_direction(clause.text)
+        rounding_direction = _rounding_only_direction(clause.text)
         clause_rules[clause] = {
             rule_name
             for rule_name in path_rules
@@ -654,7 +674,7 @@ def _principal_formula_clause_rules(
                     excerpt_text in clause_text
                     or clause_text in excerpt_text
                 )
-                for excerpt_citation_path, excerpt in _rule_source_excerpts(
+                for excerpt_citation_path, excerpt in _rule_formula_source_excerpts(
                     principal_rules[rule_name]
                 )
             )
@@ -682,6 +702,21 @@ def _rounding_direction(text: str) -> str | None:
     if _UP_ROUNDING_LANGUAGE.search(text):
         return "upward"
     return "downward"
+
+
+def _rounding_only_direction(text: str) -> str | None:
+    """Return a direction only when rounding is the clause's sole computation."""
+
+    direction = _rounding_direction(text)
+    if direction is None:
+        return None
+    without_rounding = _ROUNDING_LANGUAGE.sub("", text)
+    if (
+        _has_substantive_arithmetic_expression(without_rounding)
+        or _COMPUTATION_LANGUAGE.search(without_rounding)
+    ):
+        return None
+    return direction
 
 
 def _most_specific_excerpt_branch(

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -422,6 +422,8 @@ def _analyze_rulespec_payload(
     deferred_paths, imprecise_deferrals = _deferred_coverage(
         payload,
         corpus_citation_path=corpus_citation_path,
+        source_text=source_text,
+        branches=branches,
     )
     issues: list[str] = []
     issues.extend(imprecise_deferrals)
@@ -883,6 +885,8 @@ def _deferred_coverage(
     payload: dict[str, Any],
     *,
     corpus_citation_path: str,
+    source_text: str,
+    branches: Sequence[SourceStructureBranch],
 ) -> tuple[set[tuple[str, ...]], list[str]]:
     module = payload.get("module")
     records = module.get("deferred_outputs") if isinstance(module, dict) else None
@@ -940,17 +944,29 @@ def _deferred_coverage(
             reason,
             corpus_citation_path=corpus_citation_path,
         )
-        precise = (
-            (
+        source_scope_text = _deferred_source_scope_text(
+            path,
+            source_text=source_text,
+            branches=branches,
+        )
+        if "blocked_by" in record:
+            precise = (
                 exact_blockers
                 and bool(_MISSING_DEPENDENCY_LANGUAGE.search(reason))
                 and all(
                     _reason_identifies_blocker(reason, blocker)
                     for blocker in blocker_targets
                 )
+                and all(
+                    _reason_identifies_blocker(source_scope_text, blocker)
+                    for blocker in blocker_targets
+                )
             )
-            or reason_identifies_dependency
-        )
+        else:
+            precise = (
+                reason_identifies_dependency
+                and _reason_dependency_is_source_bound(reason, source_scope_text)
+            )
         if precise:
             covered.add(path)
         else:
@@ -964,6 +980,18 @@ def _deferred_coverage(
                 "dependency/citation."
             )
     return covered, issues
+
+
+def _deferred_source_scope_text(
+    path: tuple[str, ...],
+    *,
+    source_text: str,
+    branches: Sequence[SourceStructureBranch],
+) -> str:
+    if not path:
+        return source_text
+    candidates = [branch.text for branch in branches if branch.path == path]
+    return max(candidates, key=len, default="")
 
 
 def _reason_identifies_blocker(reason: str, blocker: str) -> bool:
@@ -988,6 +1016,36 @@ def _reason_identifies_blocker(reason: str, blocker: str) -> bool:
             normalized_reason,
         )
     )
+
+
+def _reason_dependency_is_source_bound(reason: str, source_scope_text: str) -> bool:
+    """Require a prose-only dependency citation to occur in the deferred source."""
+
+    for match in _PRECISE_DEFERRAL_DEPENDENCY.finditer(reason):
+        dependency = match.group(0).strip()
+        if "#" in dependency and ":" in dependency:
+            if _reason_identifies_blocker(source_scope_text, dependency):
+                return True
+            continue
+        section_match = re.search(r"\d+[a-z]?", dependency, flags=re.IGNORECASE)
+        if section_match and _reason_identifies_blocker(
+            source_scope_text,
+            f"xx:statutes/source/{section_match.group(0)}#dependency",
+        ):
+            return True
+        normalized_dependency = re.sub(
+            r"[^a-z0-9äöüß]+",
+            " ",
+            dependency.lower(),
+        ).strip()
+        normalized_source = re.sub(
+            r"[^a-z0-9äöüß]+",
+            " ",
+            source_scope_text.lower(),
+        ).strip()
+        if normalized_dependency and normalized_dependency in normalized_source:
+            return True
+    return False
 
 
 def _reason_names_external_dependency(

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -3618,6 +3618,9 @@ def _branch_boundary_has_test_evidence(
                         input_names=input_names,
                         formula_environment=execution.constant_environment,
                         source_interval=source_interval,
+                        source_boolean_polarity=(
+                            _source_boundary_boolean_polarity(branch.text)
+                        ),
                         extract_numeric_occurrences=(
                             extract_numeric_occurrences
                         ),
@@ -3635,6 +3638,10 @@ def _branch_boundary_has_test_evidence(
                         principal_rules=principal_rules,
                         dependency_names=set(dependency_environment),
                         formula_environment=formula_environment or {},
+                        source_interval=source_interval,
+                        source_boolean_polarity=(
+                            _source_boundary_boolean_polarity(branch.text)
+                        ),
                     )
                     for input_key, input_names, value in (
                         _case_numeric_selector_evidence(
@@ -3656,6 +3663,7 @@ def _formula_execution_binds_boundary(
     input_names: set[str],
     formula_environment: dict[str, Any],
     source_interval: _NumericInterval | None,
+    source_boolean_polarity: int,
     extract_numeric_occurrences: NumericOccurrenceExtractor | None,
     numeric_value_is_grounded: NumericGroundingPredicate,
 ) -> bool:
@@ -3679,7 +3687,7 @@ def _formula_execution_binds_boundary(
             (selector, True)
             for selector in step.selectors
         )
-    checks.append((execution.leaf, False))
+    checks.append((execution.leaf, source_boolean_polarity < 0))
     return any(
         _formula_text_has_boundary_comparison(
             text,
@@ -3710,9 +3718,7 @@ def _formula_text_has_boundary_comparison(
 ) -> bool:
     with contextlib.suppress(SyntaxError):
         expression = ast.parse(text.strip(), mode="eval").body
-        for comparison in (
-            node for node in ast.walk(expression) if isinstance(node, ast.Compare)
-        ):
+        for comparison, negated in _formula_comparisons_with_polarity(expression):
             operands = (comparison.left, *comparison.comparators)
             for operator, left, right in zip(
                 comparison.ops,
@@ -3754,10 +3760,46 @@ def _formula_text_has_boundary_comparison(
                         numeric_value_is_grounded=numeric_value_is_grounded,
                         source_interval=source_interval,
                         allow_complement_relation=allow_complement_relation,
+                        negated=negated,
                     )
                 ):
                     return True
     return False
+
+
+def _formula_comparisons_with_polarity(
+    node: ast.AST,
+    *,
+    negated: bool = False,
+) -> Iterable[tuple[ast.Compare, bool]]:
+    """Yield comparisons with the boolean negation parity that contains them."""
+
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+        yield from _formula_comparisons_with_polarity(
+            node.operand,
+            negated=not negated,
+        )
+        return
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and len(node.args) == 1
+        and not node.keywords
+        and node.func.id in {"holds", "not_holds"}
+    ):
+        yield from _formula_comparisons_with_polarity(
+            node.args[0],
+            negated=negated != (node.func.id == "not_holds"),
+        )
+        return
+    if isinstance(node, ast.Compare):
+        yield node, negated
+        return
+    for child in ast.iter_child_nodes(node):
+        yield from _formula_comparisons_with_polarity(
+            child,
+            negated=negated,
+        )
 
 
 def _formula_node_references_names(
@@ -3850,11 +3892,14 @@ def _comparison_matches_source_interval(
     numeric_value_is_grounded: NumericGroundingPredicate,
     source_interval: _NumericInterval,
     allow_complement_relation: bool,
+    negated: bool,
 ) -> bool:
     del boundary_names
     relation = _input_comparison_relation(operator, input_on_left=input_on_left)
     if relation is None:
         return False
+    if negated:
+        relation = _complement_comparison_relation(relation)
     relations = {relation}
     if allow_complement_relation:
         relations.add(_complement_comparison_relation(relation))
@@ -3971,6 +4016,8 @@ def _boundary_case_changes_formula_effect(
     principal_rules: dict[str, dict[str, Any]],
     dependency_names: set[str],
     formula_environment: dict[str, Any],
+    source_interval: _NumericInterval | None,
+    source_boolean_polarity: int,
 ) -> bool:
     inputs = case.get("input")
     if not isinstance(inputs, dict):
@@ -3981,6 +4028,22 @@ def _boundary_case_changes_formula_effect(
         else max(abs(boundary_value) * 1e-6, 1e-9)
     )
     signature = _formula_execution_effect_signature(execution)
+    boundary_boolean = _formula_execution_boolean_value(execution)
+    if (
+        boundary_boolean is not None
+        and source_interval is not None
+        and source_boolean_polarity
+        and boundary_boolean
+        != (
+            _interval_contains(source_interval, float(boundary_value))
+            if source_boolean_polarity > 0
+            else not _interval_contains(
+                source_interval,
+                float(boundary_value),
+            )
+        )
+    ):
+        return False
     for raw_key, raw_value in inputs.items():
         if (
             isinstance(raw_value, bool)
@@ -4016,16 +4079,19 @@ def _boundary_case_changes_formula_effect(
                 require_asserted_value=False,
                 allowed_names=dependency_names,
             )
-            selector_changed = any(
-                names & selector_names
-                and not math.isclose(value, float(boundary_value))
+            candidate_selector_values = tuple(
+                value
                 for _key, names, value in _case_numeric_selector_evidence(
                     candidate_case,
                     selector_names,
                     dependency_environment=candidate_dependencies,
                 )
+                if names & selector_names
             )
-            if not selector_changed:
+            if not any(
+                not math.isclose(value, float(boundary_value))
+                for value in candidate_selector_values
+            ):
                 continue
             candidate_execution = _case_formula_execution(
                 rule,
@@ -4033,13 +4099,65 @@ def _boundary_case_changes_formula_effect(
                 formula_environment=formula_environment,
                 dependency_environment=candidate_dependencies,
             )
+            candidate_boolean = (
+                _formula_execution_boolean_value(candidate_execution)
+                if candidate_execution is not None
+                else None
+            )
             if (
                 candidate_execution is not None
+                and (
+                    candidate_boolean is None
+                    or source_interval is None
+                    or not source_boolean_polarity
+                    or any(
+                        candidate_boolean
+                        == (
+                            _interval_contains(source_interval, value)
+                            if source_boolean_polarity > 0
+                            else not _interval_contains(
+                                source_interval,
+                                value,
+                            )
+                        )
+                        for value in candidate_selector_values
+                    )
+                )
                 and _formula_execution_effect_signature(candidate_execution)
                 != signature
             ):
                 return True
     return False
+
+
+def _formula_execution_boolean_value(
+    execution: _FormulaExecution | None,
+) -> bool | None:
+    if execution is None or execution.evaluated_value is None:
+        return None
+    value_type, raw_value = execution.evaluated_value
+    if value_type != "bool":
+        return None
+    return raw_value == "True"
+
+
+def _source_boundary_boolean_polarity(text: str) -> int:
+    lowered = _collapse_text(text).lower()
+    if re.search(
+        r"\b(?:keine?\s+berechtigung|keinen?\s+anspruch|"
+        r"nicht\s+berechtigt|ausgeschlossen|gilt\s+nicht|"
+        r"does\s+not\s+apply|not\s+applicable|not\s+eligible|"
+        r"ineligible|excluded)\b",
+        lowered,
+    ):
+        return -1
+    if re.search(
+        r"\b(?:gilt(?:\s+für)?|anspruch\s+besteht|berechtigt|"
+        r"appl(?:y|ies)|eligible|qualif(?:y|ies))\b",
+        lowered,
+    ):
+        return 1
+    return 0
 
 
 def _is_adjacent_integral_boundary(
@@ -4455,6 +4573,15 @@ def _toggled_formula_boolean_selectors(
                 right_dependencies,
                 right_selectors,
             ) in records[left_index + 1 :]:
+                if (
+                    _normalized_case_period(left_case)
+                    != _normalized_case_period(right_case)
+                    or not _cases_differ_by_one_boolean_input(
+                        left_case,
+                        right_case,
+                    )
+                ):
+                    continue
                 if set(left_selectors) != set(right_selectors):
                     continue
                 changed_names = {
@@ -4465,42 +4592,59 @@ def _toggled_formula_boolean_selectors(
                 if len(changed_names) != 1:
                     continue
                 selector_name = next(iter(changed_names))
-                left_execution = _case_formula_execution(
+                if left_selectors[selector_name]:
+                    blocking_case = left_case
+                    blocking_dependencies = left_dependencies
+                    ordinary_case = right_case
+                    ordinary_dependencies = right_dependencies
+                else:
+                    ordinary_case = left_case
+                    ordinary_dependencies = left_dependencies
+                    blocking_case = right_case
+                    blocking_dependencies = right_dependencies
+                ordinary_execution = _case_formula_execution(
                     rule,
-                    left_case,
+                    ordinary_case,
                     formula_environment=formula_environment,
-                    dependency_environment=left_dependencies,
+                    dependency_environment=ordinary_dependencies,
                 )
-                right_execution = _case_formula_execution(
+                blocking_execution = _case_formula_execution(
                     rule,
-                    right_case,
+                    blocking_case,
                     formula_environment=formula_environment,
-                    dependency_environment=right_dependencies,
+                    dependency_environment=blocking_dependencies,
                 )
-                if left_execution is None or right_execution is None:
+                counterfactual_execution = (
+                    _case_formula_execution_with_boolean_selector(
+                        rule,
+                        ordinary_case,
+                        selector_name=selector_name,
+                        selector_value=True,
+                        formula_environment=formula_environment,
+                        dependency_environment=ordinary_dependencies,
+                    )
+                )
+                if (
+                    ordinary_execution is None
+                    or blocking_execution is None
+                    or counterfactual_execution is None
+                ):
                     continue
-                left_asserted = _test_case_asserted_output_value(
-                    left_case,
+                ordinary_asserted = _test_case_asserted_output_value(
+                    ordinary_case,
                     rule_name,
                 )
-                right_asserted = _test_case_asserted_output_value(
-                    right_case,
+                blocking_asserted = _test_case_asserted_output_value(
+                    blocking_case,
                     rule_name,
                 )
                 if (
-                    left_asserted is not _UNRESOLVED_CONDITION_VALUE
-                    and right_asserted is not _UNRESOLVED_CONDITION_VALUE
-                    and _formula_runtime_values_equal(
-                        left_asserted,
-                        right_asserted,
+                    ordinary_asserted is _UNRESOLVED_CONDITION_VALUE
+                    or blocking_asserted is _UNRESOLVED_CONDITION_VALUE
+                    or not _exception_effect_is_blocking(
+                        ordinary_asserted,
+                        blocking_asserted,
                     )
-                ) or (
-                    (
-                        left_asserted is _UNRESOLVED_CONDITION_VALUE
-                        or right_asserted is _UNRESOLVED_CONDITION_VALUE
-                    )
-                    and _formula_execution_effect_signature(left_execution)
-                    == _formula_execution_effect_signature(right_execution)
                 ):
                     continue
                 if all(
@@ -4508,10 +4652,112 @@ def _toggled_formula_boolean_selectors(
                         execution,
                         selector_name,
                     )
-                    for execution in (left_execution, right_execution)
+                    for execution in (
+                        ordinary_execution,
+                        blocking_execution,
+                        counterfactual_execution,
+                    )
+                ) and _exception_effect_is_blocking(
+                    _formula_execution_runtime_value(ordinary_execution),
+                    _formula_execution_runtime_value(counterfactual_execution),
                 ):
                     toggled.add((rule_name, selector_name))
     return toggled
+
+
+def _cases_differ_by_one_boolean_input(
+    left_case: dict[str, Any],
+    right_case: dict[str, Any],
+) -> bool:
+    left_inputs = left_case.get("input")
+    right_inputs = right_case.get("input")
+    if not isinstance(left_inputs, dict) or not isinstance(right_inputs, dict):
+        return False
+    if set(left_inputs) != set(right_inputs):
+        return False
+    changed = [
+        key
+        for key in left_inputs
+        if not _formula_runtime_values_equal(
+            left_inputs[key],
+            right_inputs[key],
+        )
+    ]
+    if len(changed) != 1:
+        return False
+    key = changed[0]
+    left_boolean = _boolean_value(left_inputs[key])
+    right_boolean = _boolean_value(right_inputs[key])
+    return (
+        left_boolean is not None
+        and right_boolean is not None
+        and left_boolean != right_boolean
+    )
+
+
+def _case_formula_execution_with_boolean_selector(
+    rule: dict[str, Any],
+    case: dict[str, Any],
+    *,
+    selector_name: str,
+    selector_value: bool,
+    formula_environment: dict[str, Any],
+    dependency_environment: dict[str, Any],
+) -> _FormulaExecution | None:
+    dependencies = dict(dependency_environment)
+    candidate_case = case
+    if selector_name in dependencies:
+        dependencies[selector_name] = selector_value
+    else:
+        inputs = case.get("input")
+        if not isinstance(inputs, dict):
+            return None
+        matching_keys = [
+            key
+            for key in inputs
+            if selector_name in _input_key_names(key)
+        ]
+        if len(matching_keys) != 1:
+            return None
+        candidate_inputs = dict(inputs)
+        candidate_inputs[matching_keys[0]] = selector_value
+        candidate_case = dict(case)
+        candidate_case["input"] = candidate_inputs
+    return _case_formula_execution(
+        rule,
+        candidate_case,
+        formula_environment=formula_environment,
+        dependency_environment=dependencies,
+    )
+
+
+def _formula_execution_runtime_value(execution: _FormulaExecution) -> Any:
+    if execution.evaluated_value is None:
+        return _UNRESOLVED_CONDITION_VALUE
+    _value_type, raw_value = execution.evaluated_value
+    with contextlib.suppress(SyntaxError, ValueError):
+        return ast.literal_eval(raw_value)
+    return _UNRESOLVED_CONDITION_VALUE
+
+
+def _exception_effect_is_blocking(ordinary: Any, blocking: Any) -> bool:
+    if (
+        ordinary is _UNRESOLVED_CONDITION_VALUE
+        or blocking is _UNRESOLVED_CONDITION_VALUE
+    ):
+        return False
+    ordinary_boolean = _boolean_value(ordinary)
+    blocking_boolean = _boolean_value(blocking)
+    if ordinary_boolean is not None or blocking_boolean is not None:
+        return ordinary_boolean is True and blocking_boolean is False
+    if (
+        isinstance(ordinary, (int, float))
+        and not isinstance(ordinary, bool)
+        and isinstance(blocking, (int, float))
+        and not isinstance(blocking, bool)
+    ):
+        return float(blocking) < float(ordinary)
+    return False
 
 
 def _case_boolean_selector_environment(

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1417,12 +1417,38 @@ def _merge_unambiguous_numeric_bindings(
 
     merged = dict(environment)
     for name, values in values_by_name.items():
+        temporal = environment.get(name)
+        if isinstance(temporal, _TemporalFormulaValue):
+            temporal_values = [
+                float(value)
+                for _start, _end, value in temporal.versions
+                if isinstance(value, (int, float)) and not isinstance(value, bool)
+            ]
+            if _numeric_binding_sequences_match(values, temporal_values):
+                continue
+            merged.pop(name, None)
+            continue
         first = values[0]
         if all(math.isclose(float(value), float(first)) for value in values[1:]):
             merged[name] = first
         else:
             merged.pop(name, None)
     return merged
+
+
+def _numeric_binding_sequences_match(
+    left: Sequence[int | float],
+    right: Sequence[int | float],
+) -> bool:
+    if len(left) != len(right):
+        return False
+    return all(
+        math.isclose(float(left_value), float(right_value))
+        for left_value, right_value in zip(
+            sorted(left, key=float),
+            sorted(right, key=float),
+        )
+    )
 
 
 def _companion_test_issues(

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -407,6 +407,7 @@ def analyze_complete_source_unit(
     extract_named_scalars: NamedScalarExtractor,
     numeric_value_is_grounded: NumericGroundingPredicate,
     artifact_numeric_values: Sequence[float] | None = None,
+    artifact_numeric_bindings: Sequence[tuple[str, float]] | None = None,
 ) -> CompleteSourceUnitAnalysis:
     """Analyze one artifact against its authoritative, resolver-owned body."""
 
@@ -432,6 +433,7 @@ def analyze_complete_source_unit(
                 extract_named_scalars=extract_named_scalars,
                 numeric_value_is_grounded=numeric_value_is_grounded,
                 artifact_numeric_values=artifact_numeric_values,
+                artifact_numeric_bindings=artifact_numeric_bindings,
             )
 
     return CompleteSourceUnitAnalysis((), (), 0, 0, 0)
@@ -448,6 +450,7 @@ def _analyze_rulespec_payload(
     extract_named_scalars: NamedScalarExtractor,
     numeric_value_is_grounded: NumericGroundingPredicate,
     artifact_numeric_values: Sequence[float] | None,
+    artifact_numeric_bindings: Sequence[tuple[str, float]] | None,
 ) -> CompleteSourceUnitAnalysis:
     branches = recognize_source_structure(source_text)
     (
@@ -558,6 +561,12 @@ def _analyze_rulespec_payload(
         )
 
     if principal_rules:
+        formula_environment = _constant_rule_environment(payload)
+        if artifact_numeric_bindings is not None:
+            formula_environment = _merge_unambiguous_numeric_bindings(
+                formula_environment,
+                artifact_numeric_bindings,
+            )
         issues.extend(
             _companion_test_issues(
                 principal_rules,
@@ -571,7 +580,7 @@ def _analyze_rulespec_payload(
                 test_cases=test_cases,
                 extract_numeric_occurrences=extract_numeric_occurrences,
                 numeric_value_is_grounded=numeric_value_is_grounded,
-                formula_environment=_constant_rule_environment(payload),
+                formula_environment=formula_environment,
             )
         )
 
@@ -1337,23 +1346,66 @@ def collect_artifact_numeric_values(
 
     values = [float(value) for value in additional_values]
     values.extend(
-        float(item.value)
-        for item in extract_named_scalars(content)
-        if hasattr(item, "value")
+        value
+        for _name, value in collect_artifact_numeric_bindings(
+            content,
+            extract_named_scalars=extract_named_scalars,
+            imported_symbol_contents=imported_symbol_contents,
+        )
     )
+    return tuple(values)
+
+
+def collect_artifact_numeric_bindings(
+    content: str,
+    *,
+    extract_named_scalars: NamedScalarExtractor,
+    imported_symbol_contents: Sequence[tuple[str, str]] = (),
+) -> tuple[tuple[str, float], ...]:
+    """Collect exact scalar names together with strict recall values."""
+
+    bindings = [
+        (str(item.name), float(item.value))
+        for item in extract_named_scalars(content)
+        if hasattr(item, "name") and hasattr(item, "value")
+    ]
     for imported_symbol, artifact_content in imported_symbol_contents:
-        values.extend(
-            float(item.value)
+        bindings.extend(
+            (imported_symbol, float(item.value))
             for item in extract_named_scalars(artifact_content)
             if hasattr(item, "value")
             and _named_scalar_base_name(str(getattr(item, "name", "")))
             == imported_symbol
         )
-    return tuple(values)
+    return tuple(bindings)
 
 
 def _named_scalar_base_name(name: str) -> str:
     return name.split("[", 1)[0]
+
+
+def _merge_unambiguous_numeric_bindings(
+    environment: dict[str, Any],
+    bindings: Sequence[tuple[str, float]],
+) -> dict[str, Any]:
+    """Merge exact scalar bindings while rejecting conflicting definitions."""
+
+    values_by_name: dict[str, list[int | float]] = {}
+    for name, value in environment.items():
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            values_by_name.setdefault(name, []).append(value)
+    for name, value in bindings:
+        if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
+            values_by_name.setdefault(name, []).append(value)
+
+    merged = dict(environment)
+    for name, values in values_by_name.items():
+        first = values[0]
+        if all(math.isclose(float(value), float(first)) for value in values[1:]):
+            merged[name] = first
+        else:
+            merged.pop(name, None)
+    return merged
 
 
 def _companion_test_issues(

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1162,7 +1162,7 @@ def _deferred_coverage(
                     for blocker in blocker_targets
                 )
                 and all(
-                    _reason_identifies_blocker(
+                    _source_scope_identifies_blocker(
                         source_scope_text,
                         blocker,
                         corpus_citation_path=corpus_citation_path,
@@ -1266,6 +1266,55 @@ def _reason_identifies_blocker(
     )
 
 
+def _source_scope_identifies_blocker(
+    source_scope_text: str,
+    blocker: str,
+    *,
+    corpus_citation_path: str,
+) -> bool:
+    """Reject citations expressly described as unrelated to the source rule."""
+
+    if not _reason_identifies_blocker(
+        source_scope_text,
+        blocker,
+        corpus_citation_path=corpus_citation_path,
+    ):
+        return False
+    target_path = blocker.partition("#")[0]
+    section = target_path.rstrip("/").rsplit("/", 1)[-1]
+    references = tuple(
+        match
+        for match in _EXPLICIT_LEGAL_SECTION_REFERENCE.finditer(source_scope_text)
+        if match.group("section").lower() == section.lower()
+    )
+    if not references:
+        return True
+    for reference in references:
+        clause_start = max(
+            source_scope_text.rfind(separator, 0, reference.start())
+            for separator in (".", ";", "\n")
+        ) + 1
+        following_stops = [
+            position
+            for separator in (".", ";", "\n")
+            if (position := source_scope_text.find(separator, reference.end())) >= 0
+        ]
+        clause_end = min(following_stops, default=len(source_scope_text))
+        clause = source_scope_text[clause_start:clause_end]
+        if re.search(
+            r"\b(?:"
+            r"unberührt\s+bleib\w*|bleib\w*\s+unberührt|"
+            r"without\s+prejudice\s+to|remain\w*\s+unaffected|"
+            r"does\s+not\s+affect"
+            r")\b",
+            clause,
+            flags=re.IGNORECASE,
+        ):
+            continue
+        return True
+    return False
+
+
 def _citation_instrument_identity(
     citation: str,
 ) -> tuple[str, str, str] | None:
@@ -1327,7 +1376,7 @@ def _reason_dependency_is_source_bound(
     for match in _PRECISE_DEFERRAL_DEPENDENCY.finditer(reason):
         dependency = match.group(0).strip()
         if "#" in dependency and ":" in dependency:
-            if _reason_identifies_blocker(
+            if _source_scope_identifies_blocker(
                 source_scope_text,
                 dependency,
                 corpus_citation_path=corpus_citation_path,
@@ -1337,7 +1386,7 @@ def _reason_dependency_is_source_bound(
         section_match = re.search(r"\d+[a-z]?", dependency, flags=re.IGNORECASE)
         corpus_target = _rulespec_target_base(corpus_citation_path)
         corpus_instrument_target = corpus_target.rsplit("/", 1)[0]
-        if section_match and _reason_identifies_blocker(
+        if section_match and _source_scope_identifies_blocker(
             source_scope_text,
             f"{corpus_instrument_target}/{section_match.group(0)}#dependency",
             corpus_citation_path=corpus_citation_path,
@@ -1682,16 +1731,12 @@ def _companion_test_issues(
             "test evidence."
         )
 
-    boundary_branches = active_branches or [
-        SourceStructureBranch(
-            (),
-            "source-unit",
-            "source unit",
-            source_text,
-            0,
-            len(source_text),
-        )
-    ]
+    boundary_branches = _active_or_root_source_branches(
+        source_text,
+        branches=branches,
+        active_branches=active_branches,
+        deferred_paths=deferred_paths,
+    )
     boundary_obligations = _source_boundary_obligations(
         boundary_branches,
         narrative_formula_branches=formula_branches,
@@ -1915,15 +1960,11 @@ def _source_control_branches(
 ) -> tuple[SourceStructureBranch, ...]:
     """Return active boundary, exception, and applicability control clauses."""
 
-    boundary_branches = active_branches or (
-        SourceStructureBranch(
-            (),
-            "source-unit",
-            "source unit",
-            source_text,
-            0,
-            len(source_text),
-        ),
+    boundary_branches = _active_or_root_source_branches(
+        source_text,
+        branches=branches,
+        active_branches=active_branches,
+        deferred_paths=deferred_paths,
     )
     controlled = [
         branch
@@ -1947,6 +1988,31 @@ def _source_control_branches(
             (branch.path, branch.start, branch.end): branch
             for branch in controlled
         }.values()
+    )
+
+
+def _active_or_root_source_branches(
+    source_text: str,
+    *,
+    branches: Sequence[SourceStructureBranch],
+    active_branches: Sequence[SourceStructureBranch],
+    deferred_paths: set[tuple[str, ...]],
+) -> tuple[SourceStructureBranch, ...]:
+    """Use a synthetic root only when an unstructured root remains active."""
+
+    if active_branches:
+        return tuple(active_branches)
+    if branches or _path_is_deferred((), deferred_paths):
+        return ()
+    return (
+        SourceStructureBranch(
+            (),
+            "source-unit",
+            "source unit",
+            source_text,
+            0,
+            len(source_text),
+        ),
     )
 
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1501,17 +1501,27 @@ def _formula_branch_test_witnesses(
     rule_names: set[str],
     asserted_by_rule: dict[str, list[dict[str, Any]]],
     extract_numeric_occurrences: NumericOccurrenceExtractor,
-) -> set[tuple[str, int]]:
+) -> set[tuple[str, str]]:
     interval = _formula_branch_interval(
         branch,
         extract_numeric_occurrences=extract_numeric_occurrences,
     )
-    witnesses: set[tuple[str, int]] = set()
+    witnesses: set[tuple[str, str]] = set()
     for rule_name in sorted(rule_names):
-        selector_names = _rule_numeric_selector_names(principal_rules[rule_name])
+        rule = principal_rules[rule_name]
+        selector_names = _rule_numeric_selector_names(rule)
+        branch_selector_names = _rule_branch_selector_names(rule)
         for case in asserted_by_rule.get(rule_name, ()):
             if interval is None:
-                witnesses.add((rule_name, id(case)))
+                if branch_selector_names:
+                    signature = _case_selector_signature(
+                        case,
+                        branch_selector_names,
+                    )
+                    if signature:
+                        witnesses.add((rule_name, f"selectors:{signature!r}"))
+                else:
+                    witnesses.add((rule_name, f"case:{id(case)}"))
                 continue
             if selector_names and any(
                 _interval_contains(interval, value)
@@ -1519,6 +1529,56 @@ def _formula_branch_test_witnesses(
             ):
                 witnesses.add((rule_name, id(case)))
     return witnesses
+
+
+def _rule_branch_selector_names(rule: dict[str, Any]) -> set[str]:
+    """Return identifiers that choose branches in a principal formula."""
+
+    names: set[str] = set()
+    for match in re.finditer(
+        r"(?m)^[ \t]*(?:if|elif)[ \t]+(?P<condition>[^:\n]+):",
+        _rule_formula_text(rule),
+    ):
+        condition = re.sub(r"(['\"]).*?\1", "", match.group("condition"))
+        names.update(
+            identifier
+            for identifier in _FORMULA_IDENTIFIER.findall(condition)
+            if identifier.lower()
+            not in {
+                "if",
+                "elif",
+                "else",
+                "and",
+                "or",
+                "not",
+                "true",
+                "false",
+                "holds",
+                "not_holds",
+            }
+        )
+    return names
+
+
+def _case_selector_signature(
+    case: dict[str, Any],
+    selector_names: set[str],
+) -> tuple[tuple[str, str], ...]:
+    """Fingerprint only case inputs that select a principal formula branch."""
+
+    inputs = case.get("input")
+    if not isinstance(inputs, dict):
+        return ()
+    return tuple(
+        sorted(
+            (
+                str(key),
+                repr(value),
+            )
+            for key, value in inputs.items()
+            if _input_key_names(key) & selector_names
+        )
+    )
 
 
 def _branch_boundary_has_test_evidence(

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -737,6 +737,8 @@ def _branch_citation(
     corpus_citation_path: str,
     branch: SourceStructureBranch,
 ) -> str:
+    if not branch.path:
+        return f"{corpus_citation_path} [source unit]"
     citation = corpus_citation_path
     components: list[str] = []
     for index, component in enumerate(branch.path):
@@ -981,11 +983,23 @@ def _companion_test_issues(
             branch.path[: len(deferred)] == deferred for deferred in deferred_paths
         )
     ]
-    formula_branches = [
+    structured_formula_branches = [
         branch
         for branch in active_branches
-        if branch.kind == "number" and _number_branch_is_formula_leaf(branch.text)
+        if branch.kind in {"number", "letter"}
+        and _structured_branch_is_formula_leaf(
+            branch,
+            extract_numeric_occurrences=extract_numeric_occurrences,
+        )
     ]
+    narrative_formula_branches = _narrative_formula_branches(
+        source_text,
+        branches=branches,
+        active_branches=active_branches,
+        deferred_paths=deferred_paths,
+        extract_numeric_occurrences=extract_numeric_occurrences,
+    )
+    formula_branches = (*structured_formula_branches, *narrative_formula_branches)
     for branch in formula_branches:
         if _formula_branch_has_test_evidence(
             branch,
@@ -994,6 +1008,7 @@ def _companion_test_issues(
             asserted_by_rule=asserted_by_rule,
             corpus_citation_path=corpus_citation_path,
             extract_numeric_occurrences=extract_numeric_occurrences,
+            allow_explicit_cover=branch.kind != "formula-clause",
         ):
             continue
         issues.append(
@@ -1006,6 +1021,7 @@ def _companion_test_issues(
 
     boundary_obligations = _source_boundary_obligations(
         active_branches,
+        narrative_formula_branches=narrative_formula_branches,
         extract_numeric_occurrences=extract_numeric_occurrences,
     )
     missing_boundaries: list[tuple[SourceStructureBranch, float]] = []
@@ -1035,19 +1051,34 @@ def _companion_test_issues(
         branches=branches,
         deferred_paths=deferred_paths,
     )
-    exception_count = len(_EXCEPTION_LANGUAGE.findall(active_text))
-    if exception_count:
+    exception_branches = _source_exception_branches(
+        source_text,
+        branches=branches,
+        active_branches=active_branches,
+        deferred_paths=deferred_paths,
+    )
+    if exception_branches:
         toggled_exception_selectors = _toggled_formula_boolean_selectors(
             principal_rules,
             asserted_by_rule=asserted_by_rule,
         )
-        if len(toggled_exception_selectors) < exception_count:
+        missing_exception_branches = _unwitnessed_exception_branches(
+            exception_branches,
+            principal_rule_paths=principal_rule_paths,
+            toggled_exception_selectors=toggled_exception_selectors,
+        )
+        if missing_exception_branches:
+            missing_citations = ", ".join(
+                dict.fromkeys(
+                    _branch_citation(corpus_citation_path, branch)
+                    for branch in missing_exception_branches
+                )
+            )
             issues.append(
                 "[complete-source-unit:tests] Source-stated exceptions require "
                 "paired positive/blocking cases that assert the affected principal "
-                "output and toggle a boolean selector used by its formula; "
-                f"found {len(toggled_exception_selectors)} pair(s) for "
-                f"{exception_count} exception obligation(s)."
+                "output and toggle its excluding formula selector; missing at "
+                f"{missing_citations}."
             )
 
     rounding_count = len(_ROUNDING_LANGUAGE.findall(active_text))
@@ -1055,42 +1086,54 @@ def _companion_test_issues(
         down_rules = {
             name
             for name, rule in principal_rules.items()
-            if "floor(" in _rule_formula_text(rule)
+            if re.search(r"\bfloor\s*\(", _rule_formula_text(rule))
         }
         up_rules = {
             name
             for name, rule in principal_rules.items()
-            if "ceil(" in _rule_formula_text(rule)
+            if re.search(r"\bceil\s*\(", _rule_formula_text(rule))
         }
         nearest_rules = {
             name
             for name, rule in principal_rules.items()
-            if "floor(" in _rule_formula_text(rule)
+            if re.search(r"\bfloor\s*\(", _rule_formula_text(rule))
             and re.search(r"\+\s*0?\.5\b", _rule_formula_text(rule))
         }
-        applicable_rounding_rules: set[str] = set()
+        applicable_rounding_functions: dict[str, set[str]] = {}
         if _DOWN_ROUNDING_LANGUAGE.search(active_text) and not down_rules:
             issues.append(
                 "[complete-source-unit:tests] A source-stated downward-rounding "
                 "rule is absent from the principal formula (`floor(...)`)."
             )
-        applicable_rounding_rules.update(down_rules)
+        if _DOWN_ROUNDING_LANGUAGE.search(active_text):
+            for rule_name in down_rules:
+                applicable_rounding_functions.setdefault(rule_name, set()).add(
+                    "floor"
+                )
         if _UP_ROUNDING_LANGUAGE.search(active_text) and not up_rules:
             issues.append(
                 "[complete-source-unit:tests] A source-stated upward-rounding "
                 "rule is absent from the principal formula (`ceil(...)`)."
             )
-        applicable_rounding_rules.update(up_rules)
+        if _UP_ROUNDING_LANGUAGE.search(active_text):
+            for rule_name in up_rules:
+                applicable_rounding_functions.setdefault(rule_name, set()).add(
+                    "ceil"
+                )
         if _NEAREST_ROUNDING_LANGUAGE.search(active_text) and not nearest_rules:
             issues.append(
                 "[complete-source-unit:tests] A source-stated nearest/commercial "
                 "rounding rule is absent from the principal formula."
             )
-        applicable_rounding_rules.update(nearest_rules)
+        if _NEAREST_ROUNDING_LANGUAGE.search(active_text):
+            for rule_name in nearest_rules:
+                applicable_rounding_functions.setdefault(rule_name, set()).add(
+                    "nearest"
+                )
         fractional_cases = _fractional_formula_input_case_count(
             principal_rules,
             asserted_by_rule=asserted_by_rule,
-            rule_names=applicable_rounding_rules,
+            rule_functions=applicable_rounding_functions,
         )
         if fractional_cases < rounding_count:
             issues.append(
@@ -1153,11 +1196,164 @@ def _test_case_output_names(case: dict[str, Any]) -> set[str]:
     return names
 
 
-def _number_branch_is_formula_leaf(text: str) -> bool:
-    first_line = text.splitlines()[0] if text.splitlines() else text
-    return ":" in first_line and bool(
-        _ARITHMETIC_EXPRESSION.search(text)
-        or re.search(r":\s*-?\d", text)
+def _structured_branch_is_formula_leaf(
+    branch: SourceStructureBranch,
+    *,
+    extract_numeric_occurrences: NumericOccurrenceExtractor,
+) -> bool:
+    first_line = (
+        branch.text.splitlines()[0] if branch.text.splitlines() else branch.text
+    )
+    return bool(
+        (
+            source_states_explicit_computation(branch.text)
+            or re.search(r":\s*-?\d", branch.text)
+        )
+        and (
+            ":" in first_line
+            or _formula_branch_interval(
+                branch,
+                extract_numeric_occurrences=extract_numeric_occurrences,
+            )
+            is not None
+        )
+    )
+
+
+def _narrative_formula_branches(
+    source_text: str,
+    *,
+    branches: Sequence[SourceStructureBranch],
+    active_branches: Sequence[SourceStructureBranch],
+    deferred_paths: set[tuple[str, ...]],
+    extract_numeric_occurrences: NumericOccurrenceExtractor,
+) -> tuple[SourceStructureBranch, ...]:
+    """Return range-formula clauses not already represented by list branches."""
+
+    structured_ranges = [
+        (branch.start, branch.end)
+        for branch in branches
+        if branch.kind in {"number", "letter"}
+    ]
+    obligations: list[SourceStructureBranch] = []
+    for clause_index, (start, end, clause) in enumerate(
+        _source_clause_spans(source_text),
+        start=1,
+    ):
+        if any(
+            start < structured_end and structured_start < end
+            for structured_start, structured_end in structured_ranges
+        ):
+            continue
+        if _span_is_deferred(
+            start,
+            end,
+            branches=branches,
+            deferred_paths=deferred_paths,
+        ):
+            continue
+        if not source_states_explicit_computation(clause):
+            continue
+        interval = _formula_interval_from_text(
+            clause,
+            extract_numeric_occurrences=extract_numeric_occurrences,
+        )
+        if interval is None:
+            continue
+        owner = _most_specific_containing_branch(
+            start,
+            end,
+            branches=active_branches,
+        )
+        if owner is None:
+            owner = SourceStructureBranch(
+                (),
+                "source-unit",
+                "source unit",
+                source_text,
+                0,
+                len(source_text),
+            )
+        obligations.append(
+            SourceStructureBranch(
+                owner.path,
+                "formula-clause",
+                f"{owner.label} formula clause {clause_index}",
+                clause,
+                start,
+                end,
+            )
+        )
+    return tuple(obligations)
+
+
+def _source_clause_spans(source_text: str) -> Iterable[tuple[int, int, str]]:
+    """Yield offset-preserving semicolon and true sentence clauses."""
+
+    boundary = re.compile(
+        r";|[.!?](?=(?:[ \t]+[A-ZÄÖÜ(]|\s*$))",
+        flags=re.MULTILINE,
+    )
+    start = 0
+    for match in boundary.finditer(source_text):
+        end = match.end()
+        raw = source_text[start:end]
+        left_trimmed = len(raw) - len(raw.lstrip())
+        right_trimmed = len(raw.rstrip())
+        if right_trimmed > left_trimmed:
+            yield (
+                start + left_trimmed,
+                start + right_trimmed,
+                raw[left_trimmed:right_trimmed],
+            )
+        start = end
+    raw = source_text[start:]
+    left_trimmed = len(raw) - len(raw.lstrip())
+    right_trimmed = len(raw.rstrip())
+    if right_trimmed > left_trimmed:
+        yield (
+            start + left_trimmed,
+            start + right_trimmed,
+            raw[left_trimmed:right_trimmed],
+        )
+
+
+def _span_is_deferred(
+    start: int,
+    end: int,
+    *,
+    branches: Sequence[SourceStructureBranch],
+    deferred_paths: set[tuple[str, ...]],
+) -> bool:
+    return any(
+        branch.start <= start
+        and end <= branch.end
+        and any(
+            branch.path[: len(deferred)] == deferred
+            for deferred in deferred_paths
+        )
+        for branch in branches
+    )
+
+
+def _most_specific_containing_branch(
+    start: int,
+    end: int,
+    *,
+    branches: Sequence[SourceStructureBranch],
+) -> SourceStructureBranch | None:
+    candidates = [
+        branch
+        for branch in branches
+        if branch.start <= start and end <= branch.end
+    ]
+    return max(
+        candidates,
+        key=lambda branch: (
+            len(branch.path),
+            -(branch.end - branch.start),
+        ),
+        default=None,
     )
 
 
@@ -1169,6 +1365,7 @@ def _formula_branch_has_test_evidence(
     asserted_by_rule: dict[str, list[dict[str, Any]]],
     corpus_citation_path: str,
     extract_numeric_occurrences: NumericOccurrenceExtractor,
+    allow_explicit_cover: bool,
 ) -> bool:
     interval = _formula_branch_interval(
         branch,
@@ -1177,7 +1374,7 @@ def _formula_branch_has_test_evidence(
     for rule_name in _rules_covering_branch(branch, principal_rule_paths):
         selector_names = _rule_numeric_selector_names(principal_rules[rule_name])
         for case in asserted_by_rule.get(rule_name, ()):
-            if _case_explicitly_covers_branch(
+            if allow_explicit_cover and _case_explicitly_covers_branch(
                 case,
                 branch,
                 corpus_citation_path=corpus_citation_path,
@@ -1219,6 +1416,8 @@ def _rules_covering_branch(
     branch: SourceStructureBranch,
     principal_rule_paths: dict[str, set[tuple[str, ...]]],
 ) -> tuple[str, ...]:
+    if not branch.path:
+        return tuple(principal_rule_paths)
     return tuple(
         name
         for name, paths in principal_rule_paths.items()
@@ -1232,26 +1431,57 @@ def _formula_branch_interval(
     extract_numeric_occurrences: NumericOccurrenceExtractor,
 ) -> tuple[float | None, bool, float | None, bool] | None:
     first_line = branch.text.splitlines()[0] if branch.text.splitlines() else ""
-    prefix = first_line.split(":", 1)[0]
-    prefix = _NUMBER_MARKER.sub("", prefix).strip()
-    values = tuple(float(value) for value in extract_numeric_occurrences(prefix))
+    range_text = first_line.split(":", 1)[0]
+    range_text = _NUMBER_MARKER.sub("", range_text).strip()
+    return _formula_interval_from_text(
+        range_text,
+        extract_numeric_occurrences=extract_numeric_occurrences,
+    )
+
+
+def _formula_interval_from_text(
+    text: str,
+    *,
+    extract_numeric_occurrences: NumericOccurrenceExtractor,
+) -> tuple[float | None, bool, float | None, bool] | None:
+    lowered = text.lower()
+    keyword = re.search(
+        r"\b(?:von|from|unter|less\s+than|below|bis|up\s+to|höchstens|"
+        r"at\s+most|über|more\s+than|above|ab|at\s+least|mindestens)\b",
+        lowered,
+    )
+    if keyword is None:
+        return None
+    range_text = text[keyword.start() :]
+    if re.match(
+        r"ab\s+(?:dem\s+)?(?:veranlagungszeitraum|tax\s+year|calendar\s+year)\b",
+        range_text,
+        flags=re.IGNORECASE,
+    ):
+        return None
+    values = tuple(
+        float(value) for value in extract_numeric_occurrences(range_text)
+    )
     if not values:
         return None
-    lowered = prefix.lower()
-    if re.search(r"\b(?:von|from)\b", lowered) and re.search(
+    lowered_range = range_text.lower()
+    if re.match(r"(?:von|from)\b", lowered_range) and re.search(
         r"\b(?:bis|to|through)\b",
-        lowered,
+        lowered_range,
     ):
         if len(values) < 2:
             return None
-        return values[0], True, values[-1], True
-    if re.search(r"\b(?:unter|less\s+than|below)\b", lowered):
-        return None, False, values[-1], False
-    if re.search(r"\b(?:bis|up\s+to|höchstens|at\s+most)\b", lowered):
-        return None, False, values[-1], True
-    if re.search(r"\b(?:über|more\s+than|above)\b", lowered):
+        return values[0], True, values[1], True
+    if re.match(r"(?:unter|less\s+than|below)\b", lowered_range):
+        return None, False, values[0], False
+    if re.match(r"(?:bis|up\s+to|höchstens|at\s+most)\b", lowered_range):
+        return None, False, values[0], True
+    if re.match(r"(?:über|more\s+than|above)\b", lowered_range):
         return values[0], False, None, False
-    if re.search(r"\b(?:von|ab|from|at\s+least|mindestens)\b", lowered):
+    if re.match(
+        r"(?:von|ab|from|at\s+least|mindestens)\b",
+        lowered_range,
+    ):
         return values[0], True, None, False
     return None
 
@@ -1335,6 +1565,92 @@ def _input_key_names(key: object) -> set[str]:
     }
 
 
+def _source_exception_branches(
+    source_text: str,
+    *,
+    branches: Sequence[SourceStructureBranch],
+    active_branches: Sequence[SourceStructureBranch],
+    deferred_paths: set[tuple[str, ...]],
+) -> tuple[SourceStructureBranch, ...]:
+    obligations: list[SourceStructureBranch] = []
+    for match in _EXCEPTION_LANGUAGE.finditer(source_text):
+        if _span_is_deferred(
+            match.start(),
+            match.end(),
+            branches=branches,
+            deferred_paths=deferred_paths,
+        ):
+            continue
+        owner = _most_specific_containing_branch(
+            match.start(),
+            match.end(),
+            branches=active_branches,
+        )
+        obligations.append(
+            owner
+            or SourceStructureBranch(
+                (),
+                "source-unit",
+                "source unit",
+                source_text,
+                0,
+                len(source_text),
+            )
+        )
+    return tuple(obligations)
+
+
+def _unwitnessed_exception_branches(
+    exception_branches: Sequence[SourceStructureBranch],
+    *,
+    principal_rule_paths: dict[str, set[tuple[str, ...]]],
+    toggled_exception_selectors: set[tuple[str, str]],
+) -> tuple[SourceStructureBranch, ...]:
+    available_witnesses = set(toggled_exception_selectors)
+    missing: list[SourceStructureBranch] = []
+    for branch in sorted(
+        exception_branches,
+        key=lambda item: len(_exception_witnesses_for_branch(
+            item,
+            principal_rule_paths=principal_rule_paths,
+            toggled_exception_selectors=available_witnesses,
+        )),
+    ):
+        candidates = _exception_witnesses_for_branch(
+            branch,
+            principal_rule_paths=principal_rule_paths,
+            toggled_exception_selectors=available_witnesses,
+        )
+        if not candidates:
+            missing.append(branch)
+            continue
+        available_witnesses.remove(sorted(candidates)[0])
+    return tuple(missing)
+
+
+def _exception_witnesses_for_branch(
+    branch: SourceStructureBranch,
+    *,
+    principal_rule_paths: dict[str, set[tuple[str, ...]]],
+    toggled_exception_selectors: set[tuple[str, str]],
+) -> set[tuple[str, str]]:
+    affecting_rules = {
+        rule_name
+        for rule_name, paths in principal_rule_paths.items()
+        if not branch.path
+        or any(
+            path == branch.path[: len(path)]
+            for path in paths
+            if path
+        )
+    }
+    return {
+        witness
+        for witness in toggled_exception_selectors
+        if witness[0] in affecting_rules
+    }
+
+
 def _toggled_formula_boolean_selectors(
     principal_rules: dict[str, dict[str, Any]],
     *,
@@ -1342,7 +1658,7 @@ def _toggled_formula_boolean_selectors(
 ) -> set[tuple[str, str]]:
     toggled: set[tuple[str, str]] = set()
     for rule_name, rule in principal_rules.items():
-        selector_names = _rule_boolean_selector_names(rule)
+        selector_names = _rule_exception_selector_names(rule)
         if not selector_names:
             continue
         for key in _paired_boolean_toggle_keys(asserted_by_rule.get(rule_name, ())):
@@ -1351,42 +1667,134 @@ def _toggled_formula_boolean_selectors(
     return toggled
 
 
-def _rule_boolean_selector_names(rule: dict[str, Any]) -> set[str]:
+def _rule_exception_selector_names(rule: dict[str, Any]) -> set[str]:
+    """Return selectors attached to an excluding conditional branch."""
+
     formula_text = _rule_formula_text(rule)
     names: set[str] = set()
-    for match in re.finditer(r"\bif\s+(?P<condition>[^:\n]+):", formula_text):
-        names.update(
+    for condition, true_body, false_body in _formula_condition_blocks(formula_text):
+        condition_names = {
             identifier
             for identifier in re.findall(
                 r"\b[A-Za-z_][A-Za-z0-9_]*\b",
-                match.group("condition"),
+                condition,
             )
             if identifier.lower()
             not in {"and", "or", "not", "true", "false", "holds", "not_holds"}
-        )
+        }
+        if (
+            _formula_branch_is_excluding(true_body)
+            or _formula_branch_is_excluding(false_body)
+            or any(_exception_semantic_identifier(name) for name in condition_names)
+        ):
+            names.update(condition_names)
     return names
+
+
+def _formula_condition_blocks(
+    formula_text: str,
+) -> Iterable[tuple[str, str, str]]:
+    lines = formula_text.splitlines()
+    for index, line in enumerate(lines):
+        match = re.match(
+            r"^(?P<indent>[ \t]*)if\s+(?P<condition>[^:\n]+):\s*$",
+            line,
+        )
+        if match is None:
+            continue
+        indent = _formula_indent_width(match.group("indent"))
+        true_lines: list[str] = []
+        false_lines: list[str] = []
+        cursor = index + 1
+        while cursor < len(lines):
+            candidate = lines[cursor]
+            stripped = candidate.strip()
+            candidate_indent = _formula_indent_width(
+                candidate[: len(candidate) - len(candidate.lstrip())]
+            )
+            if stripped and candidate_indent <= indent:
+                break
+            true_lines.append(candidate)
+            cursor += 1
+        if (
+            cursor < len(lines)
+            and _formula_indent_width(
+                lines[cursor][
+                    : len(lines[cursor]) - len(lines[cursor].lstrip())
+                ]
+            )
+            == indent
+            and re.match(r"^[ \t]*else:\s*$", lines[cursor])
+        ):
+            cursor += 1
+            while cursor < len(lines):
+                candidate = lines[cursor]
+                stripped = candidate.strip()
+                candidate_indent = _formula_indent_width(
+                    candidate[: len(candidate) - len(candidate.lstrip())]
+                )
+                if stripped and candidate_indent <= indent:
+                    break
+                false_lines.append(candidate)
+                cursor += 1
+        yield (
+            match.group("condition"),
+            "\n".join(true_lines),
+            "\n".join(false_lines),
+        )
+
+
+def _formula_indent_width(value: str) -> int:
+    return len(value.expandtabs(4))
+
+
+def _formula_branch_is_excluding(body: str) -> bool:
+    first_statement = next(
+        (
+            line.strip()
+            for line in body.splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        ),
+        "",
+    )
+    return bool(
+        re.fullmatch(
+            r"(?:return\s+)?(?:0(?:\.0+)?|false|not_holds)",
+            first_statement,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _exception_semantic_identifier(identifier: str) -> bool:
+    return bool(
+        re.search(
+            r"(?:exception|exempt|exclud|disqual|inelig|eligib|remarri|"
+            r"barred|blocking|waiver)",
+            identifier,
+            flags=re.IGNORECASE,
+        )
+    )
 
 
 def _fractional_formula_input_case_count(
     principal_rules: dict[str, dict[str, Any]],
     *,
     asserted_by_rule: dict[str, list[dict[str, Any]]],
-    rule_names: set[str],
+    rule_functions: dict[str, set[str]],
 ) -> int:
     evidence: set[tuple[str, int]] = set()
-    for rule_name in rule_names:
-        formula_identifiers = set(
-            re.findall(
-                r"\b[A-Za-z_][A-Za-z0-9_]*\b",
-                _rule_formula_text(principal_rules[rule_name]),
-            )
+    for rule_name, functions in rule_functions.items():
+        rounded_operand_identifiers = _rounding_operand_identifier_names(
+            principal_rules[rule_name],
+            functions=functions,
         )
         for index, case in enumerate(asserted_by_rule.get(rule_name, ())):
             inputs = case.get("input")
             if not isinstance(inputs, dict):
                 continue
             if any(
-                _input_key_names(key) & formula_identifiers
+                _input_key_names(key) & rounded_operand_identifiers
                 and any(
                     not float(value).is_integer()
                     for value in _numeric_test_input_values(input_value)
@@ -1395,6 +1803,62 @@ def _fractional_formula_input_case_count(
             ):
                 evidence.add((rule_name, index))
     return len(evidence)
+
+
+def _rounding_operand_identifier_names(
+    rule: dict[str, Any],
+    *,
+    functions: set[str],
+) -> set[str]:
+    names: set[str] = set()
+    formula_text = _rule_formula_text(rule)
+    function_names = {"floor", "ceil"} & functions
+    if "nearest" in functions:
+        function_names.add("floor")
+    for function_name in function_names:
+        for operand in _balanced_call_operands(formula_text, function_name):
+            if (
+                functions == {"nearest"}
+                and not re.search(r"\+\s*0?\.5\b", operand)
+            ):
+                continue
+            names.update(
+                identifier
+                for identifier in _FORMULA_IDENTIFIER.findall(operand)
+                if identifier.lower()
+                not in {
+                    "if",
+                    "else",
+                    "and",
+                    "or",
+                    "not",
+                    "floor",
+                    "ceil",
+                    "min",
+                    "max",
+                    "true",
+                    "false",
+                    "holds",
+                    "not_holds",
+                }
+            )
+    return names
+
+
+def _balanced_call_operands(text: str, function_name: str) -> Iterable[str]:
+    for match in re.finditer(rf"\b{re.escape(function_name)}\s*\(", text):
+        open_index = match.end() - 1
+        depth = 1
+        cursor = open_index + 1
+        while cursor < len(text) and depth:
+            character = text[cursor]
+            if character == "(":
+                depth += 1
+            elif character == ")":
+                depth -= 1
+            cursor += 1
+        if depth == 0:
+            yield text[open_index + 1 : cursor - 1]
 
 
 def _case_explicitly_covers_branch(
@@ -1427,6 +1891,7 @@ def _case_explicitly_covers_branch(
 def _source_boundary_obligations(
     branches: Sequence[SourceStructureBranch],
     *,
+    narrative_formula_branches: Sequence[SourceStructureBranch] = (),
     extract_numeric_occurrences: NumericOccurrenceExtractor,
 ) -> tuple[tuple[SourceStructureBranch, float], ...]:
     obligations: list[tuple[SourceStructureBranch, float]] = []
@@ -1447,7 +1912,25 @@ def _source_boundary_obligations(
             (branch, float(value))
             for value in dict.fromkeys(extract_numeric_occurrences(prefix))
         )
-    return tuple(obligations)
+    for branch in narrative_formula_branches:
+        interval = _formula_branch_interval(
+            branch,
+            extract_numeric_occurrences=extract_numeric_occurrences,
+        )
+        if interval is None:
+            continue
+        lower, _, upper, _ = interval
+        obligations.extend(
+            (branch, boundary)
+            for boundary in (lower, upper)
+            if boundary is not None
+        )
+    return tuple(
+        {
+            (branch.path, float(value), branch.kind): (branch, float(value))
+            for branch, value in obligations
+        }.values()
+    )
 
 
 def _numeric_test_input_values(value: Any) -> tuple[float, ...]:

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1476,6 +1476,28 @@ def _companion_test_issues(
             "exceptions, and rounding rules."
         ]
 
+    colliding_cases = [
+        case
+        for case in cases
+        if _case_input_principal_output_collisions(case, set(principal_rules))
+    ]
+    for case in colliding_cases:
+        collisions = ", ".join(
+            sorted(
+                _case_input_principal_output_collisions(
+                    case,
+                    set(principal_rules),
+                )
+            )
+        )
+        issues.append(
+            "[complete-source-unit:tests] Companion case "
+            f"`{case.get('name') or '<unnamed>'}` supplies local principal "
+            f"output(s) {collisions} as inputs; derived outputs must be "
+            "computed and asserted, not shadowed."
+        )
+    cases = [case for case in cases if case not in colliding_cases]
+
     asserted_by_rule = {
         name: [
             case
@@ -1662,6 +1684,22 @@ def _test_case_output_names(case: dict[str, Any]) -> set[str]:
         text = str(key)
         names.add(text.rsplit("#", 1)[-1])
     return names
+
+
+def _case_input_principal_output_collisions(
+    case: dict[str, Any],
+    principal_rule_names: set[str],
+) -> set[str]:
+    inputs = case.get("input")
+    if not isinstance(inputs, dict):
+        return set()
+    return set().union(
+        *(
+            _input_key_names(key) & principal_rule_names
+            for key in inputs
+        ),
+        set(),
+    )
 
 
 def _source_formula_branches(
@@ -1935,6 +1973,7 @@ def _formula_branch_test_witnesses(
                     for value in _case_numeric_selector_values(
                         case,
                         selector_names,
+                        dependency_environment=dependency_environment,
                     )
                 )
             ):
@@ -1984,6 +2023,13 @@ def _formula_execution_matches_source_branch(
             math.isclose(source_multiplier, 2.0)
             and _formula_is_duplicate_addition(operative_leaf)
         )
+    ):
+        return False
+    source_divisor = _source_named_divisor(branch.text)
+    if source_divisor is not None and not _formula_has_numeric_divisor(
+        operative_leaf,
+        binding_environment,
+        source_divisor,
     ):
         return False
     if _source_describes_half(branch.text):
@@ -2065,14 +2111,18 @@ def _formula_operation_kinds(text: str) -> set[str]:
         "add": (
             r"(?:\+|\bsumme\b|\bsum\s+of\b|\bzuzüglich\b|"
             r"\b(?:summieren|addieren)\b|"
-            r"\berhöh\w*\s+(?:sich\s+)?um\b)"
+            r"\berhöh\w*\s+(?:sich\s+)?um\b|"
+            r"\bum\s+(?:\d+(?:[.,]\d+)?|[a-zäöüß]+)\s+zu\s+"
+            r"(?:erhöhen|vermehren)\b)"
         ),
         "subtract": (
             r"(?:\s[−–-]\s|\bunterschied\b|\bdifferenz\b|"
             r"\bdifference\s+between\b|\babzüglich\b|"
             r"\b(?:vermindern|kürzen)\b|"
             r"\b(?:vermindert|gekürzt|mindert|kürzt)\w*\s+"
-            r"(?:sich\s+)?um\b)"
+            r"(?:sich\s+)?um\b|"
+            r"\bum\s+(?:\d+(?:[.,]\d+)?|[a-zäöüß]+)\s+zu\s+"
+            r"(?:vermindern|kürzen)\b)"
         ),
         "multiply": (
             r"(?:[*×·•∗∙]|\bprodukt\b|\bproduct\s+of\b|"
@@ -2165,16 +2215,24 @@ def _source_named_multiplier(text: str) -> float | None:
             r"\b(?:doppelte|zweifache|verdoppelt|verdoppeln|"
             r"twice|double[ds]?)\b",
         ),
-        (3.0, r"\b(?:dreifache|verdreifacht|threefold|triple[ds]?)\b"),
-        (4.0, r"\b(?:vierfache|vervierfacht|fourfold|quadruple[ds]?)\b"),
-        (5.0, r"\b(?:fünffache|fivefold)\b"),
-        (6.0, r"\b(?:sechsfache|sixfold)\b"),
-        (7.0, r"\b(?:siebenfache|sevenfold)\b"),
-        (8.0, r"\b(?:achtfache|eightfold)\b"),
-        (9.0, r"\b(?:neunfache|ninefold)\b"),
-        (10.0, r"\b(?:zehnfache|tenfold)\b"),
+        (
+            3.0,
+            r"\b(?:dreifache|verdreifacht|verdreifachen|"
+            r"threefold|triple[ds]?)\b",
+        ),
+        (
+            4.0,
+            r"\b(?:vierfache|vervierfacht|vervierfachen|"
+            r"fourfold|quadruple[ds]?)\b",
+        ),
+        (5.0, r"\b(?:fünffache|verfünffachen|fivefold)\b"),
+        (6.0, r"\b(?:sechsfache|versechsfachen|sixfold)\b"),
+        (7.0, r"\b(?:siebenfache|versiebenfachen|sevenfold)\b"),
+        (8.0, r"\b(?:achtfache|verachtfachen|eightfold)\b"),
+        (9.0, r"\b(?:neunfache|verneunfachen|ninefold)\b"),
+        (10.0, r"\b(?:zehnfache|verzehnfachen|tenfold)\b"),
     )
-    return next(
+    named_multiplier = next(
         (
             multiplier
             for multiplier, pattern in patterns
@@ -2182,6 +2240,64 @@ def _source_named_multiplier(text: str) -> float | None:
         ),
         None,
     )
+    if named_multiplier is not None:
+        return named_multiplier
+    contextual_word = _source_contextual_number_word(
+        text,
+        patterns=(
+            r"\bmal\s+(?P<number>[a-zäöüß]+)\b",
+            r"\bmit\s+(?:(?:dem|einem)\s+faktor\s+)?"
+            r"(?:von\s+)?(?P<number>[a-zäöüß]+)\s+zu\s+"
+            r"(?:multiplizieren|vervielfachen)\b",
+            r"\bdurch\s+multiplikation\s+mit\s+"
+            r"(?:(?:(?:dem|einem)\s+)?faktor\s+)?(?:von\s+)?"
+            r"(?P<number>[a-zäöüß]+)\b",
+            r"\bunter\s+anwendung\s+(?:des|eines)\s+faktors?\s+"
+            r"(?P<number>[a-zäöüß]+)\b",
+        ),
+    )
+    return contextual_word
+
+
+def _source_named_divisor(text: str) -> float | None:
+    return _source_contextual_number_word(
+        text,
+        patterns=(
+            r"\bdurch\s+(?P<number>[a-zäöüß]+)\s+zu\s+teilen\b",
+            r"\bgeteilt\s+durch\s+(?P<number>[a-zäöüß]+)\b",
+            r"\bdurch\s+(?P<number>[a-zäöüß]+)\s+geteilt\b",
+        ),
+    )
+
+
+def _source_contextual_number_word(
+    text: str,
+    *,
+    patterns: Sequence[str],
+) -> float | None:
+    values = {
+        "ein": 1.0,
+        "eins": 1.0,
+        "eine": 1.0,
+        "einen": 1.0,
+        "einem": 1.0,
+        "einer": 1.0,
+        "eines": 1.0,
+        "zwei": 2.0,
+        "drei": 3.0,
+        "vier": 4.0,
+        "fünf": 5.0,
+        "sechs": 6.0,
+        "sieben": 7.0,
+        "acht": 8.0,
+        "neun": 9.0,
+        "zehn": 10.0,
+    }
+    for pattern in patterns:
+        match = re.search(pattern, text, flags=re.IGNORECASE)
+        if match is not None:
+            return values.get(match.group("number").lower())
+    return None
 
 
 def _source_describes_half(text: str) -> bool:
@@ -2575,8 +2691,15 @@ def _case_dependency_environment(
     inputs = _case_input_formula_environment(case)
     if inputs is None:
         return {}
+    candidates = {
+        name: rule
+        for name, rule in principal_rules.items()
+        if allowed_names is None or name in allowed_names
+    }
     environment = dict(constants)
     for name, value in inputs.items():
+        if name in candidates:
+            continue
         if name in environment and not _formula_runtime_values_equal(
             environment[name],
             value,
@@ -2584,11 +2707,6 @@ def _case_dependency_environment(
             return {}
         environment[name] = value
 
-    candidates = {
-        name: rule
-        for name, rule in principal_rules.items()
-        if allowed_names is None or name in allowed_names
-    }
     resolved: dict[str, Any] = {}
     for _ in range(len(candidates) + 1):
         changed = False
@@ -2636,12 +2754,12 @@ def _formula_runtime_values_equal(left: Any, right: Any) -> bool:
         and isinstance(right, (int, float))
         and not isinstance(right, bool)
     ):
-        with contextlib.suppress(InvalidOperation):
-            return (
-                abs(Decimal(str(left)) - Decimal(str(right)))
-                <= Decimal("1e-18")
-            )
-        return False
+        return math.isclose(
+            float(left),
+            float(right),
+            rel_tol=1e-12,
+            abs_tol=1e-12,
+        )
     return type(left) is type(right) and left == right
 
 
@@ -3217,13 +3335,7 @@ def _formula_execution_leaf_is_computational(
             and literal == 0
         ):
             return False
-    return not bool(
-        re.fullmatch(
-            r"(?:true|false|holds|not_holds|null|none)",
-            leaf,
-            flags=re.IGNORECASE,
-        )
-    )
+    return leaf not in {"true", "false", "True", "False", "null", "none"}
 
 
 def _formula_execution_references_names(
@@ -3293,12 +3405,9 @@ def _match_arm_value(
     *,
     environment: dict[str, Any],
 ) -> Any:
-    if value == "_":
-        return value
-    lowered = value.lower()
-    if lowered in {"true", "holds"}:
+    if value == "true":
         return True
-    if lowered in {"false", "not_holds"}:
+    if value == "false":
         return False
     with contextlib.suppress(SyntaxError, ValueError):
         return ast.literal_eval(value)
@@ -3336,10 +3445,9 @@ def _evaluate_condition_expression(
     if isinstance(expression, ast.Constant):
         return expression.value
     if isinstance(expression, ast.Name):
-        lowered = expression.id.lower()
-        if lowered in {"true", "holds"}:
+        if expression.id == "true":
             return True
-        if lowered in {"false", "not_holds"}:
+        if expression.id == "false":
             return False
         return environment.get(expression.id, _UNRESOLVED_CONDITION_VALUE)
     if isinstance(expression, ast.BoolOp):
@@ -4088,12 +4196,15 @@ def _rule_numeric_selector_names(rule: dict[str, Any]) -> set[str]:
 def _case_numeric_selector_values(
     case: dict[str, Any],
     selector_names: set[str],
+    *,
+    dependency_environment: dict[str, Any] | None = None,
 ) -> tuple[float, ...]:
     return tuple(
         value
         for _key, _names, value in _case_numeric_selector_evidence(
             case,
             selector_names,
+            dependency_environment=dependency_environment,
         )
     )
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -109,12 +109,18 @@ _COMPUTATION_LANGUAGE = re.compile(
     r"\b(?:"
     r"bemisst\s+sich\s+nach|berechn(?:et|en|ung)|ergibt\s+sich|"
     r"(?:zwei|drei|vier|fünf|sechs|sieben|acht|neun|zehn)fache|"
+    r"(?:das\s+)?(?:doppelte|dreifache|vierfache|fünffache|sechsfache|"
+    r"siebenfache|achtfache|neunfache|zehnfache)\s+(?:des|der|von)|"
     r"hälfte|zehntausendstel|übersteigenden\s+teils|"
     r"(?:ein(?:e[nsrm]?)?\s+)?(?:drittel|viertel|fünftel|sechstel|"
     r"siebtel|achtel|neuntel|zehntel)\s+(?:des|der|von)|"
-    r"summe\s+(?:aus|der|von)|unterschied|differenz|"
+    r"summe\s+(?:aus|der|von)|produkt\s+(?:aus|der|von)|"
+    r"unterschied|differenz|"
     r"geteilt\s+durch|durch\s+(?:\d+|[a-zäöüß]+)\s+geteilt|"
     r"multipliziert\s+mit|"
+    r"\bmal\s+(?:\d+(?:[.,]\d+)?|"
+    r"ein(?:s|e[nsrm]?)?|zwei|drei|vier|fünf|sechs|sieben|acht|neun|zehn)|"
+    r"(?:wird|werden)\s+(?:verdoppelt|verdreifacht|vervierfacht)|"
     r"\d+(?:[.,]\d+)?\s*-?fach(?:e[nsrm]?)?|"
     r"(?:vermindert|erhöht|gekürzt|vermehrt)\s+um|"
     r"(?:erhöht|mindert|vermindert|kürzt|vermehrt)\s+sich\s+um|"
@@ -767,17 +773,17 @@ def _paths_from_source_reference(
             else re.findall(r"\(([A-Za-z0-9-]+)\)", suffix)
         )
         if components:
-            paths.add(tuple(component.lower() for component in components))
+            base_components = tuple(component.lower() for component in components)
+            trailing = _reference_qualifier_tail(
+                value,
+                start=match.end(),
+                next_reference=corpus_citation_path,
+            )
+            paths.add(
+                (*base_components, *_keyword_path_components(trailing, base_components))
+            )
 
-    keyword_components: list[str] = []
-    if match := _ABSATZ_REFERENCE.search(value):
-        keyword_components.append(match.group("label").lower())
-    if match := _NUMMER_REFERENCE.search(value):
-        keyword_components.append(match.group("label").lower())
-    if match := _BUCHSTABE_REFERENCE.search(value):
-        keyword_components.append(match.group("label").lower())
-    if match := _SATZ_REFERENCE.search(value):
-        keyword_components.append(f"satz-{match.group('label')}")
+    keyword_components = _keyword_path_components(value)
     if keyword_components:
         paths.add(tuple(keyword_components))
 
@@ -790,10 +796,54 @@ def _paths_from_source_reference(
     ):
         components = re.findall(r"\(([A-Za-z0-9-]+)\)", match.group("suffix"))
         if components:
-            paths.add(tuple(component.lower() for component in components))
+            base_components = tuple(component.lower() for component in components)
+            trailing = _reference_qualifier_tail(
+                value,
+                start=match.end(),
+                next_reference=f"§{current_section}",
+            )
+            paths.add(
+                (*base_components, *_keyword_path_components(trailing, base_components))
+            )
     if not paths:
         paths.add(())
     return paths
+
+
+def _reference_qualifier_tail(
+    source: str,
+    *,
+    start: int,
+    next_reference: str,
+) -> str:
+    """Limit nested Absatz/Nummer/Satz qualifiers to one source reference."""
+
+    trailing = source[start:]
+    for separator in (";", "\n", next_reference):
+        trailing = trailing.split(separator, 1)[0]
+    return trailing
+
+
+def _keyword_path_components(
+    source: str,
+    existing: Sequence[str] = (),
+) -> tuple[str, ...]:
+    """Return hierarchical German structure qualifiers not already explicit."""
+
+    components: list[str] = []
+    existing_set = {item.lower() for item in existing}
+    for pattern, prefix in (
+        (_ABSATZ_REFERENCE, ""),
+        (_NUMMER_REFERENCE, ""),
+        (_BUCHSTABE_REFERENCE, ""),
+        (_SATZ_REFERENCE, "satz-"),
+    ):
+        if match := pattern.search(source):
+            component = f"{prefix}{match.group('label').lower()}"
+            if component not in existing_set:
+                components.append(component)
+                existing_set.add(component)
+    return tuple(components)
 
 
 def _source_reference_targets_authoritative_unit(

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1806,6 +1806,11 @@ def _rule_match_outer_branch(rule: dict[str, Any]) -> str | int | None:
             for header in multiline_headers
             if len(header.group("indent").expandtabs(8)) == outer_indent
         ]
+        outer_condition_headers = [
+            header
+            for header in outer_headers
+            if header.group("kind") in {"if", "elif"}
+        ]
         match_line_start = formula.rfind("\n", 0, match.start()) + 1
         match_indent = len(
             formula[match_line_start : match.start()].expandtabs(8)
@@ -1821,7 +1826,7 @@ def _rule_match_outer_branch(rule: dict[str, Any]) -> str | int | None:
                 branch_index = condition_index
                 condition_index += 1
             else:
-                branch_index = len(condition_headers)
+                branch_index = len(outer_condition_headers)
         return branch_index if branch_index >= 0 else None
 
     inline_condition_headers = list(

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -139,6 +139,13 @@ class _ExceptionWitness:
     numeric_transition: tuple[float, float] | None
 
 
+@dataclass(frozen=True)
+class _NamedSourceNumber:
+    """A matched source number whose word value may be unsupported."""
+
+    value: float | None
+
+
 _PARAGRAPH_MARKER = re.compile(
     r"(?m)^[ \t]*(?P<marker>\((?P<label>\d+[a-z]?|[a-z])\))(?=\s|bis\b)",
     flags=re.IGNORECASE,
@@ -168,6 +175,24 @@ _EDITORIAL_OMISSION_ONLY = re.compile(
     r"\s*[.;]?\s*$",
     flags=re.IGNORECASE,
 )
+_GERMAN_CARDINAL_VALUES = {
+    "ein": 1.0,
+    "eins": 1.0,
+    "eine": 1.0,
+    "einen": 1.0,
+    "einem": 1.0,
+    "einer": 1.0,
+    "eines": 1.0,
+    "zwei": 2.0,
+    "drei": 3.0,
+    "vier": 4.0,
+    "fünf": 5.0,
+    "sechs": 6.0,
+    "sieben": 7.0,
+    "acht": 8.0,
+    "neun": 9.0,
+    "zehn": 10.0,
+}
 _ARITHMETIC_EXPRESSION = re.compile(
     r"(?:\d+(?:[.,]\d+)?|[A-Za-zÄÖÜäöüß][A-Za-zÄÖÜäöüß]*)"
     r"[ \t]*(?:[+*/=×·•∗∙]|(?<!\w)[−–-](?!\w))[ \t]*"
@@ -195,7 +220,12 @@ _COMPUTATION_LANGUAGE = re.compile(
     r"(?:\d+(?:[.,]\d+)?|[a-zäöüß]+)\s+zu\s+ermitteln|"
     r"unter\s+anwendung\s+(?:des|eines)\s+faktors?\s+"
     r"(?:\d+(?:[.,]\d+)?|[a-zäöüß]+)\s+zu\s+ermitteln|"
-    r"(?:ist|sind)\s+zu\s+(?:verdoppeln|verdreifachen|vervierfachen)|"
+    r"(?:ist|sind)\s+zu\s+(?:"
+    r"verdoppeln|verdreifachen|vervierfachen|verfünffachen|"
+    r"versechsfachen|versiebenfachen|verachtfachen|verneunfachen|"
+    r"verzehnfachen|halbieren)|"
+    r"durch\s+halbierung\s+zu\s+ermitteln|"
+    r"in\s+(?:2|zwei)\s+gleiche\s+teile\s+zu\s+teilen|"
     r"durch\s+(?:\d+(?:[.,]\d+)?|[a-zäöüß]+)\s+zu\s+teilen|"
     r"um\s+(?:\d+(?:[.,]\d+)?|[a-zäöüß]+)\s+zu\s+"
     r"(?:erhöhen|vermindern|kürzen|vermehren)|"
@@ -2067,25 +2097,50 @@ def _formula_execution_matches_source_branch(
     ):
         return False
     source_multiplier = _source_named_multiplier(branch.text)
-    if source_multiplier is not None and not (
+    if source_multiplier is not None and (
+        source_multiplier.value is None
+        or not (
         _formula_has_numeric_factor(
             operative_leaf,
             binding_environment,
-            source_multiplier,
+            source_multiplier.value,
         )
         or (
-            math.isclose(source_multiplier, 2.0)
+            math.isclose(source_multiplier.value, 2.0)
             and _formula_is_duplicate_addition(operative_leaf)
+        )
         )
     ):
         return False
     source_divisor = _source_named_divisor(branch.text)
-    if source_divisor is not None and not _formula_has_numeric_divisor(
-        operative_leaf,
-        binding_environment,
-        source_divisor,
-    ):
-        return False
+    if source_divisor is not None:
+        if source_divisor.value is None:
+            return False
+        has_source_divisor = _formula_has_numeric_divisor(
+            operative_leaf,
+            binding_environment,
+            source_divisor.value,
+        )
+        has_equivalent_half_factor = (
+            math.isclose(source_divisor.value, 2.0)
+            and _source_describes_half(branch.text)
+            and _formula_has_numeric_factor(
+                operative_leaf,
+                binding_environment,
+                0.5,
+            )
+        )
+        if not (has_source_divisor or has_equivalent_half_factor):
+            return False
+    source_delta = _source_named_delta(branch.text)
+    if source_delta is not None:
+        if source_delta[1].value is None or not _formula_has_numeric_delta(
+            operative_leaf,
+            binding_environment,
+            operation=source_delta[0],
+            expected=source_delta[1].value,
+        ):
+            return False
     if _source_describes_half(branch.text):
         if not (
             _formula_has_numeric_factor(
@@ -2182,11 +2237,13 @@ def _formula_operation_kinds(text: str) -> set[str]:
             r"(?:[*×·•∗∙]|\bprodukt\b|\bproduct\s+of\b|"
             r"\b(?:multiplied|multiply|multiplication|multipliziert|"
             r"multiplizieren|multiplikation)\b|\bvervielfach\w*\b|\bmal\b|"
+            r"\b(?:verfünf|versechs|versieben|veracht|verneun|verzehn)"
+            r"fach\w*\b|"
             r"\b(?:doppelte|zweifache|dreifache|twice)\b)"
         ),
         "divide": (
             r"(?:/|\bgeteilt\b|\bteilen\b|\bdivided\b|"
-            r"\bhälfte\b|\bhalf\s+of\b)"
+            r"\bhälfte\b|\bhalbier\w*\b|\bhalbierung\b|\bhalf\s+of\b)"
         ),
     }
     operations.update(
@@ -2259,10 +2316,14 @@ def _formula_operations_are_compatible(
 
 def _source_describes_doubling(text: str) -> bool:
     multiplier = _source_named_multiplier(text)
-    return multiplier is not None and math.isclose(multiplier, 2.0)
+    return (
+        multiplier is not None
+        and multiplier.value is not None
+        and math.isclose(multiplier.value, 2.0)
+    )
 
 
-def _source_named_multiplier(text: str) -> float | None:
+def _source_named_multiplier(text: str) -> _NamedSourceNumber | None:
     patterns = (
         (
             2.0,
@@ -2295,8 +2356,8 @@ def _source_named_multiplier(text: str) -> float | None:
         None,
     )
     if named_multiplier is not None:
-        return named_multiplier
-    contextual_word = _source_contextual_number_word(
+        return _NamedSourceNumber(named_multiplier)
+    return _source_contextual_number_word(
         text,
         patterns=(
             r"\bmal\s+(?P<number>[a-zäöüß]+)\b",
@@ -2310,17 +2371,77 @@ def _source_named_multiplier(text: str) -> float | None:
             r"(?P<number>[a-zäöüß]+)\b",
         ),
     )
-    return contextual_word
 
 
-def _source_named_divisor(text: str) -> float | None:
+def _source_named_divisor(text: str) -> _NamedSourceNumber | None:
     return _source_contextual_number_word(
         text,
         patterns=(
             r"\bdurch\s+(?P<number>[a-zäöüß]+)\s+zu\s+teilen\b",
             r"\bgeteilt\s+durch\s+(?P<number>[a-zäöüß]+)\b",
             r"\bdurch\s+(?P<number>[a-zäöüß]+)\s+geteilt\b",
+            r"\bin\s+(?P<number>[a-zäöüß]+)\s+gleiche\s+teile\s+"
+            r"zu\s+teilen\b",
         ),
+    )
+
+
+def _source_named_delta(
+    text: str,
+) -> tuple[str, _NamedSourceNumber] | None:
+    number = r"(?P<number>\d+(?:[.,]\d+)?|[a-zäöüß]+)"
+    patterns = (
+        (
+            "add",
+            rf"\bum\s+{number}\s+zu\s+(?:erhöhen|vermehren)\b",
+        ),
+        (
+            "add",
+            rf"\b(?:erhöht|vermehrt)\w*\s+(?:sich\s+)?um\s+{number}\b",
+        ),
+        (
+            "add",
+            rf"\bwird\s+um\s+{number}\s+(?:erhöht|vermehrt)\b",
+        ),
+        (
+            "subtract",
+            rf"\bum\s+{number}\s+zu\s+(?:vermindern|kürzen)\b",
+        ),
+        (
+            "subtract",
+            rf"\b(?:vermindert|gekürzt|mindert|kürzt)\w*\s+"
+            rf"(?:sich\s+)?um\s+{number}\b",
+        ),
+        (
+            "subtract",
+            rf"\bwird\s+um\s+{number}\s+(?:vermindert|gekürzt)\b",
+        ),
+    )
+    for operation, pattern in patterns:
+        match = re.search(pattern, text, flags=re.IGNORECASE)
+        if match is None:
+            continue
+        token = match.group("number")
+        value = _source_number_token_value(token)
+        if value is None and _source_number_token_is_symbolic(token):
+            return None
+        return operation, _NamedSourceNumber(value)
+    return None
+
+
+def _source_number_token_value(token: str) -> float | None:
+    normalized = token.lower()
+    if normalized in _GERMAN_CARDINAL_VALUES:
+        return _GERMAN_CARDINAL_VALUES[normalized]
+    with contextlib.suppress(ValueError):
+        return float(normalized.replace(",", "."))
+    return None
+
+
+def _source_number_token_is_symbolic(token: str) -> bool:
+    return (
+        token.isalpha()
+        and (len(token) == 1 or token.isupper())
     )
 
 
@@ -2328,36 +2449,24 @@ def _source_contextual_number_word(
     text: str,
     *,
     patterns: Sequence[str],
-) -> float | None:
-    values = {
-        "ein": 1.0,
-        "eins": 1.0,
-        "eine": 1.0,
-        "einen": 1.0,
-        "einem": 1.0,
-        "einer": 1.0,
-        "eines": 1.0,
-        "zwei": 2.0,
-        "drei": 3.0,
-        "vier": 4.0,
-        "fünf": 5.0,
-        "sechs": 6.0,
-        "sieben": 7.0,
-        "acht": 8.0,
-        "neun": 9.0,
-        "zehn": 10.0,
-    }
+) -> _NamedSourceNumber | None:
     for pattern in patterns:
         match = re.search(pattern, text, flags=re.IGNORECASE)
         if match is not None:
-            return values.get(match.group("number").lower())
+            token = match.group("number")
+            if _source_number_token_is_symbolic(token):
+                return None
+            return _NamedSourceNumber(
+                _GERMAN_CARDINAL_VALUES.get(token.lower())
+            )
     return None
 
 
 def _source_describes_half(text: str) -> bool:
     return bool(
         re.search(
-            r"\b(?:hälfte|halb(?:e[nsrm]?)?|half)\b",
+            r"\b(?:hälfte|halb(?:e[nsrm]?)?|halbier\w*|halbierung|half)\b|"
+            r"\bin\s+(?:2|zwei)\s+gleiche\s+teile\s+zu\s+teilen\b",
             text,
             flags=re.IGNORECASE,
         )
@@ -2401,6 +2510,77 @@ def _formula_has_numeric_divisor(
             if value is not None and math.isclose(float(value), expected):
                 return True
     return False
+
+
+def _formula_has_numeric_delta(
+    text: str,
+    environment: dict[str, Any],
+    *,
+    operation: str,
+    expected: float,
+) -> bool:
+    with contextlib.suppress(SyntaxError):
+        expression = ast.parse(text.strip(), mode="eval").body
+        expression = _unwrap_formula_result_wrapper(expression)
+        if not isinstance(expression, ast.BinOp) or not isinstance(
+            expression.op,
+            (ast.Add, ast.Sub),
+        ):
+            return False
+        constant, has_dynamic_operand = _formula_additive_constant(
+            expression,
+            environment,
+        )
+        signed_expected = expected if operation == "add" else -expected
+        return has_dynamic_operand and math.isclose(
+            constant,
+            signed_expected,
+            rel_tol=1e-12,
+            abs_tol=1e-12,
+        )
+    return False
+
+
+def _unwrap_formula_result_wrapper(expression: ast.expr) -> ast.expr:
+    while (
+        isinstance(expression, ast.Call)
+        and isinstance(expression.func, ast.Name)
+        and expression.func.id in {"ceil", "floor"}
+        and len(expression.args) == 1
+        and not expression.keywords
+    ):
+        expression = expression.args[0]
+    return expression
+
+
+def _formula_additive_constant(
+    expression: ast.expr,
+    environment: dict[str, Any],
+) -> tuple[float, bool]:
+    known = _known_numeric_formula_value(expression, environment)
+    if known is not None:
+        return float(known), False
+    if isinstance(expression, ast.BinOp) and isinstance(
+        expression.op,
+        (ast.Add, ast.Sub),
+    ):
+        left_constant, left_dynamic = _formula_additive_constant(
+            expression.left,
+            environment,
+        )
+        right_constant, right_dynamic = _formula_additive_constant(
+            expression.right,
+            environment,
+        )
+        return (
+            (
+                left_constant + right_constant
+                if isinstance(expression.op, ast.Add)
+                else left_constant - right_constant
+            ),
+            left_dynamic or right_dynamic,
+        )
+    return 0.0, True
 
 
 def _formula_is_duplicate_addition(text: str) -> bool:

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -46,7 +46,7 @@ class CompleteSourceUnitAnalysis:
 
 
 _PARAGRAPH_MARKER = re.compile(
-    r"(?m)^(?P<marker>\((?P<label>\d+[a-z]?|[a-z])\))(?=\s|bis\b)",
+    r"(?m)^[ \t]*(?P<marker>\((?P<label>\d+[a-z]?|[a-z])\))(?=\s|bis\b)",
     flags=re.IGNORECASE,
 )
 _NUMBER_MARKER = re.compile(
@@ -75,14 +75,15 @@ _EDITORIAL_OMISSION_ONLY = re.compile(
     flags=re.IGNORECASE,
 )
 _ARITHMETIC_EXPRESSION = re.compile(
-    r"(?:\d|[A-Za-zÄÖÜäöüß][A-Za-zÄÖÜäöüß]*)"
+    r"(?:\d+(?:[.,]\d+)?|[A-Za-zÄÖÜäöüß][A-Za-zÄÖÜäöüß]*)"
     r"[ \t]*(?:[+*/=×·•∗∙]|(?<!\w)[−–-](?!\w))[ \t]*"
-    r"(?:\d|[A-Za-zÄÖÜäöüß][A-Za-zÄÖÜäöüß]*)"
+    r"(?:\d+(?:[.,]\d+)?|[A-Za-zÄÖÜäöüß][A-Za-zÄÖÜäöüß]*)"
 )
 _COMPUTATION_LANGUAGE = re.compile(
     r"\b(?:"
     r"bemisst\s+sich\s+nach|berechn(?:et|en|ung)|ergibt\s+sich|"
-    r"zweifache|hälfte|zehntausendstel|übersteigenden\s+teils|"
+    r"(?:zwei|drei|vier|fünf|sechs|sieben|acht|neun|zehn)fache|"
+    r"hälfte|zehntausendstel|übersteigenden\s+teils|"
     r"(?:ein(?:e[nsrm]?)?\s+)?(?:drittel|viertel|fünftel|sechstel|"
     r"siebtel|achtel|neuntel|zehntel)\s+(?:des|der|von)|"
     r"summe\s+(?:aus|der|von)|unterschied|differenz|"
@@ -93,24 +94,25 @@ _COMPUTATION_LANGUAGE = re.compile(
     r"splitting-verfahren|verfahren\s+nach\s+absatz|"
     r"calculated|computed|computation|multiplied|divided|"
     r"sum\s+of|difference\s+between|product\s+of|twice|half\s+of|"
-    r"percentage\s+of|in\s+excess\s+of"
+    r"percentage\s+of|in\s+excess\s+of|"
+    r"equals?[^.;]{0,100}\b(?:plus|minus|times)\b"
     r")\b",
     flags=re.IGNORECASE,
 )
 _ROUNDING_LANGUAGE = re.compile(
     r"\b(?:"
-    r"abgerundet(?:en|er|es)?|abzurunden|aufgerundet(?:en|er|es)?|"
+    r"abgerundet(?:e|en|er|es)?|abzurunden|aufgerundet(?:e|en|er|es)?|"
     r"aufzurunden|kaufmännisch(?:\s+zu)?\s+runden|"
     r"round(?:ed|ing)?(?:\s+(?:down|up|to\s+the\s+nearest))?"
     r")\b",
     flags=re.IGNORECASE,
 )
 _DOWN_ROUNDING_LANGUAGE = re.compile(
-    r"\b(?:abgerundet(?:en|er|es)?|abzurunden|round(?:ed|ing)?\s+down)\b",
+    r"\b(?:abgerundet(?:e|en|er|es)?|abzurunden|round(?:ed|ing)?\s+down)\b",
     flags=re.IGNORECASE,
 )
 _UP_ROUNDING_LANGUAGE = re.compile(
-    r"\b(?:aufgerundet(?:en|er|es)?|aufzurunden|round(?:ed|ing)?\s+up)\b",
+    r"\b(?:aufgerundet(?:e|en|er|es)?|aufzurunden|round(?:ed|ing)?\s+up)\b",
     flags=re.IGNORECASE,
 )
 _NEAREST_ROUNDING_LANGUAGE = re.compile(
@@ -121,7 +123,9 @@ _EXCEPTION_LANGUAGE = re.compile(
     r"\b(?:"
     r"except(?:ion)?|unless|subject\s+to|shall\s+not\s+apply|"
     r"does\s+not\s+apply|notwithstanding|vorbehaltlich|ausnahme|"
-    r"es\s+sei\s+denn|voraussetzung[^.;]{0,160}\bnicht\b"
+    r"es\s+sei\s+denn|gilt\s+nicht(?:\s*,?\s*wenn)?|"
+    r"findet\s+keine\s+anwendung|soweit\s+nicht|"
+    r"(?:[1-9]\d?)?voraussetzung[^.;]{0,160}\bnicht\b"
     r")",
     flags=re.IGNORECASE,
 )
@@ -175,10 +179,6 @@ _ENGLISH_LEGAL_CITATION = re.compile(
 _STRUCTURAL_REFERENCE = re.compile(
     r"\b(?:Absatz|Abs\.|Satz|Sätze|Nummer|Nr\.|Buchstabe|Buchst\.)"
     r"\s*\d*[a-z]?\b",
-    flags=re.IGNORECASE,
-)
-_DECIMAL_PERCENT_IDENTIFIER = re.compile(
-    r"(?<!\d)(?P<integer>\d{1,3})_(?P<fraction>\d{1,4})_percent\b",
     flags=re.IGNORECASE,
 )
 _FORMULA_IDENTIFIER = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\b")
@@ -300,10 +300,21 @@ def source_states_explicit_computation(source_text: str) -> bool:
     """Return whether text states a computation rather than only a scalar."""
 
     return bool(
-        _ARITHMETIC_EXPRESSION.search(source_text)
+        _has_substantive_arithmetic_expression(source_text)
         or _COMPUTATION_LANGUAGE.search(source_text)
         or _ROUNDING_LANGUAGE.search(source_text)
     )
+
+
+def _has_substantive_arithmetic_expression(source_text: str) -> bool:
+    """Ignore slash-separated year spans while recognizing actual arithmetic."""
+
+    for match in _ARITHMETIC_EXPRESSION.finditer(source_text):
+        expression = re.sub(r"\s+", "", match.group(0))
+        if re.fullmatch(r"(?:19|20)\d{2}/(?:19|20)\d{2}", expression):
+            continue
+        return True
+    return False
 
 
 def analyze_complete_source_unit(
@@ -676,6 +687,7 @@ def _deferred_coverage(
             continue
         reason = str(record.get("reason") or "").strip()
         blocked_by = record.get("blocked_by")
+        normalized_base_target = base_target.lower()
         exact_blockers = (
             isinstance(blocked_by, list)
             and bool(blocked_by)
@@ -688,12 +700,18 @@ def _deferred_coverage(
                     flags=re.IGNORECASE,
                 )
                 and item.strip().lower() != output.lower()
+                and not (
+                    item.strip().lower().split("#", 1)[0]
+                    == normalized_base_target
+                    or item.strip().lower().split("#", 1)[0].startswith(
+                        f"{normalized_base_target}/"
+                    )
+                )
                 for item in blocked_by
             )
         )
         reason_identifies_dependency = _reason_names_external_dependency(
             reason,
-            deferred_path=path,
             corpus_citation_path=corpus_citation_path,
         )
         precise = (
@@ -718,7 +736,6 @@ def _deferred_coverage(
 def _reason_names_external_dependency(
     reason: str,
     *,
-    deferred_path: tuple[str, ...],
     corpus_citation_path: str,
 ) -> bool:
     if not _MISSING_DEPENDENCY_LANGUAGE.search(reason):
@@ -727,12 +744,18 @@ def _reason_names_external_dependency(
     for match in _PRECISE_DEFERRAL_DEPENDENCY.finditer(reason):
         dependency = match.group(0).strip()
         normalized = dependency.lower()
-        if paragraph_match := _ABSATZ_REFERENCE.fullmatch(dependency):
-            if (
-                deferred_path
-                and paragraph_match.group("label").lower() == deferred_path[0]
-            ):
-                continue
+        if any(
+            pattern.fullmatch(dependency)
+            for pattern in (
+                _ABSATZ_REFERENCE,
+                _SATZ_REFERENCE,
+                _NUMMER_REFERENCE,
+                _BUCHSTABE_REFERENCE,
+            )
+        ):
+            # A bare structural reference names another part of this same
+            # authoritative unit, not a missing external dependency.
+            continue
         if section_match := re.fullmatch(
             r"§{1,2}\s*(\d+[a-z]?)",
             dependency,
@@ -775,9 +798,7 @@ def _path_covered(
     encoded_paths: set[tuple[str, ...]],
     deferred_paths: set[tuple[str, ...]],
 ) -> bool:
-    if path in encoded_paths:
-        return True
-    return any(path[: len(deferred)] == deferred for deferred in deferred_paths)
+    return path in encoded_paths or path in deferred_paths
 
 
 def _branch_citation(
@@ -826,122 +847,44 @@ def collect_artifact_numeric_values(
     content: str,
     *,
     extract_named_scalars: NamedScalarExtractor,
-    extract_numeric_occurrences: NumericOccurrenceExtractor,
     imported_contents: Sequence[str] = (),
     additional_values: Iterable[float] = (),
 ) -> tuple[float, ...]:
     """Collect numeric representations credited by strict recall accounting."""
 
     values = [float(value) for value in additional_values]
-    for artifact_content in (content, *imported_contents):
+    values.extend(
+        float(item.value)
+        for item in extract_named_scalars(content)
+        if hasattr(item, "value")
+    )
+    imported_symbols = _rulespec_import_symbols(content)
+    for artifact_content in imported_contents:
         values.extend(
             float(item.value)
             for item in extract_named_scalars(artifact_content)
             if hasattr(item, "value")
+            and _named_scalar_base_name(str(getattr(item, "name", "")))
+            in imported_symbols
         )
-        with contextlib.suppress(yaml.YAMLError, TypeError, ValueError):
-            payload = yaml.safe_load(artifact_content)
-            if not (
-                isinstance(payload, dict)
-                and payload.get("format") == "rulespec/v1"
-            ):
-                continue
-            rules = payload.get("rules")
-            if isinstance(rules, list):
-                for rule in rules:
-                    if not isinstance(rule, dict):
-                        continue
-                    values.extend(
-                        _numeric_concept_values(
-                            str(rule.get("name") or ""),
-                            extract_numeric_occurrences=extract_numeric_occurrences,
-                        )
-                    )
-                    versions = rule.get("versions")
-                    if isinstance(versions, list):
-                        for version in versions:
-                            formula = (
-                                version.get("formula")
-                                if isinstance(version, dict)
-                                else None
-                            )
-                            if isinstance(formula, str):
-                                for identifier in set(
-                                    _FORMULA_IDENTIFIER.findall(formula)
-                                ):
-                                    values.extend(
-                                        _numeric_concept_values(
-                                            identifier,
-                                            extract_numeric_occurrences=(
-                                                extract_numeric_occurrences
-                                            ),
-                                        )
-                                    )
-                    verification = rule.get("verification")
-                    if isinstance(verification, dict):
-                        values.extend(
-                            _verification_numeric_values(
-                                verification.get("values"),
-                                extract_numeric_occurrences=(
-                                    extract_numeric_occurrences
-                                ),
-                            )
-                        )
     return tuple(values)
 
 
-def _numeric_concept_values(
-    text: str,
-    *,
-    extract_numeric_occurrences: NumericOccurrenceExtractor,
-) -> tuple[float, ...]:
-    normalized = _DECIMAL_PERCENT_IDENTIFIER.sub(
-        lambda match: (
-            f"{match.group('integer')}.{match.group('fraction')} percent"
-        ),
-        text,
-    )
-    normalized = normalized.replace("_", " ").replace("-", " ")
-    return tuple(float(value) for value in extract_numeric_occurrences(normalized))
+def _rulespec_import_symbols(content: str) -> set[str]:
+    with contextlib.suppress(yaml.YAMLError, TypeError, ValueError):
+        payload = yaml.safe_load(content)
+        imports = payload.get("imports") if isinstance(payload, dict) else None
+        if isinstance(imports, list):
+            return {
+                item.rsplit("#", 1)[1]
+                for item in imports
+                if isinstance(item, str) and "#" in item
+            }
+    return set()
 
 
-def _verification_numeric_values(
-    value: object,
-    *,
-    extract_numeric_occurrences: NumericOccurrenceExtractor,
-) -> tuple[float, ...]:
-    if isinstance(value, bool) or value is None:
-        return ()
-    if isinstance(value, (int, float)):
-        return (float(value),)
-    if isinstance(value, str):
-        return tuple(
-            float(item) for item in extract_numeric_occurrences(value.strip())
-        )
-    values: list[float] = []
-    if isinstance(value, dict):
-        for key, item in value.items():
-            values.extend(
-                _verification_numeric_values(
-                    key,
-                    extract_numeric_occurrences=extract_numeric_occurrences,
-                )
-            )
-            values.extend(
-                _verification_numeric_values(
-                    item,
-                    extract_numeric_occurrences=extract_numeric_occurrences,
-                )
-            )
-    elif isinstance(value, list):
-        for item in value:
-            values.extend(
-                _verification_numeric_values(
-                    item,
-                    extract_numeric_occurrences=extract_numeric_occurrences,
-                )
-            )
-    return tuple(values)
+def _named_scalar_base_name(name: str) -> str:
+    return name.split("[", 1)[0]
 
 
 def _companion_test_issues(
@@ -983,49 +926,34 @@ def _companion_test_issues(
     active_branches = [
         branch
         for branch in branches
-        if not any(
-            branch.path[: len(deferred)] == deferred for deferred in deferred_paths
-        )
+        if branch.path not in deferred_paths
     ]
-    structured_formula_branches = [
-        branch
-        for branch in active_branches
-        if branch.kind in {"number", "letter"}
-        and _structured_branch_is_formula_leaf(
-            branch,
-            extract_numeric_occurrences=extract_numeric_occurrences,
-        )
-    ]
-    narrative_formula_branches = _narrative_formula_branches(
+    formula_branches = _source_formula_branches(
         source_text,
         branches=branches,
         active_branches=active_branches,
         deferred_paths=deferred_paths,
+    )
+    missing_formula_branches = _unwitnessed_formula_branches(
+        formula_branches,
+        principal_rules=principal_rules,
+        principal_rule_paths=principal_rule_paths,
+        asserted_by_rule=asserted_by_rule,
         extract_numeric_occurrences=extract_numeric_occurrences,
     )
-    formula_branches = (*structured_formula_branches, *narrative_formula_branches)
-    for branch in formula_branches:
-        if _formula_branch_has_test_evidence(
-            branch,
-            principal_rules=principal_rules,
-            principal_rule_paths=principal_rule_paths,
-            asserted_by_rule=asserted_by_rule,
-            corpus_citation_path=corpus_citation_path,
-            extract_numeric_occurrences=extract_numeric_occurrences,
-            allow_explicit_cover=branch.kind != "formula-clause",
-        ):
-            continue
+    for branch in missing_formula_branches:
         issues.append(
             "[complete-source-unit:tests] Companion tests do not demonstrate "
             f"formula branch {branch.label} at "
             f"{_branch_citation(corpus_citation_path, branch)} with a principal "
-            "output assertion and selector input in that branch (or an exact "
-            "`covers` source-branch declaration)."
+            "output assertion and, when the branch states a range, a selector "
+            "input in that branch. Each formula branch needs distinct executed "
+            "test evidence."
         )
 
     boundary_obligations = _source_boundary_obligations(
         active_branches,
-        narrative_formula_branches=narrative_formula_branches,
+        narrative_formula_branches=formula_branches,
         extract_numeric_occurrences=extract_numeric_occurrences,
     )
     missing_boundaries: list[tuple[SourceStructureBranch, float]] = []
@@ -1050,11 +978,6 @@ def _companion_test_issues(
             f"source-stated boundary input; missing: {rendered}."
         )
 
-    active_text = _source_text_without_deferred_branches(
-        source_text,
-        branches=branches,
-        deferred_paths=deferred_paths,
-    )
     exception_branches = _source_exception_branches(
         source_text,
         branches=branches,
@@ -1085,108 +1008,56 @@ def _companion_test_issues(
                 f"{missing_citations}."
             )
 
-    rounding_count = len(_ROUNDING_LANGUAGE.findall(active_text))
-    if rounding_count:
-        down_rules = {
-            name
-            for name, rule in principal_rules.items()
-            if re.search(r"\bfloor\s*\(", _rule_formula_text(rule))
-        }
-        up_rules = {
-            name
-            for name, rule in principal_rules.items()
-            if re.search(r"\bceil\s*\(", _rule_formula_text(rule))
-        }
-        nearest_rules = {
-            name
-            for name, rule in principal_rules.items()
-            if re.search(r"\bfloor\s*\(", _rule_formula_text(rule))
-            and re.search(r"\+\s*0?\.5\b", _rule_formula_text(rule))
-        }
-        applicable_rounding_functions: dict[str, set[str]] = {}
-        if _DOWN_ROUNDING_LANGUAGE.search(active_text) and not down_rules:
-            issues.append(
-                "[complete-source-unit:tests] A source-stated downward-rounding "
-                "rule is absent from the principal formula (`floor(...)`)."
-            )
-        if _DOWN_ROUNDING_LANGUAGE.search(active_text):
-            for rule_name in down_rules:
-                applicable_rounding_functions.setdefault(rule_name, set()).add(
-                    "floor"
-                )
-        if _UP_ROUNDING_LANGUAGE.search(active_text) and not up_rules:
-            issues.append(
-                "[complete-source-unit:tests] A source-stated upward-rounding "
-                "rule is absent from the principal formula (`ceil(...)`)."
-            )
-        if _UP_ROUNDING_LANGUAGE.search(active_text):
-            for rule_name in up_rules:
-                applicable_rounding_functions.setdefault(rule_name, set()).add(
-                    "ceil"
-                )
-        if _NEAREST_ROUNDING_LANGUAGE.search(active_text) and not nearest_rules:
-            issues.append(
-                "[complete-source-unit:tests] A source-stated nearest/commercial "
-                "rounding rule is absent from the principal formula."
-            )
-        if _NEAREST_ROUNDING_LANGUAGE.search(active_text):
-            for rule_name in nearest_rules:
-                applicable_rounding_functions.setdefault(rule_name, set()).add(
-                    "nearest"
-                )
-        fractional_cases = _fractional_formula_input_case_count(
-            principal_rules,
-            asserted_by_rule=asserted_by_rule,
-            rule_functions=applicable_rounding_functions,
-        )
-        if fractional_cases < rounding_count:
-            issues.append(
-                "[complete-source-unit:tests] Companion tests do not demonstrate "
-                f"all {rounding_count} source-stated rounding rule(s) with "
-                "fractional input values."
-            )
-    return issues
-
-
-def _source_text_without_deferred_branches(
-    source_text: str,
-    *,
-    branches: Sequence[SourceStructureBranch],
-    deferred_paths: set[tuple[str, ...]],
-) -> str:
-    """Remove precisely deferred spans without duplicating nested branch text."""
-
-    deferred_ranges = sorted(
-        (
-            branch.start,
-            branch.end,
-        )
-        for branch in branches
-        if any(
-            branch.path[: len(deferred)] == deferred for deferred in deferred_paths
-        )
-        and not any(
-            ancestor.path != branch.path
-            and ancestor.start <= branch.start
-            and branch.end <= ancestor.end
-            and any(
-                ancestor.path[: len(deferred)] == deferred
-                for deferred in deferred_paths
-            )
-            for ancestor in branches
-        )
+    rounding_obligations = _source_rounding_obligations(
+        source_text,
+        branches=branches,
+        active_branches=active_branches,
+        deferred_paths=deferred_paths,
     )
-    if not deferred_ranges:
-        return source_text
-    parts: list[str] = []
-    cursor = 0
-    for start, end in deferred_ranges:
-        if start < cursor:
+    missing_rounding_formula: list[tuple[SourceStructureBranch, str]] = []
+    rounding_witnesses: dict[
+        tuple[SourceStructureBranch, str], set[tuple[str, int]]
+    ] = {}
+    for obligation in rounding_obligations:
+        branch, direction = obligation
+        rule_names = {
+            name
+            for name in _rules_covering_branch(branch, principal_rule_paths)
+            if _rule_implements_rounding(principal_rules[name], direction)
+        }
+        if not rule_names:
+            missing_rounding_formula.append(obligation)
             continue
-        parts.append(source_text[cursor:start])
-        cursor = end
-    parts.append(source_text[cursor:])
-    return "".join(parts)
+        rounding_witnesses[obligation] = set().union(
+            *(
+                _fractional_rounding_case_witnesses(
+                    name,
+                    principal_rules[name],
+                    asserted_by_rule=asserted_by_rule,
+                    direction=direction,
+                )
+                for name in rule_names
+            )
+        )
+    for branch, direction in missing_rounding_formula:
+        issues.append(
+            "[complete-source-unit:tests] A source-stated "
+            f"{direction} rounding rule at "
+            f"{_branch_citation(corpus_citation_path, branch)} is absent from "
+            "the principal formula."
+        )
+    missing_rounding_tests = _unmatched_evidence_obligations(rounding_witnesses)
+    if missing_rounding_tests:
+        rendered = ", ".join(
+            _branch_citation(corpus_citation_path, branch)
+            for branch, _direction in missing_rounding_tests
+        )
+        issues.append(
+            "[complete-source-unit:tests] Companion tests do not demonstrate "
+            "every source-stated rounding rule with distinct fractional input "
+            f"evidence on its affected principal output; missing at {rendered}."
+        )
+    return issues
 
 
 def _test_case_output_names(case: dict[str, Any]) -> set[str]:
@@ -1200,55 +1071,20 @@ def _test_case_output_names(case: dict[str, Any]) -> set[str]:
     return names
 
 
-def _structured_branch_is_formula_leaf(
-    branch: SourceStructureBranch,
-    *,
-    extract_numeric_occurrences: NumericOccurrenceExtractor,
-) -> bool:
-    first_line = (
-        branch.text.splitlines()[0] if branch.text.splitlines() else branch.text
-    )
-    return bool(
-        (
-            source_states_explicit_computation(branch.text)
-            or re.search(r":\s*-?\d", branch.text)
-        )
-        and (
-            ":" in first_line
-            or _formula_branch_interval(
-                branch,
-                extract_numeric_occurrences=extract_numeric_occurrences,
-            )
-            is not None
-        )
-    )
-
-
-def _narrative_formula_branches(
+def _source_formula_branches(
     source_text: str,
     *,
     branches: Sequence[SourceStructureBranch],
     active_branches: Sequence[SourceStructureBranch],
     deferred_paths: set[tuple[str, ...]],
-    extract_numeric_occurrences: NumericOccurrenceExtractor,
 ) -> tuple[SourceStructureBranch, ...]:
-    """Return range-formula clauses not already represented by list branches."""
+    """Return every explicit computation clause with its structural owner."""
 
-    structured_ranges = [
-        (branch.start, branch.end)
-        for branch in branches
-        if branch.kind in {"number", "letter"}
-    ]
     obligations: list[SourceStructureBranch] = []
     for clause_index, (start, end, clause) in enumerate(
-        _source_clause_spans(source_text),
+        _source_clause_spans(source_text, branches=branches),
         start=1,
     ):
-        if any(
-            start < structured_end and structured_start < end
-            for structured_start, structured_end in structured_ranges
-        ):
-            continue
         if _span_is_deferred(
             start,
             end,
@@ -1257,12 +1093,6 @@ def _narrative_formula_branches(
         ):
             continue
         if not source_states_explicit_computation(clause):
-            continue
-        interval = _formula_interval_from_text(
-            clause,
-            extract_numeric_occurrences=extract_numeric_occurrences,
-        )
-        if interval is None:
             continue
         owner = _most_specific_containing_branch(
             start,
@@ -1291,16 +1121,24 @@ def _narrative_formula_branches(
     return tuple(obligations)
 
 
-def _source_clause_spans(source_text: str) -> Iterable[tuple[int, int, str]]:
-    """Yield offset-preserving semicolon and true sentence clauses."""
+def _source_clause_spans(
+    source_text: str,
+    *,
+    branches: Sequence[SourceStructureBranch],
+) -> Iterable[tuple[int, int, str]]:
+    """Yield offset-preserving clauses split at punctuation and structure."""
 
     boundary = re.compile(
         r";|[.!?](?=(?:[ \t]+[A-ZÄÖÜ(]|\s*$))",
         flags=re.MULTILINE,
     )
-    start = 0
-    for match in boundary.finditer(source_text):
-        end = match.end()
+    split_points = {
+        0,
+        len(source_text),
+        *(match.end() for match in boundary.finditer(source_text)),
+        *(branch.start for branch in branches),
+    }
+    for start, end in zip(sorted(split_points), sorted(split_points)[1:]):
         raw = source_text[start:end]
         left_trimmed = len(raw) - len(raw.lstrip())
         right_trimmed = len(raw.rstrip())
@@ -1310,16 +1148,6 @@ def _source_clause_spans(source_text: str) -> Iterable[tuple[int, int, str]]:
                 start + right_trimmed,
                 raw[left_trimmed:right_trimmed],
             )
-        start = end
-    raw = source_text[start:]
-    left_trimmed = len(raw) - len(raw.lstrip())
-    right_trimmed = len(raw.rstrip())
-    if right_trimmed > left_trimmed:
-        yield (
-            start + left_trimmed,
-            start + right_trimmed,
-            raw[left_trimmed:right_trimmed],
-        )
 
 
 def _span_is_deferred(
@@ -1332,10 +1160,7 @@ def _span_is_deferred(
     return any(
         branch.start <= start
         and end <= branch.end
-        and any(
-            branch.path[: len(deferred)] == deferred
-            for deferred in deferred_paths
-        )
+        and branch.path in deferred_paths
         for branch in branches
     )
 
@@ -1361,37 +1186,82 @@ def _most_specific_containing_branch(
     )
 
 
-def _formula_branch_has_test_evidence(
+def _unwitnessed_formula_branches(
+    branches: Sequence[SourceStructureBranch],
+    *,
+    principal_rules: dict[str, dict[str, Any]],
+    principal_rule_paths: dict[str, set[tuple[str, ...]]],
+    asserted_by_rule: dict[str, list[dict[str, Any]]],
+    extract_numeric_occurrences: NumericOccurrenceExtractor,
+) -> tuple[SourceStructureBranch, ...]:
+    """Consume each executed rule/case witness for at most one source formula."""
+
+    candidate_witnesses = {
+        branch: _formula_branch_test_witnesses(
+            branch,
+            principal_rules=principal_rules,
+            principal_rule_paths=principal_rule_paths,
+            asserted_by_rule=asserted_by_rule,
+            extract_numeric_occurrences=extract_numeric_occurrences,
+        )
+        for branch in branches
+    }
+    return _unmatched_evidence_obligations(candidate_witnesses)
+
+
+def _unmatched_evidence_obligations(
+    candidate_witnesses: dict[Any, set[Any]],
+) -> tuple[Any, ...]:
+    """Return obligations excluded by a maximum one-witness-per-item match."""
+
+    assigned_obligation_by_witness: dict[Any, Any] = {}
+
+    def assign(obligation: Any, visited: set[Any]) -> bool:
+        for witness in sorted(candidate_witnesses[obligation]):
+            if witness in visited:
+                continue
+            visited.add(witness)
+            incumbent = assigned_obligation_by_witness.get(witness)
+            if incumbent is None or assign(incumbent, visited):
+                assigned_obligation_by_witness[witness] = obligation
+                return True
+        return False
+
+    missing: list[Any] = []
+    for obligation in sorted(
+        candidate_witnesses,
+        key=lambda item: len(candidate_witnesses[item]),
+    ):
+        if not assign(obligation, set()):
+            missing.append(obligation)
+    return tuple(missing)
+
+
+def _formula_branch_test_witnesses(
     branch: SourceStructureBranch,
     *,
     principal_rules: dict[str, dict[str, Any]],
     principal_rule_paths: dict[str, set[tuple[str, ...]]],
     asserted_by_rule: dict[str, list[dict[str, Any]]],
-    corpus_citation_path: str,
     extract_numeric_occurrences: NumericOccurrenceExtractor,
-    allow_explicit_cover: bool,
-) -> bool:
+) -> set[tuple[str, int]]:
     interval = _formula_branch_interval(
         branch,
         extract_numeric_occurrences=extract_numeric_occurrences,
     )
+    witnesses: set[tuple[str, int]] = set()
     for rule_name in _rules_covering_branch(branch, principal_rule_paths):
         selector_names = _rule_numeric_selector_names(principal_rules[rule_name])
         for case in asserted_by_rule.get(rule_name, ()):
-            if allow_explicit_cover and _case_explicitly_covers_branch(
-                case,
-                branch,
-                corpus_citation_path=corpus_citation_path,
-            ):
-                return True
-            if interval is None or not selector_names:
+            if interval is None:
+                witnesses.add((rule_name, id(case)))
                 continue
-            if any(
+            if selector_names and any(
                 _interval_contains(interval, value)
                 for value in _case_numeric_selector_values(case, selector_names)
             ):
-                return True
-    return False
+                witnesses.add((rule_name, id(case)))
+    return witnesses
 
 
 def _branch_boundary_has_test_evidence(
@@ -1420,8 +1290,6 @@ def _rules_covering_branch(
     branch: SourceStructureBranch,
     principal_rule_paths: dict[str, set[tuple[str, ...]]],
 ) -> tuple[str, ...]:
-    if not branch.path:
-        return tuple(principal_rule_paths)
     return tuple(
         name
         for name, paths in principal_rule_paths.items()
@@ -1604,6 +1472,53 @@ def _source_exception_branches(
     return tuple(obligations)
 
 
+def _source_rounding_obligations(
+    source_text: str,
+    *,
+    branches: Sequence[SourceStructureBranch],
+    active_branches: Sequence[SourceStructureBranch],
+    deferred_paths: set[tuple[str, ...]],
+) -> tuple[tuple[SourceStructureBranch, str], ...]:
+    obligations: list[tuple[SourceStructureBranch, str]] = []
+    for match in _ROUNDING_LANGUAGE.finditer(source_text):
+        if _span_is_deferred(
+            match.start(),
+            match.end(),
+            branches=branches,
+            deferred_paths=deferred_paths,
+        ):
+            continue
+        owner = _most_specific_containing_branch(
+            match.start(),
+            match.end(),
+            branches=active_branches,
+        ) or SourceStructureBranch(
+            (),
+            "source-unit",
+            "source unit",
+            source_text,
+            0,
+            len(source_text),
+        )
+        matched_text = match.group(0)
+        if _NEAREST_ROUNDING_LANGUAGE.search(matched_text):
+            direction = "nearest"
+        elif _UP_ROUNDING_LANGUAGE.search(matched_text):
+            direction = "upward"
+        else:
+            direction = "downward"
+        obligation_branch = SourceStructureBranch(
+            owner.path,
+            "rounding-clause",
+            owner.label,
+            matched_text,
+            match.start(),
+            match.end(),
+        )
+        obligations.append((obligation_branch, direction))
+    return tuple(obligations)
+
+
 def _unwitnessed_exception_branches(
     exception_branches: Sequence[SourceStructureBranch],
     *,
@@ -1781,32 +1696,48 @@ def _exception_semantic_identifier(identifier: str) -> bool:
     )
 
 
-def _fractional_formula_input_case_count(
-    principal_rules: dict[str, dict[str, Any]],
+def _rule_implements_rounding(rule: dict[str, Any], direction: str) -> bool:
+    formula_text = _rule_formula_text(rule)
+    if direction == "nearest":
+        return bool(
+            re.search(r"\bfloor\s*\(", formula_text)
+            and re.search(r"\+\s*0?\.5\b", formula_text)
+        )
+    function_name = "ceil" if direction == "upward" else "floor"
+    return re.search(rf"\b{function_name}\s*\(", formula_text) is not None
+
+
+def _fractional_rounding_case_witnesses(
+    rule_name: str,
+    rule: dict[str, Any],
     *,
     asserted_by_rule: dict[str, list[dict[str, Any]]],
-    rule_functions: dict[str, set[str]],
-) -> int:
+    direction: str,
+) -> set[tuple[str, int]]:
     evidence: set[tuple[str, int]] = set()
-    for rule_name, functions in rule_functions.items():
-        rounded_operand_identifiers = _rounding_operand_identifier_names(
-            principal_rules[rule_name],
-            functions=functions,
+    functions = {
+        "nearest" if direction == "nearest" else (
+            "ceil" if direction == "upward" else "floor"
         )
-        for index, case in enumerate(asserted_by_rule.get(rule_name, ())):
-            inputs = case.get("input")
-            if not isinstance(inputs, dict):
-                continue
-            if any(
-                _input_key_names(key) & rounded_operand_identifiers
-                and any(
-                    not float(value).is_integer()
-                    for value in _numeric_test_input_values(input_value)
-                )
-                for key, input_value in inputs.items()
-            ):
-                evidence.add((rule_name, index))
-    return len(evidence)
+    }
+    rounded_operand_identifiers = _rounding_operand_identifier_names(
+        rule,
+        functions=functions,
+    )
+    for case in asserted_by_rule.get(rule_name, ()):
+        inputs = case.get("input")
+        if not isinstance(inputs, dict):
+            continue
+        if any(
+            _input_key_names(key) & rounded_operand_identifiers
+            and any(
+                not float(value).is_integer()
+                for value in _numeric_test_input_values(input_value)
+            )
+            for key, input_value in inputs.items()
+        ):
+            evidence.add((rule_name, id(case)))
+    return evidence
 
 
 def _rounding_operand_identifier_names(
@@ -1865,33 +1796,6 @@ def _balanced_call_operands(text: str, function_name: str) -> Iterable[str]:
             yield text[open_index + 1 : cursor - 1]
 
 
-def _case_explicitly_covers_branch(
-    case: dict[str, Any],
-    branch: SourceStructureBranch,
-    *,
-    corpus_citation_path: str,
-) -> bool:
-    raw_covers = case.get("covers")
-    if isinstance(raw_covers, (str, dict)):
-        raw_covers = [raw_covers]
-    if not isinstance(raw_covers, list):
-        return False
-    for item in raw_covers:
-        value = (
-            item.get("source_branch")
-            if isinstance(item, dict)
-            else item
-        )
-        if not isinstance(value, str):
-            continue
-        if branch.path in _paths_from_source_reference(
-            value,
-            corpus_citation_path=corpus_citation_path,
-        ):
-            return True
-    return False
-
-
 def _source_boundary_obligations(
     branches: Sequence[SourceStructureBranch],
     *,
@@ -1900,7 +1804,7 @@ def _source_boundary_obligations(
 ) -> tuple[tuple[SourceStructureBranch, float], ...]:
     obligations: list[tuple[SourceStructureBranch, float]] = []
     for branch in branches:
-        if branch.kind != "number":
+        if branch.kind not in {"number", "letter"}:
             continue
         first_line = branch.text.splitlines()[0] if branch.text.splitlines() else ""
         prefix = first_line.split(":", 1)[0]
@@ -1931,7 +1835,7 @@ def _source_boundary_obligations(
         )
     return tuple(
         {
-            (branch.path, float(value), branch.kind): (branch, float(value))
+            (branch.path, float(value)): (branch, float(value))
             for branch, value in obligations
         }.values()
     )

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1016,7 +1016,11 @@ def _deferred_coverage(
         else:
             precise = (
                 reason_identifies_dependency
-                and _reason_dependency_is_source_bound(reason, source_scope_text)
+                and _reason_dependency_is_source_bound(
+                    reason,
+                    source_scope_text,
+                    corpus_citation_path=corpus_citation_path,
+                )
             )
         if precise:
             covered.add(path)
@@ -1066,16 +1070,21 @@ def _reason_identifies_blocker(
         " ",
         reason.lower(),
     ).strip()
-    if (
-        target_instrument is not None
-        and corpus_instrument is not None
-        and target_instrument != corpus_instrument
-        and not _reason_names_target_instrument(
-            normalized_reason,
-            target_instrument,
-        )
-    ):
-        return False
+    if target_instrument is not None and corpus_instrument is not None:
+        if target_instrument[:2] != corpus_instrument[:2]:
+            if not _reason_names_absolute_target(
+                normalized_reason,
+                target_instrument,
+            ):
+                return False
+        elif (
+            target_instrument[2] != corpus_instrument[2]
+            and not _reason_names_target_instrument(
+                normalized_reason,
+                target_instrument,
+            )
+        ):
+            return False
     explicit_sections = {
         match.group("section").lower()
         for match in _EXPLICIT_LEGAL_SECTION_REFERENCE.finditer(reason)
@@ -1131,19 +1140,50 @@ def _reason_names_target_instrument(
     )
 
 
-def _reason_dependency_is_source_bound(reason: str, source_scope_text: str) -> bool:
+def _reason_names_absolute_target(
+    normalized_reason: str,
+    target_instrument: tuple[str, str, str],
+) -> bool:
+    jurisdiction, collection, instrument = target_instrument
+    absolute_target = " ".join((jurisdiction, collection, instrument))
+    plural_absolute_target = " ".join(
+        (jurisdiction, f"{collection}s", instrument)
+    )
+    return any(
+        re.search(
+            rf"(?<![a-z0-9äöüß]){re.escape(candidate)}"
+            r"(?![a-z0-9äöüß])",
+            normalized_reason,
+        )
+        for candidate in (absolute_target, plural_absolute_target)
+    )
+
+
+def _reason_dependency_is_source_bound(
+    reason: str,
+    source_scope_text: str,
+    *,
+    corpus_citation_path: str,
+) -> bool:
     """Require a prose-only dependency citation to occur in the deferred source."""
 
     for match in _PRECISE_DEFERRAL_DEPENDENCY.finditer(reason):
         dependency = match.group(0).strip()
         if "#" in dependency and ":" in dependency:
-            if _reason_identifies_blocker(source_scope_text, dependency):
+            if _reason_identifies_blocker(
+                source_scope_text,
+                dependency,
+                corpus_citation_path=corpus_citation_path,
+            ):
                 return True
             continue
         section_match = re.search(r"\d+[a-z]?", dependency, flags=re.IGNORECASE)
+        corpus_target = _rulespec_target_base(corpus_citation_path)
+        corpus_instrument_target = corpus_target.rsplit("/", 1)[0]
         if section_match and _reason_identifies_blocker(
             source_scope_text,
-            f"xx:statutes/source/{section_match.group(0)}#dependency",
+            f"{corpus_instrument_target}/{section_match.group(0)}#dependency",
+            corpus_citation_path=corpus_citation_path,
         ):
             return True
         normalized_dependency = re.sub(
@@ -1734,7 +1774,7 @@ def _formula_branch_test_witnesses(
                             ),
                         )
                     ):
-                        leaf = _collapse_text(execution.leaf).lower()
+                        leaf = _formula_leaf_semantic_key(execution.leaf)
                         witnesses.add((rule_name, f"leaf:{leaf}"))
                 else:
                     witnesses.add((rule_name, f"case:{id(case)}"))
@@ -1778,6 +1818,11 @@ def _formula_execution_matches_source_branch(
 ) -> bool:
     """Bind a reached leaf to numeric evidence in its exact source formula."""
 
+    source_operations = _formula_operation_kinds(branch.text)
+    if source_operations and not source_operations.issubset(
+        _formula_operation_kinds(execution.leaf)
+    ):
+        return False
     source_occurrences = tuple(
         extract_numeric_occurrences(
             authoritative_numeric_recall_text(branch.text)
@@ -1822,6 +1867,127 @@ def _formula_execution_matches_source_branch(
         )
         for source_occurrence in computation_occurrences
     )
+
+
+def _formula_operation_kinds(text: str) -> set[str]:
+    operations: set[str] = set()
+    with contextlib.suppress(SyntaxError):
+        expression = ast.parse(text.strip(), mode="eval").body
+        for node in ast.walk(expression):
+            if isinstance(node, ast.BinOp):
+                if isinstance(node.op, ast.Add):
+                    operations.add("add")
+                elif isinstance(node.op, ast.Sub):
+                    operations.add("subtract")
+                elif isinstance(node.op, ast.Mult):
+                    operations.add("multiply")
+                elif isinstance(node.op, ast.Div):
+                    operations.add("divide")
+            elif isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                lowered = node.func.id.lower()
+                if "sum" in lowered:
+                    operations.add("add")
+                elif "product" in lowered:
+                    operations.add("multiply")
+    lowered_text = text.lower()
+    operation_patterns = {
+        "add": (
+            r"(?:\+|\bsumme\b|\bsum\s+of\b|\bzuzüglich\b|"
+            r"\berhöh\w*\s+(?:sich\s+)?um\b)"
+        ),
+        "subtract": (
+            r"(?:\s[−–-]\s|\bunterschied\b|\bdifferenz\b|"
+            r"\bdifference\s+between\b|\babzüglich\b|"
+            r"\b(?:vermindert|gekürzt|mindert|kürzt)\w*\s+"
+            r"(?:sich\s+)?um\b)"
+        ),
+        "multiply": (
+            r"(?:[*×·•∗∙]|\bprodukt\b|\bproduct\s+of\b|"
+            r"\bmultipl\w*\b|\bvervielfach\w*\b|\bmal\b|"
+            r"\b(?:doppelte|zweifache|dreifache|twice)\b)"
+        ),
+        "divide": (
+            r"(?:/|\bgeteilt\b|\bdivided\b|\bhälfte\b|\bhalf\s+of\b)"
+        ),
+    }
+    operations.update(
+        operation
+        for operation, pattern in operation_patterns.items()
+        if re.search(pattern, lowered_text, flags=re.IGNORECASE)
+    )
+    return operations
+
+
+def _formula_leaf_semantic_key(leaf: str) -> str:
+    with contextlib.suppress(SyntaxError):
+        expression = ast.parse(leaf.strip(), mode="eval").body
+        return repr(_canonical_formula_node(expression))
+    return _collapse_text(leaf).lower()
+
+
+def _canonical_formula_node(node: ast.AST) -> Any:
+    if isinstance(node, ast.Name):
+        return "name", node.id.lower()
+    if isinstance(node, ast.Constant):
+        return "constant", type(node.value).__name__, repr(node.value)
+    if isinstance(node, ast.BinOp):
+        operator = type(node.op).__name__
+        if isinstance(node.op, (ast.Add, ast.Mult)):
+            operands = _commutative_formula_operands(node, type(node.op))
+            return (
+                "binop",
+                operator,
+                tuple(sorted(repr(operand) for operand in operands)),
+            )
+        return (
+            "binop",
+            operator,
+            _canonical_formula_node(node.left),
+            _canonical_formula_node(node.right),
+        )
+    if isinstance(node, ast.UnaryOp):
+        return (
+            "unary",
+            type(node.op).__name__,
+            _canonical_formula_node(node.operand),
+        )
+    if isinstance(node, ast.Call):
+        return (
+            "call",
+            _canonical_formula_node(node.func),
+            tuple(_canonical_formula_node(argument) for argument in node.args),
+        )
+    if isinstance(node, ast.Compare):
+        return (
+            "compare",
+            _canonical_formula_node(node.left),
+            tuple(type(operator).__name__ for operator in node.ops),
+            tuple(
+                _canonical_formula_node(comparator)
+                for comparator in node.comparators
+            ),
+        )
+    return ast.dump(node, annotate_fields=True, include_attributes=False).lower()
+
+
+def _commutative_formula_operands(
+    node: ast.BinOp,
+    operator_type: type[ast.operator],
+) -> tuple[Any, ...]:
+    operands: list[Any] = []
+
+    def collect(candidate: ast.AST) -> None:
+        if (
+            isinstance(candidate, ast.BinOp)
+            and isinstance(candidate.op, operator_type)
+        ):
+            collect(candidate.left)
+            collect(candidate.right)
+        else:
+            operands.append(_canonical_formula_node(candidate))
+
+    collect(node)
+    return tuple(operands)
 
 
 def _numeric_occurrences_are_equivalent(

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -4991,13 +4991,14 @@ def _source_exception_effect_requirement(text: str) -> str:
     """Classify the minimum isolated effect expressly required by one clause."""
 
     collapsed = _collapse_text(text)
+    numeric_zero = r"(?<![\d,.])0+(?:[,.]0+)?(?![\d,.])"
     if re.search(
-        r"\b(?:"
-        r"(?:beträgt|ist|wird)[^.;]{0,120}\b(?:null|0(?:[,.]0+)?)|"
-        r"auf\s+(?:null|0(?:[,.]0+)?)|"
-        r"(?:equals?|is|becomes?|set\s+to)[^.;]{0,120}"
-        r"\b(?:zero|0(?:[,.]0+)?)"
-        r")\b",
+        rf"\b(?:"
+        rf"(?:beträgt|ist|wird)[^.;]{{0,120}}\b(?:null|{numeric_zero})|"
+        rf"auf\s+(?:null|{numeric_zero})|"
+        rf"(?:equals?|is|becomes?|set\s+to)[^.;]{{0,120}}"
+        rf"\b(?:zero|{numeric_zero})"
+        rf")\b",
         collapsed,
         flags=re.IGNORECASE,
     ):

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -33,6 +33,19 @@ class NumericOccurrenceLike(Protocol):
     requires_rate_context: bool
 
 
+@dataclass(frozen=True)
+class _NumericOccurrenceView:
+    """One typed occurrence rebased into a containing source fragment."""
+
+    value: float
+    start: int
+    end: int
+    raw: str
+    has_rate_context: bool
+    source_value: float | None
+    requires_rate_context: bool
+
+
 NumericOccurrenceExtractor = Callable[[str], Sequence[NumericOccurrenceLike]]
 NamedScalarExtractor = Callable[[str], Sequence[Any]]
 NumericGroundingPredicate = Callable[
@@ -111,6 +124,19 @@ class _FormulaBranchNode:
     selectors: tuple[str, ...]
     patterns: tuple[str, ...]
     choices: tuple[str, ...]
+
+
+@dataclass(frozen=True, order=True)
+class _ExceptionWitness:
+    """One isolated exception selector effect demonstrated by paired cases."""
+
+    rule_name: str
+    selector_name: str
+    active_value: bool
+    blocks: bool
+    boolean_effect: bool
+    zeroes: bool
+    numeric_transition: tuple[float, float] | None
 
 
 _PARAGRAPH_MARKER = re.compile(
@@ -1569,7 +1595,7 @@ def _companion_test_issues(
         tuple[SourceStructureBranch, NumericOccurrenceLike]
     ] = []
     for branch, boundary in boundary_obligations:
-        if _branch_boundary_has_test_evidence(
+        if _branch_boundary_test_witnesses(
             branch,
             boundary,
             principal_rules=principal_rules,
@@ -1607,6 +1633,7 @@ def _companion_test_issues(
             exception_branches,
             principal_rule_paths=principal_rule_paths,
             toggled_exception_selectors=toggled_exception_selectors,
+            extract_numeric_occurrences=extract_numeric_occurrences,
         )
         if missing_exception_branches:
             missing_citations = ", ".join(
@@ -3594,7 +3621,7 @@ def _evaluate_condition_expression(
     return _UNRESOLVED_CONDITION_VALUE
 
 
-def _branch_boundary_has_test_evidence(
+def _branch_boundary_test_witnesses(
     branch: SourceStructureBranch,
     boundary: NumericOccurrenceLike,
     *,
@@ -3604,15 +3631,16 @@ def _branch_boundary_has_test_evidence(
     numeric_value_is_grounded: NumericGroundingPredicate,
     formula_environment: dict[str, Any] | None = None,
     extract_numeric_occurrences: NumericOccurrenceExtractor | None = None,
-) -> bool:
-    source_interval = (
-        _source_interval_for_boundary(
+) -> set[tuple[str, str]]:
+    witnesses: set[tuple[str, str]] = set()
+    source_interval, source_boolean_polarity = (
+        _source_interval_and_polarity_for_boundary(
             branch,
             boundary,
             extract_numeric_occurrences=extract_numeric_occurrences,
         )
         if extract_numeric_occurrences is not None
-        else None
+        else (None, 0)
     )
     for rule_name in _rules_covering_branch(branch, principal_rule_paths):
         rule = principal_rules[rule_name]
@@ -3645,9 +3673,7 @@ def _branch_boundary_has_test_evidence(
                         input_names=input_names,
                         formula_environment=execution.constant_environment,
                         source_interval=source_interval,
-                        source_boolean_polarity=(
-                            _source_boundary_boolean_polarity(branch.text)
-                        ),
+                        source_boolean_polarity=source_boolean_polarity,
                         extract_numeric_occurrences=(
                             extract_numeric_occurrences
                         ),
@@ -3666,9 +3692,7 @@ def _branch_boundary_has_test_evidence(
                         dependency_names=set(dependency_environment),
                         formula_environment=formula_environment or {},
                         source_interval=source_interval,
-                        source_boolean_polarity=(
-                            _source_boundary_boolean_polarity(branch.text)
-                        ),
+                        source_boolean_polarity=source_boolean_polarity,
                     )
                     for input_key, input_names, value in (
                         _case_numeric_selector_evidence(
@@ -3679,8 +3703,35 @@ def _branch_boundary_has_test_evidence(
                     )
                 )
             ):
-                return True
-    return False
+                witnesses.add((rule_name, f"case:{id(case)}"))
+    return witnesses
+
+
+def _branch_boundary_has_test_evidence(
+    branch: SourceStructureBranch,
+    boundary: NumericOccurrenceLike,
+    *,
+    principal_rules: dict[str, dict[str, Any]],
+    principal_rule_paths: dict[str, set[tuple[str, ...]]],
+    asserted_by_rule: dict[str, list[dict[str, Any]]],
+    numeric_value_is_grounded: NumericGroundingPredicate,
+    formula_environment: dict[str, Any] | None = None,
+    extract_numeric_occurrences: NumericOccurrenceExtractor | None = None,
+) -> bool:
+    """Compatibility predicate for callers that do not allocate witnesses."""
+
+    return bool(
+        _branch_boundary_test_witnesses(
+            branch,
+            boundary,
+            principal_rules=principal_rules,
+            principal_rule_paths=principal_rule_paths,
+            asserted_by_rule=asserted_by_rule,
+            numeric_value_is_grounded=numeric_value_is_grounded,
+            formula_environment=formula_environment,
+            extract_numeric_occurrences=extract_numeric_occurrences,
+        )
+    )
 
 
 def _formula_execution_binds_boundary(
@@ -3708,7 +3759,7 @@ def _formula_execution_binds_boundary(
         return False
     checks: list[tuple[str, bool]] = []
     for step in execution.trace:
-        if step.kind != "if":
+        if step.kind not in {"if", "match"}:
             continue
         checks.extend(
             (selector, True)
@@ -3884,29 +3935,84 @@ def _formula_node_boundary_value(
     )
 
 
-def _source_interval_for_boundary(
+def _source_interval_and_polarity_for_boundary(
     branch: SourceStructureBranch,
     boundary: NumericOccurrenceLike,
     *,
     extract_numeric_occurrences: NumericOccurrenceExtractor,
-) -> _NumericInterval | None:
-    for fragment in re.split(
-        r"(?:[;\n]+|(?<=[.!?])\s+)",
-        branch.text,
-    ):
-        interval = _formula_interval_from_text(
-            fragment.split(":", 1)[0],
-            extract_numeric_occurrences=extract_numeric_occurrences,
+) -> tuple[_NumericInterval | None, int]:
+    direct_text = authoritative_numeric_recall_text(branch.text)
+    for fragment_start, fragment in _source_boundary_fragments(direct_text):
+        interval = _shift_numeric_interval(
+            _formula_interval_from_text(
+                fragment.split(":", 1)[0],
+                extract_numeric_occurrences=extract_numeric_occurrences,
+            ),
+            fragment_start,
         )
         if interval is None:
             continue
         if any(
             occurrence is not None
+            and occurrence.start == boundary.start
+            and occurrence.end == boundary.end
             and _numeric_occurrences_are_equivalent(occurrence, boundary)
             for occurrence in (interval.lower, interval.upper)
         ):
-            return interval
-    return None
+            return interval, _source_boundary_boolean_polarity(fragment)
+    return None, 0
+
+
+def _source_boundary_fragments(text: str) -> Iterable[tuple[int, str]]:
+    """Yield nonempty boundary fragments with exact offsets in ``text``."""
+
+    cursor = 0
+    for separator in re.finditer(
+        r"(?:[;\n]+|(?<=[.!?])\s+)",
+        text,
+    ):
+        raw_fragment = text[cursor : separator.start()]
+        left_trim = len(raw_fragment) - len(raw_fragment.lstrip())
+        right_end = len(raw_fragment.rstrip())
+        if left_trim < right_end:
+            yield cursor + left_trim, raw_fragment[left_trim:right_end]
+        cursor = separator.end()
+    raw_fragment = text[cursor:]
+    left_trim = len(raw_fragment) - len(raw_fragment.lstrip())
+    right_end = len(raw_fragment.rstrip())
+    if left_trim < right_end:
+        yield cursor + left_trim, raw_fragment[left_trim:right_end]
+
+
+def _shift_numeric_occurrence(
+    occurrence: NumericOccurrenceLike | None,
+    offset: int,
+) -> NumericOccurrenceLike | None:
+    if occurrence is None:
+        return None
+    return _NumericOccurrenceView(
+        value=float(occurrence.value),
+        start=occurrence.start + offset,
+        end=occurrence.end + offset,
+        raw=occurrence.raw,
+        has_rate_context=occurrence.has_rate_context,
+        source_value=occurrence.source_value,
+        requires_rate_context=occurrence.requires_rate_context,
+    )
+
+
+def _shift_numeric_interval(
+    interval: _NumericInterval | None,
+    offset: int,
+) -> _NumericInterval | None:
+    if interval is None:
+        return None
+    return _NumericInterval(
+        lower=_shift_numeric_occurrence(interval.lower, offset),
+        lower_inclusive=interval.lower_inclusive,
+        upper=_shift_numeric_occurrence(interval.upper, offset),
+        upper_inclusive=interval.upper_inclusive,
+    )
 
 
 def _comparison_matches_source_interval(
@@ -4160,12 +4266,9 @@ def _boundary_case_changes_formula_effect(
 def _formula_execution_boolean_value(
     execution: _FormulaExecution | None,
 ) -> bool | None:
-    if execution is None or execution.evaluated_value is None:
+    if execution is None:
         return None
-    value_type, raw_value = execution.evaluated_value
-    if value_type != "bool":
-        return None
-    return raw_value == "True"
+    return _boolean_value(_formula_execution_runtime_value(execution))
 
 
 def _source_boundary_boolean_polarity(text: str) -> int:
@@ -4217,8 +4320,9 @@ def _formula_branch_interval(
     extract_numeric_occurrences: NumericOccurrenceExtractor,
 ) -> _NumericInterval | None:
     first_line = branch.text.splitlines()[0] if branch.text.splitlines() else ""
-    range_text = first_line.split(":", 1)[0]
-    range_text = _NUMBER_MARKER.sub("", range_text).strip()
+    range_text = authoritative_numeric_recall_text(
+        first_line.split(":", 1)[0]
+    )
     return _formula_interval_from_text(
         range_text,
         extract_numeric_occurrences=extract_numeric_occurrences,
@@ -4247,7 +4351,11 @@ def _formula_interval_from_text(
         flags=re.IGNORECASE,
     ):
         return None
-    occurrences = tuple(extract_numeric_occurrences(range_text))
+    occurrences = tuple(
+        occurrence
+        for occurrence in extract_numeric_occurrences(text)
+        if occurrence.start >= keyword.start()
+    )
     if not occurrences:
         return None
     lowered_range = range_text.lower()
@@ -4404,6 +4512,9 @@ def _source_exception_branches(
     deferred_paths: set[tuple[str, ...]],
 ) -> tuple[SourceStructureBranch, ...]:
     obligations: list[SourceStructureBranch] = []
+    source_clauses = tuple(
+        _source_clause_spans(source_text, branches=branches)
+    )
     for match in _EXCEPTION_LANGUAGE.finditer(source_text):
         if _span_is_deferred(
             match.start(),
@@ -4416,19 +4527,38 @@ def _source_exception_branches(
             match.start(),
             match.end(),
             branches=active_branches,
+        ) or SourceStructureBranch(
+            (),
+            "source-unit",
+            "source unit",
+            source_text,
+            0,
+            len(source_text),
+        )
+        clause_start, clause_end, clause_text = next(
+            (
+                (start, end, text)
+                for start, end, text in source_clauses
+                if start <= match.start() and match.end() <= end
+            ),
+            (match.start(), match.end(), match.group(0)),
         )
         obligations.append(
-            owner
-            or SourceStructureBranch(
-                (),
-                "source-unit",
-                "source unit",
-                source_text,
-                0,
-                len(source_text),
+            SourceStructureBranch(
+                owner.path,
+                "exception-clause",
+                owner.label,
+                clause_text,
+                clause_start,
+                clause_end,
             )
         )
-    return tuple(obligations)
+    return tuple(
+        {
+            (branch.path, branch.start, branch.end): branch
+            for branch in obligations
+        }.values()
+    )
 
 
 def _source_rounding_obligations(
@@ -4542,7 +4672,8 @@ def _unwitnessed_exception_branches(
     exception_branches: Sequence[SourceStructureBranch],
     *,
     principal_rule_paths: dict[str, set[tuple[str, ...]]],
-    toggled_exception_selectors: set[tuple[str, str]],
+    toggled_exception_selectors: set[_ExceptionWitness],
+    extract_numeric_occurrences: NumericOccurrenceExtractor,
 ) -> tuple[SourceStructureBranch, ...]:
     available_witnesses = set(toggled_exception_selectors)
     missing: list[SourceStructureBranch] = []
@@ -4552,12 +4683,14 @@ def _unwitnessed_exception_branches(
             item,
             principal_rule_paths=principal_rule_paths,
             toggled_exception_selectors=available_witnesses,
+            extract_numeric_occurrences=extract_numeric_occurrences,
         )),
     ):
         candidates = _exception_witnesses_for_branch(
             branch,
             principal_rule_paths=principal_rule_paths,
             toggled_exception_selectors=available_witnesses,
+            extract_numeric_occurrences=extract_numeric_occurrences,
         )
         if not candidates:
             missing.append(branch)
@@ -4570,8 +4703,9 @@ def _exception_witnesses_for_branch(
     branch: SourceStructureBranch,
     *,
     principal_rule_paths: dict[str, set[tuple[str, ...]]],
-    toggled_exception_selectors: set[tuple[str, str]],
-) -> set[tuple[str, str]]:
+    toggled_exception_selectors: set[_ExceptionWitness],
+    extract_numeric_occurrences: NumericOccurrenceExtractor,
+) -> set[_ExceptionWitness]:
     affecting_rules = {
         rule_name
         for rule_name, paths in principal_rule_paths.items()
@@ -4582,11 +4716,261 @@ def _exception_witnesses_for_branch(
             if path
         )
     }
+    requirement = _source_exception_effect_requirement(branch.text)
     return {
         witness
         for witness in toggled_exception_selectors
-        if witness[0] in affecting_rules
+        if witness.rule_name in affecting_rules
+        and (
+            _numeric_exception_witness_matches_source(
+                branch,
+                witness,
+                extract_numeric_occurrences=extract_numeric_occurrences,
+            )
+            if witness.numeric_transition is not None
+            else (
+                witness.active_value
+                == _source_exception_selector_active_value(
+                    branch.text,
+                    witness.selector_name,
+                )
+            )
+        )
+        and _source_exception_selector_is_relevant(
+            branch.text,
+            witness.selector_name,
+        )
+        and _exception_witness_satisfies_requirement(witness, requirement)
     }
+
+
+def _source_exception_effect_requirement(text: str) -> str:
+    """Classify the minimum isolated effect expressly required by one clause."""
+
+    collapsed = _collapse_text(text)
+    if re.search(
+        r"\b(?:"
+        r"(?:beträgt|ist|wird)[^.;]{0,120}\b(?:null|0(?:[,.]0+)?)|"
+        r"auf\s+(?:null|0(?:[,.]0+)?)|"
+        r"(?:equals?|is|becomes?|set\s+to)[^.;]{0,120}"
+        r"\b(?:zero|0(?:[,.]0+)?)"
+        r")\b",
+        collapsed,
+        flags=re.IGNORECASE,
+    ):
+        return "zero"
+    if re.search(
+        r"\b(?:"
+        r"gilt\s+nicht|"
+        r"findet\s+keine\s+anwendung|"
+        r"keine?\s+berechtigung|"
+        r"keinen?\s+anspruch|"
+        r"nicht\s+berechtigt|"
+        r"ausgeschlossen|"
+        r"ausgenommen|"
+        r"außer|"
+        r"ausser|"
+        r"es\s+sei\s+denn|"
+        r"soweit\s+nicht|"
+        r"jedoch\s+nicht|"
+        r"shall\s+not\s+apply|"
+        r"does\s+not\s+apply|"
+        r"not\s+eligible|"
+        r"ineligible|"
+        r"excluded|"
+        r"unless|"
+        r"except"
+        r")\b",
+        collapsed,
+        flags=re.IGNORECASE,
+    ):
+        return "exclude"
+    return "change"
+
+
+def _source_exception_selector_is_relevant(text: str, name: str) -> bool:
+    """Reject formula toggles with no semantic link to the source exception."""
+
+    normalized_name = _normalized_selector_name(name)
+    if (
+        _exception_semantic_identifier(normalized_name)
+        or _ordinary_semantic_identifier(normalized_name)
+    ):
+        return True
+    collapsed = _collapse_text(text).lower()
+    if _source_selector_concept_matches(collapsed, normalized_name):
+        return True
+    ignored = {
+        "applies",
+        "apply",
+        "case",
+        "condition",
+        "flag",
+        "has",
+        "is",
+        "status",
+        "the",
+    }
+    return any(
+        len(token) >= 4
+        and token not in ignored
+        and re.search(rf"\b{re.escape(token)}\w*", collapsed) is not None
+        for token in normalized_name.split("_")
+    )
+
+
+def _source_exception_selector_active_value(text: str, name: str) -> bool:
+    """Resolve exception orientation from source wording, not formula output."""
+
+    normalized_name = _normalized_selector_name(name)
+    source_polarity = _source_selector_concept_polarity(
+        _collapse_text(text).lower(),
+        normalized_name,
+    )
+    if source_polarity is not None:
+        selector_polarity = (
+            -1
+            if _selector_identifier_negation_count(normalized_name) % 2
+            else 1
+        )
+        return selector_polarity == source_polarity
+    return _exception_selector_semantic_active_value(normalized_name)
+
+
+def _numeric_exception_witness_matches_source(
+    branch: SourceStructureBranch,
+    witness: _ExceptionWitness,
+    *,
+    extract_numeric_occurrences: NumericOccurrenceExtractor,
+) -> bool:
+    transition = witness.numeric_transition
+    if transition is None:
+        return False
+    interval = _formula_interval_from_text(
+        authoritative_numeric_recall_text(branch.text),
+        extract_numeric_occurrences=extract_numeric_occurrences,
+    )
+    if interval is None:
+        return False
+    ordinary_value, exception_value = transition
+    return (
+        not _interval_contains(interval, ordinary_value)
+        and _interval_contains(interval, exception_value)
+    )
+
+
+def _normalized_selector_name(name: str) -> str:
+    return re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", name).lower()
+
+
+def _source_selector_concept_matches(
+    text: str,
+    normalized_name: str,
+) -> tuple[re.Match[str], ...]:
+    patterns: list[str] = []
+    concept_patterns = {
+        "certificate": r"\b(?:certificate|bescheinigung|nachweis|zertifikat)\w*",
+        "child": r"\b(?:child|kind(?:er)?)\w*",
+        "kind": r"\bkind(?:er)?\w*",
+        "condition": r"\b(?:condition|voraussetzung)\w*",
+        "eligible": r"\b(?:eligible|berechtig|anspruch)\w*",
+        "income": r"\b(?:income|einkommen)\w*",
+        "qualified": r"\b(?:qualified|berechtig|anspruch)\w*",
+        "exempt": r"\b(?:exempt|befrei)\w*",
+        "exception": r"\b(?:exception|ausnahme)\w*",
+        "surcharge": r"\b(?:surcharge|zuschlag)\w*",
+        "status": r"\bstatus\w*",
+    }
+    for concept, pattern in concept_patterns.items():
+        if concept in normalized_name:
+            patterns.append(pattern)
+    ignored = {
+        "applies",
+        "apply",
+        "case",
+        "condition",
+        "flag",
+        "for",
+        "has",
+        "is",
+        "no",
+        "non",
+        "not",
+        "status",
+        "the",
+        "without",
+    }
+    patterns.extend(
+        rf"\b{re.escape(token)}\w*"
+        for token in normalized_name.split("_")
+        if len(token) >= 4 and token not in ignored
+    )
+    matches = {
+        (match.start(), match.end(), match.group(0)): match
+        for pattern in patterns
+        for match in re.finditer(pattern, text, flags=re.IGNORECASE)
+    }
+    return tuple(matches[key] for key in sorted(matches))
+
+
+def _source_selector_concept_polarity(
+    text: str,
+    normalized_name: str,
+) -> int | None:
+    polarities: set[int] = set()
+    for match in _source_selector_concept_matches(text, normalized_name):
+        before = text[max(0, match.start() - 48) : match.start()]
+        after = text[match.end() : min(len(text), match.end() + 48)]
+        negative = bool(
+            re.search(
+                r"\b(?:kein(?:e|en|em|er|es)?|ohne|mangels|"
+                r"no|without|lack(?:ing)?(?:\s+of)?|absence\s+of)"
+                r"\b[^.;]{0,40}$|"
+                r"\b(?:nicht|not)\s+(?:\w+\s+){0,1}$",
+                before,
+                flags=re.IGNORECASE,
+            )
+            or re.match(
+                r"[^.;]{0,40}\b(?:fehlt|fehlen|nicht\s+(?:vorhanden|"
+                r"gegeben)|liegt\s+nicht\s+vor|is\s+not\s+present|"
+                r"is\s+absent)\b",
+                after,
+                flags=re.IGNORECASE,
+            )
+        )
+        polarities.add(-1 if negative else 1)
+    return next(iter(polarities)) if len(polarities) == 1 else None
+
+
+def _selector_identifier_negation_count(normalized_name: str) -> int:
+    count = sum(
+        token in {
+            "absent",
+            "lacking",
+            "missing",
+            "no",
+            "non",
+            "not",
+            "without",
+        }
+        for token in normalized_name.split("_")
+    )
+    count += sum(
+        marker in normalized_name.split("_")
+        for marker in {"disqualified", "ineligible", "unqualified"}
+    )
+    return count
+
+
+def _exception_witness_satisfies_requirement(
+    witness: _ExceptionWitness,
+    requirement: str,
+) -> bool:
+    if requirement == "zero":
+        return witness.zeroes
+    if requirement == "exclude":
+        return witness.blocks or not witness.boolean_effect
+    return True
 
 
 def _toggled_formula_boolean_selectors(
@@ -4594,8 +4978,8 @@ def _toggled_formula_boolean_selectors(
     *,
     asserted_by_rule: dict[str, list[dict[str, Any]]],
     formula_environment: dict[str, Any],
-) -> set[tuple[str, str]]:
-    toggled: set[tuple[str, str]] = set()
+) -> set[_ExceptionWitness]:
+    toggled: set[_ExceptionWitness] = set()
     for rule_name, rule in principal_rules.items():
         selector_names = _rule_exception_selector_names(rule)
         if not selector_names:
@@ -4632,7 +5016,7 @@ def _toggled_formula_boolean_selectors(
                 if (
                     _normalized_case_period(left_case)
                     != _normalized_case_period(right_case)
-                    or not _cases_differ_by_one_boolean_input(
+                    or not _cases_differ_by_one_input(
                         left_case,
                         right_case,
                     )
@@ -4648,80 +5032,306 @@ def _toggled_formula_boolean_selectors(
                 if len(changed_names) != 1:
                     continue
                 selector_name = next(iter(changed_names))
-                if left_selectors[selector_name]:
-                    blocking_case = left_case
-                    blocking_dependencies = left_dependencies
-                    ordinary_case = right_case
-                    ordinary_dependencies = right_dependencies
-                else:
-                    ordinary_case = left_case
-                    ordinary_dependencies = left_dependencies
-                    blocking_case = right_case
-                    blocking_dependencies = right_dependencies
-                ordinary_execution = _case_formula_execution(
-                    rule,
-                    ordinary_case,
-                    formula_environment=formula_environment,
-                    dependency_environment=ordinary_dependencies,
-                )
-                blocking_execution = _case_formula_execution(
-                    rule,
-                    blocking_case,
-                    formula_environment=formula_environment,
-                    dependency_environment=blocking_dependencies,
-                )
-                counterfactual_execution = (
-                    _case_formula_execution_with_boolean_selector(
+                for active_value in (False, True):
+                    witness = _exception_witness_for_case_pair(
+                        rule_name,
                         rule,
-                        ordinary_case,
                         selector_name=selector_name,
-                        selector_value=True,
+                        active_value=active_value,
+                        left_case=left_case,
+                        left_dependencies=left_dependencies,
+                        left_selector_value=left_selectors[selector_name],
+                        right_case=right_case,
+                        right_dependencies=right_dependencies,
                         formula_environment=formula_environment,
-                        dependency_environment=ordinary_dependencies,
                     )
-                )
-                if (
-                    ordinary_execution is None
-                    or blocking_execution is None
-                    or counterfactual_execution is None
-                ):
-                    continue
-                ordinary_asserted = _test_case_asserted_output_value(
-                    ordinary_case,
-                    rule_name,
-                )
-                blocking_asserted = _test_case_asserted_output_value(
-                    blocking_case,
-                    rule_name,
-                )
-                if (
-                    ordinary_asserted is _UNRESOLVED_CONDITION_VALUE
-                    or blocking_asserted is _UNRESOLVED_CONDITION_VALUE
-                    or not _exception_effect_is_blocking(
-                        ordinary_asserted,
-                        blocking_asserted,
-                    )
-                ):
-                    continue
-                if all(
-                    _formula_execution_reaches_selector(
-                        execution,
-                        selector_name,
-                    )
-                    for execution in (
-                        ordinary_execution,
-                        blocking_execution,
-                        counterfactual_execution,
-                    )
-                ) and _exception_effect_is_blocking(
-                    _formula_execution_runtime_value(ordinary_execution),
-                    _formula_execution_runtime_value(counterfactual_execution),
-                ):
-                    toggled.add((rule_name, selector_name))
+                    if witness is not None:
+                        toggled.add(witness)
+    toggled.update(
+        _toggled_formula_numeric_selectors(
+            principal_rules,
+            asserted_by_rule=asserted_by_rule,
+            formula_environment=formula_environment,
+        )
+    )
     return toggled
 
 
-def _cases_differ_by_one_boolean_input(
+def _toggled_formula_numeric_selectors(
+    principal_rules: dict[str, dict[str, Any]],
+    *,
+    asserted_by_rule: dict[str, list[dict[str, Any]]],
+    formula_environment: dict[str, Any],
+) -> set[_ExceptionWitness]:
+    witnesses: set[_ExceptionWitness] = set()
+    for rule_name, rule in principal_rules.items():
+        selector_names = _rule_numeric_selector_names(rule)
+        for left_index, left_case in enumerate(asserted_by_rule.get(rule_name, ())):
+            for right_case in asserted_by_rule[rule_name][left_index + 1 :]:
+                if (
+                    _normalized_case_period(left_case)
+                    != _normalized_case_period(right_case)
+                    or not _cases_differ_by_one_input(left_case, right_case)
+                ):
+                    continue
+                left_inputs = left_case.get("input")
+                right_inputs = right_case.get("input")
+                if not isinstance(left_inputs, dict) or not isinstance(
+                    right_inputs,
+                    dict,
+                ):
+                    continue
+                changed_key = next(
+                    key
+                    for key in left_inputs
+                    if not _formula_runtime_values_equal(
+                        left_inputs[key],
+                        right_inputs[key],
+                    )
+                )
+                left_value = left_inputs[changed_key]
+                right_value = right_inputs[changed_key]
+                if (
+                    isinstance(left_value, bool)
+                    or not isinstance(left_value, (int, float))
+                    or isinstance(right_value, bool)
+                    or not isinstance(right_value, (int, float))
+                ):
+                    continue
+                changed_names = _input_key_names(changed_key) & selector_names
+                if not changed_names:
+                    continue
+                left_dependencies = _case_asserted_dependency_environment(
+                    principal_rules,
+                    left_case,
+                    formula_environment=formula_environment,
+                )
+                right_dependencies = _case_asserted_dependency_environment(
+                    principal_rules,
+                    right_case,
+                    formula_environment=formula_environment,
+                )
+                left_execution = _case_formula_execution(
+                    rule,
+                    left_case,
+                    formula_environment=formula_environment,
+                    dependency_environment=left_dependencies,
+                )
+                right_execution = _case_formula_execution(
+                    rule,
+                    right_case,
+                    formula_environment=formula_environment,
+                    dependency_environment=right_dependencies,
+                )
+                if left_execution is None or right_execution is None:
+                    continue
+                if (
+                    (left_execution.trace or right_execution.trace)
+                    and _formula_leaf_semantic_key(
+                        left_execution.leaf,
+                        formula_environment=left_execution.constant_environment,
+                    )
+                    == _formula_leaf_semantic_key(
+                        right_execution.leaf,
+                        formula_environment=right_execution.constant_environment,
+                    )
+                ):
+                    continue
+                left_runtime = _formula_execution_runtime_value(left_execution)
+                right_runtime = _formula_execution_runtime_value(right_execution)
+                left_asserted = _test_case_asserted_output_value(
+                    left_case,
+                    rule_name,
+                )
+                right_asserted = _test_case_asserted_output_value(
+                    right_case,
+                    rule_name,
+                )
+                if not (
+                    left_asserted is not _UNRESOLVED_CONDITION_VALUE
+                    and right_asserted is not _UNRESOLVED_CONDITION_VALUE
+                    and _formula_runtime_values_equal(
+                        left_runtime,
+                        left_asserted,
+                    )
+                    and _formula_runtime_values_equal(
+                        right_runtime,
+                        right_asserted,
+                    )
+                    and _exception_effect_changes(
+                        left_runtime,
+                        right_runtime,
+                    )
+                ):
+                    continue
+                for selector_name in changed_names:
+                    if not (
+                        _formula_execution_reaches_selector(
+                            left_execution,
+                            selector_name,
+                        )
+                        and _formula_execution_reaches_selector(
+                            right_execution,
+                            selector_name,
+                        )
+                    ):
+                        continue
+                    for (
+                        ordinary_runtime,
+                        exception_runtime,
+                        ordinary_value,
+                        exception_value,
+                    ) in (
+                        (
+                            left_runtime,
+                            right_runtime,
+                            float(left_value),
+                            float(right_value),
+                        ),
+                        (
+                            right_runtime,
+                            left_runtime,
+                            float(right_value),
+                            float(left_value),
+                        ),
+                    ):
+                        witnesses.add(
+                            _ExceptionWitness(
+                                rule_name,
+                                selector_name,
+                                True,
+                                _exception_effect_is_blocking(
+                                    ordinary_runtime,
+                                    exception_runtime,
+                                ),
+                                (
+                                    _boolean_value(ordinary_runtime) is not None
+                                    and _boolean_value(exception_runtime)
+                                    is not None
+                                ),
+                                _exception_effect_is_zero(exception_runtime),
+                                (ordinary_value, exception_value),
+                            )
+                        )
+    return witnesses
+
+
+def _exception_witness_for_case_pair(
+    rule_name: str,
+    rule: dict[str, Any],
+    *,
+    selector_name: str,
+    active_value: bool,
+    left_case: dict[str, Any],
+    left_dependencies: dict[str, Any],
+    left_selector_value: bool,
+    right_case: dict[str, Any],
+    right_dependencies: dict[str, Any],
+    formula_environment: dict[str, Any],
+) -> _ExceptionWitness | None:
+    if left_selector_value == active_value:
+        exception_case = left_case
+        exception_dependencies = left_dependencies
+        ordinary_case = right_case
+        ordinary_dependencies = right_dependencies
+    else:
+        ordinary_case = left_case
+        ordinary_dependencies = left_dependencies
+        exception_case = right_case
+        exception_dependencies = right_dependencies
+    ordinary_execution = _case_formula_execution(
+        rule,
+        ordinary_case,
+        formula_environment=formula_environment,
+        dependency_environment=ordinary_dependencies,
+    )
+    exception_execution = _case_formula_execution(
+        rule,
+        exception_case,
+        formula_environment=formula_environment,
+        dependency_environment=exception_dependencies,
+    )
+    counterfactual_execution = _case_formula_execution_with_boolean_selector(
+        rule,
+        ordinary_case,
+        selector_name=selector_name,
+        selector_value=active_value,
+        formula_environment=formula_environment,
+        dependency_environment=ordinary_dependencies,
+    )
+    if (
+        ordinary_execution is None
+        or exception_execution is None
+        or counterfactual_execution is None
+    ):
+        return None
+    ordinary_asserted = _test_case_asserted_output_value(
+        ordinary_case,
+        rule_name,
+    )
+    exception_asserted = _test_case_asserted_output_value(
+        exception_case,
+        rule_name,
+    )
+    if (
+        ordinary_asserted is _UNRESOLVED_CONDITION_VALUE
+        or exception_asserted is _UNRESOLVED_CONDITION_VALUE
+        or not _exception_effect_changes(
+            ordinary_asserted,
+            exception_asserted,
+        )
+    ):
+        return None
+    ordinary_runtime = _formula_execution_runtime_value(ordinary_execution)
+    exception_runtime = _formula_execution_runtime_value(exception_execution)
+    counterfactual_runtime = _formula_execution_runtime_value(
+        counterfactual_execution
+    )
+    if not (
+        all(
+            _formula_execution_reaches_selector(execution, selector_name)
+            for execution in (
+                ordinary_execution,
+                exception_execution,
+                counterfactual_execution,
+            )
+        )
+        and _formula_runtime_values_equal(
+            ordinary_runtime,
+            ordinary_asserted,
+        )
+        and _formula_runtime_values_equal(
+            exception_runtime,
+            exception_asserted,
+        )
+        and _formula_runtime_values_equal(
+            counterfactual_runtime,
+            exception_runtime,
+        )
+        and _exception_effect_changes(
+            ordinary_runtime,
+            counterfactual_runtime,
+        )
+    ):
+        return None
+    return _ExceptionWitness(
+        rule_name,
+        selector_name,
+        active_value,
+        _exception_effect_is_blocking(
+            ordinary_runtime,
+            counterfactual_runtime,
+        ),
+        (
+            _boolean_value(ordinary_runtime) is not None
+            and _boolean_value(counterfactual_runtime) is not None
+        ),
+        _exception_effect_is_zero(counterfactual_runtime),
+        None,
+    )
+
+
+def _cases_differ_by_one_input(
     left_case: dict[str, Any],
     right_case: dict[str, Any],
 ) -> bool:
@@ -4731,23 +5341,20 @@ def _cases_differ_by_one_boolean_input(
         return False
     if set(left_inputs) != set(right_inputs):
         return False
-    changed = [
-        key
-        for key in left_inputs
-        if not _formula_runtime_values_equal(
+    return sum(
+        not _formula_runtime_values_equal(
             left_inputs[key],
             right_inputs[key],
         )
-    ]
-    if len(changed) != 1:
-        return False
-    key = changed[0]
-    left_boolean = _boolean_value(left_inputs[key])
-    right_boolean = _boolean_value(right_inputs[key])
+        for key in left_inputs
+    ) == 1
+
+
+def _exception_effect_is_zero(value: Any) -> bool:
     return (
-        left_boolean is not None
-        and right_boolean is not None
-        and left_boolean != right_boolean
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isclose(float(value), 0.0, abs_tol=1e-12)
     )
 
 
@@ -4788,12 +5395,23 @@ def _case_formula_execution_with_boolean_selector(
 
 
 def _formula_execution_runtime_value(execution: _FormulaExecution) -> Any:
-    if execution.evaluated_value is None:
-        return _UNRESOLVED_CONDITION_VALUE
-    _value_type, raw_value = execution.evaluated_value
-    with contextlib.suppress(SyntaxError, ValueError):
-        return ast.literal_eval(raw_value)
+    if execution.evaluated_value is not None:
+        _value_type, raw_value = execution.evaluated_value
+        with contextlib.suppress(SyntaxError, ValueError):
+            return ast.literal_eval(raw_value)
+    leaf_boolean = _boolean_value(execution.leaf.strip())
+    if leaf_boolean is not None:
+        return leaf_boolean
     return _UNRESOLVED_CONDITION_VALUE
+
+
+def _exception_effect_changes(ordinary: Any, exception: Any) -> bool:
+    if (
+        ordinary is _UNRESOLVED_CONDITION_VALUE
+        or exception is _UNRESOLVED_CONDITION_VALUE
+    ):
+        return False
+    return not _formula_runtime_values_equal(ordinary, exception)
 
 
 def _exception_effect_is_blocking(ordinary: Any, blocking: Any) -> bool:
@@ -4887,114 +5505,113 @@ def _formula_execution_reaches_selector(
 
 
 def _rule_exception_selector_names(rule: dict[str, Any]) -> set[str]:
-    """Return selectors attached to an excluding conditional branch."""
+    """Return formula identifiers used as boolean control selectors."""
 
     formula_text = _rule_formula_text(rule)
-    names: set[str] = set()
-    for condition, true_body, false_body in _formula_condition_blocks(formula_text):
-        condition_names = {
-            identifier
-            for identifier in re.findall(
-                r"\b[A-Za-z_][A-Za-z0-9_]*\b",
-                condition,
-            )
-            if identifier.lower()
-            not in {"and", "or", "not", "true", "false", "holds", "not_holds"}
-        }
-        if (
-            _formula_branch_is_excluding(true_body)
-            or _formula_branch_is_excluding(false_body)
-            or any(_exception_semantic_identifier(name) for name in condition_names)
-        ):
-            names.update(condition_names)
-    names.update(
+    selector_names: set[str] = set()
+
+    def record(name: str) -> None:
+        selector_names.add(name)
+
+    def inspect_expression(text: str) -> None:
+        with contextlib.suppress(SyntaxError):
+            expression = ast.parse(text.strip(), mode="eval").body
+            if not isinstance(
+                expression,
+                (ast.BoolOp, ast.Compare, ast.Name, ast.UnaryOp),
+            ):
+                return
+            function_names = {
+                node.func.id
+                for node in ast.walk(expression)
+                if isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+            }
+            for name in {
+                node.id
+                for node in ast.walk(expression)
+                if isinstance(node, ast.Name)
+                and node.id.lower()
+                not in {"true", "false", "holds", "not_holds"}
+                and node.id not in function_names
+            }:
+                record(name)
+
+    def inspect(text: str, *, depth: int = 0) -> None:
+        if depth > 32:
+            return
+        node = _first_formula_branch_node(text)
+        if node is None:
+            inspect_expression(text)
+            return
+        if node.kind == "if":
+            for condition in node.selectors:
+                for name in _exception_condition_names(condition):
+                    record(name)
+        elif node.kind == "match":
+            for selector in node.selectors:
+                for name in _exception_condition_names(selector):
+                    record(name)
+        for choice in node.choices:
+            inspect(choice, depth=depth + 1)
+        remainder = text[: node.start] + text[node.end :]
+        if remainder.strip():
+            inspect(remainder, depth=depth + 1)
+
+    inspect(formula_text)
+    return selector_names
+
+
+def _exception_condition_names(condition: str) -> set[str]:
+    return {
         identifier
-        for identifier in _FORMULA_IDENTIFIER.findall(formula_text)
-        if _exception_semantic_identifier(identifier)
-    )
-    return names
+        for identifier in _FORMULA_IDENTIFIER.findall(condition)
+        if identifier.lower()
+        not in {"and", "or", "not", "true", "false", "holds", "not_holds"}
+    }
 
 
-def _formula_condition_blocks(
-    formula_text: str,
-) -> Iterable[tuple[str, str, str]]:
-    lines = formula_text.splitlines()
-    for index, line in enumerate(lines):
-        match = re.match(
-            r"^(?P<indent>[ \t]*)if\s+(?P<condition>[^:\n]+):\s*$",
-            line,
+def _exception_selector_semantic_active_value(name: str) -> bool:
+    normalized = _normalized_selector_name(name)
+    negated = bool(_selector_identifier_negation_count(normalized) % 2)
+    if re.search(
+        r"(?:exception|exempt|befrei|ausnahme|barred|blocking|waiver)",
+        normalized,
+        flags=re.IGNORECASE,
+    ):
+        return not negated
+    if (
+        _ordinary_semantic_identifier(normalized)
+        or re.search(
+            r"(?:ineligib|disqualif|unqualif)",
+            normalized,
+            flags=re.IGNORECASE,
         )
-        if match is None:
-            continue
-        indent = _formula_indent_width(match.group("indent"))
-        true_lines: list[str] = []
-        false_lines: list[str] = []
-        cursor = index + 1
-        while cursor < len(lines):
-            candidate = lines[cursor]
-            stripped = candidate.strip()
-            candidate_indent = _formula_indent_width(
-                candidate[: len(candidate) - len(candidate.lstrip())]
-            )
-            if stripped and candidate_indent <= indent:
-                break
-            true_lines.append(candidate)
-            cursor += 1
-        if (
-            cursor < len(lines)
-            and _formula_indent_width(
-                lines[cursor][
-                    : len(lines[cursor]) - len(lines[cursor].lstrip())
-                ]
-            )
-            == indent
-            and re.match(r"^[ \t]*else:\s*$", lines[cursor])
-        ):
-            cursor += 1
-            while cursor < len(lines):
-                candidate = lines[cursor]
-                stripped = candidate.strip()
-                candidate_indent = _formula_indent_width(
-                    candidate[: len(candidate) - len(candidate.lstrip())]
-                )
-                if stripped and candidate_indent <= indent:
-                    break
-                false_lines.append(candidate)
-                cursor += 1
-        yield (
-            match.group("condition"),
-            "\n".join(true_lines),
-            "\n".join(false_lines),
-        )
+    ):
+        return negated
+    return True
 
 
 def _formula_indent_width(value: str) -> int:
     return len(value.expandtabs(4))
 
 
-def _formula_branch_is_excluding(body: str) -> bool:
-    first_statement = next(
-        (
-            line.strip()
-            for line in body.splitlines()
-            if line.strip() and not line.lstrip().startswith("#")
-        ),
-        "",
-    )
+def _exception_semantic_identifier(identifier: str) -> bool:
     return bool(
-        re.fullmatch(
-            r"(?:return\s+)?(?:0(?:\.0+)?|false|not_holds)",
-            first_statement,
+        re.search(
+            r"(?:exception|exempt|exclud|disqual|inelig|remarri|"
+            r"barred|blocking|waiver|befrei|ausnahme)",
+            identifier,
             flags=re.IGNORECASE,
         )
     )
 
 
-def _exception_semantic_identifier(identifier: str) -> bool:
+def _ordinary_semantic_identifier(identifier: str) -> bool:
     return bool(
         re.search(
-            r"(?:exception|exempt|exclud|disqual|inelig|eligib|remarri|"
-            r"barred|blocking|waiver|befrei|ausnahme)",
+            r"(?:^|_)(?:ordinary|regular|default|eligible|qualified)"
+            r"(?:_|$)",
             identifier,
             flags=re.IGNORECASE,
         )
@@ -5486,10 +6103,7 @@ def _source_boundary_obligations(
         }:
             continue
         direct_text = authoritative_numeric_recall_text(branch.text)
-        for fragment in re.split(
-            r"(?:[;\n]+|(?<=[.!?])\s+)",
-            direct_text,
-        ):
+        for fragment_start, fragment in _source_boundary_fragments(direct_text):
             range_fragment = fragment.split(":", 1)[0]
             if not re.search(
                 r"\b(?:zwischen|between|bis|von|ab|unter|über|from|to|"
@@ -5500,9 +6114,12 @@ def _source_boundary_obligations(
                 flags=re.IGNORECASE,
             ):
                 continue
-            interval = _formula_interval_from_text(
-                range_fragment,
-                extract_numeric_occurrences=extract_numeric_occurrences,
+            interval = _shift_numeric_interval(
+                _formula_interval_from_text(
+                    range_fragment,
+                    extract_numeric_occurrences=extract_numeric_occurrences,
+                ),
+                fragment_start,
             )
             if interval is None:
                 continue
@@ -5531,6 +6148,8 @@ def _source_boundary_obligations(
                 occurrence.has_rate_context,
                 occurrence.source_value,
                 occurrence.requires_rate_context,
+                occurrence.start,
+                occurrence.end,
             ): (branch, occurrence)
             for branch, occurrence in obligations
         }.values()

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -271,7 +271,7 @@ _EXCEPTION_LANGUAGE = re.compile(
     r"\b(?:"
     r"except(?:ion)?|unless|subject\s+to|shall\s+not\s+apply|"
     r"does\s+not\s+apply|notwithstanding|vorbehaltlich|ausnahme|"
-    r"es\s+sei\s+denn|gilt\s+nicht(?:\s*,?\s*wenn)?|"
+    r"es\s+sei\s+denn|gilt\b[^.;]{0,80}\bnicht(?:\s*,?\s*wenn)?|"
     r"findet\s+keine\s+anwendung|soweit\s+nicht|"
     r"außer|ausgenommen|abweichend\s+von|jedoch\s+nicht|"
     r"(?:[1-9]\d?)?voraussetzung[^.;]{0,160}\bnicht\b"
@@ -4695,6 +4695,10 @@ def _source_exception_branches(
     source_clauses = tuple(
         _source_clause_spans(source_text, branches=branches)
     )
+    matches_by_clause: dict[
+        tuple[int, int, str],
+        list[re.Match[str]],
+    ] = {}
     for match in _EXCEPTION_LANGUAGE.finditer(source_text):
         if _span_is_deferred(
             match.start(),
@@ -4703,19 +4707,7 @@ def _source_exception_branches(
             deferred_paths=deferred_paths,
         ):
             continue
-        owner = _most_specific_containing_branch(
-            match.start(),
-            match.end(),
-            branches=active_branches,
-        ) or SourceStructureBranch(
-            (),
-            "source-unit",
-            "source unit",
-            source_text,
-            0,
-            len(source_text),
-        )
-        clause_start, clause_end, clause_text = next(
+        clause = next(
             (
                 (start, end, text)
                 for start, end, text in source_clauses
@@ -4723,22 +4715,74 @@ def _source_exception_branches(
             ),
             (match.start(), match.end(), match.group(0)),
         )
-        obligations.append(
-            SourceStructureBranch(
-                owner.path,
-                "exception-clause",
-                owner.label,
-                clause_text,
-                clause_start,
-                clause_end,
+        matches_by_clause.setdefault(clause, []).append(match)
+
+    for (clause_start, clause_end, clause_text), clause_matches in (
+        matches_by_clause.items()
+    ):
+        groups: list[list[re.Match[str]]] = []
+        for match in clause_matches:
+            if (
+                groups
+                and _exception_cues_have_distinct_conditions(
+                    source_text[groups[-1][-1].end() : match.start()]
+                )
+            ):
+                groups.append([match])
+            elif groups:
+                groups[-1].append(match)
+            else:
+                groups.append([match])
+        for group_index, group in enumerate(groups):
+            match = group[0]
+            owner = _most_specific_containing_branch(
+                match.start(),
+                match.end(),
+                branches=active_branches,
+            ) or SourceStructureBranch(
+                (),
+                "source-unit",
+                "source unit",
+                source_text,
+                0,
+                len(source_text),
             )
-        )
+            if len(groups) == 1:
+                branch_start = clause_start
+                branch_end = clause_end
+                branch_text = clause_text
+            else:
+                branch_start = match.start()
+                branch_end = (
+                    groups[group_index + 1][0].start()
+                    if group_index + 1 < len(groups)
+                    else clause_end
+                )
+                branch_text = source_text[branch_start:branch_end]
+            obligations.append(
+                SourceStructureBranch(
+                    owner.path,
+                    "exception-clause",
+                    owner.label,
+                    branch_text,
+                    branch_start,
+                    branch_end,
+                )
+            )
     return tuple(
         {
             (branch.path, branch.start, branch.end): branch
             for branch in obligations
         }.values()
     )
+
+
+def _exception_cues_have_distinct_conditions(between: str) -> bool:
+    return re.search(
+        r"(?:;|\b(?:und|oder|and|or)\b)\s*$",
+        between,
+        flags=re.IGNORECASE,
+    ) is not None
 
 
 def _source_rounding_obligations(
@@ -4855,28 +4899,16 @@ def _unwitnessed_exception_branches(
     toggled_exception_selectors: set[_ExceptionWitness],
     extract_numeric_occurrences: NumericOccurrenceExtractor,
 ) -> tuple[SourceStructureBranch, ...]:
-    available_witnesses = set(toggled_exception_selectors)
-    missing: list[SourceStructureBranch] = []
-    for branch in sorted(
-        exception_branches,
-        key=lambda item: len(_exception_witnesses_for_branch(
-            item,
-            principal_rule_paths=principal_rule_paths,
-            toggled_exception_selectors=available_witnesses,
-            extract_numeric_occurrences=extract_numeric_occurrences,
-        )),
-    ):
-        candidates = _exception_witnesses_for_branch(
+    candidate_witnesses = {
+        branch: _exception_witnesses_for_branch(
             branch,
             principal_rule_paths=principal_rule_paths,
-            toggled_exception_selectors=available_witnesses,
+            toggled_exception_selectors=toggled_exception_selectors,
             extract_numeric_occurrences=extract_numeric_occurrences,
         )
-        if not candidates:
-            missing.append(branch)
-            continue
-        available_witnesses.remove(sorted(candidates)[0])
-    return tuple(missing)
+        for branch in exception_branches
+    }
+    return _unmatched_evidence_obligations(candidate_witnesses)
 
 
 def _exception_witnesses_for_branch(
@@ -4897,6 +4929,7 @@ def _exception_witnesses_for_branch(
         )
     }
     requirement = _source_exception_effect_requirement(branch.text)
+    condition_text = _source_exception_condition_text(branch.text)
     return {
         witness
         for witness in toggled_exception_selectors
@@ -4911,17 +4944,47 @@ def _exception_witnesses_for_branch(
             else (
                 witness.active_value
                 == _source_exception_selector_active_value(
-                    branch.text,
+                    condition_text,
                     witness.selector_name,
                 )
             )
         )
         and _source_exception_selector_is_relevant(
-            branch.text,
+            condition_text,
             witness.selector_name,
         )
         and _exception_witness_satisfies_requirement(witness, requirement)
     }
+
+
+def _source_exception_condition_text(text: str) -> str:
+    """Return the condition region without the ordinary claim subject."""
+
+    clause = _strip_source_clause_marker(text)
+    marker = _EXCEPTION_LANGUAGE.search(clause)
+    if marker is None:
+        return clause
+    suffix = clause[marker.start() :]
+    condition_cue = re.search(
+        r"\b(?:wenn|falls|sofern|when|if|bei|ohne|mangels)\b",
+        suffix,
+        flags=re.IGNORECASE,
+    )
+    if condition_cue is not None:
+        return suffix[condition_cue.start() :]
+    prefix = clause[: marker.start()]
+    preposed = re.match(
+        r"\s*(?P<condition>(?:"
+        r"(?:wenn|falls|sofern|when|if)\b[^,;]*|"
+        r"(?:bei|ohne|mangels)\b[^,;]*|"
+        r"im\s+falle\b[^,;]*"
+        r"))\s*,?\s*$",
+        prefix,
+        flags=re.IGNORECASE,
+    )
+    if preposed is not None:
+        return preposed.group("condition")
+    return suffix
 
 
 def _source_exception_effect_requirement(text: str) -> str:
@@ -4939,9 +5002,11 @@ def _source_exception_effect_requirement(text: str) -> str:
         flags=re.IGNORECASE,
     ):
         return "zero"
+    if _exception_reverses_negative_proposition(collapsed):
+        return "enable"
     if re.search(
         r"\b(?:"
-        r"gilt\s+nicht|"
+        r"gilt\b[^.;]{0,80}\bnicht|"
         r"findet\s+keine\s+anwendung|"
         r"keine?\s+berechtigung|"
         r"keinen?\s+anspruch|"
@@ -4968,14 +5033,31 @@ def _source_exception_effect_requirement(text: str) -> str:
     return "change"
 
 
+def _exception_reverses_negative_proposition(text: str) -> bool:
+    reversal = re.search(
+        r"\b(?:außer|ausser|es\s+sei\s+denn|unless|except)\b",
+        text,
+        flags=re.IGNORECASE,
+    )
+    if reversal is None:
+        return False
+    proposition = text[: reversal.start()]
+    return re.search(
+        r"\b(?:besteht|gilt)\b[^.;]{0,80}\bnicht\b|"
+        r"\bfindet\s+keine\s+anwendung\b|"
+        r"\b(?:does|shall)\s+not\s+apply\b|"
+        r"\b(?:is|are)\s+not\s+(?:eligible|qualified|entitled)\b|"
+        r"\bkein(?:e|en|em|er|es)?\s+(?:anspruch|berechtigung)\b",
+        proposition,
+        flags=re.IGNORECASE,
+    ) is not None
+
+
 def _source_exception_selector_is_relevant(text: str, name: str) -> bool:
     """Reject formula toggles with no semantic link to the source exception."""
 
     normalized_name = _normalized_selector_name(name)
-    if (
-        _exception_semantic_identifier(normalized_name)
-        or _ordinary_semantic_identifier(normalized_name)
-    ):
+    if _exception_semantic_identifier(normalized_name):
         return True
     collapsed = _collapse_text(text).lower()
     if _source_selector_concept_matches(collapsed, normalized_name):
@@ -5103,7 +5185,7 @@ def _source_selector_concept_polarity(
         after = text[match.end() : min(len(text), match.end() + 48)]
         negative = bool(
             re.search(
-                r"\b(?:kein(?:e|en|em|er|es)?|ohne|mangels|"
+                r"\b(?:kein(?:e|en|em|er|es)?|fehlend\w*|ohne|mangels|"
                 r"no|without|lack(?:ing)?(?:\s+of)?|absence\s+of)"
                 r"\b[^.;]{0,40}$|"
                 r"\b(?:nicht|not)\s+(?:\w+\s+){0,1}$",
@@ -5148,6 +5230,10 @@ def _exception_witness_satisfies_requirement(
 ) -> bool:
     if requirement == "zero":
         return witness.zeroes
+    if requirement == "enable":
+        return (witness.boolean_effect and not witness.blocks) or (
+            not witness.boolean_effect
+        )
     if requirement == "exclude":
         return witness.blocks or not witness.boolean_effect
     return True

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -3292,6 +3292,15 @@ def _branch_boundary_has_test_evidence(
     formula_environment: dict[str, Any] | None = None,
     extract_numeric_occurrences: NumericOccurrenceExtractor | None = None,
 ) -> bool:
+    source_interval = (
+        _source_interval_for_boundary(
+            branch,
+            boundary,
+            extract_numeric_occurrences=extract_numeric_occurrences,
+        )
+        if extract_numeric_occurrences is not None
+        else None
+    )
     for rule_name in _rules_covering_branch(branch, principal_rule_paths):
         rule = principal_rules[rule_name]
         selector_names = _rule_numeric_selector_names(rule)
@@ -3316,6 +3325,7 @@ def _branch_boundary_has_test_evidence(
                         boundary,
                         input_names=input_names,
                         formula_environment=execution.constant_environment,
+                        source_interval=source_interval,
                         extract_numeric_occurrences=(
                             extract_numeric_occurrences
                         ),
@@ -3349,6 +3359,7 @@ def _formula_execution_binds_boundary(
     *,
     input_names: set[str],
     formula_environment: dict[str, Any],
+    source_interval: _NumericInterval | None,
     extract_numeric_occurrences: NumericOccurrenceExtractor | None,
     numeric_value_is_grounded: NumericGroundingPredicate,
 ) -> bool:
@@ -3376,6 +3387,8 @@ def _formula_execution_binds_boundary(
             input_names=input_names,
             boundary_names=boundary_names,
             boundary=boundary,
+            formula_environment=formula_environment,
+            source_interval=source_interval,
             extract_numeric_occurrences=extract_numeric_occurrences,
             numeric_value_is_grounded=numeric_value_is_grounded,
         )
@@ -3389,6 +3402,8 @@ def _formula_text_has_boundary_comparison(
     input_names: set[str],
     boundary_names: set[str],
     boundary: NumericOccurrenceLike,
+    formula_environment: dict[str, Any],
+    source_interval: _NumericInterval | None,
     extract_numeric_occurrences: NumericOccurrenceExtractor | None,
     numeric_value_is_grounded: NumericGroundingPredicate,
 ) -> bool:
@@ -3398,24 +3413,45 @@ def _formula_text_has_boundary_comparison(
             node for node in ast.walk(expression) if isinstance(node, ast.Compare)
         ):
             operands = (comparison.left, *comparison.comparators)
-            for left, right in zip(operands, operands[1:]):
-                if (
-                    _formula_node_references_names(left, input_names)
-                    and _formula_node_binds_boundary(
-                        right,
+            for operator, left, right in zip(
+                comparison.ops,
+                operands,
+                operands[1:],
+            ):
+                left_is_input = _formula_node_references_names(
+                    left,
+                    input_names,
+                )
+                right_is_input = _formula_node_references_names(
+                    right,
+                    input_names,
+                )
+                boundary_node = (
+                    right if left_is_input and not right_is_input else left
+                )
+                if not (
+                    (left_is_input and not right_is_input)
+                    or (right_is_input and not left_is_input)
+                ):
+                    continue
+                boundary_value = _formula_node_boundary_value(
+                    boundary_node,
+                    boundary_names=boundary_names,
+                    boundary=boundary,
+                    formula_environment=formula_environment,
+                    extract_numeric_occurrences=extract_numeric_occurrences,
+                    numeric_value_is_grounded=numeric_value_is_grounded,
+                )
+                if boundary_value is not None and (
+                    source_interval is None
+                    or _comparison_matches_source_interval(
+                        operator,
+                        input_on_left=left_is_input,
+                        compared_boundary_value=boundary_value,
                         boundary_names=boundary_names,
                         boundary=boundary,
-                        extract_numeric_occurrences=extract_numeric_occurrences,
                         numeric_value_is_grounded=numeric_value_is_grounded,
-                    )
-                ) or (
-                    _formula_node_references_names(right, input_names)
-                    and _formula_node_binds_boundary(
-                        left,
-                        boundary_names=boundary_names,
-                        boundary=boundary,
-                        extract_numeric_occurrences=extract_numeric_occurrences,
-                        numeric_value_is_grounded=numeric_value_is_grounded,
+                        source_interval=source_interval,
                     )
                 ):
                     return True
@@ -3436,33 +3472,187 @@ def _formula_node_references_names(
     )
 
 
-def _formula_node_binds_boundary(
+def _formula_node_boundary_value(
     node: ast.AST,
     *,
     boundary_names: set[str],
     boundary: NumericOccurrenceLike,
+    formula_environment: dict[str, Any],
     extract_numeric_occurrences: NumericOccurrenceExtractor | None,
     numeric_value_is_grounded: NumericGroundingPredicate,
-) -> bool:
-    if _formula_node_references_names(node, boundary_names):
-        return True
+) -> float | None:
+    if isinstance(node, ast.Name) and node.id in boundary_names:
+        value = formula_environment.get(node.id)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return float(value)
     if isinstance(node, ast.Constant) and isinstance(
         node.value,
         (int, float),
     ) and not isinstance(node.value, bool):
         value = float(node.value)
-        return numeric_value_is_grounded(
+        if numeric_value_is_grounded(
             value,
             (boundary,),
-        ) or _is_adjacent_integral_boundary(value, boundary)
+        ) or _is_adjacent_integral_boundary(value, boundary):
+            return value
+        return None
     if extract_numeric_occurrences is None:
-        return False
+        return None
     text = ast.unparse(node)
-    return any(
-        numeric_value_is_grounded(float(occurrence.value), (boundary,))
-        or _is_adjacent_integral_boundary(float(occurrence.value), boundary)
-        for occurrence in extract_numeric_occurrences(text)
+    return next(
+        (
+            float(occurrence.value)
+            for occurrence in extract_numeric_occurrences(text)
+            if numeric_value_is_grounded(float(occurrence.value), (boundary,))
+            or _is_adjacent_integral_boundary(
+                float(occurrence.value),
+                boundary,
+            )
+        ),
+        None,
     )
+
+
+def _source_interval_for_boundary(
+    branch: SourceStructureBranch,
+    boundary: NumericOccurrenceLike,
+    *,
+    extract_numeric_occurrences: NumericOccurrenceExtractor,
+) -> _NumericInterval | None:
+    for fragment in re.split(
+        r"(?:[;\n]+|(?<=[.!?])\s+)",
+        branch.text,
+    ):
+        interval = _formula_interval_from_text(
+            fragment.split(":", 1)[0],
+            extract_numeric_occurrences=extract_numeric_occurrences,
+        )
+        if interval is None:
+            continue
+        if any(
+            occurrence is not None
+            and _numeric_occurrences_are_equivalent(occurrence, boundary)
+            for occurrence in (interval.lower, interval.upper)
+        ):
+            return interval
+    return None
+
+
+def _comparison_matches_source_interval(
+    operator: ast.cmpop,
+    *,
+    input_on_left: bool,
+    compared_boundary_value: float,
+    boundary_names: set[str],
+    boundary: NumericOccurrenceLike,
+    numeric_value_is_grounded: NumericGroundingPredicate,
+    source_interval: _NumericInterval,
+) -> bool:
+    del boundary_names
+    relation = _input_comparison_relation(operator, input_on_left=input_on_left)
+    if relation is None:
+        return False
+    relations = {relation, _complement_comparison_relation(relation)}
+    is_exact = numeric_value_is_grounded(
+        compared_boundary_value,
+        (boundary,),
+    )
+    boundary_value = float(boundary.value)
+    is_lower = (
+        source_interval.lower is not None
+        and _numeric_occurrences_are_equivalent(
+            source_interval.lower,
+            boundary,
+        )
+    )
+    is_upper = (
+        source_interval.upper is not None
+        and _numeric_occurrences_are_equivalent(
+            source_interval.upper,
+            boundary,
+        )
+    )
+    if is_lower:
+        expected = ">=" if source_interval.lower_inclusive else ">"
+        if is_exact:
+            return expected in relations
+        if (
+            _is_adjacent_integral_boundary(
+                compared_boundary_value,
+                boundary,
+            )
+            and source_interval.lower_inclusive
+            and math.isclose(compared_boundary_value, boundary_value - 1)
+        ):
+            return ">" in relations
+        if (
+            _is_adjacent_integral_boundary(
+                compared_boundary_value,
+                boundary,
+            )
+            and not source_interval.lower_inclusive
+            and math.isclose(compared_boundary_value, boundary_value + 1)
+        ):
+            return ">=" in relations
+    if is_upper:
+        expected = "<=" if source_interval.upper_inclusive else "<"
+        if is_exact:
+            return expected in relations
+        if (
+            _is_adjacent_integral_boundary(
+                compared_boundary_value,
+                boundary,
+            )
+            and source_interval.upper_inclusive
+            and math.isclose(compared_boundary_value, boundary_value + 1)
+        ):
+            return "<" in relations
+        if (
+            _is_adjacent_integral_boundary(
+                compared_boundary_value,
+                boundary,
+            )
+            and not source_interval.upper_inclusive
+            and math.isclose(compared_boundary_value, boundary_value - 1)
+        ):
+            return "<=" in relations
+    return False
+
+
+def _input_comparison_relation(
+    operator: ast.cmpop,
+    *,
+    input_on_left: bool,
+) -> str | None:
+    relation = {
+        ast.Lt: "<",
+        ast.LtE: "<=",
+        ast.Gt: ">",
+        ast.GtE: ">=",
+        ast.Eq: "==",
+        ast.NotEq: "!=",
+    }.get(type(operator))
+    if relation is None or input_on_left:
+        return relation
+    return {
+        "<": ">",
+        "<=": ">=",
+        ">": "<",
+        ">=": "<=",
+        "==": "==",
+        "!=": "!=",
+    }[relation]
+
+
+def _complement_comparison_relation(relation: str) -> str:
+    return {
+        "<": ">=",
+        "<=": ">",
+        ">": "<=",
+        ">=": "<",
+        "==": "!=",
+        "!=": "==",
+    }[relation]
 
 
 def _boundary_case_changes_formula_effect(
@@ -3555,7 +3745,8 @@ def _formula_interval_from_text(
 ) -> _NumericInterval | None:
     lowered = text.lower()
     keyword = re.search(
-        r"\b(?:zwischen|between|von|from|unter|less\s+than|below|"
+        r"\b(?:zwischen|between|von(?!\s+(?:höchstens|mindestens))|"
+        r"from|unter|less\s+than|below|"
         r"bis|up\s+to|höchstens|nicht\s+mehr\s+als|"
         r"at\s+most|über|more\s+than|above|ab|at\s+least|mindestens)\b",
         lowered,

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -549,7 +549,15 @@ def _analyze_rulespec_payload(
     issues.extend(imprecise_deferrals)
 
     for branch in branches:
-        if _path_covered(branch.path, all_covered_paths, deferred_paths):
+        if _path_covered(
+            branch.path,
+            all_covered_paths,
+            deferred_paths,
+        ) or _is_marker_only_container(
+            branch,
+            branches=branches,
+            source_text=source_text,
+        ):
             continue
         issues.append(
             "[complete-source-unit:structure] "
@@ -709,12 +717,12 @@ def _rule_coverage(
             elif not branches:
                 paths.add(())
         for path in paths:
-            all_paths.update(_path_prefixes(path))
+            all_paths.add(path)
         if kind in {"derived", "derived_relation"} and name:
             principal_rules[name] = rule
             principal_rule_paths.setdefault(name, set()).update(paths)
             for path in paths:
-                principal_paths.update(_path_prefixes(path))
+                principal_paths.add(path)
     return all_paths, principal_paths, principal_rules, principal_rule_paths
 
 
@@ -1352,10 +1360,25 @@ def _rulespec_target_base(corpus_citation_path: str) -> str:
     return f"{jurisdiction}:{plural}/{'/'.join(tail)}"
 
 
-def _path_prefixes(path: tuple[str, ...]) -> set[tuple[str, ...]]:
-    if not path:
-        return {()}
-    return {path[:index] for index in range(1, len(path) + 1)}
+def _is_marker_only_container(
+    branch: SourceStructureBranch,
+    *,
+    branches: Sequence[SourceStructureBranch],
+    source_text: str,
+) -> bool:
+    """Ignore a parent wrapper only when it has no operative chapeau text."""
+
+    direct_child_starts = [
+        candidate.start
+        for candidate in branches
+        if len(candidate.path) == len(branch.path) + 1
+        and candidate.path[: len(branch.path)] == branch.path
+        and branch.start <= candidate.start < branch.end
+    ]
+    if not direct_child_starts:
+        return False
+    chapeau = source_text[branch.start : min(direct_child_starts)]
+    return re.search(r"\w", _strip_source_clause_marker(chapeau)) is None
 
 
 def _path_covered(

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -162,7 +162,8 @@ _GLUED_SENTENCE_MARKER = re.compile(
     r"(?<![\w])(?P<label>[1-9]\d?)(?=[A-ZÄÖÜ])"
 )
 _EXPLICIT_SENTENCE_MARKER = re.compile(
-    r"(?:(?<=^)|(?<=[.;]))[ \t]*Satz[ \t]+(?P<label>[1-9]\d?)(?=[ \t]+[A-ZÄÖÜ])",
+    r"(?:(?<=^)|(?<=[.;])|(?<=\)))[ \t]*Satz[ \t]+"
+    r"(?P<label>[1-9]\d?)(?=[ \t]+[A-ZÄÖÜ])",
     flags=re.IGNORECASE | re.MULTILINE,
 )
 _EDITORIAL_OMISSION_ONLY = re.compile(

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -212,9 +212,8 @@ _WORDED_ARITHMETIC_EXPRESSION = re.compile(
     rf"{_SYMBOLIC_ARITHMETIC_OPERAND}",
     flags=re.IGNORECASE,
 )
-_EXPLICIT_SYMBOLIC_ARITHMETIC_CHAIN = re.compile(
-    rf"(?P<expression>{_SYMBOLIC_ARITHMETIC_OPERAND}"
-    rf"(?:\s*[+*/×·•∗∙−–-]\s*{_SYMBOLIC_ARITHMETIC_OPERAND}){{2,}})"
+_SYMBOLIC_ARITHMETIC_TOKEN = re.compile(
+    rf"{_SYMBOLIC_ARITHMETIC_OPERAND}|[()+*/×·•∗∙−–-]"
 )
 _COMPUTATION_LANGUAGE = re.compile(
     r"\b(?:"
@@ -2517,40 +2516,83 @@ def _formula_operation_kinds(text: str) -> set[str]:
 
 
 def _explicit_source_arithmetic_topology(text: str) -> Any | None:
-    """Parse a complete, unparenthesized symbolic source arithmetic chain."""
+    """Parse the largest complete symbolic expression, including grouping."""
 
-    for match in _EXPLICIT_SYMBOLIC_ARITHMETIC_CHAIN.finditer(text):
-        prefix = text[: match.start()].rstrip()
-        suffix = text[match.end() :].lstrip()
-        if prefix.endswith("(") or suffix.startswith(")"):
-            continue
-        expression_text = match.group("expression")
-        expression_text = re.sub(
-            r"\d{1,3}(?:[ .]\d{3})+(?:,\d+)?|\d+,\d+",
-            lambda number: number.group(0).replace(" ", "").replace(".", "").replace(
-                ",",
-                ".",
-            ),
-            expression_text,
-        )
-        expression_text = expression_text.translate(
-            str.maketrans(
-                {
-                    "×": "*",
-                    "·": "*",
-                    "•": "*",
-                    "∗": "*",
-                    "∙": "*",
-                    "−": "-",
-                    "–": "-",
-                }
+    tokens = tuple(_SYMBOLIC_ARITHMETIC_TOKEN.finditer(text))
+    candidates: list[tuple[int, int, str]] = []
+    for start_index, start_token in enumerate(tokens):
+        for end_token in tokens[start_index:]:
+            expression_text = _normalized_source_arithmetic_expression(
+                text[start_token.start() : end_token.end()]
             )
+            with contextlib.suppress(SyntaxError):
+                expression = ast.parse(expression_text, mode="eval").body
+                if not _is_supported_arithmetic_expression(expression):
+                    continue
+                operation_count = sum(
+                    isinstance(node, ast.BinOp) for node in ast.walk(expression)
+                )
+                if operation_count >= 2:
+                    candidates.append(
+                        (
+                            operation_count,
+                            end_token.end() - start_token.start(),
+                            expression_text,
+                        )
+                    )
+    if not candidates:
+        return None
+    _operation_count, _length, expression_text = max(
+        candidates,
+        key=lambda candidate: (candidate[0], candidate[1]),
+    )
+    return _formula_arithmetic_topology(expression_text, environment={})
+
+
+def _normalized_source_arithmetic_expression(text: str) -> str:
+    normalized = re.sub(
+        r"\d{1,3}(?:[ .]\d{3})+(?:,\d+)?|\d+,\d+",
+        lambda number: number.group(0).replace(" ", "").replace(".", "").replace(
+            ",",
+            ".",
+        ),
+        text,
+    )
+    return normalized.translate(
+        str.maketrans(
+            {
+                "×": "*",
+                "·": "*",
+                "•": "*",
+                "∗": "*",
+                "∙": "*",
+                "−": "-",
+                "–": "-",
+            }
         )
-        with contextlib.suppress(SyntaxError):
-            expression = ast.parse(expression_text, mode="eval").body
-            if sum(isinstance(node, ast.BinOp) for node in ast.walk(expression)) >= 2:
-                return _formula_arithmetic_topology(expression_text, environment={})
-    return None
+    )
+
+
+def _is_supported_arithmetic_expression(expression: ast.expr) -> bool:
+    return all(
+        isinstance(
+            node,
+            (
+                ast.BinOp,
+                ast.UnaryOp,
+                ast.Name,
+                ast.Constant,
+                ast.Add,
+                ast.Sub,
+                ast.Mult,
+                ast.Div,
+                ast.USub,
+                ast.UAdd,
+                ast.Load,
+            ),
+        )
+        for node in ast.walk(expression)
+    )
 
 
 def _formula_arithmetic_topology(
@@ -2563,7 +2605,8 @@ def _formula_arithmetic_topology(
     with contextlib.suppress(SyntaxError):
         expression = ast.parse(formula.strip(), mode="eval").body
         expression = _unwrap_formula_result_wrapper(expression)
-        return _formula_arithmetic_topology_node(expression, environment)
+        topology = _formula_arithmetic_topology_node(expression, environment)
+        return _canonicalize_topology_variables(topology)
     return None
 
 
@@ -2571,27 +2614,83 @@ def _formula_arithmetic_topology_node(
     node: ast.expr,
     environment: dict[str, Any],
 ) -> Any:
-    known = _known_numeric_formula_value(node, environment)
-    if known is not None:
-        return "constant", float(known)
     if isinstance(node, ast.Name):
-        return ("variable",)
+        known = _known_numeric_formula_value(node, environment)
+        if known is not None:
+            return "constant", float(known)
+        return "variable", node.id
+    if isinstance(node, ast.Constant):
+        known = _known_numeric_formula_value(node, environment)
+        if known is not None:
+            return "constant", float(known)
+        return "unsupported", type(node.value).__name__
     if isinstance(node, ast.BinOp):
         operator = type(node.op).__name__
-        operands = (
+        operands: tuple[Any, ...] = (
             _formula_arithmetic_topology_node(node.left, environment),
             _formula_arithmetic_topology_node(node.right, environment),
         )
         if isinstance(node.op, (ast.Add, ast.Mult)):
-            operands = tuple(sorted(operands, key=repr))
+            flattened: list[Any] = []
+            for operand in operands:
+                if (
+                    isinstance(operand, tuple)
+                    and len(operand) == 3
+                    and operand[:2] == ("binop", operator)
+                ):
+                    flattened.extend(operand[2])
+                else:
+                    flattened.append(operand)
+            operands = tuple(
+                sorted(
+                    flattened,
+                    key=lambda operand: repr(
+                        _topology_without_variable_names(operand)
+                    ),
+                )
+            )
         return "binop", operator, operands
     if isinstance(node, ast.UnaryOp):
+        known = _known_numeric_formula_value(node, environment)
+        if known is not None:
+            return "constant", float(known)
         return (
             "unary",
             type(node.op).__name__,
             _formula_arithmetic_topology_node(node.operand, environment),
         )
     return ("unsupported", type(node).__name__)
+
+
+def _topology_without_variable_names(topology: Any) -> Any:
+    if (
+        isinstance(topology, tuple)
+        and len(topology) == 2
+        and topology[0] == "variable"
+    ):
+        return ("variable",)
+    if isinstance(topology, tuple):
+        return tuple(_topology_without_variable_names(item) for item in topology)
+    return topology
+
+
+def _canonicalize_topology_variables(topology: Any) -> Any:
+    identities: dict[str, int] = {}
+
+    def canonicalize(item: Any) -> Any:
+        if (
+            isinstance(item, tuple)
+            and len(item) == 2
+            and item[0] == "variable"
+        ):
+            name = str(item[1])
+            identity = identities.setdefault(name, len(identities))
+            return "variable", identity
+        if isinstance(item, tuple):
+            return tuple(canonicalize(part) for part in item)
+        return item
+
+    return canonicalize(topology)
 
 
 def _formula_ast_operation_kinds(text: str) -> set[str]:

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -115,8 +115,12 @@ _COMPUTATION_LANGUAGE = re.compile(
     r"summe\s+(?:aus|der|von)|unterschied|differenz|"
     r"geteilt\s+durch|durch\s+(?:\d+|[a-zäöüß]+)\s+geteilt|"
     r"multipliziert\s+mit|"
+    r"\d+(?:[.,]\d+)?\s*-?fach(?:e[nsrm]?)?|"
     r"(?:vermindert|erhöht|gekürzt|vermehrt)\s+um|"
+    r"(?:erhöht|mindert|vermindert|kürzt|vermehrt)\s+sich\s+um|"
     r"(?:abzüglich|zuzüglich)|prozent\s+(?:des|der|von)|"
+    r"\d+(?:[.,]\d+)?\s+(?:vom\s+hundert|v\.?\s*h\.?)\s+"
+    r"(?:des|der|von)|"
     r"splitting-verfahren|verfahren\s+nach\s+absatz|"
     r"calculated|computed|computation|multiplied|divided|"
     r"sum\s+of|difference\s+between|product\s+of|twice|half\s+of|"
@@ -151,6 +155,7 @@ _EXCEPTION_LANGUAGE = re.compile(
     r"does\s+not\s+apply|notwithstanding|vorbehaltlich|ausnahme|"
     r"es\s+sei\s+denn|gilt\s+nicht(?:\s*,?\s*wenn)?|"
     r"findet\s+keine\s+anwendung|soweit\s+nicht|"
+    r"außer|ausgenommen|abweichend\s+von|jedoch\s+nicht|"
     r"(?:[1-9]\d?)?voraussetzung[^.;]{0,160}\bnicht\b"
     r")",
     flags=re.IGNORECASE,
@@ -180,7 +185,7 @@ _ABSATZ_REFERENCE = re.compile(
     flags=re.IGNORECASE,
 )
 _SATZ_REFERENCE = re.compile(
-    r"\b(?:Satz|Sätze)\s*(?P<label>\d+)\b",
+    r"\b(?:Satz(?:es)?|Sätze)\s*(?P<label>\d+)\b",
     flags=re.IGNORECASE,
 )
 _NUMMER_REFERENCE = re.compile(
@@ -203,7 +208,7 @@ _ENGLISH_LEGAL_CITATION = re.compile(
     flags=re.IGNORECASE,
 )
 _STRUCTURAL_REFERENCE = re.compile(
-    r"\b(?:Absatz|Abs\.|Satz|Sätze|Nummer|Nr\.|Buchstabe|Buchst\.)"
+    r"\b(?:Absatz|Abs\.|Satz(?:es)?|Sätze|Nummer|Nr\.|Buchstabe|Buchst\.)"
     r"\s*\d*[a-z]?\b",
     flags=re.IGNORECASE,
 )
@@ -424,24 +429,47 @@ def _analyze_rulespec_payload(
             "encoded nor precisely deferred."
         )
 
-    computation_branches = tuple(
-        branch for branch in branches if source_states_explicit_computation(branch.text)
+    active_branches = tuple(
+        branch
+        for branch in branches
+        if not _path_is_deferred(branch.path, deferred_paths)
+    )
+    all_formula_branches = _source_formula_branches(
+        source_text,
+        branches=branches,
+        active_branches=branches,
+        deferred_paths=set(),
+    )
+    formula_branches = _source_formula_branches(
+        source_text,
+        branches=branches,
+        active_branches=active_branches,
+        deferred_paths=deferred_paths,
+    )
+    principal_formula_clause_rules = _principal_formula_clause_rules(
+        formula_branches,
+        principal_rules=principal_rules,
+        principal_rule_paths=principal_rule_paths,
+        corpus_citation_path=corpus_citation_path,
     )
     source_has_computation = source_states_explicit_computation(source_text)
     if source_has_computation:
-        if computation_branches:
-            for branch in computation_branches:
-                if _path_covered(branch.path, principal_paths, deferred_paths):
+        if formula_branches:
+            for branch in formula_branches:
+                if principal_formula_clause_rules[branch]:
                     continue
                 issues.append(
                     "[complete-source-unit:formula-output] "
-                    f"Explicit source computation in "
+                    f"Explicit source computation {branch.label} in "
                     f"{_branch_citation(corpus_citation_path, branch)} has no "
                     "principal derived/relation output (`derived` or "
                     "`derived_relation`) and is not "
                     "precisely deferred; parameter-only representation is invalid."
                 )
-        elif not _path_covered((), principal_paths, deferred_paths):
+        elif (
+            not all_formula_branches
+            and not _path_covered((), principal_paths, deferred_paths)
+        ):
             issues.append(
                 "[complete-source-unit:formula-output] Explicit source computation "
                 "has no principal derived/relation output (`derived` or "
@@ -478,11 +506,13 @@ def _analyze_rulespec_payload(
             "`module.summary` is not consulted."
         )
 
-    if source_has_computation and principal_rules:
+    if formula_branches and principal_rules:
         issues.extend(
             _companion_test_issues(
                 principal_rules,
                 principal_rule_paths=principal_rule_paths,
+                principal_formula_clause_rules=principal_formula_clause_rules,
+                formula_branches=formula_branches,
                 branches=branches,
                 source_text=source_text,
                 corpus_citation_path=corpus_citation_path,
@@ -572,6 +602,86 @@ def _rule_source_excerpts(rule: dict[str, Any]) -> Iterable[tuple[str, str]]:
         if isinstance(excerpt, str) and excerpt.strip() and citation_path:
             excerpts.append((citation_path, excerpt.strip()))
     return excerpts
+
+
+def _principal_formula_clause_rules(
+    formula_branches: Sequence[SourceStructureBranch],
+    *,
+    principal_rules: dict[str, dict[str, Any]],
+    principal_rule_paths: dict[str, set[tuple[str, ...]]],
+    corpus_citation_path: str,
+) -> dict[SourceStructureBranch, set[str]]:
+    """Bind each computation clause to principal output evidence.
+
+    A direct source path is sufficient when its structural branch contains one
+    computation. When several computations share that path, each one needs a
+    source-verbatim proof excerpt on the principal rule that claims it.
+    """
+
+    clause_count_by_path: dict[tuple[str, ...], int] = {}
+    for clause in formula_branches:
+        clause_count_by_path[clause.path] = (
+            clause_count_by_path.get(clause.path, 0) + 1
+        )
+
+    clause_rules: dict[SourceStructureBranch, set[str]] = {}
+    normalized_citation_path = corpus_citation_path.strip("/").lower()
+    for clause in formula_branches:
+        path_rules = set(_rules_covering_branch(clause, principal_rule_paths))
+        if clause_count_by_path[clause.path] == 1:
+            clause_rules[clause] = path_rules
+            continue
+        clause_text = _normalized_formula_clause_text(clause.text)
+        rounding_direction = _rounding_direction(clause.text)
+        clause_rules[clause] = {
+            rule_name
+            for rule_name in path_rules
+            if (
+                rounding_direction is not None
+                and _rule_implements_rounding(
+                    principal_rules[rule_name],
+                    rounding_direction,
+                )
+            )
+            or any(
+                (
+                    excerpt_text := _normalized_formula_clause_text(excerpt)
+                )
+                and excerpt_citation_path.strip("/").lower()
+                == normalized_citation_path
+                and source_states_explicit_computation(excerpt)
+                and (
+                    excerpt_text in clause_text
+                    or clause_text in excerpt_text
+                )
+                for excerpt_citation_path, excerpt in _rule_source_excerpts(
+                    principal_rules[rule_name]
+                )
+            )
+        }
+    return clause_rules
+
+
+def _normalized_formula_clause_text(text: str) -> str:
+    """Normalize a clause while ignoring its structural marker."""
+
+    unmarked = re.sub(
+        r"^\s*(?:\((?:\d+[a-z]?|[a-z])\)|\d+[a-z]?\.|[a-z]\))\s*",
+        "",
+        text,
+        flags=re.IGNORECASE,
+    )
+    return _collapse_text(unmarked)
+
+
+def _rounding_direction(text: str) -> str | None:
+    if not _ROUNDING_LANGUAGE.search(text):
+        return None
+    if _NEAREST_ROUNDING_LANGUAGE.search(text):
+        return "nearest"
+    if _UP_ROUNDING_LANGUAGE.search(text):
+        return "upward"
+    return "downward"
 
 
 def _most_specific_excerpt_branch(
@@ -824,7 +934,22 @@ def _path_covered(
     encoded_paths: set[tuple[str, ...]],
     deferred_paths: set[tuple[str, ...]],
 ) -> bool:
-    return path in encoded_paths or path in deferred_paths
+    return path in encoded_paths or _path_is_deferred(path, deferred_paths)
+
+
+def _path_is_deferred(
+    path: tuple[str, ...],
+    deferred_paths: set[tuple[str, ...]],
+) -> bool:
+    """Let a precise non-root deferral cover its structural descendants."""
+
+    if not path:
+        return () in deferred_paths
+    return any(
+        deferred_path
+        and path[: len(deferred_path)] == deferred_path
+        for deferred_path in deferred_paths
+    )
 
 
 def _branch_citation(
@@ -917,6 +1042,8 @@ def _companion_test_issues(
     principal_rules: dict[str, dict[str, Any]],
     *,
     principal_rule_paths: dict[str, set[tuple[str, ...]]],
+    principal_formula_clause_rules: dict[SourceStructureBranch, set[str]],
+    formula_branches: Sequence[SourceStructureBranch],
     branches: Sequence[SourceStructureBranch],
     source_text: str,
     corpus_citation_path: str,
@@ -952,18 +1079,12 @@ def _companion_test_issues(
     active_branches = [
         branch
         for branch in branches
-        if branch.path not in deferred_paths
+        if not _path_is_deferred(branch.path, deferred_paths)
     ]
-    formula_branches = _source_formula_branches(
-        source_text,
-        branches=branches,
-        active_branches=active_branches,
-        deferred_paths=deferred_paths,
-    )
     missing_formula_branches = _unwitnessed_formula_branches(
         formula_branches,
         principal_rules=principal_rules,
-        principal_rule_paths=principal_rule_paths,
+        principal_formula_clause_rules=principal_formula_clause_rules,
         asserted_by_rule=asserted_by_rule,
         extract_numeric_occurrences=extract_numeric_occurrences,
     )
@@ -1185,10 +1306,12 @@ def _span_is_deferred(
     branches: Sequence[SourceStructureBranch],
     deferred_paths: set[tuple[str, ...]],
 ) -> bool:
+    if not branches:
+        return () in deferred_paths
     return any(
         branch.start <= start
         and end <= branch.end
-        and branch.path in deferred_paths
+        and _path_is_deferred(branch.path, deferred_paths)
         for branch in branches
     )
 
@@ -1218,7 +1341,7 @@ def _unwitnessed_formula_branches(
     branches: Sequence[SourceStructureBranch],
     *,
     principal_rules: dict[str, dict[str, Any]],
-    principal_rule_paths: dict[str, set[tuple[str, ...]]],
+    principal_formula_clause_rules: dict[SourceStructureBranch, set[str]],
     asserted_by_rule: dict[str, list[dict[str, Any]]],
     extract_numeric_occurrences: NumericOccurrenceExtractor,
 ) -> tuple[SourceStructureBranch, ...]:
@@ -1228,7 +1351,7 @@ def _unwitnessed_formula_branches(
         branch: _formula_branch_test_witnesses(
             branch,
             principal_rules=principal_rules,
-            principal_rule_paths=principal_rule_paths,
+            rule_names=principal_formula_clause_rules[branch],
             asserted_by_rule=asserted_by_rule,
             extract_numeric_occurrences=extract_numeric_occurrences,
         )
@@ -1269,7 +1392,7 @@ def _formula_branch_test_witnesses(
     branch: SourceStructureBranch,
     *,
     principal_rules: dict[str, dict[str, Any]],
-    principal_rule_paths: dict[str, set[tuple[str, ...]]],
+    rule_names: set[str],
     asserted_by_rule: dict[str, list[dict[str, Any]]],
     extract_numeric_occurrences: NumericOccurrenceExtractor,
 ) -> set[tuple[str, int]]:
@@ -1278,7 +1401,7 @@ def _formula_branch_test_witnesses(
         extract_numeric_occurrences=extract_numeric_occurrences,
     )
     witnesses: set[tuple[str, int]] = set()
-    for rule_name in _rules_covering_branch(branch, principal_rule_paths):
+    for rule_name in sorted(rule_names):
         selector_names = _rule_numeric_selector_names(principal_rules[rule_name])
         for case in asserted_by_rule.get(rule_name, ()):
             if interval is None:
@@ -1346,7 +1469,8 @@ def _formula_interval_from_text(
 ) -> _NumericInterval | None:
     lowered = text.lower()
     keyword = re.search(
-        r"\b(?:von|from|unter|less\s+than|below|bis|up\s+to|höchstens|"
+        r"\b(?:zwischen|between|von|from|unter|less\s+than|below|"
+        r"bis|up\s+to|höchstens|nicht\s+mehr\s+als|"
         r"at\s+most|über|more\s+than|above|ab|at\s+least|mindestens)\b",
         lowered,
     )
@@ -1363,6 +1487,13 @@ def _formula_interval_from_text(
     if not occurrences:
         return None
     lowered_range = range_text.lower()
+    if re.match(r"(?:zwischen|between)\b", lowered_range) and re.search(
+        r"\b(?:und|and)\b",
+        lowered_range,
+    ):
+        if len(occurrences) < 2:
+            return None
+        return _NumericInterval(occurrences[0], True, occurrences[1], True)
     if re.match(r"(?:von|from)\b", lowered_range) and re.search(
         r"\b(?:bis|to|through)\b",
         lowered_range,
@@ -1372,7 +1503,10 @@ def _formula_interval_from_text(
         return _NumericInterval(occurrences[0], True, occurrences[1], True)
     if re.match(r"(?:unter|less\s+than|below)\b", lowered_range):
         return _NumericInterval(None, False, occurrences[0], False)
-    if re.match(r"(?:bis|up\s+to|höchstens|at\s+most)\b", lowered_range):
+    if re.match(
+        r"(?:bis|up\s+to|höchstens|nicht\s+mehr\s+als|at\s+most)\b",
+        lowered_range,
+    ):
         return _NumericInterval(None, False, occurrences[0], True)
     if re.match(r"(?:über|more\s+than|above)\b", lowered_range):
         return _NumericInterval(occurrences[0], False, None, False)
@@ -1838,8 +1972,9 @@ def _source_boundary_obligations(
         first_line = branch.text.splitlines()[0] if branch.text.splitlines() else ""
         prefix = first_line.split(":", 1)[0]
         if not re.search(
-            r"\b(?:bis|von|ab|unter|über|from|to|through|less\s+than|"
-            r"more\s+than|at\s+least|up\s+to|above|below)\b",
+            r"\b(?:zwischen|between|bis|von|ab|unter|über|from|to|through|"
+            r"less\s+than|more\s+than|at\s+least|up\s+to|above|below|"
+            r"nicht\s+mehr\s+als)\b",
             prefix,
             flags=re.IGNORECASE,
         ):

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1713,7 +1713,23 @@ def _case_formula_branch_outcome(
                 if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name)
             }
         )
+    conditions = _rule_top_level_branch_conditions(rule)
+    condition_outcome = _evaluate_case_condition_chain(
+        conditions,
+        environment,
+    )
+    if conditions and condition_outcome is None:
+        return None
     if match_spec := _rule_match_branch_spec(rule):
+        match_guard_branch = _rule_match_outer_branch(rule)
+        if match_guard_branch is None:
+            return None
+        if isinstance(match_guard_branch, int):
+            if condition_outcome != match_guard_branch:
+                return f"if:{condition_outcome}"
+            outcome_prefix = f"if:{condition_outcome}/"
+        else:
+            outcome_prefix = ""
         selector_name, arm_patterns = match_spec
         if selector_name not in environment:
             return None
@@ -1727,12 +1743,22 @@ def _case_formula_branch_outcome(
                 if expected == "_":
                     default_index = index
                 elif selector_value == expected:
-                    return f"match:{index}"
-        return f"match:{default_index}" if default_index is not None else None
+                    return f"{outcome_prefix}match:{index}"
+        return (
+            f"{outcome_prefix}match:{default_index}"
+            if default_index is not None
+            else None
+        )
 
-    conditions = _rule_top_level_branch_conditions(rule)
     if not conditions:
         return None
+    return f"if:{condition_outcome}"
+
+
+def _evaluate_case_condition_chain(
+    conditions: Sequence[str],
+    environment: dict[str, Any],
+) -> int | None:
     for index, condition in enumerate(conditions):
         try:
             expression = ast.parse(condition, mode="eval").body
@@ -1742,8 +1768,83 @@ def _case_formula_branch_outcome(
         if evaluated is _UNRESOLVED_CONDITION_VALUE:
             return None
         if bool(evaluated):
-            return f"if:{index}"
-    return f"if:{len(conditions)}"
+            return index
+    return len(conditions)
+
+
+def _rule_match_outer_branch(rule: dict[str, Any]) -> str | int | None:
+    """Return the outer if/elif/else branch containing the first match."""
+
+    formula = _rule_formula_text(rule)
+    match = re.search(
+        r"(?<![A-Za-z0-9_])match[ \t]+"
+        r"[A-Za-z_][A-Za-z0-9_]*[ \t]*:",
+        formula,
+    )
+    if match is None:
+        return None
+
+    multiline_headers = list(
+        re.finditer(
+            r"(?m)^(?P<indent>[ \t]*)(?P<kind>if|elif|else)"
+            r"(?:[ \t]+[^:\n]+)?[ \t]*:",
+            formula,
+        )
+    )
+    condition_headers = [
+        header
+        for header in multiline_headers
+        if header.group("kind") in {"if", "elif"}
+    ]
+    if condition_headers:
+        outer_indent = min(
+            len(header.group("indent").expandtabs(8))
+            for header in condition_headers
+        )
+        outer_headers = [
+            header
+            for header in multiline_headers
+            if len(header.group("indent").expandtabs(8)) == outer_indent
+        ]
+        match_line_start = formula.rfind("\n", 0, match.start()) + 1
+        match_indent = len(
+            formula[match_line_start : match.start()].expandtabs(8)
+        )
+        if match_indent <= outer_indent:
+            return "top"
+        branch_index = -1
+        condition_index = 0
+        for header in outer_headers:
+            if header.start() >= match.start():
+                break
+            if header.group("kind") in {"if", "elif"}:
+                branch_index = condition_index
+                condition_index += 1
+            else:
+                branch_index = len(condition_headers)
+        return branch_index if branch_index >= 0 else None
+
+    inline_condition_headers = list(
+        re.finditer(
+            r"(?<![A-Za-z0-9_])(?:if)[ \t]+[^:\n]+:",
+            formula,
+        )
+    )
+    if not inline_condition_headers or match.start() < inline_condition_headers[0].start():
+        return "top"
+    inline_else_headers = list(
+        re.finditer(r"(?<![A-Za-z0-9_])else[ \t]*:", formula)
+    )
+    headers: list[tuple[int, int]] = [
+        (header.start(), index)
+        for index, header in enumerate(inline_condition_headers)
+    ]
+    headers.extend(
+        (header.start(), len(inline_condition_headers))
+        for header in inline_else_headers
+    )
+    preceding = [item for item in headers if item[0] < match.start()]
+    return max(preceding)[1] if preceding else None
 
 
 def _match_arm_value(value: str) -> Any:

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -279,6 +279,10 @@ _EXCEPTION_LANGUAGE = re.compile(
     r")",
     flags=re.IGNORECASE,
 )
+_APPLICABILITY_LANGUAGE = re.compile(
+    r"\b(?:wenn|falls|sofern|when|if)\b",
+    flags=re.IGNORECASE,
+)
 _PRECISE_DEFERRAL_DEPENDENCY = re.compile(
     r"(?:"
     r"§{1,2}\s*\d+[a-z]?|"
@@ -583,6 +587,14 @@ def _analyze_rulespec_payload(
         active_branches=active_branches,
         deferred_paths=deferred_paths,
     )
+    control_branches = _source_control_branches(
+        source_text,
+        branches=branches,
+        active_branches=active_branches,
+        deferred_paths=deferred_paths,
+        formula_branches=formula_branches,
+        extract_numeric_occurrences=extract_numeric_occurrences,
+    )
     principal_formula_clause_rules = _principal_formula_clause_rules(
         formula_branches,
         principal_rules=principal_rules,
@@ -613,6 +625,17 @@ def _analyze_rulespec_payload(
                 "`derived_relation`); "
                 "parameter-only representation is invalid."
             )
+    for branch in control_branches:
+        if _rules_covering_branch(branch, principal_rule_paths):
+            continue
+        issues.append(
+            "[complete-source-unit:formula-output] Source-stated control "
+            f"{branch.label} in "
+            f"{_branch_citation(corpus_citation_path, branch)} has no "
+            "principal derived/relation output (`derived` or "
+            "`derived_relation`) and is not precisely deferred; "
+            "parameter-only representation is invalid."
+        )
 
     source_occurrences = tuple(
         extract_numeric_occurrences(authoritative_numeric_recall_text(source_text))
@@ -1697,9 +1720,10 @@ def _companion_test_issues(
                 )
             )
             issues.append(
-                "[complete-source-unit:tests] Source-stated exceptions require "
-                "paired positive/blocking cases that assert the affected principal "
-                "output and toggle its excluding formula selector; missing at "
+                "[complete-source-unit:tests] Source-stated exceptions or "
+                "applicability conditions require paired positive/blocking cases "
+                "that assert the affected principal output and toggle its "
+                "controlling formula selector; missing at "
                 f"{missing_citations}."
             )
 
@@ -1849,6 +1873,79 @@ def _source_formula_branches(
             continue
         obligations.append(obligation)
     return tuple(obligations)
+
+
+def _source_control_branches(
+    source_text: str,
+    *,
+    branches: Sequence[SourceStructureBranch],
+    active_branches: Sequence[SourceStructureBranch],
+    deferred_paths: set[tuple[str, ...]],
+    formula_branches: Sequence[SourceStructureBranch],
+    extract_numeric_occurrences: NumericOccurrenceExtractor,
+) -> tuple[SourceStructureBranch, ...]:
+    """Return active boundary, exception, and applicability control clauses."""
+
+    boundary_branches = active_branches or (
+        SourceStructureBranch(
+            (),
+            "source-unit",
+            "source unit",
+            source_text,
+            0,
+            len(source_text),
+        ),
+    )
+    controlled = [
+        branch
+        for branch, boundary in _source_boundary_obligations(
+            boundary_branches,
+            narrative_formula_branches=formula_branches,
+            extract_numeric_occurrences=extract_numeric_occurrences,
+        )
+        if not _source_boundary_is_temporal(branch, boundary)
+    ]
+    controlled.extend(
+        _source_exception_branches(
+            source_text,
+            branches=branches,
+            active_branches=active_branches,
+            deferred_paths=deferred_paths,
+        )
+    )
+    return tuple(
+        {
+            (branch.path, branch.start, branch.end): branch
+            for branch in controlled
+        }.values()
+    )
+
+
+def _source_boundary_is_temporal(
+    branch: SourceStructureBranch,
+    boundary: NumericOccurrenceLike,
+) -> bool:
+    """Keep effective-period bounds eligible for parameter versioning."""
+
+    if not 1800 <= float(boundary.value) <= 2200:
+        return False
+    relative_start = max(0, boundary.start)
+    relative_end = max(relative_start, boundary.end)
+    context = branch.text[
+        max(0, relative_start - 80) : min(len(branch.text), relative_end + 80)
+    ]
+    return re.search(
+        r"\b(?:"
+        r"veranlagungszeitraum|besteuerungszeitraum|kalenderjahr|steuerjahr|"
+        r"tax\s+year|calendar\s+year|effective|effective_from|"
+        r"zeitraum|jahr|january|february|march|april|may|june|july|"
+        r"august|september|october|november|december|"
+        r"januar|februar|märz|april|mai|juni|juli|august|september|"
+        r"oktober|november|dezember"
+        r")\b",
+        context,
+        flags=re.IGNORECASE,
+    ) is not None
 
 
 def _rounding_clause_refers_to_previous_result(
@@ -4723,7 +4820,7 @@ def _source_exception_branches(
         tuple[int, int, str],
         list[re.Match[str]],
     ] = {}
-    for match in _EXCEPTION_LANGUAGE.finditer(source_text):
+    for match in _source_exception_or_applicability_matches(source_text):
         if _span_is_deferred(
             match.start(),
             match.end(),
@@ -4797,6 +4894,23 @@ def _source_exception_branches(
         {
             (branch.path, branch.start, branch.end): branch
             for branch in obligations
+        }.values()
+    )
+
+
+def _source_exception_or_applicability_matches(
+    source_text: str,
+) -> tuple[re.Match[str], ...]:
+    """Return ordered, de-duplicated negative and positive condition cues."""
+
+    matches = (
+        *_EXCEPTION_LANGUAGE.finditer(source_text),
+        *_APPLICABILITY_LANGUAGE.finditer(source_text),
+    )
+    return tuple(
+        {
+            (match.start(), match.end()): match
+            for match in sorted(matches, key=lambda item: (item.start(), item.end()))
         }.values()
     )
 
@@ -4985,7 +5099,7 @@ def _source_exception_condition_text(text: str) -> str:
     """Return the condition region without the ordinary claim subject."""
 
     clause = _strip_source_clause_marker(text)
-    marker = _EXCEPTION_LANGUAGE.search(clause)
+    marker = next(iter(_source_exception_or_applicability_matches(clause)), None)
     if marker is None:
         return clause
     suffix = clause[marker.start() :]

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -12,6 +12,7 @@ import ast
 import contextlib
 import math
 import re
+import textwrap
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from typing import Any, Protocol
@@ -70,6 +71,35 @@ class _NumericInterval:
     lower_inclusive: bool
     upper: NumericOccurrenceLike | None
     upper_inclusive: bool
+
+
+@dataclass(frozen=True)
+class _FormulaTraceStep:
+    """One control-flow decision evaluated by a companion case."""
+
+    kind: str
+    selectors: tuple[str, ...]
+    choice: int
+
+
+@dataclass(frozen=True)
+class _FormulaExecution:
+    """The selected control-flow path and reconstructed reachable formula."""
+
+    trace: tuple[_FormulaTraceStep, ...]
+    leaf: str
+
+
+@dataclass(frozen=True)
+class _FormulaBranchNode:
+    """One parsed RuleSpec conditional or match expression."""
+
+    start: int
+    end: int
+    kind: str
+    selectors: tuple[str, ...]
+    patterns: tuple[str, ...]
+    choices: tuple[str, ...]
 
 
 _PARAGRAPH_MARKER = re.compile(
@@ -529,6 +559,7 @@ def _analyze_rulespec_payload(
                 test_cases=test_cases,
                 extract_numeric_occurrences=extract_numeric_occurrences,
                 numeric_value_is_grounded=numeric_value_is_grounded,
+                formula_environment=_constant_rule_environment(payload),
             )
         )
 
@@ -1216,6 +1247,7 @@ def _companion_test_issues(
     test_cases: Sequence[object] | None,
     extract_numeric_occurrences: NumericOccurrenceExtractor,
     numeric_value_is_grounded: NumericGroundingPredicate,
+    formula_environment: dict[str, Any],
 ) -> list[str]:
     issues: list[str] = []
     cases = [case for case in (test_cases or ()) if isinstance(case, dict)]
@@ -1252,6 +1284,7 @@ def _companion_test_issues(
         principal_formula_clause_rules=principal_formula_clause_rules,
         asserted_by_rule=asserted_by_rule,
         extract_numeric_occurrences=extract_numeric_occurrences,
+        formula_environment=formula_environment,
     )
     for branch in missing_formula_branches:
         issues.append(
@@ -1279,6 +1312,7 @@ def _companion_test_issues(
             principal_rule_paths=principal_rule_paths,
             asserted_by_rule=asserted_by_rule,
             numeric_value_is_grounded=numeric_value_is_grounded,
+            formula_environment=formula_environment,
         ):
             continue
         missing_boundaries.append((branch, boundary))
@@ -1302,6 +1336,7 @@ def _companion_test_issues(
         toggled_exception_selectors = _toggled_formula_boolean_selectors(
             principal_rules,
             asserted_by_rule=asserted_by_rule,
+            formula_environment=formula_environment,
         )
         missing_exception_branches = _unwitnessed_exception_branches(
             exception_branches,
@@ -1349,6 +1384,7 @@ def _companion_test_issues(
                     principal_rules[name],
                     asserted_by_rule=asserted_by_rule,
                     direction=direction,
+                    formula_environment=formula_environment,
                 )
                 for name in rule_names
             )
@@ -1509,6 +1545,7 @@ def _unwitnessed_formula_branches(
     principal_formula_clause_rules: dict[SourceStructureBranch, set[str]],
     asserted_by_rule: dict[str, list[dict[str, Any]]],
     extract_numeric_occurrences: NumericOccurrenceExtractor,
+    formula_environment: dict[str, Any],
 ) -> tuple[SourceStructureBranch, ...]:
     """Consume each executed rule/case witness for at most one source formula."""
 
@@ -1519,6 +1556,7 @@ def _unwitnessed_formula_branches(
             rule_names=principal_formula_clause_rules[branch],
             asserted_by_rule=asserted_by_rule,
             extract_numeric_occurrences=extract_numeric_occurrences,
+            formula_environment=formula_environment,
         )
         for branch in branches
     }
@@ -1560,6 +1598,7 @@ def _formula_branch_test_witnesses(
     rule_names: set[str],
     asserted_by_rule: dict[str, list[dict[str, Any]]],
     extract_numeric_occurrences: NumericOccurrenceExtractor,
+    formula_environment: dict[str, Any],
 ) -> set[tuple[str, str]]:
     interval = _formula_branch_interval(
         branch,
@@ -1571,285 +1610,700 @@ def _formula_branch_test_witnesses(
         selector_names = _rule_numeric_selector_names(rule)
         has_branching_formula = _rule_has_branching_formula(rule)
         for case in asserted_by_rule.get(rule_name, ()):
+            execution = (
+                _case_formula_execution(
+                    rule,
+                    case,
+                    formula_environment=formula_environment,
+                )
+                if has_branching_formula or interval is not None
+                else None
+            )
             if interval is None:
                 if has_branching_formula:
-                    outcome = _case_formula_branch_outcome(
-                        rule,
-                        case,
-                    )
-                    if outcome is not None:
+                    if (
+                        execution is not None
+                        and _formula_execution_leaf_is_computational(execution)
+                    ):
+                        outcome = _formula_execution_outcome(execution)
                         witnesses.add((rule_name, f"branch:{outcome}"))
                 else:
                     witnesses.add((rule_name, f"case:{id(case)}"))
                 continue
-            if selector_names and any(
-                _interval_contains(interval, value)
-                for value in _case_numeric_selector_values(case, selector_names)
+            if (
+                execution is not None
+                and _formula_execution_leaf_is_computational(execution)
+                and _formula_execution_references_names(
+                    execution,
+                    selector_names,
+                )
+                and selector_names
+                and any(
+                    _interval_contains(interval, value)
+                    for value in _case_numeric_selector_values(
+                        case,
+                        selector_names,
+                    )
+                )
             ):
-                witnesses.add((rule_name, id(case)))
+                witnesses.add((rule_name, f"case:{id(case)}"))
     return witnesses
 
 
 def _rule_has_branching_formula(rule: dict[str, Any]) -> bool:
-    return bool(
-        re.search(
-            r"(?<![A-Za-z0-9_])(?:if|match)\s+[^:\n]+:",
-            _rule_formula_text(rule),
-        )
-    )
-
-
-def _rule_branch_selector_names(rule: dict[str, Any]) -> set[str]:
-    """Return identifiers that choose branches in a principal formula."""
-
-    names: set[str] = set()
-    if match_spec := _rule_match_branch_spec(rule):
-        names.add(match_spec[0])
-    for condition in _rule_top_level_branch_conditions(rule):
-        condition = re.sub(r"(['\"]).*?\1", "", condition)
-        names.update(
-            identifier
-            for identifier in _FORMULA_IDENTIFIER.findall(condition)
-            if identifier.lower()
-            not in {
-                "if",
-                "elif",
-                "else",
-                "and",
-                "or",
-                "not",
-                "true",
-                "false",
-                "holds",
-                "not_holds",
-            }
-        )
-    return names
-
-
-def _rule_top_level_branch_conditions(rule: dict[str, Any]) -> tuple[str, ...]:
-    """Return the ordered conditions in the formula's outer if/elif chain."""
-
-    matches = list(
-        re.finditer(
-            r"(?m)^(?P<indent>[ \t]*)(?:if|elif)[ \t]+"
-            r"(?P<condition>.+):[ \t]*$",
-            _rule_formula_text(rule),
-        )
-    )
-    if matches:
-        outer_indent = min(
-            len(match.group("indent").expandtabs(8)) for match in matches
-        )
-        return tuple(
-            match.group("condition").strip()
-            for match in matches
-            if len(match.group("indent").expandtabs(8)) == outer_indent
-        )
-    return tuple(
-        match.group("condition").strip()
-        for match in re.finditer(
-            r"(?<![A-Za-z0-9_])if[ \t]+(?P<condition>[^:\n]+):",
-            _rule_formula_text(rule),
-        )
-    )
-
-
-def _rule_match_branch_spec(
-    rule: dict[str, Any],
-) -> tuple[str, tuple[str, ...]] | None:
-    """Return one RuleSpec match selector and its ordered arm patterns."""
-
-    match = re.search(
-        r"(?<![A-Za-z0-9_])match[ \t]+"
-        r"(?P<selector>[A-Za-z_][A-Za-z0-9_]*)[ \t]*:"
-        r"(?P<body>[\s\S]*)",
-        _rule_formula_text(rule),
-    )
-    if match is None:
-        return None
-    body = match.group("body")
-    if "\n" in body:
-        arm_patterns = tuple(
-            arm.group("pattern").strip()
-            for arm in re.finditer(
-                r"(?m)^[ \t]*(?P<pattern>[^=\n]+?)[ \t]*=>",
-                body,
-            )
-        )
-    else:
-        arm_patterns = tuple(
-            arm.group("pattern").strip()
-            for arm in re.finditer(
-                r"(?:^|;)[ \t]*(?P<pattern>[^=;]+?)[ \t]*=>",
-                body,
-            )
-        )
-    if not arm_patterns:
-        return None
-    return match.group("selector"), arm_patterns
+    return _rule_text_has_branching_formula(_rule_formula_text(rule))
 
 
 _UNRESOLVED_CONDITION_VALUE = object()
+
+
+def _case_formula_execution(
+    rule: dict[str, Any],
+    case: dict[str, Any],
+    *,
+    formula_environment: dict[str, Any] | None = None,
+) -> _FormulaExecution | None:
+    """Resolve the reachable RuleSpec formula for one asserted test case."""
+
+    inputs = case.get("input")
+    if not isinstance(inputs, dict):
+        return None
+    environment: dict[str, Any] = dict(formula_environment or {})
+    input_environment: dict[str, Any] = {}
+    for key, value in inputs.items():
+        boolean_value = _boolean_value(value)
+        normalized_value = boolean_value if boolean_value is not None else value
+        for name in _input_key_names(key):
+            if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
+                continue
+            if name in input_environment and not _same_formula_value(
+                input_environment[name],
+                normalized_value,
+            ):
+                return None
+            input_environment[name] = normalized_value
+    environment.update(input_environment)
+    formula_text = _unambiguous_rule_formula_text(rule)
+    if formula_text is None:
+        return None
+    return _execute_formula_text(
+        formula_text,
+        environment=environment,
+    )
+
+
+def _execute_formula_text(
+    formula_text: str,
+    *,
+    environment: dict[str, Any],
+) -> _FormulaExecution | None:
+    """Interpret formula control flow without evaluating the formula itself."""
+
+    selected_text = formula_text.strip()
+    trace: list[_FormulaTraceStep] = []
+    for _depth in range(32):
+        node = _first_formula_branch_node(selected_text)
+        if node is None:
+            if _rule_text_has_branching_formula(selected_text):
+                return None
+            return _FormulaExecution(tuple(trace), selected_text.strip())
+        selected = _select_formula_branch(node, environment=environment)
+        if selected is None:
+            return None
+        choice, evaluated_selectors = selected
+        selected_body = textwrap.dedent(node.choices[choice]).strip()
+        if not selected_body:
+            return None
+        trace.append(
+            _FormulaTraceStep(
+                node.kind,
+                evaluated_selectors,
+                choice,
+            )
+        )
+        selected_text = (
+            selected_text[: node.start]
+            + selected_body
+            + selected_text[node.end :]
+        )
+    return None
+
+
+def _first_formula_branch_node(text: str) -> _FormulaBranchNode | None:
+    candidates = tuple(
+        candidate
+        for candidate in (
+            _first_multiline_if_node(text),
+            _first_multiline_match_node(text),
+            _first_inline_if_node(text),
+            _first_inline_match_node(text),
+        )
+        if candidate is not None
+    )
+    return min(candidates, key=lambda item: item.start, default=None)
+
+
+def _formula_line_records(
+    text: str,
+) -> tuple[tuple[int, int, int, str], ...]:
+    records: list[tuple[int, int, int, str]] = []
+    start = 0
+    for raw_line in text.splitlines(keepends=True):
+        content = raw_line.rstrip("\r\n")
+        content_end = start + len(content)
+        full_end = start + len(raw_line)
+        records.append((start, content_end, full_end, content))
+        start = full_end
+    if not records or start < len(text):
+        records.append((start, len(text), len(text), text[start:]))
+    return tuple(records)
+
+
+def _first_multiline_if_node(text: str) -> _FormulaBranchNode | None:
+    lines = _formula_line_records(text)
+    masked_lines = _formula_line_records(_mask_formula_strings(text))
+    for index, (start, _content_end, _full_end, line) in enumerate(lines):
+        masked_line = masked_lines[index][3]
+        header = re.match(
+            r"^(?P<indent>[ \t]*)if[ \t]+"
+            r"(?P<condition>[^:\n]+):[ \t]*$",
+            masked_line,
+        )
+        if header is None:
+            continue
+        base_indent = _formula_indent_width(header.group("indent"))
+        headers: list[tuple[int, str, str]] = [
+            (
+                index,
+                "if",
+                line[header.start("condition") : header.end("condition")].strip(),
+            )
+        ]
+        cursor = index + 1
+        while cursor < len(lines):
+            candidate = lines[cursor][3]
+            masked_candidate = masked_lines[cursor][3]
+            if not candidate.strip():
+                cursor += 1
+                continue
+            indent = _formula_indent_width(
+                candidate[: len(candidate) - len(candidate.lstrip())]
+            )
+            if indent > base_indent:
+                cursor += 1
+                continue
+            chain_header = (
+                re.match(
+                    r"^[ \t]*elif[ \t]+(?P<condition>[^:\n]+):[ \t]*$",
+                    masked_candidate,
+                )
+                if indent == base_indent
+                else None
+            )
+            if chain_header is not None:
+                headers.append(
+                    (
+                        cursor,
+                        "elif",
+                        candidate[
+                            chain_header.start("condition") :
+                            chain_header.end("condition")
+                        ].strip(),
+                    )
+                )
+                cursor += 1
+                continue
+            if indent == base_indent and re.match(
+                r"^[ \t]*else:[ \t]*$",
+                masked_candidate,
+            ):
+                headers.append((cursor, "else", ""))
+                cursor += 1
+                continue
+            break
+        chain_end = lines[cursor][0] if cursor < len(lines) else len(text)
+        conditions = tuple(
+            condition
+            for _line_index, kind, condition in headers
+            if kind != "else"
+        )
+        choices: list[str] = []
+        for header_index, (line_index, _kind, _condition) in enumerate(headers):
+            body_start = lines[line_index][2]
+            body_end = (
+                lines[headers[header_index + 1][0]][0]
+                if header_index + 1 < len(headers)
+                else chain_end
+            )
+            choices.append(text[body_start:body_end])
+        if not conditions or not choices:
+            continue
+        return _FormulaBranchNode(
+            start,
+            chain_end,
+            "if",
+            conditions,
+            (),
+            tuple(choices),
+        )
+    return None
+
+
+def _first_multiline_match_node(text: str) -> _FormulaBranchNode | None:
+    lines = _formula_line_records(text)
+    masked_lines = _formula_line_records(_mask_formula_strings(text))
+    for index, (start, _content_end, _full_end, line) in enumerate(lines):
+        masked_line = masked_lines[index][3]
+        header = re.match(
+            r"^(?P<indent>[ \t]*)match[ \t]+"
+            r"(?P<selector>[^:\n]+):[ \t]*$",
+            masked_line,
+        )
+        if header is None:
+            continue
+        base_indent = _formula_indent_width(header.group("indent"))
+        arm_headers: list[tuple[int, str, str]] = []
+        arm_indent: int | None = None
+        cursor = index + 1
+        while cursor < len(lines):
+            candidate = lines[cursor][3]
+            masked_candidate = masked_lines[cursor][3]
+            if not candidate.strip():
+                cursor += 1
+                continue
+            indent_text = candidate[: len(candidate) - len(candidate.lstrip())]
+            indent = _formula_indent_width(indent_text)
+            if indent <= base_indent:
+                break
+            arrow = masked_candidate.find("=>", len(indent_text))
+            pattern = candidate[len(indent_text) : arrow].strip()
+            is_arm = arrow >= 0 and bool(pattern)
+            if arm_indent is None and is_arm:
+                arm_indent = indent
+            if is_arm and indent == arm_indent:
+                arm_headers.append(
+                    (
+                        cursor,
+                        pattern,
+                        candidate[arrow + 2 :].lstrip(),
+                    )
+                )
+            cursor += 1
+        chain_end = lines[cursor][0] if cursor < len(lines) else len(text)
+        if not arm_headers:
+            continue
+        choices: list[str] = []
+        for arm_index, (line_index, _pattern, inline_body) in enumerate(
+            arm_headers
+        ):
+            body_end = (
+                lines[arm_headers[arm_index + 1][0]][0]
+                if arm_index + 1 < len(arm_headers)
+                else chain_end
+            )
+            trailing_body = text[lines[line_index][2] : body_end]
+            choices.append(
+                "\n".join(
+                    part
+                    for part in (inline_body, trailing_body)
+                    if part.strip()
+                )
+            )
+        return _FormulaBranchNode(
+            start,
+            chain_end,
+            "match",
+            (
+                line[
+                    header.start("selector") : header.end("selector")
+                ].strip(),
+            ),
+            tuple(pattern for _line_index, pattern, _body in arm_headers),
+            tuple(choices),
+        )
+    return None
+
+
+def _first_inline_if_node(text: str) -> _FormulaBranchNode | None:
+    masked_text = _mask_formula_strings(text)
+    for candidate in re.finditer(
+        r"(?<![A-Za-z0-9_])if[ \t]+",
+        masked_text,
+    ):
+        line_end = text.find("\n", candidate.start())
+        if line_end < 0:
+            line_end = len(text)
+        colon = masked_text.find(":", candidate.end(), line_end)
+        if colon < 0 or not text[colon + 1 : line_end].strip():
+            continue
+        chain_headers = _find_inline_chain_headers(
+            masked_text,
+            body_start=colon + 1,
+            limit=line_end,
+        )
+        if not chain_headers or chain_headers[-1][0] != "else":
+            continue
+        else_body_start = chain_headers[-1][2]
+        end = _formula_expression_end(
+            text,
+            body_start=else_body_start,
+            branch_start=candidate.start(),
+            limit=line_end,
+        )
+        conditions = [text[candidate.end() : colon].strip()]
+        conditions.extend(
+            text[condition_start:condition_end].strip()
+            for kind, _start, _body_start, condition_start, condition_end
+            in chain_headers
+            if kind == "elif"
+        )
+        body_boundaries = [
+            header_start
+            for _kind, header_start, _body_start, _condition_start, _condition_end
+            in chain_headers
+        ]
+        body_starts = [
+            colon + 1,
+            *(
+                header_body_start
+                for kind, _header_start, header_body_start, _start, _end
+                in chain_headers
+                if kind == "elif"
+            ),
+        ]
+        choices = [
+            text[start:stop]
+            for start, stop in zip(body_starts, body_boundaries)
+        ]
+        choices.append(text[else_body_start:end])
+        return _FormulaBranchNode(
+            candidate.start(),
+            end,
+            "if",
+            tuple(conditions),
+            (),
+            tuple(choices),
+        )
+    return None
+
+
+def _find_inline_chain_headers(
+    masked_text: str,
+    *,
+    body_start: int,
+    limit: int,
+) -> tuple[tuple[str, int, int, int, int], ...]:
+    nested_if_depth = 0
+    headers: list[tuple[str, int, int, int, int]] = []
+    for token in re.finditer(
+        r"\b(?:if|elif|else)\b",
+        masked_text[body_start:limit],
+    ):
+        token_start = body_start + token.start()
+        token_end = body_start + token.end()
+        kind = token.group(0)
+        if kind == "if":
+            colon = masked_text.find(":", token_end, limit)
+            if colon >= 0:
+                nested_if_depth += 1
+            continue
+        colon = masked_text.find(":", token_end, limit)
+        if colon < 0:
+            continue
+        if kind == "elif":
+            if nested_if_depth == 0:
+                headers.append(("elif", token_start, colon + 1, token_end, colon))
+            continue
+        cursor = token_end
+        while cursor < limit and masked_text[cursor] in " \t":
+            cursor += 1
+        if cursor >= limit or masked_text[cursor] != ":":
+            continue
+        if nested_if_depth:
+            nested_if_depth -= 1
+            continue
+        headers.append(("else", token_start, cursor + 1, cursor, cursor))
+        return tuple(headers)
+    return ()
+
+
+def _first_inline_match_node(text: str) -> _FormulaBranchNode | None:
+    masked_text = _mask_formula_strings(text)
+    for candidate in re.finditer(
+        r"(?<![A-Za-z0-9_])match[ \t]+",
+        masked_text,
+    ):
+        line_end = text.find("\n", candidate.start())
+        if line_end < 0:
+            line_end = len(text)
+        colon = masked_text.find(":", candidate.end(), line_end)
+        if colon < 0 or not text[colon + 1 : line_end].strip():
+            continue
+        end = _formula_expression_end(
+            text,
+            body_start=colon + 1,
+            branch_start=candidate.start(),
+            limit=line_end,
+            stop_at_semicolon=False,
+        )
+        patterns: list[str] = []
+        choices: list[str] = []
+        for arm in _split_formula_arms(text[colon + 1 : end]):
+            pattern, separator, body = arm.partition("=>")
+            if not separator or not pattern.strip() or not body.strip():
+                patterns = []
+                choices = []
+                break
+            patterns.append(pattern.strip())
+            choices.append(body)
+        if not patterns:
+            continue
+        return _FormulaBranchNode(
+            candidate.start(),
+            end,
+            "match",
+            (text[candidate.end() : colon].strip(),),
+            tuple(patterns),
+            tuple(choices),
+        )
+    return None
+
+
+def _split_formula_arms(text: str) -> tuple[str, ...]:
+    arms: list[str] = []
+    start = 0
+    stack: list[str] = []
+    quote: str | None = None
+    escaped = False
+    pairs = {")": "(", "]": "[", "}": "{"}
+    for index, character in enumerate(text):
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = None
+            continue
+        if character in {'"', "'"}:
+            quote = character
+        elif character in "([{":
+            stack.append(character)
+        elif character in pairs and stack and stack[-1] == pairs[character]:
+            stack.pop()
+        elif character == ";" and not stack:
+            arms.append(text[start:index])
+            start = index + 1
+    arms.append(text[start:])
+    return tuple(arms)
+
+
+def _formula_expression_end(
+    text: str,
+    *,
+    body_start: int,
+    branch_start: int,
+    limit: int,
+    stop_at_semicolon: bool = True,
+) -> int:
+    initial_stack = _formula_bracket_stack(text[:branch_start])
+    stack = list(initial_stack)
+    quote: str | None = None
+    escaped = False
+    pairs = {")": "(", "]": "[", "}": "{"}
+    for index in range(body_start, limit):
+        character = text[index]
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = None
+            continue
+        if character in {'"', "'"}:
+            quote = character
+        elif character in "([{":
+            stack.append(character)
+        elif character in pairs:
+            if len(stack) <= len(initial_stack):
+                return index
+            if stack[-1] == pairs[character]:
+                stack.pop()
+        elif character == "," and len(stack) == len(initial_stack):
+            return index
+        elif (
+            stop_at_semicolon
+            and character == ";"
+            and len(stack) == len(initial_stack)
+        ):
+            return index
+    return limit
+
+
+def _formula_bracket_stack(text: str) -> tuple[str, ...]:
+    stack: list[str] = []
+    quote: str | None = None
+    escaped = False
+    pairs = {")": "(", "]": "[", "}": "{"}
+    for character in text:
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = None
+            continue
+        if character in {'"', "'"}:
+            quote = character
+        elif character in "([{":
+            stack.append(character)
+        elif character in pairs and stack and stack[-1] == pairs[character]:
+            stack.pop()
+    return tuple(stack)
+
+
+def _select_formula_branch(
+    node: _FormulaBranchNode,
+    *,
+    environment: dict[str, Any],
+) -> tuple[int, tuple[str, ...]] | None:
+    if node.kind == "if":
+        evaluated: list[str] = []
+        for index, condition in enumerate(node.selectors):
+            evaluated.append(condition)
+            value = _evaluate_formula_selector(condition, environment)
+            if not isinstance(value, bool):
+                return None
+            if value:
+                return index, tuple(evaluated)
+        if len(node.choices) > len(node.selectors):
+            return len(node.selectors), tuple(evaluated)
+        return None
+
+    selector = _evaluate_formula_selector(node.selectors[0], environment)
+    if selector is _UNRESOLVED_CONDITION_VALUE:
+        return None
+    if not node.patterns:
+        return None
+    for index, pattern in enumerate(node.patterns[:-1]):
+        expected = _match_arm_value(pattern.strip())
+        if expected is _UNRESOLVED_CONDITION_VALUE:
+            return None
+        if _same_formula_value(selector, expected):
+            return index, node.selectors
+    return len(node.patterns) - 1, node.selectors
+
+
+def _evaluate_formula_selector(
+    selector: str,
+    environment: dict[str, Any],
+) -> Any:
+    try:
+        expression = ast.parse(selector, mode="eval").body
+    except SyntaxError:
+        return _UNRESOLVED_CONDITION_VALUE
+    return _evaluate_condition_expression(expression, environment)
+
+
+def _rule_text_has_branching_formula(formula_text: str) -> bool:
+    return bool(
+        re.search(
+            r"(?<![A-Za-z0-9_])(?:if|elif|else|match)(?![A-Za-z0-9_])",
+            _mask_formula_strings(formula_text),
+        )
+    )
+
+
+def _formula_execution_outcome(execution: _FormulaExecution) -> str:
+    return "/".join(
+        f"{step.kind}:{step.choice}"
+        for step in execution.trace
+    )
+
+
+def _formula_execution_leaf_is_computational(
+    execution: _FormulaExecution,
+) -> bool:
+    leaf = execution.leaf.strip()
+    with contextlib.suppress(SyntaxError, ValueError):
+        literal = ast.literal_eval(leaf)
+        if literal is False or (
+            isinstance(literal, (int, float, complex))
+            and not isinstance(literal, bool)
+            and literal == 0
+        ):
+            return False
+    return not bool(
+        re.fullmatch(
+            r"(?:true|false|holds|not_holds|null|none)",
+            leaf,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _formula_execution_references_names(
+    execution: _FormulaExecution,
+    names: set[str],
+    *,
+    selectors_only: bool = False,
+) -> bool:
+    texts = [
+        selector
+        for step in execution.trace
+        for selector in step.selectors
+    ]
+    if not selectors_only:
+        texts.append(execution.leaf)
+    return any(
+        set(_FORMULA_IDENTIFIER.findall(text)) & names
+        for text in texts
+    )
+
+
+def _same_formula_value(left: Any, right: Any) -> bool:
+    return type(left) is type(right) and left == right
+
+
+def _mask_formula_strings(text: str) -> str:
+    """Blank quoted content while preserving offsets and newlines."""
+
+    masked = list(text)
+    quote: str | None = None
+    escaped = False
+    for index, character in enumerate(text):
+        if quote is None:
+            if character in {'"', "'"}:
+                quote = character
+                masked[index] = " "
+            continue
+        if character != "\n":
+            masked[index] = " "
+        if escaped:
+            escaped = False
+        elif character == "\\":
+            escaped = True
+        elif character == quote:
+            quote = None
+    return "".join(masked)
 
 
 def _case_formula_branch_outcome(
     rule: dict[str, Any],
     case: dict[str, Any],
 ) -> str | None:
-    """Return the outer formula branch selected by one executed test case."""
+    """Return the complete reachable branch path for one test case."""
 
-    inputs = case.get("input")
-    if not isinstance(inputs, dict):
+    execution = _case_formula_execution(rule, case)
+    if (
+        execution is None
+        or not execution.trace
+        or not _formula_execution_leaf_is_computational(execution)
+    ):
         return None
-    environment: dict[str, Any] = {}
-    for key, value in inputs.items():
-        boolean_value = _boolean_value(value)
-        normalized_value = boolean_value if boolean_value is not None else value
-        environment.update(
-            {
-                name: normalized_value
-                for name in _input_key_names(key)
-                if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name)
-            }
-        )
-    conditions = _rule_top_level_branch_conditions(rule)
-    condition_outcome = _evaluate_case_condition_chain(
-        conditions,
-        environment,
-    )
-    if conditions and condition_outcome is None:
-        return None
-    if match_spec := _rule_match_branch_spec(rule):
-        match_guard_branch = _rule_match_outer_branch(rule)
-        if match_guard_branch is None:
-            return None
-        if isinstance(match_guard_branch, int):
-            if condition_outcome != match_guard_branch:
-                return f"if:{condition_outcome}"
-            outcome_prefix = f"if:{condition_outcome}/"
-        else:
-            outcome_prefix = ""
-        selector_name, arm_patterns = match_spec
-        if selector_name not in environment:
-            return None
-        selector_value = environment[selector_name]
-        default_index: int | None = None
-        for index, arm_pattern in enumerate(arm_patterns):
-            for alternative in re.split(r"[|,]", arm_pattern):
-                expected = _match_arm_value(alternative.strip())
-                if expected is _UNRESOLVED_CONDITION_VALUE:
-                    continue
-                if expected == "_":
-                    default_index = index
-                elif selector_value == expected:
-                    return f"{outcome_prefix}match:{index}"
-        return (
-            f"{outcome_prefix}match:{default_index}"
-            if default_index is not None
-            else None
-        )
-
-    if not conditions:
-        return None
-    return f"if:{condition_outcome}"
-
-
-def _evaluate_case_condition_chain(
-    conditions: Sequence[str],
-    environment: dict[str, Any],
-) -> int | None:
-    for index, condition in enumerate(conditions):
-        try:
-            expression = ast.parse(condition, mode="eval").body
-        except SyntaxError:
-            return None
-        evaluated = _evaluate_condition_expression(expression, environment)
-        if evaluated is _UNRESOLVED_CONDITION_VALUE:
-            return None
-        if bool(evaluated):
-            return index
-    return len(conditions)
-
-
-def _rule_match_outer_branch(rule: dict[str, Any]) -> str | int | None:
-    """Return the outer if/elif/else branch containing the first match."""
-
-    formula = _rule_formula_text(rule)
-    match = re.search(
-        r"(?<![A-Za-z0-9_])match[ \t]+"
-        r"[A-Za-z_][A-Za-z0-9_]*[ \t]*:",
-        formula,
-    )
-    if match is None:
-        return None
-
-    multiline_headers = list(
-        re.finditer(
-            r"(?m)^(?P<indent>[ \t]*)(?P<kind>if|elif|else)"
-            r"(?:[ \t]+[^:\n]+)?[ \t]*:",
-            formula,
-        )
-    )
-    condition_headers = [
-        header
-        for header in multiline_headers
-        if header.group("kind") in {"if", "elif"}
-    ]
-    if condition_headers:
-        outer_indent = min(
-            len(header.group("indent").expandtabs(8))
-            for header in condition_headers
-        )
-        outer_headers = [
-            header
-            for header in multiline_headers
-            if len(header.group("indent").expandtabs(8)) == outer_indent
-        ]
-        outer_condition_headers = [
-            header
-            for header in outer_headers
-            if header.group("kind") in {"if", "elif"}
-        ]
-        match_line_start = formula.rfind("\n", 0, match.start()) + 1
-        match_indent = len(
-            formula[match_line_start : match.start()].expandtabs(8)
-        )
-        if match_indent <= outer_indent:
-            return "top"
-        branch_index = -1
-        condition_index = 0
-        for header in outer_headers:
-            if header.start() >= match.start():
-                break
-            if header.group("kind") in {"if", "elif"}:
-                branch_index = condition_index
-                condition_index += 1
-            else:
-                branch_index = len(outer_condition_headers)
-        return branch_index if branch_index >= 0 else None
-
-    inline_condition_headers = list(
-        re.finditer(
-            r"(?<![A-Za-z0-9_])(?:if)[ \t]+[^:\n]+:",
-            formula,
-        )
-    )
-    if not inline_condition_headers or match.start() < inline_condition_headers[0].start():
-        return "top"
-    inline_else_headers = list(
-        re.finditer(r"(?<![A-Za-z0-9_])else[ \t]*:", formula)
-    )
-    headers: list[tuple[int, int]] = [
-        (header.start(), index)
-        for index, header in enumerate(inline_condition_headers)
-    ]
-    headers.extend(
-        (header.start(), len(inline_condition_headers))
-        for header in inline_else_headers
-    )
-    preceding = [item for item in headers if item[0] < match.start()]
-    return max(preceding)[1] if preceding else None
+    return _formula_execution_outcome(execution)
 
 
 def _match_arm_value(value: str) -> Any:
@@ -1937,8 +2391,12 @@ def _evaluate_condition_expression(
                 return right
             try:
                 if isinstance(operator, ast.Eq):
+                    if type(left) is not type(right):
+                        return _UNRESOLVED_CONDITION_VALUE
                     matched = left == right
                 elif isinstance(operator, ast.NotEq):
+                    if type(left) is not type(right):
+                        return _UNRESOLVED_CONDITION_VALUE
                     matched = left != right
                 elif isinstance(operator, ast.Lt):
                     matched = left < right
@@ -1982,15 +2440,29 @@ def _branch_boundary_has_test_evidence(
     principal_rule_paths: dict[str, set[tuple[str, ...]]],
     asserted_by_rule: dict[str, list[dict[str, Any]]],
     numeric_value_is_grounded: NumericGroundingPredicate,
+    formula_environment: dict[str, Any] | None = None,
 ) -> bool:
     for rule_name in _rules_covering_branch(branch, principal_rule_paths):
-        selector_names = _rule_numeric_selector_names(principal_rules[rule_name])
+        rule = principal_rules[rule_name]
+        selector_names = _rule_numeric_selector_names(rule)
         if not selector_names:
             continue
         for case in asserted_by_rule.get(rule_name, ()):
-            if any(
+            execution = _case_formula_execution(
+                rule,
+                case,
+                formula_environment=formula_environment,
+            )
+            if (
+                execution is not None
+                and _formula_execution_references_names(
+                    execution,
+                    selector_names,
+                )
+                and any(
                 numeric_value_is_grounded(value, (boundary,))
                 for value in _case_numeric_selector_values(case, selector_names)
+                )
             ):
                 return True
     return False
@@ -2296,15 +2768,37 @@ def _toggled_formula_boolean_selectors(
     principal_rules: dict[str, dict[str, Any]],
     *,
     asserted_by_rule: dict[str, list[dict[str, Any]]],
+    formula_environment: dict[str, Any],
 ) -> set[tuple[str, str]]:
     toggled: set[tuple[str, str]] = set()
     for rule_name, rule in principal_rules.items():
         selector_names = _rule_exception_selector_names(rule)
         if not selector_names:
             continue
-        for key in _paired_boolean_toggle_keys(asserted_by_rule.get(rule_name, ())):
-            matched_names = _input_key_names(key) & selector_names
-            toggled.update((rule_name, name) for name in matched_names)
+        cases = asserted_by_rule.get(rule_name, ())
+        for selector_name in selector_names:
+            reachable_cases = [
+                case
+                for case in cases
+                if (
+                    (
+                        execution := _case_formula_execution(
+                            rule,
+                            case,
+                            formula_environment=formula_environment,
+                        )
+                    )
+                    is not None
+                    and _formula_execution_references_names(
+                        execution,
+                        {selector_name},
+                        selectors_only=True,
+                    )
+                )
+            ]
+            for key in _paired_boolean_toggle_keys(reachable_cases):
+                if selector_name in _input_key_names(key):
+                    toggled.add((rule_name, selector_name))
     return toggled
 
 
@@ -2435,6 +2929,7 @@ def _fractional_rounding_case_witnesses(
     *,
     asserted_by_rule: dict[str, list[dict[str, Any]]],
     direction: str,
+    formula_environment: dict[str, Any],
 ) -> set[tuple[str, int]]:
     evidence: set[tuple[str, int]] = set()
     functions = {
@@ -2450,6 +2945,16 @@ def _fractional_rounding_case_witnesses(
         inputs = case.get("input")
         if not isinstance(inputs, dict):
             continue
+        execution = _case_formula_execution(
+            rule,
+            case,
+            formula_environment=formula_environment,
+        )
+        if execution is None or not _formula_execution_implements_rounding(
+            execution,
+            direction,
+        ):
+            continue
         if any(
             _input_key_names(key) & rounded_operand_identifiers
             and any(
@@ -2460,6 +2965,22 @@ def _fractional_rounding_case_witnesses(
         ):
             evidence.add((rule_name, id(case)))
     return evidence
+
+
+def _formula_execution_implements_rounding(
+    execution: _FormulaExecution,
+    direction: str,
+) -> bool:
+    if direction == "nearest":
+        return bool(
+            re.search(r"\bfloor\s*\(", execution.leaf)
+            and re.search(r"\+\s*0?\.5\b", execution.leaf)
+        )
+    function_name = "ceil" if direction == "upward" else "floor"
+    return re.search(
+        rf"\b{function_name}\s*\(",
+        execution.leaf,
+    ) is not None
 
 
 def _rounding_operand_identifier_names(
@@ -2644,6 +3165,54 @@ def _rule_formula_text(rule: dict[str, Any]) -> str:
         for version in versions
         if isinstance(version, dict) and version.get("formula") is not None
     )
+
+
+def _unambiguous_rule_formula_text(rule: dict[str, Any]) -> str | None:
+    versions = rule.get("versions")
+    if not isinstance(versions, list):
+        return None
+    formulas = tuple(
+        dict.fromkeys(
+            str(version["formula"])
+            for version in versions
+            if isinstance(version, dict) and version.get("formula") is not None
+        )
+    )
+    return formulas[0] if len(formulas) == 1 else None
+
+
+def _constant_rule_environment(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return unambiguous literal rule values usable by condition evaluation."""
+
+    environment: dict[str, Any] = {}
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return environment
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        name = str(rule.get("name") or "").strip()
+        versions = rule.get("versions")
+        if not name or not isinstance(versions, list):
+            continue
+        values: list[Any] = []
+        for version in versions:
+            if not isinstance(version, dict) or "formula" not in version:
+                continue
+            formula = version["formula"]
+            with contextlib.suppress(SyntaxError, ValueError):
+                value = ast.literal_eval(str(formula))
+                if isinstance(value, (str, int, float, bool)) and not isinstance(
+                    value,
+                    complex,
+                ):
+                    values.append(value)
+        if values and all(
+            type(value) is type(values[0]) and value == values[0]
+            for value in values[1:]
+        ):
+            environment[name] = values[0]
+    return environment
 
 
 def _collapse_text(value: str) -> str:

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -213,7 +213,9 @@ _WORDED_ARITHMETIC_EXPRESSION = re.compile(
     flags=re.IGNORECASE,
 )
 _SYMBOLIC_ARITHMETIC_TOKEN = re.compile(
-    rf"{_SYMBOLIC_ARITHMETIC_OPERAND}|[()+*/×·•∗∙−–-]"
+    rf"\b(?:plus|minus|mal)\b|{_SYMBOLIC_ARITHMETIC_OPERAND}|"
+    r"[()+*/×·•∗∙−–-]",
+    flags=re.IGNORECASE,
 )
 _COMPUTATION_LANGUAGE = re.compile(
     r"\b(?:"
@@ -2562,6 +2564,9 @@ def _normalized_source_arithmetic_expression(text: str) -> str:
         ),
         text,
     )
+    normalized = re.sub(r"\bplus\b", "+", normalized, flags=re.IGNORECASE)
+    normalized = re.sub(r"\bminus\b", "-", normalized, flags=re.IGNORECASE)
+    normalized = re.sub(r"\bmal\b", "*", normalized, flags=re.IGNORECASE)
     return normalized.translate(
         str.maketrans(
             {
@@ -6780,10 +6785,16 @@ def _rounding_call_binds_source_clause(
         extract_numeric_occurrences=extract_numeric_occurrences,
         numeric_value_is_grounded=numeric_value_is_grounded,
     )
+    source_operations = _formula_operation_kinds(source_formula_branch.text)
+    if (
+        not source_operations
+        and _formula_ast_operation_kinds(original_operand)
+    ):
+        return False
     if rounding_refers_to_result:
         return formula_match
     source_has_distinguishing_computation = bool(
-        _formula_operation_kinds(source_formula_branch.text)
+        source_operations
         or extract_numeric_occurrences(
             authoritative_numeric_recall_text(source_formula_branch.text)
         )

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -13,13 +13,29 @@ import math
 import re
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Protocol
 
 import yaml
 
-NumericOccurrenceExtractor = Callable[[str], Sequence[float]]
+
+class NumericOccurrenceLike(Protocol):
+    """Typed numeric source evidence consumed from the shared extractor."""
+
+    value: float
+    start: int
+    end: int
+    raw: str
+    has_rate_context: bool
+    source_value: float | None
+    requires_rate_context: bool
+
+
+NumericOccurrenceExtractor = Callable[[str], Sequence[NumericOccurrenceLike]]
 NamedScalarExtractor = Callable[[str], Sequence[Any]]
-NumericGroundingPredicate = Callable[[float, set[float]], bool]
+NumericGroundingPredicate = Callable[
+    [float, Iterable[NumericOccurrenceLike]],
+    bool,
+]
 
 
 @dataclass(frozen=True)
@@ -43,6 +59,16 @@ class CompleteSourceUnitAnalysis:
     source_numeric_occurrence_count: int
     covered_source_numeric_occurrence_count: int
     missing_source_numeric_occurrence_count: int
+
+
+@dataclass(frozen=True)
+class _NumericInterval:
+    """One source-stated range retaining exact endpoint evidence."""
+
+    lower: NumericOccurrenceLike | None
+    lower_inclusive: bool
+    upper: NumericOccurrenceLike | None
+    upper_inclusive: bool
 
 
 _PARAGRAPH_MARKER = re.compile(
@@ -423,7 +449,7 @@ def _analyze_rulespec_payload(
                 "parameter-only representation is invalid."
             )
 
-    source_values = tuple(
+    source_occurrences = tuple(
         extract_numeric_occurrences(authoritative_numeric_recall_text(source_text))
     )
     named_values = (
@@ -437,14 +463,14 @@ def _analyze_rulespec_payload(
     )
     covered_source_values = 0
     missing_source_values: list[float] = []
-    for value in source_values:
+    for occurrence in source_occurrences:
         if any(
-            numeric_value_is_grounded(named_value, {float(value)})
+            numeric_value_is_grounded(named_value, (occurrence,))
             for named_value in named_values
         ):
             covered_source_values += 1
         else:
-            missing_source_values.append(float(value))
+            missing_source_values.append(float(occurrence.value))
     for value in sorted(set(missing_source_values)):
         issues.append(
             "[complete-source-unit:numeric-recall] Authoritative corpus numeric "
@@ -470,7 +496,7 @@ def _analyze_rulespec_payload(
     return CompleteSourceUnitAnalysis(
         tuple(dict.fromkeys(issues)),
         branches,
-        len(source_values),
+        len(source_occurrences),
         covered_source_values,
         len(missing_source_values),
     )
@@ -956,7 +982,9 @@ def _companion_test_issues(
         narrative_formula_branches=formula_branches,
         extract_numeric_occurrences=extract_numeric_occurrences,
     )
-    missing_boundaries: list[tuple[SourceStructureBranch, float]] = []
+    missing_boundaries: list[
+        tuple[SourceStructureBranch, NumericOccurrenceLike]
+    ] = []
     for branch, boundary in boundary_obligations:
         if _branch_boundary_has_test_evidence(
             branch,
@@ -970,8 +998,8 @@ def _companion_test_issues(
         missing_boundaries.append((branch, boundary))
     if missing_boundaries:
         rendered = ", ".join(
-            f"{branch.label}={value:g}"
-            for branch, value in missing_boundaries
+            f"{branch.label}={occurrence.value:g}"
+            for branch, occurrence in missing_boundaries
         )
         issues.append(
             "[complete-source-unit:tests] Companion tests do not exercise every "
@@ -1266,7 +1294,7 @@ def _formula_branch_test_witnesses(
 
 def _branch_boundary_has_test_evidence(
     branch: SourceStructureBranch,
-    boundary: float,
+    boundary: NumericOccurrenceLike,
     *,
     principal_rules: dict[str, dict[str, Any]],
     principal_rule_paths: dict[str, set[tuple[str, ...]]],
@@ -1279,7 +1307,7 @@ def _branch_boundary_has_test_evidence(
             continue
         for case in asserted_by_rule.get(rule_name, ()):
             if any(
-                numeric_value_is_grounded(value, {boundary})
+                numeric_value_is_grounded(value, (boundary,))
                 for value in _case_numeric_selector_values(case, selector_names)
             ):
                 return True
@@ -1301,7 +1329,7 @@ def _formula_branch_interval(
     branch: SourceStructureBranch,
     *,
     extract_numeric_occurrences: NumericOccurrenceExtractor,
-) -> tuple[float | None, bool, float | None, bool] | None:
+) -> _NumericInterval | None:
     first_line = branch.text.splitlines()[0] if branch.text.splitlines() else ""
     range_text = first_line.split(":", 1)[0]
     range_text = _NUMBER_MARKER.sub("", range_text).strip()
@@ -1315,7 +1343,7 @@ def _formula_interval_from_text(
     text: str,
     *,
     extract_numeric_occurrences: NumericOccurrenceExtractor,
-) -> tuple[float | None, bool, float | None, bool] | None:
+) -> _NumericInterval | None:
     lowered = text.lower()
     keyword = re.search(
         r"\b(?:von|from|unter|less\s+than|below|bis|up\s+to|höchstens|"
@@ -1331,44 +1359,45 @@ def _formula_interval_from_text(
         flags=re.IGNORECASE,
     ):
         return None
-    values = tuple(
-        float(value) for value in extract_numeric_occurrences(range_text)
-    )
-    if not values:
+    occurrences = tuple(extract_numeric_occurrences(range_text))
+    if not occurrences:
         return None
     lowered_range = range_text.lower()
     if re.match(r"(?:von|from)\b", lowered_range) and re.search(
         r"\b(?:bis|to|through)\b",
         lowered_range,
     ):
-        if len(values) < 2:
+        if len(occurrences) < 2:
             return None
-        return values[0], True, values[1], True
+        return _NumericInterval(occurrences[0], True, occurrences[1], True)
     if re.match(r"(?:unter|less\s+than|below)\b", lowered_range):
-        return None, False, values[0], False
+        return _NumericInterval(None, False, occurrences[0], False)
     if re.match(r"(?:bis|up\s+to|höchstens|at\s+most)\b", lowered_range):
-        return None, False, values[0], True
+        return _NumericInterval(None, False, occurrences[0], True)
     if re.match(r"(?:über|more\s+than|above)\b", lowered_range):
-        return values[0], False, None, False
+        return _NumericInterval(occurrences[0], False, None, False)
     if re.match(
         r"(?:von|ab|from|at\s+least|mindestens)\b",
         lowered_range,
     ):
-        return values[0], True, None, False
+        return _NumericInterval(occurrences[0], True, None, False)
     return None
 
 
 def _interval_contains(
-    interval: tuple[float | None, bool, float | None, bool],
+    interval: _NumericInterval,
     value: float,
 ) -> bool:
-    lower, lower_inclusive, upper, upper_inclusive = interval
+    lower = interval.lower.value if interval.lower is not None else None
+    upper = interval.upper.value if interval.upper is not None else None
     if lower is not None and (
-        value < lower or (not lower_inclusive and math.isclose(value, lower))
+        value < lower
+        or (not interval.lower_inclusive and math.isclose(value, lower))
     ):
         return False
     if upper is not None and (
-        value > upper or (not upper_inclusive and math.isclose(value, upper))
+        value > upper
+        or (not interval.upper_inclusive and math.isclose(value, upper))
     ):
         return False
     return True
@@ -1801,8 +1830,8 @@ def _source_boundary_obligations(
     *,
     narrative_formula_branches: Sequence[SourceStructureBranch] = (),
     extract_numeric_occurrences: NumericOccurrenceExtractor,
-) -> tuple[tuple[SourceStructureBranch, float], ...]:
-    obligations: list[tuple[SourceStructureBranch, float]] = []
+) -> tuple[tuple[SourceStructureBranch, NumericOccurrenceLike], ...]:
+    obligations: list[tuple[SourceStructureBranch, NumericOccurrenceLike]] = []
     for branch in branches:
         if branch.kind not in {"number", "letter"}:
             continue
@@ -1817,8 +1846,8 @@ def _source_boundary_obligations(
             continue
         prefix = _NUMBER_MARKER.sub("", prefix)
         obligations.extend(
-            (branch, float(value))
-            for value in dict.fromkeys(extract_numeric_occurrences(prefix))
+            (branch, occurrence)
+            for occurrence in extract_numeric_occurrences(prefix)
         )
     for branch in narrative_formula_branches:
         interval = _formula_branch_interval(
@@ -1827,16 +1856,21 @@ def _source_boundary_obligations(
         )
         if interval is None:
             continue
-        lower, _, upper, _ = interval
         obligations.extend(
             (branch, boundary)
-            for boundary in (lower, upper)
+            for boundary in (interval.lower, interval.upper)
             if boundary is not None
         )
     return tuple(
         {
-            (branch.path, float(value)): (branch, float(value))
-            for branch, value in obligations
+            (
+                branch.path,
+                float(occurrence.value),
+                occurrence.has_rate_context,
+                occurrence.source_value,
+                occurrence.requires_rate_context,
+            ): (branch, occurrence)
+            for branch, occurrence in obligations
         }.values()
     )
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -158,9 +158,7 @@ _LETTER_MARKER = re.compile(
     r"(?m)^[ \t]*(?P<marker>(?P<label>[a-z]{1,2})\))[ \t]+",
     flags=re.IGNORECASE,
 )
-_GLUED_SENTENCE_MARKER = re.compile(
-    r"(?<![\w])(?P<label>[1-9]\d?)(?=[A-ZÄÖÜ])"
-)
+_GLUED_SENTENCE_MARKER = re.compile(r"(?<![\w])(?P<label>[1-9]\d?)(?=[A-ZÄÖÜ])")
 _EXPLICIT_SENTENCE_MARKER = re.compile(
     r"(?:(?<=^)|(?<=[.;])|(?<=\)))[ \t]*Satz[ \t]+"
     r"(?P<label>[1-9]\d?)(?:[ \t]*:[ \t]*|[ \t]+)(?=[A-ZÄÖÜ])",
@@ -395,7 +393,9 @@ def recognize_source_structure(source_text: str) -> tuple[SourceStructureBranch,
             continue
         path = (label,)
         branches.append(
-            SourceStructureBranch(path, "paragraph", match.group("marker"), text, start, end)
+            SourceStructureBranch(
+                path, "paragraph", match.group("marker"), text, start, end
+            )
         )
         paragraph_segments.append((path, start, end, text))
 
@@ -469,12 +469,12 @@ def recognize_source_structure(source_text: str) -> tuple[SourceStructureBranch,
             if _is_editorial_omission(text):
                 continue
             branches.append(
-                SourceStructureBranch(path, "sentence", f"Satz {label}", text, start, end)
+                SourceStructureBranch(
+                    path, "sentence", f"Satz {label}", text, start, end
+                )
             )
 
-    unique = {
-        (branch.path, branch.kind, branch.start): branch for branch in branches
-    }
+    unique = {(branch.path, branch.kind, branch.start): branch for branch in branches}
     return tuple(
         sorted(
             unique.values(),
@@ -649,9 +649,8 @@ def _analyze_rulespec_payload(
                     "`derived_relation`) and is not "
                     "precisely deferred; parameter-only representation is invalid."
                 )
-        elif (
-            not all_formula_branches
-            and not _path_covered((), principal_paths, deferred_paths)
+        elif not all_formula_branches and not _path_covered(
+            (), principal_paths, deferred_paths
         ):
             issues.append(
                 "[complete-source-unit:formula-output] Explicit source computation "
@@ -841,9 +840,7 @@ def _principal_formula_clause_rules(
 
     clause_count_by_path: dict[tuple[str, ...], int] = {}
     for clause in formula_branches:
-        clause_count_by_path[clause.path] = (
-            clause_count_by_path.get(clause.path, 0) + 1
-        )
+        clause_count_by_path[clause.path] = clause_count_by_path.get(clause.path, 0) + 1
 
     clause_rules: dict[SourceStructureBranch, set[str]] = {}
     normalized_citation_path = corpus_citation_path.strip("/").lower()
@@ -865,16 +862,10 @@ def _principal_formula_clause_rules(
                 )
             )
             or any(
-                (
-                    excerpt_text := _normalized_formula_clause_text(excerpt)
-                )
-                and excerpt_citation_path.strip("/").lower()
-                == normalized_citation_path
+                (excerpt_text := _normalized_formula_clause_text(excerpt))
+                and excerpt_citation_path.strip("/").lower() == normalized_citation_path
                 and source_states_explicit_computation(excerpt)
-                and (
-                    excerpt_text in clause_text
-                    or clause_text in excerpt_text
-                )
+                and (excerpt_text in clause_text or clause_text in excerpt_text)
                 for excerpt_citation_path, excerpt in _rule_formula_source_excerpts(
                     principal_rules[rule_name]
                 )
@@ -925,10 +916,9 @@ def _rounding_only_direction(text: str) -> str | None:
     if direction is None:
         return None
     without_rounding = _ROUNDING_LANGUAGE.sub("", text)
-    if (
-        _has_substantive_arithmetic_expression(without_rounding)
-        or _COMPUTATION_LANGUAGE.search(without_rounding)
-    ):
+    if _has_substantive_arithmetic_expression(
+        without_rounding
+    ) or _COMPUTATION_LANGUAGE.search(without_rounding):
         return None
     return direction
 
@@ -1119,11 +1109,11 @@ def _deferred_coverage(
         reason = str(record.get("reason") or "").strip()
         blocked_by = record.get("blocked_by")
         normalized_base_target = base_target.lower()
-        blocker_targets = tuple(
-            item.strip()
-            for item in blocked_by
-            if isinstance(item, str)
-        ) if isinstance(blocked_by, list) else ()
+        blocker_targets = (
+            tuple(item.strip() for item in blocked_by if isinstance(item, str))
+            if isinstance(blocked_by, list)
+            else ()
+        )
         exact_blockers = (
             bool(blocker_targets)
             and len(blocker_targets) == len(blocked_by)
@@ -1136,11 +1126,10 @@ def _deferred_coverage(
                 )
                 and item.lower() != output.lower()
                 and not (
-                    item.lower().split("#", 1)[0]
-                    == normalized_base_target
-                    or item.lower().split("#", 1)[0].startswith(
-                        f"{normalized_base_target}/"
-                    )
+                    item.lower().split("#", 1)[0] == normalized_base_target
+                    or item.lower()
+                    .split("#", 1)[0]
+                    .startswith(f"{normalized_base_target}/")
                 )
                 for item in blocker_targets
             )
@@ -1239,12 +1228,11 @@ def _reason_identifies_blocker(
                 target_instrument,
             ):
                 return False
-        elif (
-            target_instrument[2] != corpus_instrument[2]
-            and not _reason_names_target_instrument(
-                normalized_reason,
-                target_instrument,
-            )
+        elif target_instrument[2] != corpus_instrument[
+            2
+        ] and not _reason_names_target_instrument(
+            normalized_reason,
+            target_instrument,
         ):
             return False
     explicit_sections = {
@@ -1295,10 +1283,13 @@ def _source_scope_identifies_blocker(
     if not references:
         return True
     for reference in references:
-        clause_start = max(
-            source_scope_text.rfind(separator, 0, reference.start())
-            for separator in (".", ";", "\n")
-        ) + 1
+        clause_start = (
+            max(
+                source_scope_text.rfind(separator, 0, reference.start())
+                for separator in (".", ";", "\n")
+            )
+            + 1
+        )
         following_stops = [
             position
             for separator in (".", ";", "\n")
@@ -1358,12 +1349,15 @@ def _source_clause_links_dependency(
         flags=re.IGNORECASE,
     ):
         return True
-    return re.search(
-        r"\b(?:voraussetzung\w*|bedingung\w*|conditions?)"
-        r"[^.;]{0,160}\b(?:vorliegen|erfüllt|bestehen|apply|hold)\b",
-        clause,
-        flags=re.IGNORECASE,
-    ) is not None
+    return (
+        re.search(
+            r"\b(?:voraussetzung\w*|bedingung\w*|conditions?)"
+            r"[^.;]{0,160}\b(?:vorliegen|erfüllt|bestehen|apply|hold)\b",
+            clause,
+            flags=re.IGNORECASE,
+        )
+        is not None
+    )
 
 
 def _citation_instrument_identity(
@@ -1403,9 +1397,7 @@ def _reason_names_absolute_target(
 ) -> bool:
     jurisdiction, collection, instrument = target_instrument
     absolute_target = " ".join((jurisdiction, collection, instrument))
-    plural_absolute_target = " ".join(
-        (jurisdiction, f"{collection}s", instrument)
-    )
+    plural_absolute_target = " ".join((jurisdiction, f"{collection}s", instrument))
     return any(
         re.search(
             rf"(?<![a-z0-9äöüß]){re.escape(candidate)}"
@@ -1490,9 +1482,10 @@ def _reason_names_external_dependency(
         ):
             if section_match.group(1).lower() == current_section:
                 continue
-        if normalized.rstrip("/").endswith(
-            f"/{current_section}"
-        ) and "#" not in normalized:
+        if (
+            normalized.rstrip("/").endswith(f"/{current_section}")
+            and "#" not in normalized
+        ):
             continue
         return True
     return False
@@ -1552,8 +1545,7 @@ def _path_is_deferred(
     if not path:
         return () in deferred_paths
     return any(
-        deferred_path
-        and path[: len(deferred_path)] == deferred_path
+        deferred_path and path[: len(deferred_path)] == deferred_path
         for deferred_path in deferred_paths
     )
 
@@ -1746,11 +1738,7 @@ def _companion_test_issues(
     cases = [case for case in cases if case not in colliding_cases]
 
     asserted_by_rule = {
-        name: [
-            case
-            for case in cases
-            if name in _test_case_output_names(case)
-        ]
+        name: [case for case in cases if name in _test_case_output_names(case)]
         for name in principal_rules
     }
     for name, asserted_cases in asserted_by_rule.items():
@@ -1795,9 +1783,7 @@ def _companion_test_issues(
         narrative_formula_branches=formula_branches,
         extract_numeric_occurrences=extract_numeric_occurrences,
     )
-    missing_boundaries: list[
-        tuple[SourceStructureBranch, NumericOccurrenceLike]
-    ] = []
+    missing_boundaries: list[tuple[SourceStructureBranch, NumericOccurrenceLike]] = []
     for branch, boundary in boundary_obligations:
         if _branch_boundary_test_witnesses(
             branch,
@@ -1939,10 +1925,7 @@ def _case_input_principal_output_collisions(
     if not isinstance(inputs, dict):
         return set()
     return set().union(
-        *(
-            _input_key_names(key) & principal_rule_names
-            for key in inputs
-        ),
+        *(_input_key_names(key) & principal_rule_names for key in inputs),
         set(),
     )
 
@@ -2038,8 +2021,7 @@ def _source_control_branches(
     )
     return tuple(
         {
-            (branch.path, branch.start, branch.end): branch
-            for branch in controlled
+            (branch.path, branch.start, branch.end): branch for branch in controlled
         }.values()
     )
 
@@ -2229,9 +2211,7 @@ def _most_specific_containing_branch(
     branches: Sequence[SourceStructureBranch],
 ) -> SourceStructureBranch | None:
     candidates = [
-        branch
-        for branch in branches
-        if branch.start <= start and end <= branch.end
+        branch for branch in branches if branch.start <= start and end <= branch.end
     ]
     return max(
         candidates,
@@ -2414,15 +2394,15 @@ def _formula_execution_matches_source_branch(
     if source_multiplier is not None and (
         source_multiplier.value is None
         or not (
-        _formula_has_numeric_factor(
-            operative_leaf,
-            binding_environment,
-            source_multiplier.value,
-        )
-        or (
-            math.isclose(source_multiplier.value, 2.0)
-            and _formula_is_duplicate_addition(operative_leaf)
-        )
+            _formula_has_numeric_factor(
+                operative_leaf,
+                binding_environment,
+                source_multiplier.value,
+            )
+            or (
+                math.isclose(source_multiplier.value, 2.0)
+                and _formula_is_duplicate_addition(operative_leaf)
+            )
         )
     ):
         return False
@@ -2470,9 +2450,7 @@ def _formula_execution_matches_source_branch(
         ):
             return False
     source_occurrences = tuple(
-        extract_numeric_occurrences(
-            authoritative_numeric_recall_text(branch.text)
-        )
+        extract_numeric_occurrences(authoritative_numeric_recall_text(branch.text))
     )
     boundaries = (
         ()
@@ -2606,9 +2584,14 @@ def _explicit_source_arithmetic_topology(text: str) -> Any | None:
 def _normalized_source_arithmetic_expression(text: str) -> str:
     normalized = re.sub(
         r"\d{1,3}(?:[ .]\d{3})+(?:,\d+)?|\d+,\d+",
-        lambda number: number.group(0).replace(" ", "").replace(".", "").replace(
-            ",",
-            ".",
+        lambda number: (
+            number.group(0)
+            .replace(" ", "")
+            .replace(".", "")
+            .replace(
+                ",",
+                ".",
+            )
         ),
         text,
     )
@@ -2701,9 +2684,7 @@ def _formula_arithmetic_topology_node(
             operands = tuple(
                 sorted(
                     flattened,
-                    key=lambda operand: repr(
-                        _topology_without_variable_names(operand)
-                    ),
+                    key=lambda operand: repr(_topology_without_variable_names(operand)),
                 )
             )
         return "binop", operator, operands
@@ -2720,11 +2701,7 @@ def _formula_arithmetic_topology_node(
 
 
 def _topology_without_variable_names(topology: Any) -> Any:
-    if (
-        isinstance(topology, tuple)
-        and len(topology) == 2
-        and topology[0] == "variable"
-    ):
+    if isinstance(topology, tuple) and len(topology) == 2 and topology[0] == "variable":
         return ("variable",)
     if isinstance(topology, tuple):
         return tuple(_topology_without_variable_names(item) for item in topology)
@@ -2735,11 +2712,7 @@ def _canonicalize_topology_variables(topology: Any) -> Any:
     identities: dict[str, int] = {}
 
     def canonicalize(item: Any) -> Any:
-        if (
-            isinstance(item, tuple)
-            and len(item) == 2
-            and item[0] == "variable"
-        ):
+        if isinstance(item, tuple) and len(item) == 2 and item[0] == "variable":
             name = str(item[1])
             identity = identities.setdefault(name, len(identities))
             return "variable", identity
@@ -2935,10 +2908,7 @@ def _source_number_token_value(token: str) -> float | None:
 
 
 def _source_number_token_is_symbolic(token: str) -> bool:
-    return (
-        token.isalpha()
-        and (len(token) == 1 or token.isupper())
-    )
+    return token.isalpha() and (len(token) == 1 or token.isupper())
 
 
 def _source_contextual_number_word(
@@ -2952,9 +2922,7 @@ def _source_contextual_number_word(
             token = match.group("number")
             if _source_number_token_is_symbolic(token):
                 return None
-            return _NamedSourceNumber(
-                _GERMAN_CARDINAL_VALUES.get(token.lower())
-            )
+            return _NamedSourceNumber(_GERMAN_CARDINAL_VALUES.get(token.lower()))
     return None
 
 
@@ -3086,9 +3054,9 @@ def _formula_is_duplicate_addition(text: str) -> bool:
             expression.op,
             ast.Add,
         ):
-            return _canonical_formula_node(
-                expression.left
-            ) == _canonical_formula_node(expression.right)
+            return _canonical_formula_node(expression.left) == _canonical_formula_node(
+                expression.right
+            )
     return False
 
 
@@ -3233,8 +3201,7 @@ def _formula_node_is_provably_nonzero(
         and expression.func.id == "max"
     ):
         return any(
-            (known := _known_numeric_formula_value(argument, environment))
-            is not None
+            (known := _known_numeric_formula_value(argument, environment)) is not None
             and known > 0
             for argument in expression.args
         )
@@ -3279,8 +3246,7 @@ def _canonical_formula_node(node: ast.AST) -> Any:
             _canonical_formula_node(node.left),
             tuple(type(operator).__name__ for operator in node.ops),
             tuple(
-                _canonical_formula_node(comparator)
-                for comparator in node.comparators
+                _canonical_formula_node(comparator) for comparator in node.comparators
             ),
         )
     return ast.dump(node, annotate_fields=True, include_attributes=False).lower()
@@ -3293,10 +3259,7 @@ def _commutative_formula_operands(
     operands: list[Any] = []
 
     def collect(candidate: ast.AST) -> None:
-        if (
-            isinstance(candidate, ast.BinOp)
-            and isinstance(candidate.op, operator_type)
-        ):
+        if isinstance(candidate, ast.BinOp) and isinstance(candidate.op, operator_type):
             collect(candidate.left)
             collect(candidate.right)
         else:
@@ -3550,9 +3513,7 @@ def _execute_formula_text(
             )
         )
         selected_text = (
-            selected_text[: node.start]
-            + selected_body
-            + selected_text[node.end :]
+            selected_text[: node.start] + selected_body + selected_text[node.end :]
         )
     return None
 
@@ -3634,8 +3595,9 @@ def _first_multiline_if_node(text: str) -> _FormulaBranchNode | None:
                         cursor,
                         "elif",
                         candidate[
-                            chain_header.start("condition") :
-                            chain_header.end("condition")
+                            chain_header.start("condition") : chain_header.end(
+                                "condition"
+                            )
                         ].strip(),
                     )
                 )
@@ -3651,9 +3613,7 @@ def _first_multiline_if_node(text: str) -> _FormulaBranchNode | None:
             break
         chain_end = lines[cursor][0] if cursor < len(lines) else len(text)
         conditions = tuple(
-            condition
-            for _line_index, kind, condition in headers
-            if kind != "else"
+            condition for _line_index, kind, condition in headers if kind != "else"
         )
         choices: list[str] = []
         for header_index, (line_index, _kind, _condition) in enumerate(headers):
@@ -3721,9 +3681,7 @@ def _first_multiline_match_node(text: str) -> _FormulaBranchNode | None:
         if not arm_headers:
             continue
         choices: list[str] = []
-        for arm_index, (line_index, _pattern, inline_body) in enumerate(
-            arm_headers
-        ):
+        for arm_index, (line_index, _pattern, inline_body) in enumerate(arm_headers):
             body_end = (
                 lines[arm_headers[arm_index + 1][0]][0]
                 if arm_index + 1 < len(arm_headers)
@@ -3731,21 +3689,13 @@ def _first_multiline_match_node(text: str) -> _FormulaBranchNode | None:
             )
             trailing_body = text[lines[line_index][2] : body_end]
             choices.append(
-                "\n".join(
-                    part
-                    for part in (inline_body, trailing_body)
-                    if part.strip()
-                )
+                "\n".join(part for part in (inline_body, trailing_body) if part.strip())
             )
         return _FormulaBranchNode(
             start,
             chain_end,
             "match",
-            (
-                line[
-                    header.start("selector") : header.end("selector")
-                ].strip(),
-            ),
+            (line[header.start("selector") : header.end("selector")].strip(),),
             tuple(pattern for _line_index, pattern, _body in arm_headers),
             tuple(choices),
         )
@@ -3781,27 +3731,23 @@ def _first_inline_if_node(text: str) -> _FormulaBranchNode | None:
         conditions = [text[candidate.end() : colon].strip()]
         conditions.extend(
             text[condition_start:condition_end].strip()
-            for kind, _start, _body_start, condition_start, condition_end
-            in chain_headers
+            for kind, _start, _body_start, condition_start, condition_end in chain_headers
             if kind == "elif"
         )
         body_boundaries = [
             header_start
-            for _kind, header_start, _body_start, _condition_start, _condition_end
-            in chain_headers
+            for _kind, header_start, _body_start, _condition_start, _condition_end in chain_headers
         ]
         body_starts = [
             colon + 1,
             *(
                 header_body_start
-                for kind, _header_start, header_body_start, _start, _end
-                in chain_headers
+                for kind, _header_start, header_body_start, _start, _end in chain_headers
                 if kind == "elif"
             ),
         ]
         choices = [
-            text[start:stop]
-            for start, stop in zip(body_starts, body_boundaries)
+            text[start:stop] for start, stop in zip(body_starts, body_boundaries)
         ]
         choices.append(text[else_body_start:end])
         return _FormulaBranchNode(
@@ -3961,9 +3907,7 @@ def _formula_expression_end(
         elif character == "," and len(stack) == len(initial_stack):
             return index
         elif (
-            stop_at_semicolon
-            and character == ";"
-            and len(stack) == len(initial_stack)
+            stop_at_semicolon and character == ";" and len(stack) == len(initial_stack)
         ):
             return index
     return limit
@@ -4045,10 +3989,7 @@ def _rule_text_has_branching_formula(formula_text: str) -> bool:
 
 
 def _formula_execution_outcome(execution: _FormulaExecution) -> str:
-    return "/".join(
-        f"{step.kind}:{step.choice}"
-        for step in execution.trace
-    )
+    return "/".join(f"{step.kind}:{step.choice}" for step in execution.trace)
 
 
 def _formula_execution_leaf_is_computational(
@@ -4074,17 +4015,10 @@ def _formula_execution_references_names(
     *,
     selectors_only: bool = False,
 ) -> bool:
-    texts = [
-        selector
-        for step in execution.trace
-        for selector in step.selectors
-    ]
+    texts = [selector for step in execution.trace for selector in step.selectors]
     if not selectors_only:
         texts.append(execution.leaf)
-    return any(
-        set(_FORMULA_IDENTIFIER.findall(text)) & names
-        for text in texts
-    )
+    return any(set(_FORMULA_IDENTIFIER.findall(text)) & names for text in texts)
 
 
 def _same_formula_value(left: Any, right: Any) -> bool:
@@ -4208,10 +4142,7 @@ def _evaluate_condition_expression(
     if isinstance(expression, ast.BinOp):
         left = _evaluate_condition_expression(expression.left, environment)
         right = _evaluate_condition_expression(expression.right, environment)
-        if (
-            left is _UNRESOLVED_CONDITION_VALUE
-            or right is _UNRESOLVED_CONDITION_VALUE
-        ):
+        if left is _UNRESOLVED_CONDITION_VALUE or right is _UNRESOLVED_CONDITION_VALUE:
             return _UNRESOLVED_CONDITION_VALUE
         with contextlib.suppress(ArithmeticError, TypeError, ValueError):
             if isinstance(expression.op, ast.Add):
@@ -4272,17 +4203,12 @@ def _evaluate_condition_expression(
             _evaluate_condition_expression(argument, environment)
             for argument in expression.args
         ]
-        if any(
-            value is _UNRESOLVED_CONDITION_VALUE
-            for value in values
-        ):
+        if any(value is _UNRESOLVED_CONDITION_VALUE for value in values):
             return _UNRESOLVED_CONDITION_VALUE
         with contextlib.suppress(ArithmeticError, TypeError, ValueError):
             if function_name in {"holds", "not_holds"} and len(values) == 1:
                 return (
-                    bool(values[0])
-                    if function_name == "holds"
-                    else not bool(values[0])
+                    bool(values[0]) if function_name == "holds" else not bool(values[0])
                 )
             if function_name == "min" and values:
                 return min(values)
@@ -4335,47 +4261,40 @@ def _branch_boundary_test_witnesses(
                 formula_environment=formula_environment,
                 dependency_environment=dependency_environment,
             )
-            if (
-                execution is not None
-                and any(
-                    numeric_value_is_grounded(value, (boundary,))
-                    and _formula_execution_references_names(
-                        execution,
-                        input_names,
-                    )
-                    and _formula_execution_binds_boundary(
-                        execution,
-                        boundary,
-                        input_names=input_names,
-                        formula_environment=execution.constant_environment,
-                        source_interval=source_interval,
-                        source_boolean_polarity=source_boolean_polarity,
-                        extract_numeric_occurrences=(
-                            extract_numeric_occurrences
-                        ),
-                        numeric_value_is_grounded=(
-                            numeric_value_is_grounded
-                        ),
-                    )
-                    and _boundary_case_changes_formula_effect(
-                        rule,
+            if execution is not None and any(
+                numeric_value_is_grounded(value, (boundary,))
+                and _formula_execution_references_names(
+                    execution,
+                    input_names,
+                )
+                and _formula_execution_binds_boundary(
+                    execution,
+                    boundary,
+                    input_names=input_names,
+                    formula_environment=execution.constant_environment,
+                    source_interval=source_interval,
+                    source_boolean_polarity=source_boolean_polarity,
+                    extract_numeric_occurrences=(extract_numeric_occurrences),
+                    numeric_value_is_grounded=(numeric_value_is_grounded),
+                )
+                and _boundary_case_changes_formula_effect(
+                    rule,
+                    case,
+                    input_key=input_key,
+                    selector_names=input_names,
+                    boundary_value=value,
+                    execution=execution,
+                    principal_rules=principal_rules,
+                    dependency_names=set(dependency_environment),
+                    formula_environment=formula_environment or {},
+                    source_interval=source_interval,
+                    source_boolean_polarity=source_boolean_polarity,
+                )
+                for input_key, input_names, value in (
+                    _case_numeric_selector_evidence(
                         case,
-                        input_key=input_key,
-                        selector_names=input_names,
-                        boundary_value=value,
-                        execution=execution,
-                        principal_rules=principal_rules,
-                        dependency_names=set(dependency_environment),
-                        formula_environment=formula_environment or {},
-                        source_interval=source_interval,
-                        source_boolean_polarity=source_boolean_polarity,
-                    )
-                    for input_key, input_names, value in (
-                        _case_numeric_selector_evidence(
-                            case,
-                            selector_names,
-                            dependency_environment=dependency_environment,
-                        )
+                        selector_names,
+                        dependency_environment=dependency_environment,
                     )
                 )
             ):
@@ -4437,10 +4356,7 @@ def _formula_execution_binds_boundary(
     for step in execution.trace:
         if step.kind not in {"if", "match"}:
             continue
-        checks.extend(
-            (selector, True)
-            for selector in step.selectors
-        )
+        checks.extend((selector, True) for selector in step.selectors)
     checks.append((execution.leaf, source_boolean_polarity < 0))
     return any(
         _formula_text_has_boundary_comparison(
@@ -4487,9 +4403,7 @@ def _formula_text_has_boundary_comparison(
                     right,
                     input_names,
                 )
-                boundary_node = (
-                    right if left_is_input and not right_is_input else left
-                )
+                boundary_node = right if left_is_input and not right_is_input else left
                 if not (
                     (left_is_input and not right_is_input)
                     or (right_is_input and not left_is_input)
@@ -4583,10 +4497,14 @@ def _formula_node_boundary_value(
         value = formula_environment.get(node.id)
         if isinstance(value, (int, float)) and not isinstance(value, bool):
             return float(value)
-    if isinstance(node, ast.Constant) and isinstance(
-        node.value,
-        (int, float),
-    ) and not isinstance(node.value, bool):
+    if (
+        isinstance(node, ast.Constant)
+        and isinstance(
+            node.value,
+            (int, float),
+        )
+        and not isinstance(node.value, bool)
+    ):
         value = float(node.value)
         if numeric_value_is_grounded(
             value,
@@ -4854,14 +4772,10 @@ def _boundary_case_changes_formula_effect(
     ):
         return False
     for raw_key, raw_value in inputs.items():
-        if (
-            isinstance(raw_value, bool)
-            or not isinstance(raw_value, (int, float))
-        ):
+        if isinstance(raw_value, bool) or not isinstance(raw_value, (int, float)):
             continue
-        directly_controls_selector = (
-            raw_key == input_key
-            and bool(_input_key_names(raw_key) & selector_names)
+        directly_controls_selector = raw_key == input_key and bool(
+            _input_key_names(raw_key) & selector_names
         )
         raw_step = (
             boundary_step
@@ -4984,9 +4898,7 @@ def _rules_covering_branch(
     principal_rule_paths: dict[str, set[tuple[str, ...]]],
 ) -> tuple[str, ...]:
     return tuple(
-        name
-        for name, paths in principal_rule_paths.items()
-        if branch.path in paths
+        name for name, paths in principal_rule_paths.items() if branch.path in paths
     )
 
 
@@ -4996,9 +4908,7 @@ def _formula_branch_interval(
     extract_numeric_occurrences: NumericOccurrenceExtractor,
 ) -> _NumericInterval | None:
     first_line = branch.text.splitlines()[0] if branch.text.splitlines() else ""
-    range_text = authoritative_numeric_recall_text(
-        first_line.split(":", 1)[0]
-    )
+    range_text = authoritative_numeric_recall_text(first_line.split(":", 1)[0])
     return _formula_interval_from_text(
         range_text,
         extract_numeric_occurrences=extract_numeric_occurrences,
@@ -5107,13 +5017,11 @@ def _interval_contains(
     lower = interval.lower.value if interval.lower is not None else None
     upper = interval.upper.value if interval.upper is not None else None
     if lower is not None and (
-        value < lower
-        or (not interval.lower_inclusive and math.isclose(value, lower))
+        value < lower or (not interval.lower_inclusive and math.isclose(value, lower))
     ):
         return False
     if upper is not None and (
-        value > upper
-        or (not interval.upper_inclusive and math.isclose(value, upper))
+        value > upper or (not interval.upper_inclusive and math.isclose(value, upper))
     ):
         return False
     return True
@@ -5190,9 +5098,13 @@ def _case_numeric_selector_evidence(
             (key, matched_names, numeric_value)
             for numeric_value in _numeric_test_input_values(value)
         )
-    directly_matched_names = set().union(
-        *(names for _key, names, _value in evidence),
-    ) if evidence else set()
+    directly_matched_names = (
+        set().union(
+            *(names for _key, names, _value in evidence),
+        )
+        if evidence
+        else set()
+    )
     for name, value in (dependency_environment or {}).items():
         if name not in selector_names or name in directly_matched_names:
             continue
@@ -5222,9 +5134,7 @@ def _source_exception_branches(
     deferred_paths: set[tuple[str, ...]],
 ) -> tuple[SourceStructureBranch, ...]:
     obligations: list[SourceStructureBranch] = []
-    source_clauses = tuple(
-        _source_clause_spans(source_text, branches=branches)
-    )
+    source_clauses = tuple(_source_clause_spans(source_text, branches=branches))
     matches_by_clause: dict[
         tuple[int, int, str],
         list[re.Match[str]],
@@ -5247,16 +5157,15 @@ def _source_exception_branches(
         )
         matches_by_clause.setdefault(clause, []).append(match)
 
-    for (clause_start, clause_end, clause_text), clause_matches in (
-        matches_by_clause.items()
-    ):
+    for (
+        clause_start,
+        clause_end,
+        clause_text,
+    ), clause_matches in matches_by_clause.items():
         groups: list[list[re.Match[str]]] = []
         for match in clause_matches:
-            if (
-                groups
-                and _exception_cues_have_distinct_conditions(
-                    source_text[groups[-1][-1].end() : match.start()]
-                )
+            if groups and _exception_cues_have_distinct_conditions(
+                source_text[groups[-1][-1].end() : match.start()]
             ):
                 groups.append([match])
             elif groups:
@@ -5301,8 +5210,7 @@ def _source_exception_branches(
             )
     return tuple(
         {
-            (branch.path, branch.start, branch.end): branch
-            for branch in obligations
+            (branch.path, branch.start, branch.end): branch for branch in obligations
         }.values()
     )
 
@@ -5315,8 +5223,8 @@ def _source_exception_or_applicability_matches(
     matches = tuple(
         match
         for match in (
-        *_EXCEPTION_LANGUAGE.finditer(source_text),
-        *_APPLICABILITY_LANGUAGE.finditer(source_text),
+            *_EXCEPTION_LANGUAGE.finditer(source_text),
+            *_APPLICABILITY_LANGUAGE.finditer(source_text),
         )
         if not _is_concessive_condition_cue(source_text, match)
     )
@@ -5337,19 +5245,25 @@ def _is_concessive_condition_cue(
     if match.group(0).strip().lower() not in {"wenn", "if"}:
         return False
     prefix = source_text[max(0, match.start() - 16) : match.start()]
-    return re.search(
-        r"\b(?:auch|selbst|even)\s+$",
-        prefix,
-        flags=re.IGNORECASE,
-    ) is not None
+    return (
+        re.search(
+            r"\b(?:auch|selbst|even)\s+$",
+            prefix,
+            flags=re.IGNORECASE,
+        )
+        is not None
+    )
 
 
 def _exception_cues_have_distinct_conditions(between: str) -> bool:
-    return re.search(
-        r"(?:;|\b(?:und|oder|and|or)\b)\s*$",
-        between,
-        flags=re.IGNORECASE,
-    ) is not None
+    return (
+        re.search(
+            r"(?:;|\b(?:und|oder|and|or)\b)\s*$",
+            between,
+            flags=re.IGNORECASE,
+        )
+        is not None
+    )
 
 
 def _source_rounding_obligations(
@@ -5360,9 +5274,7 @@ def _source_rounding_obligations(
     deferred_paths: set[tuple[str, ...]],
 ) -> tuple[tuple[SourceStructureBranch, str], ...]:
     obligations: list[tuple[SourceStructureBranch, str]] = []
-    source_clauses = tuple(
-        _source_clause_spans(source_text, branches=branches)
-    )
+    source_clauses = tuple(_source_clause_spans(source_text, branches=branches))
     for match in _ROUNDING_LANGUAGE.finditer(source_text):
         if _span_is_deferred(
             match.start(),
@@ -5489,11 +5401,7 @@ def _exception_witnesses_for_branch(
         rule_name
         for rule_name, paths in principal_rule_paths.items()
         if not branch.path
-        or any(
-            path == branch.path[: len(path)]
-            for path in paths
-            if path
-        )
+        or any(path == branch.path[: len(path)] for path in paths if path)
     }
     requirement = _source_exception_effect_requirement(branch.text)
     condition_text = _source_exception_condition_text(branch.text)
@@ -5614,15 +5522,18 @@ def _exception_reverses_negative_proposition(text: str) -> bool:
     if reversal is None:
         return False
     proposition = text[: reversal.start()]
-    return re.search(
-        r"\b(?:besteht|gilt)\b[^.;]{0,80}\bnicht\b|"
-        r"\bfindet\s+keine\s+anwendung\b|"
-        r"\b(?:does|shall)\s+not\s+apply\b|"
-        r"\b(?:is|are)\s+not\s+(?:eligible|qualified|entitled)\b|"
-        r"\bkein(?:e|en|em|er|es)?\s+(?:anspruch|berechtigung)\b",
-        proposition,
-        flags=re.IGNORECASE,
-    ) is not None
+    return (
+        re.search(
+            r"\b(?:besteht|gilt)\b[^.;]{0,80}\bnicht\b|"
+            r"\bfindet\s+keine\s+anwendung\b|"
+            r"\b(?:does|shall)\s+not\s+apply\b|"
+            r"\b(?:is|are)\s+not\s+(?:eligible|qualified|entitled)\b|"
+            r"\bkein(?:e|en|em|er|es)?\s+(?:anspruch|berechtigung)\b",
+            proposition,
+            flags=re.IGNORECASE,
+        )
+        is not None
+    )
 
 
 def _source_exception_selector_is_relevant(text: str, name: str) -> bool:
@@ -5663,9 +5574,7 @@ def _source_exception_selector_active_value(text: str, name: str) -> bool:
     )
     if source_polarity is not None:
         selector_polarity = (
-            -1
-            if _selector_identifier_negation_count(normalized_name) % 2
-            else 1
+            -1 if _selector_identifier_negation_count(normalized_name) % 2 else 1
         )
         return selector_polarity == source_polarity
     return _exception_selector_semantic_active_value(normalized_name)
@@ -5687,9 +5596,8 @@ def _numeric_exception_witness_matches_source(
     if interval is None:
         return False
     ordinary_value, exception_value = transition
-    return (
-        not _interval_contains(interval, ordinary_value)
-        and _interval_contains(interval, exception_value)
+    return not _interval_contains(interval, ordinary_value) and _interval_contains(
+        interval, exception_value
     )
 
 
@@ -5778,7 +5686,8 @@ def _source_selector_concept_polarity(
 
 def _selector_identifier_negation_count(normalized_name: str) -> int:
     count = sum(
-        token in {
+        token
+        in {
             "absent",
             "lacking",
             "missing",
@@ -5826,8 +5735,7 @@ def _toggled_formula_boolean_selectors(
             (
                 case,
                 (
-                    dependency_environment
-                    := _case_asserted_dependency_environment(
+                    dependency_environment := _case_asserted_dependency_environment(
                         principal_rules,
                         case,
                         formula_environment=formula_environment,
@@ -5851,13 +5759,11 @@ def _toggled_formula_boolean_selectors(
                 right_dependencies,
                 right_selectors,
             ) in records[left_index + 1 :]:
-                if (
-                    _normalized_case_period(left_case)
-                    != _normalized_case_period(right_case)
-                    or not _cases_differ_by_one_input(
-                        left_case,
-                        right_case,
-                    )
+                if _normalized_case_period(left_case) != _normalized_case_period(
+                    right_case
+                ) or not _cases_differ_by_one_input(
+                    left_case,
+                    right_case,
                 ):
                     continue
                 if set(left_selectors) != set(right_selectors):
@@ -5906,11 +5812,9 @@ def _toggled_formula_numeric_selectors(
         selector_names = _rule_numeric_selector_names(rule)
         for left_index, left_case in enumerate(asserted_by_rule.get(rule_name, ())):
             for right_case in asserted_by_rule[rule_name][left_index + 1 :]:
-                if (
-                    _normalized_case_period(left_case)
-                    != _normalized_case_period(right_case)
-                    or not _cases_differ_by_one_input(left_case, right_case)
-                ):
+                if _normalized_case_period(left_case) != _normalized_case_period(
+                    right_case
+                ) or not _cases_differ_by_one_input(left_case, right_case):
                     continue
                 left_inputs = left_case.get("input")
                 right_inputs = right_case.get("input")
@@ -5964,15 +5868,13 @@ def _toggled_formula_numeric_selectors(
                 if left_execution is None or right_execution is None:
                     continue
                 if (
-                    (left_execution.trace or right_execution.trace)
-                    and _formula_leaf_semantic_key(
-                        left_execution.leaf,
-                        formula_environment=left_execution.constant_environment,
-                    )
-                    == _formula_leaf_semantic_key(
-                        right_execution.leaf,
-                        formula_environment=right_execution.constant_environment,
-                    )
+                    left_execution.trace or right_execution.trace
+                ) and _formula_leaf_semantic_key(
+                    left_execution.leaf,
+                    formula_environment=left_execution.constant_environment,
+                ) == _formula_leaf_semantic_key(
+                    right_execution.leaf,
+                    formula_environment=right_execution.constant_environment,
                 ):
                     continue
                 left_runtime = _formula_execution_runtime_value(left_execution)
@@ -6044,8 +5946,7 @@ def _toggled_formula_numeric_selectors(
                                 ),
                                 (
                                     _boolean_value(ordinary_runtime) is not None
-                                    and _boolean_value(exception_runtime)
-                                    is not None
+                                    and _boolean_value(exception_runtime) is not None
                                 ),
                                 _exception_effect_is_zero(exception_runtime),
                                 (ordinary_value, exception_value),
@@ -6122,9 +6023,7 @@ def _exception_witness_for_case_pair(
         return None
     ordinary_runtime = _formula_execution_runtime_value(ordinary_execution)
     exception_runtime = _formula_execution_runtime_value(exception_execution)
-    counterfactual_runtime = _formula_execution_runtime_value(
-        counterfactual_execution
-    )
+    counterfactual_runtime = _formula_execution_runtime_value(counterfactual_execution)
     if not (
         all(
             _formula_execution_reaches_selector(execution, selector_name)
@@ -6179,13 +6078,16 @@ def _cases_differ_by_one_input(
         return False
     if set(left_inputs) != set(right_inputs):
         return False
-    return sum(
-        not _formula_runtime_values_equal(
-            left_inputs[key],
-            right_inputs[key],
+    return (
+        sum(
+            not _formula_runtime_values_equal(
+                left_inputs[key],
+                right_inputs[key],
+            )
+            for key in left_inputs
         )
-        for key in left_inputs
-    ) == 1
+        == 1
+    )
 
 
 def _exception_effect_is_zero(value: Any) -> bool:
@@ -6214,9 +6116,7 @@ def _case_formula_execution_with_boolean_selector(
         if not isinstance(inputs, dict):
             return None
         matching_keys = [
-            key
-            for key in inputs
-            if selector_name in _input_key_names(key)
+            key for key in inputs if selector_name in _input_key_names(key)
         ]
         if len(matching_keys) != 1:
             return None
@@ -6362,15 +6262,13 @@ def _rule_exception_selector_names(rule: dict[str, Any]) -> set[str]:
             function_names = {
                 node.func.id
                 for node in ast.walk(expression)
-                if isinstance(node, ast.Call)
-                and isinstance(node.func, ast.Name)
+                if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
             }
             for name in {
                 node.id
                 for node in ast.walk(expression)
                 if isinstance(node, ast.Name)
-                and node.id.lower()
-                not in {"true", "false", "holds", "not_holds"}
+                and node.id.lower() not in {"true", "false", "holds", "not_holds"}
                 and node.id not in function_names
             }:
                 record(name)
@@ -6418,13 +6316,10 @@ def _exception_selector_semantic_active_value(name: str) -> bool:
         flags=re.IGNORECASE,
     ):
         return not negated
-    if (
-        _ordinary_semantic_identifier(normalized)
-        or re.search(
-            r"(?:ineligib|disqualif|unqualif)",
-            normalized,
-            flags=re.IGNORECASE,
-        )
+    if _ordinary_semantic_identifier(normalized) or re.search(
+        r"(?:ineligib|disqualif|unqualif)",
+        normalized,
+        flags=re.IGNORECASE,
     ):
         return negated
     return True
@@ -6483,9 +6378,9 @@ def _fractional_rounding_case_witnesses(
 ) -> set[tuple[str, str, str]]:
     evidence: set[tuple[str, str, str]] = set()
     functions = {
-        "nearest" if direction == "nearest" else (
-            "ceil" if direction == "upward" else "floor"
-        )
+        "nearest"
+        if direction == "nearest"
+        else ("ceil" if direction == "upward" else "floor")
     }
     for case in asserted_by_rule.get(rule_name, ()):
         inputs = case.get("input")
@@ -6554,10 +6449,8 @@ def _fractional_rounding_case_witnesses(
                 )
             ):
                 continue
-            if (
-                source_formula_branches
-                and not any(
-                    _rounding_call_binds_source_clause(
+            if source_formula_branches and not any(
+                _rounding_call_binds_source_clause(
                     source_binding_operand,
                     original_operand=effective_operand,
                     operand_value=float(operand_value),
@@ -6570,17 +6463,13 @@ def _fractional_rounding_case_witnesses(
                     require_clause_binding=require_clause_binding,
                     extract_numeric_occurrences=extract_numeric_occurrences,
                     numeric_value_is_grounded=numeric_value_is_grounded,
-                    )
-                    for source_formula_branch in source_formula_branches
                 )
+                for source_formula_branch in source_formula_branches
             ):
                 continue
-            call_key = (
-                f"{function_name}:"
-                + _formula_leaf_semantic_key(
-                    effective_operand,
-                    formula_environment=execution.constant_environment,
-                )
+            call_key = f"{function_name}:" + _formula_leaf_semantic_key(
+                effective_operand,
+                formula_environment=execution.constant_environment,
             )
             evidence.add(
                 (
@@ -6602,10 +6491,13 @@ def _formula_execution_implements_rounding(
             and re.search(r"\+\s*0?\.5\b", execution.leaf)
         )
     function_name = "ceil" if direction == "upward" else "floor"
-    return re.search(
-        rf"\b{function_name}\s*\(",
-        execution.leaf,
-    ) is not None
+    return (
+        re.search(
+            rf"\b{function_name}\s*\(",
+            execution.leaf,
+        )
+        is not None
+    )
 
 
 def _rounding_call_operands(
@@ -6629,18 +6521,12 @@ def _rounding_call_operands(
                 and not expression.keywords
             ):
                 operand = ast.unparse(expression.args[0])
-                if (
-                    functions != {"nearest"}
-                    or re.search(r"\+\s*0?\.5\b", operand)
-                ):
+                if functions != {"nearest"} or re.search(r"\+\s*0?\.5\b", operand):
                     return ((expression.func.id, operand),)
         return ()
     for function_name in function_names:
         for operand in _balanced_call_operands(formula_text, function_name):
-            if (
-                functions == {"nearest"}
-                and not re.search(r"\+\s*0?\.5\b", operand)
-            ):
+            if functions == {"nearest"} and not re.search(r"\+\s*0?\.5\b", operand):
                 continue
             calls.append((function_name, operand))
     return tuple(calls)
@@ -6689,11 +6575,7 @@ def _expand_reached_formula_dependencies(
         def visit_Name(self, node: ast.Name) -> ast.AST:
             name = node.id
             rule = principal_rules.get(name)
-            if (
-                rule is None
-                or name not in dependency_environment
-                or name in resolving
-            ):
+            if rule is None or name not in dependency_environment or name in resolving:
                 return node
             execution = _case_formula_execution(
                 rule,
@@ -6736,10 +6618,7 @@ def _fractional_input_materially_affects_operand(
     operand_names = set(_FORMULA_IDENTIFIER.findall(operand))
     uses_derived_operand = bool(operand_names & dependency_names)
     for key, value in inputs.items():
-        if (
-            isinstance(value, bool)
-            or not isinstance(value, (int, float))
-        ):
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
             continue
         aliases = _input_key_names(key) & operand_names
         if not aliases and not uses_derived_operand:
@@ -6840,10 +6719,7 @@ def _rounding_call_binds_source_clause(
     source_operations = _formula_operation_kinds(source_formula_branch.text)
     if (
         direction == "nearest"
-        and (
-            _formula_ast_operation_kinds(original_operand)
-            & {"add", "subtract"}
-        )
+        and (_formula_ast_operation_kinds(original_operand) & {"add", "subtract"})
         - source_operations
     ):
         return False
@@ -7128,9 +7004,7 @@ def _rule_formula_text_for_case(
         return None
     latest = max(effective_from for effective_from, _formula in candidates)
     formulas = {
-        formula
-        for effective_from, formula in candidates
-        if effective_from == latest
+        formula for effective_from, formula in candidates if effective_from == latest
     }
     return next(iter(formulas)) if len(formulas) == 1 else None
 
@@ -7210,13 +7084,10 @@ def _formula_environment_for_case(
             continue
         latest = max(start for start, _candidate in candidates)
         latest_values = [
-            candidate
-            for start, candidate in candidates
-            if start == latest
+            candidate for start, candidate in candidates if start == latest
         ]
         if latest_values and all(
-            type(candidate) is type(latest_values[0])
-            and candidate == latest_values[0]
+            type(candidate) is type(latest_values[0]) and candidate == latest_values[0]
             for candidate in latest_values[1:]
         ):
             resolved[name] = latest_values[0]

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -163,7 +163,7 @@ _GLUED_SENTENCE_MARKER = re.compile(
 )
 _EXPLICIT_SENTENCE_MARKER = re.compile(
     r"(?:(?<=^)|(?<=[.;])|(?<=\)))[ \t]*Satz[ \t]+"
-    r"(?P<label>[1-9]\d?)(?=[ \t]+[A-ZÄÖÜ])",
+    r"(?P<label>[1-9]\d?)(?:[ \t]*:[ \t]*|[ \t]+)(?=[A-ZÄÖÜ])",
     flags=re.IGNORECASE | re.MULTILINE,
 )
 _EDITORIAL_OMISSION_ONLY = re.compile(
@@ -205,6 +205,12 @@ _SYMBOLIC_ARITHMETIC_OPERAND = (
     r"\d{1,3}(?:[ .]\d{3})+(?:,\d+)?|"
     r"\d+(?:[.,]\d+)?"
     r")"
+)
+_WORDED_ARITHMETIC_EXPRESSION = re.compile(
+    rf"{_SYMBOLIC_ARITHMETIC_OPERAND}\s+(?:plus|minus|mal)\s+"
+    r"(?!(?:beträgt|gilt|ist|sind|wird|werden|equals?|applies?)\b)"
+    rf"{_SYMBOLIC_ARITHMETIC_OPERAND}",
+    flags=re.IGNORECASE,
 )
 _EXPLICIT_SYMBOLIC_ARITHMETIC_CHAIN = re.compile(
     rf"(?P<expression>{_SYMBOLIC_ARITHMETIC_OPERAND}"
@@ -248,7 +254,7 @@ _COMPUTATION_LANGUAGE = re.compile(
     r"\d+(?:[.,]\d+)?\s*-?fach(?:e[nsrm]?)?|"
     r"(?:vermindert|erhöht|gekürzt|vermehrt)\s+um|"
     r"(?:erhöht|mindert|vermindert|kürzt|vermehrt)\s+sich\s+um|"
-    r"(?:abzüglich|zuzüglich|plus|minus)|"
+    r"(?:abzüglich|zuzüglich)|"
     r"(?:prozent|\d+(?:[.,]\d+)?\s*%)\s+(?:des|der|von|of)|"
     r"\d+(?:[.,]\d+)?\s+(?:vom\s+hundert|v\.?\s*h\.?)\s+"
     r"(?:des|der|von)|"
@@ -292,7 +298,13 @@ _EXCEPTION_LANGUAGE = re.compile(
     flags=re.IGNORECASE,
 )
 _APPLICABILITY_LANGUAGE = re.compile(
-    r"\b(?:wenn|falls|sofern|when|if)\b",
+    r"\b(?:"
+    r"vorausgesetzt\s*,?\s+dass|"
+    r"unter\s+der\s+voraussetzung\s*,?\s+dass|"
+    r"wenn|falls|sofern|soweit|when|if|"
+    r"bei\s+(?:(?:vorliegen|bestehen)\b|"
+    r"(?:(?:einer?|bestehender)\s+)?(?:anspruchsberechtigung|berechtigung)\b)"
+    r")\b",
     flags=re.IGNORECASE,
 )
 _PRECISE_DEFERRAL_DEPENDENCY = re.compile(
@@ -480,6 +492,8 @@ def source_states_explicit_computation(source_text: str) -> bool:
 def _has_substantive_arithmetic_expression(source_text: str) -> bool:
     """Ignore slash-separated year spans while recognizing actual arithmetic."""
 
+    if _WORDED_ARITHMETIC_EXPRESSION.search(source_text):
+        return True
     for match in _ARITHMETIC_EXPRESSION.finditer(source_text):
         expression = re.sub(r"\s+", "", match.group(0))
         if re.fullmatch(r"(?:19|20)\d{2}/(?:19|20)\d{2}", expression):
@@ -1941,23 +1955,62 @@ def _source_boundary_is_temporal(
 
     if not 1800 <= float(boundary.value) <= 2200:
         return False
-    relative_start = max(0, boundary.start)
-    relative_end = max(relative_start, boundary.end)
-    context = branch.text[
-        max(0, relative_start - 80) : min(len(branch.text), relative_end + 80)
-    ]
-    return re.search(
-        r"\b(?:"
-        r"veranlagungszeitraum|besteuerungszeitraum|kalenderjahr|steuerjahr|"
-        r"tax\s+year|calendar\s+year|effective|effective_from|"
-        r"zeitraum|jahr|january|february|march|april|may|june|july|"
-        r"august|september|october|november|december|"
+    relative_start, relative_end = _boundary_span_in_branch(branch, boundary)
+    before = branch.text[max(0, relative_start - 100) : relative_start]
+    after = branch.text[relative_end : min(len(branch.text), relative_end + 80)]
+    substantive_unit = (
+        r"(?:€|eur\b|euro\b|dollar\b|prozent\b|%\b|"
+        r"einkommen\b|betrag\b|grenze\b|income\b|amount\b|threshold\b)"
+    )
+    if re.search(rf"{substantive_unit}\s*$", before, flags=re.IGNORECASE):
+        return False
+    if re.match(rf"\s*{substantive_unit}", after, flags=re.IGNORECASE):
+        return False
+    period_cue = (
+        r"(?:veranlagungszeitraum|besteuerungszeitraum|kalenderjahr|"
+        r"steuerjahr|tax\s+year|calendar\s+year|effective(?:_from)?|"
+        r"january|february|march|april|may|june|july|august|september|"
+        r"october|november|december|"
         r"januar|februar|märz|april|mai|juni|juli|august|september|"
-        r"oktober|november|dezember"
-        r")\b",
-        context,
-        flags=re.IGNORECASE,
-    ) is not None
+        r"oktober|november|dezember)"
+    )
+    return bool(
+        re.search(
+            rf"\b{period_cue}\s*$",
+            before,
+            flags=re.IGNORECASE,
+        )
+        or re.match(
+            rf"\s*{period_cue}\b",
+            after,
+            flags=re.IGNORECASE,
+        )
+        or re.search(
+            r"\b(?:ab|seit|effective\s+from)\s*$",
+            before,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _boundary_span_in_branch(
+    branch: SourceStructureBranch,
+    boundary: NumericOccurrenceLike,
+) -> tuple[int, int]:
+    """Realign offsets after structural ordinals were removed for extraction."""
+
+    raw = str(getattr(boundary, "raw", "") or "").strip()
+    if raw:
+        candidates = tuple(re.finditer(re.escape(raw), branch.text))
+        if candidates:
+            closest = min(
+                candidates,
+                key=lambda match: abs(match.start() - boundary.start),
+            )
+            return closest.start(), closest.end()
+    start = max(0, min(len(branch.text), boundary.start))
+    end = max(start, min(len(branch.text), boundary.end))
+    return start, end
 
 
 def _rounding_clause_refers_to_previous_result(
@@ -4733,9 +4786,23 @@ def _formula_interval_from_text(
     extract_numeric_occurrences: NumericOccurrenceExtractor,
 ) -> _NumericInterval | None:
     lowered = text.lower()
+    clause = _strip_source_clause_marker(text).lower()
+    if re.match(
+        r"\s*ab\s+(?:(?:dem\s+)?\d{1,2}\.\s+)?(?:"
+        r"januar|februar|märz|april|mai|juni|juli|august|september|"
+        r"oktober|november|dezember|"
+        r"january|february|march|april|may|june|july|august|"
+        r"september|october|november|december"
+        r")\b",
+        clause,
+        flags=re.IGNORECASE,
+    ):
+        return None
     keyword = re.search(
-        r"\b(?:zwischen|between|von\s+mehr\s+als|"
-        r"von(?!\s+(?:höchstens|mindestens))|"
+        r"\b(?:zwischen|between|von\s+(?:mehr|weniger)\s+als|"
+        r"mehr\s+als|weniger\s+als|"
+        r"von(?!\s+(?:mehr\s+als|weniger\s+als|höchstens|mindestens|"
+        r"nicht\s+mehr\s+als|über|unter))|"
         r"from|unter|less\s+than|below|"
         r"bis|up\s+to|höchstens|nicht\s+mehr\s+als|"
         r"at\s+most|über|more\s+than|above|ab|at\s+least|mindestens)\b",
@@ -4757,6 +4824,17 @@ def _formula_interval_from_text(
     )
     if not occurrences:
         return None
+    first_gap = text[keyword.end() : occurrences[0].start]
+    if not re.fullmatch(
+        r"\s*(?:(?:zu|bis)\s+)?"
+        r"(?:(?:einem?|einer|dem|der|das)\s+)?"
+        r"(?:(?:zu\s+versteuernd\w*|maßgeblich\w*)\s+)?"
+        r"(?:(?:einkommen|betrag|wert|income|amount)\s+)?"
+        r"(?:(?:von|of)\s+)?",
+        first_gap,
+        flags=re.IGNORECASE,
+    ):
+        return None
     lowered_range = range_text.lower()
     if re.match(r"(?:zwischen|between)\b", lowered_range) and re.search(
         r"\b(?:und|and)\b",
@@ -4772,7 +4850,10 @@ def _formula_interval_from_text(
         if len(occurrences) < 2:
             return None
         return _NumericInterval(occurrences[0], True, occurrences[1], True)
-    if re.match(r"(?:unter|less\s+than|below)\b", lowered_range):
+    if re.match(
+        r"(?:unter|less\s+than|below|(?:von\s+)?weniger\s+als)\b",
+        lowered_range,
+    ):
         return _NumericInterval(None, False, occurrences[0], False)
     if re.match(
         r"(?:bis|up\s+to|höchstens|nicht\s+mehr\s+als|at\s+most)\b",
@@ -4780,7 +4861,7 @@ def _formula_interval_from_text(
     ):
         return _NumericInterval(None, False, occurrences[0], True)
     if re.match(
-        r"(?:über|more\s+than|above|von\s+mehr\s+als)\b",
+        r"(?:(?:von\s+)?mehr\s+als|über|more\s+than|above)\b",
         lowered_range,
     ):
         return _NumericInterval(occurrences[0], False, None, False)
@@ -5004,9 +5085,13 @@ def _source_exception_or_applicability_matches(
 ) -> tuple[re.Match[str], ...]:
     """Return ordered, de-duplicated negative and positive condition cues."""
 
-    matches = (
+    matches = tuple(
+        match
+        for match in (
         *_EXCEPTION_LANGUAGE.finditer(source_text),
         *_APPLICABILITY_LANGUAGE.finditer(source_text),
+        )
+        if not _is_concessive_condition_cue(source_text, match)
     )
     return tuple(
         {
@@ -5014,6 +5099,22 @@ def _source_exception_or_applicability_matches(
             for match in sorted(matches, key=lambda item: (item.start(), item.end()))
         }.values()
     )
+
+
+def _is_concessive_condition_cue(
+    source_text: str,
+    match: re.Match[str],
+) -> bool:
+    """Exclude ``auch wenn`` / ``even if`` clauses that preserve the rule."""
+
+    if match.group(0).strip().lower() not in {"wenn", "if"}:
+        return False
+    prefix = source_text[max(0, match.start() - 16) : match.start()]
+    return re.search(
+        r"\b(?:auch|selbst|even)\s+$",
+        prefix,
+        flags=re.IGNORECASE,
+    ) is not None
 
 
 def _exception_cues_have_distinct_conditions(between: str) -> bool:
@@ -5205,7 +5306,9 @@ def _source_exception_condition_text(text: str) -> str:
         return clause
     suffix = clause[marker.start() :]
     condition_cue = re.search(
-        r"\b(?:wenn|falls|sofern|when|if|bei|ohne|mangels)\b",
+        r"\b(?:vorausgesetzt\s*,?\s+dass|"
+        r"unter\s+der\s+voraussetzung\s*,?\s+dass|"
+        r"wenn|falls|sofern|soweit|when|if|bei|ohne|mangels)\b",
         suffix,
         flags=re.IGNORECASE,
     )
@@ -5214,7 +5317,9 @@ def _source_exception_condition_text(text: str) -> str:
     prefix = clause[: marker.start()]
     preposed = re.match(
         r"\s*(?P<condition>(?:"
-        r"(?:wenn|falls|sofern|when|if)\b[^,;]*|"
+        r"(?:vorausgesetzt\s*,?\s+dass|"
+        r"unter\s+der\s+voraussetzung\s*,?\s+dass|"
+        r"wenn|falls|sofern|soweit|when|if)\b[^,;]*|"
         r"(?:bei|ohne|mangels)\b[^,;]*|"
         r"im\s+falle\b[^,;]*"
         r"))\s*,?\s*$",
@@ -6612,7 +6717,8 @@ def _source_boundary_obligations(
         for fragment_start, fragment in _source_boundary_fragments(direct_text):
             range_fragment = fragment.split(":", 1)[0]
             if not re.search(
-                r"\b(?:zwischen|between|bis|von|ab|unter|über|from|to|"
+                r"\b(?:zwischen|between|bis|von|ab|unter|über|"
+                r"mehr\s+als|weniger\s+als|from|to|"
                 r"through|less\s+than|more\s+than|at\s+least|up\s+to|"
                 r"at\s+most|above|below|höchstens|mindestens|"
                 r"nicht\s+mehr\s+als)\b",

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1316,8 +1316,54 @@ def _source_scope_identifies_blocker(
             flags=re.IGNORECASE,
         ):
             continue
-        return True
+        if _source_clause_links_dependency(
+            clause,
+            reference_start=reference.start() - clause_start,
+            reference_end=reference.end() - clause_start,
+        ):
+            return True
     return False
+
+
+def _source_clause_links_dependency(
+    clause: str,
+    *,
+    reference_start: int,
+    reference_end: int,
+) -> bool:
+    """Require syntax that makes the cited provision operative or required."""
+
+    before = clause[:reference_start]
+    after = clause[reference_end:]
+    if re.search(
+        r"\b(?:"
+        r"nach|gemäß|laut|entsprechend|under|according\s+to|pursuant\s+to|"
+        r"abhängig\s+von|depends?\s+on|setzt|requires?|benötigt"
+        r")\s*$",
+        before,
+        flags=re.IGNORECASE,
+    ):
+        return True
+    if re.search(
+        r"\b(?:voraussetzung\w*|bedingung\w*|conditions?)"
+        r"[^.;]{0,100}\b(?:des|der|nach|under)\s*$",
+        before,
+        flags=re.IGNORECASE,
+    ):
+        return True
+    if re.match(
+        r"\s*(?:ist|sind|wird|werden|is|are)?\s*"
+        r"(?:erforderlich|maßgeblich|vorausgesetzt|benötigt|required|needed)\b",
+        after,
+        flags=re.IGNORECASE,
+    ):
+        return True
+    return re.search(
+        r"\b(?:voraussetzung\w*|bedingung\w*|conditions?)"
+        r"[^.;]{0,160}\b(?:vorliegen|erfüllt|bestehen|apply|hold)\b",
+        clause,
+        flags=re.IGNORECASE,
+    ) is not None
 
 
 def _citation_instrument_identity(
@@ -1391,12 +1437,14 @@ def _reason_dependency_is_source_bound(
         section_match = re.search(r"\d+[a-z]?", dependency, flags=re.IGNORECASE)
         corpus_target = _rulespec_target_base(corpus_citation_path)
         corpus_instrument_target = corpus_target.rsplit("/", 1)[0]
-        if section_match and _source_scope_identifies_blocker(
-            source_scope_text,
-            f"{corpus_instrument_target}/{section_match.group(0)}#dependency",
-            corpus_citation_path=corpus_citation_path,
-        ):
-            return True
+        if section_match:
+            if _source_scope_identifies_blocker(
+                source_scope_text,
+                f"{corpus_instrument_target}/{section_match.group(0)}#dependency",
+                corpus_citation_path=corpus_citation_path,
+            ):
+                return True
+            continue
         normalized_dependency = re.sub(
             r"[^a-z0-9äöüß]+",
             " ",
@@ -5004,10 +5052,12 @@ def _formula_interval_from_text(
     first_gap = text[keyword.end() : occurrences[0].start]
     if not re.fullmatch(
         r"\s*(?:(?:zu|bis)\s+)?"
+        r"(?:(?:einschließlich|maximal|inklusive|including|maximum)\s+)?"
         r"(?:(?:einem?|einer|dem|der|das)\s+)?"
         r"(?:(?:zu\s+versteuernd\w*|maßgeblich\w*)\s+)?"
         r"(?:(?:einkommen|betrag|wert|income|amount)\s+)?"
-        r"(?:(?:von|of)\s+)?",
+        r"(?:(?:von|of)\s+)?"
+        r"(?:(?:einschließlich|maximal|inklusive|including|maximum)\s+)?",
         first_gap,
         flags=re.IGNORECASE,
     ):

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -199,6 +199,17 @@ _ARITHMETIC_EXPRESSION = re.compile(
     r"[ \t]*(?:[+*/=×·•∗∙]|(?<!\w)[−–-](?!\w))[ \t]*"
     r"(?:\d+(?:[.,]\d+)?|[A-Za-zÄÖÜäöüß][A-Za-zÄÖÜäöüß]*)"
 )
+_SYMBOLIC_ARITHMETIC_OPERAND = (
+    r"(?:"
+    r"[A-Za-zÄÖÜäöüß_][A-Za-z0-9ÄÖÜäöüß_]*|"
+    r"\d{1,3}(?:[ .]\d{3})+(?:,\d+)?|"
+    r"\d+(?:[.,]\d+)?"
+    r")"
+)
+_EXPLICIT_SYMBOLIC_ARITHMETIC_CHAIN = re.compile(
+    rf"(?P<expression>{_SYMBOLIC_ARITHMETIC_OPERAND}"
+    rf"(?:\s*[+*/×·•∗∙−–-]\s*{_SYMBOLIC_ARITHMETIC_OPERAND}){{2,}})"
+)
 _COMPUTATION_LANGUAGE = re.compile(
     r"\b(?:"
     r"bemisst\s+sich\s+nach|berechn(?:et|en|ung)|ergibt\s+sich|"
@@ -2209,6 +2220,12 @@ def _formula_execution_matches_source_branch(
         execution.leaf,
         environment=binding_environment,
     )
+    source_topology = _explicit_source_arithmetic_topology(branch.text)
+    if source_topology is not None and source_topology != _formula_arithmetic_topology(
+        operative_leaf,
+        environment=binding_environment,
+    ):
+        return False
     artifact_operations = _formula_ast_operation_kinds(operative_leaf)
     if not _formula_operations_are_compatible(
         source_operations,
@@ -2375,6 +2392,84 @@ def _formula_operation_kinds(text: str) -> set[str]:
         if re.search(pattern, lowered_text, flags=re.IGNORECASE)
     )
     return operations
+
+
+def _explicit_source_arithmetic_topology(text: str) -> Any | None:
+    """Parse a complete, unparenthesized symbolic source arithmetic chain."""
+
+    for match in _EXPLICIT_SYMBOLIC_ARITHMETIC_CHAIN.finditer(text):
+        prefix = text[: match.start()].rstrip()
+        suffix = text[match.end() :].lstrip()
+        if prefix.endswith("(") or suffix.startswith(")"):
+            continue
+        expression_text = match.group("expression")
+        expression_text = re.sub(
+            r"\d{1,3}(?:[ .]\d{3})+(?:,\d+)?|\d+,\d+",
+            lambda number: number.group(0).replace(" ", "").replace(".", "").replace(
+                ",",
+                ".",
+            ),
+            expression_text,
+        )
+        expression_text = expression_text.translate(
+            str.maketrans(
+                {
+                    "×": "*",
+                    "·": "*",
+                    "•": "*",
+                    "∗": "*",
+                    "∙": "*",
+                    "−": "-",
+                    "–": "-",
+                }
+            )
+        )
+        with contextlib.suppress(SyntaxError):
+            expression = ast.parse(expression_text, mode="eval").body
+            if sum(isinstance(node, ast.BinOp) for node in ast.walk(expression)) >= 2:
+                return _formula_arithmetic_topology(expression_text, environment={})
+    return None
+
+
+def _formula_arithmetic_topology(
+    formula: str,
+    *,
+    environment: dict[str, Any],
+) -> Any | None:
+    """Canonicalize arithmetic shape with bound scalars and abstract variables."""
+
+    with contextlib.suppress(SyntaxError):
+        expression = ast.parse(formula.strip(), mode="eval").body
+        expression = _unwrap_formula_result_wrapper(expression)
+        return _formula_arithmetic_topology_node(expression, environment)
+    return None
+
+
+def _formula_arithmetic_topology_node(
+    node: ast.expr,
+    environment: dict[str, Any],
+) -> Any:
+    known = _known_numeric_formula_value(node, environment)
+    if known is not None:
+        return "constant", float(known)
+    if isinstance(node, ast.Name):
+        return ("variable",)
+    if isinstance(node, ast.BinOp):
+        operator = type(node.op).__name__
+        operands = (
+            _formula_arithmetic_topology_node(node.left, environment),
+            _formula_arithmetic_topology_node(node.right, environment),
+        )
+        if isinstance(node.op, (ast.Add, ast.Mult)):
+            operands = tuple(sorted(operands, key=repr))
+        return "binop", operator, operands
+    if isinstance(node, ast.UnaryOp):
+        return (
+            "unary",
+            type(node.op).__name__,
+            _formula_arithmetic_topology_node(node.operand, environment),
+        )
+    return ("unsupported", type(node).__name__)
 
 
 def _formula_ast_operation_kinds(text: str) -> set[str]:

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -90,6 +90,14 @@ class _FormulaExecution:
     leaf: str
     evaluated_value: tuple[str, str] | None
     evaluates_to_zero: bool
+    constant_environment: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class _TemporalFormulaValue:
+    """Literal parameter values selectable by a companion case period."""
+
+    versions: tuple[tuple[str, str, Any], ...]
 
 
 @dataclass(frozen=True)
@@ -1822,7 +1830,7 @@ def _formula_branch_test_witnesses(
                     "leaf:"
                     + _formula_leaf_semantic_key(
                         execution.leaf,
-                        formula_environment=formula_environment,
+                        formula_environment=execution.constant_environment,
                     )
                     if has_branching_formula
                     else f"case:{id(case)}"
@@ -1859,9 +1867,15 @@ def _formula_execution_matches_source_branch(
     """Bind a reached leaf to numeric evidence in its exact source formula."""
 
     source_operations = _formula_operation_kinds(branch.text)
+    binding_environment = {
+        name: value
+        for name, value in formula_environment.items()
+        if not isinstance(value, _TemporalFormulaValue)
+    }
+    binding_environment.update(execution.constant_environment)
     operative_leaf = _simplified_formula_text(
         execution.leaf,
-        environment=formula_environment,
+        environment=binding_environment,
     )
     artifact_operations = _formula_ast_operation_kinds(operative_leaf)
     if not _formula_operations_are_compatible(
@@ -1869,8 +1883,36 @@ def _formula_execution_matches_source_branch(
         artifact_operations,
         source_text=branch.text,
         artifact_formula=operative_leaf,
+        artifact_environment=binding_environment,
     ):
         return False
+    source_multiplier = _source_named_multiplier(branch.text)
+    if source_multiplier is not None and not (
+        _formula_has_numeric_factor(
+            operative_leaf,
+            binding_environment,
+            source_multiplier,
+        )
+        or (
+            math.isclose(source_multiplier, 2.0)
+            and _formula_is_duplicate_addition(operative_leaf)
+        )
+    ):
+        return False
+    if _source_describes_half(branch.text):
+        if not (
+            _formula_has_numeric_factor(
+                operative_leaf,
+                binding_environment,
+                0.5,
+            )
+            or _formula_has_numeric_divisor(
+                operative_leaf,
+                binding_environment,
+                2.0,
+            )
+        ):
+            return False
     source_occurrences = tuple(
         extract_numeric_occurrences(
             authoritative_numeric_recall_text(branch.text)
@@ -1899,7 +1941,7 @@ def _formula_execution_matches_source_branch(
     leaf_names = set(_FORMULA_IDENTIFIER.findall(operative_leaf))
     candidate_values = [
         float(value)
-        for name, value in formula_environment.items()
+        for name, value in binding_environment.items()
         if name in leaf_names
         and isinstance(value, (int, float))
         and not isinstance(value, bool)
@@ -1992,13 +2034,23 @@ def _formula_operations_are_compatible(
     *,
     source_text: str,
     artifact_formula: str,
+    artifact_environment: dict[str, Any],
 ) -> bool:
     if not source_operations:
         return True
     for operation in source_operations:
         if operation in artifact_operations:
             continue
-        if operation == "divide" and "multiply" in artifact_operations:
+        if (
+            operation == "divide"
+            and "multiply" in artifact_operations
+            and _source_describes_half(source_text)
+            and _formula_has_numeric_factor(
+                artifact_formula,
+                artifact_environment,
+                0.5,
+            )
+        ):
             continue
         if (
             operation == "multiply"
@@ -2012,13 +2064,79 @@ def _formula_operations_are_compatible(
 
 
 def _source_describes_doubling(text: str) -> bool:
+    multiplier = _source_named_multiplier(text)
+    return multiplier is not None and math.isclose(multiplier, 2.0)
+
+
+def _source_named_multiplier(text: str) -> float | None:
+    patterns = (
+        (2.0, r"\b(?:doppelte|zweifache|verdoppelt|twice|double[ds]?)\b"),
+        (3.0, r"\b(?:dreifache|verdreifacht|threefold|triple[ds]?)\b"),
+        (4.0, r"\b(?:vierfache|vervierfacht|fourfold|quadruple[ds]?)\b"),
+        (5.0, r"\b(?:fünffache|fivefold)\b"),
+        (6.0, r"\b(?:sechsfache|sixfold)\b"),
+        (7.0, r"\b(?:siebenfache|sevenfold)\b"),
+        (8.0, r"\b(?:achtfache|eightfold)\b"),
+        (9.0, r"\b(?:neunfache|ninefold)\b"),
+        (10.0, r"\b(?:zehnfache|tenfold)\b"),
+    )
+    return next(
+        (
+            multiplier
+            for multiplier, pattern in patterns
+            if re.search(pattern, text, flags=re.IGNORECASE)
+        ),
+        None,
+    )
+
+
+def _source_describes_half(text: str) -> bool:
     return bool(
         re.search(
-            r"\b(?:doppelte|zweifache|verdoppelt|twice|double[ds]?)\b",
+            r"\b(?:hälfte|halb(?:e[nsrm]?)?|half)\b",
             text,
             flags=re.IGNORECASE,
         )
     )
+
+
+def _formula_has_numeric_factor(
+    text: str,
+    environment: dict[str, Any],
+    expected: float,
+) -> bool:
+    with contextlib.suppress(SyntaxError):
+        expression = ast.parse(text.strip(), mode="eval").body
+        for node in ast.walk(expression):
+            if not isinstance(node, ast.BinOp) or not isinstance(
+                node.op,
+                ast.Mult,
+            ):
+                continue
+            for operand in (node.left, node.right):
+                value = _known_numeric_formula_value(operand, environment)
+                if value is not None and math.isclose(float(value), expected):
+                    return True
+    return False
+
+
+def _formula_has_numeric_divisor(
+    text: str,
+    environment: dict[str, Any],
+    expected: float,
+) -> bool:
+    with contextlib.suppress(SyntaxError):
+        expression = ast.parse(text.strip(), mode="eval").body
+        for node in ast.walk(expression):
+            if not isinstance(node, ast.BinOp) or not isinstance(
+                node.op,
+                ast.Div,
+            ):
+                continue
+            value = _known_numeric_formula_value(node.right, environment)
+            if value is not None and math.isclose(float(value), expected):
+                return True
+    return False
 
 
 def _formula_is_duplicate_addition(text: str) -> bool:
@@ -2094,8 +2212,14 @@ def _simplify_formula_expression(
                 return left
         elif isinstance(expression.op, ast.Sub) and right_value == 0:
             return left
-        elif isinstance(expression.op, ast.Div) and right_value == 1:
-            return left
+        elif isinstance(expression.op, ast.Div):
+            if right_value == 1:
+                return left
+            if left_value == 0 and _formula_node_is_provably_nonzero(
+                right,
+                environment,
+            ):
+                return ast.Constant(value=0)
         return ast.BinOp(left=left, op=expression.op, right=right)
     if isinstance(expression, ast.UnaryOp):
         return ast.UnaryOp(
@@ -2154,6 +2278,27 @@ def _known_numeric_formula_value(
     if isinstance(value, (int, float)) and not isinstance(value, bool):
         return value
     return None
+
+
+def _formula_node_is_provably_nonzero(
+    expression: ast.expr,
+    environment: dict[str, Any],
+) -> bool:
+    value = _known_numeric_formula_value(expression, environment)
+    if value is not None:
+        return value != 0
+    if (
+        isinstance(expression, ast.Call)
+        and isinstance(expression.func, ast.Name)
+        and expression.func.id == "max"
+    ):
+        return any(
+            (known := _known_numeric_formula_value(argument, environment))
+            is not None
+            and known > 0
+            for argument in expression.args
+        )
+    return False
 
 
 def _canonical_formula_node(node: ast.AST) -> Any:
@@ -2251,7 +2396,11 @@ def _case_formula_execution(
     inputs = case.get("input")
     if not isinstance(inputs, dict):
         return None
-    environment: dict[str, Any] = dict(formula_environment or {})
+    constant_environment = _formula_environment_for_case(
+        formula_environment or {},
+        case,
+    )
+    environment: dict[str, Any] = dict(constant_environment)
     input_environment: dict[str, Any] = {}
     for key, value in inputs.items():
         boolean_value = _boolean_value(value)
@@ -2272,6 +2421,7 @@ def _case_formula_execution(
     return _execute_formula_text(
         formula_text,
         environment=environment,
+        constant_environment=constant_environment,
     )
 
 
@@ -2279,6 +2429,7 @@ def _execute_formula_text(
     formula_text: str,
     *,
     environment: dict[str, Any],
+    constant_environment: dict[str, Any],
 ) -> _FormulaExecution | None:
     """Interpret formula control flow without evaluating the formula itself."""
 
@@ -2314,6 +2465,7 @@ def _execute_formula_text(
                 leaf,
                 value_signature,
                 evaluates_to_zero,
+                constant_environment,
             )
         selected = _select_formula_branch(node, environment=environment)
         if selected is None:
@@ -2931,7 +3083,7 @@ def _match_arm_value(
     with contextlib.suppress(SyntaxError, ValueError):
         return ast.literal_eval(value)
     if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", value):
-        return environment.get(value, _UNRESOLVED_CONDITION_VALUE)
+        return environment.get(value, value)
     return _UNRESOLVED_CONDITION_VALUE
 
 
@@ -3120,7 +3272,8 @@ def _branch_boundary_has_test_evidence(
                     and _formula_execution_binds_boundary(
                         execution,
                         boundary,
-                        formula_environment=formula_environment or {},
+                        input_names=input_names,
+                        formula_environment=execution.constant_environment,
                         extract_numeric_occurrences=(
                             extract_numeric_occurrences
                         ),
@@ -3128,7 +3281,15 @@ def _branch_boundary_has_test_evidence(
                             numeric_value_is_grounded
                         ),
                     )
-                    for input_names, value in (
+                    and _boundary_case_changes_formula_effect(
+                        rule,
+                        case,
+                        input_key=input_key,
+                        boundary_value=value,
+                        execution=execution,
+                        formula_environment=formula_environment or {},
+                    )
+                    for input_key, input_names, value in (
                         _case_numeric_selector_evidence(
                             case,
                             selector_names,
@@ -3144,6 +3305,7 @@ def _formula_execution_binds_boundary(
     execution: _FormulaExecution,
     boundary: NumericOccurrenceLike,
     *,
+    input_names: set[str],
     formula_environment: dict[str, Any],
     extract_numeric_occurrences: NumericOccurrenceExtractor | None,
     numeric_value_is_grounded: NumericGroundingPredicate,
@@ -3158,17 +3320,152 @@ def _formula_execution_binds_boundary(
             or _is_adjacent_integral_boundary(float(value), boundary)
         )
     }
-    if boundary_names and _formula_execution_references_names(
-        execution,
-        boundary_names,
-    ):
+    if input_names & boundary_names:
+        return False
+    texts = [
+        selector
+        for step in execution.trace
+        for selector in step.selectors
+    ]
+    texts.append(execution.leaf)
+    return any(
+        _formula_text_has_boundary_comparison(
+            text,
+            input_names=input_names,
+            boundary_names=boundary_names,
+            boundary=boundary,
+            extract_numeric_occurrences=extract_numeric_occurrences,
+            numeric_value_is_grounded=numeric_value_is_grounded,
+        )
+        for text in texts
+    )
+
+
+def _formula_text_has_boundary_comparison(
+    text: str,
+    *,
+    input_names: set[str],
+    boundary_names: set[str],
+    boundary: NumericOccurrenceLike,
+    extract_numeric_occurrences: NumericOccurrenceExtractor | None,
+    numeric_value_is_grounded: NumericGroundingPredicate,
+) -> bool:
+    with contextlib.suppress(SyntaxError):
+        expression = ast.parse(text.strip(), mode="eval").body
+        for comparison in (
+            node for node in ast.walk(expression) if isinstance(node, ast.Compare)
+        ):
+            operands = (comparison.left, *comparison.comparators)
+            for left, right in zip(operands, operands[1:]):
+                if (
+                    _formula_node_references_names(left, input_names)
+                    and _formula_node_binds_boundary(
+                        right,
+                        boundary_names=boundary_names,
+                        boundary=boundary,
+                        extract_numeric_occurrences=extract_numeric_occurrences,
+                        numeric_value_is_grounded=numeric_value_is_grounded,
+                    )
+                ) or (
+                    _formula_node_references_names(right, input_names)
+                    and _formula_node_binds_boundary(
+                        left,
+                        boundary_names=boundary_names,
+                        boundary=boundary,
+                        extract_numeric_occurrences=extract_numeric_occurrences,
+                        numeric_value_is_grounded=numeric_value_is_grounded,
+                    )
+                ):
+                    return True
+    return False
+
+
+def _formula_node_references_names(
+    node: ast.AST,
+    names: set[str],
+) -> bool:
+    return bool(
+        {
+            candidate.id
+            for candidate in ast.walk(node)
+            if isinstance(candidate, ast.Name)
+        }
+        & names
+    )
+
+
+def _formula_node_binds_boundary(
+    node: ast.AST,
+    *,
+    boundary_names: set[str],
+    boundary: NumericOccurrenceLike,
+    extract_numeric_occurrences: NumericOccurrenceExtractor | None,
+    numeric_value_is_grounded: NumericGroundingPredicate,
+) -> bool:
+    if _formula_node_references_names(node, boundary_names):
         return True
-    if extract_numeric_occurrences is not None and any(
+    if isinstance(node, ast.Constant) and isinstance(
+        node.value,
+        (int, float),
+    ) and not isinstance(node.value, bool):
+        value = float(node.value)
+        return numeric_value_is_grounded(
+            value,
+            (boundary,),
+        ) or _is_adjacent_integral_boundary(value, boundary)
+    if extract_numeric_occurrences is None:
+        return False
+    text = ast.unparse(node)
+    return any(
         numeric_value_is_grounded(float(occurrence.value), (boundary,))
-        for occurrence in extract_numeric_occurrences(execution.leaf)
+        or _is_adjacent_integral_boundary(float(occurrence.value), boundary)
+        for occurrence in extract_numeric_occurrences(text)
+    )
+
+
+def _boundary_case_changes_formula_effect(
+    rule: dict[str, Any],
+    case: dict[str, Any],
+    *,
+    input_key: object,
+    boundary_value: float,
+    execution: _FormulaExecution,
+    formula_environment: dict[str, Any],
+) -> bool:
+    inputs = case.get("input")
+    if (
+        not isinstance(inputs, dict)
+        or input_key not in inputs
+        or isinstance(inputs[input_key], bool)
+        or not isinstance(inputs[input_key], (int, float))
     ):
-        return True
-    return not boundary_names
+        return False
+    step = (
+        1.0
+        if float(boundary_value).is_integer()
+        else max(abs(boundary_value) * 1e-6, 1e-9)
+    )
+    signature = _formula_execution_effect_signature(execution)
+    for candidate_value in (
+        boundary_value - step,
+        boundary_value + step,
+    ):
+        candidate_inputs = dict(inputs)
+        candidate_inputs[input_key] = candidate_value
+        candidate_case = dict(case)
+        candidate_case["input"] = candidate_inputs
+        candidate_execution = _case_formula_execution(
+            rule,
+            candidate_case,
+            formula_environment=formula_environment,
+        )
+        if (
+            candidate_execution is not None
+            and _formula_execution_effect_signature(candidate_execution)
+            != signature
+        ):
+            return True
+    return False
 
 
 def _is_adjacent_integral_boundary(
@@ -3327,7 +3624,7 @@ def _case_numeric_selector_values(
 ) -> tuple[float, ...]:
     return tuple(
         value
-        for _names, value in _case_numeric_selector_evidence(
+        for _key, _names, value in _case_numeric_selector_evidence(
             case,
             selector_names,
         )
@@ -3337,17 +3634,17 @@ def _case_numeric_selector_values(
 def _case_numeric_selector_evidence(
     case: dict[str, Any],
     selector_names: set[str],
-) -> tuple[tuple[set[str], float], ...]:
+) -> tuple[tuple[object, set[str], float], ...]:
     inputs = case.get("input")
     if not isinstance(inputs, dict):
         return ()
-    evidence: list[tuple[set[str], float]] = []
+    evidence: list[tuple[object, set[str], float]] = []
     for key, value in inputs.items():
         matched_names = _input_key_names(key) & selector_names
         if not matched_names:
             continue
         evidence.extend(
-            (matched_names, numeric_value)
+            (key, matched_names, numeric_value)
             for numeric_value in _numeric_test_input_values(value)
         )
     return tuple(evidence)
@@ -3525,9 +3822,26 @@ def _toggled_formula_boolean_selectors(
             )
             if left_execution is None or right_execution is None:
                 continue
-            if _formula_execution_effect_signature(
-                left_execution
-            ) == _formula_execution_effect_signature(right_execution):
+            left_asserted = _test_case_asserted_output_value(
+                left_case,
+                rule_name,
+            )
+            right_asserted = _test_case_asserted_output_value(
+                right_case,
+                rule_name,
+            )
+            if (
+                left_asserted is not _UNRESOLVED_CONDITION_VALUE
+                and right_asserted is not _UNRESOLVED_CONDITION_VALUE
+                and _same_formula_value(left_asserted, right_asserted)
+            ) or (
+                (
+                    left_asserted is _UNRESOLVED_CONDITION_VALUE
+                    or right_asserted is _UNRESOLVED_CONDITION_VALUE
+                )
+                and _formula_execution_effect_signature(left_execution)
+                == _formula_execution_effect_signature(right_execution)
+            ):
                 continue
             for selector_name in matched_names:
                 if all(
@@ -3543,11 +3857,27 @@ def _toggled_formula_boolean_selectors(
 
 def _formula_execution_effect_signature(
     execution: _FormulaExecution,
-) -> tuple[str, tuple[str, str] | None]:
-    return (
-        _collapse_text(execution.leaf).lower(),
-        execution.evaluated_value,
-    )
+) -> tuple[str, Any]:
+    if execution.evaluated_value is not None:
+        return "evaluated", execution.evaluated_value
+    return "leaf", _collapse_text(execution.leaf).lower()
+
+
+def _test_case_asserted_output_value(
+    case: dict[str, Any],
+    rule_name: str,
+) -> Any:
+    outputs = case.get("output")
+    if not isinstance(outputs, dict):
+        return _UNRESOLVED_CONDITION_VALUE
+    values = [
+        value
+        for key, value in outputs.items()
+        if str(key).rsplit("#", 1)[-1] == rule_name
+    ]
+    if len(values) != 1:
+        return _UNRESOLVED_CONDITION_VALUE
+    return values[0]
 
 
 def _formula_execution_reaches_selector(
@@ -3827,7 +4157,8 @@ def _source_boundary_obligations(
             if not re.search(
                 r"\b(?:zwischen|between|bis|von|ab|unter|über|from|to|"
                 r"through|less\s+than|more\s+than|at\s+least|up\s+to|"
-                r"above|below|nicht\s+mehr\s+als)\b",
+                r"at\s+most|above|below|höchstens|mindestens|"
+                r"nicht\s+mehr\s+als)\b",
                 range_fragment,
                 flags=re.IGNORECASE,
             ):
@@ -3969,9 +4300,7 @@ def _rule_formula_text_for_case(
     unambiguous = _unambiguous_rule_formula_text(rule)
     if unambiguous is not None:
         return unambiguous
-    period = str(case.get("period") or "").strip()
-    if re.fullmatch(r"\d{4}", period):
-        period = f"{period}-01-01"
+    period = _normalized_case_period(case)
     if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", period):
         return None
     versions = rule.get("versions")
@@ -4000,7 +4329,7 @@ def _rule_formula_text_for_case(
 
 
 def _constant_rule_environment(payload: dict[str, Any]) -> dict[str, Any]:
-    """Return unambiguous literal rule values usable by condition evaluation."""
+    """Return literal rule values, retaining resolvable temporal variants."""
 
     environment: dict[str, Any] = {}
     rules = payload.get("rules")
@@ -4013,7 +4342,7 @@ def _constant_rule_environment(payload: dict[str, Any]) -> dict[str, Any]:
         versions = rule.get("versions")
         if not name or not isinstance(versions, list):
             continue
-        values: list[Any] = []
+        entries: list[tuple[str, str, Any]] = []
         for version in versions:
             if not isinstance(version, dict) or "formula" not in version:
                 continue
@@ -4024,13 +4353,69 @@ def _constant_rule_environment(payload: dict[str, Any]) -> dict[str, Any]:
                     value,
                     complex,
                 ):
-                    values.append(value)
+                    entries.append(
+                        (
+                            str(version.get("effective_from") or "").strip(),
+                            str(version.get("effective_to") or "").strip(),
+                            value,
+                        )
+                    )
+        values = [value for _start, _end, value in entries]
         if values and all(
             type(value) is type(values[0]) and value == values[0]
             for value in values[1:]
         ):
             environment[name] = values[0]
+        elif entries and all(
+            re.fullmatch(r"\d{4}-\d{2}-\d{2}", start)
+            and (not end or re.fullmatch(r"\d{4}-\d{2}-\d{2}", end))
+            for start, end, _value in entries
+        ):
+            environment[name] = _TemporalFormulaValue(tuple(entries))
     return environment
+
+
+def _formula_environment_for_case(
+    environment: dict[str, Any],
+    case: dict[str, Any],
+) -> dict[str, Any]:
+    period = _normalized_case_period(case)
+    resolved: dict[str, Any] = {}
+    for name, value in environment.items():
+        if not isinstance(value, _TemporalFormulaValue):
+            resolved[name] = value
+            continue
+        if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", period):
+            continue
+        candidates = [
+            (start, candidate)
+            for start, end, candidate in value.versions
+            if start <= period and (not end or period <= end)
+        ]
+        if not candidates:
+            continue
+        latest = max(start for start, _candidate in candidates)
+        latest_values = [
+            candidate
+            for start, candidate in candidates
+            if start == latest
+        ]
+        if latest_values and all(
+            type(candidate) is type(latest_values[0])
+            and candidate == latest_values[0]
+            for candidate in latest_values[1:]
+        ):
+            resolved[name] = latest_values[0]
+    return resolved
+
+
+def _normalized_case_period(case: dict[str, Any]) -> str:
+    period = str(case.get("period") or "").strip()
+    if re.fullmatch(r"\d{4}", period):
+        return f"{period}-01-01"
+    if re.fullmatch(r"\d{4}-\d{2}", period):
+        return f"{period}-01"
+    return period
 
 
 def _collapse_text(value: str) -> str:

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -88,6 +88,8 @@ class _FormulaExecution:
 
     trace: tuple[_FormulaTraceStep, ...]
     leaf: str
+    evaluated_value: tuple[str, str] | None
+    evaluates_to_zero: bool
 
 
 @dataclass(frozen=True)
@@ -149,6 +151,11 @@ _COMPUTATION_LANGUAGE = re.compile(
     r"unterschied|differenz|"
     r"geteilt\s+durch|durch\s+(?:\d+|[a-zäöüß]+)\s+geteilt|"
     r"multipliziert\s+mit|"
+    r"mit\s+(?:(?:dem|einem)\s+faktor\s+)?"
+    r"(?:\d+(?:[.,]\d+)?|[a-zäöüß]+)\s+zu\s+"
+    r"(?:multiplizieren|vervielfachen)|"
+    r"unter\s+anwendung\s+(?:des|eines)\s+faktors?\s+"
+    r"(?:\d+(?:[.,]\d+)?|[a-zäöüß]+)\s+zu\s+ermitteln|"
     r"\bmal\s+(?:\d+(?:[.,]\d+)?|"
     r"ein(?:s|e[nsrm]?)?|zwei|drei|vier|fünf|sechs|sieben|acht|neun|zehn)|"
     r"(?:wird|werden)\s+(?:verdoppelt|verdreifacht|vervierfacht)|"
@@ -990,11 +997,19 @@ def _deferred_coverage(
                 exact_blockers
                 and bool(_MISSING_DEPENDENCY_LANGUAGE.search(reason))
                 and all(
-                    _reason_identifies_blocker(reason, blocker)
+                    _reason_identifies_blocker(
+                        reason,
+                        blocker,
+                        corpus_citation_path=corpus_citation_path,
+                    )
                     for blocker in blocker_targets
                 )
                 and all(
-                    _reason_identifies_blocker(source_scope_text, blocker)
+                    _reason_identifies_blocker(
+                        source_scope_text,
+                        blocker,
+                        corpus_citation_path=corpus_citation_path,
+                    )
                     for blocker in blocker_targets
                 )
             )
@@ -1030,11 +1045,37 @@ def _deferred_source_scope_text(
     return max(candidates, key=len, default="")
 
 
-def _reason_identifies_blocker(reason: str, blocker: str) -> bool:
+def _reason_identifies_blocker(
+    reason: str,
+    blocker: str,
+    *,
+    corpus_citation_path: str | None = None,
+) -> bool:
     """Bind a typed blocker to the legal section or concept named in prose."""
 
     target_path, _separator, symbol = blocker.partition("#")
     section = target_path.rstrip("/").rsplit("/", 1)[-1]
+    target_instrument = _citation_instrument_identity(target_path)
+    corpus_instrument = (
+        _citation_instrument_identity(corpus_citation_path)
+        if corpus_citation_path
+        else None
+    )
+    normalized_reason = re.sub(
+        r"[^a-z0-9äöüß]+",
+        " ",
+        reason.lower(),
+    ).strip()
+    if (
+        target_instrument is not None
+        and corpus_instrument is not None
+        and target_instrument != corpus_instrument
+        and not _reason_names_target_instrument(
+            normalized_reason,
+            target_instrument,
+        )
+    ):
+        return False
     explicit_sections = {
         match.group("section").lower()
         for match in _EXPLICIT_LEGAL_SECTION_REFERENCE.finditer(reason)
@@ -1048,12 +1089,42 @@ def _reason_identifies_blocker(reason: str, blocker: str) -> bool:
         flags=re.IGNORECASE,
     ):
         return True
-    normalized_reason = re.sub(r"[^a-z0-9äöüß]+", " ", reason.lower()).strip()
     normalized_symbol = re.sub(r"[^a-z0-9äöüß]+", " ", symbol.lower()).strip()
     return bool(
         normalized_symbol
         and re.search(
             rf"(?<![a-z0-9äöüß]){re.escape(normalized_symbol)}"
+            r"(?![a-z0-9äöüß])",
+            normalized_reason,
+        )
+    )
+
+
+def _citation_instrument_identity(
+    citation: str,
+) -> tuple[str, str, str] | None:
+    normalized = citation.split("#", 1)[0].replace(":", "/", 1).strip("/")
+    parts = [part.lower() for part in normalized.split("/") if part]
+    if len(parts) < 3:
+        return None
+    collection = parts[1].removesuffix("s")
+    return parts[0], collection, parts[2]
+
+
+def _reason_names_target_instrument(
+    normalized_reason: str,
+    target_instrument: tuple[str, str, str],
+) -> bool:
+    _jurisdiction, _collection, instrument = target_instrument
+    normalized_instrument = re.sub(
+        r"[^a-z0-9äöüß]+",
+        " ",
+        instrument,
+    ).strip()
+    return bool(
+        normalized_instrument
+        and re.search(
+            rf"(?<![a-z0-9äöüß]){re.escape(normalized_instrument)}"
             r"(?![a-z0-9äöüß])",
             normalized_reason,
         )
@@ -1295,6 +1366,7 @@ def _companion_test_issues(
         principal_formula_clause_rules=principal_formula_clause_rules,
         asserted_by_rule=asserted_by_rule,
         extract_numeric_occurrences=extract_numeric_occurrences,
+        numeric_value_is_grounded=numeric_value_is_grounded,
         formula_environment=formula_environment,
     )
     for branch in missing_formula_branches:
@@ -1334,6 +1406,7 @@ def _companion_test_issues(
             asserted_by_rule=asserted_by_rule,
             numeric_value_is_grounded=numeric_value_is_grounded,
             formula_environment=formula_environment,
+            extract_numeric_occurrences=extract_numeric_occurrences,
         ):
             continue
         missing_boundaries.append((branch, boundary))
@@ -1566,6 +1639,7 @@ def _unwitnessed_formula_branches(
     principal_formula_clause_rules: dict[SourceStructureBranch, set[str]],
     asserted_by_rule: dict[str, list[dict[str, Any]]],
     extract_numeric_occurrences: NumericOccurrenceExtractor,
+    numeric_value_is_grounded: NumericGroundingPredicate,
     formula_environment: dict[str, Any],
 ) -> tuple[SourceStructureBranch, ...]:
     """Consume each executed rule/case witness for at most one source formula."""
@@ -1577,6 +1651,7 @@ def _unwitnessed_formula_branches(
             rule_names=principal_formula_clause_rules[branch],
             asserted_by_rule=asserted_by_rule,
             extract_numeric_occurrences=extract_numeric_occurrences,
+            numeric_value_is_grounded=numeric_value_is_grounded,
             formula_environment=formula_environment,
         )
         for branch in branches
@@ -1619,6 +1694,7 @@ def _formula_branch_test_witnesses(
     rule_names: set[str],
     asserted_by_rule: dict[str, list[dict[str, Any]]],
     extract_numeric_occurrences: NumericOccurrenceExtractor,
+    numeric_value_is_grounded: NumericGroundingPredicate,
     formula_environment: dict[str, Any],
 ) -> set[tuple[str, str]]:
     interval = _formula_branch_interval(
@@ -1645,15 +1721,35 @@ def _formula_branch_test_witnesses(
                     if (
                         execution is not None
                         and _formula_execution_leaf_is_computational(execution)
+                        and _formula_execution_matches_source_branch(
+                            execution,
+                            branch,
+                            interval=interval,
+                            formula_environment=formula_environment,
+                            extract_numeric_occurrences=(
+                                extract_numeric_occurrences
+                            ),
+                            numeric_value_is_grounded=(
+                                numeric_value_is_grounded
+                            ),
+                        )
                     ):
-                        outcome = _formula_execution_outcome(execution)
-                        witnesses.add((rule_name, f"branch:{outcome}"))
+                        leaf = _collapse_text(execution.leaf).lower()
+                        witnesses.add((rule_name, f"leaf:{leaf}"))
                 else:
                     witnesses.add((rule_name, f"case:{id(case)}"))
                 continue
             if (
                 execution is not None
                 and _formula_execution_leaf_is_computational(execution)
+                and _formula_execution_matches_source_branch(
+                    execution,
+                    branch,
+                    interval=interval,
+                    formula_environment=formula_environment,
+                    extract_numeric_occurrences=extract_numeric_occurrences,
+                    numeric_value_is_grounded=numeric_value_is_grounded,
+                )
                 and _formula_execution_references_names(
                     execution,
                     selector_names,
@@ -1669,6 +1765,75 @@ def _formula_branch_test_witnesses(
             ):
                 witnesses.add((rule_name, f"case:{id(case)}"))
     return witnesses
+
+
+def _formula_execution_matches_source_branch(
+    execution: _FormulaExecution,
+    branch: SourceStructureBranch,
+    *,
+    interval: _NumericInterval | None,
+    formula_environment: dict[str, Any],
+    extract_numeric_occurrences: NumericOccurrenceExtractor,
+    numeric_value_is_grounded: NumericGroundingPredicate,
+) -> bool:
+    """Bind a reached leaf to numeric evidence in its exact source formula."""
+
+    source_occurrences = tuple(
+        extract_numeric_occurrences(
+            authoritative_numeric_recall_text(branch.text)
+        )
+    )
+    boundaries = (
+        ()
+        if interval is None
+        else tuple(
+            occurrence
+            for occurrence in (interval.lower, interval.upper)
+            if occurrence is not None
+        )
+    )
+    computation_occurrences = tuple(
+        occurrence
+        for occurrence in source_occurrences
+        if not any(
+            _numeric_occurrences_are_equivalent(occurrence, boundary)
+            for boundary in boundaries
+        )
+    )
+    if not computation_occurrences:
+        return True
+
+    leaf_names = set(_FORMULA_IDENTIFIER.findall(execution.leaf))
+    candidate_values = [
+        float(value)
+        for name, value in formula_environment.items()
+        if name in leaf_names
+        and isinstance(value, (int, float))
+        and not isinstance(value, bool)
+    ]
+    candidate_values.extend(
+        float(occurrence.value)
+        for occurrence in extract_numeric_occurrences(execution.leaf)
+    )
+    return bool(candidate_values) and all(
+        any(
+            numeric_value_is_grounded(value, (source_occurrence,))
+            for value in candidate_values
+        )
+        for source_occurrence in computation_occurrences
+    )
+
+
+def _numeric_occurrences_are_equivalent(
+    left: NumericOccurrenceLike,
+    right: NumericOccurrenceLike,
+) -> bool:
+    return (
+        math.isclose(float(left.value), float(right.value))
+        and left.has_rate_context == right.has_rate_context
+        and left.source_value == right.source_value
+        and left.requires_rate_context == right.requires_rate_context
+    )
 
 
 def _rule_has_branching_formula(rule: dict[str, Any]) -> bool:
@@ -1727,7 +1892,28 @@ def _execute_formula_text(
         if node is None:
             if _rule_text_has_branching_formula(selected_text):
                 return None
-            return _FormulaExecution(tuple(trace), selected_text.strip())
+            leaf = selected_text.strip()
+            evaluated = _evaluate_formula_selector(leaf, environment)
+            value_signature = (
+                None
+                if evaluated is _UNRESOLVED_CONDITION_VALUE
+                else (type(evaluated).__name__, repr(evaluated))
+            )
+            evaluates_to_zero = (
+                evaluated is None
+                or evaluated is False
+                or (
+                    isinstance(evaluated, (int, float))
+                    and not isinstance(evaluated, bool)
+                    and evaluated == 0
+                )
+            )
+            return _FormulaExecution(
+                tuple(trace),
+                leaf,
+                value_signature,
+                evaluates_to_zero,
+            )
         selected = _select_formula_branch(node, environment=environment)
         if selected is None:
             return None
@@ -2247,6 +2433,8 @@ def _formula_execution_outcome(execution: _FormulaExecution) -> str:
 def _formula_execution_leaf_is_computational(
     execution: _FormulaExecution,
 ) -> bool:
+    if execution.evaluates_to_zero:
+        return False
     leaf = execution.leaf.strip()
     with contextlib.suppress(SyntaxError, ValueError):
         literal = ast.literal_eval(leaf)
@@ -2442,14 +2630,35 @@ def _evaluate_condition_expression(
     if (
         isinstance(expression, ast.Call)
         and isinstance(expression.func, ast.Name)
-        and expression.func.id in {"holds", "not_holds"}
-        and len(expression.args) == 1
         and not expression.keywords
     ):
-        value = _evaluate_condition_expression(expression.args[0], environment)
-        if value is _UNRESOLVED_CONDITION_VALUE:
-            return value
-        return bool(value) if expression.func.id == "holds" else not bool(value)
+        function_name = expression.func.id
+        values = [
+            _evaluate_condition_expression(argument, environment)
+            for argument in expression.args
+        ]
+        if any(
+            value is _UNRESOLVED_CONDITION_VALUE
+            for value in values
+        ):
+            return _UNRESOLVED_CONDITION_VALUE
+        with contextlib.suppress(ArithmeticError, TypeError, ValueError):
+            if function_name in {"holds", "not_holds"} and len(values) == 1:
+                return (
+                    bool(values[0])
+                    if function_name == "holds"
+                    else not bool(values[0])
+                )
+            if function_name == "min" and values:
+                return min(values)
+            if function_name == "max" and values:
+                return max(values)
+            if function_name == "floor" and len(values) == 1:
+                return math.floor(values[0])
+            if function_name == "ceil" and len(values) == 1:
+                return math.ceil(values[0])
+            if function_name == "abs" and len(values) == 1:
+                return abs(values[0])
     return _UNRESOLVED_CONDITION_VALUE
 
 
@@ -2462,6 +2671,7 @@ def _branch_boundary_has_test_evidence(
     asserted_by_rule: dict[str, list[dict[str, Any]]],
     numeric_value_is_grounded: NumericGroundingPredicate,
     formula_environment: dict[str, Any] | None = None,
+    extract_numeric_occurrences: NumericOccurrenceExtractor | None = None,
 ) -> bool:
     for rule_name in _rules_covering_branch(branch, principal_rule_paths):
         rule = principal_rules[rule_name]
@@ -2476,17 +2686,77 @@ def _branch_boundary_has_test_evidence(
             )
             if (
                 execution is not None
-                and _formula_execution_references_names(
-                    execution,
-                    selector_names,
-                )
                 and any(
-                numeric_value_is_grounded(value, (boundary,))
-                for value in _case_numeric_selector_values(case, selector_names)
+                    numeric_value_is_grounded(value, (boundary,))
+                    and _formula_execution_references_names(
+                        execution,
+                        input_names,
+                    )
+                    and _formula_execution_binds_boundary(
+                        execution,
+                        boundary,
+                        formula_environment=formula_environment or {},
+                        extract_numeric_occurrences=(
+                            extract_numeric_occurrences
+                        ),
+                        numeric_value_is_grounded=(
+                            numeric_value_is_grounded
+                        ),
+                    )
+                    for input_names, value in (
+                        _case_numeric_selector_evidence(
+                            case,
+                            selector_names,
+                        )
+                    )
                 )
             ):
                 return True
     return False
+
+
+def _formula_execution_binds_boundary(
+    execution: _FormulaExecution,
+    boundary: NumericOccurrenceLike,
+    *,
+    formula_environment: dict[str, Any],
+    extract_numeric_occurrences: NumericOccurrenceExtractor | None,
+    numeric_value_is_grounded: NumericGroundingPredicate,
+) -> bool:
+    boundary_names = {
+        name
+        for name, value in formula_environment.items()
+        if isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and (
+            numeric_value_is_grounded(float(value), (boundary,))
+            or _is_adjacent_integral_boundary(float(value), boundary)
+        )
+    }
+    if boundary_names and _formula_execution_references_names(
+        execution,
+        boundary_names,
+    ):
+        return True
+    if extract_numeric_occurrences is not None and any(
+        numeric_value_is_grounded(float(occurrence.value), (boundary,))
+        for occurrence in extract_numeric_occurrences(execution.leaf)
+    ):
+        return True
+    return not boundary_names
+
+
+def _is_adjacent_integral_boundary(
+    value: float,
+    boundary: NumericOccurrenceLike,
+) -> bool:
+    boundary_value = float(boundary.value)
+    return (
+        not boundary.has_rate_context
+        and value.is_integer()
+        and boundary_value.is_integer()
+        and math.isclose(abs(value - boundary_value), 1.0)
+    )
 
 
 def _rules_covering_branch(
@@ -2630,15 +2900,32 @@ def _case_numeric_selector_values(
     case: dict[str, Any],
     selector_names: set[str],
 ) -> tuple[float, ...]:
+    return tuple(
+        value
+        for _names, value in _case_numeric_selector_evidence(
+            case,
+            selector_names,
+        )
+    )
+
+
+def _case_numeric_selector_evidence(
+    case: dict[str, Any],
+    selector_names: set[str],
+) -> tuple[tuple[set[str], float], ...]:
     inputs = case.get("input")
     if not isinstance(inputs, dict):
         return ()
-    values: list[float] = []
+    evidence: list[tuple[set[str], float]] = []
     for key, value in inputs.items():
-        if not (_input_key_names(key) & selector_names):
+        matched_names = _input_key_names(key) & selector_names
+        if not matched_names:
             continue
-        values.extend(_numeric_test_input_values(value))
-    return tuple(values)
+        evidence.extend(
+            (matched_names, numeric_value)
+            for numeric_value in _numeric_test_input_values(value)
+        )
+    return tuple(evidence)
 
 
 def _input_key_names(key: object) -> set[str]:
@@ -2797,30 +3084,56 @@ def _toggled_formula_boolean_selectors(
         if not selector_names:
             continue
         cases = asserted_by_rule.get(rule_name, ())
-        for selector_name in selector_names:
-            reachable_cases = [
-                case
-                for case in cases
-                if (
-                    (
-                        execution := _case_formula_execution(
-                            rule,
-                            case,
-                            formula_environment=formula_environment,
-                        )
-                    )
-                    is not None
-                    and _formula_execution_references_names(
+        for key, left_case, right_case in _paired_boolean_toggle_case_pairs(cases):
+            matched_names = _input_key_names(key) & selector_names
+            if not matched_names:
+                continue
+            left_execution = _case_formula_execution(
+                rule,
+                left_case,
+                formula_environment=formula_environment,
+            )
+            right_execution = _case_formula_execution(
+                rule,
+                right_case,
+                formula_environment=formula_environment,
+            )
+            if left_execution is None or right_execution is None:
+                continue
+            if _formula_execution_effect_signature(
+                left_execution
+            ) == _formula_execution_effect_signature(right_execution):
+                continue
+            for selector_name in matched_names:
+                if all(
+                    _formula_execution_reaches_selector(
                         execution,
-                        {selector_name},
-                        selectors_only=True,
+                        selector_name,
                     )
-                )
-            ]
-            for key in _paired_boolean_toggle_keys(reachable_cases):
-                if selector_name in _input_key_names(key):
+                    for execution in (left_execution, right_execution)
+                ):
                     toggled.add((rule_name, selector_name))
     return toggled
+
+
+def _formula_execution_effect_signature(
+    execution: _FormulaExecution,
+) -> tuple[str, tuple[str, str] | None]:
+    return (
+        _collapse_text(execution.leaf).lower(),
+        execution.evaluated_value,
+    )
+
+
+def _formula_execution_reaches_selector(
+    execution: _FormulaExecution,
+    selector_name: str,
+) -> bool:
+    return _formula_execution_references_names(
+        execution,
+        {selector_name},
+        selectors_only=bool(execution.trace),
+    )
 
 
 def _rule_exception_selector_names(rule: dict[str, Any]) -> set[str]:
@@ -2844,6 +3157,11 @@ def _rule_exception_selector_names(rule: dict[str, Any]) -> set[str]:
             or any(_exception_semantic_identifier(name) for name in condition_names)
         ):
             names.update(condition_names)
+    names.update(
+        identifier
+        for identifier in _FORMULA_IDENTIFIER.findall(formula_text)
+        if _exception_semantic_identifier(identifier)
+    )
     return names
 
 
@@ -2926,7 +3244,7 @@ def _exception_semantic_identifier(identifier: str) -> bool:
     return bool(
         re.search(
             r"(?:exception|exempt|exclud|disqual|inelig|eligib|remarri|"
-            r"barred|blocking|waiver)",
+            r"barred|blocking|waiver|befrei|ausnahme)",
             identifier,
             flags=re.IGNORECASE,
         )
@@ -2958,10 +3276,6 @@ def _fractional_rounding_case_witnesses(
             "ceil" if direction == "upward" else "floor"
         )
     }
-    rounded_operand_identifiers = _rounding_operand_identifier_names(
-        rule,
-        functions=functions,
-    )
     for case in asserted_by_rule.get(rule_name, ()):
         inputs = case.get("input")
         if not isinstance(inputs, dict):
@@ -2976,6 +3290,10 @@ def _fractional_rounding_case_witnesses(
             direction,
         ):
             continue
+        rounded_operand_identifiers = _rounding_operand_identifier_names(
+            execution.leaf,
+            functions=functions,
+        )
         if any(
             _input_key_names(key) & rounded_operand_identifiers
             and any(
@@ -3005,12 +3323,11 @@ def _formula_execution_implements_rounding(
 
 
 def _rounding_operand_identifier_names(
-    rule: dict[str, Any],
+    formula_text: str,
     *,
     functions: set[str],
 ) -> set[str]:
     names: set[str] = set()
-    formula_text = _rule_formula_text(rule)
     function_names = {"floor", "ceil"} & functions
     if "nearest" in functions:
         function_names.add("floor")
@@ -3076,28 +3393,31 @@ def _source_boundary_obligations(
             "source-unit",
         }:
             continue
-        first_line = branch.text.splitlines()[0] if branch.text.splitlines() else ""
-        prefix = first_line.split(":", 1)[0]
-        if not re.search(
-            r"\b(?:zwischen|between|bis|von|ab|unter|über|from|to|through|"
-            r"less\s+than|more\s+than|at\s+least|up\s+to|above|below|"
-            r"nicht\s+mehr\s+als)\b",
-            prefix,
-            flags=re.IGNORECASE,
+        direct_text = authoritative_numeric_recall_text(branch.text)
+        for fragment in re.split(
+            r"(?:[;\n]+|(?<=[.!?])\s+)",
+            direct_text,
         ):
-            continue
-        prefix = authoritative_numeric_recall_text(prefix)
-        interval = _formula_interval_from_text(
-            prefix,
-            extract_numeric_occurrences=extract_numeric_occurrences,
-        )
-        if interval is None:
-            continue
-        obligations.extend(
-            (branch, boundary)
-            for boundary in (interval.lower, interval.upper)
-            if boundary is not None
-        )
+            range_fragment = fragment.split(":", 1)[0]
+            if not re.search(
+                r"\b(?:zwischen|between|bis|von|ab|unter|über|from|to|"
+                r"through|less\s+than|more\s+than|at\s+least|up\s+to|"
+                r"above|below|nicht\s+mehr\s+als)\b",
+                range_fragment,
+                flags=re.IGNORECASE,
+            ):
+                continue
+            interval = _formula_interval_from_text(
+                range_fragment,
+                extract_numeric_occurrences=extract_numeric_occurrences,
+            )
+            if interval is None:
+                continue
+            obligations.extend(
+                (branch, boundary)
+                for boundary in (interval.lower, interval.upper)
+                if boundary is not None
+            )
     for branch in narrative_formula_branches:
         interval = _formula_branch_interval(
             branch,
@@ -3139,7 +3459,9 @@ def _numeric_test_input_values(value: Any) -> tuple[float, ...]:
     return tuple(values)
 
 
-def _paired_boolean_toggle_keys(cases: Iterable[dict[str, Any]]) -> set[str]:
+def _paired_boolean_toggle_case_pairs(
+    cases: Iterable[dict[str, Any]],
+) -> Iterable[tuple[str, dict[str, Any], dict[str, Any]]]:
     flattened = [
         (
             case,
@@ -3152,7 +3474,6 @@ def _paired_boolean_toggle_keys(cases: Iterable[dict[str, Any]]) -> set[str]:
         for case in cases
         if isinstance(case.get("input"), dict)
     ]
-    toggled: set[str] = set()
     for left_index, (left_case, left_values) in enumerate(flattened):
         for right_case, right_values in flattened[left_index + 1 :]:
             if set(left_values) != set(right_values):
@@ -3164,8 +3485,7 @@ def _paired_boolean_toggle_keys(cases: Iterable[dict[str, Any]]) -> set[str]:
                 continue
             if _non_boolean_inputs(left_case) != _non_boolean_inputs(right_case):
                 continue
-            toggled.add(changed[0])
-    return toggled
+            yield changed[0], left_case, right_case
 
 
 def _boolean_value(value: Any) -> bool | None:

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -9,6 +9,7 @@ from the source-unit admission policy implemented here.
 from __future__ import annotations
 
 import contextlib
+import math
 import re
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
@@ -63,8 +64,14 @@ _EXPLICIT_SENTENCE_MARKER = re.compile(
     r"(?:(?<=^)|(?<=[.;]))[ \t]*Satz[ \t]+(?P<label>[1-9]\d?)(?=[ \t]+[A-ZÄÖÜ])",
     flags=re.IGNORECASE | re.MULTILINE,
 )
-_EDITORIAL_OMISSION = re.compile(
-    r"\b(?:weggefallen|aufgehoben|repealed|omitted)\b|\.{3,}",
+_EDITORIAL_OMISSION_ONLY = re.compile(
+    r"^\s*"
+    r"(?:(?:\((?:\d+[a-z]?|[a-z])\)|\d+[a-z]?\.|[a-z]\))\s*)?"
+    r"(?:bis\s+\(\d+[a-z]?\)\s*)?"
+    r"(?:\(\s*)?"
+    r"(?:weggefallen|aufgehoben|repealed|omitted|\.{3,})"
+    r"(?:\s*\))?"
+    r"\s*[.;]?\s*$",
     flags=re.IGNORECASE,
 )
 _ARITHMETIC_EXPRESSION = re.compile(
@@ -76,6 +83,13 @@ _COMPUTATION_LANGUAGE = re.compile(
     r"\b(?:"
     r"bemisst\s+sich\s+nach|berechn(?:et|en|ung)|ergibt\s+sich|"
     r"zweifache|hälfte|zehntausendstel|übersteigenden\s+teils|"
+    r"(?:ein(?:e[nsrm]?)?\s+)?(?:drittel|viertel|fünftel|sechstel|"
+    r"siebtel|achtel|neuntel|zehntel)\s+(?:des|der|von)|"
+    r"summe\s+(?:aus|der|von)|unterschied|differenz|"
+    r"geteilt\s+durch|durch\s+(?:\d+|[a-zäöüß]+)\s+geteilt|"
+    r"multipliziert\s+mit|"
+    r"(?:vermindert|erhöht|gekürzt|vermehrt)\s+um|"
+    r"(?:abzüglich|zuzüglich)|prozent\s+(?:des|der|von)|"
     r"splitting-verfahren|verfahren\s+nach\s+absatz|"
     r"calculated|computed|computation|multiplied|divided|"
     r"sum\s+of|difference\s+between|product\s+of|twice|half\s+of|"
@@ -126,13 +140,9 @@ _PRECISE_DEFERRAL_DEPENDENCY = re.compile(
 _MISSING_DEPENDENCY_LANGUAGE = re.compile(
     r"\b(?:"
     r"requires?|depends?\s+on|missing|not\s+yet\s+encoded|unavailable|"
+    r"cannot\s+be\s+(?:computed|encoded|resolved)|until|"
     r"benötigt|abhängig|fehlt|nicht\s+codiert"
     r")\b",
-    flags=re.IGNORECASE,
-)
-_PRECISE_NONOPERATIVE_REASON = re.compile(
-    r"\b(?:non-operative|legislative\s+(?:intent|finding|purpose)|"
-    r"administrative\s+workflow|weggefallen|aufgehoben)\b",
     flags=re.IGNORECASE,
 )
 _ABSATZ_REFERENCE = re.compile(
@@ -167,6 +177,11 @@ _STRUCTURAL_REFERENCE = re.compile(
     r"\s*\d*[a-z]?\b",
     flags=re.IGNORECASE,
 )
+_DECIMAL_PERCENT_IDENTIFIER = re.compile(
+    r"(?<!\d)(?P<integer>\d{1,3})_(?P<fraction>\d{1,4})_percent\b",
+    flags=re.IGNORECASE,
+)
+_FORMULA_IDENTIFIER = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\b")
 
 
 def recognize_source_structure(source_text: str) -> tuple[SourceStructureBranch, ...]:
@@ -185,7 +200,7 @@ def recognize_source_structure(source_text: str) -> tuple[SourceStructureBranch,
         )
         label = match.group("label").lower()
         text = source_text[start:end].strip()
-        if _EDITORIAL_OMISSION.search(text):
+        if _is_editorial_omission(text):
             continue
         path = (label,)
         branches.append(
@@ -210,7 +225,7 @@ def recognize_source_structure(source_text: str) -> tuple[SourceStructureBranch,
             label = match.group("label").lower()
             path = (*paragraph_path, label)
             text = source_text[start:end].strip()
-            if _EDITORIAL_OMISSION.search(text):
+            if _is_editorial_omission(text):
                 continue
             branches.append(
                 SourceStructureBranch(
@@ -235,7 +250,7 @@ def recognize_source_structure(source_text: str) -> tuple[SourceStructureBranch,
                 label = match.group("label").lower()
                 path = (*container_path, label)
                 text = source_text[start:end].strip()
-                if _EDITORIAL_OMISSION.search(text):
+                if _is_editorial_omission(text):
                     continue
                 branches.append(
                     SourceStructureBranch(
@@ -257,21 +272,10 @@ def recognize_source_structure(source_text: str) -> tuple[SourceStructureBranch,
                 if index + 1 < len(sentence_matches)
                 else paragraph_end
             )
-            container = max(
-                (
-                    branch
-                    for branch in branches
-                    if branch.start <= start < branch.end
-                    and branch.kind in {"paragraph", "number", "letter"}
-                ),
-                key=lambda branch: len(branch.path),
-                default=None,
-            )
-            parent_path = container.path if container is not None else paragraph_path
             label = match.group("label")
-            path = (*parent_path, f"satz-{label}")
+            path = (*paragraph_path, f"satz-{label}")
             text = source_text[start:end].strip()
-            if _EDITORIAL_OMISSION.search(text):
+            if _is_editorial_omission(text):
                 continue
             branches.append(
                 SourceStructureBranch(path, "sentence", f"Satz {label}", text, start, end)
@@ -286,6 +290,10 @@ def recognize_source_structure(source_text: str) -> tuple[SourceStructureBranch,
             key=lambda branch: (branch.start, len(branch.path), branch.kind),
         )
     )
+
+
+def _is_editorial_omission(text: str) -> bool:
+    return bool(_EDITORIAL_OMISSION_ONLY.fullmatch(text))
 
 
 def source_states_explicit_computation(source_text: str) -> bool:
@@ -307,6 +315,7 @@ def analyze_complete_source_unit(
     extract_numeric_occurrences: NumericOccurrenceExtractor,
     extract_named_scalars: NamedScalarExtractor,
     numeric_value_is_grounded: NumericGroundingPredicate,
+    artifact_numeric_values: Sequence[float] | None = None,
 ) -> CompleteSourceUnitAnalysis:
     """Analyze one artifact against its authoritative, resolver-owned body."""
 
@@ -331,6 +340,7 @@ def analyze_complete_source_unit(
                 extract_numeric_occurrences=extract_numeric_occurrences,
                 extract_named_scalars=extract_named_scalars,
                 numeric_value_is_grounded=numeric_value_is_grounded,
+                artifact_numeric_values=artifact_numeric_values,
             )
 
     return CompleteSourceUnitAnalysis((), (), 0, 0, 0)
@@ -346,9 +356,15 @@ def _analyze_rulespec_payload(
     extract_numeric_occurrences: NumericOccurrenceExtractor,
     extract_named_scalars: NamedScalarExtractor,
     numeric_value_is_grounded: NumericGroundingPredicate,
+    artifact_numeric_values: Sequence[float] | None,
 ) -> CompleteSourceUnitAnalysis:
     branches = recognize_source_structure(source_text)
-    all_covered_paths, principal_paths, principal_rules = _rule_coverage(
+    (
+        all_covered_paths,
+        principal_paths,
+        principal_rules,
+        principal_rule_paths,
+    ) = _rule_coverage(
         payload,
         source_text=source_text,
         branches=branches,
@@ -397,12 +413,16 @@ def _analyze_rulespec_payload(
             )
 
     source_values = tuple(
-        extract_numeric_occurrences(_numeric_recall_source_text(source_text))
+        extract_numeric_occurrences(authoritative_numeric_recall_text(source_text))
     )
-    named_values = tuple(
-        float(item.value)
-        for item in extract_named_scalars(content)
-        if hasattr(item, "value")
+    named_values = (
+        tuple(float(value) for value in artifact_numeric_values)
+        if artifact_numeric_values is not None
+        else tuple(
+            float(item.value)
+            for item in extract_named_scalars(content)
+            if hasattr(item, "value")
+        )
     )
     covered_source_values = 0
     missing_source_values: list[float] = []
@@ -425,8 +445,10 @@ def _analyze_rulespec_payload(
         issues.extend(
             _companion_test_issues(
                 principal_rules,
+                principal_rule_paths=principal_rule_paths,
                 branches=branches,
                 source_text=source_text,
+                corpus_citation_path=corpus_citation_path,
                 deferred_paths=deferred_paths,
                 test_cases=test_cases,
                 extract_numeric_occurrences=extract_numeric_occurrences,
@@ -449,13 +471,19 @@ def _rule_coverage(
     source_text: str,
     branches: Sequence[SourceStructureBranch],
     corpus_citation_path: str,
-) -> tuple[set[tuple[str, ...]], set[tuple[str, ...]], dict[str, dict[str, Any]]]:
+) -> tuple[
+    set[tuple[str, ...]],
+    set[tuple[str, ...]],
+    dict[str, dict[str, Any]],
+    dict[str, set[tuple[str, ...]]],
+]:
     all_paths: set[tuple[str, ...]] = set()
     principal_paths: set[tuple[str, ...]] = set()
     principal_rules: dict[str, dict[str, Any]] = {}
+    principal_rule_paths: dict[str, set[tuple[str, ...]]] = {}
     rules = payload.get("rules")
     if not isinstance(rules, list):
-        return all_paths, principal_paths, principal_rules
+        return all_paths, principal_paths, principal_rules, principal_rule_paths
 
     for rule in rules:
         if not isinstance(rule, dict):
@@ -466,7 +494,12 @@ def _rule_coverage(
             str(rule.get("source") or ""),
             corpus_citation_path=corpus_citation_path,
         )
-        for excerpt in _rule_source_excerpts(rule):
+        for excerpt_citation_path, excerpt in _rule_source_excerpts(rule):
+            if (
+                excerpt_citation_path.strip("/").lower()
+                != corpus_citation_path.strip("/").lower()
+            ):
+                continue
             excerpt_branch = _most_specific_excerpt_branch(excerpt, branches)
             if excerpt_branch is not None:
                 paths.add(excerpt_branch.path)
@@ -474,12 +507,13 @@ def _rule_coverage(
             all_paths.update(_path_prefixes(path))
         if kind in {"derived", "derived_relation"} and name:
             principal_rules[name] = rule
+            principal_rule_paths.setdefault(name, set()).update(paths)
             for path in paths:
                 principal_paths.update(_path_prefixes(path))
-    return all_paths, principal_paths, principal_rules
+    return all_paths, principal_paths, principal_rules, principal_rule_paths
 
 
-def _rule_source_excerpts(rule: dict[str, Any]) -> Iterable[str]:
+def _rule_source_excerpts(rule: dict[str, Any]) -> Iterable[tuple[str, str]]:
     metadata = rule.get("metadata")
     proof = metadata.get("proof") if isinstance(metadata, dict) else None
     if not isinstance(proof, dict):
@@ -487,12 +521,17 @@ def _rule_source_excerpts(rule: dict[str, Any]) -> Iterable[str]:
     atoms = proof.get("atoms") if isinstance(proof, dict) else None
     if not isinstance(atoms, list):
         return ()
-    excerpts: list[str] = []
+    excerpts: list[tuple[str, str]] = []
     for atom in atoms:
         source = atom.get("source") if isinstance(atom, dict) else None
         excerpt = source.get("excerpt") if isinstance(source, dict) else None
-        if isinstance(excerpt, str) and excerpt.strip():
-            excerpts.append(excerpt.strip())
+        citation_path = (
+            str(source.get("corpus_citation_path") or "").strip()
+            if isinstance(source, dict)
+            else ""
+        )
+        if isinstance(excerpt, str) and excerpt.strip() and citation_path:
+            excerpts.append((citation_path, excerpt.strip()))
     return excerpts
 
 
@@ -508,7 +547,14 @@ def _most_specific_excerpt_branch(
         for branch in branches
         if normalized_excerpt in _collapse_text(branch.text)
     ]
-    return max(candidates, key=lambda branch: len(branch.path), default=None)
+    return max(
+        candidates,
+        key=lambda branch: (
+            len(branch.path),
+            -(branch.end - branch.start),
+        ),
+        default=None,
+    )
 
 
 def _paths_from_source_reference(
@@ -598,17 +644,18 @@ def _deferred_coverage(
                     item.strip(),
                     flags=re.IGNORECASE,
                 )
+                and item.strip().lower() != output.lower()
                 for item in blocked_by
             )
         )
-        reason_identifies_dependency = bool(
-            _MISSING_DEPENDENCY_LANGUAGE.search(reason)
-            and _PRECISE_DEFERRAL_DEPENDENCY.search(reason)
+        reason_identifies_dependency = _reason_names_external_dependency(
+            reason,
+            deferred_path=path,
+            corpus_citation_path=corpus_citation_path,
         )
         precise = (
             exact_blockers
             or reason_identifies_dependency
-            or bool(_PRECISE_NONOPERATIVE_REASON.search(reason))
         )
         if precise:
             covered.add(path)
@@ -618,9 +665,42 @@ def _deferred_coverage(
                 f"`module.deferred_outputs[{index}]` identifies source branch "
                 f"({path[0]}) (`{'/'.join(path)}`) but its deferral does not "
                 "name an exact missing "
-                "dependency/citation (or a precise non-operative reason)."
+                "dependency/citation."
             )
     return covered, issues
+
+
+def _reason_names_external_dependency(
+    reason: str,
+    *,
+    deferred_path: tuple[str, ...],
+    corpus_citation_path: str,
+) -> bool:
+    if not _MISSING_DEPENDENCY_LANGUAGE.search(reason):
+        return False
+    current_section = corpus_citation_path.rstrip("/").rsplit("/", 1)[-1].lower()
+    for match in _PRECISE_DEFERRAL_DEPENDENCY.finditer(reason):
+        dependency = match.group(0).strip()
+        normalized = dependency.lower()
+        if paragraph_match := _ABSATZ_REFERENCE.fullmatch(dependency):
+            if (
+                deferred_path
+                and paragraph_match.group("label").lower() == deferred_path[0]
+            ):
+                continue
+        if section_match := re.fullmatch(
+            r"§{1,2}\s*(\d+[a-z]?)",
+            dependency,
+            flags=re.IGNORECASE,
+        ):
+            if section_match.group(1).lower() == current_section:
+                continue
+        if normalized.rstrip("/").endswith(
+            f"/{current_section}"
+        ) and "#" not in normalized:
+            continue
+        return True
+    return False
 
 
 def _rulespec_target_base(corpus_citation_path: str) -> str:
@@ -671,7 +751,7 @@ def _branch_citation(
     return f"{citation}({branch.path[0]}) [{', '.join(components)}]"
 
 
-def _numeric_recall_source_text(source_text: str) -> str:
+def authoritative_numeric_recall_text(source_text: str) -> str:
     """Remove structural/citation ordinals, never substantive source values."""
 
     cleaned = _GERMAN_LEGAL_CITATION.sub("", source_text)
@@ -693,11 +773,178 @@ def _numeric_recall_source_text(source_text: str) -> str:
     return cleaned
 
 
+def collect_artifact_numeric_values(
+    content: str,
+    *,
+    extract_named_scalars: NamedScalarExtractor,
+    extract_numeric_occurrences: NumericOccurrenceExtractor,
+    imported_contents: Sequence[str] = (),
+    additional_values: Iterable[float] = (),
+) -> tuple[float, ...]:
+    """Collect numeric representations credited by strict recall accounting."""
+
+    values = [float(value) for value in additional_values]
+    for index, artifact_content in enumerate((content, *imported_contents)):
+        values.extend(
+            float(item.value)
+            for item in extract_named_scalars(artifact_content)
+            if hasattr(item, "value")
+        )
+        with contextlib.suppress(yaml.YAMLError, TypeError, ValueError):
+            payload = yaml.safe_load(artifact_content)
+            if not (
+                isinstance(payload, dict)
+                and payload.get("format") == "rulespec/v1"
+            ):
+                continue
+            rules = payload.get("rules")
+            if isinstance(rules, list):
+                for rule in rules:
+                    if not isinstance(rule, dict):
+                        continue
+                    values.extend(
+                        _numeric_concept_values(
+                            str(rule.get("name") or ""),
+                            extract_numeric_occurrences=extract_numeric_occurrences,
+                        )
+                    )
+                    versions = rule.get("versions")
+                    if isinstance(versions, list):
+                        for version in versions:
+                            formula = (
+                                version.get("formula")
+                                if isinstance(version, dict)
+                                else None
+                            )
+                            if isinstance(formula, str):
+                                for identifier in set(
+                                    _FORMULA_IDENTIFIER.findall(formula)
+                                ):
+                                    values.extend(
+                                        _numeric_concept_values(
+                                            identifier,
+                                            extract_numeric_occurrences=(
+                                                extract_numeric_occurrences
+                                            ),
+                                        )
+                                    )
+                    verification = rule.get("verification")
+                    if isinstance(verification, dict):
+                        values.extend(
+                            _verification_numeric_values(
+                                verification.get("values"),
+                                extract_numeric_occurrences=(
+                                    extract_numeric_occurrences
+                                ),
+                            )
+                        )
+            if index == 0:
+                values.extend(
+                    _deferred_numeric_values(
+                        payload,
+                        extract_numeric_occurrences=extract_numeric_occurrences,
+                    )
+                )
+    return tuple(values)
+
+
+def _numeric_concept_values(
+    text: str,
+    *,
+    extract_numeric_occurrences: NumericOccurrenceExtractor,
+) -> tuple[float, ...]:
+    normalized = _DECIMAL_PERCENT_IDENTIFIER.sub(
+        lambda match: (
+            f"{match.group('integer')}.{match.group('fraction')} percent"
+        ),
+        text,
+    )
+    normalized = normalized.replace("_", " ").replace("-", " ")
+    return tuple(float(value) for value in extract_numeric_occurrences(normalized))
+
+
+def _verification_numeric_values(
+    value: object,
+    *,
+    extract_numeric_occurrences: NumericOccurrenceExtractor,
+) -> tuple[float, ...]:
+    if isinstance(value, bool) or value is None:
+        return ()
+    if isinstance(value, (int, float)):
+        return (float(value),)
+    if isinstance(value, str):
+        return tuple(
+            float(item) for item in extract_numeric_occurrences(value.strip())
+        )
+    values: list[float] = []
+    if isinstance(value, dict):
+        for key, item in value.items():
+            values.extend(
+                _verification_numeric_values(
+                    key,
+                    extract_numeric_occurrences=extract_numeric_occurrences,
+                )
+            )
+            values.extend(
+                _verification_numeric_values(
+                    item,
+                    extract_numeric_occurrences=extract_numeric_occurrences,
+                )
+            )
+    elif isinstance(value, list):
+        for item in value:
+            values.extend(
+                _verification_numeric_values(
+                    item,
+                    extract_numeric_occurrences=extract_numeric_occurrences,
+                )
+            )
+    return tuple(values)
+
+
+def _deferred_numeric_values(
+    payload: dict[str, Any],
+    *,
+    extract_numeric_occurrences: NumericOccurrenceExtractor,
+) -> tuple[float, ...]:
+    module = payload.get("module")
+    records = module.get("deferred_outputs") if isinstance(module, dict) else None
+    if not isinstance(records, list):
+        return ()
+    values: list[float] = []
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        reason = record.get("reason")
+        if isinstance(reason, str):
+            values.extend(
+                float(value)
+                for value in extract_numeric_occurrences(
+                    authoritative_numeric_recall_text(reason)
+                )
+            )
+        for field in ("output", "blocked_by", "source_values"):
+            raw = record.get(field)
+            items = raw if isinstance(raw, list) else [raw]
+            for item in items:
+                if not isinstance(item, str):
+                    continue
+                values.extend(
+                    _numeric_concept_values(
+                        item.rsplit("#", 1)[-1],
+                        extract_numeric_occurrences=extract_numeric_occurrences,
+                    )
+                )
+    return tuple(values)
+
+
 def _companion_test_issues(
     principal_rules: dict[str, dict[str, Any]],
     *,
+    principal_rule_paths: dict[str, set[tuple[str, ...]]],
     branches: Sequence[SourceStructureBranch],
     source_text: str,
+    corpus_citation_path: str,
     deferred_paths: set[tuple[str, ...]],
     test_cases: Sequence[object] | None,
     extract_numeric_occurrences: NumericOccurrenceExtractor,
@@ -734,42 +981,50 @@ def _companion_test_issues(
             branch.path[: len(deferred)] == deferred for deferred in deferred_paths
         )
     ]
-    formula_leaf_count = sum(
-        1
+    formula_branches = [
+        branch
         for branch in active_branches
         if branch.kind == "number" and _number_branch_is_formula_leaf(branch.text)
-    )
-    if formula_leaf_count:
-        most_assertions = max(
-            (len(asserted_cases) for asserted_cases in asserted_by_rule.values()),
-            default=0,
+    ]
+    for branch in formula_branches:
+        if _formula_branch_has_test_evidence(
+            branch,
+            principal_rules=principal_rules,
+            principal_rule_paths=principal_rule_paths,
+            asserted_by_rule=asserted_by_rule,
+            corpus_citation_path=corpus_citation_path,
+            extract_numeric_occurrences=extract_numeric_occurrences,
+        ):
+            continue
+        issues.append(
+            "[complete-source-unit:tests] Companion tests do not demonstrate "
+            f"formula branch {branch.label} at "
+            f"{_branch_citation(corpus_citation_path, branch)} with a principal "
+            "output assertion and selector input in that branch (or an exact "
+            "`covers` source-branch declaration)."
         )
-        if most_assertions < formula_leaf_count:
-            issues.append(
-                "[complete-source-unit:tests] Source states "
-                f"{formula_leaf_count} formula branches/list branches, but no principal "
-                f"output is asserted in {formula_leaf_count} distinct cases."
-            )
 
-    boundaries = _source_boundary_values(
+    boundary_obligations = _source_boundary_obligations(
         active_branches,
         extract_numeric_occurrences=extract_numeric_occurrences,
     )
-    test_input_values = tuple(
-        value
-        for case in cases
-        for value in _numeric_test_input_values(case.get("input"))
-    )
-    missing_boundaries = [
-        boundary
-        for boundary in boundaries
-        if not any(
-            numeric_value_is_grounded(test_value, {boundary})
-            for test_value in test_input_values
-        )
-    ]
+    missing_boundaries: list[tuple[SourceStructureBranch, float]] = []
+    for branch, boundary in boundary_obligations:
+        if _branch_boundary_has_test_evidence(
+            branch,
+            boundary,
+            principal_rules=principal_rules,
+            principal_rule_paths=principal_rule_paths,
+            asserted_by_rule=asserted_by_rule,
+            numeric_value_is_grounded=numeric_value_is_grounded,
+        ):
+            continue
+        missing_boundaries.append((branch, boundary))
     if missing_boundaries:
-        rendered = ", ".join(f"{value:g}" for value in sorted(set(missing_boundaries)))
+        rendered = ", ".join(
+            f"{branch.label}={value:g}"
+            for branch, value in missing_boundaries
+        )
         issues.append(
             "[complete-source-unit:tests] Companion tests do not exercise every "
             f"source-stated boundary input; missing: {rendered}."
@@ -782,48 +1037,60 @@ def _companion_test_issues(
     )
     exception_count = len(_EXCEPTION_LANGUAGE.findall(active_text))
     if exception_count:
-        toggled_boolean_keys = _paired_boolean_toggle_keys(
-            case
-            for asserted_cases in asserted_by_rule.values()
-            for case in asserted_cases
+        toggled_exception_selectors = _toggled_formula_boolean_selectors(
+            principal_rules,
+            asserted_by_rule=asserted_by_rule,
         )
-        if len(toggled_boolean_keys) < exception_count:
+        if len(toggled_exception_selectors) < exception_count:
             issues.append(
                 "[complete-source-unit:tests] Source-stated exceptions require "
-                "paired positive/blocking cases that toggle each exception fact; "
-                f"found {len(toggled_boolean_keys)} pair(s) for "
+                "paired positive/blocking cases that assert the affected principal "
+                "output and toggle a boolean selector used by its formula; "
+                f"found {len(toggled_exception_selectors)} pair(s) for "
                 f"{exception_count} exception obligation(s)."
             )
 
     rounding_count = len(_ROUNDING_LANGUAGE.findall(active_text))
     if rounding_count:
-        formula_text = "\n".join(
-            _rule_formula_text(rule) for rule in principal_rules.values()
-        )
-        if _DOWN_ROUNDING_LANGUAGE.search(active_text) and "floor(" not in formula_text:
+        down_rules = {
+            name
+            for name, rule in principal_rules.items()
+            if "floor(" in _rule_formula_text(rule)
+        }
+        up_rules = {
+            name
+            for name, rule in principal_rules.items()
+            if "ceil(" in _rule_formula_text(rule)
+        }
+        nearest_rules = {
+            name
+            for name, rule in principal_rules.items()
+            if "floor(" in _rule_formula_text(rule)
+            and re.search(r"\+\s*0?\.5\b", _rule_formula_text(rule))
+        }
+        applicable_rounding_rules: set[str] = set()
+        if _DOWN_ROUNDING_LANGUAGE.search(active_text) and not down_rules:
             issues.append(
                 "[complete-source-unit:tests] A source-stated downward-rounding "
                 "rule is absent from the principal formula (`floor(...)`)."
             )
-        if _UP_ROUNDING_LANGUAGE.search(active_text) and "ceil(" not in formula_text:
+        applicable_rounding_rules.update(down_rules)
+        if _UP_ROUNDING_LANGUAGE.search(active_text) and not up_rules:
             issues.append(
                 "[complete-source-unit:tests] A source-stated upward-rounding "
                 "rule is absent from the principal formula (`ceil(...)`)."
             )
-        if _NEAREST_ROUNDING_LANGUAGE.search(active_text) and not (
-            "floor(" in formula_text and re.search(r"\+\s*0?\.5\b", formula_text)
-        ):
+        applicable_rounding_rules.update(up_rules)
+        if _NEAREST_ROUNDING_LANGUAGE.search(active_text) and not nearest_rules:
             issues.append(
                 "[complete-source-unit:tests] A source-stated nearest/commercial "
                 "rounding rule is absent from the principal formula."
             )
-        fractional_cases = sum(
-            1
-            for case in cases
-            if any(
-                not float(value).is_integer()
-                for value in _numeric_test_input_values(case.get("input"))
-            )
+        applicable_rounding_rules.update(nearest_rules)
+        fractional_cases = _fractional_formula_input_case_count(
+            principal_rules,
+            asserted_by_rule=asserted_by_rule,
+            rule_names=applicable_rounding_rules,
         )
         if fractional_cases < rounding_count:
             issues.append(
@@ -889,17 +1156,280 @@ def _test_case_output_names(case: dict[str, Any]) -> set[str]:
 def _number_branch_is_formula_leaf(text: str) -> bool:
     first_line = text.splitlines()[0] if text.splitlines() else text
     return ":" in first_line and bool(
-        _ARITHMETIC_EXPRESSION.search(first_line)
-        or re.search(r":\s*-?\d", first_line)
+        _ARITHMETIC_EXPRESSION.search(text)
+        or re.search(r":\s*-?\d", text)
     )
 
 
-def _source_boundary_values(
+def _formula_branch_has_test_evidence(
+    branch: SourceStructureBranch,
+    *,
+    principal_rules: dict[str, dict[str, Any]],
+    principal_rule_paths: dict[str, set[tuple[str, ...]]],
+    asserted_by_rule: dict[str, list[dict[str, Any]]],
+    corpus_citation_path: str,
+    extract_numeric_occurrences: NumericOccurrenceExtractor,
+) -> bool:
+    interval = _formula_branch_interval(
+        branch,
+        extract_numeric_occurrences=extract_numeric_occurrences,
+    )
+    for rule_name in _rules_covering_branch(branch, principal_rule_paths):
+        selector_names = _rule_numeric_selector_names(principal_rules[rule_name])
+        for case in asserted_by_rule.get(rule_name, ()):
+            if _case_explicitly_covers_branch(
+                case,
+                branch,
+                corpus_citation_path=corpus_citation_path,
+            ):
+                return True
+            if interval is None or not selector_names:
+                continue
+            if any(
+                _interval_contains(interval, value)
+                for value in _case_numeric_selector_values(case, selector_names)
+            ):
+                return True
+    return False
+
+
+def _branch_boundary_has_test_evidence(
+    branch: SourceStructureBranch,
+    boundary: float,
+    *,
+    principal_rules: dict[str, dict[str, Any]],
+    principal_rule_paths: dict[str, set[tuple[str, ...]]],
+    asserted_by_rule: dict[str, list[dict[str, Any]]],
+    numeric_value_is_grounded: NumericGroundingPredicate,
+) -> bool:
+    for rule_name in _rules_covering_branch(branch, principal_rule_paths):
+        selector_names = _rule_numeric_selector_names(principal_rules[rule_name])
+        if not selector_names:
+            continue
+        for case in asserted_by_rule.get(rule_name, ()):
+            if any(
+                numeric_value_is_grounded(value, {boundary})
+                for value in _case_numeric_selector_values(case, selector_names)
+            ):
+                return True
+    return False
+
+
+def _rules_covering_branch(
+    branch: SourceStructureBranch,
+    principal_rule_paths: dict[str, set[tuple[str, ...]]],
+) -> tuple[str, ...]:
+    return tuple(
+        name
+        for name, paths in principal_rule_paths.items()
+        if branch.path in paths
+    )
+
+
+def _formula_branch_interval(
+    branch: SourceStructureBranch,
+    *,
+    extract_numeric_occurrences: NumericOccurrenceExtractor,
+) -> tuple[float | None, bool, float | None, bool] | None:
+    first_line = branch.text.splitlines()[0] if branch.text.splitlines() else ""
+    prefix = first_line.split(":", 1)[0]
+    prefix = _NUMBER_MARKER.sub("", prefix).strip()
+    values = tuple(float(value) for value in extract_numeric_occurrences(prefix))
+    if not values:
+        return None
+    lowered = prefix.lower()
+    if re.search(r"\b(?:von|from)\b", lowered) and re.search(
+        r"\b(?:bis|to|through)\b",
+        lowered,
+    ):
+        if len(values) < 2:
+            return None
+        return values[0], True, values[-1], True
+    if re.search(r"\b(?:unter|less\s+than|below)\b", lowered):
+        return None, False, values[-1], False
+    if re.search(r"\b(?:bis|up\s+to|höchstens|at\s+most)\b", lowered):
+        return None, False, values[-1], True
+    if re.search(r"\b(?:über|more\s+than|above)\b", lowered):
+        return values[0], False, None, False
+    if re.search(r"\b(?:von|ab|from|at\s+least|mindestens)\b", lowered):
+        return values[0], True, None, False
+    return None
+
+
+def _interval_contains(
+    interval: tuple[float | None, bool, float | None, bool],
+    value: float,
+) -> bool:
+    lower, lower_inclusive, upper, upper_inclusive = interval
+    if lower is not None and (
+        value < lower or (not lower_inclusive and math.isclose(value, lower))
+    ):
+        return False
+    if upper is not None and (
+        value > upper or (not upper_inclusive and math.isclose(value, upper))
+    ):
+        return False
+    return True
+
+
+def _rule_numeric_selector_names(rule: dict[str, Any]) -> set[str]:
+    names: set[str] = set()
+    formula_text = _rule_formula_text(rule)
+    for match in re.finditer(
+        r"\b(?P<left>[A-Za-z_][A-Za-z0-9_]*)\s*"
+        r"(?:<=|>=|<|>)\s*"
+        r"(?P<right>[A-Za-z_][A-Za-z0-9_]*|-?\d+(?:\.\d+)?)",
+        formula_text,
+    ):
+        names.add(match.group("left"))
+        right = match.group("right")
+        if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", right):
+            names.add(right)
+    if not names:
+        names.update(
+            identifier
+            for identifier in _FORMULA_IDENTIFIER.findall(formula_text)
+            if identifier.lower()
+            not in {
+                "if",
+                "else",
+                "and",
+                "or",
+                "not",
+                "floor",
+                "ceil",
+                "min",
+                "max",
+                "true",
+                "false",
+                "holds",
+                "not_holds",
+            }
+        )
+    return names
+
+
+def _case_numeric_selector_values(
+    case: dict[str, Any],
+    selector_names: set[str],
+) -> tuple[float, ...]:
+    inputs = case.get("input")
+    if not isinstance(inputs, dict):
+        return ()
+    values: list[float] = []
+    for key, value in inputs.items():
+        if not (_input_key_names(key) & selector_names):
+            continue
+        values.extend(_numeric_test_input_values(value))
+    return tuple(values)
+
+
+def _input_key_names(key: object) -> set[str]:
+    text = str(key).strip()
+    fragment = text.rsplit("#", 1)[-1]
+    return {
+        text,
+        fragment,
+        fragment.rsplit(".", 1)[-1],
+        fragment.rsplit("/", 1)[-1],
+    }
+
+
+def _toggled_formula_boolean_selectors(
+    principal_rules: dict[str, dict[str, Any]],
+    *,
+    asserted_by_rule: dict[str, list[dict[str, Any]]],
+) -> set[tuple[str, str]]:
+    toggled: set[tuple[str, str]] = set()
+    for rule_name, rule in principal_rules.items():
+        selector_names = _rule_boolean_selector_names(rule)
+        if not selector_names:
+            continue
+        for key in _paired_boolean_toggle_keys(asserted_by_rule.get(rule_name, ())):
+            matched_names = _input_key_names(key) & selector_names
+            toggled.update((rule_name, name) for name in matched_names)
+    return toggled
+
+
+def _rule_boolean_selector_names(rule: dict[str, Any]) -> set[str]:
+    formula_text = _rule_formula_text(rule)
+    names: set[str] = set()
+    for match in re.finditer(r"\bif\s+(?P<condition>[^:\n]+):", formula_text):
+        names.update(
+            identifier
+            for identifier in re.findall(
+                r"\b[A-Za-z_][A-Za-z0-9_]*\b",
+                match.group("condition"),
+            )
+            if identifier.lower()
+            not in {"and", "or", "not", "true", "false", "holds", "not_holds"}
+        )
+    return names
+
+
+def _fractional_formula_input_case_count(
+    principal_rules: dict[str, dict[str, Any]],
+    *,
+    asserted_by_rule: dict[str, list[dict[str, Any]]],
+    rule_names: set[str],
+) -> int:
+    evidence: set[tuple[str, int]] = set()
+    for rule_name in rule_names:
+        formula_identifiers = set(
+            re.findall(
+                r"\b[A-Za-z_][A-Za-z0-9_]*\b",
+                _rule_formula_text(principal_rules[rule_name]),
+            )
+        )
+        for index, case in enumerate(asserted_by_rule.get(rule_name, ())):
+            inputs = case.get("input")
+            if not isinstance(inputs, dict):
+                continue
+            if any(
+                _input_key_names(key) & formula_identifiers
+                and any(
+                    not float(value).is_integer()
+                    for value in _numeric_test_input_values(input_value)
+                )
+                for key, input_value in inputs.items()
+            ):
+                evidence.add((rule_name, index))
+    return len(evidence)
+
+
+def _case_explicitly_covers_branch(
+    case: dict[str, Any],
+    branch: SourceStructureBranch,
+    *,
+    corpus_citation_path: str,
+) -> bool:
+    raw_covers = case.get("covers")
+    if isinstance(raw_covers, (str, dict)):
+        raw_covers = [raw_covers]
+    if not isinstance(raw_covers, list):
+        return False
+    for item in raw_covers:
+        value = (
+            item.get("source_branch")
+            if isinstance(item, dict)
+            else item
+        )
+        if not isinstance(value, str):
+            continue
+        if branch.path in _paths_from_source_reference(
+            value,
+            corpus_citation_path=corpus_citation_path,
+        ):
+            return True
+    return False
+
+
+def _source_boundary_obligations(
     branches: Sequence[SourceStructureBranch],
     *,
     extract_numeric_occurrences: NumericOccurrenceExtractor,
-) -> tuple[float, ...]:
-    values: list[float] = []
+) -> tuple[tuple[SourceStructureBranch, float], ...]:
+    obligations: list[tuple[SourceStructureBranch, float]] = []
     for branch in branches:
         if branch.kind != "number":
             continue
@@ -913,8 +1443,11 @@ def _source_boundary_values(
         ):
             continue
         prefix = _NUMBER_MARKER.sub("", prefix)
-        values.extend(float(value) for value in extract_numeric_occurrences(prefix))
-    return tuple(dict.fromkeys(values))
+        obligations.extend(
+            (branch, float(value))
+            for value in dict.fromkeys(extract_numeric_occurrences(prefix))
+        )
+    return tuple(obligations)
 
 
 def _numeric_test_input_values(value: Any) -> tuple[float, ...]:

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -909,26 +909,30 @@ def _deferred_coverage(
         reason = str(record.get("reason") or "").strip()
         blocked_by = record.get("blocked_by")
         normalized_base_target = base_target.lower()
+        blocker_targets = tuple(
+            item.strip()
+            for item in blocked_by
+            if isinstance(item, str)
+        ) if isinstance(blocked_by, list) else ()
         exact_blockers = (
-            isinstance(blocked_by, list)
-            and bool(blocked_by)
+            bool(blocker_targets)
+            and len(blocker_targets) == len(blocked_by)
             and all(
-                isinstance(item, str)
-                and re.fullmatch(
+                re.fullmatch(
                     r"[a-z]{2}(?:-[a-z0-9-]+)?:"
                     r"[A-Za-z0-9_./-]+#[A-Za-z_][A-Za-z0-9_]*",
-                    item.strip(),
+                    item,
                     flags=re.IGNORECASE,
                 )
-                and item.strip().lower() != output.lower()
+                and item.lower() != output.lower()
                 and not (
-                    item.strip().lower().split("#", 1)[0]
+                    item.lower().split("#", 1)[0]
                     == normalized_base_target
-                    or item.strip().lower().split("#", 1)[0].startswith(
+                    or item.lower().split("#", 1)[0].startswith(
                         f"{normalized_base_target}/"
                     )
                 )
-                for item in blocked_by
+                for item in blocker_targets
             )
         )
         reason_identifies_dependency = _reason_names_external_dependency(
@@ -936,7 +940,14 @@ def _deferred_coverage(
             corpus_citation_path=corpus_citation_path,
         )
         precise = (
-            exact_blockers
+            (
+                exact_blockers
+                and bool(_MISSING_DEPENDENCY_LANGUAGE.search(reason))
+                and all(
+                    _reason_identifies_blocker(reason, blocker)
+                    for blocker in blocker_targets
+                )
+            )
             or reason_identifies_dependency
         )
         if precise:
@@ -952,6 +963,30 @@ def _deferred_coverage(
                 "dependency/citation."
             )
     return covered, issues
+
+
+def _reason_identifies_blocker(reason: str, blocker: str) -> bool:
+    """Bind a typed blocker to the legal section or concept named in prose."""
+
+    target_path, _separator, symbol = blocker.partition("#")
+    section = target_path.rstrip("/").rsplit("/", 1)[-1]
+    if section and re.search(
+        rf"(?:§{{1,2}}\s*|\b(?:section|paragraph|paragraf|abschnitt)\s+)"
+        rf"{re.escape(section)}(?![A-Za-z0-9])",
+        reason,
+        flags=re.IGNORECASE,
+    ):
+        return True
+    normalized_reason = re.sub(r"[^a-z0-9äöüß]+", " ", reason.lower()).strip()
+    normalized_symbol = re.sub(r"[^a-z0-9äöüß]+", " ", symbol.lower()).strip()
+    return bool(
+        normalized_symbol
+        and re.search(
+            rf"(?<![a-z0-9äöüß]){re.escape(normalized_symbol)}"
+            r"(?![a-z0-9äöüß])",
+            normalized_reason,
+        )
+    )
 
 
 def _reason_names_external_dependency(

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1511,10 +1511,10 @@ def _formula_branch_test_witnesses(
     for rule_name in sorted(rule_names):
         rule = principal_rules[rule_name]
         selector_names = _rule_numeric_selector_names(rule)
-        branch_selector_names = _rule_branch_selector_names(rule)
+        has_branching_formula = _rule_has_branching_formula(rule)
         for case in asserted_by_rule.get(rule_name, ()):
             if interval is None:
-                if branch_selector_names:
+                if has_branching_formula:
                     outcome = _case_formula_branch_outcome(
                         rule,
                         case,
@@ -1532,10 +1532,21 @@ def _formula_branch_test_witnesses(
     return witnesses
 
 
+def _rule_has_branching_formula(rule: dict[str, Any]) -> bool:
+    return bool(
+        re.search(
+            r"(?<![A-Za-z0-9_])(?:if|match)\s+[^:\n]+:",
+            _rule_formula_text(rule),
+        )
+    )
+
+
 def _rule_branch_selector_names(rule: dict[str, Any]) -> set[str]:
     """Return identifiers that choose branches in a principal formula."""
 
     names: set[str] = set()
+    if match_spec := _rule_match_branch_spec(rule):
+        names.add(match_spec[0])
     for condition in _rule_top_level_branch_conditions(rule):
         condition = re.sub(r"(['\"]).*?\1", "", condition)
         names.update(
@@ -1568,14 +1579,57 @@ def _rule_top_level_branch_conditions(rule: dict[str, Any]) -> tuple[str, ...]:
             _rule_formula_text(rule),
         )
     )
-    if not matches:
-        return ()
-    outer_indent = min(len(match.group("indent").expandtabs(8)) for match in matches)
+    if matches:
+        outer_indent = min(
+            len(match.group("indent").expandtabs(8)) for match in matches
+        )
+        return tuple(
+            match.group("condition").strip()
+            for match in matches
+            if len(match.group("indent").expandtabs(8)) == outer_indent
+        )
     return tuple(
         match.group("condition").strip()
-        for match in matches
-        if len(match.group("indent").expandtabs(8)) == outer_indent
+        for match in re.finditer(
+            r"(?<![A-Za-z0-9_])if[ \t]+(?P<condition>[^:\n]+):",
+            _rule_formula_text(rule),
+        )
     )
+
+
+def _rule_match_branch_spec(
+    rule: dict[str, Any],
+) -> tuple[str, tuple[str, ...]] | None:
+    """Return one RuleSpec match selector and its ordered arm patterns."""
+
+    match = re.search(
+        r"(?<![A-Za-z0-9_])match[ \t]+"
+        r"(?P<selector>[A-Za-z_][A-Za-z0-9_]*)[ \t]*:"
+        r"(?P<body>[\s\S]*)",
+        _rule_formula_text(rule),
+    )
+    if match is None:
+        return None
+    body = match.group("body")
+    if "\n" in body:
+        arm_patterns = tuple(
+            arm.group("pattern").strip()
+            for arm in re.finditer(
+                r"(?m)^[ \t]*(?P<pattern>[^=\n]+?)[ \t]*=>",
+                body,
+            )
+        )
+    else:
+        arm_patterns = tuple(
+            arm.group("pattern").strip()
+            for arm in re.finditer(
+                r"(?:^|;)[ \t]*(?P<pattern>[^=;]+?)[ \t]*=>",
+                body,
+            )
+        )
+    if not arm_patterns:
+        return None
+    return match.group("selector"), arm_patterns
 
 
 _UNRESOLVED_CONDITION_VALUE = object()
@@ -1584,22 +1638,43 @@ _UNRESOLVED_CONDITION_VALUE = object()
 def _case_formula_branch_outcome(
     rule: dict[str, Any],
     case: dict[str, Any],
-) -> int | None:
+) -> str | None:
     """Return the outer formula branch selected by one executed test case."""
 
-    conditions = _rule_top_level_branch_conditions(rule)
     inputs = case.get("input")
-    if not conditions or not isinstance(inputs, dict):
+    if not isinstance(inputs, dict):
         return None
     environment: dict[str, Any] = {}
     for key, value in inputs.items():
+        boolean_value = _boolean_value(value)
+        normalized_value = boolean_value if boolean_value is not None else value
         environment.update(
             {
-                name: value
+                name: normalized_value
                 for name in _input_key_names(key)
                 if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name)
             }
         )
+    if match_spec := _rule_match_branch_spec(rule):
+        selector_name, arm_patterns = match_spec
+        if selector_name not in environment:
+            return None
+        selector_value = environment[selector_name]
+        default_index: int | None = None
+        for index, arm_pattern in enumerate(arm_patterns):
+            for alternative in re.split(r"[|,]", arm_pattern):
+                expected = _match_arm_value(alternative.strip())
+                if expected is _UNRESOLVED_CONDITION_VALUE:
+                    continue
+                if expected == "_":
+                    default_index = index
+                elif selector_value == expected:
+                    return f"match:{index}"
+        return f"match:{default_index}" if default_index is not None else None
+
+    conditions = _rule_top_level_branch_conditions(rule)
+    if not conditions:
+        return None
     for index, condition in enumerate(conditions):
         try:
             expression = ast.parse(condition, mode="eval").body
@@ -1609,8 +1684,23 @@ def _case_formula_branch_outcome(
         if evaluated is _UNRESOLVED_CONDITION_VALUE:
             return None
         if bool(evaluated):
-            return index
-    return len(conditions)
+            return f"if:{index}"
+    return f"if:{len(conditions)}"
+
+
+def _match_arm_value(value: str) -> Any:
+    if value == "_":
+        return value
+    lowered = value.lower()
+    if lowered in {"true", "holds"}:
+        return True
+    if lowered in {"false", "not_holds"}:
+        return False
+    with contextlib.suppress(SyntaxError, ValueError):
+        return ast.literal_eval(value)
+    if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", value):
+        return value
+    return _UNRESOLVED_CONDITION_VALUE
 
 
 def _evaluate_condition_expression(
@@ -1681,7 +1771,7 @@ def _evaluate_condition_expression(
             right = _evaluate_condition_expression(comparator, environment)
             if right is _UNRESOLVED_CONDITION_VALUE:
                 return right
-            with contextlib.suppress(TypeError, ValueError):
+            try:
                 if isinstance(operator, ast.Eq):
                     matched = left == right
                 elif isinstance(operator, ast.NotEq):
@@ -1702,6 +1792,8 @@ def _evaluate_condition_expression(
                     return _UNRESOLVED_CONDITION_VALUE
                 if not matched:
                     return False
+            except (TypeError, ValueError):
+                return _UNRESOLVED_CONDITION_VALUE
             left = right
         return True
     if (

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -330,7 +330,7 @@ _MISSING_DEPENDENCY_LANGUAGE = re.compile(
     flags=re.IGNORECASE,
 )
 _ABSATZ_REFERENCE = re.compile(
-    r"\b(?:Absatz|Abs\.)\s*(?P<label>\d+[a-z]?)\b",
+    r"\b(?:Absatz(?:es)?|Absätze(?:n)?|Abs\.)\s*(?P<label>\d+[a-z]?)\b",
     flags=re.IGNORECASE,
 )
 _SATZ_REFERENCE = re.compile(
@@ -362,8 +362,12 @@ _ENGLISH_LEGAL_CITATION = re.compile(
     flags=re.IGNORECASE,
 )
 _STRUCTURAL_REFERENCE = re.compile(
-    r"\b(?:Absatz|Abs\.|Satz(?:es)?|Sätze|Nummer|Nr\.|Buchstabe|Buchst\.)"
-    r"\s*\d*[a-z]?\b",
+    r"\b(?:"
+    r"Absatz(?:es)?|Absätze(?:n)?|Abs\.|"
+    r"Satz(?:es)?|Sätze(?:n)?|"
+    r"Nummer(?:n)?|Nr\.|Buchstabe(?:n)?|Buchst\."
+    r")\s*\d*[a-z]?"
+    r"(?:\s*(?:,|und|bis)\s*\d+[a-z]?)*\b",
     flags=re.IGNORECASE,
 )
 _FORMULA_IDENTIFIER = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\b")

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -269,7 +269,8 @@ _COMPUTATION_LANGUAGE = re.compile(
 _ROUNDING_LANGUAGE = re.compile(
     r"\b(?:"
     r"abgerundet(?:e|en|er|es)?|abzurunden|aufgerundet(?:e|en|er|es)?|"
-    r"aufzurunden|kaufmännisch(?:\s+zu)?\s+runden|"
+    r"aufzurunden|gerundet(?:e|en|er|es)?|zu\s+runden|"
+    r"kaufmännisch(?:\s+zu)?\s+runden|"
     r"round(?:ed|ing)?(?:\s+(?:down|up|to\s+the\s+nearest))?"
     r")\b",
     flags=re.IGNORECASE,
@@ -283,7 +284,9 @@ _UP_ROUNDING_LANGUAGE = re.compile(
     flags=re.IGNORECASE,
 )
 _NEAREST_ROUNDING_LANGUAGE = re.compile(
-    r"\b(?:kaufmännisch(?:\s+zu)?\s+runden|round(?:ed|ing)?\s+to\s+the\s+nearest)\b",
+    r"\b(?:gerundet(?:e|en|er|es)?|zu\s+runden|"
+    r"kaufmännisch(?:\s+zu)?\s+runden|"
+    r"round(?:ed|ing)?\s+to\s+the\s+nearest)\b",
     flags=re.IGNORECASE,
 )
 _EXCEPTION_LANGUAGE = re.compile(

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -404,7 +404,7 @@ def _analyze_rulespec_payload(
                     "`derived_relation`) and is not "
                     "precisely deferred; parameter-only representation is invalid."
                 )
-        elif not principal_rules and not deferred_paths:
+        elif not _path_covered((), principal_paths, deferred_paths):
             issues.append(
                 "[complete-source-unit:formula-output] Explicit source computation "
                 "has no principal derived/relation output (`derived` or "
@@ -503,6 +503,8 @@ def _rule_coverage(
             excerpt_branch = _most_specific_excerpt_branch(excerpt, branches)
             if excerpt_branch is not None:
                 paths.add(excerpt_branch.path)
+            elif not branches:
+                paths.add(())
         for path in paths:
             all_paths.update(_path_prefixes(path))
         if kind in {"derived", "derived_relation"} and name:
@@ -563,7 +565,10 @@ def _paths_from_source_reference(
     corpus_citation_path: str,
 ) -> set[tuple[str, ...]]:
     value = source.strip()
-    if not value:
+    if not value or not _source_reference_targets_authoritative_unit(
+        value,
+        corpus_citation_path=corpus_citation_path,
+    ):
         return set()
     paths: set[tuple[str, ...]] = set()
     escaped_path = re.escape(corpus_citation_path.rstrip("/"))
@@ -594,15 +599,51 @@ def _paths_from_source_reference(
     if keyword_components:
         paths.add(tuple(keyword_components))
 
+    current_section = corpus_citation_path.rstrip("/").rsplit("/", 1)[-1]
     for match in re.finditer(
-        r"§\s*\d+[a-z]?(?P<suffix>(?:\([A-Za-z0-9-]+\))+)",
+        rf"§\s*{re.escape(current_section)}"
+        r"(?P<suffix>(?:\([A-Za-z0-9-]+\))+)",
         value,
         flags=re.IGNORECASE,
     ):
         components = re.findall(r"\(([A-Za-z0-9-]+)\)", match.group("suffix"))
         if components:
             paths.add(tuple(component.lower() for component in components))
+    if not paths:
+        paths.add(())
     return paths
+
+
+def _source_reference_targets_authoritative_unit(
+    source: str,
+    *,
+    corpus_citation_path: str,
+) -> bool:
+    """Require branch claims to identify this unit, not merely a branch label."""
+
+    candidates = {
+        corpus_citation_path.rstrip("/"),
+        _rulespec_target_base(corpus_citation_path),
+    }
+    if any(
+        re.search(
+            rf"(?<![A-Za-z0-9_]){re.escape(candidate)}(?![A-Za-z0-9_.-])",
+            source,
+            flags=re.IGNORECASE,
+        )
+        for candidate in candidates
+        if candidate
+    ):
+        return True
+    current_section = corpus_citation_path.rstrip("/").rsplit("/", 1)[-1]
+    return bool(
+        current_section
+        and re.search(
+            rf"§{{1,2}}\s*{re.escape(current_section)}(?![A-Za-z0-9.])",
+            source,
+            flags=re.IGNORECASE,
+        )
+    )
 
 
 def _deferred_coverage(
@@ -622,14 +663,16 @@ def _deferred_coverage(
             continue
         output = str(record.get("output") or "").strip()
         output_path = output.split("#", 1)[0]
-        path: tuple[str, ...] = ()
-        if output_path.startswith(f"{base_target}/"):
+        path: tuple[str, ...] | None = None
+        if output_path == base_target:
+            path = ()
+        elif output_path.startswith(f"{base_target}/"):
             path = tuple(
                 part.lower()
                 for part in output_path[len(base_target) + 1 :].split("/")
                 if part
             )
-        if not path:
+        if path is None:
             continue
         reason = str(record.get("reason") or "").strip()
         blocked_by = record.get("blocked_by")
@@ -660,10 +703,12 @@ def _deferred_coverage(
         if precise:
             covered.add(path)
         else:
+            branch_label = path[0] if path else "source unit"
+            rendered_path = "/".join(path) or "<source-unit>"
             issues.append(
                 "[complete-source-unit:deferral] "
                 f"`module.deferred_outputs[{index}]` identifies source branch "
-                f"({path[0]}) (`{'/'.join(path)}`) but its deferral does not "
+                f"({branch_label}) (`{rendered_path}`) but its deferral does not "
                 "name an exact missing "
                 "dependency/citation."
             )
@@ -720,6 +765,8 @@ def _rulespec_target_base(corpus_citation_path: str) -> str:
 
 
 def _path_prefixes(path: tuple[str, ...]) -> set[tuple[str, ...]]:
+    if not path:
+        return {()}
     return {path[:index] for index in range(1, len(path) + 1)}
 
 
@@ -786,7 +833,7 @@ def collect_artifact_numeric_values(
     """Collect numeric representations credited by strict recall accounting."""
 
     values = [float(value) for value in additional_values]
-    for index, artifact_content in enumerate((content, *imported_contents)):
+    for artifact_content in (content, *imported_contents):
         values.extend(
             float(item.value)
             for item in extract_named_scalars(artifact_content)
@@ -840,13 +887,6 @@ def collect_artifact_numeric_values(
                                 ),
                             )
                         )
-            if index == 0:
-                values.extend(
-                    _deferred_numeric_values(
-                        payload,
-                        extract_numeric_occurrences=extract_numeric_occurrences,
-                    )
-                )
     return tuple(values)
 
 
@@ -901,42 +941,6 @@ def _verification_numeric_values(
                     extract_numeric_occurrences=extract_numeric_occurrences,
                 )
             )
-    return tuple(values)
-
-
-def _deferred_numeric_values(
-    payload: dict[str, Any],
-    *,
-    extract_numeric_occurrences: NumericOccurrenceExtractor,
-) -> tuple[float, ...]:
-    module = payload.get("module")
-    records = module.get("deferred_outputs") if isinstance(module, dict) else None
-    if not isinstance(records, list):
-        return ()
-    values: list[float] = []
-    for record in records:
-        if not isinstance(record, dict):
-            continue
-        reason = record.get("reason")
-        if isinstance(reason, str):
-            values.extend(
-                float(value)
-                for value in extract_numeric_occurrences(
-                    authoritative_numeric_recall_text(reason)
-                )
-            )
-        for field in ("output", "blocked_by", "source_values"):
-            raw = record.get(field)
-            items = raw if isinstance(raw, list) else [raw]
-            for item in items:
-                if not isinstance(item, str):
-                    continue
-                values.extend(
-                    _numeric_concept_values(
-                        item.rsplit("#", 1)[-1],
-                        extract_numeric_occurrences=extract_numeric_occurrences,
-                    )
-                )
     return tuple(values)
 
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -8,6 +8,7 @@ from the source-unit admission policy implemented here.
 
 from __future__ import annotations
 
+import ast
 import contextlib
 import math
 import re
@@ -1514,12 +1515,12 @@ def _formula_branch_test_witnesses(
         for case in asserted_by_rule.get(rule_name, ()):
             if interval is None:
                 if branch_selector_names:
-                    signature = _case_selector_signature(
+                    outcome = _case_formula_branch_outcome(
+                        rule,
                         case,
-                        branch_selector_names,
                     )
-                    if signature:
-                        witnesses.add((rule_name, f"selectors:{signature!r}"))
+                    if outcome is not None:
+                        witnesses.add((rule_name, f"branch:{outcome}"))
                 else:
                     witnesses.add((rule_name, f"case:{id(case)}"))
                 continue
@@ -1535,11 +1536,8 @@ def _rule_branch_selector_names(rule: dict[str, Any]) -> set[str]:
     """Return identifiers that choose branches in a principal formula."""
 
     names: set[str] = set()
-    for match in re.finditer(
-        r"(?m)^[ \t]*(?:if|elif)[ \t]+(?P<condition>[^:\n]+):",
-        _rule_formula_text(rule),
-    ):
-        condition = re.sub(r"(['\"]).*?\1", "", match.group("condition"))
+    for condition in _rule_top_level_branch_conditions(rule):
+        condition = re.sub(r"(['\"]).*?\1", "", condition)
         names.update(
             identifier
             for identifier in _FORMULA_IDENTIFIER.findall(condition)
@@ -1560,25 +1558,164 @@ def _rule_branch_selector_names(rule: dict[str, Any]) -> set[str]:
     return names
 
 
-def _case_selector_signature(
-    case: dict[str, Any],
-    selector_names: set[str],
-) -> tuple[tuple[str, str], ...]:
-    """Fingerprint only case inputs that select a principal formula branch."""
+def _rule_top_level_branch_conditions(rule: dict[str, Any]) -> tuple[str, ...]:
+    """Return the ordered conditions in the formula's outer if/elif chain."""
 
-    inputs = case.get("input")
-    if not isinstance(inputs, dict):
-        return ()
-    return tuple(
-        sorted(
-            (
-                str(key),
-                repr(value),
-            )
-            for key, value in inputs.items()
-            if _input_key_names(key) & selector_names
+    matches = list(
+        re.finditer(
+            r"(?m)^(?P<indent>[ \t]*)(?:if|elif)[ \t]+"
+            r"(?P<condition>.+):[ \t]*$",
+            _rule_formula_text(rule),
         )
     )
+    if not matches:
+        return ()
+    outer_indent = min(len(match.group("indent").expandtabs(8)) for match in matches)
+    return tuple(
+        match.group("condition").strip()
+        for match in matches
+        if len(match.group("indent").expandtabs(8)) == outer_indent
+    )
+
+
+_UNRESOLVED_CONDITION_VALUE = object()
+
+
+def _case_formula_branch_outcome(
+    rule: dict[str, Any],
+    case: dict[str, Any],
+) -> int | None:
+    """Return the outer formula branch selected by one executed test case."""
+
+    conditions = _rule_top_level_branch_conditions(rule)
+    inputs = case.get("input")
+    if not conditions or not isinstance(inputs, dict):
+        return None
+    environment: dict[str, Any] = {}
+    for key, value in inputs.items():
+        environment.update(
+            {
+                name: value
+                for name in _input_key_names(key)
+                if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name)
+            }
+        )
+    for index, condition in enumerate(conditions):
+        try:
+            expression = ast.parse(condition, mode="eval").body
+        except SyntaxError:
+            return None
+        evaluated = _evaluate_condition_expression(expression, environment)
+        if evaluated is _UNRESOLVED_CONDITION_VALUE:
+            return None
+        if bool(evaluated):
+            return index
+    return len(conditions)
+
+
+def _evaluate_condition_expression(
+    expression: ast.expr,
+    environment: dict[str, Any],
+) -> Any:
+    """Evaluate a small side-effect-free subset of RuleSpec conditions."""
+
+    if isinstance(expression, ast.Constant):
+        return expression.value
+    if isinstance(expression, ast.Name):
+        lowered = expression.id.lower()
+        if lowered in {"true", "holds"}:
+            return True
+        if lowered in {"false", "not_holds"}:
+            return False
+        return environment.get(expression.id, _UNRESOLVED_CONDITION_VALUE)
+    if isinstance(expression, ast.BoolOp):
+        if isinstance(expression.op, ast.And):
+            for item in expression.values:
+                value = _evaluate_condition_expression(item, environment)
+                if value is _UNRESOLVED_CONDITION_VALUE:
+                    return value
+                if not bool(value):
+                    return False
+            return True
+        if isinstance(expression.op, ast.Or):
+            for item in expression.values:
+                value = _evaluate_condition_expression(item, environment)
+                if value is _UNRESOLVED_CONDITION_VALUE:
+                    return value
+                if bool(value):
+                    return True
+            return False
+    if isinstance(expression, ast.UnaryOp):
+        value = _evaluate_condition_expression(expression.operand, environment)
+        if value is _UNRESOLVED_CONDITION_VALUE:
+            return value
+        if isinstance(expression.op, ast.Not):
+            return not bool(value)
+        if isinstance(expression.op, ast.USub) and isinstance(value, (int, float)):
+            return -value
+    if isinstance(expression, ast.BinOp):
+        left = _evaluate_condition_expression(expression.left, environment)
+        right = _evaluate_condition_expression(expression.right, environment)
+        if (
+            left is _UNRESOLVED_CONDITION_VALUE
+            or right is _UNRESOLVED_CONDITION_VALUE
+        ):
+            return _UNRESOLVED_CONDITION_VALUE
+        with contextlib.suppress(ArithmeticError, TypeError, ValueError):
+            if isinstance(expression.op, ast.Add):
+                return left + right
+            if isinstance(expression.op, ast.Sub):
+                return left - right
+            if isinstance(expression.op, ast.Mult):
+                return left * right
+            if isinstance(expression.op, ast.Div):
+                return left / right
+            if isinstance(expression.op, ast.Mod):
+                return left % right
+        return _UNRESOLVED_CONDITION_VALUE
+    if isinstance(expression, ast.Compare):
+        left = _evaluate_condition_expression(expression.left, environment)
+        if left is _UNRESOLVED_CONDITION_VALUE:
+            return left
+        for operator, comparator in zip(expression.ops, expression.comparators):
+            right = _evaluate_condition_expression(comparator, environment)
+            if right is _UNRESOLVED_CONDITION_VALUE:
+                return right
+            with contextlib.suppress(TypeError, ValueError):
+                if isinstance(operator, ast.Eq):
+                    matched = left == right
+                elif isinstance(operator, ast.NotEq):
+                    matched = left != right
+                elif isinstance(operator, ast.Lt):
+                    matched = left < right
+                elif isinstance(operator, ast.LtE):
+                    matched = left <= right
+                elif isinstance(operator, ast.Gt):
+                    matched = left > right
+                elif isinstance(operator, ast.GtE):
+                    matched = left >= right
+                elif isinstance(operator, ast.In):
+                    matched = left in right
+                elif isinstance(operator, ast.NotIn):
+                    matched = left not in right
+                else:
+                    return _UNRESOLVED_CONDITION_VALUE
+                if not matched:
+                    return False
+            left = right
+        return True
+    if (
+        isinstance(expression, ast.Call)
+        and isinstance(expression.func, ast.Name)
+        and expression.func.id in {"holds", "not_holds"}
+        and len(expression.args) == 1
+        and not expression.keywords
+    ):
+        value = _evaluate_condition_expression(expression.args[0], environment)
+        if value is _UNRESOLVED_CONDITION_VALUE:
+            return value
+        return bool(value) if expression.func.id == "holds" else not bool(value)
+    return _UNRESOLVED_CONDITION_VALUE
 
 
 def _branch_boundary_has_test_evidence(

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1799,42 +1799,15 @@ def _formula_branch_test_witnesses(
         selector_names = _rule_numeric_selector_names(rule)
         has_branching_formula = _rule_has_branching_formula(rule)
         for case in asserted_by_rule.get(rule_name, ()):
-            execution = (
-                _case_formula_execution(
-                    rule,
-                    case,
-                    formula_environment=formula_environment,
-                )
-                if has_branching_formula or interval is not None
-                else None
+            execution = _case_formula_execution(
+                rule,
+                case,
+                formula_environment=formula_environment,
             )
-            if interval is None:
-                if has_branching_formula:
-                    if (
-                        execution is not None
-                        and _formula_execution_leaf_is_computational(execution)
-                        and _formula_execution_matches_source_branch(
-                            execution,
-                            branch,
-                            interval=interval,
-                            formula_environment=formula_environment,
-                            extract_numeric_occurrences=(
-                                extract_numeric_occurrences
-                            ),
-                            numeric_value_is_grounded=(
-                                numeric_value_is_grounded
-                            ),
-                        )
-                    ):
-                        leaf = _formula_leaf_semantic_key(execution.leaf)
-                        witnesses.add((rule_name, f"leaf:{leaf}"))
-                else:
-                    witnesses.add((rule_name, f"case:{id(case)}"))
-                continue
             if (
-                execution is not None
-                and _formula_execution_leaf_is_computational(execution)
-                and _formula_execution_matches_source_branch(
+                execution is None
+                or not _formula_execution_leaf_is_computational(execution)
+                or not _formula_execution_matches_source_branch(
                     execution,
                     branch,
                     interval=interval,
@@ -1842,7 +1815,22 @@ def _formula_branch_test_witnesses(
                     extract_numeric_occurrences=extract_numeric_occurrences,
                     numeric_value_is_grounded=numeric_value_is_grounded,
                 )
-                and _formula_execution_references_names(
+            ):
+                continue
+            if interval is None:
+                witness = (
+                    "leaf:"
+                    + _formula_leaf_semantic_key(
+                        execution.leaf,
+                        formula_environment=formula_environment,
+                    )
+                    if has_branching_formula
+                    else f"case:{id(case)}"
+                )
+                witnesses.add((rule_name, witness))
+                continue
+            if (
+                _formula_execution_references_names(
                     execution,
                     selector_names,
                 )
@@ -1871,8 +1859,16 @@ def _formula_execution_matches_source_branch(
     """Bind a reached leaf to numeric evidence in its exact source formula."""
 
     source_operations = _formula_operation_kinds(branch.text)
-    if source_operations and not source_operations.issubset(
-        _formula_operation_kinds(execution.leaf)
+    operative_leaf = _simplified_formula_text(
+        execution.leaf,
+        environment=formula_environment,
+    )
+    artifact_operations = _formula_ast_operation_kinds(operative_leaf)
+    if not _formula_operations_are_compatible(
+        source_operations,
+        artifact_operations,
+        source_text=branch.text,
+        artifact_formula=operative_leaf,
     ):
         return False
     source_occurrences = tuple(
@@ -1900,7 +1896,7 @@ def _formula_execution_matches_source_branch(
     if not computation_occurrences:
         return True
 
-    leaf_names = set(_FORMULA_IDENTIFIER.findall(execution.leaf))
+    leaf_names = set(_FORMULA_IDENTIFIER.findall(operative_leaf))
     candidate_values = [
         float(value)
         for name, value in formula_environment.items()
@@ -1910,8 +1906,15 @@ def _formula_execution_matches_source_branch(
     ]
     candidate_values.extend(
         float(occurrence.value)
-        for occurrence in extract_numeric_occurrences(execution.leaf)
+        for occurrence in extract_numeric_occurrences(operative_leaf)
     )
+    if (
+        "multiply" in source_operations
+        and "add" in artifact_operations
+        and _source_describes_doubling(branch.text)
+        and _formula_is_duplicate_addition(operative_leaf)
+    ):
+        candidate_values.append(2.0)
     return bool(candidate_values) and all(
         any(
             numeric_value_is_grounded(value, (source_occurrence,))
@@ -1922,25 +1925,12 @@ def _formula_execution_matches_source_branch(
 
 
 def _formula_operation_kinds(text: str) -> set[str]:
+    """Recognize operations in source prose or an explicit expression."""
+
+    parsed_operations = _formula_ast_operation_kinds(text)
+    if parsed_operations:
+        return parsed_operations
     operations: set[str] = set()
-    with contextlib.suppress(SyntaxError):
-        expression = ast.parse(text.strip(), mode="eval").body
-        for node in ast.walk(expression):
-            if isinstance(node, ast.BinOp):
-                if isinstance(node.op, ast.Add):
-                    operations.add("add")
-                elif isinstance(node.op, ast.Sub):
-                    operations.add("subtract")
-                elif isinstance(node.op, ast.Mult):
-                    operations.add("multiply")
-                elif isinstance(node.op, ast.Div):
-                    operations.add("divide")
-            elif isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
-                lowered = node.func.id.lower()
-                if "sum" in lowered:
-                    operations.add("add")
-                elif "product" in lowered:
-                    operations.add("multiply")
     lowered_text = text.lower()
     operation_patterns = {
         "add": (
@@ -1955,7 +1945,8 @@ def _formula_operation_kinds(text: str) -> set[str]:
         ),
         "multiply": (
             r"(?:[*×·•∗∙]|\bprodukt\b|\bproduct\s+of\b|"
-            r"\bmultipl\w*\b|\bvervielfach\w*\b|\bmal\b|"
+            r"\b(?:multiplied|multiply|multiplication|multipliziert|"
+            r"multiplizieren|multiplikation)\b|\bvervielfach\w*\b|\bmal\b|"
             r"\b(?:doppelte|zweifache|dreifache|twice)\b)"
         ),
         "divide": (
@@ -1970,11 +1961,199 @@ def _formula_operation_kinds(text: str) -> set[str]:
     return operations
 
 
-def _formula_leaf_semantic_key(leaf: str) -> str:
+def _formula_ast_operation_kinds(text: str) -> set[str]:
+    operations: set[str] = set()
+    try:
+        expression = ast.parse(text.strip(), mode="eval").body
+    except SyntaxError:
+        return operations
+    for node in ast.walk(expression):
+        if isinstance(node, ast.BinOp):
+            if isinstance(node.op, ast.Add):
+                operations.add("add")
+            elif isinstance(node.op, ast.Sub):
+                operations.add("subtract")
+            elif isinstance(node.op, ast.Mult):
+                operations.add("multiply")
+            elif isinstance(node.op, ast.Div):
+                operations.add("divide")
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            lowered = node.func.id.lower()
+            if "sum" in lowered:
+                operations.add("add")
+            elif "product" in lowered:
+                operations.add("multiply")
+    return operations
+
+
+def _formula_operations_are_compatible(
+    source_operations: set[str],
+    artifact_operations: set[str],
+    *,
+    source_text: str,
+    artifact_formula: str,
+) -> bool:
+    if not source_operations:
+        return True
+    for operation in source_operations:
+        if operation in artifact_operations:
+            continue
+        if operation == "divide" and "multiply" in artifact_operations:
+            continue
+        if (
+            operation == "multiply"
+            and "add" in artifact_operations
+            and _source_describes_doubling(source_text)
+            and _formula_is_duplicate_addition(artifact_formula)
+        ):
+            continue
+        return False
+    return True
+
+
+def _source_describes_doubling(text: str) -> bool:
+    return bool(
+        re.search(
+            r"\b(?:doppelte|zweifache|verdoppelt|twice|double[ds]?)\b",
+            text,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _formula_is_duplicate_addition(text: str) -> bool:
+    with contextlib.suppress(SyntaxError):
+        expression = ast.parse(text.strip(), mode="eval").body
+        if isinstance(expression, ast.BinOp) and isinstance(
+            expression.op,
+            ast.Add,
+        ):
+            return _canonical_formula_node(
+                expression.left
+            ) == _canonical_formula_node(expression.right)
+    return False
+
+
+def _formula_leaf_semantic_key(
+    leaf: str,
+    *,
+    formula_environment: dict[str, Any] | None = None,
+) -> str:
+    leaf = _simplified_formula_text(
+        leaf,
+        environment=formula_environment or {},
+    )
     with contextlib.suppress(SyntaxError):
         expression = ast.parse(leaf.strip(), mode="eval").body
         return repr(_canonical_formula_node(expression))
     return _collapse_text(leaf).lower()
+
+
+def _simplified_formula_text(
+    text: str,
+    *,
+    environment: dict[str, Any],
+) -> str:
+    with contextlib.suppress(SyntaxError):
+        expression = ast.parse(text.strip(), mode="eval").body
+        simplified = _simplify_formula_expression(
+            expression,
+            environment=environment,
+        )
+        return ast.unparse(ast.fix_missing_locations(simplified))
+    return text
+
+
+def _simplify_formula_expression(
+    expression: ast.expr,
+    *,
+    environment: dict[str, Any],
+) -> ast.expr:
+    if isinstance(expression, ast.BinOp):
+        left = _simplify_formula_expression(
+            expression.left,
+            environment=environment,
+        )
+        right = _simplify_formula_expression(
+            expression.right,
+            environment=environment,
+        )
+        left_value = _known_numeric_formula_value(left, environment)
+        right_value = _known_numeric_formula_value(right, environment)
+        if isinstance(expression.op, ast.Mult):
+            if left_value == 0 or right_value == 0:
+                return ast.Constant(value=0)
+            if left_value == 1:
+                return right
+            if right_value == 1:
+                return left
+        elif isinstance(expression.op, ast.Add):
+            if left_value == 0:
+                return right
+            if right_value == 0:
+                return left
+        elif isinstance(expression.op, ast.Sub) and right_value == 0:
+            return left
+        elif isinstance(expression.op, ast.Div) and right_value == 1:
+            return left
+        return ast.BinOp(left=left, op=expression.op, right=right)
+    if isinstance(expression, ast.UnaryOp):
+        return ast.UnaryOp(
+            op=expression.op,
+            operand=_simplify_formula_expression(
+                expression.operand,
+                environment=environment,
+            ),
+        )
+    if isinstance(expression, ast.Call):
+        return ast.Call(
+            func=expression.func,
+            args=[
+                _simplify_formula_expression(
+                    argument,
+                    environment=environment,
+                )
+                for argument in expression.args
+            ],
+            keywords=expression.keywords,
+        )
+    if isinstance(expression, ast.Compare):
+        return ast.Compare(
+            left=_simplify_formula_expression(
+                expression.left,
+                environment=environment,
+            ),
+            ops=expression.ops,
+            comparators=[
+                _simplify_formula_expression(
+                    comparator,
+                    environment=environment,
+                )
+                for comparator in expression.comparators
+            ],
+        )
+    if isinstance(expression, ast.BoolOp):
+        return ast.BoolOp(
+            op=expression.op,
+            values=[
+                _simplify_formula_expression(
+                    value,
+                    environment=environment,
+                )
+                for value in expression.values
+            ],
+        )
+    return expression
+
+
+def _known_numeric_formula_value(
+    expression: ast.expr,
+    environment: dict[str, Any],
+) -> int | float | None:
+    value = _evaluate_condition_expression(expression, environment)
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return value
+    return None
 
 
 def _canonical_formula_node(node: ast.AST) -> Any:
@@ -2087,7 +2266,7 @@ def _case_formula_execution(
                 return None
             input_environment[name] = normalized_value
     environment.update(input_environment)
-    formula_text = _unambiguous_rule_formula_text(rule)
+    formula_text = _rule_formula_text_for_case(rule, case)
     if formula_text is None:
         return None
     return _execute_formula_text(
@@ -2124,6 +2303,10 @@ def _execute_formula_text(
                     isinstance(evaluated, (int, float))
                     and not isinstance(evaluated, bool)
                     and evaluated == 0
+                )
+                or _formula_expression_is_definitely_zero(
+                    leaf,
+                    environment=environment,
                 )
             )
             return _FormulaExecution(
@@ -2613,7 +2796,7 @@ def _select_formula_branch(
     if not node.patterns:
         return None
     for index, pattern in enumerate(node.patterns[:-1]):
-        expected = _match_arm_value(pattern.strip())
+        expected = _match_arm_value(pattern.strip(), environment=environment)
         if expected is _UNRESOLVED_CONDITION_VALUE:
             return None
         if _same_formula_value(selector, expected):
@@ -2733,7 +2916,11 @@ def _case_formula_branch_outcome(
     return _formula_execution_outcome(execution)
 
 
-def _match_arm_value(value: str) -> Any:
+def _match_arm_value(
+    value: str,
+    *,
+    environment: dict[str, Any],
+) -> Any:
     if value == "_":
         return value
     lowered = value.lower()
@@ -2744,8 +2931,28 @@ def _match_arm_value(value: str) -> Any:
     with contextlib.suppress(SyntaxError, ValueError):
         return ast.literal_eval(value)
     if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", value):
-        return value
+        return environment.get(value, _UNRESOLVED_CONDITION_VALUE)
     return _UNRESOLVED_CONDITION_VALUE
+
+
+def _formula_expression_is_definitely_zero(
+    text: str,
+    *,
+    environment: dict[str, Any],
+) -> bool:
+    with contextlib.suppress(SyntaxError):
+        expression = ast.parse(text.strip(), mode="eval").body
+        simplified = _simplify_formula_expression(
+            expression,
+            environment=environment,
+        )
+        value = _evaluate_condition_expression(simplified, environment)
+        return (
+            isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and value == 0
+        )
+    return False
 
 
 def _evaluate_condition_expression(
@@ -3751,6 +3958,45 @@ def _unambiguous_rule_formula_text(rule: dict[str, Any]) -> str | None:
         )
     )
     return formulas[0] if len(formulas) == 1 else None
+
+
+def _rule_formula_text_for_case(
+    rule: dict[str, Any],
+    case: dict[str, Any],
+) -> str | None:
+    """Resolve one temporal formula when the companion case identifies a period."""
+
+    unambiguous = _unambiguous_rule_formula_text(rule)
+    if unambiguous is not None:
+        return unambiguous
+    period = str(case.get("period") or "").strip()
+    if re.fullmatch(r"\d{4}", period):
+        period = f"{period}-01-01"
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", period):
+        return None
+    versions = rule.get("versions")
+    if not isinstance(versions, list):
+        return None
+    candidates: list[tuple[str, str]] = []
+    for version in versions:
+        if not isinstance(version, dict) or version.get("formula") is None:
+            continue
+        effective_from = str(version.get("effective_from") or "").strip()
+        effective_to = str(version.get("effective_to") or "").strip()
+        if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", effective_from):
+            continue
+        if effective_from > period or (effective_to and effective_to < period):
+            continue
+        candidates.append((effective_from, str(version["formula"])))
+    if not candidates:
+        return None
+    latest = max(effective_from for effective_from, _formula in candidates)
+    formulas = {
+        formula
+        for effective_from, formula in candidates
+        if effective_from == latest
+    }
+    return next(iter(formulas)) if len(formulas) == 1 else None
 
 
 def _constant_rule_environment(payload: dict[str, Any]) -> dict[str, Any]:

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1594,10 +1594,15 @@ def _companion_test_issues(
     )
     missing_rounding_formula: list[tuple[SourceStructureBranch, str]] = []
     rounding_witnesses: dict[
-        tuple[SourceStructureBranch, str], set[tuple[str, int]]
+        tuple[SourceStructureBranch, str], set[tuple[str, int, str]]
     ] = {}
+    require_rounding_clause_binding = len(rounding_obligations) > 1
     for obligation in rounding_obligations:
         branch, direction = obligation
+        source_formula_branch = _rounding_source_formula_branch(
+            branch,
+            formula_branches=formula_branches,
+        )
         rule_names = {
             name
             for name in _rules_covering_branch(branch, principal_rule_paths)
@@ -1614,6 +1619,10 @@ def _companion_test_issues(
                     asserted_by_rule=asserted_by_rule,
                     direction=direction,
                     formula_environment=formula_environment,
+                    source_formula_branch=source_formula_branch,
+                    require_clause_binding=require_rounding_clause_binding,
+                    extract_numeric_occurrences=extract_numeric_occurrences,
+                    numeric_value_is_grounded=numeric_value_is_grounded,
                 )
                 for name in rule_names
             )
@@ -2443,6 +2452,26 @@ def _case_formula_execution(
         case,
     )
     environment: dict[str, Any] = dict(constant_environment)
+    input_environment = _case_input_formula_environment(case)
+    if input_environment is None:
+        return None
+    environment.update(input_environment)
+    formula_text = _rule_formula_text_for_case(rule, case)
+    if formula_text is None:
+        return None
+    return _execute_formula_text(
+        formula_text,
+        environment=environment,
+        constant_environment=constant_environment,
+    )
+
+
+def _case_input_formula_environment(
+    case: dict[str, Any],
+) -> dict[str, Any] | None:
+    inputs = case.get("input")
+    if not isinstance(inputs, dict):
+        return None
     input_environment: dict[str, Any] = {}
     for key, value in inputs.items():
         boolean_value = _boolean_value(value)
@@ -2456,15 +2485,7 @@ def _case_formula_execution(
             ):
                 return None
             input_environment[name] = normalized_value
-    environment.update(input_environment)
-    formula_text = _rule_formula_text_for_case(rule, case)
-    if formula_text is None:
-        return None
-    return _execute_formula_text(
-        formula_text,
-        environment=environment,
-        constant_environment=constant_environment,
-    )
+    return input_environment
 
 
 def _execute_formula_text(
@@ -3003,7 +3024,7 @@ def _evaluate_formula_selector(
     environment: dict[str, Any],
 ) -> Any:
     try:
-        expression = ast.parse(selector, mode="eval").body
+        expression = ast.parse(selector.strip(), mode="eval").body
     except SyntaxError:
         return _UNRESOLVED_CONDITION_VALUE
     return _evaluate_condition_expression(expression, environment)
@@ -3976,6 +3997,38 @@ def _source_rounding_obligations(
     return tuple(obligations)
 
 
+def _rounding_source_formula_branch(
+    rounding_branch: SourceStructureBranch,
+    *,
+    formula_branches: Sequence[SourceStructureBranch],
+) -> SourceStructureBranch | None:
+    containing = [
+        branch
+        for branch in formula_branches
+        if branch.path == rounding_branch.path
+        and branch.start <= rounding_branch.start
+        and rounding_branch.end <= branch.end
+    ]
+    if containing:
+        return min(
+            containing,
+            key=lambda branch: branch.end - branch.start,
+        )
+    same_path = [
+        branch
+        for branch in formula_branches
+        if branch.path == rounding_branch.path
+    ]
+    return min(
+        same_path,
+        key=lambda branch: min(
+            abs(branch.start - rounding_branch.end),
+            abs(rounding_branch.start - branch.end),
+        ),
+        default=None,
+    )
+
+
 def _unwitnessed_exception_branches(
     exception_branches: Sequence[SourceStructureBranch],
     *,
@@ -4257,8 +4310,12 @@ def _fractional_rounding_case_witnesses(
     asserted_by_rule: dict[str, list[dict[str, Any]]],
     direction: str,
     formula_environment: dict[str, Any],
-) -> set[tuple[str, int]]:
-    evidence: set[tuple[str, int]] = set()
+    source_formula_branch: SourceStructureBranch | None,
+    require_clause_binding: bool,
+    extract_numeric_occurrences: NumericOccurrenceExtractor,
+    numeric_value_is_grounded: NumericGroundingPredicate,
+) -> set[tuple[str, int, str]]:
+    evidence: set[tuple[str, int, str]] = set()
     functions = {
         "nearest" if direction == "nearest" else (
             "ceil" if direction == "upward" else "floor"
@@ -4278,19 +4335,63 @@ def _fractional_rounding_case_witnesses(
             direction,
         ):
             continue
-        rounded_operand_identifiers = _rounding_operand_identifier_names(
+        operative_leaf = _simplified_formula_text(
             execution.leaf,
-            functions=functions,
+            environment=execution.constant_environment,
         )
-        if any(
-            _input_key_names(key) & rounded_operand_identifiers
-            and any(
-                not float(value).is_integer()
-                for value in _numeric_test_input_values(input_value)
-            )
-            for key, input_value in inputs.items()
+        input_environment = _case_input_formula_environment(case)
+        if input_environment is None:
+            continue
+        evaluation_environment = dict(execution.constant_environment)
+        evaluation_environment.update(input_environment)
+        for function_name, operand in _rounding_call_operands(
+            operative_leaf,
+            functions=functions,
         ):
-            evidence.add((rule_name, id(case)))
+            effective_operand = _rounding_demonstrated_operand(
+                operand,
+                direction=direction,
+            )
+            if effective_operand is None:
+                continue
+            operand_value = _evaluate_formula_selector(
+                effective_operand,
+                evaluation_environment,
+            )
+            if (
+                not isinstance(operand_value, (int, float))
+                or isinstance(operand_value, bool)
+                or float(operand_value).is_integer()
+                or not _fractional_input_materially_affects_operand(
+                    case,
+                    effective_operand,
+                    evaluation_environment=evaluation_environment,
+                    operand_value=float(operand_value),
+                )
+            ):
+                continue
+            if (
+                source_formula_branch is not None
+                and not _rounding_call_binds_source_clause(
+                    effective_operand,
+                    operand_value=float(operand_value),
+                    execution=execution,
+                    source_formula_branch=source_formula_branch,
+                    formula_environment=formula_environment,
+                    require_clause_binding=require_clause_binding,
+                    extract_numeric_occurrences=extract_numeric_occurrences,
+                    numeric_value_is_grounded=numeric_value_is_grounded,
+                )
+            ):
+                continue
+            call_key = (
+                f"{function_name}:"
+                + _formula_leaf_semantic_key(
+                    effective_operand,
+                    formula_environment=execution.constant_environment,
+                )
+            )
+            evidence.add((rule_name, id(case), call_key))
     return evidence
 
 
@@ -4310,12 +4411,12 @@ def _formula_execution_implements_rounding(
     ) is not None
 
 
-def _rounding_operand_identifier_names(
+def _rounding_call_operands(
     formula_text: str,
     *,
     functions: set[str],
-) -> set[str]:
-    names: set[str] = set()
+) -> tuple[tuple[str, str], ...]:
+    calls: list[tuple[str, str]] = []
     function_names = {"floor", "ceil"} & functions
     if "nearest" in functions:
         function_names.add("floor")
@@ -4326,27 +4427,207 @@ def _rounding_operand_identifier_names(
                 and not re.search(r"\+\s*0?\.5\b", operand)
             ):
                 continue
-            names.update(
-                identifier
-                for identifier in _FORMULA_IDENTIFIER.findall(operand)
-                if identifier.lower()
-                not in {
-                    "if",
-                    "else",
-                    "and",
-                    "or",
-                    "not",
-                    "floor",
-                    "ceil",
-                    "min",
-                    "max",
-                    "true",
-                    "false",
-                    "holds",
-                    "not_holds",
-                }
-            )
-    return names
+            calls.append((function_name, operand))
+    return tuple(calls)
+
+
+def _rounding_demonstrated_operand(
+    operand: str,
+    *,
+    direction: str,
+) -> str | None:
+    if direction != "nearest":
+        return operand
+    with contextlib.suppress(SyntaxError):
+        expression = ast.parse(operand.strip(), mode="eval").body
+        if isinstance(expression, ast.BinOp) and isinstance(
+            expression.op,
+            ast.Add,
+        ):
+            left_value = _known_numeric_formula_value(expression.left, {})
+            right_value = _known_numeric_formula_value(expression.right, {})
+            if left_value is not None and math.isclose(float(left_value), 0.5):
+                return ast.unparse(expression.right)
+            if right_value is not None and math.isclose(float(right_value), 0.5):
+                return ast.unparse(expression.left)
+    return None
+
+
+def _fractional_input_materially_affects_operand(
+    case: dict[str, Any],
+    operand: str,
+    *,
+    evaluation_environment: dict[str, Any],
+    operand_value: float,
+) -> bool:
+    inputs = case.get("input")
+    if not isinstance(inputs, dict):
+        return False
+    operand_names = set(_FORMULA_IDENTIFIER.findall(operand))
+    for key, value in inputs.items():
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or float(value).is_integer()
+        ):
+            continue
+        aliases = _input_key_names(key) & operand_names
+        if not aliases:
+            continue
+        replacement = float(math.floor(float(value)))
+        changed_environment = dict(evaluation_environment)
+        for alias in aliases:
+            changed_environment[alias] = replacement
+        changed_value = _evaluate_formula_selector(
+            operand,
+            changed_environment,
+        )
+        if (
+            isinstance(changed_value, (int, float))
+            and not isinstance(changed_value, bool)
+            and not math.isclose(float(changed_value), operand_value)
+        ):
+            return True
+    return False
+
+
+def _rounding_call_matches_source_formula(
+    operand: str,
+    *,
+    operand_value: float,
+    execution: _FormulaExecution,
+    source_formula_branch: SourceStructureBranch,
+    formula_environment: dict[str, Any],
+    extract_numeric_occurrences: NumericOccurrenceExtractor,
+    numeric_value_is_grounded: NumericGroundingPredicate,
+) -> bool:
+    interval = _formula_branch_interval(
+        source_formula_branch,
+        extract_numeric_occurrences=extract_numeric_occurrences,
+    )
+    operand_execution = _FormulaExecution(
+        (),
+        operand,
+        (type(operand_value).__name__, repr(operand_value)),
+        operand_value == 0,
+        execution.constant_environment,
+    )
+    return _formula_execution_matches_source_branch(
+        operand_execution,
+        source_formula_branch,
+        interval=interval,
+        formula_environment=formula_environment,
+        extract_numeric_occurrences=extract_numeric_occurrences,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
+
+
+def _rounding_call_binds_source_clause(
+    operand: str,
+    *,
+    operand_value: float,
+    execution: _FormulaExecution,
+    source_formula_branch: SourceStructureBranch,
+    formula_environment: dict[str, Any],
+    require_clause_binding: bool,
+    extract_numeric_occurrences: NumericOccurrenceExtractor,
+    numeric_value_is_grounded: NumericGroundingPredicate,
+) -> bool:
+    formula_match = _rounding_call_matches_source_formula(
+        operand,
+        operand_value=operand_value,
+        execution=execution,
+        source_formula_branch=source_formula_branch,
+        formula_environment=formula_environment,
+        extract_numeric_occurrences=extract_numeric_occurrences,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
+    if not require_clause_binding:
+        return formula_match
+    source_has_distinguishing_computation = bool(
+        _formula_operation_kinds(source_formula_branch.text)
+        or extract_numeric_occurrences(
+            authoritative_numeric_recall_text(source_formula_branch.text)
+        )
+    )
+    if source_has_distinguishing_computation:
+        return formula_match
+    return _rounding_call_matches_clause_tokens(
+        operand,
+        source_formula_branch,
+    )
+
+
+def _rounding_call_matches_clause_tokens(
+    operand: str,
+    branch: SourceStructureBranch,
+) -> bool:
+    operand_tokens = _rounding_semantic_tokens(operand)
+    source_tokens = _rounding_semantic_tokens(branch.text)
+    ordinal_by_path = {
+        "1": "first",
+        "2": "second",
+        "3": "third",
+        "4": "fourth",
+        "5": "fifth",
+    }
+    source_tokens.update(
+        ordinal_by_path[item]
+        for item in branch.path
+        if item in ordinal_by_path
+    )
+    return bool(operand_tokens & source_tokens)
+
+
+def _rounding_semantic_tokens(text: str) -> set[str]:
+    normalized = re.sub(r"(?<=[a-z])(?=[A-Z])", " ", text)
+    tokens = {
+        token.lower()
+        for token in re.findall(r"[A-Za-zÄÖÜäöüß]+", normalized)
+    }
+    translations = {
+        "erste": "first",
+        "erster": "first",
+        "erstes": "first",
+        "zweite": "second",
+        "zweiter": "second",
+        "zweites": "second",
+        "dritte": "third",
+        "dritter": "third",
+        "drittes": "third",
+    }
+    tokens.update(
+        translations[token]
+        for token in tuple(tokens)
+        if token in translations
+    )
+    return tokens - {
+        "amount",
+        "betrag",
+        "der",
+        "die",
+        "das",
+        "ein",
+        "eine",
+        "einkommen",
+        "income",
+        "ergebnis",
+        "result",
+        "steuer",
+        "tax",
+        "wird",
+        "ist",
+        "und",
+        "and",
+        "auf",
+        "volle",
+        "euro",
+        "round",
+        "rounded",
+        "rounding",
+        "abzurunden",
+        "aufzurunden",
+    }
 
 
 def _balanced_call_operands(text: str, function_name: str) -> Iterable[str]:

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1033,7 +1033,7 @@ def collect_artifact_numeric_values(
     content: str,
     *,
     extract_named_scalars: NamedScalarExtractor,
-    imported_contents: Sequence[str] = (),
+    imported_symbol_contents: Sequence[tuple[str, str]] = (),
     additional_values: Iterable[float] = (),
 ) -> tuple[float, ...]:
     """Collect numeric representations credited by strict recall accounting."""
@@ -1044,29 +1044,15 @@ def collect_artifact_numeric_values(
         for item in extract_named_scalars(content)
         if hasattr(item, "value")
     )
-    imported_symbols = _rulespec_import_symbols(content)
-    for artifact_content in imported_contents:
+    for imported_symbol, artifact_content in imported_symbol_contents:
         values.extend(
             float(item.value)
             for item in extract_named_scalars(artifact_content)
             if hasattr(item, "value")
             and _named_scalar_base_name(str(getattr(item, "name", "")))
-            in imported_symbols
+            == imported_symbol
         )
     return tuple(values)
-
-
-def _rulespec_import_symbols(content: str) -> set[str]:
-    with contextlib.suppress(yaml.YAMLError, TypeError, ValueError):
-        payload = yaml.safe_load(content)
-        imports = payload.get("imports") if isinstance(payload, dict) else None
-        if isinstance(imports, list):
-            return {
-                item.rsplit("#", 1)[1]
-                for item in imports
-                if isinstance(item, str) and "#" in item
-            }
-    return set()
 
 
 def _named_scalar_base_name(name: str) -> str:

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -6511,6 +6511,7 @@ def _fractional_rounding_case_witnesses(
                     source_binding_operand,
                     original_operand=effective_operand,
                     operand_value=float(operand_value),
+                    direction=direction,
                     rule_name=rule_name,
                     execution=execution,
                     source_formula_branch=source_formula_branch,
@@ -6767,6 +6768,7 @@ def _rounding_call_binds_source_clause(
     *,
     original_operand: str,
     operand_value: float,
+    direction: str,
     rule_name: str,
     execution: _FormulaExecution,
     source_formula_branch: SourceStructureBranch,
@@ -6787,8 +6789,12 @@ def _rounding_call_binds_source_clause(
     )
     source_operations = _formula_operation_kinds(source_formula_branch.text)
     if (
-        not source_operations
-        and _formula_ast_operation_kinds(original_operand)
+        direction == "nearest"
+        and (
+            _formula_ast_operation_kinds(original_operand)
+            & {"add", "subtract"}
+        )
+        - source_operations
     ):
         return False
     if rounding_refers_to_result:

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -15,6 +15,7 @@ import re
 import textwrap
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
 from typing import Any, Protocol
 
 import yaml
@@ -1594,7 +1595,7 @@ def _companion_test_issues(
     )
     missing_rounding_formula: list[tuple[SourceStructureBranch, str]] = []
     rounding_witnesses: dict[
-        tuple[SourceStructureBranch, str], set[tuple[str, int, str]]
+        tuple[SourceStructureBranch, str], set[tuple[str, str, str]]
     ] = {}
     require_rounding_clause_binding = len(rounding_obligations) > 1
     for obligation in rounding_obligations:
@@ -1616,10 +1617,14 @@ def _companion_test_issues(
                 _fractional_rounding_case_witnesses(
                     name,
                     principal_rules[name],
+                    principal_rules=principal_rules,
                     asserted_by_rule=asserted_by_rule,
                     direction=direction,
                     formula_environment=formula_environment,
                     source_formula_branch=source_formula_branch,
+                    rounding_refers_to_result=(
+                        _rounding_text_refers_to_result(branch.text)
+                    ),
                     require_clause_binding=require_rounding_clause_binding,
                     extract_numeric_occurrences=extract_numeric_occurrences,
                     numeric_value_is_grounded=numeric_value_is_grounded,
@@ -1696,17 +1701,49 @@ def _source_formula_branches(
                 0,
                 len(source_text),
             )
-        obligations.append(
-            SourceStructureBranch(
-                owner.path,
-                "formula-clause",
-                f"{owner.label} formula clause {clause_index}",
-                clause,
-                start,
-                end,
-            )
+        obligation = SourceStructureBranch(
+            owner.path,
+            "formula-clause",
+            f"{owner.label} formula clause {clause_index}",
+            clause,
+            start,
+            end,
         )
+        if _rounding_clause_refers_to_previous_result(
+            obligation,
+            previous=obligations[-1] if obligations else None,
+            source_text=source_text,
+        ):
+            continue
+        obligations.append(obligation)
     return tuple(obligations)
+
+
+def _rounding_clause_refers_to_previous_result(
+    clause: SourceStructureBranch,
+    *,
+    previous: SourceStructureBranch | None,
+    source_text: str,
+) -> bool:
+    """Attach a standalone rounding modifier to its preceding computation."""
+
+    return bool(
+        previous is not None
+        and previous.path == clause.path
+        and _rounding_only_direction(clause.text) is not None
+        and _rounding_text_refers_to_result(clause.text)
+        and not re.search(r"\w", source_text[previous.end : clause.start])
+    )
+
+
+def _rounding_text_refers_to_result(text: str) -> bool:
+    return bool(
+        re.match(
+            r"\s*(?:das\s+ergebnis|the\s+result)\b",
+            text,
+            flags=re.IGNORECASE,
+        )
+    )
 
 
 def _source_clause_spans(
@@ -1851,10 +1888,16 @@ def _formula_branch_test_witnesses(
         selector_names = _rule_numeric_selector_names(rule)
         has_branching_formula = _rule_has_branching_formula(rule)
         for case in asserted_by_rule.get(rule_name, ()):
+            dependency_environment = _case_asserted_dependency_environment(
+                principal_rules,
+                case,
+                formula_environment=formula_environment,
+            )
             execution = _case_formula_execution(
                 rule,
                 case,
                 formula_environment=formula_environment,
+                dependency_environment=dependency_environment,
             )
             if (
                 execution is None
@@ -2441,6 +2484,7 @@ def _case_formula_execution(
     case: dict[str, Any],
     *,
     formula_environment: dict[str, Any] | None = None,
+    dependency_environment: dict[str, Any] | None = None,
 ) -> _FormulaExecution | None:
     """Resolve the reachable RuleSpec formula for one asserted test case."""
 
@@ -2452,10 +2496,23 @@ def _case_formula_execution(
         case,
     )
     environment: dict[str, Any] = dict(constant_environment)
+    for name, value in (dependency_environment or {}).items():
+        if name in environment and not _formula_runtime_values_equal(
+            environment[name],
+            value,
+        ):
+            return None
+        environment[name] = value
     input_environment = _case_input_formula_environment(case)
     if input_environment is None:
         return None
-    environment.update(input_environment)
+    for name, value in input_environment.items():
+        if name in environment and not _formula_runtime_values_equal(
+            environment[name],
+            value,
+        ):
+            return None
+        environment[name] = value
     formula_text = _rule_formula_text_for_case(rule, case)
     if formula_text is None:
         return None
@@ -2486,6 +2543,106 @@ def _case_input_formula_environment(
                 return None
             input_environment[name] = normalized_value
     return input_environment
+
+
+def _case_asserted_dependency_environment(
+    principal_rules: dict[str, dict[str, Any]],
+    case: dict[str, Any],
+    *,
+    formula_environment: dict[str, Any],
+) -> dict[str, Any]:
+    """Resolve only derived values corroborated by this case's assertions."""
+
+    return _case_dependency_environment(
+        principal_rules,
+        case,
+        formula_environment=formula_environment,
+        require_asserted_value=True,
+    )
+
+
+def _case_dependency_environment(
+    principal_rules: dict[str, dict[str, Any]],
+    case: dict[str, Any],
+    *,
+    formula_environment: dict[str, Any],
+    require_asserted_value: bool,
+    allowed_names: set[str] | None = None,
+) -> dict[str, Any]:
+    """Evaluate an acyclic reached subset of local principal outputs."""
+
+    constants = _formula_environment_for_case(formula_environment, case)
+    inputs = _case_input_formula_environment(case)
+    if inputs is None:
+        return {}
+    environment = dict(constants)
+    for name, value in inputs.items():
+        if name in environment and not _formula_runtime_values_equal(
+            environment[name],
+            value,
+        ):
+            return {}
+        environment[name] = value
+
+    candidates = {
+        name: rule
+        for name, rule in principal_rules.items()
+        if allowed_names is None or name in allowed_names
+    }
+    resolved: dict[str, Any] = {}
+    for _ in range(len(candidates) + 1):
+        changed = False
+        for name, rule in candidates.items():
+            if name in resolved or name in environment:
+                continue
+            formula_text = _rule_formula_text_for_case(rule, case)
+            if formula_text is None:
+                continue
+            execution = _execute_formula_text(
+                formula_text,
+                environment=environment,
+                constant_environment=constants,
+            )
+            if execution is None:
+                continue
+            value = _evaluate_formula_selector(execution.leaf, environment)
+            if value is _UNRESOLVED_CONDITION_VALUE:
+                continue
+            if require_asserted_value:
+                asserted = _test_case_asserted_output_value(case, name)
+                if (
+                    asserted is _UNRESOLVED_CONDITION_VALUE
+                    or not _formula_runtime_values_equal(value, asserted)
+                ):
+                    continue
+            resolved[name] = value
+            environment[name] = value
+            changed = True
+        if not changed:
+            break
+    return resolved
+
+
+def _formula_runtime_values_equal(left: Any, right: Any) -> bool:
+    """Mirror RuleSpec scalar equality for evidence-bearing runtime values."""
+
+    left_boolean = _boolean_value(left)
+    right_boolean = _boolean_value(right)
+    if left_boolean is not None or right_boolean is not None:
+        return left_boolean is not None and left_boolean == right_boolean
+    if (
+        isinstance(left, (int, float))
+        and not isinstance(left, bool)
+        and isinstance(right, (int, float))
+        and not isinstance(right, bool)
+    ):
+        with contextlib.suppress(InvalidOperation):
+            return (
+                abs(Decimal(str(left)) - Decimal(str(right)))
+                <= Decimal("1e-18")
+            )
+        return False
+    return type(left) is type(right) and left == right
 
 
 def _execute_formula_text(
@@ -3146,7 +3303,7 @@ def _match_arm_value(
     with contextlib.suppress(SyntaxError, ValueError):
         return ast.literal_eval(value)
     if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", value):
-        return environment.get(value, value)
+        return environment.get(value, _UNRESOLVED_CONDITION_VALUE)
     return _UNRESOLVED_CONDITION_VALUE
 
 
@@ -3328,10 +3485,16 @@ def _branch_boundary_has_test_evidence(
         if not selector_names:
             continue
         for case in asserted_by_rule.get(rule_name, ()):
+            dependency_environment = _case_asserted_dependency_environment(
+                principal_rules,
+                case,
+                formula_environment=formula_environment or {},
+            )
             execution = _case_formula_execution(
                 rule,
                 case,
                 formula_environment=formula_environment,
+                dependency_environment=dependency_environment,
             )
             if (
                 execution is not None
@@ -3358,14 +3521,18 @@ def _branch_boundary_has_test_evidence(
                         rule,
                         case,
                         input_key=input_key,
+                        selector_names=input_names,
                         boundary_value=value,
                         execution=execution,
+                        principal_rules=principal_rules,
+                        dependency_names=set(dependency_environment),
                         formula_environment=formula_environment or {},
                     )
                     for input_key, input_names, value in (
                         _case_numeric_selector_evidence(
                             case,
                             selector_names,
+                            dependency_environment=dependency_environment,
                         )
                     )
                 )
@@ -3396,15 +3563,19 @@ def _formula_execution_binds_boundary(
     }
     if input_names & boundary_names:
         return False
-    texts = [
-        selector
-        for step in execution.trace
-        for selector in step.selectors
-    ]
-    texts.append(execution.leaf)
+    checks: list[tuple[str, bool]] = []
+    for step in execution.trace:
+        if step.kind != "if":
+            continue
+        checks.extend(
+            (selector, True)
+            for selector in step.selectors
+        )
+    checks.append((execution.leaf, False))
     return any(
         _formula_text_has_boundary_comparison(
             text,
+            allow_complement_relation=allow_complement_relation,
             input_names=input_names,
             boundary_names=boundary_names,
             boundary=boundary,
@@ -3413,13 +3584,14 @@ def _formula_execution_binds_boundary(
             extract_numeric_occurrences=extract_numeric_occurrences,
             numeric_value_is_grounded=numeric_value_is_grounded,
         )
-        for text in texts
+        for text, allow_complement_relation in checks
     )
 
 
 def _formula_text_has_boundary_comparison(
     text: str,
     *,
+    allow_complement_relation: bool,
     input_names: set[str],
     boundary_names: set[str],
     boundary: NumericOccurrenceLike,
@@ -3473,6 +3645,7 @@ def _formula_text_has_boundary_comparison(
                         boundary=boundary,
                         numeric_value_is_grounded=numeric_value_is_grounded,
                         source_interval=source_interval,
+                        allow_complement_relation=allow_complement_relation,
                     )
                 ):
                     return True
@@ -3568,12 +3741,15 @@ def _comparison_matches_source_interval(
     boundary: NumericOccurrenceLike,
     numeric_value_is_grounded: NumericGroundingPredicate,
     source_interval: _NumericInterval,
+    allow_complement_relation: bool,
 ) -> bool:
     del boundary_names
     relation = _input_comparison_relation(operator, input_on_left=input_on_left)
     if relation is None:
         return False
-    relations = {relation, _complement_comparison_relation(relation)}
+    relations = {relation}
+    if allow_complement_relation:
+        relations.add(_complement_comparison_relation(relation))
     is_exact = numeric_value_is_grounded(
         compared_boundary_value,
         (boundary,),
@@ -3681,43 +3857,80 @@ def _boundary_case_changes_formula_effect(
     case: dict[str, Any],
     *,
     input_key: object,
+    selector_names: set[str],
     boundary_value: float,
     execution: _FormulaExecution,
+    principal_rules: dict[str, dict[str, Any]],
+    dependency_names: set[str],
     formula_environment: dict[str, Any],
 ) -> bool:
     inputs = case.get("input")
-    if (
-        not isinstance(inputs, dict)
-        or input_key not in inputs
-        or isinstance(inputs[input_key], bool)
-        or not isinstance(inputs[input_key], (int, float))
-    ):
+    if not isinstance(inputs, dict):
         return False
-    step = (
+    boundary_step = (
         1.0
         if float(boundary_value).is_integer()
         else max(abs(boundary_value) * 1e-6, 1e-9)
     )
     signature = _formula_execution_effect_signature(execution)
-    for candidate_value in (
-        boundary_value - step,
-        boundary_value + step,
-    ):
-        candidate_inputs = dict(inputs)
-        candidate_inputs[input_key] = candidate_value
-        candidate_case = dict(case)
-        candidate_case["input"] = candidate_inputs
-        candidate_execution = _case_formula_execution(
-            rule,
-            candidate_case,
-            formula_environment=formula_environment,
-        )
+    for raw_key, raw_value in inputs.items():
         if (
-            candidate_execution is not None
-            and _formula_execution_effect_signature(candidate_execution)
-            != signature
+            isinstance(raw_value, bool)
+            or not isinstance(raw_value, (int, float))
         ):
-            return True
+            continue
+        directly_controls_selector = (
+            raw_key == input_key
+            and bool(_input_key_names(raw_key) & selector_names)
+        )
+        raw_step = (
+            boundary_step
+            if directly_controls_selector
+            else (
+                1.0
+                if float(raw_value).is_integer()
+                else max(abs(float(raw_value)) * 1e-6, 1e-9)
+            )
+        )
+        base_value = boundary_value if directly_controls_selector else float(raw_value)
+        for candidate_value in (
+            base_value - raw_step,
+            base_value + raw_step,
+        ):
+            candidate_inputs = dict(inputs)
+            candidate_inputs[raw_key] = candidate_value
+            candidate_case = dict(case)
+            candidate_case["input"] = candidate_inputs
+            candidate_dependencies = _case_dependency_environment(
+                principal_rules,
+                candidate_case,
+                formula_environment=formula_environment,
+                require_asserted_value=False,
+                allowed_names=dependency_names,
+            )
+            selector_changed = any(
+                names & selector_names
+                and not math.isclose(value, float(boundary_value))
+                for _key, names, value in _case_numeric_selector_evidence(
+                    candidate_case,
+                    selector_names,
+                    dependency_environment=candidate_dependencies,
+                )
+            )
+            if not selector_changed:
+                continue
+            candidate_execution = _case_formula_execution(
+                rule,
+                candidate_case,
+                formula_environment=formula_environment,
+                dependency_environment=candidate_dependencies,
+            )
+            if (
+                candidate_execution is not None
+                and _formula_execution_effect_signature(candidate_execution)
+                != signature
+            ):
+                return True
     return False
 
 
@@ -3888,6 +4101,8 @@ def _case_numeric_selector_values(
 def _case_numeric_selector_evidence(
     case: dict[str, Any],
     selector_names: set[str],
+    *,
+    dependency_environment: dict[str, Any] | None = None,
 ) -> tuple[tuple[object, set[str], float], ...]:
     inputs = case.get("input")
     if not isinstance(inputs, dict):
@@ -3899,6 +4114,16 @@ def _case_numeric_selector_evidence(
             continue
         evidence.extend(
             (key, matched_names, numeric_value)
+            for numeric_value in _numeric_test_input_values(value)
+        )
+    directly_matched_names = set().union(
+        *(names for _key, names, _value in evidence),
+    ) if evidence else set()
+    for name, value in (dependency_environment or {}).items():
+        if name not in selector_names or name in directly_matched_names:
+            continue
+        evidence.extend(
+            (name, {name}, numeric_value)
             for numeric_value in _numeric_test_input_values(value)
         )
     return tuple(evidence)
@@ -3958,6 +4183,9 @@ def _source_rounding_obligations(
     deferred_paths: set[tuple[str, ...]],
 ) -> tuple[tuple[SourceStructureBranch, str], ...]:
     obligations: list[tuple[SourceStructureBranch, str]] = []
+    source_clauses = tuple(
+        _source_clause_spans(source_text, branches=branches)
+    )
     for match in _ROUNDING_LANGUAGE.finditer(source_text):
         if _span_is_deferred(
             match.start(),
@@ -3978,10 +4206,18 @@ def _source_rounding_obligations(
             0,
             len(source_text),
         )
-        matched_text = match.group(0)
-        if _NEAREST_ROUNDING_LANGUAGE.search(matched_text):
+        matched_language = match.group(0)
+        clause_start, clause_end, clause_text = next(
+            (
+                (start, end, text)
+                for start, end, text in source_clauses
+                if start <= match.start() and match.end() <= end
+            ),
+            (match.start(), match.end(), matched_language),
+        )
+        if _NEAREST_ROUNDING_LANGUAGE.search(matched_language):
             direction = "nearest"
-        elif _UP_ROUNDING_LANGUAGE.search(matched_text):
+        elif _UP_ROUNDING_LANGUAGE.search(matched_language):
             direction = "upward"
         else:
             direction = "downward"
@@ -3989,9 +4225,9 @@ def _source_rounding_obligations(
             owner.path,
             "rounding-clause",
             owner.label,
-            matched_text,
-            match.start(),
-            match.end(),
+            clause_text,
+            clause_start,
+            clause_end,
         )
         obligations.append((obligation_branch, direction))
     return tuple(obligations)
@@ -4014,19 +4250,7 @@ def _rounding_source_formula_branch(
             containing,
             key=lambda branch: branch.end - branch.start,
         )
-    same_path = [
-        branch
-        for branch in formula_branches
-        if branch.path == rounding_branch.path
-    ]
-    return min(
-        same_path,
-        key=lambda branch: min(
-            abs(branch.start - rounding_branch.end),
-            abs(rounding_branch.start - branch.end),
-        ),
-        default=None,
-    )
+    return None
 
 
 def _unwitnessed_exception_branches(
@@ -4091,45 +4315,83 @@ def _toggled_formula_boolean_selectors(
         selector_names = _rule_exception_selector_names(rule)
         if not selector_names:
             continue
-        cases = asserted_by_rule.get(rule_name, ())
-        for key, left_case, right_case in _paired_boolean_toggle_case_pairs(cases):
-            matched_names = _input_key_names(key) & selector_names
-            if not matched_names:
-                continue
-            left_execution = _case_formula_execution(
-                rule,
-                left_case,
-                formula_environment=formula_environment,
-            )
-            right_execution = _case_formula_execution(
-                rule,
-                right_case,
-                formula_environment=formula_environment,
-            )
-            if left_execution is None or right_execution is None:
-                continue
-            left_asserted = _test_case_asserted_output_value(
-                left_case,
-                rule_name,
-            )
-            right_asserted = _test_case_asserted_output_value(
-                right_case,
-                rule_name,
-            )
-            if (
-                left_asserted is not _UNRESOLVED_CONDITION_VALUE
-                and right_asserted is not _UNRESOLVED_CONDITION_VALUE
-                and _same_formula_value(left_asserted, right_asserted)
-            ) or (
+        records = [
+            (
+                case,
                 (
-                    left_asserted is _UNRESOLVED_CONDITION_VALUE
-                    or right_asserted is _UNRESOLVED_CONDITION_VALUE
+                    dependency_environment
+                    := _case_asserted_dependency_environment(
+                        principal_rules,
+                        case,
+                        formula_environment=formula_environment,
+                    )
+                ),
+                _case_boolean_selector_environment(
+                    case,
+                    selector_names,
+                    dependency_environment=dependency_environment,
+                ),
+            )
+            for case in asserted_by_rule.get(rule_name, ())
+        ]
+        for left_index, (
+            left_case,
+            left_dependencies,
+            left_selectors,
+        ) in enumerate(records):
+            for (
+                right_case,
+                right_dependencies,
+                right_selectors,
+            ) in records[left_index + 1 :]:
+                if set(left_selectors) != set(right_selectors):
+                    continue
+                changed_names = {
+                    name
+                    for name in left_selectors
+                    if left_selectors[name] != right_selectors[name]
+                }
+                if len(changed_names) != 1:
+                    continue
+                selector_name = next(iter(changed_names))
+                left_execution = _case_formula_execution(
+                    rule,
+                    left_case,
+                    formula_environment=formula_environment,
+                    dependency_environment=left_dependencies,
                 )
-                and _formula_execution_effect_signature(left_execution)
-                == _formula_execution_effect_signature(right_execution)
-            ):
-                continue
-            for selector_name in matched_names:
+                right_execution = _case_formula_execution(
+                    rule,
+                    right_case,
+                    formula_environment=formula_environment,
+                    dependency_environment=right_dependencies,
+                )
+                if left_execution is None or right_execution is None:
+                    continue
+                left_asserted = _test_case_asserted_output_value(
+                    left_case,
+                    rule_name,
+                )
+                right_asserted = _test_case_asserted_output_value(
+                    right_case,
+                    rule_name,
+                )
+                if (
+                    left_asserted is not _UNRESOLVED_CONDITION_VALUE
+                    and right_asserted is not _UNRESOLVED_CONDITION_VALUE
+                    and _formula_runtime_values_equal(
+                        left_asserted,
+                        right_asserted,
+                    )
+                ) or (
+                    (
+                        left_asserted is _UNRESOLVED_CONDITION_VALUE
+                        or right_asserted is _UNRESOLVED_CONDITION_VALUE
+                    )
+                    and _formula_execution_effect_signature(left_execution)
+                    == _formula_execution_effect_signature(right_execution)
+                ):
+                    continue
                 if all(
                     _formula_execution_reaches_selector(
                         execution,
@@ -4141,10 +4403,44 @@ def _toggled_formula_boolean_selectors(
     return toggled
 
 
+def _case_boolean_selector_environment(
+    case: dict[str, Any],
+    selector_names: set[str],
+    *,
+    dependency_environment: dict[str, Any],
+) -> dict[str, bool]:
+    values: dict[str, bool] = {}
+    inputs = case.get("input")
+    if not isinstance(inputs, dict):
+        return values
+    for key, value in inputs.items():
+        boolean = _boolean_value(value)
+        if boolean is None:
+            continue
+        for name in _input_key_names(key) & selector_names:
+            if name in values and values[name] != boolean:
+                return {}
+            values[name] = boolean
+    for name, value in dependency_environment.items():
+        if name not in selector_names:
+            continue
+        boolean = _boolean_value(value)
+        if boolean is None:
+            continue
+        if name in values and values[name] != boolean:
+            return {}
+        values[name] = boolean
+    return values
+
+
 def _formula_execution_effect_signature(
     execution: _FormulaExecution,
 ) -> tuple[str, Any]:
     if execution.evaluated_value is not None:
+        value_type, raw_value = execution.evaluated_value
+        if value_type in {"int", "float"}:
+            with contextlib.suppress(InvalidOperation):
+                return "evaluated-number", Decimal(raw_value)
         return "evaluated", execution.evaluated_value
     return "leaf", _collapse_text(execution.leaf).lower()
 
@@ -4307,15 +4603,17 @@ def _fractional_rounding_case_witnesses(
     rule_name: str,
     rule: dict[str, Any],
     *,
+    principal_rules: dict[str, dict[str, Any]],
     asserted_by_rule: dict[str, list[dict[str, Any]]],
     direction: str,
     formula_environment: dict[str, Any],
     source_formula_branch: SourceStructureBranch | None,
+    rounding_refers_to_result: bool,
     require_clause_binding: bool,
     extract_numeric_occurrences: NumericOccurrenceExtractor,
     numeric_value_is_grounded: NumericGroundingPredicate,
-) -> set[tuple[str, int, str]]:
-    evidence: set[tuple[str, int, str]] = set()
+) -> set[tuple[str, str, str]]:
+    evidence: set[tuple[str, str, str]] = set()
     functions = {
         "nearest" if direction == "nearest" else (
             "ceil" if direction == "upward" else "floor"
@@ -4325,10 +4623,16 @@ def _fractional_rounding_case_witnesses(
         inputs = case.get("input")
         if not isinstance(inputs, dict):
             continue
+        dependency_environment = _case_asserted_dependency_environment(
+            principal_rules,
+            case,
+            formula_environment=formula_environment,
+        )
         execution = _case_formula_execution(
             rule,
             case,
             formula_environment=formula_environment,
+            dependency_environment=dependency_environment,
         )
         if execution is None or not _formula_execution_implements_rounding(
             execution,
@@ -4343,6 +4647,7 @@ def _fractional_rounding_case_witnesses(
         if input_environment is None:
             continue
         evaluation_environment = dict(execution.constant_environment)
+        evaluation_environment.update(dependency_environment)
         evaluation_environment.update(input_environment)
         for function_name, operand in _rounding_call_operands(
             operative_leaf,
@@ -4354,6 +4659,13 @@ def _fractional_rounding_case_witnesses(
             )
             if effective_operand is None:
                 continue
+            source_binding_operand = _expand_reached_formula_dependencies(
+                effective_operand,
+                principal_rules=principal_rules,
+                case=case,
+                formula_environment=formula_environment,
+                dependency_environment=dependency_environment,
+            )
             operand_value = _evaluate_formula_selector(
                 effective_operand,
                 evaluation_environment,
@@ -4367,17 +4679,23 @@ def _fractional_rounding_case_witnesses(
                     effective_operand,
                     evaluation_environment=evaluation_environment,
                     operand_value=float(operand_value),
+                    principal_rules=principal_rules,
+                    formula_environment=formula_environment,
+                    dependency_names=set(dependency_environment),
                 )
             ):
                 continue
             if (
                 source_formula_branch is not None
                 and not _rounding_call_binds_source_clause(
-                    effective_operand,
+                    source_binding_operand,
+                    original_operand=effective_operand,
                     operand_value=float(operand_value),
+                    rule_name=rule_name,
                     execution=execution,
                     source_formula_branch=source_formula_branch,
                     formula_environment=formula_environment,
+                    rounding_refers_to_result=rounding_refers_to_result,
                     require_clause_binding=require_clause_binding,
                     extract_numeric_occurrences=extract_numeric_occurrences,
                     numeric_value_is_grounded=numeric_value_is_grounded,
@@ -4391,7 +4709,13 @@ def _fractional_rounding_case_witnesses(
                     formula_environment=execution.constant_environment,
                 )
             )
-            evidence.add((rule_name, id(case), call_key))
+            evidence.add(
+                (
+                    rule_name,
+                    _formula_execution_outcome(execution),
+                    call_key,
+                )
+            )
     return evidence
 
 
@@ -4453,17 +4777,73 @@ def _rounding_demonstrated_operand(
     return None
 
 
+def _expand_reached_formula_dependencies(
+    expression_text: str,
+    *,
+    principal_rules: dict[str, dict[str, Any]],
+    case: dict[str, Any],
+    formula_environment: dict[str, Any],
+    dependency_environment: dict[str, Any],
+) -> str:
+    """Inline reached, assertion-corroborated intermediates for source matching."""
+
+    try:
+        expression = ast.parse(expression_text.strip(), mode="eval").body
+    except SyntaxError:
+        return expression_text
+
+    resolving: set[str] = set()
+
+    class DependencyExpander(ast.NodeTransformer):
+        def visit_Name(self, node: ast.Name) -> ast.AST:
+            name = node.id
+            rule = principal_rules.get(name)
+            if (
+                rule is None
+                or name not in dependency_environment
+                or name in resolving
+            ):
+                return node
+            execution = _case_formula_execution(
+                rule,
+                case,
+                formula_environment=formula_environment,
+                dependency_environment=dependency_environment,
+            )
+            if execution is None:
+                return node
+            try:
+                replacement = ast.parse(
+                    execution.leaf.strip(),
+                    mode="eval",
+                ).body
+            except SyntaxError:
+                return node
+            resolving.add(name)
+            expanded = self.visit(replacement)
+            resolving.remove(name)
+            return ast.copy_location(expanded, node)
+
+    expanded = DependencyExpander().visit(expression)
+    ast.fix_missing_locations(expanded)
+    return ast.unparse(expanded)
+
+
 def _fractional_input_materially_affects_operand(
     case: dict[str, Any],
     operand: str,
     *,
     evaluation_environment: dict[str, Any],
     operand_value: float,
+    principal_rules: dict[str, dict[str, Any]],
+    formula_environment: dict[str, Any],
+    dependency_names: set[str],
 ) -> bool:
     inputs = case.get("input")
     if not isinstance(inputs, dict):
         return False
     operand_names = set(_FORMULA_IDENTIFIER.findall(operand))
+    uses_derived_operand = bool(operand_names & dependency_names)
     for key, value in inputs.items():
         if (
             isinstance(value, bool)
@@ -4472,12 +4852,29 @@ def _fractional_input_materially_affects_operand(
         ):
             continue
         aliases = _input_key_names(key) & operand_names
-        if not aliases:
+        if not aliases and not uses_derived_operand:
             continue
         replacement = float(math.floor(float(value)))
-        changed_environment = dict(evaluation_environment)
-        for alias in aliases:
-            changed_environment[alias] = replacement
+        candidate_inputs = dict(inputs)
+        candidate_inputs[key] = replacement
+        candidate_case = dict(case)
+        candidate_case["input"] = candidate_inputs
+        candidate_dependencies = _case_dependency_environment(
+            principal_rules,
+            candidate_case,
+            formula_environment=formula_environment,
+            require_asserted_value=False,
+            allowed_names=dependency_names,
+        )
+        changed_environment = _formula_environment_for_case(
+            formula_environment,
+            candidate_case,
+        )
+        changed_environment.update(candidate_dependencies)
+        changed_inputs = _case_input_formula_environment(candidate_case)
+        if changed_inputs is None:
+            continue
+        changed_environment.update(changed_inputs)
         changed_value = _evaluate_formula_selector(
             operand,
             changed_environment,
@@ -4525,10 +4922,13 @@ def _rounding_call_matches_source_formula(
 def _rounding_call_binds_source_clause(
     operand: str,
     *,
+    original_operand: str,
     operand_value: float,
+    rule_name: str,
     execution: _FormulaExecution,
     source_formula_branch: SourceStructureBranch,
     formula_environment: dict[str, Any],
+    rounding_refers_to_result: bool,
     require_clause_binding: bool,
     extract_numeric_occurrences: NumericOccurrenceExtractor,
     numeric_value_is_grounded: NumericGroundingPredicate,
@@ -4542,8 +4942,8 @@ def _rounding_call_binds_source_clause(
         extract_numeric_occurrences=extract_numeric_occurrences,
         numeric_value_is_grounded=numeric_value_is_grounded,
     )
-    if not require_clause_binding:
-        return formula_match
+    if rounding_refers_to_result:
+        return True
     source_has_distinguishing_computation = bool(
         _formula_operation_kinds(source_formula_branch.text)
         or extract_numeric_occurrences(
@@ -4552,82 +4952,54 @@ def _rounding_call_binds_source_clause(
     )
     if source_has_distinguishing_computation:
         return formula_match
-    return _rounding_call_matches_clause_tokens(
-        operand,
-        source_formula_branch,
+    if require_clause_binding:
+        return True
+    return _rounding_operand_is_output_stage(
+        original_operand,
+        rule_name=rule_name,
     )
 
 
-def _rounding_call_matches_clause_tokens(
+def _rounding_operand_is_output_stage(
     operand: str,
-    branch: SourceStructureBranch,
+    *,
+    rule_name: str,
 ) -> bool:
-    operand_tokens = _rounding_semantic_tokens(operand)
-    source_tokens = _rounding_semantic_tokens(branch.text)
-    ordinal_by_path = {
-        "1": "first",
-        "2": "second",
-        "3": "third",
-        "4": "fourth",
-        "5": "fifth",
-    }
-    source_tokens.update(
-        ordinal_by_path[item]
-        for item in branch.path
-        if item in ordinal_by_path
+    output_subject = _rounding_stage_subject(rule_name)
+    return bool(output_subject) and any(
+        _rounding_stage_subject(identifier) == output_subject
+        for identifier in _FORMULA_IDENTIFIER.findall(operand)
     )
-    return bool(operand_tokens & source_tokens)
 
 
-def _rounding_semantic_tokens(text: str) -> set[str]:
-    normalized = re.sub(r"(?<=[a-z])(?=[A-Z])", " ", text)
-    tokens = {
-        token.lower()
-        for token in re.findall(r"[A-Za-zÄÖÜäöüß]+", normalized)
-    }
-    translations = {
-        "erste": "first",
-        "erster": "first",
-        "erstes": "first",
-        "zweite": "second",
-        "zweiter": "second",
-        "zweites": "second",
-        "dritte": "third",
-        "dritter": "third",
-        "drittes": "third",
-    }
-    tokens.update(
-        translations[token]
-        for token in tuple(tokens)
-        if token in translations
-    )
-    return tokens - {
-        "amount",
-        "betrag",
-        "der",
-        "die",
-        "das",
-        "ein",
-        "eine",
-        "einkommen",
-        "income",
-        "ergebnis",
-        "result",
-        "steuer",
-        "tax",
-        "wird",
-        "ist",
-        "und",
-        "and",
-        "auf",
-        "volle",
-        "euro",
+def _rounding_stage_subject(identifier: str) -> tuple[str, ...]:
+    normalized = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", identifier)
+    stage_tokens = {
         "round",
         "rounded",
         "rounding",
-        "abzurunden",
-        "aufzurunden",
+        "unrounded",
+        "raw",
+        "pre",
+        "post",
+        "before",
+        "after",
+        "floor",
+        "floored",
+        "ceil",
+        "ceiled",
+        "down",
+        "downward",
+        "up",
+        "upward",
+        "nearest",
+        "final",
     }
+    return tuple(
+        token
+        for token in re.findall(r"[A-Za-z0-9]+", normalized.lower())
+        if token not in stage_tokens
+    )
 
 
 def _balanced_call_operands(text: str, function_name: str) -> Iterable[str]:

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -239,6 +239,11 @@ _GERMAN_LEGAL_CITATION = re.compile(
     r"(?:\s*(?:und|bis)\s*\d+[a-z]?)*",
     flags=re.IGNORECASE,
 )
+_EXPLICIT_LEGAL_SECTION_REFERENCE = re.compile(
+    r"(?:§{1,2}\s*|\b(?:sections?|paragra(?:f|phs?))\s+)"
+    r"(?P<section>\d+[a-z]?)",
+    flags=re.IGNORECASE,
+)
 _ENGLISH_LEGAL_CITATION = re.compile(
     r"\b(?:sections?|secs?\.?|regulations?|paragraphs?)\s+"
     r"\d+(?:\.\d+)*(?:\s*(?:through|to|-|and|,)\s*\d+(?:\.\d+)*)*",
@@ -545,7 +550,7 @@ def _analyze_rulespec_payload(
             "`module.summary` is not consulted."
         )
 
-    if formula_branches and principal_rules:
+    if principal_rules:
         issues.extend(
             _companion_test_issues(
                 principal_rules,
@@ -1030,6 +1035,12 @@ def _reason_identifies_blocker(reason: str, blocker: str) -> bool:
 
     target_path, _separator, symbol = blocker.partition("#")
     section = target_path.rstrip("/").rsplit("/", 1)[-1]
+    explicit_sections = {
+        match.group("section").lower()
+        for match in _EXPLICIT_LEGAL_SECTION_REFERENCE.finditer(reason)
+    }
+    if explicit_sections and section.lower() not in explicit_sections:
+        return False
     if section and re.search(
         rf"(?:§{{1,2}}\s*|\b(?:section|paragraph|paragraf|abschnitt)\s+)"
         rf"{re.escape(section)}(?![A-Za-z0-9])",
@@ -1253,9 +1264,9 @@ def _companion_test_issues(
     cases = [case for case in (test_cases or ()) if isinstance(case, dict)]
     if not cases:
         return [
-            "[complete-source-unit:tests] Explicit source computations require "
-            "a companion test suite covering branches, boundaries, exceptions, "
-            "and rounding rules."
+            "[complete-source-unit:tests] Complete source-unit controls require "
+            "a companion test suite covering outputs, branches, boundaries, "
+            "exceptions, and rounding rules."
         ]
 
     asserted_by_rule = {
@@ -1296,8 +1307,18 @@ def _companion_test_issues(
             "test evidence."
         )
 
+    boundary_branches = active_branches or [
+        SourceStructureBranch(
+            (),
+            "source-unit",
+            "source unit",
+            source_text,
+            0,
+            len(source_text),
+        )
+    ]
     boundary_obligations = _source_boundary_obligations(
-        active_branches,
+        boundary_branches,
         narrative_formula_branches=formula_branches,
         extract_numeric_occurrences=extract_numeric_occurrences,
     )
@@ -3047,7 +3068,13 @@ def _source_boundary_obligations(
 ) -> tuple[tuple[SourceStructureBranch, NumericOccurrenceLike], ...]:
     obligations: list[tuple[SourceStructureBranch, NumericOccurrenceLike]] = []
     for branch in branches:
-        if branch.kind not in {"number", "letter"}:
+        if branch.kind not in {
+            "paragraph",
+            "number",
+            "letter",
+            "sentence",
+            "source-unit",
+        }:
             continue
         first_line = branch.text.splitlines()[0] if branch.text.splitlines() else ""
         prefix = first_line.split(":", 1)[0]
@@ -3059,10 +3086,17 @@ def _source_boundary_obligations(
             flags=re.IGNORECASE,
         ):
             continue
-        prefix = _NUMBER_MARKER.sub("", prefix)
+        prefix = authoritative_numeric_recall_text(prefix)
+        interval = _formula_interval_from_text(
+            prefix,
+            extract_numeric_occurrences=extract_numeric_occurrences,
+        )
+        if interval is None:
+            continue
         obligations.extend(
-            (branch, occurrence)
-            for occurrence in extract_numeric_occurrences(prefix)
+            (branch, boundary)
+            for boundary in (interval.lower, interval.upper)
+            if boundary is not None
         )
     for branch in narrative_formula_branches:
         interval = _formula_branch_interval(

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -4575,6 +4575,11 @@ def _constant_rule_environment(payload: dict[str, Any]) -> dict[str, Any]:
         versions = rule.get("versions")
         if not name or not isinstance(versions, list):
             continue
+        formula_version_count = sum(
+            1
+            for version in versions
+            if isinstance(version, dict) and "formula" in version
+        )
         entries: list[tuple[str, str, Any]] = []
         for version in versions:
             if not isinstance(version, dict) or "formula" not in version:
@@ -4593,6 +4598,8 @@ def _constant_rule_environment(payload: dict[str, Any]) -> dict[str, Any]:
                             value,
                         )
                     )
+        if len(entries) != formula_version_count:
+            continue
         values = [value for _start, _end, value in entries]
         if values and all(
             type(value) is type(values[0]) and value == values[0]

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1,0 +1,998 @@
+"""Opt-in authoritative source-unit completeness accounting.
+
+This module deliberately sits beside, rather than inside, the numeric
+extractor.  It consumes the extractor and scalar-inventory interfaces supplied
+by :mod:`validator_pipeline`, which keeps locale-tokenizer work independent
+from the source-unit admission policy implemented here.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import re
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import yaml
+
+NumericOccurrenceExtractor = Callable[[str], Sequence[float]]
+NamedScalarExtractor = Callable[[str], Sequence[Any]]
+NumericGroundingPredicate = Callable[[float, set[float]], bool]
+
+
+@dataclass(frozen=True)
+class SourceStructureBranch:
+    """One operative structural branch in an authoritative source unit."""
+
+    path: tuple[str, ...]
+    kind: str
+    label: str
+    text: str
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class CompleteSourceUnitAnalysis:
+    """Deterministic completeness results for one RuleSpec/source pair."""
+
+    issues: tuple[str, ...]
+    branches: tuple[SourceStructureBranch, ...]
+    source_numeric_occurrence_count: int
+    covered_source_numeric_occurrence_count: int
+    missing_source_numeric_occurrence_count: int
+
+
+_PARAGRAPH_MARKER = re.compile(
+    r"(?m)^(?P<marker>\((?P<label>\d+[a-z]?|[a-z])\))(?=\s|bis\b)",
+    flags=re.IGNORECASE,
+)
+_NUMBER_MARKER = re.compile(
+    r"(?m)^[ \t]*(?P<marker>(?P<label>\d+[a-z]?)\.)[ \t]+",
+    flags=re.IGNORECASE,
+)
+_LETTER_MARKER = re.compile(
+    r"(?m)^[ \t]*(?P<marker>(?P<label>[a-z]{1,2})\))[ \t]+",
+    flags=re.IGNORECASE,
+)
+_GLUED_SENTENCE_MARKER = re.compile(
+    r"(?<![\w])(?P<label>[1-9]\d?)(?=[A-ZÄÖÜ])"
+)
+_EXPLICIT_SENTENCE_MARKER = re.compile(
+    r"(?:(?<=^)|(?<=[.;]))[ \t]*Satz[ \t]+(?P<label>[1-9]\d?)(?=[ \t]+[A-ZÄÖÜ])",
+    flags=re.IGNORECASE | re.MULTILINE,
+)
+_EDITORIAL_OMISSION = re.compile(
+    r"\b(?:weggefallen|aufgehoben|repealed|omitted)\b|\.{3,}",
+    flags=re.IGNORECASE,
+)
+_ARITHMETIC_EXPRESSION = re.compile(
+    r"(?:\d|[A-Za-zÄÖÜäöüß][A-Za-zÄÖÜäöüß]*)"
+    r"[ \t]*(?:[+*/=×·•∗∙]|(?<!\w)[−–-](?!\w))[ \t]*"
+    r"(?:\d|[A-Za-zÄÖÜäöüß][A-Za-zÄÖÜäöüß]*)"
+)
+_COMPUTATION_LANGUAGE = re.compile(
+    r"\b(?:"
+    r"bemisst\s+sich\s+nach|berechn(?:et|en|ung)|ergibt\s+sich|"
+    r"zweifache|hälfte|zehntausendstel|übersteigenden\s+teils|"
+    r"splitting-verfahren|verfahren\s+nach\s+absatz|"
+    r"calculated|computed|computation|multiplied|divided|"
+    r"sum\s+of|difference\s+between|product\s+of|twice|half\s+of|"
+    r"percentage\s+of|in\s+excess\s+of"
+    r")\b",
+    flags=re.IGNORECASE,
+)
+_ROUNDING_LANGUAGE = re.compile(
+    r"\b(?:"
+    r"abgerundet(?:en|er|es)?|abzurunden|aufgerundet(?:en|er|es)?|"
+    r"aufzurunden|kaufmännisch(?:\s+zu)?\s+runden|"
+    r"round(?:ed|ing)?(?:\s+(?:down|up|to\s+the\s+nearest))?"
+    r")\b",
+    flags=re.IGNORECASE,
+)
+_DOWN_ROUNDING_LANGUAGE = re.compile(
+    r"\b(?:abgerundet(?:en|er|es)?|abzurunden|round(?:ed|ing)?\s+down)\b",
+    flags=re.IGNORECASE,
+)
+_UP_ROUNDING_LANGUAGE = re.compile(
+    r"\b(?:aufgerundet(?:en|er|es)?|aufzurunden|round(?:ed|ing)?\s+up)\b",
+    flags=re.IGNORECASE,
+)
+_NEAREST_ROUNDING_LANGUAGE = re.compile(
+    r"\b(?:kaufmännisch(?:\s+zu)?\s+runden|round(?:ed|ing)?\s+to\s+the\s+nearest)\b",
+    flags=re.IGNORECASE,
+)
+_EXCEPTION_LANGUAGE = re.compile(
+    r"\b(?:"
+    r"except(?:ion)?|unless|subject\s+to|shall\s+not\s+apply|"
+    r"does\s+not\s+apply|notwithstanding|vorbehaltlich|ausnahme|"
+    r"es\s+sei\s+denn|voraussetzung[^.;]{0,160}\bnicht\b"
+    r")",
+    flags=re.IGNORECASE,
+)
+_PRECISE_DEFERRAL_DEPENDENCY = re.compile(
+    r"(?:"
+    r"§{1,2}\s*\d+[a-z]?|"
+    r"\b(?:section|subsection|paragraph|absatz|abs\.|satz|nummer|nr\.)"
+    r"\s*\d+[a-z]?|"
+    r"\b[a-z]{2}(?:-[a-z0-9-]+)?/(?:statute|regulation|guidance|manual)/"
+    r"[A-Za-z0-9_./-]+|"
+    r"\b[a-z]{2}(?:-[a-z0-9-]+)?:"
+    r"(?:statutes|regulations|guidance|manuals)/[A-Za-z0-9_./-]+#[A-Za-z0-9_]+"
+    r")",
+    flags=re.IGNORECASE,
+)
+_MISSING_DEPENDENCY_LANGUAGE = re.compile(
+    r"\b(?:"
+    r"requires?|depends?\s+on|missing|not\s+yet\s+encoded|unavailable|"
+    r"benötigt|abhängig|fehlt|nicht\s+codiert"
+    r")\b",
+    flags=re.IGNORECASE,
+)
+_PRECISE_NONOPERATIVE_REASON = re.compile(
+    r"\b(?:non-operative|legislative\s+(?:intent|finding|purpose)|"
+    r"administrative\s+workflow|weggefallen|aufgehoben)\b",
+    flags=re.IGNORECASE,
+)
+_ABSATZ_REFERENCE = re.compile(
+    r"\b(?:Absatz|Abs\.)\s*(?P<label>\d+[a-z]?)\b",
+    flags=re.IGNORECASE,
+)
+_SATZ_REFERENCE = re.compile(
+    r"\b(?:Satz|Sätze)\s*(?P<label>\d+)\b",
+    flags=re.IGNORECASE,
+)
+_NUMMER_REFERENCE = re.compile(
+    r"\b(?:Nummer|Nr\.)\s*(?P<label>\d+[a-z]?)\b",
+    flags=re.IGNORECASE,
+)
+_BUCHSTABE_REFERENCE = re.compile(
+    r"\b(?:Buchstabe|Buchst\.)\s*(?P<label>[a-z])\b",
+    flags=re.IGNORECASE,
+)
+_GERMAN_LEGAL_CITATION = re.compile(
+    r"§{1,2}\s*\d+[a-z]?"
+    r"(?:\s*,\s*\d+[a-z]?)*"
+    r"(?:\s*(?:und|bis)\s*\d+[a-z]?)*",
+    flags=re.IGNORECASE,
+)
+_ENGLISH_LEGAL_CITATION = re.compile(
+    r"\b(?:sections?|secs?\.?|regulations?|paragraphs?)\s+"
+    r"\d+(?:\.\d+)*(?:\s*(?:through|to|-|and|,)\s*\d+(?:\.\d+)*)*",
+    flags=re.IGNORECASE,
+)
+_STRUCTURAL_REFERENCE = re.compile(
+    r"\b(?:Absatz|Abs\.|Satz|Sätze|Nummer|Nr\.|Buchstabe|Buchst\.)"
+    r"\s*\d*[a-z]?\b",
+    flags=re.IGNORECASE,
+)
+
+
+def recognize_source_structure(source_text: str) -> tuple[SourceStructureBranch, ...]:
+    """Recognize paragraph, list, letter, and glued German sentence markers."""
+
+    paragraph_matches = list(_PARAGRAPH_MARKER.finditer(source_text))
+    branches: list[SourceStructureBranch] = []
+    paragraph_segments: list[tuple[tuple[str, ...], int, int, str]] = []
+
+    for index, match in enumerate(paragraph_matches):
+        start = match.start()
+        end = (
+            paragraph_matches[index + 1].start()
+            if index + 1 < len(paragraph_matches)
+            else len(source_text)
+        )
+        label = match.group("label").lower()
+        text = source_text[start:end].strip()
+        if _EDITORIAL_OMISSION.search(text):
+            continue
+        path = (label,)
+        branches.append(
+            SourceStructureBranch(path, "paragraph", match.group("marker"), text, start, end)
+        )
+        paragraph_segments.append((path, start, end, text))
+
+    if not paragraph_segments:
+        paragraph_segments = [((), 0, len(source_text), source_text)]
+
+    for paragraph_path, paragraph_start, paragraph_end, _ in paragraph_segments:
+        paragraph_text = source_text[paragraph_start:paragraph_end]
+        number_matches = list(_NUMBER_MARKER.finditer(paragraph_text))
+        number_segments: list[tuple[tuple[str, ...], int, int]] = []
+        for index, match in enumerate(number_matches):
+            start = paragraph_start + match.start()
+            end = (
+                paragraph_start + number_matches[index + 1].start()
+                if index + 1 < len(number_matches)
+                else paragraph_end
+            )
+            label = match.group("label").lower()
+            path = (*paragraph_path, label)
+            text = source_text[start:end].strip()
+            if _EDITORIAL_OMISSION.search(text):
+                continue
+            branches.append(
+                SourceStructureBranch(
+                    path, "number", match.group("marker"), text, start, end
+                )
+            )
+            number_segments.append((path, start, end))
+
+        letter_containers = number_segments or [
+            (paragraph_path, paragraph_start, paragraph_end)
+        ]
+        for container_path, container_start, container_end in letter_containers:
+            container_text = source_text[container_start:container_end]
+            letter_matches = list(_LETTER_MARKER.finditer(container_text))
+            for index, match in enumerate(letter_matches):
+                start = container_start + match.start()
+                end = (
+                    container_start + letter_matches[index + 1].start()
+                    if index + 1 < len(letter_matches)
+                    else container_end
+                )
+                label = match.group("label").lower()
+                path = (*container_path, label)
+                text = source_text[start:end].strip()
+                if _EDITORIAL_OMISSION.search(text):
+                    continue
+                branches.append(
+                    SourceStructureBranch(
+                        path, "letter", match.group("marker"), text, start, end
+                    )
+                )
+
+        sentence_matches = sorted(
+            (
+                *_GLUED_SENTENCE_MARKER.finditer(paragraph_text),
+                *_EXPLICIT_SENTENCE_MARKER.finditer(paragraph_text),
+            ),
+            key=lambda item: item.start(),
+        )
+        for index, match in enumerate(sentence_matches):
+            start = paragraph_start + match.start()
+            end = (
+                paragraph_start + sentence_matches[index + 1].start()
+                if index + 1 < len(sentence_matches)
+                else paragraph_end
+            )
+            container = max(
+                (
+                    branch
+                    for branch in branches
+                    if branch.start <= start < branch.end
+                    and branch.kind in {"paragraph", "number", "letter"}
+                ),
+                key=lambda branch: len(branch.path),
+                default=None,
+            )
+            parent_path = container.path if container is not None else paragraph_path
+            label = match.group("label")
+            path = (*parent_path, f"satz-{label}")
+            text = source_text[start:end].strip()
+            if _EDITORIAL_OMISSION.search(text):
+                continue
+            branches.append(
+                SourceStructureBranch(path, "sentence", f"Satz {label}", text, start, end)
+            )
+
+    unique = {
+        (branch.path, branch.kind, branch.start): branch for branch in branches
+    }
+    return tuple(
+        sorted(
+            unique.values(),
+            key=lambda branch: (branch.start, len(branch.path), branch.kind),
+        )
+    )
+
+
+def source_states_explicit_computation(source_text: str) -> bool:
+    """Return whether text states a computation rather than only a scalar."""
+
+    return bool(
+        _ARITHMETIC_EXPRESSION.search(source_text)
+        or _COMPUTATION_LANGUAGE.search(source_text)
+        or _ROUNDING_LANGUAGE.search(source_text)
+    )
+
+
+def analyze_complete_source_unit(
+    content: str,
+    authoritative_source_text: str,
+    *,
+    corpus_citation_path: str,
+    test_cases: Sequence[object] | None,
+    extract_numeric_occurrences: NumericOccurrenceExtractor,
+    extract_named_scalars: NamedScalarExtractor,
+    numeric_value_is_grounded: NumericGroundingPredicate,
+) -> CompleteSourceUnitAnalysis:
+    """Analyze one artifact against its authoritative, resolver-owned body."""
+
+    source_text = authoritative_source_text.strip()
+    if not source_text:
+        issue = (
+            "[complete-source-unit:authoritative-source] "
+            "The authoritative corpus body is required; `module.summary` is "
+            "never completeness evidence."
+        )
+        return CompleteSourceUnitAnalysis((issue,), (), 0, 0, 0)
+
+    with contextlib.suppress(yaml.YAMLError, TypeError, ValueError):
+        payload = yaml.safe_load(content)
+        if isinstance(payload, dict) and payload.get("format") == "rulespec/v1":
+            return _analyze_rulespec_payload(
+                payload,
+                content=content,
+                source_text=source_text,
+                corpus_citation_path=corpus_citation_path,
+                test_cases=test_cases,
+                extract_numeric_occurrences=extract_numeric_occurrences,
+                extract_named_scalars=extract_named_scalars,
+                numeric_value_is_grounded=numeric_value_is_grounded,
+            )
+
+    return CompleteSourceUnitAnalysis((), (), 0, 0, 0)
+
+
+def _analyze_rulespec_payload(
+    payload: dict[str, Any],
+    *,
+    content: str,
+    source_text: str,
+    corpus_citation_path: str,
+    test_cases: Sequence[object] | None,
+    extract_numeric_occurrences: NumericOccurrenceExtractor,
+    extract_named_scalars: NamedScalarExtractor,
+    numeric_value_is_grounded: NumericGroundingPredicate,
+) -> CompleteSourceUnitAnalysis:
+    branches = recognize_source_structure(source_text)
+    all_covered_paths, principal_paths, principal_rules = _rule_coverage(
+        payload,
+        source_text=source_text,
+        branches=branches,
+        corpus_citation_path=corpus_citation_path,
+    )
+    deferred_paths, imprecise_deferrals = _deferred_coverage(
+        payload,
+        corpus_citation_path=corpus_citation_path,
+    )
+    issues: list[str] = []
+    issues.extend(imprecise_deferrals)
+
+    for branch in branches:
+        if _path_covered(branch.path, all_covered_paths, deferred_paths):
+            continue
+        issues.append(
+            "[complete-source-unit:structure] "
+            f"Source branch {branch.label} at "
+            f"{_branch_citation(corpus_citation_path, branch)} is neither "
+            "encoded nor precisely deferred."
+        )
+
+    computation_branches = tuple(
+        branch for branch in branches if source_states_explicit_computation(branch.text)
+    )
+    source_has_computation = source_states_explicit_computation(source_text)
+    if source_has_computation:
+        if computation_branches:
+            for branch in computation_branches:
+                if _path_covered(branch.path, principal_paths, deferred_paths):
+                    continue
+                issues.append(
+                    "[complete-source-unit:formula-output] "
+                    f"Explicit source computation in "
+                    f"{_branch_citation(corpus_citation_path, branch)} has no "
+                    "principal derived/relation output (`derived` or "
+                    "`derived_relation`) and is not "
+                    "precisely deferred; parameter-only representation is invalid."
+                )
+        elif not principal_rules and not deferred_paths:
+            issues.append(
+                "[complete-source-unit:formula-output] Explicit source computation "
+                "has no principal derived/relation output (`derived` or "
+                "`derived_relation`); "
+                "parameter-only representation is invalid."
+            )
+
+    source_values = tuple(
+        extract_numeric_occurrences(_numeric_recall_source_text(source_text))
+    )
+    named_values = tuple(
+        float(item.value)
+        for item in extract_named_scalars(content)
+        if hasattr(item, "value")
+    )
+    covered_source_values = 0
+    missing_source_values: list[float] = []
+    for value in source_values:
+        if any(
+            numeric_value_is_grounded(named_value, {float(value)})
+            for named_value in named_values
+        ):
+            covered_source_values += 1
+        else:
+            missing_source_values.append(float(value))
+    for value in sorted(set(missing_source_values)):
+        issues.append(
+            "[complete-source-unit:numeric-recall] Authoritative corpus numeric "
+            f"value {value:g} has no named scalar representation. "
+            "`module.summary` is not consulted."
+        )
+
+    if source_has_computation and principal_rules:
+        issues.extend(
+            _companion_test_issues(
+                principal_rules,
+                branches=branches,
+                source_text=source_text,
+                deferred_paths=deferred_paths,
+                test_cases=test_cases,
+                extract_numeric_occurrences=extract_numeric_occurrences,
+                numeric_value_is_grounded=numeric_value_is_grounded,
+            )
+        )
+
+    return CompleteSourceUnitAnalysis(
+        tuple(dict.fromkeys(issues)),
+        branches,
+        len(source_values),
+        covered_source_values,
+        len(missing_source_values),
+    )
+
+
+def _rule_coverage(
+    payload: dict[str, Any],
+    *,
+    source_text: str,
+    branches: Sequence[SourceStructureBranch],
+    corpus_citation_path: str,
+) -> tuple[set[tuple[str, ...]], set[tuple[str, ...]], dict[str, dict[str, Any]]]:
+    all_paths: set[tuple[str, ...]] = set()
+    principal_paths: set[tuple[str, ...]] = set()
+    principal_rules: dict[str, dict[str, Any]] = {}
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return all_paths, principal_paths, principal_rules
+
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        kind = str(rule.get("kind") or "").strip().lower()
+        name = str(rule.get("name") or "").strip()
+        paths = _paths_from_source_reference(
+            str(rule.get("source") or ""),
+            corpus_citation_path=corpus_citation_path,
+        )
+        for excerpt in _rule_source_excerpts(rule):
+            excerpt_branch = _most_specific_excerpt_branch(excerpt, branches)
+            if excerpt_branch is not None:
+                paths.add(excerpt_branch.path)
+        for path in paths:
+            all_paths.update(_path_prefixes(path))
+        if kind in {"derived", "derived_relation"} and name:
+            principal_rules[name] = rule
+            for path in paths:
+                principal_paths.update(_path_prefixes(path))
+    return all_paths, principal_paths, principal_rules
+
+
+def _rule_source_excerpts(rule: dict[str, Any]) -> Iterable[str]:
+    metadata = rule.get("metadata")
+    proof = metadata.get("proof") if isinstance(metadata, dict) else None
+    if not isinstance(proof, dict):
+        proof = rule.get("proof")
+    atoms = proof.get("atoms") if isinstance(proof, dict) else None
+    if not isinstance(atoms, list):
+        return ()
+    excerpts: list[str] = []
+    for atom in atoms:
+        source = atom.get("source") if isinstance(atom, dict) else None
+        excerpt = source.get("excerpt") if isinstance(source, dict) else None
+        if isinstance(excerpt, str) and excerpt.strip():
+            excerpts.append(excerpt.strip())
+    return excerpts
+
+
+def _most_specific_excerpt_branch(
+    excerpt: str,
+    branches: Sequence[SourceStructureBranch],
+) -> SourceStructureBranch | None:
+    normalized_excerpt = _collapse_text(excerpt)
+    if not normalized_excerpt:
+        return None
+    candidates = [
+        branch
+        for branch in branches
+        if normalized_excerpt in _collapse_text(branch.text)
+    ]
+    return max(candidates, key=lambda branch: len(branch.path), default=None)
+
+
+def _paths_from_source_reference(
+    source: str,
+    *,
+    corpus_citation_path: str,
+) -> set[tuple[str, ...]]:
+    value = source.strip()
+    if not value:
+        return set()
+    paths: set[tuple[str, ...]] = set()
+    escaped_path = re.escape(corpus_citation_path.rstrip("/"))
+    for match in re.finditer(
+        rf"(?<![A-Za-z0-9_]){escaped_path}"
+        r"(?P<suffix>(?:/[A-Za-z0-9-]+)+|(?:\([A-Za-z0-9-]+\))+)",
+        value,
+        flags=re.IGNORECASE,
+    ):
+        suffix = match.group("suffix")
+        components = (
+            [part for part in suffix.split("/") if part]
+            if suffix.startswith("/")
+            else re.findall(r"\(([A-Za-z0-9-]+)\)", suffix)
+        )
+        if components:
+            paths.add(tuple(component.lower() for component in components))
+
+    keyword_components: list[str] = []
+    if match := _ABSATZ_REFERENCE.search(value):
+        keyword_components.append(match.group("label").lower())
+    if match := _NUMMER_REFERENCE.search(value):
+        keyword_components.append(match.group("label").lower())
+    if match := _BUCHSTABE_REFERENCE.search(value):
+        keyword_components.append(match.group("label").lower())
+    if match := _SATZ_REFERENCE.search(value):
+        keyword_components.append(f"satz-{match.group('label')}")
+    if keyword_components:
+        paths.add(tuple(keyword_components))
+
+    for match in re.finditer(
+        r"§\s*\d+[a-z]?(?P<suffix>(?:\([A-Za-z0-9-]+\))+)",
+        value,
+        flags=re.IGNORECASE,
+    ):
+        components = re.findall(r"\(([A-Za-z0-9-]+)\)", match.group("suffix"))
+        if components:
+            paths.add(tuple(component.lower() for component in components))
+    return paths
+
+
+def _deferred_coverage(
+    payload: dict[str, Any],
+    *,
+    corpus_citation_path: str,
+) -> tuple[set[tuple[str, ...]], list[str]]:
+    module = payload.get("module")
+    records = module.get("deferred_outputs") if isinstance(module, dict) else None
+    if not isinstance(records, list):
+        return set(), []
+    base_target = _rulespec_target_base(corpus_citation_path)
+    covered: set[tuple[str, ...]] = set()
+    issues: list[str] = []
+    for index, record in enumerate(records):
+        if not isinstance(record, dict):
+            continue
+        output = str(record.get("output") or "").strip()
+        output_path = output.split("#", 1)[0]
+        path: tuple[str, ...] = ()
+        if output_path.startswith(f"{base_target}/"):
+            path = tuple(
+                part.lower()
+                for part in output_path[len(base_target) + 1 :].split("/")
+                if part
+            )
+        if not path:
+            continue
+        reason = str(record.get("reason") or "").strip()
+        blocked_by = record.get("blocked_by")
+        exact_blockers = (
+            isinstance(blocked_by, list)
+            and bool(blocked_by)
+            and all(
+                isinstance(item, str)
+                and re.fullmatch(
+                    r"[a-z]{2}(?:-[a-z0-9-]+)?:"
+                    r"[A-Za-z0-9_./-]+#[A-Za-z_][A-Za-z0-9_]*",
+                    item.strip(),
+                    flags=re.IGNORECASE,
+                )
+                for item in blocked_by
+            )
+        )
+        reason_identifies_dependency = bool(
+            _MISSING_DEPENDENCY_LANGUAGE.search(reason)
+            and _PRECISE_DEFERRAL_DEPENDENCY.search(reason)
+        )
+        precise = (
+            exact_blockers
+            or reason_identifies_dependency
+            or bool(_PRECISE_NONOPERATIVE_REASON.search(reason))
+        )
+        if precise:
+            covered.add(path)
+        else:
+            issues.append(
+                "[complete-source-unit:deferral] "
+                f"`module.deferred_outputs[{index}]` identifies source branch "
+                f"({path[0]}) (`{'/'.join(path)}`) but its deferral does not "
+                "name an exact missing "
+                "dependency/citation (or a precise non-operative reason)."
+            )
+    return covered, issues
+
+
+def _rulespec_target_base(corpus_citation_path: str) -> str:
+    parts = [part for part in corpus_citation_path.strip("/").split("/") if part]
+    if len(parts) < 3:
+        return corpus_citation_path
+    jurisdiction, document_class, *tail = parts
+    plural = {
+        "statute": "statutes",
+        "regulation": "regulations",
+        "manual": "manuals",
+        "guidance": "guidance",
+        "policy": "policies",
+        "form": "forms",
+    }.get(document_class, f"{document_class}s")
+    return f"{jurisdiction}:{plural}/{'/'.join(tail)}"
+
+
+def _path_prefixes(path: tuple[str, ...]) -> set[tuple[str, ...]]:
+    return {path[:index] for index in range(1, len(path) + 1)}
+
+
+def _path_covered(
+    path: tuple[str, ...],
+    encoded_paths: set[tuple[str, ...]],
+    deferred_paths: set[tuple[str, ...]],
+) -> bool:
+    if path in encoded_paths:
+        return True
+    return any(path[: len(deferred)] == deferred for deferred in deferred_paths)
+
+
+def _branch_citation(
+    corpus_citation_path: str,
+    branch: SourceStructureBranch,
+) -> str:
+    citation = corpus_citation_path
+    components: list[str] = []
+    for index, component in enumerate(branch.path):
+        if component.startswith("satz-"):
+            components.append(f"Satz {component.removeprefix('satz-')}")
+        elif index == 0:
+            components.append(f"Absatz {component}")
+        elif branch.kind == "letter" and index == len(branch.path) - 1:
+            components.append(f"Buchstabe {component}")
+        else:
+            components.append(f"Nummer {component}")
+    return f"{citation}({branch.path[0]}) [{', '.join(components)}]"
+
+
+def _numeric_recall_source_text(source_text: str) -> str:
+    """Remove structural/citation ordinals, never substantive source values."""
+
+    cleaned = _GERMAN_LEGAL_CITATION.sub("", source_text)
+    cleaned = _ENGLISH_LEGAL_CITATION.sub("", cleaned)
+    cleaned = _STRUCTURAL_REFERENCE.sub("", cleaned)
+    cleaned = re.sub(
+        r"(?m)^[ \t]*\((?:\d+[a-z]?|[a-z])\)(?:[ \t]+bis[ \t]+\(\d+[a-z]?\))?",
+        "",
+        cleaned,
+        flags=re.IGNORECASE,
+    )
+    cleaned = re.sub(
+        r"(?m)^[ \t]*\d+[a-z]?\.[ \t]+",
+        "",
+        cleaned,
+        flags=re.IGNORECASE,
+    )
+    cleaned = _GLUED_SENTENCE_MARKER.sub("", cleaned)
+    return cleaned
+
+
+def _companion_test_issues(
+    principal_rules: dict[str, dict[str, Any]],
+    *,
+    branches: Sequence[SourceStructureBranch],
+    source_text: str,
+    deferred_paths: set[tuple[str, ...]],
+    test_cases: Sequence[object] | None,
+    extract_numeric_occurrences: NumericOccurrenceExtractor,
+    numeric_value_is_grounded: NumericGroundingPredicate,
+) -> list[str]:
+    issues: list[str] = []
+    cases = [case for case in (test_cases or ()) if isinstance(case, dict)]
+    if not cases:
+        return [
+            "[complete-source-unit:tests] Explicit source computations require "
+            "a companion test suite covering branches, boundaries, exceptions, "
+            "and rounding rules."
+        ]
+
+    asserted_by_rule = {
+        name: [
+            case
+            for case in cases
+            if name in _test_case_output_names(case)
+        ]
+        for name in principal_rules
+    }
+    for name, asserted_cases in asserted_by_rule.items():
+        if not asserted_cases:
+            issues.append(
+                "[complete-source-unit:tests] Principal output "
+                f"`{name}` is never asserted by a companion test."
+            )
+
+    active_branches = [
+        branch
+        for branch in branches
+        if not any(
+            branch.path[: len(deferred)] == deferred for deferred in deferred_paths
+        )
+    ]
+    formula_leaf_count = sum(
+        1
+        for branch in active_branches
+        if branch.kind == "number" and _number_branch_is_formula_leaf(branch.text)
+    )
+    if formula_leaf_count:
+        most_assertions = max(
+            (len(asserted_cases) for asserted_cases in asserted_by_rule.values()),
+            default=0,
+        )
+        if most_assertions < formula_leaf_count:
+            issues.append(
+                "[complete-source-unit:tests] Source states "
+                f"{formula_leaf_count} formula branches/list branches, but no principal "
+                f"output is asserted in {formula_leaf_count} distinct cases."
+            )
+
+    boundaries = _source_boundary_values(
+        active_branches,
+        extract_numeric_occurrences=extract_numeric_occurrences,
+    )
+    test_input_values = tuple(
+        value
+        for case in cases
+        for value in _numeric_test_input_values(case.get("input"))
+    )
+    missing_boundaries = [
+        boundary
+        for boundary in boundaries
+        if not any(
+            numeric_value_is_grounded(test_value, {boundary})
+            for test_value in test_input_values
+        )
+    ]
+    if missing_boundaries:
+        rendered = ", ".join(f"{value:g}" for value in sorted(set(missing_boundaries)))
+        issues.append(
+            "[complete-source-unit:tests] Companion tests do not exercise every "
+            f"source-stated boundary input; missing: {rendered}."
+        )
+
+    active_text = _source_text_without_deferred_branches(
+        source_text,
+        branches=branches,
+        deferred_paths=deferred_paths,
+    )
+    exception_count = len(_EXCEPTION_LANGUAGE.findall(active_text))
+    if exception_count:
+        toggled_boolean_keys = _paired_boolean_toggle_keys(
+            case
+            for asserted_cases in asserted_by_rule.values()
+            for case in asserted_cases
+        )
+        if len(toggled_boolean_keys) < exception_count:
+            issues.append(
+                "[complete-source-unit:tests] Source-stated exceptions require "
+                "paired positive/blocking cases that toggle each exception fact; "
+                f"found {len(toggled_boolean_keys)} pair(s) for "
+                f"{exception_count} exception obligation(s)."
+            )
+
+    rounding_count = len(_ROUNDING_LANGUAGE.findall(active_text))
+    if rounding_count:
+        formula_text = "\n".join(
+            _rule_formula_text(rule) for rule in principal_rules.values()
+        )
+        if _DOWN_ROUNDING_LANGUAGE.search(active_text) and "floor(" not in formula_text:
+            issues.append(
+                "[complete-source-unit:tests] A source-stated downward-rounding "
+                "rule is absent from the principal formula (`floor(...)`)."
+            )
+        if _UP_ROUNDING_LANGUAGE.search(active_text) and "ceil(" not in formula_text:
+            issues.append(
+                "[complete-source-unit:tests] A source-stated upward-rounding "
+                "rule is absent from the principal formula (`ceil(...)`)."
+            )
+        if _NEAREST_ROUNDING_LANGUAGE.search(active_text) and not (
+            "floor(" in formula_text and re.search(r"\+\s*0?\.5\b", formula_text)
+        ):
+            issues.append(
+                "[complete-source-unit:tests] A source-stated nearest/commercial "
+                "rounding rule is absent from the principal formula."
+            )
+        fractional_cases = sum(
+            1
+            for case in cases
+            if any(
+                not float(value).is_integer()
+                for value in _numeric_test_input_values(case.get("input"))
+            )
+        )
+        if fractional_cases < rounding_count:
+            issues.append(
+                "[complete-source-unit:tests] Companion tests do not demonstrate "
+                f"all {rounding_count} source-stated rounding rule(s) with "
+                "fractional input values."
+            )
+    return issues
+
+
+def _source_text_without_deferred_branches(
+    source_text: str,
+    *,
+    branches: Sequence[SourceStructureBranch],
+    deferred_paths: set[tuple[str, ...]],
+) -> str:
+    """Remove precisely deferred spans without duplicating nested branch text."""
+
+    deferred_ranges = sorted(
+        (
+            branch.start,
+            branch.end,
+        )
+        for branch in branches
+        if any(
+            branch.path[: len(deferred)] == deferred for deferred in deferred_paths
+        )
+        and not any(
+            ancestor.path != branch.path
+            and ancestor.start <= branch.start
+            and branch.end <= ancestor.end
+            and any(
+                ancestor.path[: len(deferred)] == deferred
+                for deferred in deferred_paths
+            )
+            for ancestor in branches
+        )
+    )
+    if not deferred_ranges:
+        return source_text
+    parts: list[str] = []
+    cursor = 0
+    for start, end in deferred_ranges:
+        if start < cursor:
+            continue
+        parts.append(source_text[cursor:start])
+        cursor = end
+    parts.append(source_text[cursor:])
+    return "".join(parts)
+
+
+def _test_case_output_names(case: dict[str, Any]) -> set[str]:
+    outputs = case.get("output")
+    if not isinstance(outputs, dict):
+        return set()
+    names: set[str] = set()
+    for key in outputs:
+        text = str(key)
+        names.add(text.rsplit("#", 1)[-1])
+    return names
+
+
+def _number_branch_is_formula_leaf(text: str) -> bool:
+    first_line = text.splitlines()[0] if text.splitlines() else text
+    return ":" in first_line and bool(
+        _ARITHMETIC_EXPRESSION.search(first_line)
+        or re.search(r":\s*-?\d", first_line)
+    )
+
+
+def _source_boundary_values(
+    branches: Sequence[SourceStructureBranch],
+    *,
+    extract_numeric_occurrences: NumericOccurrenceExtractor,
+) -> tuple[float, ...]:
+    values: list[float] = []
+    for branch in branches:
+        if branch.kind != "number":
+            continue
+        first_line = branch.text.splitlines()[0] if branch.text.splitlines() else ""
+        prefix = first_line.split(":", 1)[0]
+        if not re.search(
+            r"\b(?:bis|von|ab|unter|über|from|to|through|less\s+than|"
+            r"more\s+than|at\s+least|up\s+to|above|below)\b",
+            prefix,
+            flags=re.IGNORECASE,
+        ):
+            continue
+        prefix = _NUMBER_MARKER.sub("", prefix)
+        values.extend(float(value) for value in extract_numeric_occurrences(prefix))
+    return tuple(dict.fromkeys(values))
+
+
+def _numeric_test_input_values(value: Any) -> tuple[float, ...]:
+    values: list[float] = []
+    if isinstance(value, bool):
+        return ()
+    if isinstance(value, (int, float)):
+        return (float(value),)
+    if isinstance(value, dict):
+        for item in value.values():
+            values.extend(_numeric_test_input_values(item))
+    elif isinstance(value, list):
+        for item in value:
+            values.extend(_numeric_test_input_values(item))
+    return tuple(values)
+
+
+def _paired_boolean_toggle_keys(cases: Iterable[dict[str, Any]]) -> set[str]:
+    flattened = [
+        (
+            case,
+            {
+                str(key): _boolean_value(value)
+                for key, value in (case.get("input") or {}).items()
+                if _boolean_value(value) is not None
+            },
+        )
+        for case in cases
+        if isinstance(case.get("input"), dict)
+    ]
+    toggled: set[str] = set()
+    for left_index, (left_case, left_values) in enumerate(flattened):
+        for right_case, right_values in flattened[left_index + 1 :]:
+            if set(left_values) != set(right_values):
+                continue
+            changed = [
+                key for key in left_values if left_values[key] != right_values[key]
+            ]
+            if len(changed) != 1:
+                continue
+            if _non_boolean_inputs(left_case) != _non_boolean_inputs(right_case):
+                continue
+            toggled.add(changed[0])
+    return toggled
+
+
+def _boolean_value(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    normalized = str(value).strip().lower().replace("-", "_")
+    if normalized in {"holds", "true"}:
+        return True
+    if normalized in {"not_holds", "false"}:
+        return False
+    return None
+
+
+def _non_boolean_inputs(case: dict[str, Any]) -> dict[str, Any]:
+    inputs = case.get("input")
+    if not isinstance(inputs, dict):
+        return {}
+    return {
+        str(key): value
+        for key, value in inputs.items()
+        if _boolean_value(value) is None
+    }
+
+
+def _rule_formula_text(rule: dict[str, Any]) -> str:
+    versions = rule.get("versions")
+    if not isinstance(versions, list):
+        return ""
+    return "\n".join(
+        str(version.get("formula"))
+        for version in versions
+        if isinstance(version, dict) and version.get("formula") is not None
+    )
+
+
+def _collapse_text(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip()

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -764,13 +764,26 @@ def _principal_formula_clause_rules(
 def _normalized_formula_clause_text(text: str) -> str:
     """Normalize a clause while ignoring its structural marker."""
 
-    unmarked = re.sub(
-        r"^\s*(?:\((?:\d+[a-z]?|[a-z])\)|\d+[a-z]?\.|[a-z]\))\s*",
+    unmarked = _strip_source_clause_marker(text)
+    return _collapse_text(unmarked)
+
+
+def _strip_source_clause_marker(text: str) -> str:
+    """Remove a leading paragraph/list/Satz marker, including glued statutes."""
+
+    return re.sub(
+        r"^\s*(?:"
+        r"\((?:\d+[a-z]?|[a-z])\)|"
+        r"\d+[a-z]?\.|"
+        r"[a-z]\)|"
+        r"satz\s+\d+[a-z]?\s*:?\s*|"
+        r"\d+(?=(?-i:[A-ZÄÖÜ]))"
+        r")\s*",
         "",
         text,
+        count=1,
         flags=re.IGNORECASE,
     )
-    return _collapse_text(unmarked)
 
 
 def _rounding_direction(text: str) -> str | None:
@@ -1622,7 +1635,7 @@ def _companion_test_issues(
     require_rounding_clause_binding = len(rounding_obligations) > 1
     for obligation in rounding_obligations:
         branch, direction = obligation
-        source_formula_branch = _rounding_source_formula_branch(
+        source_formula_branches = _rounding_source_formula_branches(
             branch,
             formula_branches=formula_branches,
         )
@@ -1643,7 +1656,7 @@ def _companion_test_issues(
                     asserted_by_rule=asserted_by_rule,
                     direction=direction,
                     formula_environment=formula_environment,
-                    source_formula_branch=source_formula_branch,
+                    source_formula_branches=source_formula_branches,
                     rounding_refers_to_result=(
                         _rounding_text_refers_to_result(branch.text)
                     ),
@@ -1767,18 +1780,32 @@ def _rounding_clause_refers_to_previous_result(
 
     return bool(
         previous is not None
-        and previous.path == clause.path
+        and _same_top_level_source_path(previous.path, clause.path)
         and _rounding_only_direction(clause.text) is not None
         and _rounding_text_refers_to_result(clause.text)
         and not re.search(r"\w", source_text[previous.end : clause.start])
     )
 
 
+def _same_top_level_source_path(
+    left: tuple[str, ...],
+    right: tuple[str, ...],
+) -> bool:
+    if not left or not right:
+        return left == right
+    return left[0] == right[0]
+
+
 def _rounding_text_refers_to_result(text: str) -> bool:
+    unmarked = _strip_source_clause_marker(text)
     return bool(
         re.match(
-            r"\s*(?:das\s+ergebnis|the\s+result)\b",
-            text,
+            r"\s*(?:"
+            r"das\s+ergebnis|"
+            r"the\s+result|"
+            r"der\s+sich\s+ergebende\s+steuerbetrag"
+            r")\b",
+            unmarked,
             flags=re.IGNORECASE,
         )
     )
@@ -4462,11 +4489,11 @@ def _source_rounding_obligations(
     return tuple(obligations)
 
 
-def _rounding_source_formula_branch(
+def _rounding_source_formula_branches(
     rounding_branch: SourceStructureBranch,
     *,
     formula_branches: Sequence[SourceStructureBranch],
-) -> SourceStructureBranch | None:
+) -> tuple[SourceStructureBranch, ...]:
     containing = [
         branch
         for branch in formula_branches
@@ -4475,11 +4502,20 @@ def _rounding_source_formula_branch(
         and rounding_branch.end <= branch.end
     ]
     if containing:
-        return min(
-            containing,
-            key=lambda branch: branch.end - branch.start,
+        return (
+            min(
+                containing,
+                key=lambda branch: branch.end - branch.start,
+            ),
         )
-    return None
+    if not _rounding_text_refers_to_result(rounding_branch.text):
+        return ()
+    return tuple(
+        branch
+        for branch in formula_branches
+        if branch.end <= rounding_branch.start
+        and _same_top_level_source_path(branch.path, rounding_branch.path)
+    )
 
 
 def _unwitnessed_exception_branches(
@@ -4964,7 +5000,7 @@ def _fractional_rounding_case_witnesses(
     asserted_by_rule: dict[str, list[dict[str, Any]]],
     direction: str,
     formula_environment: dict[str, Any],
-    source_formula_branch: SourceStructureBranch | None,
+    source_formula_branches: Sequence[SourceStructureBranch],
     rounding_refers_to_result: bool,
     require_clause_binding: bool,
     extract_numeric_occurrences: NumericOccurrenceExtractor,
@@ -5009,6 +5045,7 @@ def _fractional_rounding_case_witnesses(
         for function_name, operand in _rounding_call_operands(
             operative_leaf,
             functions=functions,
+            root_only=rounding_refers_to_result,
         ):
             effective_operand = _rounding_demonstrated_operand(
                 operand,
@@ -5043,8 +5080,9 @@ def _fractional_rounding_case_witnesses(
             ):
                 continue
             if (
-                source_formula_branch is not None
-                and not _rounding_call_binds_source_clause(
+                source_formula_branches
+                and not any(
+                    _rounding_call_binds_source_clause(
                     source_binding_operand,
                     original_operand=effective_operand,
                     operand_value=float(operand_value),
@@ -5056,6 +5094,8 @@ def _fractional_rounding_case_witnesses(
                     require_clause_binding=require_clause_binding,
                     extract_numeric_occurrences=extract_numeric_occurrences,
                     numeric_value_is_grounded=numeric_value_is_grounded,
+                    )
+                    for source_formula_branch in source_formula_branches
                 )
             ):
                 continue
@@ -5096,11 +5136,29 @@ def _rounding_call_operands(
     formula_text: str,
     *,
     functions: set[str],
+    root_only: bool = False,
 ) -> tuple[tuple[str, str], ...]:
     calls: list[tuple[str, str]] = []
     function_names = {"floor", "ceil"} & functions
     if "nearest" in functions:
         function_names.add("floor")
+    if root_only:
+        with contextlib.suppress(SyntaxError):
+            expression = ast.parse(formula_text.strip(), mode="eval").body
+            if (
+                isinstance(expression, ast.Call)
+                and isinstance(expression.func, ast.Name)
+                and expression.func.id in function_names
+                and len(expression.args) == 1
+                and not expression.keywords
+            ):
+                operand = ast.unparse(expression.args[0])
+                if (
+                    functions != {"nearest"}
+                    or re.search(r"\+\s*0?\.5\b", operand)
+                ):
+                    return ((expression.func.id, operand),)
+        return ()
     for function_name in function_names:
         for operand in _balanced_call_operands(formula_text, function_name):
             if (
@@ -5205,13 +5263,16 @@ def _fractional_input_materially_affects_operand(
         if (
             isinstance(value, bool)
             or not isinstance(value, (int, float))
-            or float(value).is_integer()
         ):
             continue
         aliases = _input_key_names(key) & operand_names
         if not aliases and not uses_derived_operand:
             continue
-        replacement = float(math.floor(float(value)))
+        replacement: int | float
+        if float(value).is_integer():
+            replacement = int(value) + 1
+        else:
+            replacement = float(math.floor(float(value)))
         candidate_inputs = dict(inputs)
         candidate_inputs[key] = replacement
         candidate_case = dict(case)
@@ -5300,7 +5361,7 @@ def _rounding_call_binds_source_clause(
         numeric_value_is_grounded=numeric_value_is_grounded,
     )
     if rounding_refers_to_result:
-        return True
+        return formula_match
     source_has_distinguishing_computation = bool(
         _formula_operation_kinds(source_formula_branch.text)
         or extract_numeric_occurrences(
@@ -5324,9 +5385,25 @@ def _rounding_operand_is_output_stage(
 ) -> bool:
     output_subject = _rounding_stage_subject(rule_name)
     return bool(output_subject) and any(
-        _rounding_stage_subject(identifier) == output_subject
+        _rounding_stage_subject_matches(
+            _rounding_stage_subject(identifier),
+            output_subject,
+        )
         for identifier in _FORMULA_IDENTIFIER.findall(operand)
     )
+
+
+def _rounding_stage_subject_matches(
+    operand_subject: tuple[str, ...],
+    output_subject: tuple[str, ...],
+) -> bool:
+    if not operand_subject:
+        return False
+    shorter, longer = sorted(
+        (operand_subject, output_subject),
+        key=len,
+    )
+    return longer[: len(shorter)] == shorter
 
 
 def _rounding_stage_subject(identifier: str) -> tuple[str, ...]:

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -23475,11 +23475,11 @@ class ValidatorPipeline:
             if source_verification is not None
             else ((), "")
         )
-        corpus_citation_path = (
-            self.source_citation_path or (citation_paths[0] if citation_paths else "")
+        corpus_citation_path = self.source_citation_path or (
+            citation_paths[0] if citation_paths else ""
         )
-        imported_symbol_contents = (
-            self._complete_source_unit_import_symbol_contents(rules_file)
+        imported_symbol_contents = self._complete_source_unit_import_symbol_contents(
+            rules_file
         )
         artifact_numeric_bindings = collect_artifact_numeric_bindings(
             content,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -23481,7 +23481,9 @@ class ValidatorPipeline:
         artifact_numeric_values = collect_artifact_numeric_values(
             content,
             extract_named_scalars=extract_named_scalar_occurrences,
-            imported_contents=self._complete_source_unit_import_contents(rules_file),
+            imported_symbol_contents=(
+                self._complete_source_unit_import_symbol_contents(rules_file)
+            ),
         )
         numeric_occurrence_extractor = functools.partial(
             extract_typed_numeric_inventory_occurrences_from_text,
@@ -23499,38 +23501,43 @@ class ValidatorPipeline:
         )
         return list(completeness.issues)
 
-    def _complete_source_unit_import_contents(
+    def _complete_source_unit_import_symbol_contents(
         self,
         rules_file: Path | None,
-    ) -> tuple[str, ...]:
-        """Return only artifacts named by this file's direct imports."""
+    ) -> tuple[tuple[str, str], ...]:
+        """Bind every directly imported symbol to its exact resolved artifact."""
 
         if rules_file is None:
             return ()
         try:
             source_root = self._validation_source_root(rules_file)
-            dependencies = self._resolve_import_dependencies(
-                rules_file,
-                source_root,
-            )
+            import_items = self._extract_import_items(rules_file.read_text())
         except (OSError, ValueError, UnsafeRulespecContextPath):
             return ()
-        seen = {rules_file.resolve()}
-        contents: list[str] = []
-        for dependency in dependencies:
-            resolved = dependency.resolve()
-            if resolved in seen:
+        seen: set[tuple[Path, str]] = set()
+        bindings: list[tuple[str, str]] = []
+        for import_item in import_items:
+            _target, separator, imported_symbol = import_item.rpartition("#")
+            imported_symbol = imported_symbol.strip()
+            if not separator or not imported_symbol:
                 continue
-            seen.add(resolved)
             try:
-                dependency = validate_rulespec_context_file(
-                    dependency,
-                    source_root,
+                dependency = _resolve_rulespec_import_file_static(
+                    import_item,
+                    rules_file=rules_file,
+                    policy_repo_path=source_root,
+                    rulespec_dependency_roots=self.rulespec_dependency_roots,
                 )
-                contents.append(dependency.read_text())
+                if dependency is None:
+                    continue
+                binding_key = (dependency.resolve(), imported_symbol)
+                if binding_key in seen:
+                    continue
+                seen.add(binding_key)
+                bindings.append((imported_symbol, dependency.read_text()))
             except (OSError, ValueError, UnsafeRulespecContextPath):
                 continue
-        return tuple(contents)
+        return tuple(bindings)
 
     def _rulespec_compile_roots(self) -> tuple[Path, ...]:
         """Return the exact country checkouts authorized for engine compilation."""

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -115,7 +115,7 @@ from .proof_validator import (
 )
 from .source_completeness import (
     analyze_complete_source_unit,
-    collect_artifact_numeric_values,
+    collect_artifact_numeric_bindings,
 )
 
 logger = logging.getLogger(__name__)
@@ -23478,12 +23478,16 @@ class ValidatorPipeline:
         corpus_citation_path = (
             self.source_citation_path or (citation_paths[0] if citation_paths else "")
         )
-        artifact_numeric_values = collect_artifact_numeric_values(
+        imported_symbol_contents = (
+            self._complete_source_unit_import_symbol_contents(rules_file)
+        )
+        artifact_numeric_bindings = collect_artifact_numeric_bindings(
             content,
             extract_named_scalars=extract_named_scalar_occurrences,
-            imported_symbol_contents=(
-                self._complete_source_unit_import_symbol_contents(rules_file)
-            ),
+            imported_symbol_contents=imported_symbol_contents,
+        )
+        artifact_numeric_values = tuple(
+            value for _name, value in artifact_numeric_bindings
         )
         numeric_occurrence_extractor = functools.partial(
             extract_typed_numeric_inventory_occurrences_from_text,
@@ -23498,6 +23502,7 @@ class ValidatorPipeline:
             extract_named_scalars=extract_named_scalar_occurrences,
             numeric_value_is_grounded=numeric_value_is_grounded,
             artifact_numeric_values=artifact_numeric_values,
+            artifact_numeric_bindings=artifact_numeric_bindings,
         )
         return list(completeness.issues)
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -113,6 +113,10 @@ from .proof_validator import (
     find_rulespec_proof_issues,
     validate_rulespec_proofs,
 )
+from .source_completeness import (
+    analyze_complete_source_unit,
+    collect_artifact_numeric_values,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -23147,6 +23151,7 @@ class ValidatorPipeline:
         policyengine_runtime: PolicyEngineRuntime | None = None,
         policyengine_rule_hint: str | None = None,
         require_policy_proofs: bool = False,
+        require_complete_source_unit: bool = False,
         enforce_repository_layout: bool = True,
         source_text: str | None = None,
         source_metadata: dict[str, object] | None = None,
@@ -23191,6 +23196,9 @@ class ValidatorPipeline:
         self.session_id = session_id
         self.policyengine_rule_hint = policyengine_rule_hint
         self.require_policy_proofs = require_policy_proofs
+        if not isinstance(require_complete_source_unit, bool):
+            raise TypeError("require_complete_source_unit must be a boolean")
+        self.require_complete_source_unit = require_complete_source_unit
         self.enforce_repository_layout = enforce_repository_layout
         self.source_text = source_text
         if source_metadata is not None and not isinstance(source_metadata, dict):
@@ -23427,6 +23435,89 @@ class ValidatorPipeline:
             f"the trusted requested source `{trusted_primary}`, but declared "
             f"{declared}."
         ]
+
+    def _complete_source_unit_issues(
+        self,
+        content: str,
+        *,
+        validation_source_texts: Mapping[str, str] | None,
+        test_cases: Sequence[object] | None,
+        rules_file: Path | None = None,
+    ) -> list[str]:
+        """Apply opt-in completeness checks to the resolver-owned corpus body."""
+
+        if not self.require_complete_source_unit:
+            return []
+        authoritative_source_text = _extract_source_verification_text(
+            content,
+            source_texts=(
+                dict(validation_source_texts)
+                if validation_source_texts is not None
+                else None
+            ),
+        )
+        source_verification = None
+        with contextlib.suppress(yaml.YAMLError, TypeError, ValueError):
+            rulespec_payload = yaml.safe_load(content)
+            if isinstance(rulespec_payload, dict):
+                source_verification = _source_verification_block(rulespec_payload)
+        citation_paths, _source_label = (
+            _source_verification_source_fields(source_verification)
+            if source_verification is not None
+            else ((), "")
+        )
+        corpus_citation_path = (
+            self.source_citation_path or (citation_paths[0] if citation_paths else "")
+        )
+        artifact_numeric_values = collect_artifact_numeric_values(
+            content,
+            extract_named_scalars=extract_named_scalar_occurrences,
+            extract_numeric_occurrences=extract_numeric_occurrences_from_text,
+            imported_contents=self._complete_source_unit_import_contents(rules_file),
+        )
+        completeness = analyze_complete_source_unit(
+            content,
+            authoritative_source_text or "",
+            corpus_citation_path=corpus_citation_path,
+            test_cases=test_cases,
+            extract_numeric_occurrences=extract_numeric_occurrences_from_text,
+            extract_named_scalars=extract_named_scalar_occurrences,
+            numeric_value_is_grounded=numeric_value_is_grounded,
+            artifact_numeric_values=artifact_numeric_values,
+        )
+        return list(completeness.issues)
+
+    def _complete_source_unit_import_contents(
+        self,
+        rules_file: Path | None,
+    ) -> tuple[str, ...]:
+        if rules_file is None:
+            return ()
+        try:
+            source_root = self._validation_source_root(rules_file)
+            pending = self._resolve_import_dependencies(rules_file, source_root)
+        except (OSError, ValueError, UnsafeRulespecContextPath):
+            return ()
+        seen = {rules_file.resolve()}
+        contents: list[str] = []
+        while pending:
+            dependency = pending.pop()
+            resolved = dependency.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            try:
+                dependency = validate_rulespec_context_file(
+                    dependency,
+                    source_root,
+                )
+                contents.append(dependency.read_text())
+                pending.extend(
+                    self._resolve_import_dependencies(dependency, source_root)
+                )
+            except (OSError, ValueError, UnsafeRulespecContextPath):
+                continue
+        return tuple(contents)
 
     def _rulespec_compile_roots(self) -> tuple[Path, ...]:
         """Return the exact country checkouts authorized for engine compilation."""
@@ -24809,6 +24900,7 @@ class ValidatorPipeline:
         """Run RuleSpec compile, executable tests, and source-grounding checks."""
         start = time.time()
         issues: list[str] = []
+        complete_source_unit_test_cases: list[Any] | None = None
         content = rules_file.read_text()
         raw_output: str | None = None
         compiled_payload: dict[str, Any] | None = None
@@ -25067,6 +25159,8 @@ class ValidatorPipeline:
                     else:
                         issues.append("RuleSpec tests must be a YAML list of cases.")
                         payload = None
+                if isinstance(payload, list):
+                    complete_source_unit_test_cases = payload
                 if isinstance(payload, list) and compiled_payload and compiled_path:
                     pre_test_issue_count = len(issues)
                     if strict_layout_checks:
@@ -25103,6 +25197,15 @@ class ValidatorPipeline:
                         )
         elif not issues and not self._is_nonassertable_rulespec_artifact(rules_file):
             issues.append("No tests found.")
+
+        issues.extend(
+            self._complete_source_unit_issues(
+                content,
+                validation_source_texts=validation_source_texts,
+                test_cases=complete_source_unit_test_cases,
+                rules_file=rules_file,
+            )
+        )
 
         duration = int((time.time() - start) * 1000)
         try:

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -23503,17 +23503,21 @@ class ValidatorPipeline:
         self,
         rules_file: Path | None,
     ) -> tuple[str, ...]:
+        """Return only artifacts named by this file's direct imports."""
+
         if rules_file is None:
             return ()
         try:
             source_root = self._validation_source_root(rules_file)
-            pending = self._resolve_import_dependencies(rules_file, source_root)
+            dependencies = self._resolve_import_dependencies(
+                rules_file,
+                source_root,
+            )
         except (OSError, ValueError, UnsafeRulespecContextPath):
             return ()
         seen = {rules_file.resolve()}
         contents: list[str] = []
-        while pending:
-            dependency = pending.pop()
+        for dependency in dependencies:
             resolved = dependency.resolve()
             if resolved in seen:
                 continue
@@ -23524,9 +23528,6 @@ class ValidatorPipeline:
                     source_root,
                 )
                 contents.append(dependency.read_text())
-                pending.extend(
-                    self._resolve_import_dependencies(dependency, source_root)
-                )
             except (OSError, ValueError, UnsafeRulespecContextPath):
                 continue
         return tuple(contents)

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -23448,13 +23448,22 @@ class ValidatorPipeline:
 
         if not self.require_complete_source_unit:
             return []
-        authoritative_source_text = _extract_source_verification_text(
-            content,
-            source_texts=(
-                dict(validation_source_texts)
-                if validation_source_texts is not None
-                else None
-            ),
+        source_texts = (
+            dict(validation_source_texts)
+            if validation_source_texts is not None
+            else None
+        )
+        authoritative_source_text = (
+            _source_verification_text(
+                citation_paths=(self.source_citation_path,),
+                source_label=self.source_citation_path,
+                source_texts=source_texts,
+            )
+            if self.source_citation_path
+            else _extract_source_verification_text(
+                content,
+                source_texts=source_texts,
+            )
         )
         source_verification = None
         with contextlib.suppress(yaml.YAMLError, TypeError, ValueError):
@@ -23472,7 +23481,6 @@ class ValidatorPipeline:
         artifact_numeric_values = collect_artifact_numeric_values(
             content,
             extract_named_scalars=extract_named_scalar_occurrences,
-            extract_numeric_occurrences=extract_numeric_occurrences_from_text,
             imported_contents=self._complete_source_unit_import_contents(rules_file),
         )
         completeness = analyze_complete_source_unit(

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -23483,12 +23483,16 @@ class ValidatorPipeline:
             extract_named_scalars=extract_named_scalar_occurrences,
             imported_contents=self._complete_source_unit_import_contents(rules_file),
         )
+        numeric_occurrence_extractor = functools.partial(
+            extract_typed_numeric_inventory_occurrences_from_text,
+            profile=_numeric_profile_for_citation_path(corpus_citation_path),
+        )
         completeness = analyze_complete_source_unit(
             content,
             authoritative_source_text or "",
             corpus_citation_path=corpus_citation_path,
             test_cases=test_cases,
-            extract_numeric_occurrences=extract_numeric_occurrences_from_text,
+            extract_numeric_occurrences=numeric_occurrence_extractor,
             extract_named_scalars=extract_named_scalar_occurrences,
             numeric_value_is_grounded=numeric_value_is_grounded,
             artifact_numeric_values=artifact_numeric_values,

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -1623,11 +1623,35 @@ def _assemble(*blocks: str) -> str:
 
 ENCODER_PROMPT = _assemble(*_PROMPT_BLOCKS)
 
+_COMPLETE_SOURCE_UNIT_PROTOCOL = """
+Complete-source-unit mode is enabled for this request:
+- Treat the entire authoritative source unit as the completeness inventory.
+  `module.summary` is only a concise reviewer orientation and contributes
+  nothing to completeness accounting.
+- Every explicit computation stated in the source unit must have a principal
+  `kind: derived` or `kind: derived_relation` output. Naming its constants as
+  parameters without encoding the stated formula is invalid.
+- Encode every structural paragraph and list branch, including Absatz markers
+  such as `(1)` and `(2)`, `Abs. 5`, numbered items such as `1.` and `1a.`, and
+  Satz enumerations. If a branch cannot be encoded, use a precise typed
+  deferral that names the exact branch and its missing dependency or citation;
+  never omit it silently. Put the structural branch in the deferred output
+  path (for example, `de:statutes/estg/32a/6#surviving_spouse_tariff`) and list
+  exact missing RuleSpec targets under `blocked_by`.
+- Companion tests must cover every source-stated formula branch, boundary,
+  exception, and rounding rule. When a formula branch cannot be identified
+  from a numeric selector input, add an exact canonical source branch under
+  the executing case's `covers` list (for example,
+  `covers: [de/statute/estg/32a/1/2]`).
+- A genuinely scalar-only source unit may remain parameter-only.
+"""
+
 
 def get_encoder_prompt(
     citation: str,
     output_path: str,
     corpus_citation_path: str | None = None,
+    require_complete_source_unit: bool = False,
 ) -> str:
     """Return a complete RuleSpec task prompt for a source unit."""
     corpus_section = ""
@@ -1641,6 +1665,10 @@ Never emit `corpus_citation_paths`. A provision split across storage rows must
 be composed by the corpus resolver under this one canonical path. If another
 legal source is required, import its separately attested RuleSpec or defer the
 affected executable surface.
+"""
+    if require_complete_source_unit:
+        corpus_section += f"""
+{_COMPLETE_SOURCE_UNIT_PROTOCOL.strip()}
 """
 
     return f"""{ENCODER_PROMPT}

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -1638,11 +1638,10 @@ Complete-source-unit mode is enabled for this request:
   never omit it silently. Put the structural branch in the deferred output
   path (for example, `de:statutes/estg/32a/6#surviving_spouse_tariff`) and list
   exact missing RuleSpec targets under `blocked_by`.
-- Companion tests must cover every source-stated formula branch, boundary,
-  exception, and rounding rule. When a formula branch cannot be identified
-  from a numeric selector input, add an exact canonical source branch under
-  the executing case's `covers` list (for example,
-  `covers: [de/statute/estg/32a/1/2]`).
+- Companion tests must execute every source-stated formula branch, boundary,
+  exception, and rounding rule with assertions on the affected principal
+  output. Each branch needs distinct runtime evidence; descriptive test
+  metadata is not coverage evidence.
 - A genuinely scalar-only source unit may remain parameter-only.
 """
 

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -1636,8 +1636,10 @@ Complete-source-unit mode is enabled for this request:
   Satz enumerations. If a branch cannot be encoded, use a precise typed
   deferral that names the exact branch and its missing dependency or citation;
   never omit it silently. Put the structural branch in the deferred output
-  path (for example, `de:statutes/estg/32a/6#surviving_spouse_tariff`) and list
-  exact missing RuleSpec targets under `blocked_by`.
+  path (for example, `de:statutes/estg/32a/6#surviving_spouse_tariff`). Include
+  `blocked_by` only for known exact RuleSpec targets with a `#rule_fragment`;
+  otherwise omit `blocked_by` and name the exact missing legal dependency or
+  citation in `reason`. Never guess a blocker target.
 - Companion tests must execute every source-stated formula branch, boundary,
   exception, and rounding rule with assertions on the affected principal
   output. Each branch needs distinct runtime evidence; descriptive test

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3919,6 +3919,7 @@ class TestCmdEvalSuiteRevalidate:
                     "    corpus_citation_path: us/statute/7/2014/e/6/A",
                     "    oracle: policyengine",
                     "    policyengine_rule_hint: snap_net_income_pre_shelter",
+                    "    require_complete_source_unit: true",
                 ]
             )
         )
@@ -4001,6 +4002,7 @@ class TestCmdEvalSuiteRevalidate:
             "actual_cost_usd": None,
             "retrieved_files": [],
             "unexpected_accesses": [],
+            "require_complete_source_unit": True,
             "metrics": {
                 "compile_pass": False,
                 "compile_issues": ["old"],
@@ -4190,6 +4192,7 @@ class TestCmdEvalSuiteRevalidate:
         assert mock_eval.call_args.kwargs["rulespec_dependency_roots"] == [
             dependency_root
         ]
+        assert mock_eval.call_args.kwargs["require_complete_source_unit"] is True
         ledger = json.loads((source_output / "suite-results.jsonl").read_text())
         assert ledger["result"]["metrics"]["compile_pass"] is compile_pass
         assert ledger["result"]["metrics"]["ci_pass"] is ci_pass

--- a/tests/test_complete_source_mode_plumbing.py
+++ b/tests/test_complete_source_mode_plumbing.py
@@ -1,0 +1,259 @@
+"""Focused opt-in complete-source-unit mode plumbing tests."""
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from axiom_encode import cli
+from axiom_encode.harness import evals
+from axiom_encode.harness.evals import EvalWorkspace
+from axiom_encode.harness.validator_pipeline import ValidatorPipeline
+from axiom_encode.prompts.encoder import get_encoder_prompt
+
+_REQUIRED_PATH_ARGS = [
+    "--corpus-path",
+    "/tmp/axiom-corpus",
+    "--axiom-rules-engine-path",
+    "/tmp/axiom-rules-engine",
+]
+
+
+@pytest.mark.parametrize(
+    ("command_args", "handler"),
+    [
+        (["validate", "fixture.yaml", *_REQUIRED_PATH_ARGS], "cmd_validate"),
+        (
+            [
+                "encode",
+                "us/statute/26/32a",
+                *_REQUIRED_PATH_ARGS,
+                "--policy-repo-path",
+                "/tmp/rulespec-us",
+            ],
+            "cmd_encode",
+        ),
+        (
+            [
+                "eval",
+                "us/statute/26/32a",
+                *_REQUIRED_PATH_ARGS,
+                "--policy-repo-path",
+                "/tmp/rulespec-us",
+            ],
+            "cmd_eval",
+        ),
+        (
+            [
+                "eval-source",
+                "de/statute/estg/32a",
+                *_REQUIRED_PATH_ARGS,
+                "--policy-repo-path",
+                "/tmp/rulespec-de",
+            ],
+            "cmd_eval_source",
+        ),
+    ],
+)
+@pytest.mark.parametrize("enabled", [False, True])
+def test_complete_source_unit_flag_is_default_off_and_opt_in(
+    command_args,
+    handler,
+    enabled,
+):
+    argv = ["axiom-encode", *command_args]
+    if enabled:
+        argv.append("--require-complete-source-unit")
+
+    with patch("sys.argv", argv), patch.object(cli, handler) as command:
+        cli.main()
+
+    parsed = command.call_args.args[0]
+    assert parsed.require_complete_source_unit is enabled
+
+
+def test_generic_encoder_prompt_adds_completeness_only_when_enabled():
+    kwargs = {
+        "citation": "de/statute/estg/32a",
+        "output_path": "de/statutes/estg/32a.yaml",
+        "corpus_citation_path": "de/statute/estg/32a",
+    }
+
+    default_prompt = get_encoder_prompt(**kwargs)
+    explicit_off_prompt = get_encoder_prompt(
+        **kwargs,
+        require_complete_source_unit=False,
+    )
+    complete_prompt = get_encoder_prompt(
+        **kwargs,
+        require_complete_source_unit=True,
+    )
+
+    assert explicit_off_prompt == default_prompt
+    assert "Complete-source-unit mode is enabled" not in default_prompt
+    assert "Complete-source-unit mode is enabled" in complete_prompt
+    assert "parameters without encoding the stated formula is invalid" in complete_prompt
+    assert "missing dependency or citation" in complete_prompt
+    assert "formula branch, boundary,\n  exception, and rounding rule" in complete_prompt
+    assert "scalar-only source unit may remain parameter-only" in complete_prompt
+
+
+def test_validator_pipeline_complete_source_mode_is_default_off(tmp_path):
+    kwargs = {
+        "policy_repo_path": tmp_path / "rulespec-de",
+        "axiom_rules_path": tmp_path / "axiom-rules-engine",
+        "local_corpus_release": None,
+        "enable_oracles": False,
+    }
+
+    default_pipeline = ValidatorPipeline(**kwargs)
+    complete_pipeline = ValidatorPipeline(
+        **kwargs,
+        require_complete_source_unit=True,
+    )
+
+    assert default_pipeline.require_complete_source_unit is False
+    assert complete_pipeline.require_complete_source_unit is True
+
+
+def test_pipeline_complete_mode_uses_resolver_body_not_summary(tmp_path):
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  summary: Der Freibetrag beträgt 259 Euro.
+rules:
+  - name: allowance_amount
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 259
+"""
+    authoritative_body = (
+        "(1) Der Freibetrag beträgt 259 Euro; der Zuschlag beträgt 73 Euro."
+    )
+    kwargs = {
+        "policy_repo_path": tmp_path / "rulespec-de",
+        "axiom_rules_path": tmp_path / "axiom-rules-engine",
+        "local_corpus_release": None,
+        "enable_oracles": False,
+    }
+    default_pipeline = ValidatorPipeline(**kwargs)
+    complete_pipeline = ValidatorPipeline(
+        **kwargs,
+        require_complete_source_unit=True,
+    )
+    source_texts = {"de/statute/estg/32a": authoritative_body}
+
+    assert (
+        default_pipeline._complete_source_unit_issues(
+            content,
+            validation_source_texts=source_texts,
+            test_cases=[],
+        )
+        == []
+    )
+    strict_issues = complete_pipeline._complete_source_unit_issues(
+        content,
+        validation_source_texts=source_texts,
+        test_cases=[],
+    )
+
+    assert any(
+        "authoritative corpus numeric value 73" in issue.lower()
+        for issue in strict_issues
+    )
+    assert not any(
+        "authoritative corpus numeric value 259" in issue.lower()
+        for issue in strict_issues
+    )
+
+
+def test_eval_prompt_adds_completeness_only_when_enabled(tmp_path):
+    source_file = tmp_path / "source.txt"
+    source_file.write_text("The amount is 12.")
+    workspace = EvalWorkspace(
+        root=tmp_path,
+        source_text_file=source_file,
+        manifest_file=tmp_path / "context-manifest.json",
+    )
+    kwargs = {
+        "citation": "de/statute/example/1",
+        "mode": "cold",
+        "workspace": workspace,
+        "context_files": [],
+        "target_file_name": "1.yaml",
+        "include_tests": True,
+        "runner_backend": "openai",
+    }
+
+    default_prompt = evals._build_eval_prompt(**kwargs)
+    explicit_off_prompt = evals._build_eval_prompt(
+        **kwargs,
+        require_complete_source_unit=False,
+    )
+    complete_prompt = evals._build_eval_prompt(
+        **kwargs,
+        require_complete_source_unit=True,
+    )
+
+    assert explicit_off_prompt == default_prompt
+    assert "Complete-source-unit mode is enabled" not in default_prompt
+    assert "Complete-source-unit mode is enabled" in complete_prompt
+    assert "authoritative `./source.txt` body" in complete_prompt
+    assert "parameters without encoding the stated formula is invalid" in complete_prompt
+
+
+def test_run_model_eval_forces_tests_and_forwards_complete_mode(tmp_path):
+    source_unit = object()
+    result = object()
+    with (
+        patch.object(evals, "_validate_eval_oracle_runtime"),
+        patch.object(evals, "resolve_corpus_source_unit", return_value=source_unit),
+        patch.object(evals, "_authoritative_rulespec_dependency_scope", return_value=nullcontext()),
+        patch.object(evals, "_run_single_eval", return_value=result) as run_single,
+    ):
+        actual = evals.run_model_eval(
+            citations=["de/statute/estg/32a"],
+            runner_specs=["codex:test-model"],
+            output_root=tmp_path / "output",
+            policy_path=tmp_path / "rulespec-de",
+            runtime_axiom_rules_path=tmp_path / "axiom-rules-engine",
+            corpus_release=object(),
+            include_tests=False,
+            require_complete_source_unit=True,
+        )
+
+    assert actual == [result]
+    assert run_single.call_args.kwargs["include_tests"] is True
+    assert run_single.call_args.kwargs["require_complete_source_unit"] is True
+
+
+def test_repair_revalidation_keeps_complete_mode(tmp_path):
+    metrics = SimpleNamespace(ci_issues=["repairable"])
+    with (
+        patch.object(evals, "evaluate_artifact", return_value=metrics) as evaluate,
+        patch.object(
+            evals,
+            "_apply_generated_eval_repairs",
+            return_value=["companion-test-repair"],
+        ),
+    ):
+        actual = evals._evaluate_generated_artifact_with_repairs(
+            rulespec_file=tmp_path / "artifact.yaml",
+            policy_repo_root=tmp_path / "rulespec-de",
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+            source_text="Source body",
+            local_corpus_release=object(),
+            require_complete_source_unit=True,
+        )
+
+    assert actual is metrics
+    assert evaluate.call_count == 2
+    assert all(
+        call.kwargs["require_complete_source_unit"] is True
+        for call in evaluate.call_args_list
+    )

--- a/tests/test_complete_source_mode_plumbing.py
+++ b/tests/test_complete_source_mode_plumbing.py
@@ -95,6 +95,8 @@ def test_generic_encoder_prompt_adds_completeness_only_when_enabled():
     assert "Complete-source-unit mode is enabled" in complete_prompt
     assert "parameters without encoding the stated formula is invalid" in complete_prompt
     assert "missing dependency or citation" in complete_prompt
+    assert "exact missing RuleSpec targets under `blocked_by`" not in complete_prompt
+    assert "Only include `blocked_by` entries when you know the exact" in complete_prompt
     assert "formula branch, boundary,\n  exception, and rounding rule" in complete_prompt
     assert "scalar-only source unit may remain parameter-only" in complete_prompt
 
@@ -205,6 +207,8 @@ def test_eval_prompt_adds_completeness_only_when_enabled(tmp_path):
     assert "Complete-source-unit mode is enabled" in complete_prompt
     assert "authoritative `./source.txt` body" in complete_prompt
     assert "parameters without encoding the stated formula is invalid" in complete_prompt
+    assert "exact missing RuleSpec targets under `blocked_by`" not in complete_prompt
+    assert "Only include `blocked_by` entries when you know the exact" in complete_prompt
 
 
 def test_run_model_eval_forces_tests_and_forwards_complete_mode(tmp_path):

--- a/tests/test_complete_source_mode_plumbing.py
+++ b/tests/test_complete_source_mode_plumbing.py
@@ -93,11 +93,17 @@ def test_generic_encoder_prompt_adds_completeness_only_when_enabled():
     assert explicit_off_prompt == default_prompt
     assert "Complete-source-unit mode is enabled" not in default_prompt
     assert "Complete-source-unit mode is enabled" in complete_prompt
-    assert "parameters without encoding the stated formula is invalid" in complete_prompt
+    assert (
+        "parameters without encoding the stated formula is invalid" in complete_prompt
+    )
     assert "missing dependency or citation" in complete_prompt
     assert "exact missing RuleSpec targets under `blocked_by`" not in complete_prompt
-    assert "Only include `blocked_by` entries when you know the exact" in complete_prompt
-    assert "formula branch, boundary,\n  exception, and rounding rule" in complete_prompt
+    assert (
+        "Only include `blocked_by` entries when you know the exact" in complete_prompt
+    )
+    assert (
+        "formula branch, boundary,\n  exception, and rounding rule" in complete_prompt
+    )
     assert "scalar-only source unit may remain parameter-only" in complete_prompt
 
 
@@ -206,9 +212,13 @@ def test_eval_prompt_adds_completeness_only_when_enabled(tmp_path):
     assert "Complete-source-unit mode is enabled" not in default_prompt
     assert "Complete-source-unit mode is enabled" in complete_prompt
     assert "authoritative `./source.txt` body" in complete_prompt
-    assert "parameters without encoding the stated formula is invalid" in complete_prompt
+    assert (
+        "parameters without encoding the stated formula is invalid" in complete_prompt
+    )
     assert "exact missing RuleSpec targets under `blocked_by`" not in complete_prompt
-    assert "Only include `blocked_by` entries when you know the exact" in complete_prompt
+    assert (
+        "Only include `blocked_by` entries when you know the exact" in complete_prompt
+    )
 
 
 def test_run_model_eval_forces_tests_and_forwards_complete_mode(tmp_path):
@@ -217,7 +227,11 @@ def test_run_model_eval_forces_tests_and_forwards_complete_mode(tmp_path):
     with (
         patch.object(evals, "_validate_eval_oracle_runtime"),
         patch.object(evals, "resolve_corpus_source_unit", return_value=source_unit),
-        patch.object(evals, "_authoritative_rulespec_dependency_scope", return_value=nullcontext()),
+        patch.object(
+            evals,
+            "_authoritative_rulespec_dependency_scope",
+            return_value=nullcontext(),
+        ),
         patch.object(evals, "_run_single_eval", return_value=result) as run_single,
     ):
         actual = evals.run_model_eval(

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -7341,8 +7341,7 @@ rules:
         pass_source_citation_path,
     ):
         authoritative_source_text = (
-            "(1) Der Freibetrag beträgt 259 Euro; "
-            "der Zuschlag beträgt 73 Euro."
+            "(1) Der Freibetrag beträgt 259 Euro; der Zuschlag beträgt 73 Euro."
         )
         caller_source_summary = "(1) Der Freibetrag beträgt 259 Euro."
         corpus_release = _write_test_corpus_provision(
@@ -7395,9 +7394,7 @@ rules:
         assert any("73" in issue for issue in metrics.numeric_occurrence_issues)
 
     def test_complete_mode_numeric_recall_is_summary_invariant(self, tmp_path):
-        source_text = (
-            "If the 3rd digit is 5 or more, increase the 2nd digit by 1."
-        )
+        source_text = "If the 3rd digit is 5 or more, increase the 2nd digit by 1."
         citation_path = "ca/policy/cra/example/rounding"
         corpus_release = _write_test_corpus_provision(
             tmp_path,
@@ -13212,18 +13209,19 @@ class TestEvalSuiteManifest:
         explicit_off_case = replace(default_case, require_complete_source_unit=False)
         complete_case = replace(default_case, require_complete_source_unit=True)
 
-        default_identity = evals_module._canonical_eval_suite_case_payload(
-            default_case
-        )
+        default_identity = evals_module._canonical_eval_suite_case_payload(default_case)
         assert default_case.require_complete_source_unit is False
         assert (
             evals_module._canonical_eval_suite_case_payload(explicit_off_case)
             == default_identity
         )
         assert "require_complete_source_unit" not in default_identity
-        assert evals_module._canonical_eval_suite_case_payload(complete_case)[
-            "require_complete_source_unit"
-        ] is True
+        assert (
+            evals_module._canonical_eval_suite_case_payload(complete_case)[
+                "require_complete_source_unit"
+            ]
+            is True
+        )
 
     @pytest.mark.parametrize("value", [None, 0, 1, "true", []])
     def test_complete_source_unit_case_mode_requires_a_boolean(
@@ -20182,9 +20180,7 @@ def test_persisted_revalidation_keeps_complete_source_unit_mode():
         require_complete_source_unit=True,
     )
 
-    assert (
-        evaluate_mock.call_args.kwargs["require_complete_source_unit"] is True
-    )
+    assert evaluate_mock.call_args.kwargs["require_complete_source_unit"] is True
 
 
 @pytest.mark.parametrize(

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -7328,15 +7328,21 @@ rules:
         assert metrics.source_numeric_occurrence_count == 0
         assert metrics.numeric_occurrence_issues == []
 
-    def test_complete_mode_numeric_recall_uses_authoritative_body(self, tmp_path):
-        source_text = (
+    @pytest.mark.parametrize("pass_source_citation_path", [False, True])
+    def test_complete_mode_numeric_recall_uses_authoritative_body(
+        self,
+        tmp_path,
+        pass_source_citation_path,
+    ):
+        authoritative_source_text = (
             "(1) Der Freibetrag beträgt 259 Euro; "
             "der Zuschlag beträgt 73 Euro."
         )
+        caller_source_summary = "(1) Der Freibetrag beträgt 259 Euro."
         corpus_release = _write_test_corpus_provision(
             tmp_path,
             citation_path="de/statute/estg/32a",
-            body=source_text,
+            body=authoritative_source_text,
         )
         rulespec_file = tmp_path / "statutes" / "estg" / "32a.yaml"
         rulespec_file.parent.mkdir(parents=True)
@@ -7368,9 +7374,11 @@ rules:
                 rulespec_file=rulespec_file,
                 policy_repo_root=_canonical_rulespec_content_root(tmp_path, "de"),
                 axiom_rules_path=Path("/tmp/axiom-rules-engine"),
-                source_text=source_text,
+                source_text=caller_source_summary,
                 local_corpus_release=corpus_release,
-                source_citation_path="de/statute/estg/32a",
+                source_citation_path=(
+                    "de/statute/estg/32a" if pass_source_citation_path else None
+                ),
                 require_complete_source_unit=True,
             )
 

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -7652,6 +7652,9 @@ rules:
         assert metrics.ci_pass
         assert metrics.grounded_numeric_count == 1
         assert metrics.ungrounded_numeric_count == 0
+        if require_complete_source_unit:
+            assert metrics.source_numeric_occurrence_count == 1
+            assert metrics.missing_source_numeric_occurrence_count == 0
 
     def test_generated_numeric_grounding_never_uses_module_summary(self, tmp_path):
         source_text = (
@@ -7705,9 +7708,6 @@ rules:
         assert not metrics.ci_pass
         assert metrics.ungrounded_numeric_count == 1
         assert any("144" in issue for issue in metrics.ci_issues)
-        if require_complete_source_unit:
-            assert metrics.source_numeric_occurrence_count == 1
-            assert metrics.missing_source_numeric_occurrence_count == 0
 
     def test_numeric_grounding_uses_de_profile_from_source_citation(self, tmp_path):
         source_text = "Der Betrag beläuft sich auf 1 034,87 Punkte."

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -6083,6 +6083,12 @@ def test_eval_result_payload_round_trips_prompt_digests():
     result.require_complete_source_unit = False
     assert "require_complete_source_unit" not in result.to_dict()
 
+    malformed_payload = dict(strict_payload)
+    malformed_payload["require_complete_source_unit"] = "true"
+    malformed_payload = _bind_eval_result_payload(malformed_payload)
+    with pytest.raises(ValueError, match="invalid boolean field"):
+        _eval_result_from_payload(malformed_payload)
+
     def test_wait_for_codex_process_terminates_after_persistent_output(self, tmp_path):
         last_message = tmp_path / ".codex-last-message.txt"
         last_message.write_text("ready\n")
@@ -13126,6 +13132,78 @@ class TestEvalSuiteManifest:
 
         assert manifest.cases[0].citation == "7 USC 2017"
 
+    def test_complete_source_unit_case_mode_is_default_off_and_identity_preserving(
+        self,
+        tmp_path,
+    ):
+        payload = _strict_eval_suite_manifest_payload()
+        manifest_file = tmp_path / "suite.yaml"
+        manifest_file.write_text(yaml.safe_dump(payload))
+
+        default_case = load_eval_suite_manifest(manifest_file).cases[0]
+        explicit_off_case = replace(default_case, require_complete_source_unit=False)
+        complete_case = replace(default_case, require_complete_source_unit=True)
+
+        default_identity = evals_module._canonical_eval_suite_case_payload(
+            default_case
+        )
+        assert default_case.require_complete_source_unit is False
+        assert (
+            evals_module._canonical_eval_suite_case_payload(explicit_off_case)
+            == default_identity
+        )
+        assert "require_complete_source_unit" not in default_identity
+        assert evals_module._canonical_eval_suite_case_payload(complete_case)[
+            "require_complete_source_unit"
+        ] is True
+
+    @pytest.mark.parametrize("value", [None, 0, 1, "true", []])
+    def test_complete_source_unit_case_mode_requires_a_boolean(
+        self,
+        tmp_path,
+        value,
+    ):
+        payload = _strict_eval_suite_manifest_payload()
+        payload["cases"][0]["require_complete_source_unit"] = value
+        manifest_file = tmp_path / "suite.yaml"
+        manifest_file.write_text(yaml.safe_dump(payload))
+
+        with pytest.raises(
+            ValueError,
+            match="require_complete_source_unit.*must be a boolean",
+        ):
+            load_eval_suite_manifest(manifest_file)
+
+    def test_complete_source_unit_case_mode_loads_when_enabled(self, tmp_path):
+        payload = _strict_eval_suite_manifest_payload()
+        payload["cases"][0]["require_complete_source_unit"] = True
+        manifest_file = tmp_path / "suite.yaml"
+        manifest_file.write_text(yaml.safe_dump(payload))
+
+        manifest = load_eval_suite_manifest(manifest_file)
+
+        assert manifest.cases[0].require_complete_source_unit is True
+
+    def test_complete_source_unit_case_rejects_mismatched_runner_result(self):
+        case = EvalSuiteCase(
+            kind="source",
+            name="sample",
+            mode="cold",
+            corpus_citation_path="us/statute/7/2017",
+            require_complete_source_unit=True,
+        )
+        result = _fake_eval_result(
+            "openai-gpt-5.4",
+            "us/statute/7/2017",
+        )
+
+        with pytest.raises(ValueError, match="different complete-source-unit mode"):
+            evals_module._validate_new_eval_suite_case_results(
+                case,
+                [result],
+                [parse_runner_spec("openai:gpt-5.4")],
+            )
+
     def test_manifest_context_path_does_not_rewrite_legacy_checkout_layout(
         self, tmp_path
     ):
@@ -13762,6 +13840,54 @@ cases:
         assert mock_source.call_args.kwargs["rulespec_dependency_roots"] == [
             dependency_root
         ]
+
+    def test_run_eval_suite_forwards_complete_source_unit_mode_per_case(
+        self,
+        tmp_path,
+    ):
+        payload = _strict_eval_suite_manifest_payload()
+        payload["cases"] = [
+            {
+                "kind": "source",
+                "name": "source-case",
+                "corpus_citation_path": "us/statute/7/2017",
+                "require_complete_source_unit": True,
+            },
+            {
+                "kind": "citation",
+                "name": "citation-case",
+                "citation": "7 USC 2017",
+                "require_complete_source_unit": True,
+            },
+        ]
+        manifest_file = tmp_path / "suite.yaml"
+        manifest_file.write_text(yaml.safe_dump(payload))
+        manifest = load_eval_suite_manifest(manifest_file)
+        corpus_release = _write_test_corpus_provision(tmp_path)
+
+        with (
+            patch(
+                "axiom_encode.harness.evals.run_source_eval",
+                side_effect=RuntimeError("source runner stopped"),
+            ) as mock_source,
+            patch(
+                "axiom_encode.harness.evals.run_model_eval",
+                side_effect=RuntimeError("citation runner stopped"),
+            ) as mock_model,
+        ):
+            results = run_eval_suite(
+                manifest=manifest,
+                output_root=tmp_path / "out",
+                axiom_rules_path=tmp_path / "axiom-rules-engine",
+                policy_repo_path=tmp_path / "rulespec-us",
+                corpus_release=corpus_release,
+                suite_retry_attempts=0,
+            )
+
+        assert mock_source.call_args.kwargs["require_complete_source_unit"] is True
+        assert mock_model.call_args.kwargs["require_complete_source_unit"] is True
+        assert len(results) == 2
+        assert all(result.require_complete_source_unit is True for result in results)
 
     def test_run_eval_suite_passes_policyengine_rule_hint_to_source_runner(
         self, tmp_path
@@ -19926,6 +20052,8 @@ def _revalidation_result(
 def _run_case_revalidation(
     persisted: EvalArtifactMetrics | None,
     fresh: EvalArtifactMetrics | None,
+    *,
+    require_complete_source_unit: bool = False,
     **result_overrides,
 ):
     case = evals_module.EvalSuiteCase(
@@ -19933,6 +20061,7 @@ def _run_case_revalidation(
         name="vat_standard_rate",
         mode="cold",
         corpus_citation_path="uk/statute/ukpga/1994/23/2",
+        require_complete_source_unit=require_complete_source_unit,
     )
     source_unit = SimpleNamespace(body="The rate of VAT is 20 percent.")
     with (
@@ -19974,6 +20103,20 @@ def test_persisted_revalidation_ignores_reviewer_outcomes():
     )
     evaluate_mock = _run_case_revalidation(persisted, fresh)
     assert evaluate_mock.call_args.kwargs["skip_reviewers"] is True
+
+
+def test_persisted_revalidation_keeps_complete_source_unit_mode():
+    metrics = _revalidation_metrics()
+
+    evaluate_mock = _run_case_revalidation(
+        metrics,
+        metrics,
+        require_complete_source_unit=True,
+    )
+
+    assert (
+        evaluate_mock.call_args.kwargs["require_complete_source_unit"] is True
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -6067,15 +6067,21 @@ def test_eval_result_payload_round_trips_prompt_digests():
             "requested_corpus_citation_path": "us/statute/7/2014/e/6/A",
             "source_sha256": "a" * 64,
         },
+        require_complete_source_unit=True,
     )
 
-    restored = _eval_result_from_payload(result.to_dict())
+    strict_payload = result.to_dict()
+    restored = _eval_result_from_payload(strict_payload)
 
+    assert strict_payload["require_complete_source_unit"] is True
+    assert restored.require_complete_source_unit is True
     assert restored.generation_prompt_sha256 == "generation-digest"
     assert restored.retry_count == 1
     assert restored.metrics is not None
     assert restored.metrics.generalist_review_prompt_sha256 == "review-digest"
     assert restored.source_attestation == result.source_attestation
+    result.require_complete_source_unit = False
+    assert "require_complete_source_unit" not in result.to_dict()
 
     def test_wait_for_codex_process_terminates_after_persistent_output(self, tmp_path):
         last_message = tmp_path / ".codex-last-message.txt"
@@ -7321,6 +7327,58 @@ rules:
         assert metrics.ci_pass
         assert metrics.source_numeric_occurrence_count == 0
         assert metrics.numeric_occurrence_issues == []
+
+    def test_complete_mode_numeric_recall_uses_authoritative_body(self, tmp_path):
+        source_text = (
+            "(1) Der Freibetrag beträgt 259 Euro; "
+            "der Zuschlag beträgt 73 Euro."
+        )
+        corpus_release = _write_test_corpus_provision(
+            tmp_path,
+            citation_path="de/statute/estg/32a",
+            body=source_text,
+        )
+        rulespec_file = tmp_path / "statutes" / "estg" / "32a.yaml"
+        rulespec_file.parent.mkdir(parents=True)
+        rulespec_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  summary: Der Freibetrag beträgt 259 Euro.
+rules:
+  - name: allowance_amount
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 259
+"""
+        )
+        compile_result = ValidationResult("compile", True, issues=[])
+        ci_result = ValidationResult("ci", True, issues=[])
+
+        with (
+            patch.object(
+                ValidatorPipeline, "_run_compile_check", return_value=compile_result
+            ),
+            patch.object(ValidatorPipeline, "_run_ci", return_value=ci_result),
+        ):
+            metrics = evaluate_artifact(
+                rulespec_file=rulespec_file,
+                policy_repo_root=_canonical_rulespec_content_root(tmp_path, "de"),
+                axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+                source_text=source_text,
+                local_corpus_release=corpus_release,
+                source_citation_path="de/statute/estg/32a",
+                require_complete_source_unit=True,
+            )
+
+        assert not metrics.ci_pass
+        assert metrics.source_numeric_occurrence_count == 2
+        assert metrics.covered_source_numeric_occurrence_count == 1
+        assert metrics.missing_source_numeric_occurrence_count == 1
+        assert any("73" in issue for issue in metrics.numeric_occurrence_issues)
 
     def test_numeric_occurrence_check_counts_inline_source_table_bounds(self, tmp_path):
         rulespec_file = tmp_path / "statutes" / "26" / "3241" / "b.yaml"

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -7394,6 +7394,74 @@ rules:
         assert metrics.missing_source_numeric_occurrence_count == 1
         assert any("73" in issue for issue in metrics.numeric_occurrence_issues)
 
+    def test_complete_mode_numeric_recall_is_summary_invariant(self, tmp_path):
+        source_text = (
+            "If the 3rd digit is 5 or more, increase the 2nd digit by 1."
+        )
+        citation_path = "ca/policy/cra/example/rounding"
+        corpus_release = _write_test_corpus_provision(
+            tmp_path,
+            citation_path=citation_path,
+            body=source_text,
+        )
+        rulespec_file = tmp_path / "policies" / "cra" / "example" / "rounding.yaml"
+        rulespec_file.parent.mkdir(parents=True)
+        signatures = []
+
+        for summary in (
+            source_text,
+            "A deliberately terse summary with no numeric inventory.",
+        ):
+            rulespec_file.write_text(
+                f"""format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: {citation_path}
+  summary: {summary}
+rules:
+  - name: rounding_half_unit
+    kind: parameter
+    dtype: Decimal
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.5
+"""
+            )
+            with (
+                patch.object(
+                    ValidatorPipeline,
+                    "_run_compile_check",
+                    return_value=ValidationResult("compile", True, issues=[]),
+                ),
+                patch.object(
+                    ValidatorPipeline,
+                    "_run_ci",
+                    return_value=ValidationResult("ci", True, issues=[]),
+                ),
+            ):
+                metrics = evaluate_artifact(
+                    rulespec_file=rulespec_file,
+                    policy_repo_root=_canonical_rulespec_content_root(
+                        tmp_path,
+                        "ca",
+                    ),
+                    axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+                    source_text=source_text,
+                    local_corpus_release=corpus_release,
+                    source_citation_path=citation_path,
+                    require_complete_source_unit=True,
+                )
+            signatures.append(
+                (
+                    metrics.source_numeric_occurrence_count,
+                    metrics.covered_source_numeric_occurrence_count,
+                    metrics.missing_source_numeric_occurrence_count,
+                    metrics.numeric_occurrence_issues,
+                )
+            )
+
+        assert signatures[0] == signatures[1]
+
     def test_numeric_occurrence_check_counts_inline_source_table_bounds(self, tmp_path):
         rulespec_file = tmp_path / "statutes" / "26" / "3241" / "b.yaml"
         rulespec_file.parent.mkdir(parents=True)

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -7588,8 +7588,11 @@ rules: []
         assert metrics.source_numeric_occurrence_count == 0
         assert metrics.numeric_occurrence_issues == []
 
+    @pytest.mark.parametrize("require_complete_source_unit", [False, True])
     def test_generated_numeric_grounding_uses_authoritative_module_source(
-        self, tmp_path
+        self,
+        tmp_path,
+        require_complete_source_unit,
     ):
         source_text = (
             "(a) Households in which each member receives qualifying public "
@@ -7637,6 +7640,7 @@ rules:
                 axiom_rules_path=Path("/tmp/axiom-rules-engine"),
                 source_text=source_text,
                 local_corpus_release=corpus_release,
+                require_complete_source_unit=require_complete_source_unit,
             )
 
         assert metrics.ci_pass
@@ -7695,6 +7699,9 @@ rules:
         assert not metrics.ci_pass
         assert metrics.ungrounded_numeric_count == 1
         assert any("144" in issue for issue in metrics.ci_issues)
+        if require_complete_source_unit:
+            assert metrics.source_numeric_occurrence_count == 1
+            assert metrics.missing_source_numeric_occurrence_count == 0
 
     def test_numeric_grounding_uses_de_profile_from_source_citation(self, tmp_path):
         source_text = "Der Betrag beläuft sich auf 1 034,87 Punkte."

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -585,6 +585,19 @@ rules: []
     assert _has_issue(result, marker, "source branch")
 
 
+def test_explicit_satz_markers_after_absatz_are_recognized():
+    branches = recognize_source_structure(
+        "(1) Satz 1 Die Hauptregel gilt; Satz 2 Die Sonderregel gilt."
+    )
+
+    assert {
+        branch.path for branch in branches if branch.kind == "sentence"
+    } == {
+        ("1", "satz-1"),
+        ("1", "satz-2"),
+    }
+
+
 def test_imprecise_absatz_deferral_does_not_cover_branch():
     content = """\
 format: rulespec/v1

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -7669,3 +7669,73 @@ def test_inflected_absatz_references_are_not_numeric_inventory(source: str):
 
     assert not result.issues
     assert result.source_numeric_occurrence_count == 1
+
+
+def test_worded_arithmetic_chain_preserves_formula_topology():
+    source = "(1) Der Betrag ist Einkommen mal 2 plus 3."
+    correct = _analyze(
+        _three_term_topology_content("income * two + three"),
+        source,
+        test_cases=[
+            {
+                "name": "worded source formula",
+                "input": {"income": 10},
+                "output": {"amount": 23},
+            }
+        ],
+    )
+    wrong = _analyze(
+        _three_term_topology_content("income + two * three"),
+        source,
+        test_cases=[
+            {
+                "name": "different worded formula",
+                "input": {"income": 10},
+                "output": {"amount": 16},
+            }
+        ],
+    )
+
+    assert not correct.issues
+    assert _has_issue(wrong, "formula branch")
+
+
+def test_nearest_rounding_offset_cannot_cancel_itself():
+    source = "(1) Das Einkommen ist auf volle Euro gerundet."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: rounded_income
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions: [{formula: FORMULA}]
+"""
+    correct = _analyze(
+        content.replace("FORMULA", "floor(income + 0.5)"),
+        source,
+        test_cases=[
+            {
+                "name": "nearest result",
+                "input": {"income": 10.75},
+                "output": {"rounded_income": 11},
+            }
+        ],
+    )
+    cancelled = _analyze(
+        content.replace("FORMULA", "floor(income - 0.5 + 0.5)"),
+        source,
+        test_cases=[
+            {
+                "name": "cancelled offset",
+                "input": {"income": 10.75},
+                "output": {"rounded_income": 10},
+            }
+        ],
+    )
+
+    assert not correct.issues
+    assert _has_issue(cancelled, "rounding", "fractional")

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -2118,6 +2118,148 @@ rules:
     assert not _has_issue(both_branches, "formula branch")
 
 
+@pytest.mark.parametrize("inline", [False, True])
+def test_match_formula_branches_require_distinct_arm_executions(inline: bool):
+    source = """\
+(1) Bei Verheirateten ist der Betrag Einkommen * 2.
+(2) Bei Alleinstehenden ist der Betrag Einkommen * 3.
+"""
+    match_formula = (
+        'match filing_status: "married" => income * married_multiplier; '
+        '"single" => income * single_multiplier'
+        if inline
+        else """\
+match filing_status:
+  "married" => income * married_multiplier
+  "single" => income * single_multiplier"""
+    )
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: married_multiplier
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2
+  - name: single_multiplier
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(2)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 3
+  - name: amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1); de/statute/estg/32a(2)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+{chr(10).join(f"          {line}" for line in match_formula.splitlines())}
+"""
+
+    def case(name: str, status: str, income: int) -> dict[str, object]:
+        return {
+            "name": name,
+            "input": {"filing_status": status, "income": income},
+            "output": {"amount": income * (2 if status == "married" else 3)},
+        }
+
+    repeated_arm = _analyze(
+        content,
+        source,
+        test_cases=[
+            case("married one", "married", 10),
+            case("married two", "married", 20),
+        ],
+    )
+    both_arms = _analyze(
+        content,
+        source,
+        test_cases=[
+            case("married", "married", 10),
+            case("single", "single", 10),
+        ],
+    )
+
+    assert _has_issue(repeated_arm, "formula branch", "distinct")
+    assert not _has_issue(both_arms, "formula branch")
+
+
+def test_inline_if_formula_requires_distinct_runtime_branch_executions():
+    source = """\
+(1) Bei Ehegatten ist der Betrag Einkommen * 2.
+(2) Bei Alleinstehenden ist der Betrag Einkommen * 3.
+"""
+    content = MULTI_PARAGRAPH_FORMULA_CONTENT.replace(
+        "formula: income * first_multiplier + income * second_multiplier",
+        "formula: >-\n"
+        "          if married or high_income: income * first_multiplier "
+        "else: income * second_multiplier",
+    ).replace(
+        "first_multiplier",
+        "married_multiplier",
+    ).replace(
+        "second_multiplier",
+        "single_multiplier",
+    )
+
+    def case(name: str, married: bool, high_income: bool) -> dict[str, object]:
+        return {
+            "name": name,
+            "input": {
+                "income": 10,
+                "married": married,
+                "high_income": high_income,
+            },
+            "output": {"combined_amount": 20 if married or high_income else 30},
+        }
+
+    repeated_branch = _analyze(
+        content,
+        source,
+        test_cases=[
+            case("married ordinary", True, False),
+            case("married high income", True, True),
+        ],
+    )
+    both_branches = _analyze(
+        content,
+        source,
+        test_cases=[
+            case("married", True, False),
+            case("single", False, False),
+        ],
+    )
+
+    assert _has_issue(repeated_branch, "formula branch", "distinct")
+    assert not _has_issue(both_branches, "formula branch")
+
+
+def test_judgment_selector_normalizes_holds_and_not_holds():
+    rule = {
+        "versions": [
+            {
+                "formula": "if eligible: eligible_amount else: ineligible_amount",
+            }
+        ]
+    }
+
+    assert completeness_module._case_formula_branch_outcome(
+        rule,
+        {"input": {"eligible": "holds"}},
+    ) == "if:0"
+    assert completeness_module._case_formula_branch_outcome(
+        rule,
+        {"input": {"eligible": "not_holds"}},
+    ) == "if:1"
+
+
 def test_numbered_prose_formulas_require_distinct_executed_cases():
     source = """\
 (1) Es gelten folgende Berechnungen:

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -658,6 +658,32 @@ rules: []
     assert _has_issue(result, "(6)", "deferral", "dependency")
 
 
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "Arbitrary placeholder.",
+        "Requires an external assessment base.",
+    ],
+)
+def test_deferral_blocker_must_be_identified_by_dependency_reason(reason: str):
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  deferred_outputs:
+    - output: de:statutes/estg/32a/6#splitting_rule
+      reason: {reason}
+      blocked_by:
+        - de:statutes/estg/9999#fictional_amount
+rules: []
+"""
+
+    result = _analyze(content, ABSATZ_6, test_cases=[])
+
+    assert _has_issue(result, "(6)", "deferral", "dependency")
+
+
 def test_root_deferral_does_not_blanket_structured_source_unit():
     content = """\
 format: rulespec/v1

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -922,6 +922,9 @@ rules: []
         "Der Betrag ist das Produkt aus Einkommen und Faktor.",
         "Der Betrag entspricht Einkommen mal zwei.",
         "Der Betrag wird verdoppelt.",
+        "Der Betrag beträgt das Einkommen plus 10 Euro.",
+        "Der Betrag beträgt das Einkommen minus 10 Euro.",
+        "Der Betrag beträgt 10 % des Einkommens.",
     ],
 )
 def test_common_german_formula_language_is_computation(source: str):
@@ -939,6 +942,9 @@ def test_common_german_formula_language_is_computation(source: str):
         ("(1) Der Betrag ist das Produkt aus Einkommen und Faktor.", 2),
         ("(1) Der Betrag entspricht Einkommen mal zwei.", 2),
         ("(1) Der Betrag wird verdoppelt.", 2),
+        ("(1) Der Betrag beträgt das Einkommen plus 10 Euro.", 10),
+        ("(1) Der Betrag beträgt das Einkommen minus 10 Euro.", 10),
+        ("(1) Der Betrag beträgt 10 % des Einkommens.", 0.1),
     ],
 )
 def test_common_german_formula_language_rejects_parameter_only(
@@ -4257,6 +4263,59 @@ rules:
     assert not correct.issues
 
 
+def test_formula_witness_preserves_source_operation_topology():
+    source = "(1) Der Betrag wird als Einkommen * 2 + 3 berechnet."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: factor
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 2}]
+  - name: supplement
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 3}]
+  - name: amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions:
+      - formula: FORMULA
+"""
+
+    correct = _analyze(
+        content.replace("FORMULA", "income * factor + supplement"),
+        source,
+        test_cases=[
+            {
+                "name": "source computation",
+                "input": {"income": 10},
+                "output": {"amount": 23},
+            }
+        ],
+    )
+    wrong = _analyze(
+        content.replace("FORMULA", "income + factor * supplement"),
+        source,
+        test_cases=[
+            {
+                "name": "different computation",
+                "input": {"income": 10},
+                "output": {"amount": 16},
+            }
+        ],
+    )
+
+    assert not correct.issues
+    assert _has_issue(wrong, "formula branch")
+
+
 def test_indexed_expression_multiplied_by_zero_cannot_witness_formula():
     source = "(1) Der Betrag wird als Einkommen * 2 berechnet."
     content = """\
@@ -4680,6 +4739,12 @@ def test_adjacent_integral_boundary_requires_the_equivalent_comparator():
         ("unter 100 Euro", "income < income_limit", False, "income <= income_limit"),
         ("ab 100 Euro", "income >= income_limit", True, "income <= income_limit"),
         ("über 100 Euro", "income > income_limit", False, "income >= income_limit"),
+        (
+            "von mehr als 100 Euro",
+            "income > income_limit",
+            False,
+            "income >= income_limit",
+        ),
     ],
 )
 def test_boundary_comparator_preserves_direction_and_inclusivity(

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -681,6 +681,117 @@ def test_complete_companion_suite_covers_source_controls():
     assert not result.issues
 
 
+NARRATIVE_PIECEWISE_SOURCE = """\
+(1) Bis 100 Euro wird die Steuer als Einkommen * 5 Prozent berechnet; über 100 Euro wird die Steuer als Einkommen * 7 Prozent berechnet.
+"""
+
+NARRATIVE_PIECEWISE_CONTENT = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  summary: Narrative piecewise tariff.
+rules:
+  - name: tariff_boundary
+    kind: parameter
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 100
+  - name: lower_tariff_rate_percent
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 5
+  - name: upper_tariff_rate_percent
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 7
+  - name: tariff_income_tax_amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: de/statute/estg/32a
+              excerpt: "Bis 100 Euro wird die Steuer als Einkommen * 5 Prozent berechnet; über 100 Euro wird die Steuer als Einkommen * 7 Prozent berechnet."
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if taxable_income <= tariff_boundary:
+            taxable_income * lower_tariff_rate_percent / 100
+          else:
+            taxable_income * upper_tariff_rate_percent / 100
+"""
+
+
+def _narrative_piecewise_test(
+    name: str,
+    taxable_income: int,
+    expected_tax: int,
+) -> dict[str, object]:
+    return {
+        "name": name,
+        "period": "2026",
+        "input": {"taxable_income": taxable_income},
+        "output": {
+            "de:statutes/estg/32a#tariff_income_tax_amount": expected_tax,
+        },
+    }
+
+
+def test_narrative_piecewise_formula_requires_every_clause_and_boundary():
+    lower_only = _narrative_piecewise_test("lower zone", 90, 4)
+    lower_only["covers"] = ["de/statute/estg/32a(1)"]
+
+    result = _analyze(
+        NARRATIVE_PIECEWISE_CONTENT,
+        NARRATIVE_PIECEWISE_SOURCE,
+        test_cases=[lower_only],
+    )
+
+    assert _has_issue(result, "do not demonstrate", "formula branch")
+    assert _has_issue(result, "boundary", "test")
+
+
+def test_narrative_piecewise_zone_cases_still_require_exact_boundary():
+    result = _analyze(
+        NARRATIVE_PIECEWISE_CONTENT,
+        NARRATIVE_PIECEWISE_SOURCE,
+        test_cases=[
+            _narrative_piecewise_test("lower zone", 90, 4),
+            _narrative_piecewise_test("upper zone", 110, 7),
+        ],
+    )
+
+    assert not _has_issue(result, "do not demonstrate", "formula branch")
+    assert _has_issue(result, "boundary", "test")
+
+
+def test_narrative_piecewise_complete_zone_and_boundary_cases_pass():
+    result = _analyze(
+        NARRATIVE_PIECEWISE_CONTENT,
+        NARRATIVE_PIECEWISE_SOURCE,
+        test_cases=[
+            _narrative_piecewise_test("lower zone", 90, 4),
+            _narrative_piecewise_test("upper zone", 110, 7),
+            _narrative_piecewise_test("exact boundary", 100, 5),
+        ],
+    )
+
+    assert not result.issues
+
+
 @pytest.mark.parametrize(
     ("test_cases", "expected_issue_term"),
     [
@@ -758,6 +869,10 @@ def test_unrelated_numeric_input_cannot_cover_tariff_boundary():
 
 
 def test_unrelated_boolean_toggle_cannot_cover_source_exception():
+    content_with_unrelated_formula_gate = COMPANION_COVERAGE_CONTENT.replace(
+        "          else:\n            floor(\n",
+        "          else:\n            if unrelated_toggle:\n              floor(\n",
+    )
     test_cases = [
         case
         for case in COMPLETE_COMPANION_TESTS
@@ -776,7 +891,7 @@ def test_unrelated_boolean_toggle_cannot_cover_source_exception():
         )
 
     result = _analyze(
-        COMPANION_COVERAGE_CONTENT,
+        content_with_unrelated_formula_gate,
         COMPANION_COVERAGE_SOURCE,
         test_cases=test_cases,
     )
@@ -784,7 +899,55 @@ def test_unrelated_boolean_toggle_cannot_cover_source_exception():
     assert _has_issue(result, "exception", "test")
 
 
+def test_exception_toggle_from_another_source_branch_cannot_cover_exception():
+    source = (
+        COMPANION_COVERAGE_SOURCE
+        + "(2) Der Sonderbetrag wird als Einkommen + Einkommen berechnet.\n"
+    )
+    content = COMPANION_COVERAGE_CONTENT + """\
+  - name: special_status_amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(2)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if special_status_applies:
+            0
+          else:
+            taxable_income
+"""
+    test_cases = [
+        case
+        for case in COMPLETE_COMPANION_TESTS
+        if case["name"] != "exception applies"
+    ]
+    for value, expected in ((False, 90), (True, 0)):
+        test_cases.append(
+            {
+                "name": f"other branch status {value}",
+                "period": "2026",
+                "input": {
+                    "taxable_income": 90,
+                    "exception_applies": False,
+                    "special_status_applies": value,
+                },
+                "output": {
+                    "de:statutes/estg/32a#special_status_amount": expected,
+                },
+            }
+        )
+
+    result = _analyze(content, source, test_cases=test_cases)
+
+    assert _has_issue(result, "exception", "test")
+
+
 def test_unrelated_fractional_input_cannot_cover_rounding_rule():
+    content_with_unrelated_formula_amount = COMPANION_COVERAGE_CONTENT.replace(
+        "            )\n",
+        "            ) + unrelated_amount * 0\n",
+    )
     test_cases = [
         case
         for case in COMPLETE_COMPANION_TESTS
@@ -802,9 +965,27 @@ def test_unrelated_fractional_input_cannot_cover_rounding_rule():
     )
 
     result = _analyze(
-        COMPANION_COVERAGE_CONTENT,
+        content_with_unrelated_formula_amount,
         COMPANION_COVERAGE_SOURCE,
         test_cases=test_cases,
     )
 
     assert _has_issue(result, "rounding", "test")
+
+
+def test_nested_whitespace_rounding_operand_accepts_fractional_input():
+    content = COMPANION_COVERAGE_CONTENT.replace(
+        "            floor(\n",
+        "            floor (\n              max(0,\n",
+    ).replace(
+        "            )\n",
+        "              )\n            )\n",
+    )
+
+    result = _analyze(
+        content,
+        COMPANION_COVERAGE_SOURCE,
+        test_cases=COMPLETE_COMPANION_TESTS,
+    )
+
+    assert not _has_issue(result, "rounding", "test")

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -7641,3 +7641,31 @@ rules:
 
     assert not correct.issues
     assert _has_issue(duplicated, "formula branch")
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        (
+            "(1) Der nach Maßgabe des Absatzes 2 festgelegte Freibetrag "
+            "beträgt 259 Euro."
+        ),
+        (
+            "(1) Der nach den Absätzen 2 und 3 festgelegte Freibetrag "
+            "beträgt 259 Euro."
+        ),
+    ],
+)
+def test_inflected_absatz_references_are_not_numeric_inventory(source: str):
+    content = _scalar_snapshot_content()
+    case = {
+        "name": "scalar with structural cross-reference",
+        "period": "2026",
+        "input": {},
+        "output": {"allowance_amount": 259},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert not result.issues
+    assert result.source_numeric_occurrence_count == 1

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -378,6 +378,37 @@ rules:
     )
 
 
+def test_deferral_prose_and_targets_cannot_hide_authoritative_source_number():
+    source = "(1) Der Freibetrag beträgt 259 Euro; der Zuschlag beträgt 73 Euro."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  summary: Der Freibetrag beträgt 259 Euro.
+  deferred_outputs:
+    - output: de:statutes/estg/32a/1#supplement_73_amount
+      reason: The 73 Euro supplement requires an unavailable dependency.
+      blocked_by:
+        - de:statutes/estg/99#dependency_73_value
+rules:
+  - name: allowance_amount
+    kind: parameter
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 259
+"""
+
+    issues = _pipeline_issues(content, source, test_cases=[])
+
+    assert any(
+        "authoritative corpus numeric value 73" in issue.lower()
+        for issue in issues
+    )
+
+
 @pytest.mark.parametrize(
     ("source", "marker"),
     [
@@ -562,6 +593,97 @@ rules:
     result = _analyze(content, source, test_cases=[])
 
     assert _has_issue(result, "(1)", "source branch")
+
+
+def test_unrelated_rule_source_cannot_cover_requested_branch():
+    source = "(1) Die Hauptregel gilt."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  summary: Hauptregel.
+rules:
+  - name: unrelated_output
+    kind: derived
+    dtype: Money
+    source: de/statute/other/99 Absatz 1
+    versions:
+      - effective_from: '2026-01-01'
+        formula: unrelated_value
+"""
+
+    result = _analyze(content, source, test_cases=[])
+
+    assert _has_issue(result, "(1)", "source branch")
+
+
+def test_unstructured_formula_requires_principal_output_bound_to_source_unit():
+    source = (
+        "Die Steuer ergibt sich aus dem Einkommen geteilt durch den Grundwert."
+    )
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  summary: Steuerberechnung.
+rules:
+  - name: unrelated_output
+    kind: derived
+    dtype: Money
+    source: de/statute/other/99
+    versions:
+      - effective_from: '2026-01-01'
+        formula: unrelated_value
+"""
+    test_cases = [
+        {
+            "name": "unrelated output",
+            "period": "2026",
+            "input": {"unrelated_value": 5},
+            "output": {"de:statutes/estg/32a#unrelated_output": 5},
+        }
+    ]
+
+    unrelated = _analyze(content, source, test_cases=test_cases)
+    bound = _analyze(
+        content.replace("de/statute/other/99", CORPUS_CITATION_PATH),
+        source,
+        test_cases=test_cases,
+    )
+
+    assert _has_issue(unrelated, "explicit source computation", "principal")
+    assert not _has_issue(bound, "formula-output")
+
+
+def test_unstructured_formula_requires_unit_level_deferral():
+    source = (
+        "Die Steuer ergibt sich aus dem Einkommen geteilt durch den Grundwert."
+    )
+    child_deferral = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  summary: Steuerberechnung.
+  deferred_outputs:
+    - output: de:statutes/estg/32a/99#income_tax_amount
+      reason: Requires the missing assessment base under EStG section 26.
+      blocked_by:
+        - de:statutes/estg/26#assessment_base
+rules: []
+"""
+
+    unrelated = _analyze(child_deferral, source, test_cases=[])
+    whole_unit = _analyze(
+        child_deferral.replace("/32a/99#", "/32a#"),
+        source,
+        test_cases=[],
+    )
+
+    assert _has_issue(unrelated, "explicit source computation", "principal")
+    assert not whole_unit.issues
 
 
 COMPANION_COVERAGE_SOURCE = """\

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -1959,6 +1959,36 @@ rules:
     assert _has_issue(result, "formula-output", "control", "parameter-only")
 
 
+def test_piecewise_condition_rejects_constants_only():
+    source = (
+        "(1) Wenn das Einkommen 100 Euro nicht übersteigt, beträgt die "
+        "Steuer 10 Euro; anderenfalls 20 Euro."
+    )
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: income_limit
+    kind: parameter
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 100}]
+  - name: lower_amount
+    kind: parameter
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 10}]
+  - name: upper_amount
+    kind: parameter
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 20}]
+"""
+
+    result = _analyze(content, source, test_cases=[])
+
+    assert _has_issue(result, "formula-output", "control", "parameter-only")
+
+
 def test_positive_applicability_condition_requires_paired_cases():
     source = (
         "(1) Der Zuschlag beträgt 259 Euro, wenn die Person "

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -5976,6 +5976,360 @@ def test_positive_ordinary_selector_is_false_active_for_ineligibility(
 
 
 @pytest.mark.parametrize(
+    (
+        "source",
+        "selector_name",
+        "formula",
+        "false_output",
+        "true_output",
+    ),
+    [
+        (
+            "(1) Der Anspruch gilt nicht, wenn eine Befreiung vorliegt.",
+            "eligible",
+            "if eligible: false else: true",
+            True,
+            False,
+        ),
+        (
+            "(1) Der Anspruch gilt nicht, wenn eine Befreiung vorliegt.",
+            "eligible",
+            "not eligible",
+            True,
+            False,
+        ),
+        (
+            "(1) Der Anspruch gilt nicht, wenn eine Befreiung vorliegt.",
+            "eligible",
+            "match eligible: true => false; false => true",
+            True,
+            False,
+        ),
+        (
+            "(1) Der Anspruch gilt nicht, wenn eine Befreiung vorliegt.",
+            "qualified",
+            "if qualified: false else: true",
+            True,
+            False,
+        ),
+        (
+            "(1) Der Anspruch gilt nicht, wenn eine Befreiung vorliegt.",
+            "ordinary_case",
+            "if ordinary_case: true else: false",
+            False,
+            True,
+        ),
+        (
+            "(1) Der Anspruch gilt nicht, wenn eine Befreiung vorliegt.",
+            "regular_case",
+            "if regular_case: true else: false",
+            False,
+            True,
+        ),
+        (
+            "(1) Der Anspruch gilt nicht, wenn eine Befreiung vorliegt.",
+            "default_case",
+            "if default_case: true else: false",
+            False,
+            True,
+        ),
+        (
+            "(1) The claim does not apply when no certificate is present.",
+            "has_claim",
+            "if has_claim: false else: true",
+            True,
+            False,
+        ),
+        (
+            "(1) Der Anspruch gilt nicht, wenn keine Bescheinigung vorliegt.",
+            "has_anspruch",
+            "if has_anspruch: false else: true",
+            True,
+            False,
+        ),
+    ],
+)
+def test_exception_selector_must_match_the_condition_not_the_claim(
+    source: str,
+    selector_name: str,
+    formula: str,
+    false_output: bool,
+    true_output: bool,
+):
+    content = _exception_control_content(formula)
+    cases = [
+        {
+            "name": "selector false",
+            "input": {selector_name: False},
+            "output": {"result": false_output},
+        },
+        {
+            "name": "selector true",
+            "input": {selector_name: True},
+            "output": {"result": true_output},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert _has_issue(result, "exception", "test")
+
+
+def test_exception_condition_does_not_borrow_a_preceding_main_clause_concept():
+    source = """\
+(1) Bei einer Bescheinigung besteht der Anspruch, außer wenn kein Kind vorhanden ist.
+"""
+    content = _exception_control_content(
+        "if has_certificate: false else: true"
+    )
+    cases = [
+        {
+            "name": "without certificate",
+            "input": {"has_certificate": False},
+            "output": {"result": True},
+        },
+        {
+            "name": "with certificate",
+            "input": {"has_certificate": True},
+            "output": {"result": False},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert _has_issue(result, "exception", "test")
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "(1) Wenn keine Berechtigung besteht, gilt der Anspruch nicht.",
+        "(1) Bei fehlender Berechtigung gilt der Anspruch nicht.",
+        "(1) Ohne Berechtigung gilt der Anspruch nicht.",
+    ],
+)
+def test_preposed_exception_condition_preserves_ordinary_selector(source: str):
+    branches = recognize_source_structure(source)
+    obligations = completeness_module._source_exception_branches(
+        source,
+        branches=branches,
+        active_branches=branches,
+        deferred_paths=set(),
+    )
+    content = _exception_control_content("eligible")
+    cases = [
+        {
+            "name": "eligible",
+            "input": {"eligible": True},
+            "output": {"result": True},
+        },
+        {
+            "name": "ineligible",
+            "input": {"eligible": False},
+            "output": {"result": False},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert len(obligations) == 1
+    assert not result.issues
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "(1) Der Anspruch besteht nicht, außer bei einer Bescheinigung.",
+        "(1) Der Anspruch gilt nicht, es sei denn, eine Bescheinigung liegt vor.",
+        (
+            "(1) Für diese Person gilt der Anspruch weiterhin nicht, "
+            "außer bei einer Bescheinigung."
+        ),
+        "(1) The claim does not apply unless there is a certificate.",
+    ],
+)
+def test_exception_to_negative_rule_must_enable_the_claim(source: str):
+    correct = _exception_control_content(
+        "if has_certificate: true else: false"
+    )
+    wrong = _exception_control_content(
+        "if has_certificate: false else: true"
+    )
+    correct_cases = [
+        {
+            "name": "without certificate",
+            "input": {"has_certificate": False},
+            "output": {"result": False},
+        },
+        {
+            "name": "with certificate",
+            "input": {"has_certificate": True},
+            "output": {"result": True},
+        },
+    ]
+    wrong_cases = [
+        {
+            "name": "without certificate",
+            "input": {"has_certificate": False},
+            "output": {"result": True},
+        },
+        {
+            "name": "with certificate",
+            "input": {"has_certificate": True},
+            "output": {"result": False},
+        },
+    ]
+
+    correct_result = _analyze(correct, source, test_cases=correct_cases)
+    wrong_result = _analyze(wrong, source, test_cases=wrong_cases)
+
+    assert not correct_result.issues
+    assert _has_issue(wrong_result, "exception", "test")
+
+
+def test_exception_to_negative_rule_accepts_numeric_deduction_effect():
+    source = """\
+(1) Der Abzug gilt nicht, außer bei einer Bescheinigung.
+"""
+    content = _exception_control_content(
+        "if has_certificate: tax_with_deduction else: tax_without_deduction"
+    )
+    cases = [
+        {
+            "name": "without certificate",
+            "input": {
+                "has_certificate": False,
+                "tax_with_deduction": 10,
+                "tax_without_deduction": 20,
+            },
+            "output": {"result": 20},
+        },
+        {
+            "name": "with certificate",
+            "input": {
+                "has_certificate": True,
+                "tax_with_deduction": 10,
+                "tax_without_deduction": 20,
+            },
+            "output": {"result": 10},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert not result.issues
+
+
+def test_coordinated_exception_cues_require_distinct_witnesses():
+    source = """\
+(1) Außer bei einer Befreiung und außer bei einer Sperre besteht der Anspruch.
+"""
+    complete = _exception_control_content(
+        "if exemption_applies: false "
+        "else: if barred: false else: true"
+    )
+    incomplete = _exception_control_content(
+        "if exemption_applies: false else: true"
+    )
+    complete_cases = [
+        {
+            "name": "ordinary",
+            "input": {"exemption_applies": False, "barred": False},
+            "output": {"result": True},
+        },
+        {
+            "name": "exemption",
+            "input": {"exemption_applies": True, "barred": False},
+            "output": {"result": False},
+        },
+        {
+            "name": "barred",
+            "input": {"exemption_applies": False, "barred": True},
+            "output": {"result": False},
+        },
+    ]
+    incomplete_cases = [
+        {
+            "name": "ordinary",
+            "input": {"exemption_applies": False},
+            "output": {"result": True},
+        },
+        {
+            "name": "exemption",
+            "input": {"exemption_applies": True},
+            "output": {"result": False},
+        },
+    ]
+
+    complete_result = _analyze(complete, source, test_cases=complete_cases)
+    incomplete_result = _analyze(
+        incomplete,
+        source,
+        test_cases=incomplete_cases,
+    )
+
+    assert not complete_result.issues
+    assert _has_issue(incomplete_result, "exception", "test")
+
+
+def test_exception_witness_allocation_uses_maximum_matching():
+    source = """\
+(1) Der Anspruch besteht, außer bei einer Bescheinigung oder einem Kind.
+Der Anspruch besteht, außer bei einer Bescheinigung oder einem Status.
+Der Anspruch besteht, außer bei einer Bescheinigung oder einem Status.
+"""
+    content = _exception_control_content(
+        "if has_certificate: false else: "
+        "if has_child: false else: "
+        "if has_status: false else: true"
+    )
+    ordinary = {
+        "has_certificate": False,
+        "has_child": False,
+        "has_status": False,
+    }
+    cases = [
+        {
+            "name": "ordinary",
+            "input": ordinary,
+            "output": {"result": True},
+        }
+    ]
+    for selector in ordinary:
+        inputs = dict(ordinary)
+        inputs[selector] = True
+        cases.append(
+            {
+                "name": selector,
+                "input": inputs,
+                "output": {"result": False},
+            }
+        )
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert not result.issues
+
+
+def test_synonymous_exception_cues_in_one_condition_are_one_obligation():
+    source = "(1) Außer bei einer Befreiung gilt der Anspruch nicht."
+    branches = recognize_source_structure(source)
+    language_matches = tuple(
+        completeness_module._EXCEPTION_LANGUAGE.finditer(source)
+    )
+
+    obligations = completeness_module._source_exception_branches(
+        source,
+        branches=branches,
+        active_branches=branches,
+        deferred_paths=set(),
+    )
+
+    assert len(language_matches) == 2
+    assert len(obligations) == 1
+
+
+@pytest.mark.parametrize(
     ("source", "selector_name", "formula"),
     [
         (

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -7372,3 +7372,60 @@ rules:
     result = _analyze(content, source, test_cases=[case])
 
     assert not result.issues
+
+
+@pytest.mark.parametrize(
+    "rounding_text",
+    [
+        "auf volle Euro gerundet",
+        "auf volle Euro zu runden",
+    ],
+)
+def test_generic_german_rounding_requires_nearest_rounding_and_fractional_proof(
+    rounding_text: str,
+):
+    source = (
+        "(1) Der Betrag wird als Einkommen * 2 berechnet und ist "
+        f"{rounding_text}."
+    )
+    unrounded = _single_rounding_content("income * multiplier")
+    rounded = _single_rounding_content(
+        "floor(income * multiplier + 0.5)",
+    )
+    fractional_case = {
+        "name": "nearest fractional result",
+        "period": "2026",
+        "input": {"income": 10.25},
+        "output": {"amount": 21},
+    }
+    integral_case = {
+        "name": "integral result only",
+        "period": "2026",
+        "input": {"income": 10},
+        "output": {"amount": 20},
+    }
+
+    missing_operator = _analyze(
+        unrounded,
+        source,
+        test_cases=[
+            {
+                **fractional_case,
+                "output": {"amount": 20.5},
+            }
+        ],
+    )
+    missing_fractional_proof = _analyze(
+        rounded,
+        source,
+        test_cases=[integral_case],
+    )
+    complete = _analyze(
+        rounded,
+        source,
+        test_cases=[fractional_case],
+    )
+
+    assert _has_issue(missing_operator, "rounding", "principal formula")
+    assert _has_issue(missing_fractional_proof, "rounding", "fractional")
+    assert not complete.issues

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -6488,6 +6488,41 @@ rules:
     assert _has_issue(result, "exception", "test") is expected_issue
 
 
+@pytest.mark.parametrize(
+    "source",
+    [
+        "(1) Im Ausnahmefall beträgt der Betrag 0,5 Euro.",
+        "(1) In the exception case, the amount equals 0.5 euros.",
+    ],
+)
+def test_nonzero_decimal_exception_is_not_classified_as_zero(source: str):
+    content = _exception_control_content(
+        "if exception_applies: exception_amount else: 10",
+        extra_rules="""\
+  - name: exception_amount
+    kind: parameter
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 0.5}]
+""",
+    )
+    cases = [
+        {
+            "name": "ordinary",
+            "input": {"exception_applies": False},
+            "output": {"result": 10},
+        },
+        {
+            "name": "exception",
+            "input": {"exception_applies": True},
+            "output": {"result": 0.5},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert not result.issues
+
+
 def test_generic_deviation_may_increase_the_principal_output():
     source = "(1) Abweichend von der Hauptregel erhöht eine Ausnahme den Betrag."
     content = _exception_control_content(

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -4,8 +4,11 @@ from pathlib import Path
 
 import pytest
 
+from axiom_encode.harness import source_completeness as completeness_module
 from axiom_encode.harness.source_completeness import (
     analyze_complete_source_unit,
+    authoritative_numeric_recall_text,
+    collect_artifact_numeric_values,
     recognize_source_structure,
     source_states_explicit_computation,
 )
@@ -378,6 +381,42 @@ rules:
     )
 
 
+def test_trusted_requested_path_controls_authoritative_recall_body():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/other
+  summary: Der Freibetrag beträgt 259 Euro.
+rules:
+  - name: allowance_amount
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 259
+"""
+    pipeline = ValidatorPipeline(
+        policy_repo_path=Path("/tmp/rulespec-de"),
+        axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+        local_corpus_release=None,
+        enable_oracles=False,
+        source_citation_path=CORPUS_CITATION_PATH,
+        require_complete_source_unit=True,
+    )
+
+    issues = pipeline._complete_source_unit_issues(
+        content,
+        validation_source_texts={
+            CORPUS_CITATION_PATH: "(1) Der Zuschlag beträgt 73 Euro.",
+            "de/statute/estg/other": "(1) Der Freibetrag beträgt 259 Euro.",
+        },
+        test_cases=[],
+    )
+
+    assert any("numeric value 73" in issue.lower() for issue in issues)
+
+
 def test_deferral_prose_and_targets_cannot_hide_authoritative_source_number():
     source = "(1) Der Freibetrag beträgt 259 Euro; der Zuschlag beträgt 73 Euro."
     content = """\
@@ -472,6 +511,92 @@ rules: []
 
 
 @pytest.mark.parametrize(
+    "reason",
+    [
+        "Absatz 6 hängt von Absatz 5 ab.",
+        "Satz 2 fehlt.",
+        "Nummer 1 wird benötigt.",
+        "Buchstabe a ist nicht codiert.",
+    ],
+)
+def test_deferral_cannot_use_bare_internal_structure_as_dependency(reason: str):
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  deferred_outputs:
+    - output: de:statutes/estg/32a/6#splitting_rule
+      reason: {reason}
+rules: []
+"""
+
+    result = _analyze(content, ABSATZ_6, test_cases=[])
+
+    assert _has_issue(result, "(6)", "deferral", "dependency")
+
+
+def test_deferral_cannot_use_another_output_in_same_unit_as_blocker():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  deferred_outputs:
+    - output: de:statutes/estg/32a/6#splitting_rule
+      reason: Absatz 6 benötigt die noch fehlende Tarifberechnung.
+      blocked_by:
+        - de:statutes/estg/32a#tariff_income_tax_amount
+rules: []
+"""
+
+    result = _analyze(content, ABSATZ_6, test_cases=[])
+
+    assert _has_issue(result, "(6)", "deferral", "dependency")
+
+
+def test_root_deferral_does_not_blanket_structured_source_unit():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  deferred_outputs:
+    - output: de:statutes/estg/32a#whole_unit
+      reason: Requires an external assessment base.
+      blocked_by:
+        - de:statutes/estg/26#assessment_base
+rules: []
+"""
+
+    result = _analyze(content, "(1) Regel eins.\n(2) Regel zwei.", test_cases=[])
+
+    assert _has_issue(result, "(1)", "source branch")
+    assert _has_issue(result, "(2)", "source branch")
+
+
+def test_parent_deferral_does_not_blanket_nested_list_branches():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  deferred_outputs:
+    - output: de:statutes/estg/32a/1#paragraph_rule
+      reason: Requires an external assessment base.
+      blocked_by:
+        - de:statutes/estg/26#assessment_base
+rules: []
+"""
+    source = "(1) Es gelten:\n1. Zweig eins;\n2. Zweig zwei."
+
+    result = _analyze(content, source, test_cases=[])
+
+    assert _has_issue(result, "1.", "source branch")
+    assert _has_issue(result, "2.", "source branch")
+
+
+@pytest.mark.parametrize(
     "source",
     [
         "Der Betrag ist ein Drittel des Einkommens.",
@@ -484,10 +609,90 @@ def test_common_german_formula_language_is_computation(source: str):
     assert source_states_explicit_computation(source)
 
 
+@pytest.mark.parametrize(
+    "source",
+    [
+        "Der Betrag ist das Dreifache des Einkommens.",
+        "The amount equals income plus supplement.",
+    ],
+)
+def test_additional_formula_language_is_computation(source: str):
+    assert source_states_explicit_computation(source)
+
+
 def test_scalar_amount_language_is_not_computation():
     assert not source_states_explicit_computation(
         "Der Freibetrag beträgt 259 Euro."
     )
+
+
+def test_scalar_year_span_is_not_computation():
+    assert not source_states_explicit_computation(
+        "Für den Zeitraum 2025/2026 beträgt der Freibetrag 259 Euro."
+    )
+
+
+def test_indented_absatz_markers_are_recognized():
+    branches = recognize_source_structure("  (1) Regel eins.\n\t(2) Regel zwei.")
+
+    assert {branch.path for branch in branches} >= {("1",), ("2",)}
+
+
+def test_numeric_recall_does_not_credit_rule_or_formula_identifier_digits():
+    source = "(1) Der Zuschlag beträgt 73 Euro."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: placeholder_73
+    kind: parameter
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: missing_value_73
+    verification:
+      values: [73]
+"""
+
+    result = _analyze(content, source, test_cases=[])
+
+    assert _has_issue(result, "73", "numeric-recall")
+
+
+def test_imported_numeric_recall_only_credits_explicit_imported_scalar():
+    content = """\
+format: rulespec/v1
+imports:
+  - de:statutes/estg/99#needed_amount
+rules: []
+"""
+    imported = """\
+format: rulespec/v1
+rules:
+  - name: needed_amount
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 5
+  - name: unrelated_73_amount
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 73
+"""
+
+    values = collect_artifact_numeric_values(
+        content,
+        extract_named_scalars=extract_named_scalar_occurrences,
+        imported_contents=(imported,),
+    )
+
+    assert values == (5.0,)
 
 
 def test_glued_satz_markers_are_paragraph_children_not_list_children():
@@ -548,6 +753,109 @@ def test_exact_released_estg_32a_structure_paths():
         path[:3] == ("6", "2", "c") and path[-1].startswith("satz-")
         for path in paths
     )
+
+
+def test_released_estg_32a_constants_without_tariff_output_fail():
+    values = extract_numeric_occurrences_from_text(
+        authoritative_numeric_recall_text(RELEASED_ESTG_32A_BODY)
+    )
+    rules = "\n".join(
+        f"""\
+  - name: released_constant_{index}
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: {value!r}"""
+        for index, value in enumerate(dict.fromkeys(values), start=1)
+    )
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  summary: Released constants only.
+rules:
+{rules}
+"""
+
+    result = _analyze(content, RELEASED_ESTG_32A_BODY, test_cases=[])
+
+    assert result.missing_source_numeric_occurrence_count == 0
+    assert _has_issue(result, "principal", "derived/relation")
+
+
+def test_released_estg_32a_omitted_absatz_5_and_6_are_visible():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: paragraph_one_snapshot
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0
+"""
+
+    result = _analyze(content, RELEASED_ESTG_32A_BODY, test_cases=[])
+
+    assert _has_issue(result, "(5)", "source branch")
+    assert _has_issue(result, "(6)", "source branch")
+
+
+def test_released_estg_32a_does_not_invent_boundary_from_omission_line():
+    branches = recognize_source_structure(RELEASED_ESTG_32A_BODY)
+    formula_branches = completeness_module._source_formula_branches(
+        RELEASED_ESTG_32A_BODY,
+        branches=branches,
+        active_branches=branches,
+        deferred_paths=set(),
+    )
+    obligations = completeness_module._source_boundary_obligations(
+        branches,
+        narrative_formula_branches=formula_branches,
+        extract_numeric_occurrences=extract_numeric_occurrences_from_text,
+    )
+
+    assert not any(branch.path == () for branch, _value in obligations)
+    assert not any(value == 34 for _branch, value in obligations)
+    assert any(value == 12348 for _branch, value in obligations)
+
+
+def test_released_estg_32a_feminine_rounding_is_computation():
+    assert source_states_explicit_computation(
+        "Die Größe x ist das auf volle Euro abgerundete Einkommen."
+    )
+
+
+def test_letter_formula_boundaries_are_inventoried():
+    source = """\
+(1) Die Berechnung umfasst:
+1. folgende Zweige:
+a) Bis 73 Euro: Einkommen * 2;
+b) Von 74 Euro an: Einkommen * 3.
+"""
+    branches = recognize_source_structure(source)
+    formula_branches = completeness_module._source_formula_branches(
+        source,
+        branches=branches,
+        active_branches=branches,
+        deferred_paths=set(),
+    )
+
+    obligations = completeness_module._source_boundary_obligations(
+        branches,
+        narrative_formula_branches=formula_branches,
+        extract_numeric_occurrences=extract_numeric_occurrences_from_text,
+    )
+
+    assert any(branch.path[-1] == "a" and value == 73 for branch, value in obligations)
+    assert any(branch.path[-1] == "b" and value == 74 for branch, value in obligations)
 
 
 def test_nested_editorial_omission_does_not_drop_operative_paragraph():
@@ -1111,3 +1419,228 @@ def test_nested_whitespace_rounding_operand_accepts_fractional_input():
     )
 
     assert not _has_issue(result, "rounding", "test")
+
+
+MULTI_PARAGRAPH_FORMULA_SOURCE = """\
+(1) Der erste Betrag ist Einkommen * 2.
+(2) Der zweite Betrag ist Einkommen * 3.
+"""
+
+MULTI_PARAGRAPH_FORMULA_CONTENT = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: first_multiplier
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2
+  - name: second_multiplier
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(2)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 3
+  - name: combined_amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1); de/statute/estg/32a(2)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: income * first_multiplier + income * second_multiplier
+"""
+
+
+def _combined_formula_test(name: str, income: int) -> dict[str, object]:
+    return {
+        "name": name,
+        "period": "2026",
+        "input": {"income": income},
+        "output": {"de:statutes/estg/32a#combined_amount": income * 5},
+    }
+
+
+def test_each_paragraph_formula_requires_distinct_executed_case():
+    one_case = _combined_formula_test("one execution", 10)
+    one_case["covers"] = [
+        "de/statute/estg/32a(1)",
+        "de/statute/estg/32a(2)",
+    ]
+
+    result = _analyze(
+        MULTI_PARAGRAPH_FORMULA_CONTENT,
+        MULTI_PARAGRAPH_FORMULA_SOURCE,
+        test_cases=[one_case],
+    )
+
+    assert _has_issue(result, "formula branch", "distinct")
+
+
+def test_distinct_cases_cover_distinct_paragraph_formulas():
+    result = _analyze(
+        MULTI_PARAGRAPH_FORMULA_CONTENT,
+        MULTI_PARAGRAPH_FORMULA_SOURCE,
+        test_cases=[
+            _combined_formula_test("first execution", 10),
+            _combined_formula_test("second execution", 20),
+        ],
+    )
+
+    assert not _has_issue(result, "formula branch")
+
+
+def test_numbered_prose_formulas_require_distinct_executed_cases():
+    source = """\
+(1) Es gelten folgende Berechnungen:
+1. Der erste Betrag wird als Einkommen * 2 berechnet;
+2. Der zweite Betrag wird als Einkommen * 3 berechnet.
+"""
+    content = MULTI_PARAGRAPH_FORMULA_CONTENT.replace(
+        "de/statute/estg/32a(2)",
+        "de/statute/estg/32a(1)(2)",
+    ).replace(
+        "de/statute/estg/32a(1); de/statute/estg/32a(1)(2)",
+        "de/statute/estg/32a(1)(1); de/statute/estg/32a(1)(2)",
+    )
+
+    result = _analyze(
+        content,
+        source,
+        test_cases=[_combined_formula_test("one execution", 10)],
+    )
+
+    assert _has_issue(result, "formula branch", "distinct")
+
+
+@pytest.mark.parametrize(
+    "exception_text",
+    [
+        "Die Regel gilt nicht, wenn eine Befreiung vorliegt.",
+        "Die Regel findet keine Anwendung, wenn eine Befreiung vorliegt.",
+        "Die Regel gilt, soweit nicht eine Befreiung vorliegt.",
+    ],
+)
+def test_common_german_exceptions_require_paired_cases(exception_text: str):
+    source = (
+        "(1) Der Betrag wird als Einkommen * 2 berechnet. " + exception_text
+    )
+    one_sided_tests = [
+        case
+        for case in COMPLETE_COMPANION_TESTS
+        if case["name"] != "exception applies"
+    ]
+
+    result = _analyze(
+        COMPANION_COVERAGE_CONTENT,
+        source,
+        test_cases=one_sided_tests,
+    )
+
+    assert _has_issue(result, "exception", "test")
+
+
+def test_glued_german_satz_exception_requires_paired_cases():
+    source = """\
+(6) 1Der Betrag wird aus dem Einkommen berechnet.2Voraussetzung für die Anwendung ist, dass die Person nicht befreit ist.
+"""
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(6) Satz 1; de/statute/estg/32a(6) Satz 2
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if exception_applies:
+            0
+          else:
+            income
+"""
+    test_cases = [
+        {
+            "name": "ordinary case",
+            "period": "2026",
+            "input": {"income": 10, "exception_applies": False},
+            "output": {"de:statutes/estg/32a#amount": 10},
+        }
+    ]
+
+    result = _analyze(content, source, test_cases=test_cases)
+
+    assert _has_issue(result, "exception", "test")
+
+
+def test_rounding_fractional_evidence_is_bound_to_affected_branch():
+    source = """\
+(1) Der erste Betrag ist Einkommen * 2 und auf volle Euro abzurunden.
+(2) Der zweite Betrag ist Einkommen * 3 und auf volle Euro abzurunden.
+"""
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: first_multiplier
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2
+  - name: second_multiplier
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(2)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 3
+  - name: first_amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: floor(income * first_multiplier)
+  - name: second_amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(2)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: floor(income * second_multiplier)
+"""
+    tests = [
+        {
+            "name": "first fractional execution",
+            "period": "2026",
+            "input": {"income": 10.25},
+            "output": {"de:statutes/estg/32a#first_amount": 20},
+        },
+        {
+            "name": "another first fractional execution",
+            "period": "2026",
+            "input": {"income": 11.25},
+            "output": {"de:statutes/estg/32a#first_amount": 22},
+        },
+        {
+            "name": "second integer execution",
+            "period": "2026",
+            "input": {"income": 12},
+            "output": {"de:statutes/estg/32a#second_amount": 36},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=tests)
+
+    assert _has_issue(result, "rounding", "fractional")

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -4289,17 +4289,24 @@ rules:
       - formula: FORMULA
 """
 
-    correct = _analyze(
-        content.replace("FORMULA", "income * factor + supplement"),
-        source,
-        test_cases=[
-            {
-                "name": "source computation",
-                "input": {"income": 10},
-                "output": {"amount": 23},
-            }
-        ],
-    )
+    correct_results = [
+        _analyze(
+            content.replace("FORMULA", formula),
+            source,
+            test_cases=[
+                {
+                    "name": "source computation",
+                    "input": {"income": 10},
+                    "output": {"amount": 23},
+                }
+            ],
+        )
+        for formula in (
+            "income * factor + supplement",
+            "factor * income + supplement",
+            "supplement + (income * factor)",
+        )
+    ]
     wrong = _analyze(
         content.replace("FORMULA", "income + factor * supplement"),
         source,
@@ -4312,7 +4319,7 @@ rules:
         ],
     )
 
-    assert not correct.issues
+    assert all(not result.issues for result in correct_results)
     assert _has_issue(wrong, "formula branch")
 
 

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from axiom_encode.harness import source_completeness as completeness_module
+from axiom_encode.harness import validator_pipeline as validator_pipeline_module
 from axiom_encode.harness.source_completeness import (
     analyze_complete_source_unit,
     authoritative_numeric_recall_text,
@@ -762,6 +763,9 @@ def test_scalar_amount_language_is_not_computation():
     assert not source_states_explicit_computation(
         "Der Freibetrag beträgt 259 Euro."
     )
+    assert not source_states_explicit_computation(
+        "Der Satz beträgt 45 vom Hundert."
+    )
 
 
 def test_scalar_year_span_is_not_computation():
@@ -830,6 +834,80 @@ rules:
         imported_contents=(imported,),
     )
 
+    assert values == (5.0,)
+
+
+def test_complete_import_inventory_does_not_walk_transitive_same_name(
+    tmp_path,
+    monkeypatch,
+):
+    main_file = tmp_path / "main.yaml"
+    direct_file = tmp_path / "direct.yaml"
+    transitive_file = tmp_path / "transitive.yaml"
+    main_content = """\
+format: rulespec/v1
+imports:
+  - de:statutes/direct#threshold
+rules: []
+"""
+    direct_content = """\
+format: rulespec/v1
+imports:
+  - de:statutes/transitive#threshold
+rules:
+  - name: threshold
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 5
+"""
+    transitive_content = """\
+format: rulespec/v1
+rules:
+  - name: threshold
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 73
+"""
+    main_file.write_text(main_content)
+    direct_file.write_text(direct_content)
+    transitive_file.write_text(transitive_content)
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+        local_corpus_release=None,
+        enable_oracles=False,
+        require_complete_source_unit=True,
+    )
+    monkeypatch.setattr(
+        pipeline,
+        "_validation_source_root",
+        lambda _rules_file: tmp_path,
+    )
+    monkeypatch.setattr(
+        pipeline,
+        "_resolve_import_dependencies",
+        lambda rules_file, _source_root: (
+            [direct_file] if rules_file == main_file else [transitive_file]
+        ),
+    )
+    monkeypatch.setattr(
+        validator_pipeline_module,
+        "validate_rulespec_context_file",
+        lambda path, _source_root: path,
+    )
+
+    imported_contents = pipeline._complete_source_unit_import_contents(main_file)
+    values = collect_artifact_numeric_values(
+        main_content,
+        extract_named_scalars=extract_named_scalar_occurrences,
+        imported_contents=imported_contents,
+    )
+
+    assert imported_contents == (direct_content,)
     assert values == (5.0,)
 
 
@@ -1222,7 +1300,7 @@ rules: []
 def test_each_formula_clause_requires_principal_output_evidence():
     source = (
         "(1) Der erste Betrag ist Einkommen * 2; "
-        "der zweite Betrag ist Einkommen * 3."
+        "der zweite Betrag ist Einkommen * 3 und auf volle Euro abzurunden."
     )
     content = """\
 format: rulespec/v1
@@ -1256,9 +1334,16 @@ rules:
             source:
               corpus_citation_path: de/statute/estg/32a
               excerpt: "Der erste Betrag ist Einkommen * 2;"
+          - path: dtype
+            kind: formula
+            source:
+              corpus_citation_path: de/statute/estg/32a
+              excerpt: >-
+                der zweite Betrag ist Einkommen * 3 und auf volle Euro
+                abzurunden.
     versions:
       - effective_from: '2026-01-01'
-        formula: income * first_multiplier
+        formula: floor(income * first_multiplier)
 """
     test_cases = [
         {

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 from pathlib import Path
 
 import pytest
@@ -15,11 +16,15 @@ from axiom_encode.harness.source_completeness import (
 from axiom_encode.harness.validator_pipeline import (
     ValidatorPipeline,
     extract_named_scalar_occurrences,
-    extract_numeric_occurrences_from_text,
+    extract_typed_numeric_inventory_occurrences_from_text,
     numeric_value_is_grounded,
 )
 
 CORPUS_CITATION_PATH = "de/statute/estg/32a"
+DE_NUMERIC_OCCURRENCE_EXTRACTOR = functools.partial(
+    extract_typed_numeric_inventory_occurrences_from_text,
+    profile="de-DE",
+)
 
 
 def _analyze(
@@ -33,7 +38,7 @@ def _analyze(
         authoritative_source_text,
         corpus_citation_path=CORPUS_CITATION_PATH,
         test_cases=test_cases,
-        extract_numeric_occurrences=extract_numeric_occurrences_from_text,
+        extract_numeric_occurrences=DE_NUMERIC_OCCURRENCE_EXTRACTOR,
         extract_named_scalars=extract_named_scalar_occurrences,
         numeric_value_is_grounded=numeric_value_is_grounded,
     )
@@ -87,7 +92,7 @@ def _formula_test(
 def test_constants_without_principal_tariff_output_fail():
     source = """\
 (1) Für Einkommen von 12349 bis 17799 Euro ist die Steuer
-(914.51 * y + 1400) * y; y ist (Einkommen - 12348) / 10000.
+(914,51 * y + 1400) * y; y ist (Einkommen - 12348) / 10000.
 """
     constants_only = """\
 format: rulespec/v1
@@ -378,6 +383,103 @@ rules:
     assert any(
         "authoritative corpus numeric value 73" in issue.lower()
         for issue in _pipeline_issues(content, source, test_cases=[])
+    )
+
+
+def test_de_grouped_decimal_is_one_typed_recall_occurrence():
+    source = "(1) Der Betrag beträgt 19 470,38 Euro."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  summary: Der Betrag ist festgelegt.
+rules:
+  - name: grouped_decimal_amount
+    kind: parameter
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 19470.38
+"""
+
+    result = _analyze(content, source, test_cases=[])
+
+    assert not result.issues
+    assert result.source_numeric_occurrence_count == 1
+    assert result.covered_source_numeric_occurrence_count == 1
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_missing"),
+    [
+        ("(1) Die Frist beträgt 42 Tage.", 1),
+        ("(1) Der Satz beträgt 42 Prozent.", 0),
+    ],
+)
+def test_rate_scaling_requires_occurrence_local_context(source, expected_missing):
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  summary: Ein Wert ist festgelegt.
+rules:
+  - name: candidate_value
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.42
+"""
+
+    result = _analyze(content, source, test_cases=[])
+
+    assert result.source_numeric_occurrence_count == 1
+    assert result.missing_source_numeric_occurrence_count == expected_missing
+
+
+def test_same_valued_boundaries_keep_their_own_rate_context():
+    branch = recognize_source_structure("(1) Die Grenze gilt.")[0]
+    day_occurrence = DE_NUMERIC_OCCURRENCE_EXTRACTOR("42 Tage")[0]
+    rate_occurrence = DE_NUMERIC_OCCURRENCE_EXTRACTOR("42 Prozent")[0]
+    principal_rules = {
+        "candidate": {
+            "versions": [
+                {
+                    "effective_from": "2026-01-01",
+                    "formula": "selector",
+                }
+            ]
+        }
+    }
+    principal_rule_paths = {"candidate": {branch.path}}
+    asserted_by_rule = {
+        "candidate": [
+            {
+                "input": {"selector": 0.42},
+                "output": {"candidate": 1},
+            }
+        ]
+    }
+
+    assert not completeness_module._branch_boundary_has_test_evidence(
+        branch,
+        day_occurrence,
+        principal_rules=principal_rules,
+        principal_rule_paths=principal_rule_paths,
+        asserted_by_rule=asserted_by_rule,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
+    assert completeness_module._branch_boundary_has_test_evidence(
+        branch,
+        rate_occurrence,
+        principal_rules=principal_rules,
+        principal_rule_paths=principal_rule_paths,
+        asserted_by_rule=asserted_by_rule,
+        numeric_value_is_grounded=numeric_value_is_grounded,
     )
 
 
@@ -756,8 +858,11 @@ def test_exact_released_estg_32a_structure_paths():
 
 
 def test_released_estg_32a_constants_without_tariff_output_fail():
-    values = extract_numeric_occurrences_from_text(
-        authoritative_numeric_recall_text(RELEASED_ESTG_32A_BODY)
+    values = (
+        occurrence.value
+        for occurrence in DE_NUMERIC_OCCURRENCE_EXTRACTOR(
+            authoritative_numeric_recall_text(RELEASED_ESTG_32A_BODY)
+        )
     )
     rules = "\n".join(
         f"""\
@@ -819,12 +924,14 @@ def test_released_estg_32a_does_not_invent_boundary_from_omission_line():
     obligations = completeness_module._source_boundary_obligations(
         branches,
         narrative_formula_branches=formula_branches,
-        extract_numeric_occurrences=extract_numeric_occurrences_from_text,
+        extract_numeric_occurrences=DE_NUMERIC_OCCURRENCE_EXTRACTOR,
     )
 
     assert not any(branch.path == () for branch, _value in obligations)
-    assert not any(value == 34 for _branch, value in obligations)
-    assert any(value == 12348 for _branch, value in obligations)
+    assert not any(occurrence.value == 34 for _branch, occurrence in obligations)
+    assert any(
+        occurrence.value == 12348 for _branch, occurrence in obligations
+    )
 
 
 def test_released_estg_32a_feminine_rounding_is_computation():
@@ -851,11 +958,17 @@ b) Von 74 Euro an: Einkommen * 3.
     obligations = completeness_module._source_boundary_obligations(
         branches,
         narrative_formula_branches=formula_branches,
-        extract_numeric_occurrences=extract_numeric_occurrences_from_text,
+        extract_numeric_occurrences=DE_NUMERIC_OCCURRENCE_EXTRACTOR,
     )
 
-    assert any(branch.path[-1] == "a" and value == 73 for branch, value in obligations)
-    assert any(branch.path[-1] == "b" and value == 74 for branch, value in obligations)
+    assert any(
+        branch.path[-1] == "a" and occurrence.value == 73
+        for branch, occurrence in obligations
+    )
+    assert any(
+        branch.path[-1] == "b" and occurrence.value == 74
+        for branch, occurrence in obligations
+    )
 
 
 def test_nested_editorial_omission_does_not_drop_operative_paragraph():

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -709,6 +709,10 @@ rules: []
         "Der Betrag mindert sich um 25 Euro.",
         "Der Betrag entspricht dem 1,5fachen des Einkommens.",
         "Der Betrag beträgt 45 vom Hundert des Einkommens.",
+        "Der Betrag ist das Doppelte des Einkommens.",
+        "Der Betrag ist das Produkt aus Einkommen und Faktor.",
+        "Der Betrag entspricht Einkommen mal zwei.",
+        "Der Betrag wird verdoppelt.",
     ],
 )
 def test_common_german_formula_language_is_computation(source: str):
@@ -722,6 +726,10 @@ def test_common_german_formula_language_is_computation(source: str):
         ("(1) Der Betrag mindert sich um 25 Euro.", 25),
         ("(1) Der Betrag entspricht dem 1,5fachen des Einkommens.", 1.5),
         ("(1) Der Betrag beträgt 45 vom Hundert des Einkommens.", 0.45),
+        ("(1) Der Betrag ist das Doppelte des Einkommens.", 2),
+        ("(1) Der Betrag ist das Produkt aus Einkommen und Faktor.", 2),
+        ("(1) Der Betrag entspricht Einkommen mal zwei.", 2),
+        ("(1) Der Betrag wird verdoppelt.", 2),
     ],
 )
 def test_common_german_formula_language_rejects_parameter_only(
@@ -778,6 +786,55 @@ def test_indented_absatz_markers_are_recognized():
     branches = recognize_source_structure("  (1) Regel eins.\n\t(2) Regel zwei.")
 
     assert {branch.path for branch in branches} >= {("1",), ("2",)}
+
+
+def test_nested_satz_source_references_bind_to_paragraph_paths():
+    source = """\
+(1) 1Die erste Berechnung ergibt sich aus Einkommen * 2.2Die zweite Berechnung ergibt sich aus Einkommen * 3.
+"""
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: first_amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1) Satz 1
+    versions:
+      - effective_from: '2026-01-01'
+        formula: income * 2
+  - name: second_amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1) Satz 2
+    versions:
+      - effective_from: '2026-01-01'
+        formula: income * 3
+"""
+    test_cases = [
+        {
+            "name": "first sentence",
+            "input": {"income": 10},
+            "output": {"first_amount": 20},
+        },
+        {
+            "name": "second sentence",
+            "input": {"income": 10},
+            "output": {"second_amount": 30},
+        },
+    ]
+
+    paths = completeness_module._paths_from_source_reference(
+        "de/statute/estg/32a(1) Satz 1; "
+        "de/statute/estg/32a(1) Satz 2",
+        corpus_citation_path=CORPUS_CITATION_PATH,
+    )
+    result = _analyze(content, source, test_cases=test_cases)
+
+    assert {("1", "satz-1"), ("1", "satz-2")} <= paths
+    assert not _has_issue(result, "source branch", "neither encoded")
 
 
 def test_numeric_recall_does_not_credit_rule_or_formula_identifier_digits():

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -3490,7 +3490,16 @@ rules:
     [
         "(1) Das Einkommen ist mit 2 zu multiplizieren.",
         "(1) Das Einkommen ist mit dem Faktor 2 zu vervielfachen.",
+        "(1) Das Einkommen ist mit dem Faktor von 2 zu multiplizieren.",
+        "(1) Das Einkommen ist mit einem Faktor von 2 zu vervielfachen.",
+        "(1) Das Einkommen ist durch Multiplikation mit Faktor 2 zu ermitteln.",
+        "(1) Das Einkommen ist durch Multiplikation mit dem Faktor 2 zu ermitteln.",
         "(1) Der Betrag ist unter Anwendung des Faktors 2 zu ermitteln.",
+        "(1) Das Einkommen ist zu verdoppeln.",
+        "(1) Der Betrag ist durch zwei zu teilen.",
+        "(1) Der Betrag ist um 2 zu erhöhen.",
+        "(1) Der Betrag ist um 2 zu vermindern.",
+        "(1) Der Betrag ist aus Einkommen und Zuschlag zu summieren.",
     ],
 )
 def test_german_infinitive_formula_wording_rejects_parameter_only(source: str):

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -3545,8 +3545,18 @@ rules:
         "(1) Das Einkommen ist durch Multiplikation mit dem Faktor 2 zu ermitteln.",
         "(1) Der Betrag ist unter Anwendung des Faktors 2 zu ermitteln.",
         "(1) Das Einkommen ist zu verdoppeln.",
+        "(1) Das Einkommen ist zu verfünffachen.",
+        "(1) Das Einkommen ist zu versechsfachen.",
+        "(1) Das Einkommen ist zu versiebenfachen.",
+        "(1) Das Einkommen ist zu verachtfachen.",
+        "(1) Das Einkommen ist zu verneunfachen.",
+        "(1) Das Einkommen ist zu verzehnfachen.",
+        "(1) Das Einkommen ist zu halbieren.",
+        "(1) Das Einkommen ist durch Halbierung zu ermitteln.",
+        "(1) Das Einkommen ist in zwei gleiche Teile zu teilen.",
         "(1) Der Betrag ist durch zwei zu teilen.",
         "(1) Der Betrag ist um 2 zu erhöhen.",
+        "(1) Der Betrag ist um zwei zu erhöhen.",
         "(1) Der Betrag ist um 2 zu vermindern.",
         "(1) Der Betrag ist aus Einkommen und Zuschlag zu summieren.",
     ],
@@ -3679,6 +3689,322 @@ rules:
 
     assert not correct.issues
     assert _has_issue(wrong, "formula branch")
+
+
+@pytest.mark.parametrize(
+    ("word", "factor"),
+    [
+        ("verfünffachen", 5),
+        ("versechsfachen", 6),
+        ("versiebenfachen", 7),
+        ("verachtfachen", 8),
+        ("verneunfachen", 9),
+        ("verzehnfachen", 10),
+    ],
+)
+def test_german_infinitive_multiplier_binds_exact_factor(
+    word: str,
+    factor: int,
+):
+    source = f"(1) Das Einkommen ist zu {word}."
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: factor
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - formula: {factor}
+  - name: amount
+    kind: derived
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - formula: FORMULA
+"""
+
+    correct = _analyze(
+        content.replace("FORMULA", "income * factor"),
+        source,
+        test_cases=[
+            {
+                "name": "exact multiplier",
+                "input": {"income": 12},
+                "output": {"amount": 12 * factor},
+            }
+        ],
+    )
+    wrong = _analyze(
+        content.replace("FORMULA", "income * 2"),
+        source,
+        test_cases=[
+            {
+                "name": "wrong multiplier",
+                "input": {"income": 12},
+                "output": {"amount": 24},
+            }
+        ],
+    )
+
+    assert not correct.issues
+    assert _has_issue(wrong, "formula branch")
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "(1) Der Betrag ist zu halbieren.",
+        "(1) Der Betrag ist durch Halbierung zu ermitteln.",
+        "(1) Der Betrag ist in zwei gleiche Teile zu teilen.",
+    ],
+)
+def test_german_half_wording_binds_exact_division(source: str):
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: divisor
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - formula: 2
+  - name: amount
+    kind: derived
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - formula: FORMULA
+"""
+
+    divided = _analyze(
+        content.replace("FORMULA", "income / divisor"),
+        source,
+        test_cases=[
+            {
+                "name": "divide by two",
+                "input": {"income": 12},
+                "output": {"amount": 6},
+            }
+        ],
+    )
+    multiplied = _analyze(
+        content.replace("FORMULA", "income * 0.5"),
+        source,
+        test_cases=[
+            {
+                "name": "multiply by half",
+                "input": {"income": 12},
+                "output": {"amount": 6},
+            }
+        ],
+    )
+    wrong = _analyze(
+        content.replace("FORMULA", "income / 3"),
+        source,
+        test_cases=[
+            {
+                "name": "wrong divisor",
+                "input": {"income": 12},
+                "output": {"amount": 4},
+            }
+        ],
+    )
+
+    assert not divided.issues
+    assert not multiplied.issues
+    assert _has_issue(wrong, "formula branch")
+
+
+@pytest.mark.parametrize(
+    ("source", "delta", "correct_formula", "wrong_formula", "correct_output"),
+    [
+        (
+            "(1) Der Betrag ist um zwei zu erhöhen.",
+            2,
+            "income + delta",
+            "income + 3",
+            14,
+        ),
+        (
+            "(1) Der Betrag ist um vier zu vermehren.",
+            4,
+            "income + delta",
+            "income + 2",
+            16,
+        ),
+        (
+            "(1) Der Betrag ist um drei zu vermindern.",
+            3,
+            "income - delta",
+            "income - 2",
+            9,
+        ),
+        (
+            "(1) Der Betrag ist um fünf zu kürzen.",
+            5,
+            "income - delta",
+            "income - 2",
+            7,
+        ),
+    ],
+)
+def test_german_word_delta_binds_exact_signed_value(
+    source: str,
+    delta: int,
+    correct_formula: str,
+    wrong_formula: str,
+    correct_output: int,
+):
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: delta
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - formula: {delta}
+  - name: amount
+    kind: derived
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - formula: FORMULA
+"""
+
+    correct = _analyze(
+        content.replace("FORMULA", correct_formula),
+        source,
+        test_cases=[
+            {
+                "name": "exact delta",
+                "input": {"income": 12},
+                "output": {"amount": correct_output},
+            }
+        ],
+    )
+    wrong = _analyze(
+        content.replace("FORMULA", wrong_formula),
+        source,
+        test_cases=[
+            {
+                "name": "wrong delta",
+                "input": {"income": 12},
+                "output": {"amount": 15},
+            }
+        ],
+    )
+
+    assert not correct.issues
+    assert _has_issue(wrong, "formula branch")
+
+
+def test_unknown_german_word_operand_fails_closed():
+    source = "(1) Der Betrag ist um elf zu erhöhen."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: delta
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - formula: 11
+  - name: amount
+    kind: derived
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - formula: income + delta
+"""
+    case = {
+        "name": "unsupported word numeral",
+        "input": {"income": 12},
+        "output": {"amount": 23},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert _has_issue(result, "formula branch")
+
+
+def test_symbolic_german_factor_is_not_treated_as_unknown_number_word():
+    source = "(1) Das Einkommen ist mit dem Faktor F zu multiplizieren."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: factor
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - formula: 0.5
+  - name: amount
+    kind: derived
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - formula: income * factor
+"""
+    case = {
+        "name": "symbolic factor",
+        "input": {"income": 10},
+        "output": {"amount": 5},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert not result.issues
+
+
+def test_word_delta_binding_survives_result_rounding_wrapper():
+    source = """\
+(1) Der Betrag ist um zwei zu erhöhen und auf volle Euro abzurunden.
+"""
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: delta
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - formula: 2
+  - name: amount
+    kind: derived
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - formula: floor(income + delta)
+"""
+    case = {
+        "name": "fractional result",
+        "input": {"income": 10.5},
+        "output": {"amount": 12},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert not result.issues
 
 
 def test_nonbranching_formula_must_execute_the_source_computation():

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -2589,6 +2589,67 @@ def test_match_uses_last_arm_as_runtime_fallback():
     ) == "match:1"
 
 
+@pytest.mark.parametrize(
+    ("pattern", "pattern_input"),
+    [
+        ("holds", {"holds": "married"}),
+        ("_", {"_": "married"}),
+    ],
+)
+def test_bare_match_patterns_resolve_as_runtime_names(
+    pattern: str,
+    pattern_input: dict[str, str],
+):
+    rule = {
+        "versions": [
+            {
+                "formula": (
+                    f'match status: {pattern} => married_amount; '
+                    '"fallback" => fallback_amount'
+                ),
+            }
+        ]
+    }
+
+    assert completeness_module._case_formula_branch_outcome(
+        rule,
+        {
+            "input": {
+                "status": True if pattern == "holds" else "_",
+                **pattern_input,
+            }
+        },
+    ) == "match:1"
+
+
+@pytest.mark.parametrize(
+    ("guard_name", "guard_value"),
+    [
+        ("holds", False),
+        ("not_holds", False),
+        ("TRUE", False),
+    ],
+)
+def test_bare_condition_names_are_not_boolean_aliases(
+    guard_name: str,
+    guard_value: bool,
+):
+    rule = {
+        "versions": [
+            {
+                "formula": (
+                    f"if {guard_name}: enabled_amount else: disabled_amount"
+                ),
+            }
+        ]
+    }
+
+    assert completeness_module._case_formula_branch_outcome(
+        rule,
+        {"input": {guard_name: guard_value}},
+    ) == "if:1"
+
+
 def test_quoted_control_text_does_not_confuse_formula_execution():
     rule = {
         "versions": [
@@ -3522,6 +3583,114 @@ rules:
 
     assert source_states_explicit_computation(source)
     assert _has_issue(result, "formula-output", "parameter-only")
+
+
+@pytest.mark.parametrize(
+    ("source", "parameter_name", "parameter_value", "correct_formula", "wrong_formula"),
+    [
+        (
+            "(1) Das Einkommen ist zu verdreifachen.",
+            "factor",
+            3,
+            "income * factor",
+            "income * 2",
+        ),
+        (
+            "(1) Das Einkommen ist mit drei zu multiplizieren.",
+            "factor",
+            3,
+            "income * factor",
+            "income * 2",
+        ),
+        (
+            "(1) Das Einkommen ist mal drei zu nehmen.",
+            "factor",
+            3,
+            "income * factor",
+            "income * 2",
+        ),
+        (
+            "(1) Der Betrag ist durch zwei zu teilen.",
+            "divisor",
+            2,
+            "income / divisor",
+            "income / 3",
+        ),
+        (
+            "(1) Der Betrag ist um 2 zu erhöhen.",
+            "increment",
+            2,
+            "income + increment",
+            "income * increment",
+        ),
+    ],
+)
+def test_german_worded_computation_binds_operation_and_factor(
+    source: str,
+    parameter_name: str,
+    parameter_value: int,
+    correct_formula: str,
+    wrong_formula: str,
+):
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: {parameter_name}
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - formula: {parameter_value}
+  - name: amount
+    kind: derived
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - formula: FORMULA
+"""
+
+    correct = _analyze(
+        content.replace("FORMULA", correct_formula),
+        source,
+        test_cases=[
+            {
+                "name": "correct computation",
+                "input": {"income": 12},
+                "output": {
+                    "amount": (
+                        6
+                        if parameter_name == "divisor"
+                        else 14
+                        if parameter_name == "increment"
+                        else 36
+                    )
+                },
+            }
+        ],
+    )
+    wrong = _analyze(
+        content.replace("FORMULA", wrong_formula),
+        source,
+        test_cases=[
+            {
+                "name": "wrong computation",
+                "input": {"income": 12},
+                "output": {
+                    "amount": (
+                        4
+                        if parameter_name == "divisor"
+                        else 24
+                    )
+                },
+            }
+        ],
+    )
+
+    assert not correct.issues
+    assert _has_issue(wrong, "formula branch")
 
 
 def test_nonbranching_formula_must_execute_the_source_computation():
@@ -4627,6 +4796,97 @@ rules:
     result = _analyze(content, source, test_cases=[case])
 
     assert not result.issues
+
+
+def test_range_formula_branches_accept_asserted_derived_selector_values():
+    source = """\
+(1) Für Einkommen bis 100 Euro beträgt der Betrag Einkommen * 2.
+(2) Für Einkommen über 100 Euro beträgt der Betrag Einkommen * 3.
+"""
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: first_limit
+    kind: parameter
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 100}]
+  - name: first_multiplier
+    kind: parameter
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 2}]
+  - name: second_multiplier
+    kind: parameter
+    source: de/statute/estg/32a(2)
+    versions: [{formula: 3}]
+  - name: taxable_income
+    kind: derived
+    source: de/statute/estg/32a(1); de/statute/estg/32a(2)
+    versions: [{formula: 'gross_income - deduction'}]
+  - name: amount
+    kind: derived
+    source: de/statute/estg/32a(1); de/statute/estg/32a(2)
+    versions:
+      - formula: >-
+          if taxable_income <= first_limit:
+            taxable_income * first_multiplier
+          else:
+            taxable_income * second_multiplier
+"""
+    cases = [
+        {
+            "name": "derived lower selector",
+            "input": {"gross_income": 120, "deduction": 20},
+            "output": {"taxable_income": 100, "amount": 200},
+        },
+        {
+            "name": "derived upper selector",
+            "input": {"gross_income": 121, "deduction": 20},
+            "output": {"taxable_income": 101, "amount": 303},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert not result.issues
+
+
+def test_companion_input_cannot_shadow_local_derived_selector():
+    source = "(1) Der Anspruch gilt bis 100 Euro Einkommen."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: income_limit
+    kind: parameter
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 100}]
+  - name: taxable_income
+    kind: derived
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 'gross_income - deduction'}]
+  - name: eligible
+    kind: derived
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 'taxable_income <= income_limit'}]
+"""
+    case = {
+        "name": "shadowed derived selector",
+        "input": {
+            "gross_income": 999,
+            "deduction": 0,
+            "taxable_income": 100,
+        },
+        "output": {"taxable_income": 100, "eligible": True},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert _has_issue(result, "shadowed derived selector", "shadowed")
 
 
 def test_exception_accepts_asserted_reached_derived_selector_toggle():

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -711,6 +711,8 @@ rules: []
         "de:statutes/estg/9999#bemessungsgrundlage",
         "de:statutes/fake/26#bemessungsgrundlage",
         "xx:statutes/anything/26#bemessungsgrundlage",
+        "xx:statutes/estg/26#bemessungsgrundlage",
+        "de:regulations/estg/26#bemessungsgrundlage",
     ],
 )
 def test_deferral_symbol_cannot_mask_a_conflicting_citation(blocker: str):
@@ -725,6 +727,26 @@ module:
         Absatz 1 cannot be computed because the Bemessungsgrundlage is missing.
       blocked_by:
         - {blocker}
+rules: []
+"""
+    source = "(1) Maßgeblich ist die Bemessungsgrundlage nach § 26."
+
+    result = _analyze(content, source, test_cases=[])
+
+    assert _has_issue(result, "(1)", "deferral", "dependency")
+
+
+def test_prose_deferral_rejects_wrong_absolute_jurisdiction():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  deferred_outputs:
+    - output: de:statutes/estg/32a/1#amount
+      reason: >-
+        Cannot be computed until
+        xx:statutes/estg/26#bemessungsgrundlage is available.
 rules: []
 """
     source = "(1) Maßgeblich ist die Bemessungsgrundlage nach § 26."
@@ -3090,6 +3112,47 @@ formula: |-
         MULTI_PARAGRAPH_FORMULA_SOURCE,
         test_cases=cases,
     )
+
+    assert _has_issue(result, "formula branch", "distinct")
+
+
+def test_commutative_duplicate_cannot_witness_different_source_operations():
+    source = """\
+(1) Der erste Betrag ist die Summe aus Einkommen und Zuschlag.
+(2) Der zweite Betrag ist der Unterschied zwischen Einkommen und Zuschlag.
+"""
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1); de/statute/estg/32a(2)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if first_order:
+            income + supplement
+          else:
+            supplement + income
+"""
+    cases = [
+        {
+            "name": f"sum order {first_order}",
+            "input": {
+                "first_order": first_order,
+                "income": 10,
+                "supplement": 3,
+            },
+            "output": {"amount": 13},
+        }
+        for first_order in (False, True)
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
 
     assert _has_issue(result, "formula branch", "distinct")
 

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -2030,6 +2030,72 @@ def test_distinct_cases_cover_distinct_paragraph_formulas():
     assert not _has_issue(result, "formula branch")
 
 
+def test_non_range_formula_branches_require_distinct_selector_executions():
+    source = """\
+(1) Bei Ehegatten ist der Betrag Einkommen * 2.
+(2) Bei Alleinstehenden ist der Betrag Einkommen * 3.
+"""
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: married_multiplier
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2
+  - name: single_multiplier
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(2)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 3
+  - name: amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1); de/statute/estg/32a(2)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if married:
+            income * married_multiplier
+          else:
+            income * single_multiplier
+"""
+
+    def case(name: str, *, married: bool, income: int) -> dict[str, object]:
+        return {
+            "name": name,
+            "input": {"married": married, "income": income},
+            "output": {"amount": income * (2 if married else 3)},
+        }
+
+    repeated_married = _analyze(
+        content,
+        source,
+        test_cases=[
+            case("married one", married=True, income=10),
+            case("married two", married=True, income=20),
+        ],
+    )
+    both_branches = _analyze(
+        content,
+        source,
+        test_cases=[
+            case("married", married=True, income=10),
+            case("single", married=False, income=10),
+        ],
+    )
+
+    assert _has_issue(repeated_married, "formula branch", "distinct")
+    assert not _has_issue(both_branches, "formula branch")
+
+
 def test_numbered_prose_formulas_require_distinct_executed_cases():
     source = """\
 (1) Es gelten folgende Berechnungen:

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -165,7 +165,8 @@ ABSATZ_5 = (
 )
 ABSATZ_6 = (
     "(6) Das Splittingverfahren gilt für verwitwete Personen, wenn die "
-    "Voraussetzungen vorliegen, es sei denn, sie haben wieder geheiratet."
+    "Voraussetzungen nach § 26 und § 32 vorliegen, es sei denn, sie haben "
+    "wieder geheiratet."
 )
 
 ABSATZ_1_RULES = """\
@@ -684,6 +685,45 @@ rules: []
     assert _has_issue(result, "(6)", "deferral", "dependency")
 
 
+def test_deferral_cannot_invent_source_unstated_section():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  deferred_outputs:
+    - output: de:statutes/estg/32a/6#splitting_rule
+      reason: Cannot be computed because section 9999 is missing.
+      blocked_by:
+        - de:statutes/estg/9999#fictional_amount
+rules: []
+"""
+    source = "(6) Das Einkommen wird mit 2 multipliziert."
+
+    result = _analyze(content, source, test_cases=[])
+
+    assert _has_issue(result, "(6)", "deferral", "dependency")
+
+
+def test_invalid_present_blocker_cannot_fall_back_to_prose_dependency():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  deferred_outputs:
+    - output: de:statutes/estg/32a/6#splitting_rule
+      reason: Cannot be computed until the conditions under section 26 exist.
+      blocked_by:
+        - de:statutes/estg/32a#same_unit
+rules: []
+"""
+
+    result = _analyze(content, ABSATZ_6, test_cases=[])
+
+    assert _has_issue(result, "(6)", "deferral", "dependency")
+
+
 def test_root_deferral_does_not_blanket_structured_source_unit():
     content = """\
 format: rulespec/v1
@@ -717,7 +757,11 @@ module:
         - de:statutes/estg/26#assessment_base
 rules: []
 """
-    source = "(1) Es gelten:\n1. Zweig eins;\n2. Zweig zwei."
+    source = (
+        "(1) Für die Bemessungsgrundlage nach § 26 gelten:\n"
+        "1. Zweig eins;\n"
+        "2. Zweig zwei."
+    )
 
     result = _analyze(content, source, test_cases=[])
 
@@ -1432,7 +1476,8 @@ rules:
 
 def test_unstructured_formula_requires_unit_level_deferral():
     source = (
-        "Die Steuer ergibt sich aus dem Einkommen geteilt durch den Grundwert."
+        "Die Steuer ergibt sich aus dem Einkommen geteilt durch den Grundwert "
+        "nach § 26."
     )
     child_deferral = """\
 format: rulespec/v1

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -2378,9 +2378,49 @@ rules:
             case("single", disabled=False, filing_status="single"),
         ],
     )
+    nested_guard_content = content.replace(
+        """\
+          if disabled:
+            0
+          else:
+""",
+        """\
+          if disabled:
+            if audited:
+              0
+            else:
+              0
+          else:
+""",
+    )
+    executed_match_below_nested_guard = _analyze(
+        nested_guard_content,
+        source,
+        test_cases=[
+            {
+                **case("nested married", disabled=False, filing_status="married"),
+                "input": {
+                    "disabled": False,
+                    "audited": False,
+                    "filing_status": "married",
+                    "income": 10,
+                },
+            },
+            {
+                **case("nested single", disabled=False, filing_status="single"),
+                "input": {
+                    "disabled": False,
+                    "audited": False,
+                    "filing_status": "single",
+                    "income": 10,
+                },
+            },
+        ],
+    )
 
     assert _has_issue(bypassed_match, "formula branch", "distinct")
     assert not _has_issue(executed_match, "formula branch")
+    assert not _has_issue(executed_match_below_nested_guard, "formula branch")
 
 
 def test_numbered_prose_formulas_require_distinct_executed_cases():

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -3511,3 +3511,298 @@ rules:
 
     assert source_states_explicit_computation(source)
     assert _has_issue(result, "formula-output", "parameter-only")
+
+
+def test_nonbranching_formula_must_execute_the_source_computation():
+    source = "(1) Der Betrag wird als Einkommen * 2 berechnet."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: multiplier
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2
+  - name: amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: unrelated_amount
+"""
+    case = {
+        "name": "unrelated output",
+        "period": "2026",
+        "input": {"income": 10, "unrelated_amount": 2},
+        "output": {"amount": 2},
+    }
+
+    unrelated = _analyze(content, source, test_cases=[case])
+    correct = _analyze(
+        content.replace(
+            "formula: unrelated_amount",
+            "formula: income * multiplier",
+        ),
+        source,
+        test_cases=[
+            {
+                **case,
+                "name": "operative output",
+                "output": {"amount": 20},
+            }
+        ],
+    )
+
+    assert _has_issue(unrelated, "formula branch")
+    assert not correct.issues
+
+
+def test_indexed_expression_multiplied_by_zero_cannot_witness_formula():
+    source = "(1) Der Betrag wird als Einkommen * 2 berechnet."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: multiplier
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2
+  - name: neutralizer
+    kind: parameter
+    dtype: Decimal
+    indexed_by: Integer
+    versions:
+      - effective_from: '2026-01-01'
+        values:
+          1: 1
+  - name: amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if disabled:
+            0 * neutralizer[index] * multiplier
+          else:
+            income * multiplier
+"""
+    case = {
+        "name": "disabled zero",
+        "period": "2026",
+        "input": {"disabled": True, "index": 1, "income": 10},
+        "output": {"amount": 0},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert _has_issue(result, "formula branch")
+
+
+def test_named_match_pattern_uses_constant_value_not_identifier_text():
+    source = """\
+(1) Bei Ehegatten ist der Betrag Einkommen * 2.
+(2) Bei Alleinstehenden ist der Betrag Einkommen * 3.
+"""
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: special_status
+    kind: parameter
+    dtype: String
+    versions:
+      - effective_from: '2026-01-01'
+        formula: married
+  - name: first_multiplier
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2
+  - name: second_multiplier
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(2)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 3
+  - name: amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1); de/statute/estg/32a(2)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: >-
+          match status: special_status => income * first_multiplier;
+          "single" => income * second_multiplier
+"""
+    cases = [
+        {
+            "name": status,
+            "input": {"status": status, "income": 10},
+            "output": {"amount": 30},
+        }
+        for status in ("special_status", "other")
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert _has_issue(result, "formula branch", "distinct")
+
+
+def test_neutral_terms_cannot_bind_or_distinguish_formula_branches():
+    source = """\
+(1) Der erste Betrag ist Einkommen + 2.
+(2) Der zweite Betrag ist Einkommen + 3.
+"""
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: two
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2
+  - name: three
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(2)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 3
+  - name: amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1); de/statute/estg/32a(2)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if first:
+            income + two
+          else:
+            income + two + 0 * three
+"""
+    cases = [
+        {
+            "name": str(first),
+            "input": {"first": first, "income": 10},
+            "output": {"amount": 12},
+        }
+        for first in (True, False)
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert _has_issue(result, "formula branch", "distinct")
+
+
+@pytest.mark.parametrize(
+    ("source", "formula", "expected"),
+    [
+        (
+            "(1) Der Betrag ist die Hälfte des Einkommens.",
+            "income * half_factor",
+            5,
+        ),
+        (
+            "(1) Der Betrag ist das Doppelte des Einkommens.",
+            "income + income",
+            20,
+        ),
+    ],
+)
+def test_common_algebraic_formula_equivalents_are_accepted(
+    source: str,
+    formula: str,
+    expected: int,
+):
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: half_factor
+    kind: parameter
+    dtype: Decimal
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.5
+  - name: amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if applies:
+            {formula}
+          else:
+            0
+"""
+    case = {
+        "name": "applies",
+        "input": {"applies": True, "income": 10},
+        "output": {"amount": expected},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert not result.issues
+
+
+def test_case_period_selects_nonbranching_temporal_formula():
+    source = "(1) Der Betrag wird als Einkommen * 2 berechnet."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: multiplier
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2
+  - name: amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2025-01-01'
+        formula: unrelated_amount
+      - effective_from: '2026-01-01'
+        formula: income * multiplier
+"""
+    case = {
+        "name": "current formula",
+        "period": "2026",
+        "input": {"income": 10, "unrelated_amount": 99},
+        "output": {"amount": 20},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert not result.issues

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -598,6 +598,30 @@ def test_explicit_satz_markers_after_absatz_are_recognized():
     }
 
 
+def test_colon_satz_markers_are_recognized_and_independently_required():
+    source = "(1) Satz 1: Die Hauptregel gilt. Satz 2: Die Sonderregel gilt."
+    branches = recognize_source_structure(source)
+
+    assert {
+        branch.path for branch in branches if branch.kind == "sentence"
+    } == {
+        ("1", "satz-1"),
+        ("1", "satz-2"),
+    }
+
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules: []
+"""
+    result = _analyze(content, source, test_cases=[])
+
+    assert _has_issue(result, "Satz 1", "source branch")
+    assert _has_issue(result, "Satz 2", "source branch")
+
+
 @pytest.mark.parametrize(
     ("source", "source_reference", "parent_label"),
     [
@@ -4752,6 +4776,24 @@ def test_adjacent_integral_boundary_requires_the_equivalent_comparator():
             False,
             "income >= income_limit",
         ),
+        (
+            "mehr als 100 Euro",
+            "income > income_limit",
+            False,
+            "income >= income_limit",
+        ),
+        (
+            "weniger als 100 Euro",
+            "income < income_limit",
+            False,
+            "income <= income_limit",
+        ),
+        (
+            "von weniger als 100 Euro",
+            "income < income_limit",
+            False,
+            "income <= income_limit",
+        ),
     ],
 )
 def test_boundary_comparator_preserves_direction_and_inclusivity(
@@ -7156,3 +7198,177 @@ def test_opposite_bare_boolean_predicate_cannot_witness_boundary():
     result = _analyze(content, source, test_cases=[case])
 
     assert _has_issue(result, "boundary", "100")
+
+
+def _scalar_snapshot_content(
+    *,
+    rule_name: str = "allowance_amount",
+    value: int = 259,
+) -> str:
+    return f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: {rule_name}
+    kind: parameter
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: {value}
+"""
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "(1) Der Freibetrag Plus beträgt 259 Euro.",
+        "(1) Unter diesem Gesetz beträgt der Freibetrag 259 Euro.",
+        (
+            "(1) Der Freibetrag beträgt 259 Euro, auch wenn die "
+            "Veröffentlichung später erfolgt."
+        ),
+        (
+            "(1) Der Freibetrag beträgt 259 Euro, selbst wenn die "
+            "Veröffentlichung später erfolgt."
+        ),
+    ],
+)
+def test_unconditional_scalar_wording_remains_scalar_only(source: str):
+    content = _scalar_snapshot_content()
+    case = {
+        "name": "scalar snapshot",
+        "period": "2026",
+        "input": {},
+        "output": {"allowance_amount": 259},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert not result.issues
+
+
+def test_leading_effective_month_does_not_steal_later_scalar_as_boundary():
+    source = "(1) Ab Januar beträgt der Freibetrag 259 Euro."
+    content = _scalar_snapshot_content()
+    case = {
+        "name": "effective scalar snapshot",
+        "period": "2026",
+        "input": {},
+        "output": {"allowance_amount": 259},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert not result.issues
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        (
+            "(1) Für das Kalenderjahr 2026 beträgt der Zuschlag 259 Euro "
+            "bis zu einem Einkommen von 2000 Euro."
+        ),
+        "(1) Der Anspruch gilt bis 2000 Euro Einkommen pro Jahr.",
+    ],
+)
+def test_monetary_threshold_near_year_language_is_not_temporal(source: str):
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: tax_year
+    kind: parameter
+    dtype: Integer
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 2026}]
+  - name: supplement_amount
+    kind: parameter
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 259}]
+  - name: annual_limit
+    kind: parameter
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 2000}]
+"""
+    case = {
+        "name": "parameter snapshot",
+        "input": {},
+        "output": {
+            "tax_year": 2026,
+            "supplement_amount": 259,
+            "annual_limit": 2000,
+        },
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert _has_issue(result, "formula-output", "control", "parameter-only")
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        (
+            "(1) Vorausgesetzt, dass Anspruchsberechtigung besteht, "
+            "beträgt der Zuschlag 259 Euro."
+        ),
+        (
+            "(1) Unter der Voraussetzung, dass Anspruchsberechtigung "
+            "besteht, beträgt der Zuschlag 259 Euro."
+        ),
+        "(1) Bei Anspruchsberechtigung beträgt der Zuschlag 259 Euro.",
+        (
+            "(1) Der Zuschlag beträgt 259 Euro, soweit "
+            "Anspruchsberechtigung besteht."
+        ),
+    ],
+)
+def test_common_positive_conditions_control_scalar_outputs(source: str):
+    content = _scalar_snapshot_content(
+        rule_name="supplement_amount",
+    )
+
+    result = _analyze(content, source, test_cases=[])
+
+    assert _has_issue(result, "formula-output", "control", "parameter-only")
+
+
+def test_unter_anwendung_computation_is_not_a_numeric_upper_boundary():
+    source = (
+        "(1) Der Betrag ist unter Anwendung eines Faktors 2 auf das "
+        "Einkommen zu ermitteln."
+    )
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: factor
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 2}]
+  - name: amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 'income * factor'}]
+"""
+    case = {
+        "name": "factor computation",
+        "input": {"income": 10},
+        "output": {"amount": 20},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert not result.issues

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -457,7 +457,7 @@ def test_same_valued_boundaries_keep_their_own_rate_context():
             "versions": [
                 {
                     "effective_from": "2026-01-01",
-                    "formula": "selector",
+                    "formula": "selector <= 0.42",
                 }
             ]
         }
@@ -467,7 +467,7 @@ def test_same_valued_boundaries_keep_their_own_rate_context():
         "candidate": [
             {
                 "input": {"selector": 0.42},
-                "output": {"candidate": 1},
+                "output": {"candidate": True},
             }
         ]
     }
@@ -479,6 +479,7 @@ def test_same_valued_boundaries_keep_their_own_rate_context():
         principal_rule_paths=principal_rule_paths,
         asserted_by_rule=asserted_by_rule,
         numeric_value_is_grounded=numeric_value_is_grounded,
+        extract_numeric_occurrences=DE_NUMERIC_OCCURRENCE_EXTRACTOR,
     )
     assert completeness_module._branch_boundary_has_test_evidence(
         branch,
@@ -487,6 +488,7 @@ def test_same_valued_boundaries_keep_their_own_rate_context():
         principal_rule_paths=principal_rule_paths,
         asserted_by_rule=asserted_by_rule,
         numeric_value_is_grounded=numeric_value_is_grounded,
+        extract_numeric_occurrences=DE_NUMERIC_OCCURRENCE_EXTRACTOR,
     )
 
 
@@ -3626,7 +3628,7 @@ rules:
     dtype: String
     versions:
       - effective_from: '2026-01-01'
-        formula: married
+        formula: '"married"'
   - name: first_multiplier
     kind: parameter
     dtype: Decimal
@@ -3663,6 +3665,32 @@ rules:
     result = _analyze(content, source, test_cases=cases)
 
     assert _has_issue(result, "formula branch", "distinct")
+
+
+def test_bare_enum_match_patterns_remain_literal_values():
+    rule = {
+        "versions": [
+            {
+                "effective_from": "2026-01-01",
+                "formula": (
+                    "match status: married => income * 2; "
+                    "single => income * 3"
+                ),
+            }
+        ]
+    }
+
+    married = completeness_module._case_formula_branch_outcome(
+        rule,
+        {"input": {"status": "married", "income": 10}},
+    )
+    single = completeness_module._case_formula_branch_outcome(
+        rule,
+        {"input": {"status": "single", "income": 10}},
+    )
+
+    assert married == "match:0"
+    assert single == "match:1"
 
 
 def test_neutral_terms_cannot_bind_or_distinguish_formula_branches():
@@ -3806,3 +3834,282 @@ rules:
     result = _analyze(content, source, test_cases=[case])
 
     assert not result.issues
+
+
+def _boundary_control_content(
+    *,
+    formula: str,
+    limit_versions: str,
+    extra_rules: str = "",
+) -> str:
+    return f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+{extra_rules}  - name: income_limit
+    kind: parameter
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions:
+{limit_versions}
+  - name: eligible
+    kind: derived
+    dtype: bool
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: >-
+          {formula}
+"""
+
+
+def test_boundary_requires_one_operative_input_threshold_comparison():
+    source = "(1) Die Regel gilt für Einkommen bis 100 Euro."
+    limit_versions = """\
+      - effective_from: '2026-01-01'
+        formula: 100"""
+    inert = _boundary_control_content(
+        formula="if income > 0: income_limit > 0 else: false",
+        limit_versions=limit_versions,
+    )
+    operative = _boundary_control_content(
+        formula="income <= income_limit",
+        limit_versions=limit_versions,
+    )
+    case = {
+        "name": "at threshold",
+        "period": "2026-01",
+        "input": {"income": 100},
+        "output": {"eligible": True},
+    }
+
+    inert_result = _analyze(inert, source, test_cases=[case])
+    operative_result = _analyze(operative, source, test_cases=[case])
+
+    assert _has_issue(inert_result, "boundary", "100")
+    assert not operative_result.issues
+
+
+def test_adjacent_integral_boundary_requires_the_equivalent_comparator():
+    source = "(1) Die Regel gilt für Einkommen bis 100 Euro."
+    source_limit_rule = """\
+  - name: source_limit
+    kind: parameter
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 100
+"""
+    limit_versions = """\
+      - effective_from: '2026-01-01'
+        formula: 101"""
+    correct = _boundary_control_content(
+        formula="income < income_limit",
+        limit_versions=limit_versions,
+        extra_rules=source_limit_rule,
+    )
+    wrong = _boundary_control_content(
+        formula="income <= income_limit",
+        limit_versions=limit_versions,
+        extra_rules=source_limit_rule,
+    )
+    case = {
+        "name": "inclusive source endpoint",
+        "period": "2026",
+        "input": {"income": 100},
+        "output": {"eligible": True},
+    }
+
+    correct_result = _analyze(correct, source, test_cases=[case])
+    wrong_result = _analyze(wrong, source, test_cases=[case])
+
+    assert not correct_result.issues
+    assert _has_issue(wrong_result, "boundary", "100")
+
+
+@pytest.mark.parametrize(
+    ("wording", "formula"),
+    [
+        ("höchstens 100 Euro", "income <= income_limit"),
+        ("mindestens 100 Euro", "income >= income_limit"),
+    ],
+)
+def test_german_minimum_and_maximum_boundaries_are_controlled(
+    wording: str,
+    formula: str,
+):
+    source = f"(1) Die Regel gilt für Einkommen von {wording}."
+    content = _boundary_control_content(
+        formula=formula,
+        limit_versions="""\
+      - effective_from: '2026-01-01'
+        formula: 100""",
+    )
+    case = {
+        "name": "at threshold",
+        "period": "2026",
+        "input": {"income": 100},
+        "output": {"eligible": True},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert not result.issues
+
+
+def test_monthly_case_period_resolves_versioned_boundary_constant():
+    source = "(1) Die Regel gilt für Einkommen bis 100 Euro."
+    content = _boundary_control_content(
+        formula="income <= income_limit",
+        limit_versions="""\
+      - effective_from: '2025-01-01'
+        formula: 90
+      - effective_from: '2026-01-01'
+        formula: 100""",
+    )
+    case = {
+        "name": "current threshold",
+        "period": "2026-01",
+        "input": {"income": 100},
+        "output": {"eligible": True},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert not result.issues
+
+
+def test_equal_asserted_exception_effects_do_not_count_as_toggle():
+    source = (
+        "(1) Ein Anspruch besteht, es sei denn, eine Befreiung liegt vor."
+    )
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: eligible
+    kind: derived
+    dtype: bool
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if exemption_applies:
+            false
+          else:
+            0 == 1
+"""
+    same_effect_cases = [
+        {
+            "name": str(exemption_applies),
+            "input": {"exemption_applies": exemption_applies},
+            "output": {"eligible": False},
+        }
+        for exemption_applies in (False, True)
+    ]
+    proper_content = content.replace(
+        """\
+formula: |-
+          if exemption_applies:
+            false
+          else:
+            0 == 1""",
+        "formula: not exemption_applies",
+    )
+    proper_cases = [
+        {
+            "name": str(exemption_applies),
+            "input": {"exemption_applies": exemption_applies},
+            "output": {"eligible": not exemption_applies},
+        }
+        for exemption_applies in (False, True)
+    ]
+
+    same_effect = _analyze(content, source, test_cases=same_effect_cases)
+    proper_effect = _analyze(proper_content, source, test_cases=proper_cases)
+
+    assert _has_issue(same_effect, "exception", "test")
+    assert not proper_effect.issues
+
+
+def test_division_cannot_be_witnessed_by_multiplying_by_the_divisor():
+    source = "(1) Der Betrag ist Einkommen / 2."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: divisor
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2
+  - name: amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: income * divisor
+"""
+    case = {
+        "name": "wrong inverse",
+        "period": "2026",
+        "input": {"income": 10},
+        "output": {"amount": 20},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert _has_issue(result, "formula branch")
+
+
+def test_zero_over_provably_nonzero_indexed_term_cannot_witness_division():
+    source = "(1) Der Betrag ist Einkommen / 2."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: divisor
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2
+  - name: dummy_table
+    kind: parameter
+    dtype: Decimal
+    indexed_by: Integer
+    versions:
+      - effective_from: '2026-01-01'
+        values:
+          1: 10
+  - name: amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0 / max(1, dummy_table[index]) / divisor
+"""
+    case = {
+        "name": "zero bypass",
+        "period": "2026",
+        "input": {"income": 10, "index": 1},
+        "output": {"amount": 0},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert _has_issue(result, "formula branch")

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -2305,6 +2305,107 @@ def test_judgment_selector_normalizes_holds_and_not_holds():
     ) == "if:1"
 
 
+def test_inline_elif_formula_reports_each_reachable_branch():
+    rule = {
+        "versions": [
+            {
+                "formula": "if first: A elif second: B else: C",
+            }
+        ]
+    }
+
+    assert completeness_module._case_formula_branch_outcome(
+        rule,
+        {"input": {"first": True, "second": False}},
+    ) == "if:0"
+    assert completeness_module._case_formula_branch_outcome(
+        rule,
+        {"input": {"first": False, "second": True}},
+    ) == "if:1"
+    assert completeness_module._case_formula_branch_outcome(
+        rule,
+        {"input": {"first": False, "second": False}},
+    ) == "if:2"
+
+
+def test_formula_execution_fails_closed_on_non_boolean_guard_and_alias_conflict():
+    rule = {
+        "versions": [
+            {
+                "formula": "if enabled: enabled_amount else: disabled_amount",
+            }
+        ]
+    }
+
+    assert (
+        completeness_module._case_formula_branch_outcome(
+            rule,
+            {"input": {"enabled": 1}},
+        )
+        is None
+    )
+    assert (
+        completeness_module._case_formula_branch_outcome(
+            rule,
+            {"input": {"enabled": True, "other#enabled": False}},
+        )
+        is None
+    )
+
+
+def test_match_uses_last_arm_as_runtime_fallback():
+    rule = {
+        "versions": [
+            {
+                "formula": (
+                    'match filing_status: "married" => joint_amount; '
+                    '"single" => single_amount'
+                ),
+            }
+        ]
+    }
+
+    assert completeness_module._case_formula_branch_outcome(
+        rule,
+        {"input": {"filing_status": "unknown"}},
+    ) == "match:1"
+
+
+def test_quoted_control_text_does_not_confuse_formula_execution():
+    rule = {
+        "versions": [
+            {
+                "formula": (
+                    'if code == "if x: y else: z": selected_amount '
+                    "else: other_amount"
+                ),
+            }
+        ]
+    }
+
+    assert completeness_module._case_formula_branch_outcome(
+        rule,
+        {"input": {"code": "if x: y else: z"}},
+    ) == "if:0"
+
+
+def test_formula_execution_rejects_ambiguous_versions():
+    rule = {
+        "versions": [
+            {"formula": "if enabled: first_amount else: zero_amount"},
+            {"formula": "if enabled: second_amount else: zero_amount"},
+        ]
+    }
+
+    assert (
+        completeness_module._case_formula_branch_outcome(
+            rule,
+            {"input": {"enabled": True}},
+        )
+        is None
+    )
+
+
 def test_nested_match_arms_do_not_count_when_outer_guard_bypasses_them():
     source = """\
 (1) Bei Verheirateten ist der Betrag Einkommen * 2.
@@ -2421,6 +2522,281 @@ rules:
     assert _has_issue(bypassed_match, "formula branch", "distinct")
     assert not _has_issue(executed_match, "formula branch")
     assert not _has_issue(executed_match_below_nested_guard, "formula branch")
+
+
+def test_nested_if_bypass_cannot_witness_arithmetic_branches():
+    content = MULTI_PARAGRAPH_FORMULA_CONTENT.replace(
+        "formula: income * first_multiplier + income * second_multiplier",
+        """\
+formula: |-
+          if disabled:
+            0
+          else:
+            if married:
+              income * first_multiplier
+            else:
+              income * second_multiplier""",
+    )
+
+    def case(
+        name: str,
+        *,
+        disabled: bool,
+        married: bool,
+    ) -> dict[str, object]:
+        expected = 0 if disabled else 10 * (2 if married else 3)
+        return {
+            "name": name,
+            "input": {
+                "disabled": disabled,
+                "married": married,
+                "income": 10,
+            },
+            "output": {"combined_amount": expected},
+        }
+
+    bypass_plus_one_branch = _analyze(
+        content,
+        MULTI_PARAGRAPH_FORMULA_SOURCE,
+        test_cases=[
+            case("disabled single", disabled=True, married=False),
+            case("enabled married", disabled=False, married=True),
+        ],
+    )
+    both_arithmetic_branches = _analyze(
+        content,
+        MULTI_PARAGRAPH_FORMULA_SOURCE,
+        test_cases=[
+            case("enabled married", disabled=False, married=True),
+            case("enabled single", disabled=False, married=False),
+        ],
+    )
+
+    assert _has_issue(bypass_plus_one_branch, "formula branch", "distinct")
+    assert not _has_issue(both_arithmetic_branches, "formula branch")
+
+
+def test_match_arm_bypasses_cannot_witness_arithmetic_branches():
+    content = MULTI_PARAGRAPH_FORMULA_CONTENT.replace(
+        "formula: income * first_multiplier + income * second_multiplier",
+        """\
+formula: |-
+          match filing_status:
+            "married" => if disabled: 0 else: income * first_multiplier
+            "single" => if disabled: 0 else: income * second_multiplier""",
+    )
+
+    def case(
+        status: str,
+        *,
+        disabled: bool,
+    ) -> dict[str, object]:
+        expected = 0 if disabled else 10 * (2 if status == "married" else 3)
+        return {
+            "name": f"{status} disabled={disabled}",
+            "input": {
+                "disabled": disabled,
+                "filing_status": status,
+                "income": 10,
+            },
+            "output": {"combined_amount": expected},
+        }
+
+    bypassed_arms = _analyze(
+        content,
+        MULTI_PARAGRAPH_FORMULA_SOURCE,
+        test_cases=[
+            case("married", disabled=True),
+            case("single", disabled=True),
+        ],
+    )
+    executed_arms = _analyze(
+        content,
+        MULTI_PARAGRAPH_FORMULA_SOURCE,
+        test_cases=[
+            case("married", disabled=False),
+            case("single", disabled=False),
+        ],
+    )
+
+    assert _has_issue(bypassed_arms, "formula branch", "distinct")
+    assert not _has_issue(executed_arms, "formula branch")
+
+
+def test_interval_cases_must_reach_the_piecewise_formula():
+    content = NARRATIVE_PIECEWISE_CONTENT.replace(
+        """\
+          if taxable_income <= tariff_boundary:
+            taxable_income * lower_tariff_rate_percent / 100
+          else:
+            taxable_income * upper_tariff_rate_percent / 100""",
+        """\
+          if disabled:
+            0
+          else:
+            if taxable_income <= tariff_boundary:
+              taxable_income * lower_tariff_rate_percent / 100
+            else:
+              taxable_income * upper_tariff_rate_percent / 100""",
+    )
+
+    def case(name: str, income: int, *, disabled: bool) -> dict[str, object]:
+        expected = (
+            0
+            if disabled
+            else int(income * (5 if income <= 100 else 7) / 100)
+        )
+        return {
+            "name": name,
+            "input": {"disabled": disabled, "taxable_income": income},
+            "output": {"tariff_income_tax_amount": expected},
+        }
+
+    bypassed_intervals = _analyze(
+        content,
+        NARRATIVE_PIECEWISE_SOURCE,
+        test_cases=[
+            case("disabled lower", 90, disabled=True),
+            case("disabled upper", 110, disabled=True),
+            case("disabled boundary", 100, disabled=True),
+        ],
+    )
+    executed_intervals = _analyze(
+        content,
+        NARRATIVE_PIECEWISE_SOURCE,
+        test_cases=[
+            case("lower", 90, disabled=False),
+            case("upper", 110, disabled=False),
+            case("boundary", 100, disabled=False),
+        ],
+    )
+
+    assert _has_issue(bypassed_intervals, "formula branch", "distinct")
+    assert _has_issue(bypassed_intervals, "boundary", "test")
+    assert not executed_intervals.issues
+
+
+def test_exception_toggle_must_be_reached_by_both_cases():
+    source = """\
+(1) Der Betrag wird als Einkommen * 2 berechnet. Ausnahme: Bei einer Befreiung beträgt der Betrag null.
+"""
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: multiplier
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2
+  - name: amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if disabled:
+            0
+          else:
+            if exemption_applies:
+              0
+            else:
+              income * multiplier
+"""
+
+    def case(
+        name: str,
+        *,
+        disabled: bool,
+        exemption_applies: bool,
+    ) -> dict[str, object]:
+        expected = 0 if disabled or exemption_applies else 20
+        return {
+            "name": name,
+            "input": {
+                "disabled": disabled,
+                "exemption_applies": exemption_applies,
+                "income": 10,
+            },
+            "output": {"amount": expected},
+        }
+
+    unreachable_toggle = _analyze(
+        content,
+        source,
+        test_cases=[
+            case("disabled ordinary", disabled=True, exemption_applies=False),
+            case("disabled exempt", disabled=True, exemption_applies=True),
+        ],
+    )
+    reached_toggle = _analyze(
+        content,
+        source,
+        test_cases=[
+            case("ordinary", disabled=False, exemption_applies=False),
+            case("exempt", disabled=False, exemption_applies=True),
+        ],
+    )
+
+    assert _has_issue(unreachable_toggle, "exception", "test")
+    assert not reached_toggle.issues
+
+
+def test_rounding_witness_must_reach_the_rounding_operator():
+    source = """\
+(1) Der Betrag wird als Einkommen * 2 berechnet und auf volle Euro abzurunden.
+"""
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: multiplier
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2
+  - name: amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if disabled:
+            0
+          else:
+            floor(income * multiplier)
+"""
+
+    def case(name: str, *, disabled: bool) -> dict[str, object]:
+        return {
+            "name": name,
+            "input": {"disabled": disabled, "income": 10.25},
+            "output": {"amount": 0 if disabled else 20},
+        }
+
+    bypassed_rounding = _analyze(
+        content,
+        source,
+        test_cases=[case("disabled fractional", disabled=True)],
+    )
+    executed_rounding = _analyze(
+        content,
+        source,
+        test_cases=[case("enabled fractional", disabled=False)],
+    )
+
+    assert _has_issue(bypassed_rounding, "rounding", "fractional")
+    assert not executed_rounding.issues
 
 
 def test_numbered_prose_formulas_require_distinct_executed_cases():

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -4658,6 +4658,7 @@ def test_standalone_result_rounding_requires_the_final_computation():
             "6Der sich ergebende Steuerbetrag ist auf den nächsten vollen "
             "Euro-Betrag abzurunden."
         ),
+        "Satz 2 Das Ergebnis ist auf volle Euro abzurunden.",
         (
             "Satz 6: Der sich ergebende Steuerbetrag ist auf den nächsten "
             "vollen Euro-Betrag abzurunden."
@@ -4669,7 +4670,7 @@ def test_statutory_result_rounding_attaches_to_preceding_computation(
 ):
     source = f"(1) Der Steuerbetrag ist Einkommen * 2. {result_clause}"
     content = _single_rounding_content("floor(income * multiplier)")
-    if result_clause.startswith("6"):
+    if result_clause.startswith(("6", "Satz 2 ")):
         content = content.replace(
             """\
   - name: amount
@@ -4702,6 +4703,66 @@ def test_statutory_result_rounding_attaches_to_preceding_computation(
     result = _analyze(content, source, test_cases=[case])
 
     assert not result.issues
+
+
+def test_result_rounding_cannot_bind_an_earlier_component():
+    source = (
+        "(1) Der Grundbetrag ist Einkommen * 2. "
+        "Der Endbetrag ist Grundbetrag + Zuschlag. "
+        "Das Ergebnis ist auf volle Euro abzurunden."
+    )
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: multiplier
+    kind: parameter
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 2}]
+  - name: base_amount
+    kind: derived
+    source: de/statute/estg/32a(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: de/statute/estg/32a
+              excerpt: Der Grundbetrag ist Einkommen * 2.
+    versions: [{formula: 'income * multiplier'}]
+  - name: unrounded_amount
+    kind: derived
+    source: de/statute/estg/32a(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: de/statute/estg/32a
+              excerpt: Der Endbetrag ist Grundbetrag + Zuschlag.
+    versions: [{formula: 'base_amount + supplement'}]
+  - name: amount
+    kind: derived
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 'floor(base_amount)'}]
+"""
+    case = {
+        "name": "earlier component rounded",
+        "input": {"income": 10.25, "supplement": 0.25},
+        "output": {
+            "base_amount": 20.5,
+            "unrounded_amount": 20.75,
+            "amount": 20,
+        },
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert _has_issue(result, "rounding", "fractional")
 
 
 def test_integral_input_can_produce_fractional_rounding_operand():
@@ -4821,6 +4882,8 @@ rules:
             False,
         ),
         ("basic_allowance", "floor(child_allowance)", True),
+        ("basic_allowance", "floor(basic_allowance_child)", True),
+        ("basic_allowance_amount", "floor(basic)", True),
     ],
 )
 def test_single_rounding_binds_to_affected_output_stage(
@@ -4841,11 +4904,7 @@ rules:
     versions:
       - formula: FORMULA
 """.replace("FORMULA", formula).replace("RULE_NAME", rule_name)
-    operand_name = (
-        "child_allowance"
-        if "child_allowance" in formula
-        else "unrounded_basic_allowance"
-    )
+    operand_name = formula.removeprefix("floor(").removesuffix(")")
     case = {
         "name": "single pure rounding",
         "input": {operand_name: 10.5},

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -4235,3 +4235,166 @@ rules:
     result = _analyze(content, source, test_cases=[case])
 
     assert _has_issue(result, "formula branch")
+
+
+def _single_rounding_content(formula: str) -> str:
+    return f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: multiplier
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2
+  - name: amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: {formula}
+"""
+
+
+def test_neutralized_fractional_input_cannot_witness_rounding():
+    source = (
+        "(1) Der Betrag wird als Einkommen * 2 berechnet und "
+        "auf volle Euro abzurunden."
+    )
+    content = _single_rounding_content(
+        "floor(income * multiplier + fractional_probe * 0)",
+    )
+    case = {
+        "name": "neutral fractional probe",
+        "period": "2026",
+        "input": {"income": 10, "fractional_probe": 0.5},
+        "output": {"amount": 20},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert _has_issue(result, "rounding", "fractional")
+
+
+def test_fractional_input_must_leave_the_rounded_operand_fractional():
+    source = (
+        "(1) Der Betrag wird als Einkommen * 2 berechnet und "
+        "auf volle Euro abzurunden."
+    )
+    content = _single_rounding_content("floor(income * multiplier)")
+    case = {
+        "name": "integral computed operand",
+        "period": "2026",
+        "input": {"income": 10.5},
+        "output": {"amount": 21},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert _has_issue(result, "rounding", "fractional")
+
+
+def test_dead_rounding_call_cannot_witness_source_rounding():
+    source = (
+        "(1) Der Betrag wird als Einkommen * 2 berechnet. "
+        "Das Ergebnis ist auf volle Euro abzurunden."
+    )
+    content = _single_rounding_content(
+        "floor(income * multiplier) + 0 * floor(dummy_amount)",
+    )
+    case = {
+        "name": "dead fractional call",
+        "period": "2026",
+        "input": {"income": 10, "dummy_amount": 10.5},
+        "output": {"amount": 20},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert _has_issue(result, "rounding", "fractional")
+
+
+MULTI_ROUNDING_SOURCE = """\
+(1) Der erste Betrag ist auf volle Euro abzurunden.
+(2) Der zweite Betrag ist auf volle Euro abzurunden.
+"""
+
+MULTI_ROUNDING_CONTENT = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: total_amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1); de/statute/estg/32a(2)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: floor(first_amount) + floor(second_amount)
+"""
+
+
+def _multi_rounding_case(
+    name: str,
+    *,
+    first_amount: float,
+    second_amount: float,
+) -> dict[str, object]:
+    return {
+        "name": name,
+        "period": "2026",
+        "input": {
+            "first_amount": first_amount,
+            "second_amount": second_amount,
+        },
+        "output": {
+            "total_amount": int(first_amount // 1 + second_amount // 1),
+        },
+    }
+
+
+def test_each_source_rounding_clause_needs_its_own_affected_call():
+    first_only = [
+        _multi_rounding_case(
+            "first fractional one",
+            first_amount=10.5,
+            second_amount=20,
+        ),
+        _multi_rounding_case(
+            "first fractional two",
+            first_amount=11.5,
+            second_amount=20,
+        ),
+    ]
+    complete = [
+        _multi_rounding_case(
+            "first fractional",
+            first_amount=10.5,
+            second_amount=20,
+        ),
+        _multi_rounding_case(
+            "second fractional",
+            first_amount=10,
+            second_amount=20.5,
+        ),
+    ]
+
+    missing_second = _analyze(
+        MULTI_ROUNDING_CONTENT,
+        MULTI_ROUNDING_SOURCE,
+        test_cases=first_only,
+    )
+    both_calls = _analyze(
+        MULTI_ROUNDING_CONTENT,
+        MULTI_ROUNDING_SOURCE,
+        test_cases=complete,
+    )
+
+    assert _has_issue(missing_second, "rounding", "fractional")
+    assert not both_calls.issues

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -7700,8 +7700,17 @@ def test_worded_arithmetic_chain_preserves_formula_topology():
     assert _has_issue(wrong, "formula branch")
 
 
-def test_nearest_rounding_offset_cannot_cancel_itself():
-    source = "(1) Das Einkommen ist auf volle Euro gerundet."
+@pytest.mark.parametrize(
+    "source",
+    [
+        "(1) Das Einkommen ist auf volle Euro gerundet.",
+        (
+            "(1) Der Betrag entspricht dem Einkommen. "
+            "Das Ergebnis ist kaufmännisch zu runden."
+        ),
+    ],
+)
+def test_nearest_rounding_offset_cannot_cancel_itself(source: str):
     content = """\
 format: rulespec/v1
 module:

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -1957,6 +1957,32 @@ def test_complete_companion_suite_covers_source_controls():
 """,
         ),
         (
+            (
+                "(1) Der Zuschlag beträgt 259 Euro für Einkommen bis "
+                "einschließlich 100 Euro."
+            ),
+            """\
+  - name: income_limit
+    kind: parameter
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 100}]
+""",
+        ),
+        (
+            (
+                "(1) Der Zuschlag beträgt 259 Euro für Einkommen bis "
+                "maximal 100 Euro."
+            ),
+            """\
+  - name: income_limit
+    kind: parameter
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 100}]
+""",
+        ),
+        (
             "(1) Der Zuschlag beträgt 259 Euro, außer bei einer Befreiung.",
             "",
         ),
@@ -4794,6 +4820,18 @@ def test_adjacent_integral_boundary_requires_the_equivalent_comparator():
             False,
             "income <= income_limit",
         ),
+        (
+            "bis einschließlich 100 Euro",
+            "income <= income_limit",
+            True,
+            "income >= income_limit",
+        ),
+        (
+            "bis maximal 100 Euro",
+            "income <= income_limit",
+            True,
+            "income >= income_limit",
+        ),
     ],
 )
 def test_boundary_comparator_preserves_direction_and_inclusivity(
@@ -7484,10 +7522,19 @@ rules:
     assert not result.issues
 
 
-def test_unrelated_source_citation_cannot_authenticate_typed_deferral():
-    source = (
-        "(1) Der Betrag ist Einkommen * 2. Unberührt bleibt § 26."
-    )
+@pytest.mark.parametrize(
+    "source",
+    [
+        "(1) Der Betrag ist Einkommen * 2. Unberührt bleibt § 26.",
+        (
+            "(1) Der Betrag ist Einkommen * 2. "
+            "§ 26 regelt ausschließlich das Inkrafttreten."
+        ),
+    ],
+)
+def test_unrelated_source_citation_cannot_authenticate_typed_deferral(
+    source: str,
+):
     content = """\
 format: rulespec/v1
 module:

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -5448,7 +5448,7 @@ def test_statutory_result_rounding_attaches_to_preceding_computation(
 ):
     source = f"(1) Der Steuerbetrag ist Einkommen * 2. {result_clause}"
     content = _single_rounding_content("floor(income * multiplier)")
-    if result_clause.startswith(("6", "Satz 2 ")):
+    if result_clause.startswith(("6", "Satz 2 ", "Satz 6:")):
         content = content.replace(
             """\
   - name: amount

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -831,7 +831,7 @@ rules:
     values = collect_artifact_numeric_values(
         content,
         extract_named_scalars=extract_named_scalar_occurrences,
-        imported_contents=(imported,),
+        imported_symbol_contents=(("needed_amount", imported),),
     )
 
     assert values == (5.0,)
@@ -888,27 +888,106 @@ rules:
         lambda _rules_file: tmp_path,
     )
     monkeypatch.setattr(
-        pipeline,
-        "_resolve_import_dependencies",
-        lambda rules_file, _source_root: (
-            [direct_file] if rules_file == main_file else [transitive_file]
+        validator_pipeline_module,
+        "_resolve_rulespec_import_file_static",
+        lambda import_path, **_kwargs: (
+            direct_file
+            if import_path == "de:statutes/direct#threshold"
+            else transitive_file
         ),
     )
-    monkeypatch.setattr(
-        validator_pipeline_module,
-        "validate_rulespec_context_file",
-        lambda path, _source_root: path,
-    )
 
-    imported_contents = pipeline._complete_source_unit_import_contents(main_file)
+    imported_symbol_contents = (
+        pipeline._complete_source_unit_import_symbol_contents(main_file)
+    )
     values = collect_artifact_numeric_values(
         main_content,
         extract_named_scalars=extract_named_scalar_occurrences,
-        imported_contents=imported_contents,
+        imported_symbol_contents=imported_symbol_contents,
     )
 
-    assert imported_contents == (direct_content,)
+    assert imported_symbol_contents == (("threshold", direct_content),)
     assert values == (5.0,)
+
+
+def test_complete_import_inventory_binds_same_name_to_exact_direct_file(
+    tmp_path,
+    monkeypatch,
+):
+    main_file = tmp_path / "main.yaml"
+    first_file = tmp_path / "first.yaml"
+    second_file = tmp_path / "second.yaml"
+    main_content = """\
+format: rulespec/v1
+imports:
+  - de:statutes/first#threshold
+  - de:statutes/second#other
+rules: []
+"""
+    first_content = """\
+format: rulespec/v1
+rules:
+  - name: threshold
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 5
+"""
+    second_content = """\
+format: rulespec/v1
+rules:
+  - name: other
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 11
+  - name: threshold
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 73
+"""
+    main_file.write_text(main_content)
+    first_file.write_text(first_content)
+    second_file.write_text(second_content)
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+        local_corpus_release=None,
+        enable_oracles=False,
+        require_complete_source_unit=True,
+    )
+    monkeypatch.setattr(
+        pipeline,
+        "_validation_source_root",
+        lambda _rules_file: tmp_path,
+    )
+    monkeypatch.setattr(
+        validator_pipeline_module,
+        "_resolve_rulespec_import_file_static",
+        lambda import_path, **_kwargs: {
+            "de:statutes/first#threshold": first_file,
+            "de:statutes/second#other": second_file,
+        }[import_path],
+    )
+
+    imported_symbol_contents = (
+        pipeline._complete_source_unit_import_symbol_contents(main_file)
+    )
+    values = collect_artifact_numeric_values(
+        main_content,
+        extract_named_scalars=extract_named_scalar_occurrences,
+        imported_symbol_contents=imported_symbol_contents,
+    )
+
+    assert imported_symbol_contents == (
+        ("threshold", first_content),
+        ("other", second_content),
+    )
+    assert values == (5.0, 11.0)
 
 
 def test_glued_satz_markers_are_paragraph_children_not_list_children():

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -3953,6 +3953,58 @@ def test_adjacent_integral_boundary_requires_the_equivalent_comparator():
 
 
 @pytest.mark.parametrize(
+    ("wording", "correct_formula", "correct_output", "wrong_formula"),
+    [
+        ("bis 100 Euro", "income <= income_limit", True, "income >= income_limit"),
+        ("unter 100 Euro", "income < income_limit", False, "income <= income_limit"),
+        ("ab 100 Euro", "income >= income_limit", True, "income <= income_limit"),
+        ("über 100 Euro", "income > income_limit", False, "income >= income_limit"),
+    ],
+)
+def test_boundary_comparator_preserves_direction_and_inclusivity(
+    wording: str,
+    correct_formula: str,
+    correct_output: bool,
+    wrong_formula: str,
+):
+    source = f"(1) Die Regel gilt für Einkommen {wording}."
+    limit_versions = """\
+      - effective_from: '2026-01-01'
+        formula: 100"""
+    correct = _boundary_control_content(
+        formula=correct_formula,
+        limit_versions=limit_versions,
+    )
+    wrong = _boundary_control_content(
+        formula=wrong_formula,
+        limit_versions=limit_versions,
+    )
+    base_case = {
+        "name": "source endpoint",
+        "period": "2026",
+        "input": {"income": 100},
+    }
+
+    correct_result = _analyze(
+        correct,
+        source,
+        test_cases=[
+            {**base_case, "output": {"eligible": correct_output}},
+        ],
+    )
+    wrong_result = _analyze(
+        wrong,
+        source,
+        test_cases=[
+            {**base_case, "output": {"eligible": True}},
+        ],
+    )
+
+    assert not correct_result.issues
+    assert _has_issue(wrong_result, "boundary", "100")
+
+
+@pytest.mark.parametrize(
     ("wording", "formula"),
     [
         ("höchstens 100 Euro", "income <= income_limit"),

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -7511,3 +7511,133 @@ rules:
     result = _analyze(content, source, test_cases=[])
 
     assert _has_issue(result, "deferral", "dependency")
+
+
+def _three_term_topology_content(formula: str) -> str:
+    return f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: two
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions: [{{formula: 2}}]
+  - name: three
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions: [{{formula: 3}}]
+  - name: amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions: [{{formula: {formula!r}}}]
+"""
+
+
+@pytest.mark.parametrize(
+    ("source_expression", "correct_formula", "correct_output", "wrong_formula"),
+    [
+        (
+            "(Einkommen * 2 + 3)",
+            "income * two + three",
+            23,
+            "income + two * three",
+        ),
+        (
+            "Einkommen * (2 + 3)",
+            "income * (two + three)",
+            50,
+            "income * two + three",
+        ),
+    ],
+)
+def test_parenthesized_source_formula_preserves_topology(
+    source_expression: str,
+    correct_formula: str,
+    correct_output: int,
+    wrong_formula: str,
+):
+    source = f"(1) Der Betrag wird als {source_expression} berechnet."
+    correct = _analyze(
+        _three_term_topology_content(correct_formula),
+        source,
+        test_cases=[
+            {
+                "name": "parenthesized source computation",
+                "input": {"income": 10},
+                "output": {"amount": correct_output},
+            }
+        ],
+    )
+    wrong = _analyze(
+        _three_term_topology_content(wrong_formula),
+        source,
+        test_cases=[
+            {
+                "name": "different parenthesized computation",
+                "input": {"income": 10},
+                "output": {"amount": 16 if source_expression.startswith("(") else 23},
+            }
+        ],
+    )
+
+    assert not correct.issues
+    assert _has_issue(wrong, "formula branch")
+
+
+def test_formula_topology_accepts_associative_regrouping():
+    source = "(1) Der Betrag wird als Einkommen + 2 + 3 berechnet."
+    content = _three_term_topology_content("income + (two + three)")
+    case = {
+        "name": "associatively regrouped sum",
+        "input": {"income": 10},
+        "output": {"amount": 15},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert not result.issues
+
+
+def test_formula_topology_preserves_distinct_source_variables():
+    source = (
+        "(1) Der Betrag wird als Einkommen * Partnereinkommen + 3 berechnet."
+    )
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: supplement
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 3}]
+  - name: amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions: [{formula: FORMULA}]
+"""
+    case = {
+        "name": "two distinct inputs",
+        "input": {"income": 10, "spouse_income": 4},
+    }
+    correct = _analyze(
+        content.replace("FORMULA", "income * spouse_income + supplement"),
+        source,
+        test_cases=[{**case, "output": {"amount": 43}}],
+    )
+    duplicated = _analyze(
+        content.replace("FORMULA", "income * income + supplement"),
+        source,
+        test_cases=[{**case, "output": {"amount": 103}}],
+    )
+
+    assert not correct.issues
+    assert _has_issue(duplicated, "formula branch")

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -7429,3 +7429,85 @@ def test_generic_german_rounding_requires_nearest_rounding_and_fractional_proof(
     assert _has_issue(missing_operator, "rounding", "principal formula")
     assert _has_issue(missing_fractional_proof, "rounding", "fractional")
     assert not complete.issues
+
+
+@pytest.mark.parametrize(
+    ("source", "output"),
+    [
+        (
+            (
+                "(1) Der Zuschlag beträgt 259 Euro bis zu einem Einkommen "
+                "von 100 Euro nach § 26."
+            ),
+            "de:statutes/estg/32a/1#income_limited_supplement",
+        ),
+        (
+            (
+                "Der Zuschlag beträgt 259 Euro bis zu einem Einkommen "
+                "von 100 Euro nach § 26."
+            ),
+            "de:statutes/estg/32a#income_limited_supplement",
+        ),
+    ],
+)
+def test_precisely_deferred_control_is_not_rescanned(
+    source: str,
+    output: str,
+):
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  deferred_outputs:
+    - output: {output}
+      reason: >-
+        The income-limited supplement cannot be computed until EStG section 26
+        eligibility is available.
+      blocked_by:
+        - de:statutes/estg/26#eligibility
+rules:
+  - name: supplement_amount
+    kind: parameter
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions: [{{formula: 259}}]
+  - name: income_limit
+    kind: parameter
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions: [{{formula: 100}}]
+"""
+
+    result = _analyze(content, source, test_cases=[])
+
+    assert not result.issues
+
+
+def test_unrelated_source_citation_cannot_authenticate_typed_deferral():
+    source = (
+        "(1) Der Betrag ist Einkommen * 2. Unberührt bleibt § 26."
+    )
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  deferred_outputs:
+    - output: de:statutes/estg/32a/1#amount
+      reason: >-
+        The amount cannot be computed until the EStG section 26 base is
+        available.
+      blocked_by:
+        - de:statutes/estg/26#base
+rules:
+  - name: factor
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 2}]
+"""
+
+    result = _analyze(content, source, test_cases=[])
+
+    assert _has_issue(result, "deferral", "dependency")

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -3858,6 +3858,43 @@ rules:
     assert not pipeline_shaped.issues
 
 
+def test_partial_literal_versions_do_not_become_global_formula_constants():
+    source = "(1) Der Betrag wird als Einkommen * 2 berechnet."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: multiplier
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2025-01-01'
+        formula: external_factor
+      - effective_from: '2026-01-01'
+        formula: 2
+  - name: amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2025-01-01'
+        formula: income * multiplier
+"""
+    case = {
+        "name": "unresolved historical coefficient",
+        "period": "2025",
+        "input": {"income": 10},
+        "output": {"amount": 20},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert _has_issue(result, "formula branch")
+
+
 def _boundary_control_content(
     *,
     formula: str,

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -705,8 +705,16 @@ rules: []
     assert _has_issue(result, "(6)", "deferral", "dependency")
 
 
-def test_deferral_symbol_cannot_mask_a_conflicting_source_section():
-    content = """\
+@pytest.mark.parametrize(
+    "blocker",
+    [
+        "de:statutes/estg/9999#bemessungsgrundlage",
+        "de:statutes/fake/26#bemessungsgrundlage",
+        "xx:statutes/anything/26#bemessungsgrundlage",
+    ],
+)
+def test_deferral_symbol_cannot_mask_a_conflicting_citation(blocker: str):
+    content = f"""\
 format: rulespec/v1
 module:
   source_verification:
@@ -716,7 +724,7 @@ module:
       reason: >-
         Absatz 1 cannot be computed because the Bemessungsgrundlage is missing.
       blocked_by:
-        - de:statutes/estg/9999#bemessungsgrundlage
+        - {blocker}
 rules: []
 """
     source = "(1) Maßgeblich ist die Bemessungsgrundlage nach § 26."
@@ -3049,3 +3057,308 @@ rules:
     result = _analyze(content, source, test_cases=tests)
 
     assert _has_issue(result, "rounding", "fractional")
+
+
+def test_same_computation_leaf_cannot_witness_two_source_formulas():
+    content = MULTI_PARAGRAPH_FORMULA_CONTENT.replace(
+        "formula: income * first_multiplier + income * second_multiplier",
+        """\
+formula: |-
+          if disabled:
+            income * first_multiplier
+          else:
+            if married:
+              income * first_multiplier
+            else:
+              income * second_multiplier""",
+    )
+    cases = [
+        {
+            "name": "outer first computation",
+            "input": {"disabled": True, "married": True, "income": 10},
+            "output": {"combined_amount": 20},
+        },
+        {
+            "name": "nested first computation",
+            "input": {"disabled": False, "married": True, "income": 10},
+            "output": {"combined_amount": 20},
+        },
+    ]
+
+    result = _analyze(
+        content,
+        MULTI_PARAGRAPH_FORMULA_SOURCE,
+        test_cases=cases,
+    )
+
+    assert _has_issue(result, "formula branch", "distinct")
+
+
+@pytest.mark.parametrize(
+    ("bypass_formula", "extra_input"),
+    [
+        ("0 + 0", {}),
+        ("min(0, 0)", {}),
+        ("disabled_amount", {"disabled_amount": 0}),
+    ],
+)
+def test_zero_valued_bypass_expression_is_not_computation_evidence(
+    bypass_formula: str,
+    extra_input: dict[str, object],
+):
+    source = "(1) Der Betrag wird als Einkommen * 2 berechnet."
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: multiplier
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2
+  - name: amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if disabled:
+            {bypass_formula}
+          else:
+            income * multiplier
+"""
+    case = {
+        "name": "bypass",
+        "input": {"disabled": True, "income": 10, **extra_input},
+        "output": {"amount": 0},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert _has_issue(result, "formula branch", "distinct")
+
+
+def test_boundary_evidence_is_bound_to_reached_comparator_and_input():
+    source = """\
+(1) Der Anspruch besteht für berechtigte Personen.
+Er gilt bis 100 Euro Einkommen.
+"""
+    base_content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: income_limit
+    kind: parameter
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 100
+  - name: eligible
+    kind: derived
+    dtype: bool
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: income <= income_limit
+"""
+    continuation_missing = _analyze(
+        base_content,
+        source,
+        test_cases=[
+            {
+                "name": "below only",
+                "input": {"income": 50},
+                "output": {"eligible": True},
+            }
+        ],
+    )
+    bypass_content = base_content.replace(
+        "formula: income <= income_limit",
+        (
+            "formula: >-\n"
+            "          if disabled: income == income "
+            "else: income <= income_limit"
+        ),
+    )
+    bypassed_comparator = _analyze(
+        bypass_content,
+        source,
+        test_cases=[
+            {
+                "name": "exact but bypassed",
+                "input": {"disabled": True, "income": 100},
+                "output": {"eligible": True},
+            }
+        ],
+    )
+    other_input_content = base_content.replace(
+        "formula: income <= income_limit",
+        (
+            "formula: >-\n"
+            "          if use_age: age <= external_age_limit "
+            "else: income <= income_limit"
+        ),
+    )
+    unused_boundary_input = _analyze(
+        other_input_content,
+        source,
+        test_cases=[
+            {
+                "name": "unused exact income",
+                "input": {
+                    "use_age": True,
+                    "age": 18,
+                    "external_age_limit": 21,
+                    "income": 100,
+                },
+                "output": {"eligible": True},
+            }
+        ],
+    )
+
+    assert _has_issue(continuation_missing, "boundary", "test")
+    assert _has_issue(bypassed_comparator, "boundary", "test")
+    assert _has_issue(unused_boundary_input, "boundary", "test")
+
+
+def test_exception_toggle_must_change_the_reached_formula_effect():
+    source = "(1) Der Anspruch gilt nicht, wenn eine Befreiung vorliegt."
+    short_circuited_content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: eligible
+    kind: derived
+    dtype: bool
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if disabled or exemption_applies:
+            false
+          else:
+            true
+"""
+    short_circuited_cases = [
+        {
+            "name": f"disabled exemption={value}",
+            "input": {"disabled": True, "exemption_applies": value},
+            "output": {"eligible": False},
+        }
+        for value in (False, True)
+    ]
+    short_circuited = _analyze(
+        short_circuited_content,
+        source,
+        test_cases=short_circuited_cases,
+    )
+
+    direct_relation_content = short_circuited_content.replace(
+        """\
+formula: |-
+          if disabled or exemption_applies:
+            false
+          else:
+            true""",
+        "formula: not exemption_applies",
+    )
+    direct_relation_cases = [
+        {
+            "name": f"direct exemption={value}",
+            "input": {"exemption_applies": value},
+            "output": {"eligible": not value},
+        }
+        for value in (False, True)
+    ]
+    direct_relation = _analyze(
+        direct_relation_content,
+        source,
+        test_cases=direct_relation_cases,
+    )
+
+    assert _has_issue(short_circuited, "exception", "test")
+    assert not direct_relation.issues
+
+
+def test_rounding_fraction_must_belong_to_reached_operand():
+    source = """\
+(1) Der Betrag wird als Einkommen * 2 berechnet und auf volle Euro abzurunden.
+"""
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: multiplier
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2
+  - name: amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if use_other:
+            floor(other_amount)
+          else:
+            floor(income * multiplier)
+"""
+    case = {
+        "name": "unused fractional operand",
+        "input": {
+            "use_other": False,
+            "other_amount": 10.5,
+            "income": 10,
+        },
+        "output": {"amount": 20},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert _has_issue(result, "rounding", "fractional")
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "(1) Das Einkommen ist mit 2 zu multiplizieren.",
+        "(1) Das Einkommen ist mit dem Faktor 2 zu vervielfachen.",
+        "(1) Der Betrag ist unter Anwendung des Faktors 2 zu ermitteln.",
+    ],
+)
+def test_german_infinitive_formula_wording_rejects_parameter_only(source: str):
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: multiplier
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2
+"""
+
+    result = _analyze(content, source, test_cases=[])
+
+    assert source_states_explicit_computation(source)
+    assert _has_issue(result, "formula-output", "parameter-only")

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -598,6 +598,74 @@ def test_explicit_satz_markers_after_absatz_are_recognized():
     }
 
 
+@pytest.mark.parametrize(
+    ("source", "source_reference", "parent_label"),
+    [
+        (
+            "(1) Anspruch besteht nur bei Wohnsitz.\n"
+            "1. Der Freibetrag beträgt 259 Euro.",
+            "de/statute/estg/32a(1)(1)",
+            "(1)",
+        ),
+        (
+            "1. Anspruch besteht nur bei Wohnsitz.\n"
+            "a) Der Freibetrag beträgt 259 Euro.",
+            "de/statute/estg/32a Nummer 1 Buchstabe a",
+            "1.",
+        ),
+    ],
+)
+def test_child_encoding_cannot_hide_substantive_parent_chapeau(
+    source: str,
+    source_reference: str,
+    parent_label: str,
+):
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  summary: Scalar child only.
+rules:
+  - name: allowance_amount
+    kind: parameter
+    dtype: Money
+    source: {source_reference}
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 259
+"""
+
+    result = _analyze(content, source, test_cases=[])
+
+    assert any(
+        f"Source branch {parent_label} at " in issue for issue in result.issues
+    )
+
+
+def test_child_encoding_covers_marker_only_parent_container():
+    source = "(1)\n1. Der Freibetrag beträgt 259 Euro."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  summary: Scalar child.
+rules:
+  - name: allowance_amount
+    kind: parameter
+    dtype: Money
+    source: de/statute/estg/32a(1)(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 259
+"""
+
+    result = _analyze(content, source, test_cases=[])
+
+    assert not result.issues
+
+
 def test_imprecise_absatz_deferral_does_not_cover_branch():
     content = """\
 format: rulespec/v1

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -4212,6 +4212,61 @@ def test_boundary_comparator_preserves_direction_and_inclusivity(
 
 
 @pytest.mark.parametrize(
+    ("formula", "endpoint_output", "expected_issue"),
+    [
+        ("income <= income_limit", True, False),
+        ("not (income > income_limit)", True, False),
+        ("if income > income_limit: false else: true", True, False),
+        ("not (income <= income_limit)", False, True),
+        ("if income > income_limit: true else: false", False, True),
+        ("if income <= income_limit: false else: true", False, True),
+    ],
+)
+def test_boundary_predicate_preserves_applicability_polarity(
+    formula: str,
+    endpoint_output: bool,
+    expected_issue: bool,
+):
+    source = "(1) Die Regel gilt für Einkommen bis 100 Euro."
+    content = _boundary_control_content(
+        formula=formula,
+        limit_versions="""\
+      - effective_from: '2026-01-01'
+        formula: 100""",
+    )
+    case = {
+        "name": "endpoint polarity",
+        "period": "2026",
+        "input": {"income": 100},
+        "output": {"eligible": endpoint_output},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert _has_issue(result, "boundary", "100") is expected_issue
+
+
+def test_negative_boundary_prose_inverts_boolean_applicability():
+    source = "(1) Einkommen bis 100 Euro begründen keine Berechtigung."
+    content = _boundary_control_content(
+        formula="income > income_limit",
+        limit_versions="""\
+      - effective_from: '2026-01-01'
+        formula: 100""",
+    )
+    case = {
+        "name": "excluded endpoint",
+        "period": "2026",
+        "input": {"income": 100},
+        "output": {"eligible": False},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert not result.issues
+
+
+@pytest.mark.parametrize(
     ("wording", "formula"),
     [
         ("höchstens 100 Euro", "income <= income_limit"),
@@ -4924,6 +4979,144 @@ rules:
     result = _analyze(content, source, test_cases=cases)
 
     assert not result.issues
+
+
+def _exception_control_content(formula: str, *, extra_rules: str = "") -> str:
+    return f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+{extra_rules}  - name: result
+    kind: derived
+    source: de/statute/estg/32a(1)
+    versions:
+      - formula: '{formula}'
+"""
+
+
+def test_exception_toggle_cannot_borrow_effect_from_changed_numeric_input():
+    source = "(1) Der Anspruch gilt nicht, wenn eine Befreiung vorliegt."
+    content = _exception_control_content(
+        "if exemption_applies: income else: income",
+    )
+    cases = [
+        {
+            "name": "ordinary low",
+            "input": {"exemption_applies": False, "income": 10},
+            "output": {"result": 10},
+        },
+        {
+            "name": "exempt high",
+            "input": {"exemption_applies": True, "income": 20},
+            "output": {"result": 20},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert _has_issue(result, "exception", "test")
+
+
+def test_exception_toggle_cannot_borrow_effect_from_another_boolean():
+    source = "(1) Der Anspruch gilt nicht, wenn eine Befreiung vorliegt."
+    content = _exception_control_content(
+        "if exemption_applies: "
+        "(if bonus_applies: income + 1 else: income) "
+        "else: (if bonus_applies: income + 1 else: income)",
+    )
+    cases = [
+        {
+            "name": "ordinary without bonus",
+            "input": {
+                "exemption_applies": False,
+                "bonus_applies": False,
+                "income": 10,
+            },
+            "output": {"result": 10},
+        },
+        {
+            "name": "exempt with bonus",
+            "input": {
+                "exemption_applies": True,
+                "bonus_applies": True,
+                "income": 10,
+            },
+            "output": {"result": 11},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert _has_issue(result, "exception", "test")
+
+
+def test_exception_toggle_cases_must_share_period():
+    source = "(1) Der Anspruch gilt nicht, wenn eine Befreiung vorliegt."
+    content = _exception_control_content(
+        "if exemption_applies: base_amount else: base_amount",
+        extra_rules="""\
+  - name: base_amount
+    kind: parameter
+    versions:
+      - effective_from: '2025-01-01'
+        effective_to: '2025-12-31'
+        formula: 10
+      - effective_from: '2026-01-01'
+        formula: 20
+""",
+    )
+    cases = [
+        {
+            "name": "ordinary old",
+            "period": "2025",
+            "input": {"exemption_applies": False},
+            "output": {"result": 10},
+        },
+        {
+            "name": "exempt new",
+            "period": "2026",
+            "input": {"exemption_applies": True},
+            "output": {"result": 20},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert _has_issue(result, "exception", "test")
+
+
+@pytest.mark.parametrize(
+    ("formula", "ordinary_output", "blocking_output"),
+    [
+        ("if exemption_applies: true else: false", False, True),
+        ("if exemption_applies: 20 else: 10", 10, 20),
+    ],
+)
+def test_exception_selector_must_block_not_enable(
+    formula: str,
+    ordinary_output: bool | int,
+    blocking_output: bool | int,
+):
+    source = "(1) Der Anspruch gilt nicht, wenn eine Befreiung vorliegt."
+    content = _exception_control_content(formula)
+    cases = [
+        {
+            "name": "ordinary",
+            "input": {"exemption_applies": False},
+            "output": {"result": ordinary_output},
+        },
+        {
+            "name": "blocking",
+            "input": {"exemption_applies": True},
+            "output": {"result": blocking_output},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert _has_issue(result, "exception", "test")
 
 
 def test_derived_match_pattern_cannot_fall_back_to_identifier_text():

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -2305,6 +2305,84 @@ def test_judgment_selector_normalizes_holds_and_not_holds():
     ) == "if:1"
 
 
+def test_nested_match_arms_do_not_count_when_outer_guard_bypasses_them():
+    source = """\
+(1) Bei Verheirateten ist der Betrag Einkommen * 2.
+(2) Bei Alleinstehenden ist der Betrag Einkommen * 3.
+"""
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: married_multiplier
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2
+  - name: single_multiplier
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(2)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 3
+  - name: amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1); de/statute/estg/32a(2)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if disabled:
+            0
+          else:
+            match filing_status:
+              "married" => income * married_multiplier
+              "single" => income * single_multiplier
+"""
+
+    def case(
+        name: str,
+        *,
+        disabled: bool,
+        filing_status: str,
+    ) -> dict[str, object]:
+        multiplier = 2 if filing_status == "married" else 3
+        return {
+            "name": name,
+            "input": {
+                "disabled": disabled,
+                "filing_status": filing_status,
+                "income": 10,
+            },
+            "output": {"amount": 0 if disabled else 10 * multiplier},
+        }
+
+    bypassed_match = _analyze(
+        content,
+        source,
+        test_cases=[
+            case("disabled married", disabled=True, filing_status="married"),
+            case("disabled single", disabled=True, filing_status="single"),
+        ],
+    )
+    executed_match = _analyze(
+        content,
+        source,
+        test_cases=[
+            case("married", disabled=False, filing_status="married"),
+            case("single", disabled=False, filing_status="single"),
+        ],
+    )
+
+    assert _has_issue(bypassed_match, "formula branch", "distinct")
+    assert not _has_issue(executed_match, "formula branch")
+
+
 def test_numbered_prose_formulas_require_distinct_executed_cases():
     source = """\
 (1) Es gelten folgende Berechnungen:

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -3676,15 +3676,16 @@ rules:
     assert _has_issue(result, "formula branch", "distinct")
 
 
-def test_bare_enum_match_patterns_remain_literal_values():
+def test_quoted_enum_match_patterns_are_literal_values():
     rule = {
         "versions": [
             {
                 "effective_from": "2026-01-01",
-                "formula": (
-                    "match status: married => income * 2; "
-                    "single => income * 3"
-                ),
+                "formula": """\
+match status:
+  "married" => income * 2
+  "single" => income * 3
+""",
             }
         ]
     }
@@ -4398,3 +4399,371 @@ def test_each_source_rounding_clause_needs_its_own_affected_call():
 
     assert _has_issue(missing_second, "rounding", "fractional")
     assert not both_calls.issues
+
+
+def test_standalone_result_rounding_modifies_preceding_computation():
+    source = (
+        "(1) Der Betrag wird als Einkommen * 2 berechnet. "
+        "Das Ergebnis ist auf volle Euro abzurunden."
+    )
+    content = _single_rounding_content("floor(income * multiplier)")
+    case = {
+        "name": "split rounding sentence",
+        "period": "2026",
+        "input": {"income": 10.25},
+        "output": {"amount": 20},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert not result.issues
+
+
+def test_rounding_accepts_asserted_reached_intermediate_output():
+    source = (
+        "(1) Der Betrag wird als Einkommen * 2 berechnet und "
+        "auf volle Euro abgerundet."
+    )
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: multiplier
+    kind: parameter
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 2}]
+  - name: unrounded_amount
+    kind: derived
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 'income * multiplier'}]
+  - name: amount
+    kind: derived
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 'floor(unrounded_amount)'}]
+"""
+    case = {
+        "name": "derived rounding operand",
+        "input": {"income": 10.25},
+        "output": {"unrounded_amount": 20.5, "amount": 20},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert not result.issues
+
+
+def test_mismatched_asserted_intermediate_cannot_witness_rounding():
+    source = (
+        "(1) Der Betrag wird als Einkommen * 2 berechnet und "
+        "auf volle Euro abgerundet."
+    )
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: multiplier
+    kind: parameter
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 2}]
+  - name: unrounded_amount
+    kind: derived
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 'income * multiplier'}]
+  - name: amount
+    kind: derived
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 'floor(unrounded_amount)'}]
+"""
+    case = {
+        "name": "false intermediate assertion",
+        "input": {"income": 10},
+        "output": {"unrounded_amount": 20.5, "amount": 20},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert _has_issue(result, "rounding", "fractional")
+
+
+@pytest.mark.parametrize(
+    ("formula", "expected_issue"),
+    [
+        ("floor(unrounded_basic_allowance)", False),
+        ("floor(child_allowance)", True),
+    ],
+)
+def test_single_rounding_binds_to_affected_output_stage(
+    formula: str,
+    expected_issue: bool,
+):
+    source = "(1) Der Grundfreibetrag ist auf volle Euro abzurunden."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: basic_allowance
+    kind: derived
+    source: de/statute/estg/32a(1)
+    versions:
+      - formula: FORMULA
+""".replace("FORMULA", formula)
+    operand_name = (
+        "child_allowance"
+        if "child_allowance" in formula
+        else "unrounded_basic_allowance"
+    )
+    case = {
+        "name": "single pure rounding",
+        "input": {operand_name: 10.5},
+        "output": {"basic_allowance": 10},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert _has_issue(result, "rounding", "fractional") is expected_issue
+
+
+def test_translated_multi_rounding_uses_distinct_operative_calls():
+    source = """\
+(1) Der Grundfreibetrag ist auf volle Euro abzurunden.
+(2) Der Kinderfreibetrag ist auf volle Euro abzurunden.
+"""
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: total_amount
+    kind: derived
+    source: de/statute/estg/32a(1); de/statute/estg/32a(2)
+    versions:
+      - formula: floor(basic_allowance) + floor(child_allowance)
+"""
+    cases = [
+        {
+            "name": "basic fractional",
+            "input": {"basic_allowance": 10.5, "child_allowance": 20},
+            "output": {"total_amount": 30},
+        },
+        {
+            "name": "child fractional",
+            "input": {"basic_allowance": 10, "child_allowance": 20.5},
+            "output": {"total_amount": 30},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert not result.issues
+
+
+def test_one_ambiguous_rounding_call_cannot_cover_two_source_clauses():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: total_amount
+    kind: derived
+    source: de/statute/estg/32a(1); de/statute/estg/32a(2)
+    versions:
+      - formula: floor(first_second_amount)
+"""
+    cases = [
+        {
+            "name": "fractional one",
+            "input": {"first_second_amount": 10.5},
+            "output": {"total_amount": 10},
+        },
+        {
+            "name": "fractional two",
+            "input": {"first_second_amount": 11.5},
+            "output": {"total_amount": 11},
+        },
+    ]
+
+    result = _analyze(content, MULTI_ROUNDING_SOURCE, test_cases=cases)
+
+    assert _has_issue(result, "rounding", "fractional")
+
+
+def test_boundary_accepts_asserted_reached_derived_selector():
+    source = (
+        "(1) Der Anspruch gilt bis 100 Euro zu versteuerndes Einkommen."
+    )
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: income_limit
+    kind: parameter
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 100}]
+  - name: taxable_income
+    kind: derived
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 'gross_income - deduction'}]
+  - name: eligible
+    kind: derived
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 'taxable_income <= income_limit'}]
+"""
+    case = {
+        "name": "derived boundary selector",
+        "input": {"gross_income": 120, "deduction": 20},
+        "output": {"taxable_income": 100, "eligible": True},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert not result.issues
+
+
+def test_exception_accepts_asserted_reached_derived_selector_toggle():
+    source = "(1) Der Anspruch gilt nicht, wenn eine Befreiung vorliegt."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: exemption_applies
+    kind: derived
+    dtype: bool
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 'has_certificate'}]
+  - name: eligible
+    kind: derived
+    dtype: bool
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 'if exemption_applies: false else: true'}]
+"""
+    cases = [
+        {
+            "name": "ordinary",
+            "input": {"has_certificate": False},
+            "output": {"exemption_applies": False, "eligible": True},
+        },
+        {
+            "name": "exempt",
+            "input": {"has_certificate": True},
+            "output": {"exemption_applies": True, "eligible": False},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert not result.issues
+
+
+def test_derived_match_pattern_cannot_fall_back_to_identifier_text():
+    source = """\
+(1) Bei Status A ist der Betrag Einkommen * 2.
+(2) Bei Status B ist der Betrag Einkommen * 3.
+"""
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: special_status
+    kind: derived
+    dtype: String
+    versions:
+      - formula: 'if flag: "married" else: "joint"'
+  - name: first_multiplier
+    kind: parameter
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 2}]
+  - name: second_multiplier
+    kind: parameter
+    source: de/statute/estg/32a(2)
+    versions: [{formula: 3}]
+  - name: amount
+    kind: derived
+    source: de/statute/estg/32a(1); de/statute/estg/32a(2)
+    versions:
+      - formula: |-
+          match status:
+            special_status => income * first_multiplier
+            "single" => income * second_multiplier
+"""
+    cases = [
+        {
+            "name": "identifier text falls through",
+            "input": {"flag": True, "status": "special_status", "income": 10},
+            "output": {"special_status": "married", "amount": 30},
+        },
+        {
+            "name": "ordinary fallback",
+            "input": {"flag": True, "status": "other", "income": 10},
+            "output": {"special_status": "married", "amount": 30},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert _has_issue(result, "formula branch", "distinct")
+
+
+def test_exception_numeric_representations_do_not_fake_changed_effect():
+    source = "(1) Der Anspruch gilt nicht, wenn eine Befreiung vorliegt."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: amount
+    kind: derived
+    source: de/statute/estg/32a(1)
+    versions:
+      - formula: 'if exemption_applies: 0 else: 0.0'
+"""
+    cases = [
+        {
+            "name": "ordinary",
+            "input": {"exemption_applies": False},
+            "output": {"amount": 0},
+        },
+        {
+            "name": "exempt",
+            "input": {"exemption_applies": True},
+            "output": {"amount": 0.0},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert _has_issue(result, "exception", "test")
+
+
+def test_opposite_bare_boolean_predicate_cannot_witness_boundary():
+    source = "(1) Die Regel gilt für Einkommen bis 100 Euro."
+    content = _boundary_control_content(
+        formula="income > income_limit",
+        limit_versions="""\
+      - effective_from: '2026-01-01'
+        formula: 100""",
+    )
+    case = {
+        "name": "opposite endpoint",
+        "period": "2026",
+        "input": {"income": 100},
+        "output": {"eligible": False},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert _has_issue(result, "boundary", "100")

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -2048,14 +2048,6 @@ def test_narrative_piecewise_complete_zone_and_boundary_cases_pass():
             ],
             "exception",
         ),
-        (
-            [
-                case
-                for case in COMPLETE_COMPANION_TESTS
-                if case["name"] != "rounding down to full euro"
-            ],
-            "rounding",
-        ),
     ],
 )
 def test_missing_companion_coverage_fails(
@@ -2173,29 +2165,25 @@ def test_exception_toggle_from_another_source_branch_cannot_cover_exception():
 
 
 def test_unrelated_fractional_input_cannot_cover_rounding_rule():
-    content_with_unrelated_formula_amount = COMPANION_COVERAGE_CONTENT.replace(
-        "            )\n",
-        "            ) + unrelated_amount * 0\n",
+    source = (
+        "(1) Der Betrag wird als Einkommen * 2 berechnet und "
+        "auf volle Euro abzurunden."
+    )
+    content = _single_rounding_content(
+        "floor(income * multiplier + unrelated_amount * 0)",
     )
     test_cases = [
-        case
-        for case in COMPLETE_COMPANION_TESTS
-        if case["name"] != "rounding down to full euro"
-    ]
-    test_cases.append(
         {
-            **_companion_test("unrelated fractional input", 90, 4),
-            "input": {
-                "taxable_income": 90,
-                "exception_applies": False,
-                "unrelated_amount": 90.5,
-            },
-        }
-    )
+            "name": "unrelated fractional input",
+            "period": "2026",
+            "input": {"income": 10, "unrelated_amount": 90.5},
+            "output": {"amount": 20},
+        },
+    ]
 
     result = _analyze(
-        content_with_unrelated_formula_amount,
-        COMPANION_COVERAGE_SOURCE,
+        content,
+        source,
         test_cases=test_cases,
     )
 
@@ -4643,6 +4631,112 @@ def test_standalone_result_rounding_modifies_preceding_computation():
     assert not result.issues
 
 
+def test_standalone_result_rounding_requires_the_final_computation():
+    source = (
+        "(1) Der Betrag wird als Einkommen * 2 + Zuschlag berechnet. "
+        "Das Ergebnis ist auf volle Euro abzurunden."
+    )
+    content = _single_rounding_content(
+        "floor(income * multiplier) + supplement",
+    )
+    case = {
+        "name": "rounded component only",
+        "period": "2026",
+        "input": {"income": 10.25, "supplement": 0.25},
+        "output": {"amount": 20.25},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert _has_issue(result, "rounding", "fractional")
+
+
+@pytest.mark.parametrize(
+    "result_clause",
+    [
+        (
+            "6Der sich ergebende Steuerbetrag ist auf den nächsten vollen "
+            "Euro-Betrag abzurunden."
+        ),
+        (
+            "Satz 6: Der sich ergebende Steuerbetrag ist auf den nächsten "
+            "vollen Euro-Betrag abzurunden."
+        ),
+    ],
+)
+def test_statutory_result_rounding_attaches_to_preceding_computation(
+    result_clause: str,
+):
+    source = f"(1) Der Steuerbetrag ist Einkommen * 2. {result_clause}"
+    content = _single_rounding_content("floor(income * multiplier)")
+    if result_clause.startswith("6"):
+        content = content.replace(
+            """\
+  - name: amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions:""",
+            f"""\
+  - name: amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: de/statute/estg/32a
+              excerpt: {result_clause!r}
+    versions:""",
+        )
+    case = {
+        "name": "statutory result rounding",
+        "period": "2026",
+        "input": {"income": 10.25},
+        "output": {"amount": 20},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert not result.issues
+
+
+def test_integral_input_can_produce_fractional_rounding_operand():
+    source = (
+        "(1) Der Betrag wird als Einkommen * 1,5 berechnet und "
+        "auf volle Euro abgerundet."
+    )
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: multiplier
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 1.5}]
+  - name: amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 'floor(income * multiplier)'}]
+"""
+    case = {
+        "name": "computed fractional operand",
+        "input": {"income": 1},
+        "output": {"amount": 1},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert not result.issues
+
+
 def test_rounding_accepts_asserted_reached_intermediate_output():
     source = (
         "(1) Der Betrag wird als Einkommen * 2 berechnet und "
@@ -4714,13 +4808,23 @@ rules:
 
 
 @pytest.mark.parametrize(
-    ("formula", "expected_issue"),
+    ("rule_name", "formula", "expected_issue"),
     [
-        ("floor(unrounded_basic_allowance)", False),
-        ("floor(child_allowance)", True),
+        (
+            "basic_allowance",
+            "floor(unrounded_basic_allowance)",
+            False,
+        ),
+        (
+            "basic_allowance_amount",
+            "floor(unrounded_basic_allowance)",
+            False,
+        ),
+        ("basic_allowance", "floor(child_allowance)", True),
     ],
 )
 def test_single_rounding_binds_to_affected_output_stage(
+    rule_name: str,
     formula: str,
     expected_issue: bool,
 ):
@@ -4731,12 +4835,12 @@ module:
   source_verification:
     corpus_citation_path: de/statute/estg/32a
 rules:
-  - name: basic_allowance
+  - name: RULE_NAME
     kind: derived
     source: de/statute/estg/32a(1)
     versions:
       - formula: FORMULA
-""".replace("FORMULA", formula)
+""".replace("FORMULA", formula).replace("RULE_NAME", rule_name)
     operand_name = (
         "child_allowance"
         if "child_allowance" in formula
@@ -4745,7 +4849,7 @@ rules:
     case = {
         "name": "single pure rounding",
         "input": {operand_name: 10.5},
-        "output": {"basic_allowance": 10},
+        "output": {rule_name: 10},
     }
 
     result = _analyze(content, source, test_cases=[case])

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -677,7 +677,7 @@ rules: []
     assert _has_issue(result, "(2)", "source branch")
 
 
-def test_parent_deferral_does_not_blanket_nested_list_branches():
+def test_precise_non_root_deferral_covers_nested_list_branches():
     content = """\
 format: rulespec/v1
 module:
@@ -694,8 +694,7 @@ rules: []
 
     result = _analyze(content, source, test_cases=[])
 
-    assert _has_issue(result, "1.", "source branch")
-    assert _has_issue(result, "2.", "source branch")
+    assert not result.issues
 
 
 @pytest.mark.parametrize(
@@ -705,10 +704,47 @@ rules: []
         "Der Betrag ist die Summe aus Einkommen und Zuschlag.",
         "Der Betrag wird um 20 Prozent des Einkommens vermindert.",
         "Der Betrag ist durch drei geteilt zu berechnen.",
+        "Der Betrag erhöht sich um 25 Euro.",
+        "Der Betrag mindert sich um 25 Euro.",
+        "Der Betrag entspricht dem 1,5fachen des Einkommens.",
+        "Der Betrag beträgt 45 vom Hundert des Einkommens.",
     ],
 )
 def test_common_german_formula_language_is_computation(source: str):
     assert source_states_explicit_computation(source)
+
+
+@pytest.mark.parametrize(
+    ("source", "parameter_value"),
+    [
+        ("(1) Der Betrag erhöht sich um 25 Euro.", 25),
+        ("(1) Der Betrag mindert sich um 25 Euro.", 25),
+        ("(1) Der Betrag entspricht dem 1,5fachen des Einkommens.", 1.5),
+        ("(1) Der Betrag beträgt 45 vom Hundert des Einkommens.", 0.45),
+    ],
+)
+def test_common_german_formula_language_rejects_parameter_only(
+    source: str,
+    parameter_value: float,
+):
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: formula_constant
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: {parameter_value}
+"""
+
+    result = _analyze(content, source, test_cases=[])
+
+    assert _has_issue(result, "formula-output", "parameter-only")
 
 
 @pytest.mark.parametrize(
@@ -857,6 +893,29 @@ def test_exact_released_estg_32a_structure_paths():
     )
 
 
+def test_released_estg_32a_typed_absatz_6_deferral_passes():
+    source = "(6) " + RELEASED_ESTG_32A_BODY.split("\n(6) ", 1)[1]
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  deferred_outputs:
+    - output: de:statutes/estg/32a/6#surviving_spouse_splitting_tax
+      reason: >-
+        Absatz 6 cannot be computed until the exact joint-assessment
+        eligibility conditions under EStG section 26 are available.
+      blocked_by:
+        - de:statutes/estg/26#joint_assessment_eligibility
+rules: []
+"""
+
+    result = _analyze(content, source, test_cases=[])
+
+    assert not result.issues
+    assert not _pipeline_issues(content, source, test_cases=[])
+
+
 def test_released_estg_32a_constants_without_tariff_output_fail():
     values = (
         occurrence.value
@@ -969,6 +1028,59 @@ b) Von 74 Euro an: Einkommen * 3.
         branch.path[-1] == "b" and occurrence.value == 74
         for branch, occurrence in obligations
     )
+
+
+def test_common_german_range_boundaries_are_inventoried():
+    source = """\
+(1) Die Berechnung umfasst:
+1. Zwischen 100 und 200 Euro: Einkommen * 2;
+2. Nicht mehr als 300 Euro: Einkommen * 3.
+"""
+    branches = recognize_source_structure(source)
+    formula_branches = completeness_module._source_formula_branches(
+        source,
+        branches=branches,
+        active_branches=branches,
+        deferred_paths=set(),
+    )
+
+    obligations = completeness_module._source_boundary_obligations(
+        branches,
+        narrative_formula_branches=formula_branches,
+        extract_numeric_occurrences=DE_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+    boundaries = {
+        (branch.path, occurrence.value)
+        for branch, occurrence in obligations
+    }
+
+    assert (("1", "1"), 100) in boundaries
+    assert (("1", "1"), 200) in boundaries
+    assert (("1", "2"), 300) in boundaries
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "außer bei einer Befreiung",
+        "ausgenommen Härtefälle",
+        "abweichend von der Hauptregel",
+        "jedoch nicht bei Einzelveranlagung",
+    ],
+)
+def test_common_german_exception_language_is_inventoried(phrase: str):
+    source = f"(1) Die Steuer ist Einkommen * 2, {phrase}."
+    branches = recognize_source_structure(source)
+
+    obligations = completeness_module._source_exception_branches(
+        source,
+        branches=branches,
+        active_branches=branches,
+        deferred_paths=set(),
+    )
+
+    assert obligations
+    assert obligations[0].path == ("1",)
 
 
 def test_nested_editorial_omission_does_not_drop_operative_paragraph():
@@ -1105,6 +1217,70 @@ rules: []
 
     assert _has_issue(unrelated, "explicit source computation", "principal")
     assert not whole_unit.issues
+
+
+def test_each_formula_clause_requires_principal_output_evidence():
+    source = (
+        "(1) Der erste Betrag ist Einkommen * 2; "
+        "der zweite Betrag ist Einkommen * 3."
+    )
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: first_multiplier
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2
+  - name: unused_second_multiplier
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 3
+  - name: computed_amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: de/statute/estg/32a
+              excerpt: "Der erste Betrag ist Einkommen * 2;"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: income * first_multiplier
+"""
+    test_cases = [
+        {
+            "name": "first ordinary case",
+            "input": {"income": 10},
+            "output": {"computed_amount": 20},
+        },
+        {
+            "name": "second ordinary case",
+            "input": {"income": 20},
+            "output": {"computed_amount": 40},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=test_cases)
+
+    assert _has_issue(
+        result,
+        "formula-output",
+        "formula clause 2",
+        "principal",
+    )
 
 
 COMPANION_COVERAGE_SOURCE = """\

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -2062,33 +2062,55 @@ rules:
     versions:
       - effective_from: '2026-01-01'
         formula: |-
-          if married:
+          if married or high_income:
             income * married_multiplier
           else:
             income * single_multiplier
 """
 
-    def case(name: str, *, married: bool, income: int) -> dict[str, object]:
+    def case(
+        name: str,
+        *,
+        married: bool,
+        high_income: bool,
+        income: int,
+    ) -> dict[str, object]:
         return {
             "name": name,
-            "input": {"married": married, "income": income},
-            "output": {"amount": income * (2 if married else 3)},
+            "input": {
+                "married": married,
+                "high_income": high_income,
+                "income": income,
+            },
+            "output": {
+                "amount": income * (2 if married or high_income else 3)
+            },
         }
 
     repeated_married = _analyze(
         content,
         source,
         test_cases=[
-            case("married one", married=True, income=10),
-            case("married two", married=True, income=20),
+            case(
+                "married ordinary",
+                married=True,
+                high_income=False,
+                income=10,
+            ),
+            case(
+                "married high income",
+                married=True,
+                high_income=True,
+                income=20,
+            ),
         ],
     )
     both_branches = _analyze(
         content,
         source,
         test_cases=[
-            case("married", married=True, income=10),
-            case("single", married=False, income=10),
+            case("married", married=True, high_income=False, income=10),
+            case("single", married=False, high_income=False, income=10),
         ],
     )
 

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from axiom_encode.harness.source_completeness import (
     analyze_complete_source_unit,
+    recognize_source_structure,
+    source_states_explicit_computation,
 )
 from axiom_encode.harness.validator_pipeline import (
+    ValidatorPipeline,
     extract_named_scalar_occurrences,
     extract_numeric_occurrences_from_text,
     numeric_value_is_grounded,
@@ -39,6 +44,28 @@ def _has_issue(result, *needles: str) -> bool:
     )
 
 
+def _pipeline_issues(
+    content: str,
+    authoritative_source_text: str,
+    *,
+    test_cases: list[object] | None = None,
+) -> list[str]:
+    pipeline = ValidatorPipeline(
+        policy_repo_path=Path("/tmp/rulespec-de"),
+        axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+        local_corpus_release=None,
+        enable_oracles=False,
+        require_complete_source_unit=True,
+    )
+    return pipeline._complete_source_unit_issues(
+        content,
+        validation_source_texts={
+            CORPUS_CITATION_PATH: authoritative_source_text,
+        },
+        test_cases=test_cases,
+    )
+
+
 def _formula_test(
     name: str,
     taxable_income: int,
@@ -69,36 +96,42 @@ rules:
   - name: first_zone_start
     kind: parameter
     dtype: Money
+    source: de/statute/estg/32a(1)
     versions:
       - effective_from: '2026-01-01'
         formula: 12349
   - name: first_zone_end
     kind: parameter
     dtype: Money
+    source: de/statute/estg/32a(1)
     versions:
       - effective_from: '2026-01-01'
         formula: 17799
   - name: first_zone_quadratic_coefficient
     kind: parameter
     dtype: Decimal
+    source: de/statute/estg/32a(1)
     versions:
       - effective_from: '2026-01-01'
         formula: 914.51
   - name: first_zone_linear_coefficient
     kind: parameter
     dtype: Decimal
+    source: de/statute/estg/32a(1)
     versions:
       - effective_from: '2026-01-01'
         formula: 1400
   - name: basic_allowance
     kind: parameter
     dtype: Money
+    source: de/statute/estg/32a(1)
     versions:
       - effective_from: '2026-01-01'
         formula: 12348
   - name: tariff_zone_scale
     kind: parameter
     dtype: Decimal
+    source: de/statute/estg/32a(1)
     versions:
       - effective_from: '2026-01-01'
         formula: 10000
@@ -110,6 +143,10 @@ rules:
     assert result.covered_source_numeric_occurrence_count == 6
     assert result.missing_source_numeric_occurrence_count == 0
     assert _has_issue(result, "principal", "derived/relation")
+    assert any(
+        "principal derived/relation" in issue
+        for issue in _pipeline_issues(constants_only, source, test_cases=[])
+    )
 
 
 ABSATZ_1 = "(1) Die Steuer ist das Einkommen multipliziert mit 10 Prozent."
@@ -126,6 +163,7 @@ ABSATZ_1_RULES = """\
   - name: tariff_rate
     kind: parameter
     dtype: Rate
+    source: de/statute/estg/32a(1)
     metadata:
       proof:
         atoms:
@@ -140,6 +178,7 @@ ABSATZ_1_RULES = """\
   - name: tariff_income_tax_amount
     kind: derived
     dtype: Money
+    source: de/statute/estg/32a(1)
     metadata:
       proof:
         atoms:
@@ -157,6 +196,7 @@ ABSATZ_5_RULE = """\
   - name: joint_assessment_tariff_income_tax_amount
     kind: derived
     dtype: Money
+    source: de/statute/estg/32a(5)
     metadata:
       proof:
         atoms:
@@ -207,6 +247,14 @@ def test_omitting_absatz_5_fails():
     )
 
     assert _has_issue(result, "(5)", "source branch")
+    assert any(
+        "(5)" in issue and "source branch" in issue.lower()
+        for issue in _pipeline_issues(
+            _encoded_absatz_content(include_absatz_5=False),
+            f"{ABSATZ_1}\n{ABSATZ_5}",
+            test_cases=ENCODED_FORMULA_TESTS,
+        )
+    )
 
 
 def test_silently_omitting_absatz_6_fails():
@@ -217,6 +265,14 @@ def test_silently_omitting_absatz_6_fails():
     )
 
     assert _has_issue(result, "(6)", "source branch")
+    assert any(
+        "(6)" in issue and "source branch" in issue.lower()
+        for issue in _pipeline_issues(
+            _encoded_absatz_content(include_absatz_5=True),
+            f"{ABSATZ_1}\n{ABSATZ_5}\n{ABSATZ_6}",
+            test_cases=ENCODED_FORMULA_TESTS,
+        )
+    )
 
 
 def test_precise_typed_absatz_6_deferral_passes():
@@ -243,6 +299,11 @@ def test_precise_typed_absatz_6_deferral_passes():
     )
 
     assert not result.issues
+    assert not _pipeline_issues(
+        content,
+        f"{ABSATZ_1}\n{ABSATZ_5}\n{ABSATZ_6}",
+        test_cases=ENCODED_FORMULA_TESTS,
+    )
 
 
 def test_scalar_only_source_passes_with_parameter_snapshot():
@@ -257,6 +318,7 @@ rules:
   - name: allowance_amount
     kind: parameter
     dtype: Money
+    source: de/statute/estg/32a(1)
     metadata:
       proof:
         atoms:
@@ -284,6 +346,7 @@ rules:
     assert result.source_numeric_occurrence_count == 1
     assert result.covered_source_numeric_occurrence_count == 1
     assert result.missing_source_numeric_occurrence_count == 0
+    assert not _pipeline_issues(content, source, test_cases=test_cases)
 
 
 def test_summary_omission_cannot_hide_authoritative_source_number():
@@ -309,6 +372,10 @@ rules:
     assert result.covered_source_numeric_occurrence_count == 1
     assert result.missing_source_numeric_occurrence_count == 1
     assert _has_issue(result, "73", "authoritative")
+    assert any(
+        "authoritative corpus numeric value 73" in issue.lower()
+        for issue in _pipeline_issues(content, source, test_cases=[])
+    )
 
 
 @pytest.mark.parametrize(
@@ -355,6 +422,148 @@ rules: []
     assert _has_issue(result, "(6)", "deferral")
 
 
+def test_deferral_cannot_name_its_own_branch_as_missing_dependency():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  summary: Splittingverfahren.
+  deferred_outputs:
+    - output: de:statutes/estg/32a/6#splitting_rule
+      reason: Absatz 6 fehlt.
+rules: []
+"""
+
+    result = _analyze(content, ABSATZ_6, test_cases=[])
+
+    assert _has_issue(result, "(6)", "deferral", "dependency")
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "Der Betrag ist ein Drittel des Einkommens.",
+        "Der Betrag ist die Summe aus Einkommen und Zuschlag.",
+        "Der Betrag wird um 20 Prozent des Einkommens vermindert.",
+        "Der Betrag ist durch drei geteilt zu berechnen.",
+    ],
+)
+def test_common_german_formula_language_is_computation(source: str):
+    assert source_states_explicit_computation(source)
+
+
+def test_scalar_amount_language_is_not_computation():
+    assert not source_states_explicit_computation(
+        "Der Freibetrag beträgt 259 Euro."
+    )
+
+
+def test_glued_satz_markers_are_paragraph_children_not_list_children():
+    source = """\
+(1) 1Die tarifliche Einkommensteuer wird nach Nummern berechnet.
+1. Grundtarif;
+5. Spitzentarif.3Die Steuer ist abzurunden.4Die Grenze gilt entsprechend.
+(6) 1Das Verfahren gilt für Ehegatten.
+1. Voraussetzung eins,
+2. Voraussetzung zwei,
+c) Voraussetzung drei.2Voraussetzung ist außerdem der Status.
+"""
+
+    paths = {branch.path for branch in recognize_source_structure(source)}
+
+    assert ("1", "satz-3") in paths
+    assert ("1", "satz-4") in paths
+    assert ("6", "satz-2") in paths
+    assert ("1", "5", "satz-3") not in paths
+    assert ("6", "2", "c", "satz-2") not in paths
+
+
+RELEASED_ESTG_32A_BODY = """\
+(1) 1Die tarifliche Einkommensteuer bemisst sich nach dem auf volle Euro abgerundeten zu versteuernden Einkommen. 2Sie beträgt ab dem Veranlagungszeitraum 2026 vorbehaltlich der §§ 32b, 32d, 34, 34a, 34b und 34c jeweils in Euro für zu versteuernde Einkommen
+1. bis 12 348 Euro (Grundfreibetrag):0;
+2. von 12 349 Euro bis 17 799 Euro:(914,51 • y + 1 400) • y;
+3. von 17 800 Euro bis 69 878 Euro:(173,10 • z + 2 397) • z + 1 034,87;
+4. von 69 879 Euro bis 277 825 Euro:0,42 • x – 11 135,63;
+5. von 277 826 Euro an:0,45 • x – 19 470,38.3Die Größe „y“ ist ein Zehntausendstel des den Grundfreibetrag übersteigenden Teils des auf einen vollen Euro-Betrag abgerundeten zu versteuernden Einkommens. 4Die Größe „z“ ist ein Zehntausendstel des 17 799 Euro übersteigenden Teils des auf einen vollen Euro-Betrag abgerundeten zu versteuernden Einkommens. 5Die Größe „x“ ist das auf einen vollen Euro-Betrag abgerundete zu versteuernde Einkommen. 6Der sich ergebende Steuerbetrag ist auf den nächsten vollen Euro-Betrag abzurunden.
+(2) bis (4) (weggefallen)
+(5) Bei Ehegatten, die nach den §§ 26, 26b zusammen zur Einkommensteuer veranlagt werden, beträgt die tarifliche Einkommensteuer vorbehaltlich der §§ 32b, 32d, 34, 34a, 34b und 34c das Zweifache des Steuerbetrags, der sich für die Hälfte ihres gemeinsam zu versteuernden Einkommens nach Absatz 1 ergibt (Splitting-Verfahren).
+(6) 1Das Verfahren nach Absatz 5 ist auch anzuwenden zur Berechnung der tariflichen Einkommensteuer für das zu versteuernde Einkommen
+1. bei einem verwitweten Steuerpflichtigen für den Veranlagungszeitraum, der dem Kalenderjahr folgt, in dem der Ehegatte verstorben ist, wenn der Steuerpflichtige und sein verstorbener Ehegatte im Zeitpunkt seines Todes die Voraussetzungen des § 26 Absatz 1 Satz 1 erfüllt haben,
+2. bei einem Steuerpflichtigen, dessen Ehe in dem Kalenderjahr, in dem er sein Einkommen bezogen hat, aufgelöst worden ist, wenn in diesem Kalenderjahr
+a) der Steuerpflichtige und sein bisheriger Ehegatte die Voraussetzungen des § 26 Absatz 1 Satz 1 erfüllt haben,
+b) der bisherige Ehegatte wieder geheiratet hat und
+c) der bisherige Ehegatte und dessen neuer Ehegatte ebenfalls die Voraussetzungen des § 26 Absatz 1 Satz 1 erfüllen.2Voraussetzung für die Anwendung des Satzes 1 ist, dass der Steuerpflichtige nicht nach den §§ 26, 26a einzeln zur Einkommensteuer veranlagt wird."""
+
+
+def test_exact_released_estg_32a_structure_paths():
+    paths = {
+        branch.path
+        for branch in recognize_source_structure(RELEASED_ESTG_32A_BODY)
+    }
+
+    assert {("1",), ("5",), ("6",)} <= paths
+    assert ("2",) not in paths
+    assert {("1", str(number)) for number in range(1, 6)} <= paths
+    assert {("6", "1"), ("6", "2")} <= paths
+    assert {("6", "2", letter) for letter in ("a", "b", "c")} <= paths
+    assert {("1", f"satz-{number}") for number in range(1, 7)} <= paths
+    assert {("6", "satz-1"), ("6", "satz-2")} <= paths
+    assert not any(
+        path[:2] == ("1", "5") and path[-1].startswith("satz-")
+        for path in paths
+    )
+    assert not any(
+        path[:3] == ("6", "2", "c") and path[-1].startswith("satz-")
+        for path in paths
+    )
+
+
+def test_nested_editorial_omission_does_not_drop_operative_paragraph():
+    source = """\
+(1) Die Hauptregel gilt:
+1. weggefallen;
+2. Die operative Ausnahme gilt.
+"""
+
+    branches = recognize_source_structure(source)
+    paths = {branch.path for branch in branches}
+
+    assert ("1",) in paths
+    assert ("1", "1") not in paths
+    assert ("1", "2") in paths
+
+
+def test_unrelated_proof_citation_cannot_cover_requested_branch():
+    source = "(1) Die Steuer ist Einkommen * 10."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  summary: Tarif.
+rules:
+  - name: tariff_income_tax_amount
+    kind: derived
+    dtype: Money
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: de/statute/bgbl/example
+              excerpt: "Die Steuer ist Einkommen * 10."
+    versions:
+      - effective_from: '2026-01-01'
+        formula: taxable_income * 10
+"""
+
+    result = _analyze(content, source, test_cases=[])
+
+    assert _has_issue(result, "(1)", "source branch")
+
+
 COMPANION_COVERAGE_SOURCE = """\
 (1) Die Steuer wird nach folgenden Tarifzweigen berechnet:
 1. Bis 100 Euro: Einkommen * 5 Prozent;
@@ -374,30 +583,35 @@ rules:
   - name: lower_tariff_rate_percent
     kind: parameter
     dtype: Decimal
+    source: de/statute/estg/32a(1)(1)
     versions:
       - effective_from: '2026-01-01'
         formula: 5
   - name: upper_tariff_rate_percent
     kind: parameter
     dtype: Decimal
+    source: de/statute/estg/32a(1)(2)
     versions:
       - effective_from: '2026-01-01'
         formula: 7
   - name: lower_tariff_maximum
     kind: parameter
     dtype: Money
+    source: de/statute/estg/32a(1)(1)
     versions:
       - effective_from: '2026-01-01'
         formula: 100
   - name: upper_tariff_minimum
     kind: parameter
     dtype: Money
+    source: de/statute/estg/32a(1)(2)
     versions:
       - effective_from: '2026-01-01'
         formula: 101
   - name: tariff_income_tax_amount
     kind: derived
     dtype: Money
+    source: de/statute/estg/32a(1)
     metadata:
       proof:
         atoms:
@@ -451,8 +665,8 @@ COMPLETE_COMPANION_TESTS = [
     _companion_test("upper tariff formula branch", 110, 7),
     _companion_test("lower exact tariff boundary", 100, 5),
     _companion_test("upper exact tariff boundary", 101, 7),
-    _companion_test("exception does not apply", 110, 7),
-    _companion_test("exception applies", 110, 0, exception_applies=True),
+    _companion_test("exception does not apply", 90, 4),
+    _companion_test("exception applies", 90, 0, exception_applies=True),
     _companion_test("rounding down to full euro", 90.5, 4),
 ]
 
@@ -470,7 +684,14 @@ def test_complete_companion_suite_covers_source_controls():
 @pytest.mark.parametrize(
     ("test_cases", "expected_issue_term"),
     [
-        ([COMPLETE_COMPANION_TESTS[0]], "formula branch"),
+        (
+            [
+                case
+                for case in COMPLETE_COMPANION_TESTS
+                if case["input"]["taxable_income"] <= 100
+            ],
+            "formula branch",
+        ),
         (
             [
                 case
@@ -508,3 +729,82 @@ def test_missing_companion_coverage_fails(
     )
 
     assert _has_issue(result, expected_issue_term, "test")
+
+
+def test_unrelated_numeric_input_cannot_cover_tariff_boundary():
+    test_cases = [
+        case
+        for case in COMPLETE_COMPANION_TESTS
+        if "exact tariff boundary" not in case["name"]
+    ]
+    test_cases.append(
+        {
+            **_companion_test("unrelated numeric input", 90, 4),
+            "input": {
+                "taxable_income": 90,
+                "exception_applies": False,
+                "unrelated_amount": 101,
+            },
+        }
+    )
+
+    result = _analyze(
+        COMPANION_COVERAGE_CONTENT,
+        COMPANION_COVERAGE_SOURCE,
+        test_cases=test_cases,
+    )
+
+    assert _has_issue(result, "boundary", "test")
+
+
+def test_unrelated_boolean_toggle_cannot_cover_source_exception():
+    test_cases = [
+        case
+        for case in COMPLETE_COMPANION_TESTS
+        if case["name"] != "exception applies"
+    ]
+    for value in (False, True):
+        test_cases.append(
+            {
+                **_companion_test(f"unrelated toggle {value}", 90, 4),
+                "input": {
+                    "taxable_income": 90,
+                    "exception_applies": False,
+                    "unrelated_toggle": value,
+                },
+            }
+        )
+
+    result = _analyze(
+        COMPANION_COVERAGE_CONTENT,
+        COMPANION_COVERAGE_SOURCE,
+        test_cases=test_cases,
+    )
+
+    assert _has_issue(result, "exception", "test")
+
+
+def test_unrelated_fractional_input_cannot_cover_rounding_rule():
+    test_cases = [
+        case
+        for case in COMPLETE_COMPANION_TESTS
+        if case["name"] != "rounding down to full euro"
+    ]
+    test_cases.append(
+        {
+            **_companion_test("unrelated fractional input", 90, 4),
+            "input": {
+                "taxable_income": 90,
+                "exception_applies": False,
+                "unrelated_amount": 90.5,
+            },
+        }
+    )
+
+    result = _analyze(
+        COMPANION_COVERAGE_CONTENT,
+        COMPANION_COVERAGE_SOURCE,
+        test_cases=test_cases,
+    )
+
+    assert _has_issue(result, "rounding", "test")

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -10,6 +10,7 @@ from axiom_encode.harness import validator_pipeline as validator_pipeline_module
 from axiom_encode.harness.source_completeness import (
     analyze_complete_source_unit,
     authoritative_numeric_recall_text,
+    collect_artifact_numeric_bindings,
     collect_artifact_numeric_values,
     recognize_source_structure,
     source_states_explicit_computation,
@@ -33,6 +34,8 @@ def _analyze(
     authoritative_source_text: str,
     *,
     test_cases: list[object] | None = None,
+    artifact_numeric_values: tuple[float, ...] | None = None,
+    artifact_numeric_bindings: tuple[tuple[str, float], ...] | None = None,
 ):
     return analyze_complete_source_unit(
         content,
@@ -42,6 +45,8 @@ def _analyze(
         extract_numeric_occurrences=DE_NUMERIC_OCCURRENCE_EXTRACTOR,
         extract_named_scalars=extract_named_scalar_occurrences,
         numeric_value_is_grounded=numeric_value_is_grounded,
+        artifact_numeric_values=artifact_numeric_values,
+        artifact_numeric_bindings=artifact_numeric_bindings,
     )
 
 
@@ -1013,6 +1018,87 @@ rules:
     )
 
     assert values == (5.0,)
+
+
+def test_imported_scalar_bindings_witness_exact_formula_branches():
+    source = """\
+(1) Bei Ehegatten ist der Betrag Einkommen * 2.
+(2) Bei Alleinstehenden ist der Betrag Einkommen * 3.
+"""
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+imports:
+  - de:statutes/constants#married_multiplier
+  - de:statutes/constants#single_multiplier
+rules:
+  - name: amount
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1); de/statute/estg/32a(2)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if married:
+            income * married_multiplier
+          else:
+            income * single_multiplier
+"""
+    bindings = (
+        ("married_multiplier", 2.0),
+        ("single_multiplier", 3.0),
+    )
+    cases = [
+        {
+            "name": "married",
+            "input": {"married": True, "income": 10},
+            "output": {"amount": 20},
+        },
+        {
+            "name": "single",
+            "input": {"married": False, "income": 10},
+            "output": {"amount": 30},
+        },
+    ]
+
+    result = _analyze(
+        content,
+        source,
+        test_cases=cases,
+        artifact_numeric_values=(2.0, 3.0),
+        artifact_numeric_bindings=bindings,
+    )
+
+    assert not result.issues
+
+
+def test_artifact_numeric_bindings_preserve_imported_symbol_names():
+    content = """\
+format: rulespec/v1
+imports:
+  - de:statutes/constants#needed_amount
+rules: []
+"""
+    imported = """\
+format: rulespec/v1
+rules:
+  - name: needed_amount
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 5
+"""
+
+    bindings = collect_artifact_numeric_bindings(
+        content,
+        extract_named_scalars=extract_named_scalar_occurrences,
+        imported_symbol_contents=(("needed_amount", imported),),
+    )
+
+    assert bindings == (("needed_amount", 5.0),)
 
 
 def test_complete_import_inventory_does_not_walk_transitive_same_name(

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -4254,6 +4254,144 @@ def test_negative_boundary_prose_inverts_boolean_applicability():
     assert not result.issues
 
 
+def test_repeated_boundary_value_keeps_fragment_span_and_polarity():
+    source = (
+        "(1) Die Regel gilt für Einkommen bis 100 Euro. "
+        "Einkommen bis 100 Euro begründen keine Berechtigung."
+    )
+    branches = recognize_source_structure(source)
+    obligations = completeness_module._source_boundary_obligations(
+        branches,
+        extract_numeric_occurrences=DE_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+    repeated = [
+        (branch, occurrence)
+        for branch, occurrence in obligations
+        if occurrence.value == 100
+    ]
+
+    assert len(repeated) == 2
+    assert len({occurrence.start for _branch, occurrence in repeated}) == 2
+    assert [
+        completeness_module._source_interval_and_polarity_for_boundary(
+            branch,
+            occurrence,
+            extract_numeric_occurrences=DE_NUMERIC_OCCURRENCE_EXTRACTOR,
+        )[1]
+        for branch, occurrence in repeated
+    ] == [1, -1]
+
+
+def test_repeated_opposite_boundary_requires_both_polarity_witnesses():
+    source = (
+        "(1) Die Regel gilt für Einkommen bis 100 Euro. "
+        "Einkommen bis 100 Euro begründen keine Berechtigung."
+    )
+    content = _boundary_control_content(
+        formula="income <= income_limit",
+        limit_versions="""\
+      - effective_from: '2026-01-01'
+        formula: 100""",
+        extra_rules="""\
+  - name: excluded_income_limit
+    kind: parameter
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 100
+""",
+    )
+    case = {
+        "name": "positive endpoint only",
+        "period": "2026",
+        "input": {"income": 100},
+        "output": {"eligible": True},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert _has_issue(result, "boundary", "100")
+
+
+@pytest.mark.parametrize(
+    ("formula", "endpoint_output", "expected_issue"),
+    [
+        (
+            "if income <= income_limit: holds else: not_holds",
+            "holds",
+            False,
+        ),
+        (
+            "if income <= income_limit: not_holds else: holds",
+            "not_holds",
+            True,
+        ),
+    ],
+)
+def test_judgment_boundary_polarity_is_checked(
+    formula: str,
+    endpoint_output: str,
+    expected_issue: bool,
+):
+    source = "(1) Die Regel gilt für Einkommen bis 100 Euro."
+    content = _boundary_control_content(
+        formula=formula,
+        limit_versions="""\
+      - effective_from: '2026-01-01'
+        formula: 100""",
+    ).replace("dtype: bool", "dtype: Judgment")
+    case = {
+        "name": "Judgment endpoint",
+        "period": "2026",
+        "input": {"income": 100},
+        "output": {"eligible": endpoint_output},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert _has_issue(result, "boundary", "100") is expected_issue
+
+
+@pytest.mark.parametrize(
+    ("formula", "endpoint_output", "expected_issue"),
+    [
+        (
+            "match income <= income_limit: true => true; false => false",
+            True,
+            False,
+        ),
+        (
+            "match income <= income_limit: true => false; false => true",
+            False,
+            True,
+        ),
+    ],
+)
+def test_match_boundary_selector_preserves_polarity(
+    formula: str,
+    endpoint_output: bool,
+    expected_issue: bool,
+):
+    source = "(1) Die Regel gilt für Einkommen bis 100 Euro."
+    content = _boundary_control_content(
+        formula=formula,
+        limit_versions="""\
+      - effective_from: '2026-01-01'
+        formula: 100""",
+    )
+    case = {
+        "name": "match endpoint",
+        "period": "2026",
+        "input": {"income": 100},
+        "output": {"eligible": endpoint_output},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert _has_issue(result, "boundary", "100") is expected_issue
+
+
 @pytest.mark.parametrize(
     ("wording", "formula"),
     [
@@ -5250,17 +5388,190 @@ def test_exception_toggle_cases_must_share_period():
     assert _has_issue(result, "exception", "test")
 
 
+def test_boolean_exception_selector_must_block_not_enable():
+    source = "(1) Der Anspruch gilt nicht, wenn eine Befreiung vorliegt."
+    content = _exception_control_content(
+        "if exemption_applies: true else: false"
+    )
+    cases = [
+        {
+            "name": "ordinary",
+            "input": {"exemption_applies": False},
+            "output": {"result": False},
+        },
+        {
+            "name": "enabling exception",
+            "input": {"exemption_applies": True},
+            "output": {"result": True},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert _has_issue(result, "exception", "test")
+
+
+def test_numeric_exclusion_effect_is_direction_neutral_without_amount_wording():
+    source = "(1) Der Abzug gilt nicht, wenn eine Befreiung vorliegt."
+    content = _exception_control_content(
+        "if exemption_applies: tax_without_deduction "
+        "else: tax_with_deduction"
+    )
+    cases = [
+        {
+            "name": "deduction applies",
+            "input": {
+                "exemption_applies": False,
+                "tax_with_deduction": 10,
+                "tax_without_deduction": 20,
+            },
+            "output": {"result": 10},
+        },
+        {
+            "name": "deduction excluded",
+            "input": {
+                "exemption_applies": True,
+                "tax_with_deduction": 10,
+                "tax_without_deduction": 20,
+            },
+            "output": {"result": 20},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert not result.issues
+
+
 @pytest.mark.parametrize(
-    ("formula", "ordinary_output", "blocking_output"),
+    ("formula", "ordinary_output", "exception_output", "expected_issue"),
     [
-        ("if exemption_applies: true else: false", False, True),
-        ("if exemption_applies: 20 else: 10", 10, 20),
+        ("if has_certificate: true else: false", False, True, True),
+        ("if has_certificate: false else: true", True, False, False),
     ],
 )
-def test_exception_selector_must_block_not_enable(
+def test_german_ausser_binds_neutral_selector_orientation(
     formula: str,
-    ordinary_output: bool | int,
-    blocking_output: bool | int,
+    ordinary_output: bool,
+    exception_output: bool,
+    expected_issue: bool,
+):
+    source = "(1) Der Anspruch besteht, außer bei einer Bescheinigung."
+    content = _exception_control_content(formula)
+    cases = [
+        {
+            "name": "without certificate",
+            "input": {"has_certificate": False},
+            "output": {"result": ordinary_output},
+        },
+        {
+            "name": "with certificate",
+            "input": {"has_certificate": True},
+            "output": {"result": exception_output},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert _has_issue(result, "exception", "test") is expected_issue
+
+
+@pytest.mark.parametrize(
+    ("formula", "ordinary_input", "exception_input"),
+    [
+        ("if no_exemption: true else: false", True, False),
+        ("no_exemption", True, False),
+        ("if has_certificate: false else: true", False, True),
+        ("not has_certificate", False, True),
+        ("exemption_applies == false", False, True),
+    ],
+)
+def test_exception_selector_forms_preserve_source_orientation(
+    formula: str,
+    ordinary_input: bool,
+    exception_input: bool,
+):
+    selector_name = (
+        "no_exemption"
+        if "no_exemption" in formula
+        else (
+            "has_certificate"
+            if "has_certificate" in formula
+            else "exemption_applies"
+        )
+    )
+    source_condition = (
+        "eine Bescheinigung vorliegt"
+        if selector_name == "has_certificate"
+        else "eine Befreiung vorliegt"
+    )
+    source = f"(1) Der Anspruch gilt nicht, wenn {source_condition}."
+    content = _exception_control_content(formula)
+    cases = [
+        {
+            "name": "ordinary",
+            "input": {selector_name: ordinary_input},
+            "output": {"result": True},
+        },
+        {
+            "name": "exception",
+            "input": {selector_name: exception_input},
+            "output": {"result": False},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert not result.issues
+
+
+def test_compound_direct_exception_expression_is_discovered():
+    source = (
+        "(1) Der Anspruch gilt nicht, wenn eine Befreiung oder Sperre vorliegt."
+    )
+    content = _exception_control_content(
+        "not (exemption_applies or barred)"
+    )
+    cases = [
+        {
+            "name": "ordinary",
+            "input": {"exemption_applies": False, "barred": False},
+            "output": {"result": True},
+        },
+        {
+            "name": "exempt",
+            "input": {"exemption_applies": True, "barred": False},
+            "output": {"result": False},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert not result.issues
+
+
+@pytest.mark.parametrize(
+    ("formula", "ordinary_output", "exception_output", "expected_issue"),
+    [
+        (
+            "match exemption_applies: true => false; false => true",
+            True,
+            False,
+            False,
+        ),
+        (
+            "match exemption_applies: true => true; false => false",
+            False,
+            True,
+            True,
+        ),
+    ],
+)
+def test_match_exception_selector_preserves_polarity(
+    formula: str,
+    ordinary_output: bool,
+    exception_output: bool,
+    expected_issue: bool,
 ):
     source = "(1) Der Anspruch gilt nicht, wenn eine Befreiung vorliegt."
     content = _exception_control_content(formula)
@@ -5271,9 +5582,484 @@ def test_exception_selector_must_block_not_enable(
             "output": {"result": ordinary_output},
         },
         {
-            "name": "blocking",
+            "name": "exception",
             "input": {"exemption_applies": True},
-            "output": {"result": blocking_output},
+            "output": {"result": exception_output},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert _has_issue(result, "exception", "test") is expected_issue
+
+
+def test_exception_semantics_override_ordinary_word_in_selector_name():
+    source = "(1) Der Anspruch gilt nicht, wenn eine Ausnahme vorliegt."
+    content = _exception_control_content(
+        "if eligible_for_exception: false else: true"
+    )
+    cases = [
+        {
+            "name": "ordinary",
+            "input": {"eligible_for_exception": False},
+            "output": {"result": True},
+        },
+        {
+            "name": "exception",
+            "input": {"eligible_for_exception": True},
+            "output": {"result": False},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert not result.issues
+
+
+@pytest.mark.parametrize(
+    ("formula", "eligible_output", "ineligible_output", "expected_issue"),
+    [
+        ("if eligible: true else: false", True, False, False),
+        ("if eligible: false else: true", False, True, True),
+    ],
+)
+def test_positive_ordinary_selector_is_false_active_for_ineligibility(
+    formula: str,
+    eligible_output: bool,
+    ineligible_output: bool,
+    expected_issue: bool,
+):
+    source = "(1) Der Anspruch gilt nicht, wenn keine Berechtigung besteht."
+    content = _exception_control_content(formula)
+    cases = [
+        {
+            "name": "eligible",
+            "input": {"eligible": True},
+            "output": {"result": eligible_output},
+        },
+        {
+            "name": "ineligible",
+            "input": {"eligible": False},
+            "output": {"result": ineligible_output},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert _has_issue(result, "exception", "test") is expected_issue
+
+
+@pytest.mark.parametrize(
+    ("source", "selector_name", "formula"),
+    [
+        (
+            "(1) Der Anspruch gilt nicht, wenn keine Bescheinigung vorliegt.",
+            "has_certificate",
+            "has_certificate",
+        ),
+        (
+            "(1) Der Anspruch gilt nicht, wenn kein Kind vorhanden ist.",
+            "kind_vorhanden",
+            "kind_vorhanden",
+        ),
+        (
+            "(1) Der Anspruch gilt nicht, wenn das Kind nicht vorhanden ist.",
+            "kind_vorhanden",
+            "kind_vorhanden",
+        ),
+        (
+            "(1) The claim does not apply when the child is not present.",
+            "child_present",
+            "child_present",
+        ),
+    ],
+)
+def test_source_negation_controls_neutral_selector_orientation(
+    source: str,
+    selector_name: str,
+    formula: str,
+):
+    content = _exception_control_content(formula)
+    cases = [
+        {
+            "name": "positive fact",
+            "input": {selector_name: True},
+            "output": {"result": True},
+        },
+        {
+            "name": "missing fact",
+            "input": {selector_name: False},
+            "output": {"result": False},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert not result.issues
+
+
+def test_adjectival_source_negation_rejects_opposite_selector_polarity():
+    source = (
+        "(1) Der Anspruch gilt nicht, wenn das Kind nicht vorhanden ist."
+    )
+    content = _exception_control_content("not kind_vorhanden")
+    cases = [
+        {
+            "name": "child absent",
+            "input": {"kind_vorhanden": False},
+            "output": {"result": True},
+        },
+        {
+            "name": "child present",
+            "input": {"kind_vorhanden": True},
+            "output": {"result": False},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert _has_issue(result, "exception", "test")
+
+
+def test_unrelated_excluding_selector_cannot_witness_source_exception():
+    source = "(1) Der Anspruch gilt nicht, wenn eine Befreiung vorliegt."
+    content = _exception_control_content(
+        "if bonus_applies: false else: true"
+    )
+    cases = [
+        {
+            "name": "without bonus",
+            "input": {"bonus_applies": False},
+            "output": {"result": True},
+        },
+        {
+            "name": "with bonus",
+            "input": {"bonus_applies": True},
+            "output": {"result": False},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert _has_issue(result, "exception", "test")
+
+
+def test_selector_relevance_uses_tokens_not_substrings():
+    source = "(1) The claim does not apply at a separate status."
+    content = _exception_control_content("if rate: false else: true")
+    cases = [
+        {
+            "name": "rate false",
+            "input": {"rate": False},
+            "output": {"result": True},
+        },
+        {
+            "name": "rate true",
+            "input": {"rate": True},
+            "output": {"result": False},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert _has_issue(result, "exception", "test")
+
+
+@pytest.mark.parametrize(
+    ("exception_value", "expected_issue"),
+    [(5, True), (0, False)],
+)
+def test_explicit_numeric_zero_exception_reaches_zero(
+    exception_value: int,
+    expected_issue: bool,
+):
+    source = "(1) Im Ausnahmefall beträgt der Betrag 0 Euro."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: zero_amount
+    kind: parameter
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 0}]
+  - name: result
+    kind: derived
+    source: de/statute/estg/32a(1)
+    versions:
+      - formula: 'if exception_applies: EXCEPTION_VALUE else: 10'
+""".replace("EXCEPTION_VALUE", str(exception_value))
+    cases = [
+        {
+            "name": "ordinary",
+            "input": {"exception_applies": False},
+            "output": {"result": 10},
+        },
+        {
+            "name": "exception",
+            "input": {"exception_applies": True},
+            "output": {"result": exception_value},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert _has_issue(result, "exception", "test") is expected_issue
+
+
+def test_generic_deviation_may_increase_the_principal_output():
+    source = "(1) Abweichend von der Hauptregel erhöht eine Ausnahme den Betrag."
+    content = _exception_control_content(
+        "if exception_applies: income + bonus else: income"
+    )
+    cases = [
+        {
+            "name": "ordinary",
+            "input": {"exception_applies": False, "income": 10, "bonus": 5},
+            "output": {"result": 10},
+        },
+        {
+            "name": "exception",
+            "input": {"exception_applies": True, "income": 10, "bonus": 5},
+            "output": {"result": 15},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert not result.issues
+
+
+def test_mixed_exception_clauses_keep_local_effect_requirements():
+    source = """\
+(1) Abweichend von der Hauptregel erhöht eine Ausnahme den Betrag.
+Der Anspruch besteht, außer bei einer Befreiung.
+"""
+    content = _exception_control_content(
+        "if exemption_applies: 0 "
+        "else: if exception_applies: 20 else: 10"
+    )
+    cases = [
+        {
+            "name": "ordinary",
+            "input": {
+                "exception_applies": False,
+                "exemption_applies": False,
+            },
+            "output": {"result": 10},
+        },
+        {
+            "name": "increasing exception",
+            "input": {
+                "exception_applies": True,
+                "exemption_applies": False,
+            },
+            "output": {"result": 20},
+        },
+        {
+            "name": "blocking exemption",
+            "input": {
+                "exception_applies": False,
+                "exemption_applies": True,
+            },
+            "output": {"result": 0},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert not result.issues
+
+
+def test_derived_exception_selector_may_be_driven_by_one_numeric_input():
+    source = "(1) Der Anspruch gilt nicht, wenn eine Befreiung vorliegt."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: exemption_applies
+    kind: derived
+    dtype: bool
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 'exemption_code == 1'}]
+  - name: eligible
+    kind: derived
+    dtype: bool
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 'not exemption_applies'}]
+"""
+    cases = [
+        {
+            "name": "ordinary code",
+            "input": {"exemption_code": 0},
+            "output": {"exemption_applies": False, "eligible": True},
+        },
+        {
+            "name": "exemption code",
+            "input": {"exemption_code": 1},
+            "output": {"exemption_applies": True, "eligible": False},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert not result.issues
+
+
+@pytest.mark.parametrize(
+    ("formula", "ordinary_output", "exception_output", "expected_issue"),
+    [
+        (
+            "if income > income_limit: false else: true",
+            True,
+            False,
+            False,
+        ),
+        (
+            "if income > income_limit: true else: false",
+            False,
+            True,
+            True,
+        ),
+    ],
+)
+def test_numeric_predicate_can_directly_witness_exception(
+    formula: str,
+    ordinary_output: bool,
+    exception_output: bool,
+    expected_issue: bool,
+):
+    source = (
+        "(1) Der Anspruch gilt nicht, wenn Einkommen über 100 Euro liegt."
+    )
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: income_limit
+    kind: parameter
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 100}]
+  - name: eligible
+    kind: derived
+    dtype: bool
+    source: de/statute/estg/32a(1)
+    versions:
+      - formula: 'FORMULA'
+""".replace("FORMULA", formula)
+    cases = [
+        {
+            "name": "ordinary endpoint",
+            "input": {"income": 100},
+            "output": {"eligible": ordinary_output},
+        },
+        {
+            "name": "over-limit exception",
+            "input": {"income": 101},
+            "output": {"eligible": exception_output},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert _has_issue(result, "exception", "test") is expected_issue
+
+
+def test_numeric_input_change_cannot_hide_identical_exception_branches():
+    source = (
+        "(1) Der Anspruch gilt nicht, wenn Einkommen über 100 Euro liegt."
+    )
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: income_limit
+    kind: parameter
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 100}]
+  - name: result
+    kind: derived
+    source: de/statute/estg/32a(1)
+    versions:
+      - formula: 'if income > income_limit: income else: income'
+"""
+    cases = [
+        {
+            "name": "ordinary endpoint",
+            "input": {"income": 100},
+            "output": {"result": 100},
+        },
+        {
+            "name": "over-limit",
+            "input": {"income": 101},
+            "output": {"result": 101},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert _has_issue(result, "exception", "test")
+
+
+def test_judgment_exception_requires_holds_to_not_holds_effect():
+    source = "(1) Der Anspruch gilt nicht, wenn eine Befreiung vorliegt."
+    content = _exception_control_content(
+        "if exemption_applies: not_holds else: holds"
+    ).replace("kind: derived", "kind: derived\n    dtype: Judgment")
+    cases = [
+        {
+            "name": "ordinary",
+            "input": {"exemption_applies": False},
+            "output": {"result": "holds"},
+        },
+        {
+            "name": "exempt",
+            "input": {"exemption_applies": True},
+            "output": {"result": "not_holds"},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert not result.issues
+
+
+def test_derived_exception_selector_wrong_polarity_is_rejected():
+    source = "(1) Der Anspruch gilt nicht, wenn eine Befreiung vorliegt."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: exemption_applies
+    kind: derived
+    dtype: bool
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 'has_certificate'}]
+  - name: eligible
+    kind: derived
+    dtype: bool
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 'if exemption_applies: true else: false'}]
+"""
+    cases = [
+        {
+            "name": "ordinary",
+            "input": {"has_certificate": False},
+            "output": {"exemption_applies": False, "eligible": False},
+        },
+        {
+            "name": "exempt",
+            "input": {"has_certificate": True},
+            "output": {"exemption_applies": True, "eligible": True},
         },
     ]
 

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -1,0 +1,510 @@
+from __future__ import annotations
+
+import pytest
+
+from axiom_encode.harness.source_completeness import (
+    analyze_complete_source_unit,
+)
+from axiom_encode.harness.validator_pipeline import (
+    extract_named_scalar_occurrences,
+    extract_numeric_occurrences_from_text,
+    numeric_value_is_grounded,
+)
+
+CORPUS_CITATION_PATH = "de/statute/estg/32a"
+
+
+def _analyze(
+    content: str,
+    authoritative_source_text: str,
+    *,
+    test_cases: list[object] | None = None,
+):
+    return analyze_complete_source_unit(
+        content,
+        authoritative_source_text,
+        corpus_citation_path=CORPUS_CITATION_PATH,
+        test_cases=test_cases,
+        extract_numeric_occurrences=extract_numeric_occurrences_from_text,
+        extract_named_scalars=extract_named_scalar_occurrences,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
+
+
+def _has_issue(result, *needles: str) -> bool:
+    lowered_needles = tuple(needle.lower() for needle in needles)
+    return any(
+        all(needle in issue.lower() for needle in lowered_needles)
+        for issue in result.issues
+    )
+
+
+def _formula_test(
+    name: str,
+    taxable_income: int,
+    expected_tax: int,
+) -> dict[str, object]:
+    return {
+        "name": name,
+        "period": "2026",
+        "input": {"taxable_income": taxable_income},
+        "output": {
+            "de:statutes/estg/32a#tariff_income_tax_amount": expected_tax,
+        },
+    }
+
+
+def test_constants_without_principal_tariff_output_fail():
+    source = """\
+(1) Für Einkommen von 12349 bis 17799 Euro ist die Steuer
+(914.51 * y + 1400) * y; y ist (Einkommen - 12348) / 10000.
+"""
+    constants_only = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  summary: Constants for the first tariff zone.
+rules:
+  - name: first_zone_start
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 12349
+  - name: first_zone_end
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 17799
+  - name: first_zone_quadratic_coefficient
+    kind: parameter
+    dtype: Decimal
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 914.51
+  - name: first_zone_linear_coefficient
+    kind: parameter
+    dtype: Decimal
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 1400
+  - name: basic_allowance
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 12348
+  - name: tariff_zone_scale
+    kind: parameter
+    dtype: Decimal
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 10000
+"""
+
+    result = _analyze(constants_only, source, test_cases=[])
+
+    assert result.source_numeric_occurrence_count == 6
+    assert result.covered_source_numeric_occurrence_count == 6
+    assert result.missing_source_numeric_occurrence_count == 0
+    assert _has_issue(result, "principal", "derived/relation")
+
+
+ABSATZ_1 = "(1) Die Steuer ist das Einkommen multipliziert mit 10 Prozent."
+ABSATZ_5 = (
+    "(5) Bei zusammen veranlagten Ehegatten ist die Steuer das Doppelte "
+    "der Steuer auf die Hälfte ihres Einkommens."
+)
+ABSATZ_6 = (
+    "(6) Das Splittingverfahren gilt für verwitwete Personen, wenn die "
+    "Voraussetzungen vorliegen, es sei denn, sie haben wieder geheiratet."
+)
+
+ABSATZ_1_RULES = """\
+  - name: tariff_rate
+    kind: parameter
+    dtype: Rate
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: rate
+            source:
+              corpus_citation_path: de/statute/estg/32a
+              excerpt: "Die Steuer ist das Einkommen multipliziert mit 10 Prozent."
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.1
+  - name: tariff_income_tax_amount
+    kind: derived
+    dtype: Money
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: de/statute/estg/32a
+              excerpt: "Die Steuer ist das Einkommen multipliziert mit 10 Prozent."
+    versions:
+      - effective_from: '2026-01-01'
+        formula: taxable_income * tariff_rate
+"""
+
+ABSATZ_5_RULE = """\
+  - name: joint_assessment_tariff_income_tax_amount
+    kind: derived
+    dtype: Money
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: de/statute/estg/32a
+              excerpt: "Bei zusammen veranlagten Ehegatten ist die Steuer das Doppelte der Steuer auf die Hälfte ihres Einkommens."
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2 * tariff_income_tax_amount(taxable_income / 2)
+"""
+
+
+def _encoded_absatz_content(*, include_absatz_5: bool) -> str:
+    rules = ABSATZ_1_RULES
+    if include_absatz_5:
+        rules += ABSATZ_5_RULE
+    return f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  summary: Income-tax tariff.
+rules:
+{rules}"""
+
+
+ENCODED_FORMULA_TESTS = [
+    _formula_test("individual tariff formula", 100, 10),
+    {
+        "name": "joint assessment formula",
+        "period": "2026",
+        "input": {"taxable_income": 100},
+        "output": {
+            "de:statutes/estg/32a#tariff_income_tax_amount": 10,
+            "de:statutes/estg/32a#joint_assessment_tariff_income_tax_amount": 10,
+        },
+    },
+]
+
+
+def test_omitting_absatz_5_fails():
+    result = _analyze(
+        _encoded_absatz_content(include_absatz_5=False),
+        f"{ABSATZ_1}\n{ABSATZ_5}",
+        test_cases=ENCODED_FORMULA_TESTS,
+    )
+
+    assert _has_issue(result, "(5)", "source branch")
+
+
+def test_silently_omitting_absatz_6_fails():
+    result = _analyze(
+        _encoded_absatz_content(include_absatz_5=True),
+        f"{ABSATZ_1}\n{ABSATZ_5}\n{ABSATZ_6}",
+        test_cases=ENCODED_FORMULA_TESTS,
+    )
+
+    assert _has_issue(result, "(6)", "source branch")
+
+
+def test_precise_typed_absatz_6_deferral_passes():
+    content = _encoded_absatz_content(include_absatz_5=True).replace(
+        "  summary: Income-tax tariff.\n",
+        """\
+  summary: Income-tax tariff.
+  deferred_outputs:
+    - output: de:statutes/estg/32a/6#surviving_spouse_splitting_tax
+      reason: >-
+        Absatz 6 cannot be computed until taxable income under EStG section 26
+        and surviving-spouse or remarriage status under EStG section 32 are
+        available.
+      blocked_by:
+        - de:statutes/estg/26#taxable_income
+        - de:statutes/estg/32#surviving_spouse_or_remarried
+""",
+    )
+
+    result = _analyze(
+        content,
+        f"{ABSATZ_1}\n{ABSATZ_5}\n{ABSATZ_6}",
+        test_cases=ENCODED_FORMULA_TESTS,
+    )
+
+    assert not result.issues
+
+
+def test_scalar_only_source_passes_with_parameter_snapshot():
+    source = "(1) Der Freibetrag beträgt 259 Euro."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  summary: Der Freibetrag beträgt 259 Euro.
+rules:
+  - name: allowance_amount
+    kind: parameter
+    dtype: Money
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: de/statute/estg/32a
+              excerpt: "Der Freibetrag beträgt 259 Euro."
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 259
+"""
+    test_cases = [
+        {
+            "name": "allowance parameter snapshot",
+            "period": "2026",
+            "input": {},
+            "output": {"de:statutes/estg/32a#allowance_amount": 259},
+        }
+    ]
+
+    result = _analyze(content, source, test_cases=test_cases)
+
+    assert not result.issues
+    assert result.source_numeric_occurrence_count == 1
+    assert result.covered_source_numeric_occurrence_count == 1
+    assert result.missing_source_numeric_occurrence_count == 0
+
+
+def test_summary_omission_cannot_hide_authoritative_source_number():
+    source = "(1) Der Freibetrag beträgt 259 Euro; der Zuschlag beträgt 73 Euro."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  summary: Der Freibetrag beträgt 259 Euro.
+rules:
+  - name: allowance_amount
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 259
+"""
+
+    result = _analyze(content, source, test_cases=[])
+
+    assert result.source_numeric_occurrence_count == 2
+    assert result.covered_source_numeric_occurrence_count == 1
+    assert result.missing_source_numeric_occurrence_count == 1
+    assert _has_issue(result, "73", "authoritative")
+
+
+@pytest.mark.parametrize(
+    ("source", "marker"),
+    [
+        ("(1) Die Hauptregel gilt.", "(1)"),
+        ("(2) Die zweite Absatzregel gilt.", "(2)"),
+        ("1. Die erste Nummer gilt.", "1."),
+        ("1a. Die erweiterte Nummer gilt.", "1a."),
+        ("a) Die Buchstabenregel gilt.", "a)"),
+        ("Die Hauptregel gilt.2Die Sonderregel gilt.", "Satz 2"),
+    ],
+)
+def test_german_structural_markers_require_coverage(source: str, marker: str):
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  summary: Leeres Beispiel.
+rules: []
+"""
+
+    result = _analyze(content, source, test_cases=[])
+
+    assert _has_issue(result, marker, "source branch")
+
+
+def test_imprecise_absatz_deferral_does_not_cover_branch():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  summary: Splittingverfahren.
+  deferred_outputs:
+    - output: de:statutes/estg/32a/6#splitting_rule
+      reason: Nicht umgesetzt.
+rules: []
+"""
+
+    result = _analyze(content, ABSATZ_6, test_cases=[])
+
+    assert _has_issue(result, "(6)", "deferral")
+
+
+COMPANION_COVERAGE_SOURCE = """\
+(1) Die Steuer wird nach folgenden Tarifzweigen berechnet:
+1. Bis 100 Euro: Einkommen * 5 Prozent;
+2. Von 101 Euro an: Einkommen * 7 Prozent.
+An der Tarifgrenze von 101 Euro gilt der obere Tarifzweig.
+Ausnahme: Bei einer Befreiung beträgt die Steuer null.
+Das Ergebnis ist auf volle Euro abzurunden.
+"""
+
+COMPANION_COVERAGE_CONTENT = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  summary: Tariff branches, boundary, exception, and rounding.
+rules:
+  - name: lower_tariff_rate_percent
+    kind: parameter
+    dtype: Decimal
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 5
+  - name: upper_tariff_rate_percent
+    kind: parameter
+    dtype: Decimal
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 7
+  - name: lower_tariff_maximum
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 100
+  - name: upper_tariff_minimum
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 101
+  - name: tariff_income_tax_amount
+    kind: derived
+    dtype: Money
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: de/statute/estg/32a
+              excerpt: "1. Bis 100 Euro: Einkommen * 5 Prozent;"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: de/statute/estg/32a
+              excerpt: "2. Von 101 Euro an: Einkommen * 7 Prozent."
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if exception_applies:
+            0
+          else:
+            floor(
+              if taxable_income <= lower_tariff_maximum:
+                taxable_income * lower_tariff_rate_percent / 100
+              else:
+                taxable_income * upper_tariff_rate_percent / 100
+            )
+"""
+
+
+def _companion_test(
+    name: str,
+    taxable_income: float,
+    expected_tax: int,
+    *,
+    exception_applies: bool = False,
+) -> dict[str, object]:
+    return {
+        "name": name,
+        "period": "2026",
+        "input": {
+            "taxable_income": taxable_income,
+            "exception_applies": exception_applies,
+        },
+        "output": {
+            "de:statutes/estg/32a#tariff_income_tax_amount": expected_tax,
+        },
+    }
+
+
+COMPLETE_COMPANION_TESTS = [
+    _companion_test("lower tariff formula branch", 90, 4),
+    _companion_test("upper tariff formula branch", 110, 7),
+    _companion_test("lower exact tariff boundary", 100, 5),
+    _companion_test("upper exact tariff boundary", 101, 7),
+    _companion_test("exception does not apply", 110, 7),
+    _companion_test("exception applies", 110, 0, exception_applies=True),
+    _companion_test("rounding down to full euro", 90.5, 4),
+]
+
+
+def test_complete_companion_suite_covers_source_controls():
+    result = _analyze(
+        COMPANION_COVERAGE_CONTENT,
+        COMPANION_COVERAGE_SOURCE,
+        test_cases=COMPLETE_COMPANION_TESTS,
+    )
+
+    assert not result.issues
+
+
+@pytest.mark.parametrize(
+    ("test_cases", "expected_issue_term"),
+    [
+        ([COMPLETE_COMPANION_TESTS[0]], "formula branch"),
+        (
+            [
+                case
+                for case in COMPLETE_COMPANION_TESTS
+                if "exact tariff boundary" not in case["name"]
+            ],
+            "boundary",
+        ),
+        (
+            [
+                case
+                for case in COMPLETE_COMPANION_TESTS
+                if case["name"] != "exception applies"
+            ],
+            "exception",
+        ),
+        (
+            [
+                case
+                for case in COMPLETE_COMPANION_TESTS
+                if case["name"] != "rounding down to full euro"
+            ],
+            "rounding",
+        ),
+    ],
+)
+def test_missing_companion_coverage_fails(
+    test_cases: list[dict[str, object]],
+    expected_issue_term: str,
+):
+    result = _analyze(
+        COMPANION_COVERAGE_CONTENT,
+        COMPANION_COVERAGE_SOURCE,
+        test_cases=test_cases,
+    )
+
+    assert _has_issue(result, expected_issue_term, "test")

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -554,8 +554,7 @@ rules:
     issues = _pipeline_issues(content, source, test_cases=[])
 
     assert any(
-        "authoritative corpus numeric value 73" in issue.lower()
-        for issue in issues
+        "authoritative corpus numeric value 73" in issue.lower() for issue in issues
     )
 
 
@@ -590,9 +589,7 @@ def test_explicit_satz_markers_after_absatz_are_recognized():
         "(1) Satz 1 Die Hauptregel gilt; Satz 2 Die Sonderregel gilt."
     )
 
-    assert {
-        branch.path for branch in branches if branch.kind == "sentence"
-    } == {
+    assert {branch.path for branch in branches if branch.kind == "sentence"} == {
         ("1", "satz-1"),
         ("1", "satz-2"),
     }
@@ -602,9 +599,7 @@ def test_colon_satz_markers_are_recognized_and_independently_required():
     source = "(1) Satz 1: Die Hauptregel gilt. Satz 2: Die Sonderregel gilt."
     branches = recognize_source_structure(source)
 
-    assert {
-        branch.path for branch in branches if branch.kind == "sentence"
-    } == {
+    assert {branch.path for branch in branches if branch.kind == "sentence"} == {
         ("1", "satz-1"),
         ("1", "satz-2"),
     }
@@ -662,9 +657,7 @@ rules:
 
     result = _analyze(content, source, test_cases=[])
 
-    assert any(
-        f"Source branch {parent_label} at " in issue for issue in result.issues
-    )
+    assert any(f"Source branch {parent_label} at " in issue for issue in result.issues)
 
 
 def test_child_encoding_covers_marker_only_parent_container():
@@ -1007,12 +1000,8 @@ def test_additional_formula_language_is_computation(source: str):
 
 
 def test_scalar_amount_language_is_not_computation():
-    assert not source_states_explicit_computation(
-        "Der Freibetrag beträgt 259 Euro."
-    )
-    assert not source_states_explicit_computation(
-        "Der Satz beträgt 45 vom Hundert."
-    )
+    assert not source_states_explicit_computation("Der Freibetrag beträgt 259 Euro.")
+    assert not source_states_explicit_computation("Der Satz beträgt 45 vom Hundert.")
 
 
 def test_scalar_year_span_is_not_computation():
@@ -1066,8 +1055,7 @@ rules:
     ]
 
     paths = completeness_module._paths_from_source_reference(
-        "de/statute/estg/32a(1) Satz 1; "
-        "de/statute/estg/32a(1) Satz 2",
+        "de/statute/estg/32a(1) Satz 1; de/statute/estg/32a(1) Satz 2",
         corpus_citation_path=CORPUS_CITATION_PATH,
     )
     result = _analyze(content, source, test_cases=test_cases)
@@ -1274,8 +1262,8 @@ rules:
         ),
     )
 
-    imported_symbol_contents = (
-        pipeline._complete_source_unit_import_symbol_contents(main_file)
+    imported_symbol_contents = pipeline._complete_source_unit_import_symbol_contents(
+        main_file
     )
     values = collect_artifact_numeric_values(
         main_content,
@@ -1351,8 +1339,8 @@ rules:
         }[import_path],
     )
 
-    imported_symbol_contents = (
-        pipeline._complete_source_unit_import_symbol_contents(main_file)
+    imported_symbol_contents = pipeline._complete_source_unit_import_symbol_contents(
+        main_file
     )
     values = collect_artifact_numeric_values(
         main_content,
@@ -1406,8 +1394,7 @@ c) der bisherige Ehegatte und dessen neuer Ehegatte ebenfalls die Voraussetzunge
 
 def test_exact_released_estg_32a_structure_paths():
     paths = {
-        branch.path
-        for branch in recognize_source_structure(RELEASED_ESTG_32A_BODY)
+        branch.path for branch in recognize_source_structure(RELEASED_ESTG_32A_BODY)
     }
 
     assert {("1",), ("5",), ("6",)} <= paths
@@ -1418,12 +1405,10 @@ def test_exact_released_estg_32a_structure_paths():
     assert {("1", f"satz-{number}") for number in range(1, 7)} <= paths
     assert {("6", "satz-1"), ("6", "satz-2")} <= paths
     assert not any(
-        path[:2] == ("1", "5") and path[-1].startswith("satz-")
-        for path in paths
+        path[:2] == ("1", "5") and path[-1].startswith("satz-") for path in paths
     )
     assert not any(
-        path[:3] == ("6", "2", "c") and path[-1].startswith("satz-")
-        for path in paths
+        path[:3] == ("6", "2", "c") and path[-1].startswith("satz-") for path in paths
     )
 
 
@@ -1522,9 +1507,7 @@ def test_released_estg_32a_does_not_invent_boundary_from_omission_line():
 
     assert not any(branch.path == () for branch, _value in obligations)
     assert not any(occurrence.value == 34 for _branch, occurrence in obligations)
-    assert any(
-        occurrence.value == 12348 for _branch, occurrence in obligations
-    )
+    assert any(occurrence.value == 12348 for _branch, occurrence in obligations)
 
 
 def test_released_estg_32a_feminine_rounding_is_computation():
@@ -1583,10 +1566,7 @@ def test_common_german_range_boundaries_are_inventoried():
         narrative_formula_branches=formula_branches,
         extract_numeric_occurrences=DE_NUMERIC_OCCURRENCE_EXTRACTOR,
     )
-    boundaries = {
-        (branch.path, occurrence.value)
-        for branch, occurrence in obligations
-    }
+    boundaries = {(branch.path, occurrence.value) for branch, occurrence in obligations}
 
     assert (("1", "1"), 100) in boundaries
     assert (("1", "1"), 200) in boundaries
@@ -1686,9 +1666,7 @@ rules:
 
 
 def test_unstructured_formula_requires_principal_output_bound_to_source_unit():
-    source = (
-        "Die Steuer ergibt sich aus dem Einkommen geteilt durch den Grundwert."
-    )
+    source = "Die Steuer ergibt sich aus dem Einkommen geteilt durch den Grundwert."
     content = """\
 format: rulespec/v1
 module:
@@ -1946,8 +1924,7 @@ def test_complete_companion_suite_covers_source_controls():
     ("source", "extra_parameter"),
     [
         (
-            "(1) Der Zuschlag beträgt 259 Euro bis zu einem Einkommen "
-            "von 100 Euro.",
+            "(1) Der Zuschlag beträgt 259 Euro bis zu einem Einkommen von 100 Euro.",
             """\
   - name: income_limit
     kind: parameter
@@ -1970,10 +1947,7 @@ def test_complete_companion_suite_covers_source_controls():
 """,
         ),
         (
-            (
-                "(1) Der Zuschlag beträgt 259 Euro für Einkommen bis "
-                "maximal 100 Euro."
-            ),
+            ("(1) Der Zuschlag beträgt 259 Euro für Einkommen bis maximal 100 Euro."),
             """\
   - name: income_limit
     kind: parameter
@@ -2047,8 +2021,7 @@ rules:
 
 def test_positive_applicability_condition_requires_paired_cases():
     source = (
-        "(1) Der Zuschlag beträgt 259 Euro, wenn die Person "
-        "anspruchsberechtigt ist."
+        "(1) Der Zuschlag beträgt 259 Euro, wenn die Person anspruchsberechtigt ist."
     )
     content = """\
 format: rulespec/v1
@@ -2351,9 +2324,7 @@ def test_unrelated_boolean_toggle_cannot_cover_source_exception():
         "          else:\n            if unrelated_toggle:\n              floor(\n",
     )
     test_cases = [
-        case
-        for case in COMPLETE_COMPANION_TESTS
-        if case["name"] != "exception applies"
+        case for case in COMPLETE_COMPANION_TESTS if case["name"] != "exception applies"
     ]
     for value in (False, True):
         test_cases.append(
@@ -2381,7 +2352,9 @@ def test_exception_toggle_from_another_source_branch_cannot_cover_exception():
         COMPANION_COVERAGE_SOURCE
         + "(2) Der Sonderbetrag wird als Einkommen + Einkommen berechnet.\n"
     )
-    content = COMPANION_COVERAGE_CONTENT + """\
+    content = (
+        COMPANION_COVERAGE_CONTENT
+        + """\
   - name: special_status_amount
     kind: derived
     dtype: Money
@@ -2394,10 +2367,9 @@ def test_exception_toggle_from_another_source_branch_cannot_cover_exception():
           else:
             taxable_income
 """
+    )
     test_cases = [
-        case
-        for case in COMPLETE_COMPANION_TESTS
-        if case["name"] != "exception applies"
+        case for case in COMPLETE_COMPANION_TESTS if case["name"] != "exception applies"
     ]
     for value, expected in ((False, 90), (True, 0)):
         test_cases.append(
@@ -2422,8 +2394,7 @@ def test_exception_toggle_from_another_source_branch_cannot_cover_exception():
 
 def test_unrelated_fractional_input_cannot_cover_rounding_rule():
     source = (
-        "(1) Der Betrag wird als Einkommen * 2 berechnet und "
-        "auf volle Euro abzurunden."
+        "(1) Der Betrag wird als Einkommen * 2 berechnet und auf volle Euro abzurunden."
     )
     content = _single_rounding_content(
         "floor(income * multiplier + unrelated_amount * 0)",
@@ -2589,9 +2560,7 @@ rules:
                 "high_income": high_income,
                 "income": income,
             },
-            "output": {
-                "amount": income * (2 if married or high_income else 3)
-            },
+            "output": {"amount": income * (2 if married or high_income else 3)},
         }
 
     repeated_married = _analyze(
@@ -2703,17 +2672,21 @@ def test_inline_if_formula_requires_distinct_runtime_branch_executions():
 (1) Bei Ehegatten ist der Betrag Einkommen * 2.
 (2) Bei Alleinstehenden ist der Betrag Einkommen * 3.
 """
-    content = MULTI_PARAGRAPH_FORMULA_CONTENT.replace(
-        "formula: income * first_multiplier + income * second_multiplier",
-        "formula: >-\n"
-        "          if married or high_income: income * first_multiplier "
-        "else: income * second_multiplier",
-    ).replace(
-        "first_multiplier",
-        "married_multiplier",
-    ).replace(
-        "second_multiplier",
-        "single_multiplier",
+    content = (
+        MULTI_PARAGRAPH_FORMULA_CONTENT.replace(
+            "formula: income * first_multiplier + income * second_multiplier",
+            "formula: >-\n"
+            "          if married or high_income: income * first_multiplier "
+            "else: income * second_multiplier",
+        )
+        .replace(
+            "first_multiplier",
+            "married_multiplier",
+        )
+        .replace(
+            "second_multiplier",
+            "single_multiplier",
+        )
     )
 
     def case(name: str, married: bool, high_income: bool) -> dict[str, object]:
@@ -2757,14 +2730,20 @@ def test_judgment_selector_normalizes_holds_and_not_holds():
         ]
     }
 
-    assert completeness_module._case_formula_branch_outcome(
-        rule,
-        {"input": {"eligible": "holds"}},
-    ) == "if:0"
-    assert completeness_module._case_formula_branch_outcome(
-        rule,
-        {"input": {"eligible": "not_holds"}},
-    ) == "if:1"
+    assert (
+        completeness_module._case_formula_branch_outcome(
+            rule,
+            {"input": {"eligible": "holds"}},
+        )
+        == "if:0"
+    )
+    assert (
+        completeness_module._case_formula_branch_outcome(
+            rule,
+            {"input": {"eligible": "not_holds"}},
+        )
+        == "if:1"
+    )
 
 
 def test_inline_elif_formula_reports_each_reachable_branch():
@@ -2776,18 +2755,27 @@ def test_inline_elif_formula_reports_each_reachable_branch():
         ]
     }
 
-    assert completeness_module._case_formula_branch_outcome(
-        rule,
-        {"input": {"first": True, "second": False}},
-    ) == "if:0"
-    assert completeness_module._case_formula_branch_outcome(
-        rule,
-        {"input": {"first": False, "second": True}},
-    ) == "if:1"
-    assert completeness_module._case_formula_branch_outcome(
-        rule,
-        {"input": {"first": False, "second": False}},
-    ) == "if:2"
+    assert (
+        completeness_module._case_formula_branch_outcome(
+            rule,
+            {"input": {"first": True, "second": False}},
+        )
+        == "if:0"
+    )
+    assert (
+        completeness_module._case_formula_branch_outcome(
+            rule,
+            {"input": {"first": False, "second": True}},
+        )
+        == "if:1"
+    )
+    assert (
+        completeness_module._case_formula_branch_outcome(
+            rule,
+            {"input": {"first": False, "second": False}},
+        )
+        == "if:2"
+    )
 
 
 def test_formula_execution_fails_closed_on_non_boolean_guard_and_alias_conflict():
@@ -2827,10 +2815,13 @@ def test_match_uses_last_arm_as_runtime_fallback():
         ]
     }
 
-    assert completeness_module._case_formula_branch_outcome(
-        rule,
-        {"input": {"filing_status": "unknown"}},
-    ) == "match:1"
+    assert (
+        completeness_module._case_formula_branch_outcome(
+            rule,
+            {"input": {"filing_status": "unknown"}},
+        )
+        == "match:1"
+    )
 
 
 @pytest.mark.parametrize(
@@ -2848,22 +2839,25 @@ def test_bare_match_patterns_resolve_as_runtime_names(
         "versions": [
             {
                 "formula": (
-                    f'match status: {pattern} => married_amount; '
+                    f"match status: {pattern} => married_amount; "
                     '"fallback" => fallback_amount'
                 ),
             }
         ]
     }
 
-    assert completeness_module._case_formula_branch_outcome(
-        rule,
-        {
-            "input": {
-                "status": True if pattern == "holds" else "_",
-                **pattern_input,
-            }
-        },
-    ) == "match:1"
+    assert (
+        completeness_module._case_formula_branch_outcome(
+            rule,
+            {
+                "input": {
+                    "status": True if pattern == "holds" else "_",
+                    **pattern_input,
+                }
+            },
+        )
+        == "match:1"
+    )
 
 
 @pytest.mark.parametrize(
@@ -2881,17 +2875,18 @@ def test_bare_condition_names_are_not_boolean_aliases(
     rule = {
         "versions": [
             {
-                "formula": (
-                    f"if {guard_name}: enabled_amount else: disabled_amount"
-                ),
+                "formula": (f"if {guard_name}: enabled_amount else: disabled_amount"),
             }
         ]
     }
 
-    assert completeness_module._case_formula_branch_outcome(
-        rule,
-        {"input": {guard_name: guard_value}},
-    ) == "if:1"
+    assert (
+        completeness_module._case_formula_branch_outcome(
+            rule,
+            {"input": {guard_name: guard_value}},
+        )
+        == "if:1"
+    )
 
 
 def test_quoted_control_text_does_not_confuse_formula_execution():
@@ -2899,17 +2894,19 @@ def test_quoted_control_text_does_not_confuse_formula_execution():
         "versions": [
             {
                 "formula": (
-                    'if code == "if x: y else: z": selected_amount '
-                    "else: other_amount"
+                    'if code == "if x: y else: z": selected_amount else: other_amount'
                 ),
             }
         ]
     }
 
-    assert completeness_module._case_formula_branch_outcome(
-        rule,
-        {"input": {"code": "if x: y else: z"}},
-    ) == "if:0"
+    assert (
+        completeness_module._case_formula_branch_outcome(
+            rule,
+            {"input": {"code": "if x: y else: z"}},
+        )
+        == "if:0"
+    )
 
 
 def test_formula_execution_rejects_ambiguous_versions():
@@ -3164,11 +3161,7 @@ def test_interval_cases_must_reach_the_piecewise_formula():
     )
 
     def case(name: str, income: int, *, disabled: bool) -> dict[str, object]:
-        expected = (
-            0
-            if disabled
-            else int(income * (5 if income <= 100 else 7) / 100)
-        )
+        expected = 0 if disabled else int(income * (5 if income <= 100 else 7) / 100)
         return {
             "name": name,
             "input": {"disabled": disabled, "taxable_income": income},
@@ -3354,13 +3347,9 @@ def test_numbered_prose_formulas_require_distinct_executed_cases():
     ],
 )
 def test_common_german_exceptions_require_paired_cases(exception_text: str):
-    source = (
-        "(1) Der Betrag wird als Einkommen * 2 berechnet. " + exception_text
-    )
+    source = "(1) Der Betrag wird als Einkommen * 2 berechnet. " + exception_text
     one_sided_tests = [
-        case
-        for case in COMPLETE_COMPANION_TESTS
-        if case["name"] != "exception applies"
+        case for case in COMPLETE_COMPANION_TESTS if case["name"] != "exception applies"
     ]
 
     result = _analyze(
@@ -3932,13 +3921,7 @@ rules:
             {
                 "name": "wrong computation",
                 "input": {"income": 12},
-                "output": {
-                    "amount": (
-                        4
-                        if parameter_name == "divisor"
-                        else 24
-                    )
-                },
+                "output": {"amount": (4 if parameter_name == "divisor" else 24)},
             }
         ],
     )
@@ -5134,9 +5117,7 @@ def test_monthly_case_period_resolves_versioned_boundary_constant():
 
 
 def test_equal_asserted_exception_effects_do_not_count_as_toggle():
-    source = (
-        "(1) Ein Anspruch besteht, es sei denn, eine Befreiung liegt vor."
-    )
+    source = "(1) Ein Anspruch besteht, es sei denn, eine Befreiung liegt vor."
     content = """\
 format: rulespec/v1
 module:
@@ -5292,8 +5273,7 @@ rules:
 
 def test_neutralized_fractional_input_cannot_witness_rounding():
     source = (
-        "(1) Der Betrag wird als Einkommen * 2 berechnet und "
-        "auf volle Euro abzurunden."
+        "(1) Der Betrag wird als Einkommen * 2 berechnet und auf volle Euro abzurunden."
     )
     content = _single_rounding_content(
         "floor(income * multiplier + fractional_probe * 0)",
@@ -5312,8 +5292,7 @@ def test_neutralized_fractional_input_cannot_witness_rounding():
 
 def test_fractional_input_must_leave_the_rounded_operand_fractional():
     source = (
-        "(1) Der Betrag wird als Einkommen * 2 berechnet und "
-        "auf volle Euro abzurunden."
+        "(1) Der Betrag wird als Einkommen * 2 berechnet und auf volle Euro abzurunden."
     )
     content = _single_rounding_content("floor(income * multiplier)")
     case = {
@@ -5616,8 +5595,7 @@ rules:
 
 def test_rounding_accepts_asserted_reached_intermediate_output():
     source = (
-        "(1) Der Betrag wird als Einkommen * 2 berechnet und "
-        "auf volle Euro abgerundet."
+        "(1) Der Betrag wird als Einkommen * 2 berechnet und auf volle Euro abgerundet."
     )
     content = """\
 format: rulespec/v1
@@ -5651,8 +5629,7 @@ rules:
 
 def test_mismatched_asserted_intermediate_cannot_witness_rounding():
     source = (
-        "(1) Der Betrag wird als Einkommen * 2 berechnet und "
-        "auf volle Euro abgerundet."
+        "(1) Der Betrag wird als Einkommen * 2 berechnet und auf volle Euro abgerundet."
     )
     content = """\
 format: rulespec/v1
@@ -5799,9 +5776,7 @@ rules:
 
 
 def test_boundary_accepts_asserted_reached_derived_selector():
-    source = (
-        "(1) Der Anspruch gilt bis 100 Euro zu versteuerndes Einkommen."
-    )
+    source = "(1) Der Anspruch gilt bis 100 Euro zu versteuerndes Einkommen."
     content = """\
 format: rulespec/v1
 module:
@@ -6068,9 +6043,7 @@ def test_exception_toggle_cases_must_share_period():
 
 def test_boolean_exception_selector_must_block_not_enable():
     source = "(1) Der Anspruch gilt nicht, wenn eine Befreiung vorliegt."
-    content = _exception_control_content(
-        "if exemption_applies: true else: false"
-    )
+    content = _exception_control_content("if exemption_applies: true else: false")
     cases = [
         {
             "name": "ordinary",
@@ -6092,8 +6065,7 @@ def test_boolean_exception_selector_must_block_not_enable():
 def test_numeric_exclusion_effect_is_direction_neutral_without_amount_wording():
     source = "(1) Der Abzug gilt nicht, wenn eine Befreiung vorliegt."
     content = _exception_control_content(
-        "if exemption_applies: tax_without_deduction "
-        "else: tax_with_deduction"
+        "if exemption_applies: tax_without_deduction else: tax_with_deduction"
     )
     cases = [
         {
@@ -6173,9 +6145,7 @@ def test_exception_selector_forms_preserve_source_orientation(
         "no_exemption"
         if "no_exemption" in formula
         else (
-            "has_certificate"
-            if "has_certificate" in formula
-            else "exemption_applies"
+            "has_certificate" if "has_certificate" in formula else "exemption_applies"
         )
     )
     source_condition = (
@@ -6204,12 +6174,8 @@ def test_exception_selector_forms_preserve_source_orientation(
 
 
 def test_compound_direct_exception_expression_is_discovered():
-    source = (
-        "(1) Der Anspruch gilt nicht, wenn eine Befreiung oder Sperre vorliegt."
-    )
-    content = _exception_control_content(
-        "not (exemption_applies or barred)"
-    )
+    source = "(1) Der Anspruch gilt nicht, wenn eine Befreiung oder Sperre vorliegt."
+    content = _exception_control_content("not (exemption_applies or barred)")
     cases = [
         {
             "name": "ordinary",
@@ -6273,9 +6239,7 @@ def test_match_exception_selector_preserves_polarity(
 
 def test_exception_semantics_override_ordinary_word_in_selector_name():
     source = "(1) Der Anspruch gilt nicht, wenn eine Ausnahme vorliegt."
-    content = _exception_control_content(
-        "if eligible_for_exception: false else: true"
-    )
+    content = _exception_control_content("if eligible_for_exception: false else: true")
     cases = [
         {
             "name": "ordinary",
@@ -6431,9 +6395,7 @@ def test_exception_condition_does_not_borrow_a_preceding_main_clause_concept():
     source = """\
 (1) Bei einer Bescheinigung besteht der Anspruch, außer wenn kein Kind vorhanden ist.
 """
-    content = _exception_control_content(
-        "if has_certificate: false else: true"
-    )
+    content = _exception_control_content("if has_certificate: false else: true")
     cases = [
         {
             "name": "without certificate",
@@ -6501,12 +6463,8 @@ def test_preposed_exception_condition_preserves_ordinary_selector(source: str):
     ],
 )
 def test_exception_to_negative_rule_must_enable_the_claim(source: str):
-    correct = _exception_control_content(
-        "if has_certificate: true else: false"
-    )
-    wrong = _exception_control_content(
-        "if has_certificate: false else: true"
-    )
+    correct = _exception_control_content("if has_certificate: true else: false")
+    wrong = _exception_control_content("if has_certificate: false else: true")
     correct_cases = [
         {
             "name": "without certificate",
@@ -6577,12 +6535,9 @@ def test_coordinated_exception_cues_require_distinct_witnesses():
 (1) Außer bei einer Befreiung und außer bei einer Sperre besteht der Anspruch.
 """
     complete = _exception_control_content(
-        "if exemption_applies: false "
-        "else: if barred: false else: true"
+        "if exemption_applies: false else: if barred: false else: true"
     )
-    incomplete = _exception_control_content(
-        "if exemption_applies: false else: true"
-    )
+    incomplete = _exception_control_content("if exemption_applies: false else: true")
     complete_cases = [
         {
             "name": "ordinary",
@@ -6666,9 +6621,7 @@ Der Anspruch besteht, außer bei einer Bescheinigung oder einem Status.
 def test_synonymous_exception_cues_in_one_condition_are_one_obligation():
     source = "(1) Außer bei einer Befreiung gilt der Anspruch nicht."
     branches = recognize_source_structure(source)
-    language_matches = tuple(
-        completeness_module._EXCEPTION_LANGUAGE.finditer(source)
-    )
+    language_matches = tuple(completeness_module._EXCEPTION_LANGUAGE.finditer(source))
 
     obligations = completeness_module._source_exception_branches(
         source,
@@ -6731,9 +6684,7 @@ def test_source_negation_controls_neutral_selector_orientation(
 
 
 def test_adjectival_source_negation_rejects_opposite_selector_polarity():
-    source = (
-        "(1) Der Anspruch gilt nicht, wenn das Kind nicht vorhanden ist."
-    )
+    source = "(1) Der Anspruch gilt nicht, wenn das Kind nicht vorhanden ist."
     content = _exception_control_content("not kind_vorhanden")
     cases = [
         {
@@ -6755,9 +6706,7 @@ def test_adjectival_source_negation_rejects_opposite_selector_polarity():
 
 def test_unrelated_excluding_selector_cannot_witness_source_exception():
     source = "(1) Der Anspruch gilt nicht, wenn eine Befreiung vorliegt."
-    content = _exception_control_content(
-        "if bonus_applies: false else: true"
-    )
+    content = _exception_control_content("if bonus_applies: false else: true")
     cases = [
         {
             "name": "without bonus",
@@ -6904,8 +6853,7 @@ def test_mixed_exception_clauses_keep_local_effect_requirements():
 Der Anspruch besteht, außer bei einer Befreiung.
 """
     content = _exception_control_content(
-        "if exemption_applies: 0 "
-        "else: if exception_applies: 20 else: 10"
+        "if exemption_applies: 0 else: if exception_applies: 20 else: 10"
     )
     cases = [
         {
@@ -6999,9 +6947,7 @@ def test_numeric_predicate_can_directly_witness_exception(
     exception_output: bool,
     expected_issue: bool,
 ):
-    source = (
-        "(1) Der Anspruch gilt nicht, wenn Einkommen über 100 Euro liegt."
-    )
+    source = "(1) Der Anspruch gilt nicht, wenn Einkommen über 100 Euro liegt."
     content = """\
 format: rulespec/v1
 module:
@@ -7038,9 +6984,7 @@ rules:
 
 
 def test_numeric_input_change_cannot_hide_identical_exception_branches():
-    source = (
-        "(1) Der Anspruch gilt nicht, wenn Einkommen über 100 Euro liegt."
-    )
+    source = "(1) Der Anspruch gilt nicht, wenn Einkommen über 100 Euro liegt."
     content = """\
 format: rulespec/v1
 module:
@@ -7363,10 +7307,7 @@ rules:
             "besteht, beträgt der Zuschlag 259 Euro."
         ),
         "(1) Bei Anspruchsberechtigung beträgt der Zuschlag 259 Euro.",
-        (
-            "(1) Der Zuschlag beträgt 259 Euro, soweit "
-            "Anspruchsberechtigung besteht."
-        ),
+        ("(1) Der Zuschlag beträgt 259 Euro, soweit Anspruchsberechtigung besteht."),
     ],
 )
 def test_common_positive_conditions_control_scalar_outputs(source: str):
@@ -7422,10 +7363,7 @@ rules:
 def test_generic_german_rounding_requires_nearest_rounding_and_fractional_proof(
     rounding_text: str,
 ):
-    source = (
-        "(1) Der Betrag wird als Einkommen * 2 berechnet und ist "
-        f"{rounding_text}."
-    )
+    source = f"(1) Der Betrag wird als Einkommen * 2 berechnet und ist {rounding_text}."
     unrounded = _single_rounding_content("income * multiplier")
     rounded = _single_rounding_content(
         "floor(income * multiplier + 0.5)",
@@ -7651,9 +7589,7 @@ def test_formula_topology_accepts_associative_regrouping():
 
 
 def test_formula_topology_preserves_distinct_source_variables():
-    source = (
-        "(1) Der Betrag wird als Einkommen * Partnereinkommen + 3 berechnet."
-    )
+    source = "(1) Der Betrag wird als Einkommen * Partnereinkommen + 3 berechnet."
     content = """\
 format: rulespec/v1
 module:
@@ -7697,10 +7633,7 @@ rules:
             "(1) Der nach Maßgabe des Absatzes 2 festgelegte Freibetrag "
             "beträgt 259 Euro."
         ),
-        (
-            "(1) Der nach den Absätzen 2 und 3 festgelegte Freibetrag "
-            "beträgt 259 Euro."
-        ),
+        ("(1) Der nach den Absätzen 2 und 3 festgelegte Freibetrag beträgt 259 Euro."),
     ],
 )
 def test_inflected_absatz_references_are_not_numeric_inventory(source: str):

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -705,6 +705,27 @@ rules: []
     assert _has_issue(result, "(6)", "deferral", "dependency")
 
 
+def test_deferral_symbol_cannot_mask_a_conflicting_source_section():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+  deferred_outputs:
+    - output: de:statutes/estg/32a/1#amount
+      reason: >-
+        Absatz 1 cannot be computed because the Bemessungsgrundlage is missing.
+      blocked_by:
+        - de:statutes/estg/9999#bemessungsgrundlage
+rules: []
+"""
+    source = "(1) Maßgeblich ist die Bemessungsgrundlage nach § 26."
+
+    result = _analyze(content, source, test_cases=[])
+
+    assert _has_issue(result, "(1)", "deferral", "dependency")
+
+
 def test_invalid_present_blocker_cannot_fall_back_to_prose_dependency():
     content = """\
 format: rulespec/v1
@@ -1690,6 +1711,85 @@ def test_complete_companion_suite_covers_source_controls():
     )
 
     assert not result.issues
+
+
+def test_predicate_only_boundary_requires_an_exact_boundary_case():
+    source = "(1) Der Anspruch gilt bis 100 Euro Einkommen."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: income_limit
+    kind: parameter
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 100
+  - name: eligible
+    kind: derived
+    dtype: bool
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: income <= income_limit
+"""
+
+    def case(income: int) -> dict[str, object]:
+        return {
+            "name": f"income {income}",
+            "input": {"income": income},
+            "output": {"eligible": income <= 100},
+        }
+
+    below_only = _analyze(content, source, test_cases=[case(50)])
+    exact_boundary = _analyze(content, source, test_cases=[case(100)])
+
+    assert _has_issue(below_only, "boundary", "test")
+    assert not exact_boundary.issues
+
+
+def test_predicate_only_exception_requires_paired_cases():
+    source = """\
+(1) Der Anspruch gilt nicht, wenn eine Befreiung vorliegt.
+"""
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: eligible
+    kind: derived
+    dtype: bool
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if exemption_applies:
+            false
+          else:
+            true
+"""
+
+    def case(exemption_applies: bool) -> dict[str, object]:
+        return {
+            "name": f"exemption={exemption_applies}",
+            "input": {"exemption_applies": exemption_applies},
+            "output": {"eligible": not exemption_applies},
+        }
+
+    ordinary_only = _analyze(content, source, test_cases=[case(False)])
+    paired = _analyze(
+        content,
+        source,
+        test_cases=[case(False), case(True)],
+    )
+
+    assert _has_issue(ordinary_only, "exception", "test")
+    assert not paired.issues
 
 
 NARRATIVE_PIECEWISE_SOURCE = """\

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -3821,6 +3821,8 @@ rules:
     dtype: Decimal
     source: de/statute/estg/32a(1)
     versions:
+      - effective_from: '2025-01-01'
+        formula: 1.5
       - effective_from: '2026-01-01'
         formula: 2
   - name: amount
@@ -3841,8 +3843,19 @@ rules:
     }
 
     result = _analyze(content, source, test_cases=[case])
+    pipeline_shaped = _analyze(
+        content,
+        source,
+        test_cases=[case],
+        artifact_numeric_values=(1.5, 2.0),
+        artifact_numeric_bindings=(
+            ("multiplier", 1.5),
+            ("multiplier", 2.0),
+        ),
+    )
 
     assert not result.issues
+    assert not pipeline_shaped.issues
 
 
 def _boundary_control_content(
@@ -3987,8 +4000,19 @@ def test_monthly_case_period_resolves_versioned_boundary_constant():
     }
 
     result = _analyze(content, source, test_cases=[case])
+    pipeline_shaped = _analyze(
+        content,
+        source,
+        test_cases=[case],
+        artifact_numeric_values=(90.0, 100.0),
+        artifact_numeric_bindings=(
+            ("income_limit", 90.0),
+            ("income_limit", 100.0),
+        ),
+    )
 
     assert not result.issues
+    assert not pipeline_shaped.issues
 
 
 def test_equal_asserted_exception_effects_do_not_count_as_toggle():

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -1912,6 +1912,95 @@ def test_complete_companion_suite_covers_source_controls():
     assert not result.issues
 
 
+@pytest.mark.parametrize(
+    ("source", "extra_parameter"),
+    [
+        (
+            "(1) Der Zuschlag beträgt 259 Euro bis zu einem Einkommen "
+            "von 100 Euro.",
+            """\
+  - name: income_limit
+    kind: parameter
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 100}]
+""",
+        ),
+        (
+            "(1) Der Zuschlag beträgt 259 Euro, außer bei einer Befreiung.",
+            "",
+        ),
+        (
+            "(1) Der Zuschlag beträgt 259 Euro, wenn die Person "
+            "anspruchsberechtigt ist.",
+            "",
+        ),
+    ],
+)
+def test_controlled_scalar_source_rejects_parameter_only(
+    source: str,
+    extra_parameter: str,
+):
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: supplement_amount
+    kind: parameter
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions: [{{formula: 259}}]
+{extra_parameter}"""
+
+    result = _analyze(content, source, test_cases=[])
+
+    assert _has_issue(result, "formula-output", "control", "parameter-only")
+
+
+def test_positive_applicability_condition_requires_paired_cases():
+    source = (
+        "(1) Der Zuschlag beträgt 259 Euro, wenn die Person "
+        "anspruchsberechtigt ist."
+    )
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: supplement_amount
+    kind: parameter
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions: [{formula: 259}]
+  - name: payable_supplement
+    kind: derived
+    dtype: Money
+    source: de/statute/estg/32a(1)
+    versions:
+      - formula: 'if is_eligible: supplement_amount else: 0'
+"""
+
+    def case(is_eligible: bool) -> dict[str, object]:
+        return {
+            "name": f"eligible={is_eligible}",
+            "input": {"is_eligible": is_eligible},
+            "output": {"payable_supplement": 259 if is_eligible else 0},
+        }
+
+    positive_only = _analyze(content, source, test_cases=[case(True)])
+    paired = _analyze(
+        content,
+        source,
+        test_cases=[case(False), case(True)],
+    )
+
+    assert _has_issue(positive_only, "applicability", "paired")
+    assert not paired.issues
+
+
 def test_predicate_only_boundary_requires_an_exact_boundary_case():
     source = "(1) Der Anspruch gilt bis 100 Euro Einkommen."
     content = """\

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1383"
+version = "0.2.1384"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
Second half of the full-provision program (with #1285): an **opt-in completeness gate** that makes "encode the document in full" enforceable instead of aspirational. Design: the rulespec-de#1 defensive audit.

## What it enforces (when on)

Activated via `--require-complete-source-unit` or per eval-suite case `require_complete_source_unit: true` (no env switch). When active:

- **Parameter-only output is invalid when the source states a formula** — every explicit computation in the source unit needs a principal derived/relation output.
- **Structural coverage understands German statutes** — Absätze `(1)/(2)`, Nummern `1./1a.` (incl. inflected ordinal forms), and Satz enumeration; every branch is either encoded or **precisely deferred** (typed deferral naming the missing dependency; a deferral cannot name its own branch, cannot be hidden in prose, and imprecise deferrals don't cover a branch).
- **Numeric recall runs against the authoritative corpus body** — `module.summary` can never shrink the inventory (the embedded-source substitution is dead for grounding; the default lane's long-standing recall-metrics scope is preserved).
- **Formula fidelity hardening** — grouped/parenthesized source formulas canonicalized; German worded computations bound exactly; generic German nearest-rounding recognized; decimal exceptions distinguished from zero; rounding-offset guards scoped.
- Genuinely scalar-only provisions still pass as parameter snapshots.

Default **off**: zero behavior change for existing lanes (suite-verified).

## Proof tests (all passing, run independently by the reviewing agent)

The six from the audit — §32a constants-without-tariff fails; Abs. 5 omission fails; silent Abs. 6 omission fails; precise typed Abs. 6 deferral passes; scalar-only passes; summary omission cannot hide an authoritative source number — plus adversarial extensions (deferral-prose hiding, self-referential deferrals, inflected Absatz ordinal leakage, parenthesized formula topology, residual precision bypasses). `tests/test_source_completeness.py` + `tests/test_complete_source_mode_plumbing.py`: **367 passed**.

## Verification

- Rebased onto current main (includes #1285's typed occurrences + locale profiles; consumes the occurrence API, no `set[float]` paths reintroduced).
- Full suite: 5,807 passed / 17 failed vs baseline 5,427 / 16 — the sole added failure was version provenance, resolved by the bump (0.2.1384; main took 1383 mid-flight).
- Ruff format + check clean; no PROGRESS.md, pins, or workflow changes.

Built cross-family (sol implements behind adversarial test/fix pairs; Claude independently re-runs the proof suites and verifies scope). Enables the DE wave re-encode (24 citations) to be dispatched in complete mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
