### PR TITLE
complete mode: exclude temporal literals from scalar recall (unblocks the DE wave)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1385"
+version = "0.2.1386"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1385"
+__version__ = "0.2.1386"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -29,6 +29,7 @@ class NumericOccurrenceLike(Protocol):
     end: int
     raw: str
     has_rate_context: bool
+    has_temporal_context: bool
     source_value: float | None
     requires_rate_context: bool
 
@@ -42,6 +43,7 @@ class _NumericOccurrenceView:
     end: int
     raw: str
     has_rate_context: bool
+    has_temporal_context: bool
     source_value: float | None
     requires_rate_context: bool
 
@@ -2052,69 +2054,11 @@ def _active_or_root_source_branches(
 
 
 def _source_boundary_is_temporal(
-    branch: SourceStructureBranch,
+    _branch: SourceStructureBranch,
     boundary: NumericOccurrenceLike,
 ) -> bool:
-    """Keep effective-period bounds eligible for parameter versioning."""
-
-    if not 1800 <= float(boundary.value) <= 2200:
-        return False
-    relative_start, relative_end = _boundary_span_in_branch(branch, boundary)
-    before = branch.text[max(0, relative_start - 100) : relative_start]
-    after = branch.text[relative_end : min(len(branch.text), relative_end + 80)]
-    substantive_unit = (
-        r"(?:€|eur\b|euro\b|dollar\b|prozent\b|%\b|"
-        r"einkommen\b|betrag\b|grenze\b|income\b|amount\b|threshold\b)"
-    )
-    if re.search(rf"{substantive_unit}\s*$", before, flags=re.IGNORECASE):
-        return False
-    if re.match(rf"\s*{substantive_unit}", after, flags=re.IGNORECASE):
-        return False
-    period_cue = (
-        r"(?:veranlagungszeitraum|besteuerungszeitraum|kalenderjahr|"
-        r"steuerjahr|tax\s+year|calendar\s+year|effective(?:_from)?|"
-        r"january|february|march|april|may|june|july|august|september|"
-        r"october|november|december|"
-        r"januar|februar|märz|april|mai|juni|juli|august|september|"
-        r"oktober|november|dezember)"
-    )
-    return bool(
-        re.search(
-            rf"\b{period_cue}\s*$",
-            before,
-            flags=re.IGNORECASE,
-        )
-        or re.match(
-            rf"\s*{period_cue}\b",
-            after,
-            flags=re.IGNORECASE,
-        )
-        or re.search(
-            r"\b(?:ab|seit|effective\s+from)\s*$",
-            before,
-            flags=re.IGNORECASE,
-        )
-    )
-
-
-def _boundary_span_in_branch(
-    branch: SourceStructureBranch,
-    boundary: NumericOccurrenceLike,
-) -> tuple[int, int]:
-    """Realign offsets after structural ordinals were removed for extraction."""
-
-    raw = str(getattr(boundary, "raw", "") or "").strip()
-    if raw:
-        candidates = tuple(re.finditer(re.escape(raw), branch.text))
-        if candidates:
-            closest = min(
-                candidates,
-                key=lambda match: abs(match.start() - boundary.start),
-            )
-            return closest.start(), closest.end()
-    start = max(0, min(len(branch.text), boundary.start))
-    end = max(start, min(len(branch.text), boundary.end))
-    return start, end
+    """Read temporal boundary context from the shared typed occurrence."""
+    return boundary.has_temporal_context
 
 
 def _rounding_clause_refers_to_previous_result(
@@ -3276,6 +3220,7 @@ def _numeric_occurrences_are_equivalent(
     return (
         math.isclose(float(left.value), float(right.value))
         and left.has_rate_context == right.has_rate_context
+        and left.has_temporal_context == right.has_temporal_context
         and left.source_value == right.source_value
         and left.requires_rate_context == right.requires_rate_context
     )
@@ -4590,6 +4535,7 @@ def _shift_numeric_occurrence(
         end=occurrence.end + offset,
         raw=occurrence.raw,
         has_rate_context=occurrence.has_rate_context,
+        has_temporal_context=occurrence.has_temporal_context,
         source_value=occurrence.source_value,
         requires_rate_context=occurrence.requires_rate_context,
     )

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -6775,6 +6775,7 @@ def _source_boundary_obligations(
         }:
             continue
         direct_text = authoritative_numeric_recall_text(branch.text)
+        direct_inventory = tuple(extract_numeric_occurrences(direct_text))
         for fragment_start, fragment in _source_boundary_fragments(direct_text):
             range_fragment = fragment.split(":", 1)[0]
             if not re.search(
@@ -6800,6 +6801,12 @@ def _source_boundary_obligations(
                 (branch, boundary)
                 for boundary in (interval.lower, interval.upper)
                 if boundary is not None
+                and any(
+                    boundary.start == occurrence.start
+                    and boundary.end == occurrence.end
+                    and _numeric_occurrences_are_equivalent(boundary, occurrence)
+                    for occurrence in direct_inventory
+                )
             )
     for branch in narrative_formula_branches:
         interval = _formula_branch_interval(

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -1710,11 +1710,13 @@ _GERMAN_MONTH_NAME_BODY = (
 )
 _GERMAN_DAY_MONTH_YEAR_PATTERN = re.compile(
     rf"(?<!\w)(?P<day>0?[1-9]|[12]\d|3[01])\.\s*"
-    rf"{_GERMAN_MONTH_NAME_BODY}\s+(?P<year>{_TEMPORAL_YEAR_BODY})(?!\d)",
+    rf"{_GERMAN_MONTH_NAME_BODY}\s+(?:des\s+Jahres\s+)?"
+    rf"(?P<year>{_TEMPORAL_YEAR_BODY})(?!\d)",
     re.IGNORECASE,
 )
 _GERMAN_MONTH_YEAR_PATTERN = re.compile(
-    rf"\b{_GERMAN_MONTH_NAME_BODY}\s+(?P<year>{_TEMPORAL_YEAR_BODY})(?!\d)",
+    rf"\b{_GERMAN_MONTH_NAME_BODY}\s+(?:des\s+Jahres\s+)?"
+    rf"(?P<year>{_TEMPORAL_YEAR_BODY})(?!\d)",
     re.IGNORECASE,
 )
 _ENGLISH_MONTH_DAY_YEAR_PATTERN = re.compile(
@@ -1738,9 +1740,16 @@ _TEMPORAL_YEAR_CUE_PATTERN = re.compile(
     rf"veranlagungszeitraum(?:s|es)?|besteuerungszeitraum(?:s|es)?|"
     rf"steuerjahr(?:es|e|en)?|"
     rf"years?|calendar\s+years?|tax(?:able)?\s+years?|assessment\s+years?"
-    rf")\s+(?P<years>{_TEMPORAL_YEAR_BODY}"
-    rf"(?:\s*(?:bis|to|through|thru|[-–—]|,|und|and|or)\s*"
+    rf")\b\s*(?:[:=]\s*)?(?P<years>{_TEMPORAL_YEAR_BODY}"
+    rf"(?:\s*(?:bis|to|through|thru|[-–—/]|,|und|and|or)\s*"
     rf"{_TEMPORAL_YEAR_BODY})*)",
+    re.IGNORECASE,
+)
+_TEMPORAL_YEAR_RANGE_PATTERN = re.compile(
+    rf"(?<!\d)(?P<start>{_TEMPORAL_YEAR_BODY})(?!\d)\s*"
+    rf"(?:bis(?:\s+(?:einschließlich|einschl\.?))?|to|through|thru|"
+    rf"[-\u2010-\u2015])\s*"
+    rf"(?P<end>{_TEMPORAL_YEAR_BODY})(?!\d)",
     re.IGNORECASE,
 )
 _TEMPORAL_PREPOSITION_YEAR_PATTERN = re.compile(
@@ -1750,7 +1759,7 @@ _TEMPORAL_PREPOSITION_YEAR_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _CURRENCY_MARKER_BEFORE_NUMBER_PATTERN = re.compile(
-    r"(?:[$£€¥₹]|(?:eur|usd|gbp|cad|aud|chf)\b)\s*$",
+    r"(?:[$£€¥₹]|(?:euros?|eur|usd|gbp|cad|aud|chf)\b)\s*$",
     re.IGNORECASE,
 )
 _CURRENCY_MARKER_AFTER_NUMBER_PATTERN = re.compile(
@@ -5722,15 +5731,47 @@ class _LegacyNumericCollector:
     grounding: list[NumericOccurrence] = field(default_factory=list)
     inventory: list[NumericOccurrence] = field(default_factory=list)
     rate_table_cell_spans: tuple[tuple[int, int], ...] = field(init=False)
+    shared_rate_spans: tuple[tuple[int, int], ...] = field(init=False)
     temporal_component_spans: tuple[tuple[int, int], ...] = field(init=False)
     money_spans: tuple[tuple[int, int], ...] = field(init=False)
 
     def __post_init__(self) -> None:
         self.rate_table_cell_spans = _pipe_table_rate_cell_spans(self.source)
         self.temporal_component_spans = _temporal_numeric_component_spans(self.source)
-        self.money_spans = tuple(
+        money_spans = {
             span for span, _value in _iter_raw_european_money_value_matches(self.source)
-        )
+        }
+        shared_rate_spans: set[tuple[int, int]] = set()
+        for match in _TEMPORAL_YEAR_RANGE_PATTERN.finditer(self.source):
+            endpoint_spans = (match.span("start"), match.span("end"))
+            has_money_context = (
+                any(
+                    endpoint_start >= money_start and endpoint_end <= money_end
+                    for endpoint_start, endpoint_end in endpoint_spans
+                    for money_start, money_end in money_spans
+                )
+                or bool(
+                    _CURRENCY_MARKER_BEFORE_NUMBER_PATTERN.search(
+                        self.source[max(0, match.start() - 16) : match.start()]
+                    )
+                )
+                or bool(
+                    _CURRENCY_MARKER_AFTER_NUMBER_PATTERN.match(
+                        self.source[
+                            match.end() : min(len(self.source), match.end() + 16)
+                        ]
+                    )
+                )
+            )
+            if has_money_context:
+                money_spans.update(endpoint_spans)
+            if _LOCAL_RATE_CONTEXT_AFTER_NUMBER_PATTERN.match(
+                self.source,
+                match.end(),
+            ):
+                shared_rate_spans.update(endpoint_spans)
+        self.money_spans = tuple(sorted(money_spans))
+        self.shared_rate_spans = tuple(sorted(shared_rate_spans))
 
     def occurrence(
         self,
@@ -5752,6 +5793,10 @@ class _LegacyNumericCollector:
             force_rate_context
             or bool(_LOCAL_RATE_CONTEXT_AFTER_NUMBER_PATTERN.match(self.source, end))
             or has_table_rate_context
+            or any(
+                start >= rate_start and end <= rate_end
+                for rate_start, rate_end in self.shared_rate_spans
+            )
         )
         has_money_context = (
             any(
@@ -6099,6 +6144,9 @@ def _temporal_numeric_component_spans(
         _TEMPORAL_PREPOSITION_YEAR_PATTERN,
     ):
         spans.update(match.span("year") for match in pattern.finditer(text))
+    for match in _TEMPORAL_YEAR_RANGE_PATTERN.finditer(text):
+        spans.add(match.span("start"))
+        spans.add(match.span("end"))
     for match in _TEMPORAL_YEAR_CUE_PATTERN.finditer(text):
         years_start = match.start("years")
         spans.update(
@@ -6140,6 +6188,60 @@ def _non_temporal_numeric_inventory(
     )
 
 
+def _complete_typed_year_occurrences(
+    collector: _LegacyNumericCollector,
+    occurrences: Iterable[NumericOccurrence],
+) -> tuple[NumericOccurrence, ...]:
+    """Normalize and recover typed year tokens removed by structural cleaning."""
+    typed_year_spans = {
+        span
+        for span in collector.temporal_component_spans
+        if _TEMPORAL_YEAR_TOKEN_PATTERN.fullmatch(
+            collector.source[span[0] : span[1]]
+        )
+    }
+    normalized = [
+        occurrence
+        for occurrence in occurrences
+        if not any(
+            occurrence.span != year_span
+            and occurrence.start < year_span[0]
+            and occurrence.end == year_span[1]
+            and collector.source[occurrence.start : year_span[0]] == "-"
+            for year_span in typed_year_spans
+        )
+    ]
+    existing_spans = {occurrence.span for occurrence in normalized}
+    source_view = _NumericTextView.identity(collector.source)
+    for span in sorted(typed_year_spans):
+        if span in existing_spans:
+            continue
+        raw = collector.source[span[0] : span[1]]
+        occurrence = collector.occurrence(source_view, span, float(raw))
+        insertion_index = next(
+            (
+                index
+                for index, existing in enumerate(normalized)
+                if existing.start > occurrence.start
+            ),
+            len(normalized),
+        )
+        normalized.insert(insertion_index, occurrence)
+        existing_spans.add(span)
+    typed_indices = [
+        index
+        for index, occurrence in enumerate(normalized)
+        if occurrence.span in typed_year_spans
+    ]
+    typed_occurrences = sorted(
+        (normalized[index] for index in typed_indices),
+        key=lambda occurrence: occurrence.span,
+    )
+    for index, occurrence in zip(typed_indices, typed_occurrences, strict=True):
+        normalized[index] = occurrence
+    return tuple(normalized)
+
+
 def _tokenize_profiled_numeric_occurrences(
     text: str,
     *,
@@ -6150,18 +6252,6 @@ def _tokenize_profiled_numeric_occurrences(
     view = _NumericTextView.aligned(text, cleaned)
     collector = _LegacyNumericCollector(text)
     occurrences: list[NumericOccurrence] = []
-
-    if profile == "de-DE":
-        source_view = _NumericTextView.identity(text)
-        for match in _DOTTED_DATE_PATTERN.finditer(text):
-            with contextlib.suppress(ValueError):
-                occurrences.append(
-                    collector.occurrence(
-                        source_view,
-                        match.span("year"),
-                        float(match.group("year")),
-                    )
-                )
 
     for span in _iter_locale_numeric_envelopes(cleaned, profile=profile):
         if not _locale_numeric_envelope_has_token_boundaries(cleaned, span):
@@ -6179,6 +6269,7 @@ def _tokenize_profiled_numeric_occurrences(
             if value is not None:
                 occurrences.append(collector.occurrence(view, match.span(), value))
 
+    occurrences = list(_complete_typed_year_occurrences(collector, occurrences))
     occurrences.sort(key=lambda occurrence: (occurrence.start, occurrence.end))
     return _NumericTokenization(
         grounding=tuple(occurrences),
@@ -6341,13 +6432,6 @@ def _tokenize_numeric_occurrences_from_text(
         if value is not None:
             year_matches.append((match.span(), value * 12))
     for span, value in unique_matches(year_matches):
-        add_both(raw_view, span, value)
-
-    dotted_year_matches: list[tuple[tuple[int, int], float]] = []
-    for match in _DOTTED_DATE_PATTERN.finditer(raw_text):
-        with contextlib.suppress(ValueError):
-            dotted_year_matches.append((match.span("year"), float(match.group("year"))))
-    for span, value in unique_matches(dotted_year_matches):
         add_both(raw_view, span, value)
 
     centime_match = _CENTIME_UNIT_PATTERN.search(raw_text)
@@ -6799,6 +6883,12 @@ def _tokenize_numeric_occurrences_from_text(
         )
         grounding_spans.append(match.span(1))
 
+    collector.grounding = list(
+        _complete_typed_year_occurrences(collector, collector.grounding)
+    )
+    collector.inventory = list(
+        _complete_typed_year_occurrences(collector, collector.inventory)
+    )
     occurrence_counts = Counter(occurrence.value for occurrence in collector.inventory)
     normalized_inventory = _non_temporal_numeric_inventory(
         occurrence

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -1702,7 +1702,10 @@ _TABLE_RATE_HEADER_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _TEMPORAL_YEAR_BODY = r"(?:18|19|20)\d{2}"
-_TEMPORAL_YEAR_TOKEN_PATTERN = re.compile(rf"(?<!\w){_TEMPORAL_YEAR_BODY}(?!\w)")
+_TEMPORAL_YEAR_END = r"(?!\w|[.,]\d)"
+_TEMPORAL_YEAR_TOKEN_PATTERN = re.compile(
+    rf"(?<!\w){_TEMPORAL_YEAR_BODY}{_TEMPORAL_YEAR_END}"
+)
 _GERMAN_MONTH_NAME_BODY = (
     r"(?:jan(?:uar)?|feb(?:ruar)?|märz|maerz|mrz|apr(?:il)?|mai|"
     r"jun(?:i)?|jul(?:i)?|aug(?:ust)?|sep(?:t(?:ember)?)?|"
@@ -1711,27 +1714,29 @@ _GERMAN_MONTH_NAME_BODY = (
 _GERMAN_DAY_MONTH_YEAR_PATTERN = re.compile(
     rf"(?<!\w)(?P<day>0?[1-9]|[12]\d|3[01])\.\s*"
     rf"{_GERMAN_MONTH_NAME_BODY}\s+(?:des\s+Jahres\s+)?"
-    rf"(?P<year>{_TEMPORAL_YEAR_BODY})(?!\w)",
+    rf"(?P<year>{_TEMPORAL_YEAR_BODY}){_TEMPORAL_YEAR_END}",
     re.IGNORECASE,
 )
 _GERMAN_MONTH_YEAR_PATTERN = re.compile(
     rf"\b{_GERMAN_MONTH_NAME_BODY}\s+(?:des\s+Jahres\s+)?"
-    rf"(?P<year>{_TEMPORAL_YEAR_BODY})(?!\w)",
+    rf"(?P<year>{_TEMPORAL_YEAR_BODY}){_TEMPORAL_YEAR_END}",
     re.IGNORECASE,
 )
 _ENGLISH_MONTH_DAY_YEAR_PATTERN = re.compile(
     rf"\b{_MONTH_NAME_BODY}\s+(?P<day>0?[1-9]|[12]\d|3[01])"
-    rf"(?:st|nd|rd|th)?\s*,?\s*(?P<year>{_TEMPORAL_YEAR_BODY})(?!\w)",
+    rf"(?:st|nd|rd|th)?\s*,?\s*(?P<year>{_TEMPORAL_YEAR_BODY})"
+    rf"{_TEMPORAL_YEAR_END}",
     re.IGNORECASE,
 )
 _ENGLISH_DAY_MONTH_YEAR_PATTERN = re.compile(
     rf"(?<!\w)(?P<day>0?[1-9]|[12]\d|3[01])"
     rf"(?:st|nd|rd|th)?\s+{_MONTH_NAME_BODY}\s+"
-    rf"(?P<year>{_TEMPORAL_YEAR_BODY})(?!\w)",
+    rf"(?P<year>{_TEMPORAL_YEAR_BODY}){_TEMPORAL_YEAR_END}",
     re.IGNORECASE,
 )
 _ENGLISH_MONTH_YEAR_PATTERN = re.compile(
-    rf"\b{_MONTH_NAME_BODY}\s+(?P<year>{_TEMPORAL_YEAR_BODY})(?!\w)",
+    rf"\b{_MONTH_NAME_BODY}\s+(?P<year>{_TEMPORAL_YEAR_BODY})"
+    rf"{_TEMPORAL_YEAR_END}",
     re.IGNORECASE,
 )
 _TEMPORAL_YEAR_CUE_PATTERN = re.compile(
@@ -1743,22 +1748,22 @@ _TEMPORAL_YEAR_CUE_PATTERN = re.compile(
     rf"years?|calendar\s+years?|tax(?:able)?\s+years?|assessment\s+years?"
     rf")\b\s*(?:[:=]\s*)?"
     rf"(?:(?:vor|nach|ab|bis|seit|before|after|from|through)\s+)?"
-    rf"(?P<years>{_TEMPORAL_YEAR_BODY}(?!\w)"
+    rf"(?P<years>{_TEMPORAL_YEAR_BODY}{_TEMPORAL_YEAR_END}"
     rf"(?:\s*(?:bis|to|through|thru|[-–—/]|,|und|and|or)\s*"
-    rf"{_TEMPORAL_YEAR_BODY}(?!\w))*)",
+    rf"{_TEMPORAL_YEAR_BODY}{_TEMPORAL_YEAR_END})*)",
     re.IGNORECASE,
 )
 _TEMPORAL_YEAR_RANGE_PATTERN = re.compile(
-    rf"(?<!\w)(?P<start>{_TEMPORAL_YEAR_BODY})(?!\w)\s*"
+    rf"(?<!\w)(?P<start>{_TEMPORAL_YEAR_BODY}){_TEMPORAL_YEAR_END}\s*"
     rf"(?:bis(?:\s+(?:einschließlich|einschl\.?))?|to|through|thru|"
     rf"[-\u2010-\u2015])\s*"
-    rf"(?P<end>{_TEMPORAL_YEAR_BODY})(?!\w)",
+    rf"(?P<end>{_TEMPORAL_YEAR_BODY}){_TEMPORAL_YEAR_END}",
     re.IGNORECASE,
 )
 _TEMPORAL_PREPOSITION_YEAR_PATTERN = re.compile(
     rf"\b(?:ab(?:\s+dem)?|bis(?:\s+zum)?|vom|seit|zum|"
     rf"from|since|until|effective\s+from)\s+"
-    rf"(?P<year>{_TEMPORAL_YEAR_BODY})(?!\w)",
+    rf"(?P<year>{_TEMPORAL_YEAR_BODY}){_TEMPORAL_YEAR_END}",
     re.IGNORECASE,
 )
 _CURRENCY_MARKER_BEFORE_NUMBER_PATTERN = re.compile(
@@ -6200,6 +6205,11 @@ def _complete_typed_year_occurrences(
         span
         for span in collector.temporal_component_spans
         if _locale_numeric_envelope_has_token_boundaries(collector.source, span)
+        if not (
+            span[1] + 1 < len(collector.source)
+            and collector.source[span[1]] in ".,"
+            and collector.source[span[1] + 1].isdigit()
+        )
         if _TEMPORAL_YEAR_TOKEN_PATTERN.fullmatch(
             collector.source[span[0] : span[1]]
         )

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -1702,7 +1702,7 @@ _TABLE_RATE_HEADER_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _TEMPORAL_YEAR_BODY = r"(?:18|19|20)\d{2}"
-_TEMPORAL_YEAR_TOKEN_PATTERN = re.compile(rf"(?<!\d){_TEMPORAL_YEAR_BODY}(?!\d)")
+_TEMPORAL_YEAR_TOKEN_PATTERN = re.compile(rf"(?<!\w){_TEMPORAL_YEAR_BODY}(?!\w)")
 _GERMAN_MONTH_NAME_BODY = (
     r"(?:jan(?:uar)?|feb(?:ruar)?|märz|maerz|mrz|apr(?:il)?|mai|"
     r"jun(?:i)?|jul(?:i)?|aug(?:ust)?|sep(?:t(?:ember)?)?|"
@@ -1711,51 +1711,54 @@ _GERMAN_MONTH_NAME_BODY = (
 _GERMAN_DAY_MONTH_YEAR_PATTERN = re.compile(
     rf"(?<!\w)(?P<day>0?[1-9]|[12]\d|3[01])\.\s*"
     rf"{_GERMAN_MONTH_NAME_BODY}\s+(?:des\s+Jahres\s+)?"
-    rf"(?P<year>{_TEMPORAL_YEAR_BODY})(?!\d)",
+    rf"(?P<year>{_TEMPORAL_YEAR_BODY})(?!\w)",
     re.IGNORECASE,
 )
 _GERMAN_MONTH_YEAR_PATTERN = re.compile(
     rf"\b{_GERMAN_MONTH_NAME_BODY}\s+(?:des\s+Jahres\s+)?"
-    rf"(?P<year>{_TEMPORAL_YEAR_BODY})(?!\d)",
+    rf"(?P<year>{_TEMPORAL_YEAR_BODY})(?!\w)",
     re.IGNORECASE,
 )
 _ENGLISH_MONTH_DAY_YEAR_PATTERN = re.compile(
     rf"\b{_MONTH_NAME_BODY}\s+(?P<day>0?[1-9]|[12]\d|3[01])"
-    rf"(?:st|nd|rd|th)?\s*,?\s*(?P<year>{_TEMPORAL_YEAR_BODY})(?!\d)",
+    rf"(?:st|nd|rd|th)?\s*,?\s*(?P<year>{_TEMPORAL_YEAR_BODY})(?!\w)",
     re.IGNORECASE,
 )
 _ENGLISH_DAY_MONTH_YEAR_PATTERN = re.compile(
     rf"(?<!\w)(?P<day>0?[1-9]|[12]\d|3[01])"
     rf"(?:st|nd|rd|th)?\s+{_MONTH_NAME_BODY}\s+"
-    rf"(?P<year>{_TEMPORAL_YEAR_BODY})(?!\d)",
+    rf"(?P<year>{_TEMPORAL_YEAR_BODY})(?!\w)",
     re.IGNORECASE,
 )
 _ENGLISH_MONTH_YEAR_PATTERN = re.compile(
-    rf"\b{_MONTH_NAME_BODY}\s+(?P<year>{_TEMPORAL_YEAR_BODY})(?!\d)",
+    rf"\b{_MONTH_NAME_BODY}\s+(?P<year>{_TEMPORAL_YEAR_BODY})(?!\w)",
     re.IGNORECASE,
 )
 _TEMPORAL_YEAR_CUE_PATTERN = re.compile(
     rf"\b(?:"
     rf"jahr(?:es|e|en)?|kalenderjahr(?:es|e|en)?|"
-    rf"veranlagungszeitraum(?:s|es)?|besteuerungszeitraum(?:s|es)?|"
+    rf"veranlagungszeitr(?:aum(?:s|es)?|äume(?:n)?)|"
+    rf"besteuerungszeitr(?:aum(?:s|es)?|äume(?:n)?)|"
     rf"steuerjahr(?:es|e|en)?|"
     rf"years?|calendar\s+years?|tax(?:able)?\s+years?|assessment\s+years?"
-    rf")\b\s*(?:[:=]\s*)?(?P<years>{_TEMPORAL_YEAR_BODY}"
+    rf")\b\s*(?:[:=]\s*)?"
+    rf"(?:(?:vor|nach|ab|bis|seit|before|after|from|through)\s+)?"
+    rf"(?P<years>{_TEMPORAL_YEAR_BODY}(?!\w)"
     rf"(?:\s*(?:bis|to|through|thru|[-–—/]|,|und|and|or)\s*"
-    rf"{_TEMPORAL_YEAR_BODY})*)",
+    rf"{_TEMPORAL_YEAR_BODY}(?!\w))*)",
     re.IGNORECASE,
 )
 _TEMPORAL_YEAR_RANGE_PATTERN = re.compile(
-    rf"(?<!\d)(?P<start>{_TEMPORAL_YEAR_BODY})(?!\d)\s*"
+    rf"(?<!\w)(?P<start>{_TEMPORAL_YEAR_BODY})(?!\w)\s*"
     rf"(?:bis(?:\s+(?:einschließlich|einschl\.?))?|to|through|thru|"
     rf"[-\u2010-\u2015])\s*"
-    rf"(?P<end>{_TEMPORAL_YEAR_BODY})(?!\d)",
+    rf"(?P<end>{_TEMPORAL_YEAR_BODY})(?!\w)",
     re.IGNORECASE,
 )
 _TEMPORAL_PREPOSITION_YEAR_PATTERN = re.compile(
     rf"\b(?:ab(?:\s+dem)?|bis(?:\s+zum)?|vom|seit|zum|"
     rf"from|since|until|effective\s+from)\s+"
-    rf"(?P<year>{_TEMPORAL_YEAR_BODY})(?!\d)",
+    rf"(?P<year>{_TEMPORAL_YEAR_BODY})(?!\w)",
     re.IGNORECASE,
 )
 _CURRENCY_MARKER_BEFORE_NUMBER_PATTERN = re.compile(
@@ -6196,6 +6199,7 @@ def _complete_typed_year_occurrences(
     typed_year_spans = {
         span
         for span in collector.temporal_component_spans
+        if _locale_numeric_envelope_has_token_boundaries(collector.source, span)
         if _TEMPORAL_YEAR_TOKEN_PATTERN.fullmatch(
             collector.source[span[0] : span[1]]
         )

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -6210,9 +6210,7 @@ def _complete_typed_year_occurrences(
             and collector.source[span[1]] in ".,"
             and collector.source[span[1] + 1].isdigit()
         )
-        if _TEMPORAL_YEAR_TOKEN_PATTERN.fullmatch(
-            collector.source[span[0] : span[1]]
-        )
+        if _TEMPORAL_YEAR_TOKEN_PATTERN.fullmatch(collector.source[span[0] : span[1]])
     }
     normalized = [
         occurrence

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -815,7 +815,9 @@ GROUNDING_ALLOWED_VALUES = {-1, 0, 1, 2, 3}
 NUMERIC_GROUNDING_ABS_TOLERANCE = 1e-6
 GROUNDING_DATE_PATTERN = re.compile(r"\b\d{4}-\d{2}-\d{2}\b")
 GROUNDING_MONTH_PERIOD_PATTERN = re.compile(r"\b\d{4}-\d{2}\b")
-_DOTTED_DATE_PATTERN = re.compile(r"\b\d{1,2}\.\d{1,2}\.(?P<year>\d{4})\b")
+_DOTTED_DATE_PATTERN = re.compile(
+    r"\b(?P<day>\d{1,2})\.(?P<month>\d{1,2})\.(?P<year>\d{4})\b"
+)
 _SOURCE_URL_PATTERN = re.compile(r"https?://[^\s)\"'<>]+", re.IGNORECASE)
 GROUNDING_FORMULA_NUMBER_PATTERN = re.compile(
     r"(?<![\w./])(-?[\d,]+(?:\.\d+)?)(?![\w./])"
@@ -1699,6 +1701,62 @@ _TABLE_RATE_HEADER_PATTERN = re.compile(
     r")",
     re.IGNORECASE,
 )
+_TEMPORAL_YEAR_BODY = r"(?:18|19|20)\d{2}"
+_TEMPORAL_YEAR_TOKEN_PATTERN = re.compile(rf"(?<!\d){_TEMPORAL_YEAR_BODY}(?!\d)")
+_GERMAN_MONTH_NAME_BODY = (
+    r"(?:jan(?:uar)?|feb(?:ruar)?|märz|maerz|mrz|apr(?:il)?|mai|"
+    r"jun(?:i)?|jul(?:i)?|aug(?:ust)?|sep(?:t(?:ember)?)?|"
+    r"okt(?:ober)?|nov(?:ember)?|dez(?:ember)?)\.?"
+)
+_GERMAN_DAY_MONTH_YEAR_PATTERN = re.compile(
+    rf"(?<!\w)(?P<day>0?[1-9]|[12]\d|3[01])\.\s*"
+    rf"{_GERMAN_MONTH_NAME_BODY}\s+(?P<year>{_TEMPORAL_YEAR_BODY})(?!\d)",
+    re.IGNORECASE,
+)
+_GERMAN_MONTH_YEAR_PATTERN = re.compile(
+    rf"\b{_GERMAN_MONTH_NAME_BODY}\s+(?P<year>{_TEMPORAL_YEAR_BODY})(?!\d)",
+    re.IGNORECASE,
+)
+_ENGLISH_MONTH_DAY_YEAR_PATTERN = re.compile(
+    rf"\b{_MONTH_NAME_BODY}\s+(?P<day>0?[1-9]|[12]\d|3[01])"
+    rf"(?:st|nd|rd|th)?\s*,?\s*(?P<year>{_TEMPORAL_YEAR_BODY})(?!\d)",
+    re.IGNORECASE,
+)
+_ENGLISH_DAY_MONTH_YEAR_PATTERN = re.compile(
+    rf"(?<!\w)(?P<day>0?[1-9]|[12]\d|3[01])"
+    rf"(?:st|nd|rd|th)?\s+{_MONTH_NAME_BODY}\s+"
+    rf"(?P<year>{_TEMPORAL_YEAR_BODY})(?!\d)",
+    re.IGNORECASE,
+)
+_ENGLISH_MONTH_YEAR_PATTERN = re.compile(
+    rf"\b{_MONTH_NAME_BODY}\s+(?P<year>{_TEMPORAL_YEAR_BODY})(?!\d)",
+    re.IGNORECASE,
+)
+_TEMPORAL_YEAR_CUE_PATTERN = re.compile(
+    rf"\b(?:"
+    rf"jahr(?:es|e|en)?|kalenderjahr(?:es|e|en)?|"
+    rf"veranlagungszeitraum(?:s|es)?|besteuerungszeitraum(?:s|es)?|"
+    rf"steuerjahr(?:es|e|en)?|"
+    rf"years?|calendar\s+years?|tax(?:able)?\s+years?|assessment\s+years?"
+    rf")\s+(?P<years>{_TEMPORAL_YEAR_BODY}"
+    rf"(?:\s*(?:bis|to|through|thru|[-–—]|,|und|and|or)\s*"
+    rf"{_TEMPORAL_YEAR_BODY})*)",
+    re.IGNORECASE,
+)
+_TEMPORAL_PREPOSITION_YEAR_PATTERN = re.compile(
+    rf"\b(?:ab(?:\s+dem)?|bis(?:\s+zum)?|vom|seit|zum|"
+    rf"from|since|until|effective\s+from)\s+"
+    rf"(?P<year>{_TEMPORAL_YEAR_BODY})(?!\d)",
+    re.IGNORECASE,
+)
+_CURRENCY_MARKER_BEFORE_NUMBER_PATTERN = re.compile(
+    r"(?:[$£€¥₹]|(?:eur|usd|gbp|cad|aud|chf)\b)\s*$",
+    re.IGNORECASE,
+)
+_CURRENCY_MARKER_AFTER_NUMBER_PATTERN = re.compile(
+    r"^\s*(?:[$£€¥₹]|(?:euros?|eur|dollars?|usd|pounds?|gbp)\b)",
+    re.IGNORECASE,
+)
 _VEHICLE_TAX_FISCAL_POWER_TABLE_CELL_PATTERN = re.compile(
     r"\b(?P<cv>[5-9]|1\d|20)\s+"
     r"(?=(?:\d{1,3}[.\u00a0\u202f]\d{3},\d{2}|\d{2,3}[,.]\d{2})"
@@ -1786,6 +1844,7 @@ class NumericOccurrence:
     end: int
     raw: str
     has_rate_context: bool = False
+    has_temporal_context: bool = False
     source_value: float | None = None
     requires_rate_context: bool = False
 
@@ -5663,9 +5722,15 @@ class _LegacyNumericCollector:
     grounding: list[NumericOccurrence] = field(default_factory=list)
     inventory: list[NumericOccurrence] = field(default_factory=list)
     rate_table_cell_spans: tuple[tuple[int, int], ...] = field(init=False)
+    temporal_component_spans: tuple[tuple[int, int], ...] = field(init=False)
+    money_spans: tuple[tuple[int, int], ...] = field(init=False)
 
     def __post_init__(self) -> None:
         self.rate_table_cell_spans = _pipe_table_rate_cell_spans(self.source)
+        self.temporal_component_spans = _temporal_numeric_component_spans(self.source)
+        self.money_spans = tuple(
+            span for span, _value in _iter_raw_european_money_value_matches(self.source)
+        )
 
     def occurrence(
         self,
@@ -5683,14 +5748,42 @@ class _LegacyNumericCollector:
             start >= cell_start and end <= cell_end
             for cell_start, cell_end in self.rate_table_cell_spans
         )
+        has_rate_context = (
+            force_rate_context
+            or bool(_LOCAL_RATE_CONTEXT_AFTER_NUMBER_PATTERN.match(self.source, end))
+            or has_table_rate_context
+        )
+        has_money_context = (
+            any(
+                start >= money_start and end <= money_end
+                for money_start, money_end in self.money_spans
+            )
+            or bool(
+                _CURRENCY_MARKER_BEFORE_NUMBER_PATTERN.search(
+                    self.source[max(0, start - 16) : start]
+                )
+            )
+            or bool(
+                _CURRENCY_MARKER_AFTER_NUMBER_PATTERN.match(
+                    self.source[end : min(len(self.source), end + 16)]
+                )
+            )
+        )
+        has_temporal_context = (
+            not has_rate_context
+            and not has_money_context
+            and any(
+                start >= temporal_start and end <= temporal_end
+                for temporal_start, temporal_end in self.temporal_component_spans
+            )
+        )
         return NumericOccurrence(
             value=value,
             start=start,
             end=end,
             raw=self.source[start:end],
-            has_rate_context=force_rate_context
-            or bool(_LOCAL_RATE_CONTEXT_AFTER_NUMBER_PATTERN.match(self.source, end))
-            or has_table_rate_context,
+            has_rate_context=has_rate_context,
+            has_temporal_context=has_temporal_context,
             source_value=value if source_value is None else source_value,
             requires_rate_context=requires_rate_context,
         )
@@ -5985,6 +6078,41 @@ def _locale_numeric_envelope_has_token_boundaries(
     )
 
 
+def _temporal_numeric_component_spans(
+    text: str,
+) -> tuple[tuple[int, int], ...]:
+    """Classify exact numeric tokens that form source-stated dates or periods."""
+    spans: set[tuple[int, int]] = set()
+    for match in _DOTTED_DATE_PATTERN.finditer(text):
+        spans.update(match.span(group_name) for group_name in ("day", "month", "year"))
+    for pattern in (
+        _GERMAN_DAY_MONTH_YEAR_PATTERN,
+        _ENGLISH_MONTH_DAY_YEAR_PATTERN,
+        _ENGLISH_DAY_MONTH_YEAR_PATTERN,
+    ):
+        for match in pattern.finditer(text):
+            spans.add(match.span("day"))
+            spans.add(match.span("year"))
+    for pattern in (
+        _GERMAN_MONTH_YEAR_PATTERN,
+        _ENGLISH_MONTH_YEAR_PATTERN,
+        _TEMPORAL_PREPOSITION_YEAR_PATTERN,
+    ):
+        spans.update(match.span("year") for match in pattern.finditer(text))
+    for match in _TEMPORAL_YEAR_CUE_PATTERN.finditer(text):
+        years_start = match.start("years")
+        spans.update(
+            (
+                years_start + year_match.start(),
+                years_start + year_match.end(),
+            )
+            for year_match in _TEMPORAL_YEAR_TOKEN_PATTERN.finditer(
+                match.group("years")
+            )
+        )
+    return tuple(sorted(spans))
+
+
 def _has_malformed_profiled_numeric_envelope(
     text: str,
     *,
@@ -6003,6 +6131,15 @@ def _has_malformed_profiled_numeric_envelope(
     )
 
 
+def _non_temporal_numeric_inventory(
+    occurrences: Iterable[NumericOccurrence],
+) -> tuple[NumericOccurrence, ...]:
+    """Project typed grounding evidence into scalar-recall obligations."""
+    return tuple(
+        occurrence for occurrence in occurrences if not occurrence.has_temporal_context
+    )
+
+
 def _tokenize_profiled_numeric_occurrences(
     text: str,
     *,
@@ -6013,6 +6150,18 @@ def _tokenize_profiled_numeric_occurrences(
     view = _NumericTextView.aligned(text, cleaned)
     collector = _LegacyNumericCollector(text)
     occurrences: list[NumericOccurrence] = []
+
+    if profile == "de-DE":
+        source_view = _NumericTextView.identity(text)
+        for match in _DOTTED_DATE_PATTERN.finditer(text):
+            with contextlib.suppress(ValueError):
+                occurrences.append(
+                    collector.occurrence(
+                        source_view,
+                        match.span("year"),
+                        float(match.group("year")),
+                    )
+                )
 
     for span in _iter_locale_numeric_envelopes(cleaned, profile=profile):
         if not _locale_numeric_envelope_has_token_boundaries(cleaned, span):
@@ -6033,7 +6182,7 @@ def _tokenize_profiled_numeric_occurrences(
     occurrences.sort(key=lambda occurrence: (occurrence.start, occurrence.end))
     return _NumericTokenization(
         grounding=tuple(occurrences),
-        inventory=tuple(occurrences),
+        inventory=_non_temporal_numeric_inventory(occurrences),
     )
 
 
@@ -6572,8 +6721,6 @@ def _tokenize_numeric_occurrences_from_text(
                 continue
             if _number_span_is_immediately_followed_by_percent_marker(cleaned, span):
                 continue
-            if value.is_integer() and 1900 <= value <= 2100:
-                continue
             if _has_captured_percentage_rate(
                 direct_percentage_rate_matches,
                 value,
@@ -6606,8 +6753,6 @@ def _tokenize_numeric_occurrences_from_text(
         with contextlib.suppress(ValueError):
             value = float(match.group(1))
             collector.add_grounding(cleaned_view, match.span(1), value)
-            if value.is_integer() and 1900 <= value <= 2100:
-                continue
             if _ordinal_is_calendar_day_reference(cleaned, match.end(), value):
                 continue
             collector.add_inventory(cleaned_view, match.span(1), value)
@@ -6655,7 +6800,7 @@ def _tokenize_numeric_occurrences_from_text(
         grounding_spans.append(match.span(1))
 
     occurrence_counts = Counter(occurrence.value for occurrence in collector.inventory)
-    normalized_inventory = tuple(
+    normalized_inventory = _non_temporal_numeric_inventory(
         occurrence
         for occurrence in collector.inventory
         if not (

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -8287,7 +8287,14 @@ def test_de_numeric_profile_types_local_rate_context(source_text, expected):
         ),
         ("Veranlagungszeitraum 2026", [2026.0]),
         ("für die Jahre 2022 bis 2025", [2022.0, 2025.0]),
+        ("2022 bis 2025", [2022.0, 2025.0]),
+        ("2022–2025", [2022.0, 2025.0]),
+        ("Jahre 2022–2025", [2022.0, 2025.0]),
         ("31.12.2022", [2022.0]),
+        ("01.10.2022 bis 31.12.2022", [2022.0, 2022.0]),
+        ("zum 31. Dezember des Jahres 2025", [31.0, 2025.0]),
+        ("Jahr: 2025", [2025.0]),
+        ("Jahre 2022/2025", [2022.0, 2025.0]),
     ),
 )
 def test_typed_temporal_occurrences_stay_grounding_only(
@@ -8330,6 +8337,64 @@ def test_year_shaped_money_is_not_temporal(profile):
     occurrence = next(item for item in grounding if item.value == 2025)
     assert not occurrence.has_temporal_context
     assert [(item.value, item.raw) for item in inventory] == [(2025.0, "2025")]
+
+
+@pytest.mark.parametrize("profile", ("legacy", "de-DE"))
+@pytest.mark.parametrize(
+    "source_text",
+    (
+        "Die Werte betragen 2025 Euro bis 2026 Euro.",
+        "Die Werte betragen 2025 bis 2026 Euro.",
+        "Die Werte betragen 2025-2026 Euro.",
+        "Die Werte betragen Euro 2025 bis 2026.",
+    ),
+)
+def test_money_markers_override_temporal_year_range_typing(profile, source_text):
+    grounding = extract_typed_numeric_occurrences_from_text(
+        source_text,
+        profile=profile,
+    )
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        source_text,
+        profile=profile,
+    )
+
+    year_occurrences = [
+        occurrence for occurrence in grounding if occurrence.raw in {"2025", "2026"}
+    ]
+    assert year_occurrences
+    assert all(not occurrence.has_temporal_context for occurrence in year_occurrences)
+    assert [(item.value, item.raw) for item in inventory] == [
+        (2025.0, "2025"),
+        (2026.0, "2026"),
+    ]
+
+
+@pytest.mark.parametrize("profile", ("legacy", "de-DE"))
+def test_shared_rate_marker_overrides_temporal_year_range_typing(profile):
+    source_text = "Der Satz beträgt 2025 bis 2026 Prozent."
+
+    grounding = extract_typed_numeric_occurrences_from_text(
+        source_text,
+        profile=profile,
+    )
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        source_text,
+        profile=profile,
+    )
+
+    year_occurrences = [
+        occurrence for occurrence in grounding if occurrence.raw in {"2025", "2026"}
+    ]
+    assert year_occurrences
+    assert all(
+        occurrence.has_rate_context and not occurrence.has_temporal_context
+        for occurrence in year_occurrences
+    )
+    assert [(item.value, item.raw) for item in inventory] == [
+        (2025.0, "2025"),
+        (2026.0, "2026"),
+    ]
 
 
 def test_temporal_recall_filter_does_not_exempt_generated_literal_grounding():
@@ -12325,12 +12390,16 @@ def test_numeric_occurrence_extraction_accepts_french_hundreds():
     assert 800 in extract_numeric_occurrences_from_text(text)
 
 
-def test_numeric_occurrence_extraction_accepts_belgian_dotted_date_year():
+def test_belgian_dotted_date_year_stays_available_only_for_grounding():
     text = "Cette disposition produit ses effets le 01.01.2028."
 
-    values = extract_numeric_occurrences_from_text(text)
+    grounding = extract_typed_numeric_occurrences_from_text(text)
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(text)
 
-    assert values == [2028.0]
+    assert [(item.value, item.has_temporal_context) for item in grounding] == [
+        (2028.0, True)
+    ]
+    assert inventory == []
 
 
 def test_numeric_occurrence_extraction_ignores_section_symbol_reference():

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -8323,7 +8323,15 @@ def test_typed_temporal_occurrences_stay_grounding_only(
 
 
 @pytest.mark.parametrize("profile", ("legacy", "de-DE"))
-@pytest.mark.parametrize("source_text", ("Jahr 2025a", "year 2025_code"))
+@pytest.mark.parametrize(
+    "source_text",
+    (
+        "Jahr 2025a",
+        "year 2025_code",
+        "Jahr 2025.1",
+        "Jahr 2025,00a",
+    ),
+)
 def test_temporal_year_recovery_respects_numeric_token_boundaries(
     profile,
     source_text,
@@ -8337,8 +8345,14 @@ def test_temporal_year_recovery_respects_numeric_token_boundaries(
         profile=profile,
     )
 
-    assert all(occurrence.value != 2025 for occurrence in grounding)
-    assert all(occurrence.value != 2025 for occurrence in inventory)
+    assert all(
+        occurrence.raw != "2025" and not occurrence.has_temporal_context
+        for occurrence in grounding
+    )
+    assert all(
+        occurrence.raw != "2025" and not occurrence.has_temporal_context
+        for occurrence in inventory
+    )
 
 
 @pytest.mark.parametrize("profile", ("legacy", "de-DE"))

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -8295,6 +8295,7 @@ def test_de_numeric_profile_types_local_rate_context(source_text, expected):
         ("zum 31. Dezember des Jahres 2025", [31.0, 2025.0]),
         ("Jahr: 2025", [2025.0]),
         ("Jahre 2022/2025", [2022.0, 2025.0]),
+        ("für Veranlagungszeiträume vor 1996", [1996.0]),
     ),
 )
 def test_typed_temporal_occurrences_stay_grounding_only(
@@ -8319,6 +8320,25 @@ def test_typed_temporal_occurrences_stay_grounding_only(
         occurrence.raw == source_text[occurrence.start : occurrence.end]
         for occurrence in grounding
     )
+
+
+@pytest.mark.parametrize("profile", ("legacy", "de-DE"))
+@pytest.mark.parametrize("source_text", ("Jahr 2025a", "year 2025_code"))
+def test_temporal_year_recovery_respects_numeric_token_boundaries(
+    profile,
+    source_text,
+):
+    grounding = extract_typed_numeric_occurrences_from_text(
+        source_text,
+        profile=profile,
+    )
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        source_text,
+        profile=profile,
+    )
+
+    assert all(occurrence.value != 2025 for occurrence in grounding)
+    assert all(occurrence.value != 2025 for occurrence in inventory)
 
 
 @pytest.mark.parametrize("profile", ("legacy", "de-DE"))

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -52,6 +52,7 @@ from axiom_encode.harness.validator_pipeline import (
     extract_named_scalar_occurrences,
     extract_numbers_from_text,
     extract_numeric_occurrences_from_text,
+    extract_typed_numeric_inventory_occurrences_from_text,
     extract_typed_numeric_occurrences_from_text,
     find_aggregate_exception_predicate_issues,
     find_anaphoric_scope_omission_issues,
@@ -8272,6 +8273,86 @@ def test_de_numeric_profile_types_local_rate_context(source_text, expected):
     )
 
     assert numeric_value_is_grounded(0.42, occurrences) is expected
+
+
+@pytest.mark.parametrize("profile", ("legacy", "de-DE"))
+@pytest.mark.parametrize(
+    ("source_text", "expected_temporal_values"),
+    (
+        ("für das Jahr 2025", [2025.0]),
+        ("ab dem 1. Januar 2025", [1.0, 2025.0]),
+        (
+            "vom 1. Oktober 2022 bis zum 31. Dezember 2022",
+            [1.0, 2022.0, 31.0, 2022.0],
+        ),
+        ("Veranlagungszeitraum 2026", [2026.0]),
+        ("für die Jahre 2022 bis 2025", [2022.0, 2025.0]),
+        ("31.12.2022", [2022.0]),
+    ),
+)
+def test_typed_temporal_occurrences_stay_grounding_only(
+    profile,
+    source_text,
+    expected_temporal_values,
+):
+    grounding = extract_typed_numeric_occurrences_from_text(
+        source_text,
+        profile=profile,
+    )
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        source_text,
+        profile=profile,
+    )
+
+    assert [
+        occurrence.value for occurrence in grounding if occurrence.has_temporal_context
+    ] == expected_temporal_values
+    assert not inventory
+    assert all(
+        occurrence.raw == source_text[occurrence.start : occurrence.end]
+        for occurrence in grounding
+    )
+
+
+@pytest.mark.parametrize("profile", ("legacy", "de-DE"))
+def test_year_shaped_money_is_not_temporal(profile):
+    source_text = "Die Pauschale beträgt 2025 Euro."
+
+    grounding = extract_typed_numeric_occurrences_from_text(
+        source_text,
+        profile=profile,
+    )
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        source_text,
+        profile=profile,
+    )
+
+    occurrence = next(item for item in grounding if item.value == 2025)
+    assert not occurrence.has_temporal_context
+    assert [(item.value, item.raw) for item in inventory] == [(2025.0, "2025")]
+
+
+def test_temporal_recall_filter_does_not_exempt_generated_literal_grounding():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/regulation/example/1
+rules:
+  - name: fabricated_year_value
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2025
+"""
+
+    issues = find_ungrounded_numeric_issues(
+        content,
+        source_text="Die Regel gilt für das Jahr 2026.",
+    )
+
+    assert any("2025" in issue for issue in issues), issues
 
 
 @pytest.mark.parametrize(

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import hashlib
 from pathlib import Path
 
 import pytest
@@ -33,6 +34,7 @@ def _analyze(
     content: str,
     authoritative_source_text: str,
     *,
+    corpus_citation_path: str = CORPUS_CITATION_PATH,
     test_cases: list[object] | None = None,
     artifact_numeric_values: tuple[float, ...] | None = None,
     artifact_numeric_bindings: tuple[tuple[str, float], ...] | None = None,
@@ -40,7 +42,7 @@ def _analyze(
     return analyze_complete_source_unit(
         content,
         authoritative_source_text,
-        corpus_citation_path=CORPUS_CITATION_PATH,
+        corpus_citation_path=corpus_citation_path,
         test_cases=test_cases,
         extract_numeric_occurrences=DE_NUMERIC_OCCURRENCE_EXTRACTOR,
         extract_named_scalars=extract_named_scalar_occurrences,
@@ -62,6 +64,7 @@ def _pipeline_issues(
     content: str,
     authoritative_source_text: str,
     *,
+    corpus_citation_path: str = CORPUS_CITATION_PATH,
     test_cases: list[object] | None = None,
 ) -> list[str]:
     pipeline = ValidatorPipeline(
@@ -74,7 +77,7 @@ def _pipeline_issues(
     return pipeline._complete_source_unit_issues(
         content,
         validation_source_texts={
-            CORPUS_CITATION_PATH: authoritative_source_text,
+            corpus_citation_path: authoritative_source_text,
         },
         test_cases=test_cases,
     )
@@ -416,6 +419,253 @@ rules:
     assert not result.issues
     assert result.source_numeric_occurrence_count == 1
     assert result.covered_source_numeric_occurrence_count == 1
+
+
+SVBEZGRV_2025_SECTION_1_BODY = (
+    "Die Bezugsgröße nach § 18 Absatz 1 des Vierten Buches Sozialgesetzbuch "
+    "für das Jahr 2025 beträgt 44 940 Euro. Umgerechnet auf den Monat ergeben "
+    "sich 3 745 Euro."
+)
+SVBEZGRV_2025_SECTION_2_BODY = (
+    "(1) Die Jahresarbeitsentgeltgrenze nach § 6 Absatz 6 des Fünften Buches "
+    "Sozialgesetzbuch wird für das Jahr 2025 auf 73 800 Euro festgesetzt. "
+    "Umgerechnet auf den Monat ergeben sich 6 150 Euro.\n"
+    "(2) Die Jahresarbeitsentgeltgrenze nach § 6 Absatz 7 des Fünften Buches "
+    "Sozialgesetzbuch wird für das Jahr 2025 auf 66 150 Euro festgesetzt. "
+    "Umgerechnet auf den Monat ergeben sich 5 512,50 Euro."
+)
+MINUHV_SECTION_1_BODY = (
+    "Der monatliche Mindestunterhalt minderjähriger Kinder gemäß § 1612a "
+    "Absatz 1 des Bürgerlichen Gesetzbuchs beträgt\n"
+    "1. in der ersten Altersstufe (§ 1612a Absatz 1 Satz 3 Nummer 1 des "
+    "Bürgerlichen Gesetzbuchs) 482 Euro ab dem 1. Januar 2025 und 486 Euro "
+    "ab dem 1. Januar 2026,\n"
+    "2. in der zweiten Altersstufe (§ 1612a Absatz 1 Satz 3 Nummer 2 des "
+    "Bürgerlichen Gesetzbuchs) 554 Euro ab dem 1. Januar 2025 und 558 Euro "
+    "ab dem 1. Januar 2026,\n"
+    "3. in der dritten Altersstufe (§ 1612a Absatz 1 Satz 3 Nummer 3 des "
+    "Bürgerlichen Gesetzbuchs) 649 Euro ab dem 1. Januar 2025 und 653 Euro "
+    "ab dem 1. Januar 2026."
+)
+
+
+def test_exact_svbezgrv_2025_section_1_excludes_temporal_year_from_recall():
+    citation_path = "de/regulation/svbezgrv-2025/1"
+    assert (
+        hashlib.sha256(SVBEZGRV_2025_SECTION_1_BODY.encode()).hexdigest()
+        == "c2ab73a6ea8b7573c7073a340e2ec0714b44a50e70390d62cb46f741da614694"
+    )
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: {citation_path}
+rules:
+  - name: annual_reference_amount
+    kind: parameter
+    dtype: Money
+    source: {citation_path}
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 44940
+  - name: monthly_reference_amount
+    kind: parameter
+    dtype: Money
+    source: {citation_path}
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 3745
+"""
+
+    result = _analyze(
+        content,
+        SVBEZGRV_2025_SECTION_1_BODY,
+        corpus_citation_path=citation_path,
+        test_cases=[],
+    )
+
+    assert not result.issues
+    assert (
+        result.source_numeric_occurrence_count,
+        result.covered_source_numeric_occurrence_count,
+        result.missing_source_numeric_occurrence_count,
+    ) == (2, 2, 0)
+    assert not _pipeline_issues(
+        content,
+        SVBEZGRV_2025_SECTION_1_BODY,
+        corpus_citation_path=citation_path,
+        test_cases=[],
+    )
+
+
+def test_exact_svbezgrv_2025_section_2_excludes_temporal_years_from_recall():
+    citation_path = "de/regulation/svbezgrv-2025/2"
+    assert (
+        hashlib.sha256(SVBEZGRV_2025_SECTION_2_BODY.encode()).hexdigest()
+        == "becd570c345b18381e5edd54a33754085b0ba1f80e879de6af961c07a9192bf4"
+    )
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: {citation_path}
+rules:
+  - name: general_annual_income_limit
+    kind: parameter
+    dtype: Money
+    source: {citation_path}(1)
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 73800
+  - name: general_monthly_income_limit
+    kind: parameter
+    dtype: Money
+    source: {citation_path}(1)
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 6150
+  - name: special_annual_income_limit
+    kind: parameter
+    dtype: Money
+    source: {citation_path}(2)
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 66150
+  - name: special_monthly_income_limit
+    kind: parameter
+    dtype: Money
+    source: {citation_path}(2)
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 5512.5
+"""
+
+    result = _analyze(
+        content,
+        SVBEZGRV_2025_SECTION_2_BODY,
+        corpus_citation_path=citation_path,
+        test_cases=[],
+    )
+
+    assert not result.issues
+    assert (
+        result.source_numeric_occurrence_count,
+        result.covered_source_numeric_occurrence_count,
+        result.missing_source_numeric_occurrence_count,
+    ) == (4, 4, 0)
+    assert not _pipeline_issues(
+        content,
+        SVBEZGRV_2025_SECTION_2_BODY,
+        corpus_citation_path=citation_path,
+        test_cases=[],
+    )
+
+
+def test_exact_minuhv_section_1_excludes_date_and_nummer_values_from_recall():
+    citation_path = "de/regulation/minuhv/1"
+    assert (
+        hashlib.sha256(MINUHV_SECTION_1_BODY.encode()).hexdigest()
+        == "dc5fe67760f3cd298fd3ce3c7fa2625e4ea1bb60216be9cf05353316c44c3b7a"
+    )
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: {citation_path}
+rules:
+  - name: first_age_band_amount
+    kind: derived
+    dtype: Money
+    source: {citation_path}(1)
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 482
+      - effective_from: '2026-01-01'
+        formula: 486
+  - name: second_age_band_amount
+    kind: derived
+    dtype: Money
+    source: {citation_path}(2)
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 554
+      - effective_from: '2026-01-01'
+        formula: 558
+  - name: third_age_band_amount
+    kind: derived
+    dtype: Money
+    source: {citation_path}(3)
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 649
+      - effective_from: '2026-01-01'
+        formula: 653
+"""
+    test_cases = [
+        {
+            "name": "2025",
+            "period": "2025",
+            "input": {},
+            "output": {
+                "first_age_band_amount": 482,
+                "second_age_band_amount": 554,
+                "third_age_band_amount": 649,
+            },
+        },
+        {
+            "name": "2026",
+            "period": "2026",
+            "input": {},
+            "output": {
+                "first_age_band_amount": 486,
+                "second_age_band_amount": 558,
+                "third_age_band_amount": 653,
+            },
+        },
+    ]
+
+    result = _analyze(
+        content,
+        MINUHV_SECTION_1_BODY,
+        corpus_citation_path=citation_path,
+        test_cases=test_cases,
+    )
+
+    assert not result.issues
+    assert (
+        result.source_numeric_occurrence_count,
+        result.covered_source_numeric_occurrence_count,
+        result.missing_source_numeric_occurrence_count,
+    ) == (6, 6, 0)
+    assert not _pipeline_issues(
+        content,
+        MINUHV_SECTION_1_BODY,
+        corpus_citation_path=citation_path,
+        test_cases=test_cases,
+    )
+
+
+def test_year_shaped_money_still_requires_complete_mode_representation():
+    citation_path = "de/regulation/example/1"
+    source = "Die Pauschale beträgt 2025 Euro."
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: {citation_path}
+rules: []
+"""
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path=citation_path,
+        test_cases=[],
+    )
+
+    assert result.source_numeric_occurrence_count == 1
+    assert result.missing_source_numeric_occurrence_count == 1
+    assert _has_issue(result, "2025", "numeric-recall")
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1385"
+version = "0.2.1386"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
Fixes the wave-blocking false positive found by the first production signed-apply dispatch (rulespec-de run 30193739949): `[complete-source-unit:numeric-recall] Authoritative corpus numeric value 2025 has no named scalar representation` — the gate demanded a parameter for **the year** in "für das Jahr 2025". Every German provision carries years/dates in prose, so this blocked all 24 wave citations.

## Mechanism

Temporal occurrences (German dates, ranges, `Jahr`/`Kalenderjahr`, qualified `Veranlagungs-`/`Besteuerungszeiträume`, embedded year prefixes) are **typed** on the shared occurrence machinery (#1285) with money/rate precedence applied first, and the complete-mode recall inventory excludes them from the named-scalar demand. Grounding is untouched — a generated temporal literal still grounds exactly as before, and temporal values remain available to effective-date validation. The old parallel temporal regex path in `source_completeness.py` is removed in favor of the shared typed flag (both extraction paths stay consistent by construction).

## Verified against the exact bodies that failed live

- `svbezgrv-2025/1` and `/2`: named scalars demanded for `{44 940, 3 745}` / `{73 800, 6 150, 66 150, 5 512,50}`, **no demand for 2025** (reviewer-probed directly on the released text, not just fixtures).
- `minuhv/1`: six money values demanded across the 2025/2026 effective versions; no demand for the years or date-day ordinals.
- **Negative control**: "Die Pauschale beträgt 2025 Euro." → 2025 **still demanded** (money context beats year heuristics).
- Complete-mode proof/plumbing suites: 371 passed (re-run independently). Focused temporal/grounding matrix: 54 passed. Full suite delta vs baseline: +52 passes, sole expected version-gate failure resolved by the bump (0.2.1385).

Built cross-family (sol implements, Claude verifies with direct probes on the released corpus bodies). Second finding from the live dispatch — the model ladder (terra→sol) and grounding gates behaved correctly; this was the one genuine gate bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
