### PR TITLE
Isolate targeted re-encode concurrency

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -81,7 +81,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: targeted-signed-reencode
+  group: targeted-signed-reencode-${{ github.actor == 'github-actions[bot]' && inputs.queue_id && inputs.queue_item_generation_sha256 || github.run_id }}
   cancel-in-progress: false
 
 jobs:

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1821,6 +1821,34 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     trigger = workflow.get("on", workflow.get(True))
     assert set(trigger) == {"workflow_dispatch"}
     assert workflow["permissions"] == {"actions": "read", "contents": "read"}
+    assert workflow["concurrency"] == {
+        "group": (
+            "targeted-signed-reencode-${{ "
+            "github.actor == 'github-actions[bot]' && inputs.queue_id && "
+            "inputs.queue_item_generation_sha256 || github.run_id }}"
+        ),
+        "cancel-in-progress": False,
+    }
+
+    def concurrency_suffix(
+        actor: str, queue_id: str, generation_sha: str, run_id: str
+    ) -> str:
+        return (
+            generation_sha
+            if actor == "github-actions[bot]" and queue_id and generation_sha
+            else run_id
+        )
+
+    assert (
+        concurrency_suffix("github-actions[bot]", "snap", "queue-generation", "run-1")
+        == "queue-generation"
+    )
+    assert (
+        concurrency_suffix("manual-user", "snap", "queue-generation", "run-2")
+        == "run-2"
+    )
+    assert concurrency_suffix("manual-user", "", "queue-generation", "run-3") == "run-3"
+    assert concurrency_suffix("github-actions[bot]", "snap", "", "run-4") == "run-4"
     inputs = trigger["workflow_dispatch"]["inputs"]
     assert "allowlisted reviewed SHA" in inputs["rulespec_ref"]["description"]
     assert "artifact-only" in inputs["rulespec_ref"]["description"]


### PR DESCRIPTION
## Summary
- isolate ad-hoc targeted signed re-encodes by workflow run ID
- serialize duplicate protected queue generations by immutable generation SHA only
- prevent non-bot queue-shaped dispatches from entering protected queue concurrency groups
- cover trusted queue, forged queue-shape, ad-hoc, and incomplete queue inputs

## Motivation
Eight independent North Carolina repair runs were cancelled because the static workflow concurrency group permits only one pending run and newer pending runs replace older ones. This keeps queue idempotency while allowing unrelated ad-hoc runs to wait for production signing independently.

## Review Cycle
- independent review of `602ebd6e`: P2 ad-hoc dispatch could supply a queue generation hash; fixed
- independent review of `8211d2d4`: P2 manual queue-shaped dispatch could contend before the job guard; fixed
- independent review of exact `82ae5050d14e8cd4997786818a0f3b3a08d57a18`: clean, no actionable findings

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- focused workflow test passed
- full suite before final actor gate: 5,754 passed, 119 skipped
- full suite on exact head running locally; hosted CI required green before merge
- `git diff --check origin/main...HEAD`