### PR TITLE
Pin Kansas income-tax oracle repair

### DIFF
--- a/changelog.d/ks-2026-oracle-repair-pin.changed.md
+++ b/changelog.d/ks-2026-oracle-repair-pin.changed.md
@@ -1,0 +1,1 @@
+Pin axiom-oracles to the reviewed Kansas tax-year-2026 deduction-election rationale and sourced additional-standard-deduction count-ceiling classifications.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1384"
+version = "0.2.1385"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@343e9fae8a76e02c55c4e072c500b72a80656ef4",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@eeca677b4bbce143fb0a109e4b63bcce59453e3d",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1384"
+__version__ = "0.2.1385"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1384"
+version = "0.2.1385"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=343e9fae8a76e02c55c4e072c500b72a80656ef4" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=eeca677b4bbce143fb0a109e4b63bcce59453e3d" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=343e9fae8a76e02c55c4e072c500b72a80656ef4#343e9fae8a76e02c55c4e072c500b72a80656ef4" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=eeca677b4bbce143fb0a109e4b63bcce59453e3d#eeca677b4bbce143fb0a109e4b63bcce59453e3d" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- pin `axiom-oracles` to merged Kansas resident-income-tax repair commit `eeca677b4bbce143fb0a109e4b63bcce59453e3d`
- bump `axiom-encode` from `0.2.1384` to `0.2.1385` consistently and regenerate `uv.lock`
- add the Kansas 2026 oracle-repair pin changelog fragment

## Validation

- upstream oracle post-merge CI run `30194102653`: terminal `SUCCESS`
- `uv run --python 3.13 ruff check pyproject.toml src/axiom_encode scripts tests`
- `.venv/bin/python -m compileall -q src/axiom_encode scripts`
- focused oracle/classifier suite: `493 passed, 23 skipped`
- focused provenance/coverage slice: `419 passed`
- full suite: `5748 passed, 119 skipped`
- `uv lock --check`; isolated sdist/wheel build and METADATA inspection
- `git diff --check`
- independent review cycle: no actionable findings; exact installed oracle provenance, all 34 Kansas mappings, both new P4 ceiling classifications, version/lock consistency, package scope, and changelog verified

## Notes

Python 3.13 was selected explicitly because the unconstrained local `uv` default selected Python 3.14, where the locked `pyroaring==1.0.3` dependency does not build on macOS. The repository-supported Python 3.13 environment is green.