### PR TITLE
Pin current reviewed RuleSpec hard-cut head

### DIFF
--- a/.github/workflows/prepare-all-state-snap-queue.yml
+++ b/.github/workflows/prepare-all-state-snap-queue.yml
@@ -26,7 +26,7 @@ jobs:
       RELEASE_NAME: us-rulespec-2026-07-24-snap-cms-pit-union
       RELEASE_SHA: cb275c76c4f07f8ad37470a32296bb1763e5db853d152697524ab07021b6d544
       RULES_ENGINE_REF: 05eac9d2f89dabe5c6673176260762cef3a58f47
-      RULESPEC_REF: 8f224620540f9e285428ec839d094835396f7d99
+      RULESPEC_REF: b61918da93fe8a1a29b35b9330aef2085291a5d0
       SUPABASE_URL: https://swocpijqqahhuwtuahwc.supabase.co
     steps:
       - name: Checkout immutable encoder main

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -21,7 +21,7 @@ REVIEWED_RULESPEC_REFS = frozenset(
     {
         (
             "us",
-            "8f224620540f9e285428ec839d094835396f7d99",
+            "b61918da93fe8a1a29b35b9330aef2085291a5d0",
         ),
         (
             "ca",

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -280,7 +280,7 @@ def test_validate_rulespec_base_rejects_stale_main_pr_base(
 @pytest.mark.parametrize(
     ("country", "reviewed_ref"),
     [
-        ("us", "8f224620540f9e285428ec839d094835396f7d99"),
+        ("us", "b61918da93fe8a1a29b35b9330aef2085291a5d0"),
         ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
     ],
 )
@@ -293,7 +293,7 @@ def test_validate_rulespec_base_accepts_exact_reviewed_head_artifact_only(
     repo = tmp_path / f"rulespec-{country}"
     assert REVIEWED_RULESPEC_REFS == frozenset(
         {
-            ("us", "8f224620540f9e285428ec839d094835396f7d99"),
+            ("us", "b61918da93fe8a1a29b35b9330aef2085291a5d0"),
             ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
         }
     )
@@ -323,7 +323,7 @@ def test_validate_rulespec_base_accepts_exact_reviewed_protected_branch_tip(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repo = tmp_path / "rulespec-us"
-    reviewed_ref = "8f224620540f9e285428ec839d094835396f7d99"
+    reviewed_ref = "b61918da93fe8a1a29b35b9330aef2085291a5d0"
     git_calls: list[tuple[str, ...]] = []
 
     def fake_git(_repo: Path, *args: str) -> bytes:
@@ -357,7 +357,7 @@ def test_validate_rulespec_base_rejects_stale_reviewed_protected_branch_tip(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repo = tmp_path / "rulespec-us"
-    reviewed_ref = "8f224620540f9e285428ec839d094835396f7d99"
+    reviewed_ref = "b61918da93fe8a1a29b35b9330aef2085291a5d0"
 
     def fake_git(_repo: Path, *args: str) -> bytes:
         if args[-1] == "refs/remotes/origin/hard-cut/canonical-layout-us":
@@ -385,7 +385,7 @@ def test_validate_rulespec_base_rejects_unapproved_reviewed_pr_branch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repo = tmp_path / "rulespec-us"
-    reviewed_ref = "8f224620540f9e285428ec839d094835396f7d99"
+    reviewed_ref = "b61918da93fe8a1a29b35b9330aef2085291a5d0"
     monkeypatch.setattr(
         "scripts.prepare_signed_backfill._git",
         lambda _repo, *_args: f"{reviewed_ref}\n".encode(),


### PR DESCRIPTION
## Summary
- rotate the reviewed US RuleSpec allowlist to the exact current hard-cut tip `b61918da93fe8a1a29b35b9330aef2085291a5d0`
- prepare future all-state SNAP queue generation against that reviewed tip
- keep the existing signed, paused queue baseline unchanged until the finalize workflow performs its validated repin

## Review cycle
Independent review found no actionable issues. It verified the remote protected-branch identity, stale-reference behavior, finalize repin path, and focused coverage. No changes were required after review.

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest` (5364 passed, 119 skipped)
- focused queue/backfill tests (88 passed)
- `git diff --check`