### PR TITLE
Support two-dependent signed re-encodes

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -42,6 +42,14 @@ on:
         description: Independent-review finding for the direct dependent
         required: false
         type: string
+      second_dependent_citation:
+        description: Second direct dependent to re-encode in the same signed change
+        required: false
+        type: string
+      second_dependent_review_finding:
+        description: Independent-review finding for the second direct dependent
+        required: false
+        type: string
       open_pr:
         description: Commit, push, and open a draft RuleSpec pull request
         required: false
@@ -491,17 +499,30 @@ jobs:
           PY
 
       - name: Validate dependent cascade
-        if: ${{ inputs.dependent_citation != '' }}
+        if: >-
+          ${{
+            inputs.dependent_citation != ''
+            || inputs.second_dependent_citation != ''
+          }}
         env:
           CITATION: ${{ inputs.citation }}
           DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
+          SECOND_DEPENDENT_CITATION: ${{ inputs.second_dependent_citation }}
           RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
         run: |
           set -euo pipefail
+          if [ -z "$DEPENDENT_CITATION" ]; then
+            echo "first dependent citation is required before a second dependent" >&2
+            exit 1
+          fi
+          dependent_citations=("$DEPENDENT_CITATION")
+          if [ -n "$SECOND_DEPENDENT_CITATION" ]; then
+            dependent_citations+=("$SECOND_DEPENDENT_CITATION")
+          fi
           axiom-encode/.venv/bin/python \
             axiom-encode/scripts/prepare_signed_backfill.py \
             validate-dependent-cascade \
-            "$RULESPEC_CHECKOUT" "$CITATION" "$DEPENDENT_CITATION"
+            "$RULESPEC_CHECKOUT" "$CITATION" "${dependent_citations[@]}"
 
       - name: Encode, review, validate, and apply
         env:
@@ -511,9 +532,13 @@ jobs:
           REVIEW_FINDING: ${{ inputs.review_finding }}
           DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
           DEPENDENT_REVIEW_FINDING: ${{ inputs.dependent_review_finding }}
+          SECOND_DEPENDENT_CITATION: ${{ inputs.second_dependent_citation }}
+          SECOND_DEPENDENT_REVIEW_FINDING: ${{ inputs.second_dependent_review_finding }}
           RULESPEC_CHECKOUT: ${{ github.workspace }}/rulespec-${{ inputs.country }}
         run: |
           set -euo pipefail
+          : "${SECOND_DEPENDENT_CITATION:=}"
+          : "${SECOND_DEPENDENT_REVIEW_FINDING:=}"
 
           run_signed_encode() {
             local citation="$1"
@@ -558,23 +583,49 @@ jobs:
               -- "${args[@]}"
           }
 
+          if [ -n "$DEPENDENT_REVIEW_FINDING" ] && [ -z "$DEPENDENT_CITATION" ]; then
+            echo "dependent citation is required with dependent review finding" >&2
+            exit 1
+          fi
+          if [ -n "$DEPENDENT_CITATION" ] && [ -z "$DEPENDENT_REVIEW_FINDING" ]; then
+            echo "dependent review finding is required with dependent citation" >&2
+            exit 1
+          fi
+          if [ -n "$SECOND_DEPENDENT_CITATION" ] && [ -z "$DEPENDENT_CITATION" ]; then
+            echo "first dependent citation is required before a second dependent" >&2
+            exit 1
+          fi
+          if [ -n "$SECOND_DEPENDENT_REVIEW_FINDING" ] && \
+            [ -z "$SECOND_DEPENDENT_CITATION" ]; then
+            echo "second dependent citation is required with its review finding" >&2
+            exit 1
+          fi
+          if [ -n "$SECOND_DEPENDENT_CITATION" ] && \
+            [ -z "$SECOND_DEPENDENT_REVIEW_FINDING" ]; then
+            echo "second dependent review finding is required" >&2
+            exit 1
+          fi
+          if [ -n "$DEPENDENT_CITATION" ] && [ "$DEPENDENT_CITATION" = "$CITATION" ]; then
+            echo "dependent citation must differ from the target citation" >&2
+            exit 1
+          fi
+          if [ -n "$SECOND_DEPENDENT_CITATION" ] && \
+            { [ "$SECOND_DEPENDENT_CITATION" = "$CITATION" ] || \
+              [ "$SECOND_DEPENDENT_CITATION" = "$DEPENDENT_CITATION" ]; }; then
+            echo "second dependent citation must be unique" >&2
+            exit 1
+          fi
+
           if [ -n "$DEPENDENT_CITATION" ]; then
-            if [ "$DEPENDENT_CITATION" = "$CITATION" ]; then
-              echo "dependent citation must differ from the target citation" >&2
-              exit 1
-            fi
-            if [ -z "$DEPENDENT_REVIEW_FINDING" ]; then
-              echo "dependent review finding is required with dependent citation" >&2
-              exit 1
-            fi
             run_signed_encode "$CITATION" "$REVIEW_FINDING" true target
             run_signed_encode \
               "$DEPENDENT_CITATION" "$DEPENDENT_REVIEW_FINDING" false dependent
-          else
-            if [ -n "$DEPENDENT_REVIEW_FINDING" ]; then
-              echo "dependent citation is required with dependent review finding" >&2
-              exit 1
+            if [ -n "$SECOND_DEPENDENT_CITATION" ]; then
+              run_signed_encode \
+                "$SECOND_DEPENDENT_CITATION" \
+                "$SECOND_DEPENDENT_REVIEW_FINDING" false dependent-2
             fi
+          else
             run_signed_encode "$CITATION" "$REVIEW_FINDING" false target
           fi
 
@@ -599,6 +650,8 @@ jobs:
           CITATION: ${{ inputs.citation }}
           DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
           DEPENDENT_REVIEW_FINDING_PRESENT: ${{ inputs.dependent_review_finding != '' }}
+          SECOND_DEPENDENT_CITATION: ${{ inputs.second_dependent_citation }}
+          SECOND_DEPENDENT_REVIEW_FINDING_PRESENT: ${{ inputs.second_dependent_review_finding != '' }}
           PR_BASE_BRANCH: ${{ inputs.pr_base_branch }}
           QUEUE_ID: ${{ inputs.queue_id }}
           QUEUE_ITEM_ID: ${{ inputs.queue_item_id }}
@@ -645,9 +698,14 @@ jobs:
               )
           )
           dependent_citation = os.environ.get("DEPENDENT_CITATION") or ""
+          second_dependent_citation = (
+              os.environ.get("SECOND_DEPENDENT_CITATION") or ""
+          )
           expected_citations = {os.environ["CITATION"]}
           if dependent_citation:
               expected_citations.add(dependent_citation)
+          if second_dependent_citation:
+              expected_citations.add(second_dependent_citation)
 
           matches = {}
           for relative_path in sorted(manifest_paths):
@@ -676,6 +734,20 @@ jobs:
                       os.environ["DEPENDENT_REVIEW_FINDING_PRESENT"] == "true",
                       Path(sys.argv[1]).with_name("dependent-context-manifest.json"),
                       "dependent",
+                  )
+              )
+          if second_dependent_citation:
+              expected.append(
+                  (
+                      second_dependent_citation,
+                      (
+                          os.environ["SECOND_DEPENDENT_REVIEW_FINDING_PRESENT"]
+                          == "true"
+                      ),
+                      Path(sys.argv[1]).with_name(
+                          "dependent-2-context-manifest.json"
+                      ),
+                      "dependent-2",
                   )
               )
 
@@ -768,6 +840,9 @@ jobs:
               "schema": "axiom-encode/targeted-reencode-artifact/v1",
               "citation": os.environ["CITATION"],
               "dependent_citation": os.environ.get("DEPENDENT_CITATION") or None,
+              "second_dependent_citation": (
+                  os.environ.get("SECOND_DEPENDENT_CITATION") or None
+              ),
               "pr_base_branch": os.environ["PR_BASE_BRANCH"],
               "queue_id": os.environ.get("QUEUE_ID") or None,
               "queue_item_id": os.environ.get("QUEUE_ITEM_ID") or None,
@@ -815,6 +890,8 @@ jobs:
           GH_TOKEN: ${{ secrets.AXIOM_REPO_TOKEN }}
           COUNTRY: ${{ inputs.country }}
           CITATION: ${{ inputs.citation }}
+          DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
+          SECOND_DEPENDENT_CITATION: ${{ inputs.second_dependent_citation }}
           RULESPEC_REF: ${{ inputs.rulespec_ref }}
           PR_BASE_BRANCH: ${{ inputs.pr_base_branch }}
           QUEUE_ID: ${{ inputs.queue_id }}
@@ -836,6 +913,8 @@ jobs:
             '## Signed apply manifest' \
             '' \
             "Citation: \`${CITATION}\`" \
+            "Direct dependent: \`${DEPENDENT_CITATION:-n/a}\`" \
+            "Second direct dependent: \`${SECOND_DEPENDENT_CITATION:-n/a}\`" \
             "Base commit: \`${RULESPEC_REF}\`" \
             "Base branch: \`${PR_BASE_BRANCH}\`" \
             "Queue item: \`${QUEUE_ID:-ad-hoc}/${QUEUE_ITEM_ID:-ad-hoc}\`" \

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -166,20 +166,27 @@ def _citation_rulespec_path(citation: str) -> tuple[str, PurePosixPath]:
 def validate_dependent_cascade(
     repo: Path,
     target_citation: str,
-    dependent_citation: str,
-) -> PurePosixPath:
-    """Require the supplied module to be the target's only direct dependent."""
+    *dependent_citations: str,
+) -> tuple[PurePosixPath, ...]:
+    """Require the supplied modules to be all of the target's direct dependents."""
 
     import yaml
 
     target_jurisdiction, target_relative = _citation_rulespec_path(target_citation)
-    dependent_jurisdiction, dependent_relative = _citation_rulespec_path(
-        dependent_citation
-    )
-    if target_jurisdiction != dependent_jurisdiction:
-        raise ValueError("target and dependent must use the same jurisdiction")
-    if target_relative == dependent_relative:
-        raise ValueError("dependent citation must differ from the target citation")
+    if not dependent_citations:
+        raise ValueError("at least one dependent citation is required")
+    dependent_relatives: list[PurePosixPath] = []
+    for dependent_citation in dependent_citations:
+        dependent_jurisdiction, dependent_relative = _citation_rulespec_path(
+            dependent_citation
+        )
+        if target_jurisdiction != dependent_jurisdiction:
+            raise ValueError("target and dependents must use the same jurisdiction")
+        if target_relative == dependent_relative:
+            raise ValueError("dependent citation must differ from the target citation")
+        dependent_relatives.append(dependent_relative)
+    if len(set(dependent_relatives)) != len(dependent_relatives):
+        raise ValueError("dependent citations must be unique")
 
     repo_prefix = "rulespec-"
     if not repo.name.startswith(repo_prefix):
@@ -192,11 +199,14 @@ def validate_dependent_cascade(
 
     content_root = repo / target_jurisdiction
     target_path = content_root / target_relative
-    dependent_path = content_root / dependent_relative
     if not target_path.is_file() or target_path.is_symlink():
         raise ValueError("target citation has no regular baseline RuleSpec module")
-    if not dependent_path.is_file() or dependent_path.is_symlink():
-        raise ValueError("dependent citation has no regular baseline RuleSpec module")
+    for dependent_relative in dependent_relatives:
+        dependent_path = content_root / dependent_relative
+        if not dependent_path.is_file() or dependent_path.is_symlink():
+            raise ValueError(
+                "dependent citation has no regular baseline RuleSpec module"
+            )
 
     target_import = target_relative.with_suffix("").as_posix()
     canonical_target_import = f"{target_jurisdiction}:{target_import}"
@@ -233,14 +243,14 @@ def validate_dependent_cascade(
                     PurePosixPath(candidate.relative_to(content_root).as_posix())
                 )
 
-    expected = {dependent_relative}
+    expected = set(dependent_relatives)
     if direct_dependents != expected:
         rendered = ", ".join(map(str, sorted(direct_dependents))) or "<none>"
         raise ValueError(
-            "target direct-dependent set does not exactly match supplied dependent: "
+            "target direct-dependent set does not exactly match supplied dependents: "
             f"{rendered}"
         )
-    return dependent_relative
+    return tuple(dependent_relatives)
 
 
 def _git(repo: Path, *args: str) -> bytes:
@@ -384,7 +394,7 @@ def main() -> None:
     cascade_parser = subparsers.add_parser("validate-dependent-cascade")
     cascade_parser.add_argument("repo", type=Path)
     cascade_parser.add_argument("target_citation")
-    cascade_parser.add_argument("dependent_citation")
+    cascade_parser.add_argument("dependent_citations", nargs="+")
     args = parser.parse_args()
     try:
         if args.command == "validate-country":
@@ -415,7 +425,7 @@ def main() -> None:
                 validate_dependent_cascade(
                     args.repo,
                     args.target_citation,
-                    args.dependent_citation,
+                    *args.dependent_citations,
                 )
             )
         else:

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -190,7 +190,7 @@ def test_validate_dependent_cascade_accepts_only_direct_dependent(
         repo,
         "us/regulation/42/435/555",
         "us/regulation/42/435/559",
-    ) == dependent.relative_to(repo / "us")
+    ) == (dependent.relative_to(repo / "us"),)
 
 
 def test_validate_dependent_cascade_rejects_unrelated_dependent(
@@ -213,7 +213,30 @@ def test_validate_dependent_cascade_rejects_unrelated_dependent(
         )
 
 
-def test_validate_dependent_cascade_rejects_multiple_direct_dependents(
+def test_validate_dependent_cascade_accepts_all_direct_dependents(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    _write_module(repo, "regulations/42-cfr/435/555.yaml")
+    dependents = []
+    for section in ("559", "561"):
+        dependents.append(
+            _write_module(
+                repo,
+                f"regulations/42-cfr/435/{section}.yaml",
+                imports=("regulations/42-cfr/435/555",),
+            ).relative_to(repo / "us")
+        )
+
+    assert validate_dependent_cascade(
+        repo,
+        "us/regulation/42/435/555",
+        "us/regulation/42/435/559",
+        "us/regulation/42/435/561",
+    ) == tuple(dependents)
+
+
+def test_validate_dependent_cascade_rejects_incomplete_direct_dependents(
     tmp_path: Path,
 ) -> None:
     repo = _repo(tmp_path)

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1836,6 +1836,8 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert inputs["pr_base_branch"]["default"] == "main"
     assert inputs["dependent_citation"]["required"] is False
     assert inputs["dependent_review_finding"]["required"] is False
+    assert inputs["second_dependent_citation"]["required"] is False
+    assert inputs["second_dependent_review_finding"]["required"] is False
     assert inputs["queue_id"]["required"] is False
     assert inputs["queue_item_id"]["required"] is False
     assert inputs["queue_manifest_sha256"]["required"] is False
@@ -1974,10 +1976,15 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     cascade_step = next(
         step for step in steps if step.get("name") == "Validate dependent cascade"
     )
-    assert cascade_step["if"] == "${{ inputs.dependent_citation != '' }}"
+    assert "inputs.dependent_citation != ''" in cascade_step["if"]
+    assert "inputs.second_dependent_citation != ''" in cascade_step["if"]
     assert "validate-dependent-cascade" in cascade_step["run"]
+    assert 'dependent_citations=("$DEPENDENT_CITATION")' in cascade_step["run"]
     assert (
-        '"$RULESPEC_CHECKOUT" "$CITATION" "$DEPENDENT_CITATION"'
+        'dependent_citations+=("$SECOND_DEPENDENT_CITATION")' in (cascade_step["run"])
+    )
+    assert (
+        '"$RULESPEC_CHECKOUT" "$CITATION" "${dependent_citations[@]}"'
         in (cascade_step["run"])
     )
 
@@ -2008,6 +2015,8 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert 'args+=(--review-findings "$review_finding_path")' in command
     assert "args+=(--apply-target-only)" in command
     assert '--output "$RUNNER_TEMP/generated/$output_lane"' in command
+    assert '"$SECOND_DEPENDENT_CITATION"' in command
+    assert '"$SECOND_DEPENDENT_REVIEW_FINDING" false dependent-2' in command
     assert 'run_signed_encode "$CITATION" "$REVIEW_FINDING" true target' in command
     assert (
         '"$DEPENDENT_CITATION" "$DEPENDENT_REVIEW_FINDING" false dependent' in command
@@ -2398,7 +2407,11 @@ def test_snap_queue_activation_checks_and_merge_revalidate_live_state() -> None:
     assert upload["with"]["retention-days"] == 90
 
 
-def test_targeted_signed_reencode_orders_target_and_dependent(tmp_path: Path) -> None:
+@pytest.mark.parametrize("dependent_count", [0, 1, 2])
+def test_targeted_signed_reencode_orders_target_and_dependents(
+    tmp_path: Path,
+    dependent_count: int,
+) -> None:
     workflow = yaml.safe_load(
         (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
     )
@@ -2429,45 +2442,146 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
     runner_temp = tmp_path / "runner-temp"
     runner_temp.mkdir()
 
+    environment = {
+        **os.environ,
+        "AXIOM_ENCODE_APPLY_SIGNING_KEY": "test-key",
+        "CALLS_PATH": str(calls_path),
+        "CITATION": "us/regulation/42/435/555",
+        "DEPENDENT_CITATION": "",
+        "DEPENDENT_REVIEW_FINDING": "",
+        "GITHUB_WORKSPACE": str(tmp_path),
+        "REVIEW_FINDING": "Preserve the target source.",
+        "RULESPEC_CHECKOUT": str(tmp_path / "rulespec-us"),
+        "RUNNER_TEMP": str(runner_temp),
+        "SECOND_DEPENDENT_CITATION": "",
+        "SECOND_DEPENDENT_REVIEW_FINDING": "",
+        "SIGNER_STUB": str(signer_stub),
+    }
+    if dependent_count >= 1:
+        environment.update(
+            {
+                "DEPENDENT_CITATION": "us/regulation/42/435/559",
+                "DEPENDENT_REVIEW_FINDING": "Preserve the dependent source.",
+            }
+        )
+    if dependent_count == 2:
+        environment.update(
+            {
+                "SECOND_DEPENDENT_CITATION": "us/regulation/42/435/561",
+                "SECOND_DEPENDENT_REVIEW_FINDING": (
+                    "Preserve the second dependent source."
+                ),
+            }
+        )
+
     subprocess.run(
         ["bash", "-c", command],
         check=True,
-        env={
-            **os.environ,
-            "AXIOM_ENCODE_APPLY_SIGNING_KEY": "test-key",
-            "CALLS_PATH": str(calls_path),
-            "CITATION": "us/regulation/42/435/555",
-            "DEPENDENT_CITATION": "us/regulation/42/435/559",
-            "DEPENDENT_REVIEW_FINDING": "Preserve the dependent source.",
-            "GITHUB_WORKSPACE": str(tmp_path),
-            "REVIEW_FINDING": "Preserve the target source.",
-            "RULESPEC_CHECKOUT": str(tmp_path / "rulespec-us"),
-            "RUNNER_TEMP": str(runner_temp),
-            "SIGNER_STUB": str(signer_stub),
-        },
+        env=environment,
     )
 
     calls = [
         json.loads(line) for line in calls_path.read_text(encoding="utf-8").splitlines()
     ]
-    assert len(calls) == 2
+    assert len(calls) == dependent_count + 1
     encode_args = [call[call.index("--") + 1 :] for call in calls]
     assert encode_args[0][-1] == "us/regulation/42/435/555"
-    assert "--apply-target-only" in encode_args[0]
-    assert encode_args[1][-1] == "us/regulation/42/435/559"
-    assert "--apply-target-only" not in encode_args[1]
+    assert ("--apply-target-only" in encode_args[0]) is (dependent_count > 0)
     assert (
         Path(encode_args[0][encode_args[0].index("--review-findings") + 1])
         .read_text(encoding="utf-8")
         .strip()
         == "Preserve the target source."
     )
-    assert (
-        Path(encode_args[1][encode_args[1].index("--review-findings") + 1])
-        .read_text(encoding="utf-8")
-        .strip()
-        == "Preserve the dependent source."
+    if dependent_count >= 1:
+        assert encode_args[1][-1] == "us/regulation/42/435/559"
+        assert "--apply-target-only" not in encode_args[1]
+        assert (
+            Path(encode_args[1][encode_args[1].index("--review-findings") + 1])
+            .read_text(encoding="utf-8")
+            .strip()
+            == "Preserve the dependent source."
+        )
+    if dependent_count == 2:
+        assert encode_args[2][-1] == "us/regulation/42/435/561"
+        assert "--apply-target-only" not in encode_args[2]
+        assert (
+            Path(encode_args[2][encode_args[2].index("--review-findings") + 1])
+            .read_text(encoding="utf-8")
+            .strip()
+            == "Preserve the second dependent source."
+        )
+
+
+@pytest.mark.parametrize(
+    ("overrides", "error"),
+    [
+        (
+            {
+                "SECOND_DEPENDENT_CITATION": "us/regulation/42/435/561",
+                "SECOND_DEPENDENT_REVIEW_FINDING": "Preserve the second source.",
+            },
+            "first dependent citation is required before a second dependent",
+        ),
+        (
+            {
+                "DEPENDENT_CITATION": "us/regulation/42/435/559",
+                "DEPENDENT_REVIEW_FINDING": "Preserve the dependent source.",
+                "SECOND_DEPENDENT_CITATION": "us/regulation/42/435/559",
+                "SECOND_DEPENDENT_REVIEW_FINDING": "Preserve the second source.",
+            },
+            "second dependent citation must be unique",
+        ),
+        (
+            {
+                "DEPENDENT_CITATION": "us/regulation/42/435/559",
+                "DEPENDENT_REVIEW_FINDING": "Preserve the dependent source.",
+                "SECOND_DEPENDENT_REVIEW_FINDING": "Preserve the second source.",
+            },
+            "second dependent citation is required with its review finding",
+        ),
+    ],
+)
+def test_targeted_signed_reencode_rejects_invalid_second_dependent_inputs(
+    tmp_path: Path,
+    overrides: dict[str, str],
+    error: str,
+) -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
     )
+    command = next(
+        step["run"]
+        for step in workflow["jobs"]["encode"]["steps"]
+        if step.get("name") == "Encode, review, validate, and apply"
+    )
+    runner_temp = tmp_path / "runner-temp"
+    runner_temp.mkdir()
+    environment = {
+        **os.environ,
+        "AXIOM_ENCODE_APPLY_SIGNING_KEY": "test-key",
+        "CITATION": "us/regulation/42/435/555",
+        "DEPENDENT_CITATION": "",
+        "DEPENDENT_REVIEW_FINDING": "",
+        "GITHUB_WORKSPACE": str(tmp_path),
+        "REVIEW_FINDING": "Preserve the target source.",
+        "RULESPEC_CHECKOUT": str(tmp_path / "rulespec-us"),
+        "RUNNER_TEMP": str(runner_temp),
+        "SECOND_DEPENDENT_CITATION": "",
+        "SECOND_DEPENDENT_REVIEW_FINDING": "",
+        **overrides,
+    }
+
+    completed = subprocess.run(
+        ["bash", "-c", command],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+
+    assert completed.returncode != 0
+    assert error in completed.stderr
 
 
 def test_targeted_review_finding_temp_file_is_valid_context(tmp_path: Path) -> None:
@@ -2651,6 +2765,7 @@ def test_targeted_artifact_enforces_target_and_dependent_context_lanes(
 
     target_citation = "us/regulation/42/435/555"
     dependent_citation = "us/regulation/42/435/559"
+    second_dependent_citation = "us/regulation/42/435/561"
     generated_root = tmp_path / "generated"
     contexts: dict[str, bytes] = {}
     for citation, context_citation, lane, section, finding in (
@@ -2667,6 +2782,13 @@ def test_targeted_artifact_enforces_target_and_dependent_context_lanes(
             dependent_lane,
             "559",
             "Preserve the dependent source.\n",
+        ),
+        (
+            second_dependent_citation,
+            second_dependent_citation,
+            "dependent-2",
+            "561",
+            "Preserve the second dependent source.\n",
         ),
     ):
         context_payload = {
@@ -2724,6 +2846,8 @@ def test_targeted_artifact_enforces_target_and_dependent_context_lanes(
             "CITATION": target_citation,
             "DEPENDENT_CITATION": dependent_citation,
             "DEPENDENT_REVIEW_FINDING_PRESENT": "true",
+            "SECOND_DEPENDENT_CITATION": second_dependent_citation,
+            "SECOND_DEPENDENT_REVIEW_FINDING_PRESENT": "true",
             "REVIEW_FINDING_PRESENT": "true",
             "RUNNER_TEMP": str(tmp_path),
             "RULESPEC_CHECKOUT": "rulespec-us",
@@ -2739,6 +2863,9 @@ def test_targeted_artifact_enforces_target_and_dependent_context_lanes(
     assert packaged_target.read_bytes() == contexts[target_citation]
     assert (artifact / "dependent-context-manifest.json").read_bytes() == contexts[
         dependent_citation
+    ]
+    assert (artifact / "dependent-2-context-manifest.json").read_bytes() == contexts[
+        second_dependent_citation
     ]
 
 


### PR DESCRIPTION
## Summary
- extend the protected targeted re-encode workflow to support an exact two-dependent cascade
- preserve separate signed output and provenance lanes for the target and each dependent
- validate all dependent input combinations before invoking any signer
- cover zero-, one-, and two-dependent runtime paths plus malformed second-dependent inputs

## Review cycle
Independent review initially found a P2 test gap around runtime coverage and malformed second-dependent inputs. The workflow was changed to validate every input combination before signing, and the missing runtime/rejection tests were added. Review of `f3d995aa` then found no actionable issues. CI identified a Ruff-format-only delta in the test file; after formatting, a repeated independent review of exact head `ea9939d71b48d5ddf9fed5612572ac8dd79a8650` again found no actionable issues.

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `ruff format --check src tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest`: 5749 passed, 119 skipped
- focused post-fix tests: 53 passed, 51 skipped
- `git diff --check`