### PR TITLE
signed-apply: pin post-#1290 encoder + optional require-complete-source-unit input

### DIFF
--- a/.github/workflows/signed-apply-reusable.yml
+++ b/.github/workflows/signed-apply-reusable.yml
@@ -32,6 +32,11 @@ on:
         required: false
         type: string
         default: "12"
+      require-complete-source-unit:
+        description: "Require complete source-unit coverage during encoding."
+        required: false
+        type: boolean
+        default: false
     secrets:
       openai-api-key:
         description: "OpenAI model credential, explicitly passed by the caller."
@@ -309,11 +314,16 @@ jobs:
           CITATION: ${{ matrix.item.citation }}
         run: |
           set -euo pipefail
-          # Builtin read + pure assignment only — no subprocess is forked while
-          # the signing key is in this step's environment; then exec the launcher
-          # (which unsets the key before spawning any child).
+          # Builtin read/conditionals + pure assignment only — no subprocess is
+          # forked while the signing key is in this step's environment; then exec
+          # the launcher (which unsets the key before spawning any child).
           read -r pyseg < "$RUNNER_TEMP/pyseg"
           genroot="$RUNNER_TEMP/genroot/${{ github.event.repository.name }}"
+          require_complete_source_unit=${{ inputs['require-complete-source-unit'] }}
+          complete_source_unit_args=()
+          if [[ "$require_complete_source_unit" == true ]]; then
+            complete_source_unit_args=(--require-complete-source-unit)
+          fi
           exec "$RUNNER_TEMP/axiom-encode-apply-signer" run \
             --scope apply_ed25519 \
             --key-env AXIOM_ENCODE_APPLY_SIGNING_KEY \
@@ -332,7 +342,8 @@ jobs:
             --axiom-rules-engine-path "$GITHUB_WORKSPACE/_axiom/axiom-rules-engine" \
             --policy-repo-path "$genroot" \
             --mode cold --no-sync --skip-reviewers \
-            --db "$RUNNER_TEMP/enc.db"
+            --db "$RUNNER_TEMP/enc.db" \
+            "${complete_source_unit_args[@]}"
 
       - name: Gate battery on the generated mirror (fail-closed pre-check)
         shell: bash

--- a/.github/workflows/signed-apply-reusable.yml
+++ b/.github/workflows/signed-apply-reusable.yml
@@ -56,7 +56,7 @@ env:
   # wave pin 185b2457). The validate workflow's encode-ref is bumped to the
   # same sha in this PR so the signed PRs' CI verifies manifests with the
   # same encoder generation that produced them.
-  AXIOM_ENCODE_REF: b9d376684cfb5e86202daa3451b8fc716703ed19
+  AXIOM_ENCODE_REF: 034d1acb39ae9c9cb7208bfb8532433e7eed7ceb
   AXIOM_RULES_ENGINE_REF: 05eac9d2f89dabe5c6673176260762cef3a58f47
 
 jobs:

--- a/.github/workflows/signed-apply-reusable.yml
+++ b/.github/workflows/signed-apply-reusable.yml
@@ -320,11 +320,7 @@ jobs:
           read -r pyseg < "$RUNNER_TEMP/pyseg"
           genroot="$RUNNER_TEMP/genroot/${{ github.event.repository.name }}"
           require_complete_source_unit=${{ inputs['require-complete-source-unit'] }}
-          complete_source_unit_args=()
-          if [[ "$require_complete_source_unit" == true ]]; then
-            complete_source_unit_args=(--require-complete-source-unit)
-          fi
-          exec "$RUNNER_TEMP/axiom-encode-apply-signer" run \
+          set -- "$RUNNER_TEMP/axiom-encode-apply-signer" run \
             --scope apply_ed25519 \
             --key-env AXIOM_ENCODE_APPLY_SIGNING_KEY \
             --supervisor /opt/axiom-verification/axiom-encode-signing-supervisor \
@@ -342,8 +338,11 @@ jobs:
             --axiom-rules-engine-path "$GITHUB_WORKSPACE/_axiom/axiom-rules-engine" \
             --policy-repo-path "$genroot" \
             --mode cold --no-sync --skip-reviewers \
-            --db "$RUNNER_TEMP/enc.db" \
-            "${complete_source_unit_args[@]}"
+            --db "$RUNNER_TEMP/enc.db"
+          if [[ "$require_complete_source_unit" == true ]]; then
+            set -- "$@" --require-complete-source-unit
+          fi
+          exec "$@"
 
       - name: Gate battery on the generated mirror (fail-closed pre-check)
         shell: bash

--- a/cmd/axiom-encode-apply-signer/run_test.go
+++ b/cmd/axiom-encode-apply-signer/run_test.go
@@ -62,6 +62,20 @@ func stubSupervisor(t *testing.T, dumpPath string) string {
 	return path
 }
 
+// stubSupervisorArgv records each received argument as a NUL-delimited field so
+// launcher tests can compare the supervisor argv without shell-word ambiguity.
+func stubSupervisorArgv(t *testing.T, dumpPath string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "stub-supervisor-argv")
+	script := "#!/bin/sh\n" +
+		"printf '%s\\0' \"$@\" > " + shellQuote(dumpPath) + "\n" +
+		"exit 0\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
 func shellQuote(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
 }
@@ -124,6 +138,102 @@ func TestLauncherKeepsKeyOutOfSupervisorEnvironment(t *testing.T) {
 	// The key must never appear in the launcher's own stdout/stderr either.
 	if strings.Contains(string(output), seedB64) {
 		t.Fatal("launcher output leaked the private key material")
+	}
+}
+
+func TestLauncherForwardsCompleteSourceUnitArgumentToSupervisor(t *testing.T) {
+	_, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seedB64 := base64.StdEncoding.EncodeToString(private.Seed())
+	baseCommand := []string{
+		"/opt/axiom-signing/axiom-encode",
+		"encode",
+		"uk/statute/toy",
+		"--apply",
+	}
+	tests := []struct {
+		name    string
+		command []string
+		count   int
+	}{
+		{
+			name:    "default off leaves encoder argv unchanged",
+			command: append([]string(nil), baseCommand...),
+			count:   0,
+		},
+		{
+			name: "enabled appends exactly one fixed literal",
+			command: append(
+				append([]string(nil), baseCommand...),
+				"--require-complete-source-unit",
+			),
+			count: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dump := filepath.Join(t.TempDir(), "supervisor-argv.bin")
+			supervisor := stubSupervisorArgv(t, dump)
+			launcherArguments := []string{
+				"run",
+				"--scope", "apply_ed25519",
+				"--key-env", "APPLY_SIGNER_TEST_KEY",
+				"--supervisor", supervisor,
+				"--trusted-signing-roots", "/dev/null",
+				"--expected-github-repository", "TheAxiomFoundation/rulespec-uk",
+				"--allowed-workflow-ref", "TheAxiomFoundation/rulespec-uk/.github/workflows/bulk-encode.yml@refs/heads/main",
+				"--allowed-event-name", "workflow_dispatch",
+				"--",
+			}
+			launcherArguments = append(launcherArguments, test.command...)
+			command := exec.Command(applySignerBinary, launcherArguments...)
+			command.Env = append(
+				ciEnvironmentPairs(),
+				"APPLY_SIGNER_TEST_KEY="+seedB64,
+			)
+			output, err := command.CombinedOutput()
+			if err != nil {
+				t.Fatalf("launcher failed: %v\n%s", err, output)
+			}
+
+			raw, err := os.ReadFile(dump)
+			if err != nil {
+				t.Fatalf("supervisor stub did not run: %v", err)
+			}
+			raw = bytes.TrimSuffix(raw, []byte{0})
+			fields := bytes.Split(raw, []byte{0})
+			got := make([]string, 0, len(fields))
+			for _, field := range fields {
+				got = append(got, string(field))
+			}
+			want := []string{
+				"--apply-signer-fd", "3",
+				"--trusted-signing-roots", "/dev/null",
+				"--",
+			}
+			want = append(want, test.command...)
+			if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+				t.Fatalf("supervisor argv mismatch:\n got: %q\nwant: %q", got, want)
+			}
+
+			count := 0
+			for _, argument := range got {
+				if argument == "--require-complete-source-unit" {
+					count++
+				}
+			}
+			if count != test.count {
+				t.Fatalf(
+					"complete-source-unit literal count = %d, want %d in %q",
+					count,
+					test.count,
+					got,
+				)
+			}
+		})
 	}
 }
 

--- a/cmd/axiom-encode-signing-supervisor/execution_trust_fixture_test.go
+++ b/cmd/axiom-encode-signing-supervisor/execution_trust_fixture_test.go
@@ -5,10 +5,21 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
-func TestFixturePolicyValidatesHermeticPythonChain(t *testing.T) {
+type fixturePythonChain struct {
+	runtimeRoot string
+	importRoot  string
+	packageRoot string
+	interpreter string
+	bootstrap   string
+	executable  string
+}
+
+func newFixturePythonChain(t *testing.T) fixturePythonChain {
+	t.Helper()
 	temporary, err := filepath.EvalSymlinks(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
@@ -29,7 +40,8 @@ func TestFixturePolicyValidatesHermeticPythonChain(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(packageRoot, "__init__.py"), []byte("\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(packageRoot, "_trusted_signing_bootstrap.py"), []byte("\n"), 0o600); err != nil {
+	bootstrap := filepath.Join(packageRoot, "_trusted_signing_bootstrap.py")
+	if err := os.WriteFile(bootstrap, []byte("\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	executable := filepath.Join(runtimeRoot, "axiom-encode")
@@ -37,21 +49,116 @@ func TestFixturePolicyValidatesHermeticPythonChain(t *testing.T) {
 	if err := os.WriteFile(executable, launcher, 0o700); err != nil {
 		t.Fatal(err)
 	}
+	return fixturePythonChain{
+		runtimeRoot: runtimeRoot,
+		importRoot:  filepath.Dir(packageRoot),
+		packageRoot: packageRoot,
+		interpreter: interpreter,
+		bootstrap:   bootstrap,
+		executable:  executable,
+	}
+}
+
+func TestFixturePolicyValidatesHermeticPythonChain(t *testing.T) {
+	fixture := newFixturePythonChain(t)
 
 	chain, err := validateTrustedExecutionChain(
-		executable,
-		[]string{runtimeRoot},
-		[]string{filepath.Dir(packageRoot)},
-		packageRoot,
+		fixture.executable,
+		[]string{fixture.runtimeRoot},
+		[]string{fixture.importRoot},
+		fixture.packageRoot,
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if chain.Executable != interpreter || chain.PythonInterpreter != interpreter {
+	if chain.Executable != fixture.interpreter || chain.PythonInterpreter != fixture.interpreter {
 		t.Fatalf("unexpected trusted chain: %#v", chain)
 	}
-	if chain.PythonPackageRoot != packageRoot || len(chain.PythonRuntimeRoots) != 1 {
+	if chain.PythonPackageRoot != fixture.packageRoot || len(chain.PythonRuntimeRoots) != 1 {
 		t.Fatalf("unexpected Python trust roots: %#v", chain)
+	}
+}
+
+func TestFixtureSupervisorPreservesCompleteSourceUnitArgumentThroughBootstrap(t *testing.T) {
+	fixture := newFixturePythonChain(t)
+	baseCommand := []string{
+		fixture.executable,
+		"encode",
+		"uk/statute/toy",
+		"--apply",
+	}
+	tests := []struct {
+		name    string
+		command []string
+		count   int
+	}{
+		{
+			name:    "default off leaves encoder argv unchanged",
+			command: append([]string(nil), baseCommand...),
+			count:   0,
+		},
+		{
+			name: "enabled preserves exactly one appended literal",
+			command: append(
+				append([]string(nil), baseCommand...),
+				"--require-complete-source-unit",
+			),
+			count: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			arguments := []string{
+				"--trusted-signing-roots", filepath.Join(fixture.runtimeRoot, "trust.json"),
+				"--trusted-python-runtime-root", fixture.runtimeRoot,
+				"--trusted-python-import-root", fixture.importRoot,
+				"--trusted-python-package-root", fixture.packageRoot,
+				"--",
+			}
+			arguments = append(arguments, test.command...)
+			parsed, err := parseOptions(arguments)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			want := []string{
+				fixture.interpreter,
+				"-I",
+				"-S",
+				fixture.bootstrap,
+				"--runtime-root",
+				fixture.runtimeRoot,
+				"--package-root",
+				fixture.packageRoot,
+				"--import-root",
+				fixture.importRoot,
+				"--",
+			}
+			want = append(want, test.command[1:]...)
+			if !reflect.DeepEqual(parsed.command, want) {
+				t.Fatalf(
+					"bootstrap argv mismatch:\n got: %q\nwant: %q",
+					parsed.command,
+					want,
+				)
+			}
+
+			count := 0
+			for _, argument := range parsed.command {
+				if argument == "--require-complete-source-unit" {
+					count++
+				}
+			}
+			if count != test.count {
+				t.Fatalf(
+					"complete-source-unit literal count = %d, want %d in %q",
+					count,
+					test.count,
+					parsed.command,
+				)
+			}
+		})
 	}
 }
 

--- a/tests/test_signed_apply_reusable.py
+++ b/tests/test_signed_apply_reusable.py
@@ -1,0 +1,116 @@
+"""Focused tests for the signed-apply reusable workflow contract."""
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github/workflows/signed-apply-reusable.yml"
+COMPLETE_SOURCE_FLAG = "--require-complete-source-unit"
+
+
+def _workflow_payload() -> dict:
+    return yaml.load(WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+
+def _signed_apply_script(enabled: bool) -> str:
+    payload = _workflow_payload()
+    script = next(
+        step["run"]
+        for step in payload["jobs"]["encode"]["steps"]
+        if step.get("name") == "Signed re-encode under supervisor + leaf signer"
+    )
+    replacements = {
+        "${{ inputs['require-complete-source-unit'] }}": str(enabled).lower(),
+        "${{ github.event.repository.name }}": "rulespec-de",
+        "${{ github.repository }}": "TheAxiomFoundation/rulespec-de",
+        "${{ github.event.repository.default_branch }}": "main",
+    }
+    for expression, value in replacements.items():
+        script = script.replace(expression, value)
+    assert "${{" not in script
+    return script
+
+
+def test_complete_source_unit_reusable_input_is_optional_boolean_default_off():
+    inputs = _workflow_payload()["on"]["workflow_call"]["inputs"]
+    complete_source_input = inputs["require-complete-source-unit"]
+
+    assert complete_source_input["required"] == "false"
+    assert complete_source_input["type"] == "boolean"
+    assert complete_source_input["default"] == "false"
+
+
+@pytest.mark.parametrize(
+    ("enabled", "expected_mode_args"),
+    [
+        (False, []),
+        (True, [COMPLETE_SOURCE_FLAG]),
+    ],
+)
+def test_complete_source_unit_input_composes_fixed_encoder_argv(
+    tmp_path,
+    enabled,
+    expected_mode_args,
+):
+    launcher = tmp_path / "axiom-encode-apply-signer"
+    launcher.write_text(
+        '#!/bin/bash\nprintf \'%s\\0\' "$@" > "$RUNNER_TEMP/launcher-argv.bin"\n',
+        encoding="utf-8",
+    )
+    launcher.chmod(0o755)
+    (tmp_path / "pyseg").write_text("python3.14\n", encoding="utf-8")
+
+    script = _signed_apply_script(enabled)
+    subprocess.run(
+        ["/bin/bash", "-n"],
+        input=script,
+        text=True,
+        check=True,
+    )
+    workspace = tmp_path / "rulespec-de"
+    environment = {
+        **os.environ,
+        "AXIOM_ENCODE_APPLY_SIGNING_KEY": "test-only-key",
+        "CITATION": "de/statute/estg/32a",
+        "GITHUB_REPOSITORY": "TheAxiomFoundation/rulespec-de",
+        "GITHUB_WORKSPACE": str(workspace),
+        "RUNNER_TEMP": str(tmp_path),
+    }
+    subprocess.run(
+        ["/bin/bash", "-c", script],
+        env=environment,
+        check=True,
+    )
+
+    raw_argv = (tmp_path / "launcher-argv.bin").read_bytes()
+    launcher_argv = [
+        field.decode() for field in raw_argv.removesuffix(b"\0").split(b"\0")
+    ]
+    separator = launcher_argv.index("--")
+    encoder_argv = launcher_argv[separator + 1 :]
+    assert encoder_argv == [
+        "/opt/axiom-verification/axiom-encode",
+        "encode",
+        "de/statute/estg/32a",
+        "--apply",
+        "--backend",
+        "openai",
+        "--corpus-path",
+        f"{workspace}/_axiom/axiom-corpus",
+        "--axiom-rules-engine-path",
+        f"{workspace}/_axiom/axiom-rules-engine",
+        "--policy-repo-path",
+        f"{tmp_path}/genroot/rulespec-de",
+        "--mode",
+        "cold",
+        "--no-sync",
+        "--skip-reviewers",
+        "--db",
+        f"{tmp_path}/enc.db",
+        *expected_mode_args,
+    ]
+    assert launcher_argv.count(COMPLETE_SOURCE_FLAG) == int(enabled)


### PR DESCRIPTION
Completes the infrastructure for full-provision signed regeneration (rulespec-de#1 program). Two changes, both in the reusable workflow + tests only — **zero production launcher/supervisor source changes**.

## 1. Encoder pin: `b9d37668` → `034d1acb`

The hardcoded `AXIOM_ENCODE_REF` predated #1285, so a signed-apply dispatch would have regenerated content with an encoder lacking both the typed-occurrence/de-DE grounding (#1285) and the completeness gate (#1290). The pin now targets the #1290 merge commit (encoder 0.2.1384). Trust-chain effect: provisioning re-derives the encoder snapshot, `package_tree_sha256`, and runtime attestation from the new checkout; launcher/supervisor Go sources are identical between the pins, and trust roots hold keys (not content hashes), so no rotation or schema change.

## 2. Opt-in `require-complete-source-unit` input (typed boolean, default `false`)

- `false`/omitted → the exec argv is **byte-identical** to today (tested).
- `true` → exactly **one fixed literal** (`--require-complete-source-unit`) is appended via builtins-only shell (`set --`/`[[ ]]`), preserving the no-subprocess-while-signing-key-in-env invariant. No free-text passthrough, no env-var switch — a typed boolean can only render `true`/`false`, so there is no injection surface.
- The existing chain already forwards the tail: apply-signer → supervisor `--` → Python bootstrap argv. Covered at all three layers: workflow argv composition tests (default-exact + enabled-exact), apply-signer forwarding test, supervisor bootstrap rewrite test (off/on).

## Verification

- Workflow: `bash -n`, `actionlint -shellcheck=` clean (six pre-existing findings in untouched blocks unchanged).
- Go: unit + race + vet + reproducible production builds pass; `--build-kind` still `production`.
- Python: focused suite 18 passed; signing-supervisor integration 64 passed / 3 skipped; broad runnable coverage 5,823 passed.
- No version bump required (no `src/axiom_encode` changes); no PROGRESS.md.

## Caller usage (rulespec-de follows in a lockstep PR)

```yaml
uses: TheAxiomFoundation/axiom-encode/.github/workflows/signed-apply-reusable.yml@main
with:
  citations: ${{ inputs.citations }}
  require-complete-source-unit: true
```

Built cross-family (sol implements, Claude verifies the workflow hunks, Go-source purity, and injection-surface analysis directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
