### PR TITLE
Support model replacement at existing RuleSpec paths

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -34,6 +34,10 @@ on:
         description: Validator or independent-review finding to address
         required: false
         type: string
+      replace_rulespec_path:
+        description: Existing checkout-relative RuleSpec path sourced by citation
+        required: false
+        type: string
       dependent_citation:
         description: Direct dependent to re-encode atomically after a breaking target
         required: false
@@ -506,6 +510,7 @@ jobs:
           }}
         env:
           CITATION: ${{ inputs.citation }}
+          REPLACE_RULESPEC_PATH: ${{ inputs.replace_rulespec_path }}
           DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
           SECOND_DEPENDENT_CITATION: ${{ inputs.second_dependent_citation }}
           RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
@@ -519,10 +524,17 @@ jobs:
           if [ -n "$SECOND_DEPENDENT_CITATION" ]; then
             dependent_citations+=("$SECOND_DEPENDENT_CITATION")
           fi
-          axiom-encode/.venv/bin/python \
-            axiom-encode/scripts/prepare_signed_backfill.py \
-            validate-dependent-cascade \
-            "$RULESPEC_CHECKOUT" "$CITATION" "${dependent_citations[@]}"
+          cascade_args=(
+            axiom-encode/.venv/bin/python
+            axiom-encode/scripts/prepare_signed_backfill.py
+            validate-dependent-cascade
+            "$RULESPEC_CHECKOUT" "$CITATION"
+          )
+          if [ -n "$REPLACE_RULESPEC_PATH" ]; then
+            cascade_args+=(--target-rulespec-path "$REPLACE_RULESPEC_PATH")
+          fi
+          cascade_args+=("${dependent_citations[@]}")
+          "${cascade_args[@]}"
 
       - name: Encode, review, validate, and apply
         env:
@@ -530,6 +542,8 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CITATION: ${{ inputs.citation }}
           REVIEW_FINDING: ${{ inputs.review_finding }}
+          REPLACE_RULESPEC_PATH: ${{ inputs.replace_rulespec_path }}
+          QUEUE_ID: ${{ inputs.queue_id }}
           DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
           DEPENDENT_REVIEW_FINDING: ${{ inputs.dependent_review_finding }}
           SECOND_DEPENDENT_CITATION: ${{ inputs.second_dependent_citation }}
@@ -537,6 +551,8 @@ jobs:
           RULESPEC_CHECKOUT: ${{ github.workspace }}/rulespec-${{ inputs.country }}
         run: |
           set -euo pipefail
+          : "${QUEUE_ID:=}"
+          : "${REPLACE_RULESPEC_PATH:=}"
           : "${SECOND_DEPENDENT_CITATION:=}"
           : "${SECOND_DEPENDENT_REVIEW_FINDING:=}"
 
@@ -545,6 +561,7 @@ jobs:
             local review_finding="$2"
             local target_only="$3"
             local output_lane="$4"
+            local replacement_path="$5"
             local review_finding_path=""
             local -a args=(
               /opt/axiom-verification/axiom-encode encode
@@ -560,6 +577,9 @@ jobs:
             )
             if [ "$target_only" = "true" ]; then
               args+=(--apply-target-only)
+            fi
+            if [ -n "$replacement_path" ]; then
+              args+=(--replace-rulespec-path "$replacement_path")
             fi
             if [ -n "$review_finding" ]; then
               review_finding_dir="$(mktemp -d "$RUNNER_TEMP/axiom-targeted-review-finding.XXXXXX")"
@@ -585,6 +605,10 @@ jobs:
 
           if [ -n "$DEPENDENT_REVIEW_FINDING" ] && [ -z "$DEPENDENT_CITATION" ]; then
             echo "dependent citation is required with dependent review finding" >&2
+            exit 1
+          fi
+          if [ -n "$QUEUE_ID" ] && [ -n "$REPLACE_RULESPEC_PATH" ]; then
+            echo "queue-authorized re-encodes cannot override the RuleSpec target path" >&2
             exit 1
           fi
           if [ -n "$DEPENDENT_CITATION" ] && [ -z "$DEPENDENT_REVIEW_FINDING" ]; then
@@ -617,16 +641,18 @@ jobs:
           fi
 
           if [ -n "$DEPENDENT_CITATION" ]; then
-            run_signed_encode "$CITATION" "$REVIEW_FINDING" true target
             run_signed_encode \
-              "$DEPENDENT_CITATION" "$DEPENDENT_REVIEW_FINDING" false dependent
+              "$CITATION" "$REVIEW_FINDING" true target "$REPLACE_RULESPEC_PATH"
+            run_signed_encode \
+              "$DEPENDENT_CITATION" "$DEPENDENT_REVIEW_FINDING" false dependent ""
             if [ -n "$SECOND_DEPENDENT_CITATION" ]; then
               run_signed_encode \
                 "$SECOND_DEPENDENT_CITATION" \
-                "$SECOND_DEPENDENT_REVIEW_FINDING" false dependent-2
+                "$SECOND_DEPENDENT_REVIEW_FINDING" false dependent-2 ""
             fi
           else
-            run_signed_encode "$CITATION" "$REVIEW_FINDING" false target
+            run_signed_encode \
+              "$CITATION" "$REVIEW_FINDING" false target "$REPLACE_RULESPEC_PATH"
           fi
 
       - name: Verify generated provenance
@@ -658,6 +684,7 @@ jobs:
           QUEUE_ITEM_GENERATION_SHA256: ${{ inputs.queue_item_generation_sha256 }}
           QUEUE_MANIFEST_SHA256: ${{ inputs.queue_manifest_sha256 }}
           REVIEW_FINDING_PRESENT: ${{ inputs.review_finding != '' }}
+          REPLACE_RULESPEC_PATH: ${{ inputs.replace_rulespec_path }}
           RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
         run: |
           artifact="$RUNNER_TEMP/targeted-reencode"
@@ -701,6 +728,19 @@ jobs:
           second_dependent_citation = (
               os.environ.get("SECOND_DEPENDENT_CITATION") or ""
           )
+          replacement_path = os.environ.get("REPLACE_RULESPEC_PATH") or ""
+          normalized_replacement_path = ""
+          if replacement_path:
+              candidate = Path(replacement_path)
+              if (
+                  candidate.is_absolute()
+                  or candidate.as_posix() != replacement_path
+                  or any(part in {"", ".", ".."} for part in candidate.parts)
+              ):
+                  raise SystemExit(
+                      "replacement RuleSpec path is not canonical checkout-relative"
+                  )
+              normalized_replacement_path = candidate.as_posix()
           expected_citations = {os.environ["CITATION"]}
           if dependent_citation:
               expected_citations.add(dependent_citation)
@@ -762,6 +802,25 @@ jobs:
                   )
               relative_path, applied_manifest = citation_matches[0]
               manifest_path = Path(os.environ["RULESPEC_CHECKOUT"]) / relative_path
+              if lane == "target" and normalized_replacement_path:
+                  applied_files = applied_manifest.get("applied_files")
+                  if not isinstance(applied_files, list):
+                      raise SystemExit(
+                          "replacement apply manifest has malformed applied_files"
+                      )
+                  primary_paths = sorted(
+                      item.get("path")
+                      for item in applied_files
+                      if isinstance(item, dict)
+                      and isinstance(item.get("path"), str)
+                      and item["path"].endswith(".yaml")
+                      and not item["path"].endswith(".test.yaml")
+                  )
+                  if primary_paths != [normalized_replacement_path]:
+                      raise SystemExit(
+                          "replacement apply manifest primary path does not "
+                          "match the requested RuleSpec target"
+                      )
               context_path = Path(applied_manifest["context_manifest_file"]).resolve()
               try:
                   context_path.relative_to(generated_root / lane)
@@ -842,6 +901,9 @@ jobs:
               "dependent_citation": os.environ.get("DEPENDENT_CITATION") or None,
               "second_dependent_citation": (
                   os.environ.get("SECOND_DEPENDENT_CITATION") or None
+              ),
+              "replace_rulespec_path": (
+                  os.environ.get("REPLACE_RULESPEC_PATH") or None
               ),
               "pr_base_branch": os.environ["PR_BASE_BRANCH"],
               "queue_id": os.environ.get("QUEUE_ID") or None,

--- a/changelog.d/model-replace-rulespec-path.added.md
+++ b/changelog.d/model-replace-rulespec-path.added.md
@@ -1,0 +1,3 @@
+Allow signed model encodes to replace an existing source-bound RuleSpec module
+at an explicitly selected canonical path while preserving the normal review,
+validation, provenance, and applied-manifest gates.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1386"
+version = "0.2.1387"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -163,16 +163,45 @@ def _citation_rulespec_path(citation: str) -> tuple[str, PurePosixPath]:
     return jurisdiction, relative
 
 
+def _is_regular_file_beneath(root: Path, relative: PurePosixPath) -> bool:
+    """Reject files reached through any symlink beneath the checkout root."""
+
+    cursor = root
+    for part in relative.parts:
+        cursor /= part
+        if cursor.is_symlink():
+            return False
+    return cursor.is_file()
+
+
 def validate_dependent_cascade(
     repo: Path,
     target_citation: str,
     *dependent_citations: str,
+    target_rulespec_path: str | None = None,
 ) -> tuple[PurePosixPath, ...]:
     """Require the supplied modules to be all of the target's direct dependents."""
 
     import yaml
 
     target_jurisdiction, target_relative = _citation_rulespec_path(target_citation)
+    if target_rulespec_path:
+        replacement = PurePosixPath(target_rulespec_path)
+        if (
+            replacement.is_absolute()
+            or replacement.as_posix() != target_rulespec_path
+            or any(part in {"", ".", ".."} for part in replacement.parts)
+            or len(replacement.parts) < 3
+            or replacement.parts[0] != target_jurisdiction
+            or replacement.parts[1] not in RULESPEC_ATOMIC_ROOTS
+            or replacement.suffix != ".yaml"
+            or replacement.name.endswith(".test.yaml")
+        ):
+            raise ValueError(
+                "target RuleSpec path must be a canonical checkout-relative "
+                "primary module in the citation jurisdiction"
+            )
+        target_relative = PurePosixPath(*replacement.parts[1:])
     if not dependent_citations:
         raise ValueError("at least one dependent citation is required")
     dependent_relatives: list[PurePosixPath] = []
@@ -199,11 +228,10 @@ def validate_dependent_cascade(
 
     content_root = repo / target_jurisdiction
     target_path = content_root / target_relative
-    if not target_path.is_file() or target_path.is_symlink():
+    if not _is_regular_file_beneath(content_root, target_relative):
         raise ValueError("target citation has no regular baseline RuleSpec module")
     for dependent_relative in dependent_relatives:
-        dependent_path = content_root / dependent_relative
-        if not dependent_path.is_file() or dependent_path.is_symlink():
+        if not _is_regular_file_beneath(content_root, dependent_relative):
             raise ValueError(
                 "dependent citation has no regular baseline RuleSpec module"
             )
@@ -394,6 +422,7 @@ def main() -> None:
     cascade_parser = subparsers.add_parser("validate-dependent-cascade")
     cascade_parser.add_argument("repo", type=Path)
     cascade_parser.add_argument("target_citation")
+    cascade_parser.add_argument("--target-rulespec-path")
     cascade_parser.add_argument("dependent_citations", nargs="+")
     args = parser.parse_args()
     try:
@@ -426,6 +455,7 @@ def main() -> None:
                     args.repo,
                     args.target_citation,
                     *args.dependent_citations,
+                    target_rulespec_path=args.target_rulespec_path,
                 )
             )
         else:

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -166,6 +166,8 @@ def _citation_rulespec_path(citation: str) -> tuple[str, PurePosixPath]:
 def _is_regular_file_beneath(root: Path, relative: PurePosixPath) -> bool:
     """Reject files reached through any symlink beneath the checkout root."""
 
+    if root.is_symlink() or not root.is_dir():
+        return False
     cursor = root
     for part in relative.parts:
         cursor /= part

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1386"
+__version__ = "0.2.1387"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -2002,6 +2002,15 @@ def main():
             "re-encoded in the same change set before final repository validation."
         ),
     )
+    encode_parser.add_argument(
+        "--replace-rulespec-path",
+        type=Path,
+        help=(
+            "With --apply in repo-augmented mode, regenerate an existing primary "
+            "RuleSpec at this checkout-relative path when its singular corpus "
+            "citation exactly matches the requested source"
+        ),
+    )
     _add_complete_source_unit_argument(encode_parser)
     _add_rulespec_dependency_root_argument(encode_parser)
 
@@ -19410,6 +19419,112 @@ class _EncodeAttemptExecution(NamedTuple):
     logged_run: EncodingRun | None
 
 
+class _EncodeReplacementTarget(NamedTuple):
+    relative_output: Path
+    context_paths: tuple[Path, ...]
+
+
+def _resolve_encode_replacement_target(
+    args,
+    *,
+    policy_checkout_path: Path,
+    policy_repo_path: Path,
+    source_unit,
+    corpus_release: LocalCorpusRelease,
+) -> _EncodeReplacementTarget | None:
+    raw_path = getattr(args, "replace_rulespec_path", None)
+    if raw_path is None:
+        return None
+    if getattr(args, "apply", False) is not True:
+        raise ValueError("encode --replace-rulespec-path requires --apply")
+    if getattr(args, "mode", None) != "repo-augmented":
+        raise ValueError(
+            "encode --replace-rulespec-path requires --mode repo-augmented"
+        )
+
+    checkout_relative = Path(raw_path)
+    roots = tuple(sorted(RULESPEC_ATOMIC_MODULE_ROOTS))
+    if (
+        checkout_relative.is_absolute()
+        or any(part in {"", ".", ".."} for part in checkout_relative.parts)
+        or len(checkout_relative.parts) < 3
+        or checkout_relative.parts[0] != policy_repo_path.name
+        or not _is_protected_rulespec_yaml_path(checkout_relative, roots=roots)
+        or checkout_relative.name.endswith(RULESPEC_TEST_FILE_SUFFIX)
+    ):
+        raise ValueError(
+            "encode --replace-rulespec-path must name an existing checkout-relative "
+            "primary RuleSpec under the requested source jurisdiction"
+        )
+
+    target = policy_checkout_path / checkout_relative
+    target_bytes = read_bounded_regular_file(
+        policy_checkout_path,
+        target,
+        label="replacement RuleSpec",
+        max_bytes=10 * 1024 * 1024,
+    )
+    try:
+        payload = yaml.safe_load(target_bytes.decode("utf-8"))
+    except (UnicodeError, yaml.YAMLError, RecursionError) as exc:
+        raise ValueError("replacement RuleSpec is not valid UTF-8 YAML") from exc
+    if not isinstance(payload, dict) or payload.get("format") != "rulespec/v1":
+        raise ValueError("replacement RuleSpec must declare format: rulespec/v1")
+    plural_issues = find_plural_corpus_citation_path_issues(payload)
+    if plural_issues:
+        raise ValueError(
+            "replacement RuleSpec has invalid source verification: "
+            + "; ".join(plural_issues)
+        )
+    module = payload.get("module")
+    verification = (
+        module.get("source_verification") if isinstance(module, dict) else None
+    )
+    citation_paths = (
+        _source_verification_citation_paths(verification)
+        if isinstance(verification, dict)
+        else []
+    )
+    if len(citation_paths) != 1:
+        raise ValueError(
+            "replacement RuleSpec must declare exactly one corpus citation path"
+        )
+    replacement_citation = normalize_corpus_identifier(citation_paths[0])
+    requested_citation = normalize_corpus_identifier(source_unit.requested)
+    if replacement_citation != requested_citation:
+        raise ValueError(
+            "replacement RuleSpec corpus citation does not match the requested source"
+        )
+    replacement_source = resolve_corpus_source_unit(
+        replacement_citation,
+        corpus_release,
+    )
+    if (
+        replacement_source.citation_path != source_unit.citation_path
+        or replacement_source.requested != source_unit.requested
+        or replacement_source.body != source_unit.body
+        or replacement_source.resolved_source != source_unit.resolved_source
+    ):
+        raise ValueError(
+            "replacement RuleSpec does not resolve to the exact requested corpus unit"
+        )
+
+    context_paths = [target]
+    companion = _rulespec_test_path(target)
+    if companion.exists() or companion.is_symlink():
+        read_bounded_regular_file(
+            policy_checkout_path,
+            companion,
+            label="replacement RuleSpec companion test",
+            max_bytes=10 * 1024 * 1024,
+        )
+        context_paths.append(companion)
+    return _EncodeReplacementTarget(
+        relative_output=Path(*checkout_relative.parts[1:]),
+        context_paths=tuple(context_paths),
+    )
+
+
 def _resolve_encode_escalation_config(args) -> _EncodeEscalationConfig:
     """Resolve and validate the per-section validator retry policy."""
     initial_model = getattr(args, "model", None) or DEFAULT_OPENAI_MODEL
@@ -19694,6 +19809,13 @@ def _run_encode_attempt(
         source_unit.citation_path,
         policy_checkout_path,
     )
+    replacement_target = _resolve_encode_replacement_target(
+        args,
+        policy_checkout_path=policy_checkout_path,
+        policy_repo_path=policy_repo_path,
+        source_unit=source_unit,
+        corpus_release=corpus_release,
+    )
 
     def _validate_generated_encoding_in_policy_overlay(
         result,
@@ -19721,6 +19843,9 @@ def _run_encode_attempt(
     review_findings_paths = [
         Path(path) for path in getattr(args, "review_findings", [])
     ]
+    extra_context_paths = [Path(path) for path in args.allow_context]
+    if replacement_target is not None:
+        extra_context_paths.extend(replacement_target.context_paths)
     results = run_model_eval(
         citations=[args.citation],
         runner_specs=[runner],
@@ -19729,7 +19854,7 @@ def _run_encode_attempt(
         runtime_axiom_rules_path=axiom_rules_path,
         corpus_release=corpus_release,
         mode=args.mode,
-        extra_context_paths=[Path(path) for path in args.allow_context],
+        extra_context_paths=extra_context_paths,
         review_findings_paths=review_findings_paths,
         include_tests=True,
         skip_reviewers=skip_reviewers,
@@ -19737,6 +19862,11 @@ def _run_encode_attempt(
         rulespec_dependency_roots=rulespec_dependency_roots,
         require_complete_source_unit=(
             getattr(args, "require_complete_source_unit", False) is True
+        ),
+        target_relative_output=(
+            replacement_target.relative_output
+            if replacement_target is not None
+            else None
         ),
     )
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -1360,9 +1360,14 @@ def run_model_eval(
     rulespec_dependency_roots: Sequence[Path] = (),
     review_findings_paths: list[Path] | None = None,
     require_complete_source_unit: bool = False,
+    target_relative_output: Path | None = None,
 ) -> list[EvalResult]:
     """Run a deterministic comparison over one or more citations."""
     _validate_eval_oracle_runtime(oracle, policyengine_runtime, policy_path)
+    if target_relative_output is not None and len(citations) != 1:
+        raise ValueError(
+            "A target RuleSpec output override requires exactly one citation"
+        )
     include_tests = include_tests or require_complete_source_unit
     results: list[EvalResult] = []
     runners = [parse_runner_spec(spec) for spec in runner_specs]
@@ -1393,6 +1398,7 @@ def run_model_eval(
                         rulespec_dependency_roots=rulespec_dependency_roots,
                         review_findings_paths=review_findings_paths or [],
                         require_complete_source_unit=require_complete_source_unit,
+                        target_relative_output=target_relative_output,
                     )
                 )
 
@@ -5449,6 +5455,7 @@ def prepare_eval_workspace(
     amendment_documents: Sequence[CorpusAmendmentDocument] = (),
     extra_context_paths: list[Path] | None = None,
     review_findings_paths: list[Path] | None = None,
+    target_relative_output: Path | None = None,
 ) -> EvalWorkspace:
     """Create an isolated workspace bundle for a single eval."""
     slug = _slugify(citation)
@@ -5563,7 +5570,11 @@ def prepare_eval_workspace(
             )
         )
     context_corpus_root = _repo_augmented_context_root(axiom_rules_path)
-    target_rel = _target_rel_for_eval_identifier(citation)
+    target_rel = (
+        Path(target_relative_output)
+        if target_relative_output is not None
+        else _target_rel_for_eval_identifier(citation)
+    )
     current_file = axiom_rules_path / target_rel if target_rel is not None else None
     for resolved_term in resolve_defined_terms_from_text(source_text):
         context_files.append(
@@ -7845,6 +7856,7 @@ def _run_single_eval(
     rulespec_dependency_roots: Sequence[Path] = (),
     review_findings_paths: list[Path] | None = None,
     require_complete_source_unit: bool = False,
+    target_relative_output: Path | None = None,
 ) -> EvalResult:
     include_tests = include_tests or require_complete_source_unit
     if source_unit is None:
@@ -7872,6 +7884,7 @@ def _run_single_eval(
         amendment_documents=source_unit.amendment_documents,
         extra_context_paths=extra_context_paths,
         review_findings_paths=review_findings_paths,
+        target_relative_output=target_relative_output,
     )
 
     # Derive the output path from the *requested* identifier rather than the
@@ -7882,9 +7895,13 @@ def _run_single_eval(
     # the requested identifier keeps each subsection in its own file.
     #
     is_corpus_path = _looks_like_corpus_citation_path(citation)
-    relative_output = _resolve_eval_output_path(
-        citation,
-        fallback=citation_to_relative_rulespec_path,
+    relative_output = (
+        Path(target_relative_output)
+        if target_relative_output is not None
+        else _resolve_eval_output_path(
+            citation,
+            fallback=citation_to_relative_rulespec_path,
+        )
     )
     target_ref_source = citation if is_corpus_path else source_unit.citation_path
     prompt = _build_eval_prompt(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11867,9 +11867,7 @@ class TestCmdEncode:
         )
         companion = target.with_name("pilot_liability_pipeline.test.yaml")
         replacement = SimpleNamespace(
-            relative_output=Path(
-                "policies/income_tax/pilot_liability_pipeline.yaml"
-            ),
+            relative_output=Path("policies/income_tax/pilot_liability_pipeline.yaml"),
             context_paths=(target, companion),
         )
 
@@ -32356,10 +32354,7 @@ class TestEncodeReplacementTarget:
         checkout = tmp_path / "rulespec-us"
         content_root = checkout / "us-nc"
         target = (
-            content_root
-            / "policies"
-            / "income_tax"
-            / "pilot_liability_pipeline.yaml"
+            content_root / "policies" / "income_tax" / "pilot_liability_pipeline.yaml"
         )
         target.parent.mkdir(parents=True)
         target.write_text(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -155,6 +155,7 @@ from axiom_encode.cli import (
     _require_axiom_encode_version_provenance,
     _require_clean_axiom_encode_git_provenance,
     _resolve_applied_manifest_placement,
+    _resolve_encode_replacement_target,
     _resolve_explicit_policy_repo_for_corpus_source,
     _rewrite_gpt_runner_backend,
     _rewrite_import_output_test_input_refs,
@@ -11441,6 +11442,7 @@ class TestCmdEncode:
         args.sync = overrides.get("sync", True)
         args.skip_reviewers = overrides.get("skip_reviewers", False)
         args.apply = overrides.get("apply", False)
+        args.replace_rulespec_path = overrides.get("replace_rulespec_path", None)
         args.apply_target_only = overrides.get("apply_target_only", False)
         args.allow_shrink = overrides.get("allow_shrink", False)
         return args
@@ -11847,6 +11849,48 @@ class TestCmdEncode:
 
         assert exit_code == 0
         assert mock_run.call_args.kwargs["review_findings_paths"] == [findings]
+
+    def test_encode_plumbs_existing_replacement_target_to_model_eval(self, tmp_path):
+        args = self._make_args(
+            tmp_path,
+            citation="us-nc/statute/105/105-153.7",
+            replace_rulespec_path=Path(
+                "us-nc/policies/income_tax/pilot_liability_pipeline.yaml"
+            ),
+        )
+        target = (
+            args.policy_repo_path
+            / "us-nc"
+            / "policies"
+            / "income_tax"
+            / "pilot_liability_pipeline.yaml"
+        )
+        companion = target.with_name("pilot_liability_pipeline.test.yaml")
+        replacement = SimpleNamespace(
+            relative_output=Path(
+                "policies/income_tax/pilot_liability_pipeline.yaml"
+            ),
+            context_paths=(target, companion),
+        )
+
+        with patch(
+            "axiom_encode.cli._resolve_encode_replacement_target",
+            return_value=replacement,
+        ) as mock_resolve:
+            mock_run, exit_code = self._run_encode(
+                args,
+                self._make_eval_result(True),
+            )
+
+        assert exit_code == 0
+        mock_resolve.assert_called_once()
+        assert mock_run.call_args.kwargs["target_relative_output"] == (
+            Path("policies/income_tax/pilot_liability_pipeline.yaml")
+        )
+        assert mock_run.call_args.kwargs["extra_context_paths"] == [
+            target,
+            companion,
+        ]
 
     def test_encode_codex_backend_without_auth_stops_before_running(
         self, capsys, tmp_path
@@ -32304,6 +32348,260 @@ class TestResolverOwnedManifestWriter:
                 applied_files=[rule],
                 axiom_encode_git={"commit": "a" * 40},
                 signing_broker=TEST_APPLY_SIGNING_BROKER,
+            )
+
+
+class TestEncodeReplacementTarget:
+    def _fixture(self, tmp_path: Path):
+        checkout = tmp_path / "rulespec-us"
+        content_root = checkout / "us-nc"
+        target = (
+            content_root
+            / "policies"
+            / "income_tax"
+            / "pilot_liability_pipeline.yaml"
+        )
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            "format: rulespec/v1\n"
+            "module:\n"
+            "  source_verification:\n"
+            "    corpus_citation_path: us-nc/statute/105/105-153.7\n"
+            "rules: []\n"
+        )
+        companion = target.with_name("pilot_liability_pipeline.test.yaml")
+        companion.write_text("[]\n")
+        resolved_source = object()
+        source_unit = SimpleNamespace(
+            requested="us-nc/statute/105/105-153.7",
+            citation_path="us-nc/statute/105/105-153.7",
+            body="official source",
+            resolved_source=resolved_source,
+        )
+        replacement_source = SimpleNamespace(
+            requested=source_unit.requested,
+            citation_path=source_unit.citation_path,
+            body=source_unit.body,
+            resolved_source=resolved_source,
+        )
+        args = SimpleNamespace(
+            replace_rulespec_path=Path(
+                "us-nc/policies/income_tax/pilot_liability_pipeline.yaml"
+            ),
+            apply=True,
+            mode="repo-augmented",
+        )
+        return (
+            args,
+            checkout,
+            content_root,
+            target,
+            companion,
+            source_unit,
+            replacement_source,
+        )
+
+    def test_accepts_exact_existing_source_bound_primary(self, tmp_path):
+        (
+            args,
+            checkout,
+            content_root,
+            target,
+            companion,
+            source_unit,
+            replacement_source,
+        ) = self._fixture(tmp_path)
+
+        with patch(
+            "axiom_encode.cli.resolve_corpus_source_unit",
+            return_value=replacement_source,
+        ):
+            resolved = _resolve_encode_replacement_target(
+                args,
+                policy_checkout_path=checkout,
+                policy_repo_path=content_root,
+                source_unit=source_unit,
+                corpus_release=SimpleNamespace(),
+            )
+
+        assert resolved is not None
+        assert resolved.relative_output == Path(
+            "policies/income_tax/pilot_liability_pipeline.yaml"
+        )
+        assert resolved.context_paths == (target, companion)
+
+    def test_accepts_requested_child_with_resolved_parent_fallback(self, tmp_path):
+        (
+            args,
+            checkout,
+            content_root,
+            _target,
+            _companion,
+            source_unit,
+            replacement_source,
+        ) = self._fixture(tmp_path)
+        source_unit.citation_path = "us-nc/statute/105/105-153"
+        replacement_source.citation_path = source_unit.citation_path
+
+        with patch(
+            "axiom_encode.cli.resolve_corpus_source_unit",
+            return_value=replacement_source,
+        ):
+            resolved = _resolve_encode_replacement_target(
+                args,
+                policy_checkout_path=checkout,
+                policy_repo_path=content_root,
+                source_unit=source_unit,
+                corpus_release=SimpleNamespace(),
+            )
+
+        assert resolved is not None
+        assert resolved.relative_output == Path(
+            "policies/income_tax/pilot_liability_pipeline.yaml"
+        )
+
+    @pytest.mark.parametrize(
+        ("attribute", "value", "match"),
+        [
+            ("apply", False, "requires --apply"),
+            ("mode", "cold", "requires --mode repo-augmented"),
+            (
+                "replace_rulespec_path",
+                Path("../outside.yaml"),
+                "existing checkout-relative primary RuleSpec",
+            ),
+        ],
+    )
+    def test_rejects_unsafe_invocation(
+        self,
+        tmp_path,
+        attribute,
+        value,
+        match,
+    ):
+        args, checkout, content_root, *_rest = self._fixture(tmp_path)
+        setattr(args, attribute, value)
+
+        with pytest.raises(ValueError, match=match):
+            _resolve_encode_replacement_target(
+                args,
+                policy_checkout_path=checkout,
+                policy_repo_path=content_root,
+                source_unit=SimpleNamespace(),
+                corpus_release=SimpleNamespace(),
+            )
+
+    def test_rejects_different_declared_source(self, tmp_path):
+        (
+            args,
+            checkout,
+            content_root,
+            target,
+            _companion,
+            source_unit,
+            _replacement_source,
+        ) = self._fixture(tmp_path)
+        target.write_text(
+            target.read_text().replace(
+                "us-nc/statute/105/105-153.7",
+                "us-nc/statute/105/105-153.5",
+            )
+        )
+
+        with pytest.raises(ValueError, match="does not match the requested source"):
+            _resolve_encode_replacement_target(
+                args,
+                policy_checkout_path=checkout,
+                policy_repo_path=content_root,
+                source_unit=source_unit,
+                corpus_release=SimpleNamespace(),
+            )
+
+    @pytest.mark.parametrize("symlink_kind", ["target", "companion"])
+    def test_rejects_symlinked_replacement_context(self, tmp_path, symlink_kind):
+        (
+            args,
+            checkout,
+            content_root,
+            target,
+            companion,
+            source_unit,
+            replacement_source,
+        ) = self._fixture(tmp_path)
+        outside = tmp_path / f"outside-{symlink_kind}.yaml"
+        outside.write_text(target.read_text() if symlink_kind == "target" else "[]\n")
+        symlink = target if symlink_kind == "target" else companion
+        symlink.unlink()
+        symlink.symlink_to(outside)
+
+        with (
+            patch(
+                "axiom_encode.cli.resolve_corpus_source_unit",
+                return_value=replacement_source,
+            ),
+            pytest.raises(UnsafeCorpusPathError, match="safely open"),
+        ):
+            _resolve_encode_replacement_target(
+                args,
+                policy_checkout_path=checkout,
+                policy_repo_path=content_root,
+                source_unit=source_unit,
+                corpus_release=SimpleNamespace(),
+            )
+
+    def test_rejects_symlinked_replacement_parent(self, tmp_path):
+        (
+            args,
+            checkout,
+            content_root,
+            target,
+            companion,
+            source_unit,
+            _replacement_source,
+        ) = self._fixture(tmp_path)
+        outside_parent = tmp_path / "outside-income-tax"
+        outside_parent.mkdir()
+        (outside_parent / target.name).write_text(target.read_text())
+        (outside_parent / companion.name).write_text(companion.read_text())
+        target.unlink()
+        companion.unlink()
+        target.parent.rmdir()
+        target.parent.symlink_to(outside_parent)
+
+        with pytest.raises(UnsafeCorpusPathError, match="safely open"):
+            _resolve_encode_replacement_target(
+                args,
+                policy_checkout_path=checkout,
+                policy_repo_path=content_root,
+                source_unit=source_unit,
+                corpus_release=SimpleNamespace(),
+            )
+
+    @pytest.mark.parametrize(
+        "replacement_path",
+        [
+            Path("us-or/policies/income_tax/pilot_liability_pipeline.yaml"),
+            Path("us-nc/policies/income_tax/missing.yaml"),
+        ],
+    )
+    def test_rejects_wrong_jurisdiction_or_missing_target(
+        self,
+        tmp_path,
+        replacement_path,
+    ):
+        args, checkout, content_root, *_rest = self._fixture(tmp_path)
+        args.replace_rulespec_path = replacement_path
+
+        with pytest.raises(
+            (ValueError, UnsafeCorpusPathError),
+            match="existing checkout-relative|safely open",
+        ):
+            _resolve_encode_replacement_target(
+                args,
+                policy_checkout_path=checkout,
+                policy_repo_path=content_root,
+                source_unit=SimpleNamespace(),
+                corpus_release=SimpleNamespace(),
             )
 
 

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -1525,6 +1525,157 @@ def test_model_eval_reuses_identical_resolved_source_for_all_runners(tmp_path):
     )
 
 
+def test_model_eval_passes_single_target_output_override(tmp_path):
+    corpus_release, source_unit = _write_test_source_unit(
+        tmp_path,
+        "authoritative source",
+        citation_path="us-nc/statute/105/105-153.7",
+    )
+    target = Path("policies/income_tax/pilot_liability_pipeline.yaml")
+    result = Mock(name="result")
+
+    with (
+        patch(
+            "axiom_encode.harness.evals.resolve_corpus_source_unit",
+            return_value=source_unit,
+        ),
+        patch(
+            "axiom_encode.harness.evals._run_single_eval",
+            return_value=result,
+        ) as mock_run,
+    ):
+        actual = run_model_eval(
+            citations=["us-nc/statute/105/105-153.7"],
+            runner_specs=["openai:model-a"],
+            output_root=tmp_path / "out",
+            policy_path=tmp_path / "rulespec-us" / "us-nc",
+            runtime_axiom_rules_path=tmp_path / "engine",
+            corpus_release=corpus_release,
+            target_relative_output=target,
+        )
+
+    assert actual == [result]
+    assert mock_run.call_args.kwargs["target_relative_output"] == target
+
+
+def test_model_eval_rejects_target_override_for_multiple_citations(tmp_path):
+    corpus_release, _source_unit = _write_test_source_unit(
+        tmp_path,
+        "authoritative source",
+        citation_path="us/statute/26/1",
+    )
+
+    with pytest.raises(ValueError, match="requires exactly one citation"):
+        run_model_eval(
+            citations=["us/statute/26/1", "us/statute/26/2"],
+            runner_specs=["openai:model-a"],
+            output_root=tmp_path / "out",
+            policy_path=tmp_path / "rulespec-us" / "us",
+            runtime_axiom_rules_path=tmp_path / "engine",
+            corpus_release=corpus_release,
+            target_relative_output=Path("policies/income_tax/pipeline.yaml"),
+        )
+
+
+def test_workspace_classifies_output_override_as_existing_target(tmp_path):
+    policy_root = _canonical_rulespec_content_root(tmp_path, "us-nc")
+    target_relative = Path(
+        "policies/income_tax/pilot_liability_pipeline.yaml"
+    )
+    target = policy_root / target_relative
+    target.parent.mkdir(parents=True)
+    target.write_text("format: rulespec/v1\nrules: []\n")
+    companion = target.with_name("pilot_liability_pipeline.test.yaml")
+    companion.write_text("[]\n")
+
+    workspace = prepare_eval_workspace(
+        citation="us-nc/statute/105/105-153.7",
+        runner=parse_runner_spec("openai:gpt-5.4"),
+        output_root=tmp_path / "out",
+        source_text="Authoritative source.",
+        axiom_rules_path=policy_root,
+        mode="repo-augmented",
+        extra_context_paths=[target, companion],
+        target_relative_output=target_relative,
+    )
+
+    kinds = {Path(item.source_path): item.kind for item in workspace.context_files}
+    assert kinds[target.resolve()] == "existing_target"
+    assert kinds[companion.resolve()] == "existing_target_test_context"
+
+
+def test_model_eval_uses_output_override_for_prompt_and_artifact_path(tmp_path):
+    corpus_release, _source_unit = _write_test_source_unit(
+        tmp_path,
+        "Authoritative source.",
+        citation_path="us-nc/statute/105/105-153.7",
+    )
+    policy_root = _canonical_rulespec_content_root(tmp_path, "us-nc")
+    target_relative = Path(
+        "policies/income_tax/pilot_liability_pipeline.yaml"
+    )
+    target = policy_root / target_relative
+    target.parent.mkdir(parents=True)
+    target.write_text("format: rulespec/v1\nrules: []\n")
+    companion = target.with_name("pilot_liability_pipeline.test.yaml")
+    companion.write_text("[]\n")
+    output_root = tmp_path / "out"
+
+    def generate_override_artifact(**kwargs):
+        output_file = kwargs["output_file"]
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        output_file.write_text("format: rulespec/v1\nrules: []\n")
+        return (
+            EvalPromptResponse(text="generated", duration_ms=1),
+            True,
+            0,
+            frozenset({output_file}),
+        )
+
+    with (
+        patch(
+            "axiom_encode.harness.evals._run_prompt_eval_with_empty_artifact_retry",
+            side_effect=generate_override_artifact,
+        ),
+        patch(
+            "axiom_encode.harness.evals._evaluate_generated_artifact_with_repairs",
+            return_value=EvalArtifactMetrics(
+                compile_pass=True,
+                compile_issues=[],
+                ci_pass=True,
+                ci_issues=[],
+                embedded_source_present=False,
+                grounded_numeric_count=0,
+                ungrounded_numeric_count=0,
+                grounding=[],
+            ),
+        ),
+        patch(
+            "axiom_encode.harness.evals._build_eval_prompt",
+            wraps=evals_module._build_eval_prompt,
+        ) as mock_prompt,
+    ):
+        result = run_model_eval(
+            citations=["us-nc/statute/105/105-153.7"],
+            runner_specs=["openai:model-a"],
+            output_root=output_root,
+            policy_path=policy_root,
+            runtime_axiom_rules_path=tmp_path / "engine",
+            corpus_release=corpus_release,
+            mode="repo-augmented",
+            extra_context_paths=[target, companion],
+            target_relative_output=target_relative,
+        )[0]
+
+    assert Path(result.output_file) == (
+        output_root / "openai-model-a" / target_relative
+    )
+    assert mock_prompt.call_args.kwargs["target_file_name"] == target.name
+    assert mock_prompt.call_args.kwargs["target_ref_prefix"] == (
+        "us-nc:policies/income_tax/pilot_liability_pipeline"
+    )
+
+
 def test_resolve_corpus_source_unit_concatenates_descendant_text_rows(tmp_path):
     rows = [
         {

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -1579,9 +1579,7 @@ def test_model_eval_rejects_target_override_for_multiple_citations(tmp_path):
 
 def test_workspace_classifies_output_override_as_existing_target(tmp_path):
     policy_root = _canonical_rulespec_content_root(tmp_path, "us-nc")
-    target_relative = Path(
-        "policies/income_tax/pilot_liability_pipeline.yaml"
-    )
+    target_relative = Path("policies/income_tax/pilot_liability_pipeline.yaml")
     target = policy_root / target_relative
     target.parent.mkdir(parents=True)
     target.write_text("format: rulespec/v1\nrules: []\n")
@@ -1611,9 +1609,7 @@ def test_model_eval_uses_output_override_for_prompt_and_artifact_path(tmp_path):
         citation_path="us-nc/statute/105/105-153.7",
     )
     policy_root = _canonical_rulespec_content_root(tmp_path, "us-nc")
-    target_relative = Path(
-        "policies/income_tax/pilot_liability_pipeline.yaml"
-    )
+    target_relative = Path("policies/income_tax/pilot_liability_pipeline.yaml")
     target = policy_root / target_relative
     target.parent.mkdir(parents=True)
     target.write_text("format: rulespec/v1\nrules: []\n")

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -278,6 +278,36 @@ def test_validate_dependent_cascade_rejects_symlinked_replacement_parent(
         )
 
 
+def test_validate_dependent_cascade_rejects_symlinked_jurisdiction_root(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "rulespec-us"
+    repo.mkdir()
+    outside = tmp_path / "outside-us"
+    _write_module(
+        outside.parent / "rulespec-outside",
+        "policies/income_tax/target.yaml",
+    )
+    outside_source = outside.parent / "rulespec-outside" / "us"
+    (repo / "us").symlink_to(outside_source, target_is_directory=True)
+    _write_module(
+        outside.parent / "rulespec-outside",
+        "regulations/42-cfr/435/559.yaml",
+        imports=("us:policies/income_tax/target#target_rule",),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="target citation has no regular baseline RuleSpec module",
+    ):
+        validate_dependent_cascade(
+            repo,
+            "us/regulation/42/435/555",
+            "us/regulation/42/435/559",
+            target_rulespec_path="us/policies/income_tax/target.yaml",
+        )
+
+
 def test_validate_dependent_cascade_rejects_unrelated_dependent(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -204,9 +204,7 @@ def test_validate_dependent_cascade_uses_nondefault_replacement_target(
     dependent = _write_module(
         repo,
         "regulations/42-cfr/435/559.yaml",
-        imports=(
-            "us:policies/income_tax/pilot_liability_pipeline#target_rule",
-        ),
+        imports=("us:policies/income_tax/pilot_liability_pipeline#target_rule",),
     )
     _write_module(repo, "regulations/42-cfr/435/555.yaml")
 

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -193,6 +193,91 @@ def test_validate_dependent_cascade_accepts_only_direct_dependent(
     ) == (dependent.relative_to(repo / "us"),)
 
 
+def test_validate_dependent_cascade_uses_nondefault_replacement_target(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    replacement = _write_module(
+        repo,
+        "policies/income_tax/pilot_liability_pipeline.yaml",
+    )
+    dependent = _write_module(
+        repo,
+        "regulations/42-cfr/435/559.yaml",
+        imports=(
+            "us:policies/income_tax/pilot_liability_pipeline#target_rule",
+        ),
+    )
+    _write_module(repo, "regulations/42-cfr/435/555.yaml")
+
+    assert validate_dependent_cascade(
+        repo,
+        "us/regulation/42/435/555",
+        "us/regulation/42/435/559",
+        target_rulespec_path=replacement.relative_to(repo).as_posix(),
+    ) == (dependent.relative_to(repo / "us"),)
+
+
+@pytest.mark.parametrize(
+    "replacement_path",
+    [
+        "../outside.yaml",
+        "us-nc/policies/income_tax/pipeline.yaml",
+        "us/policies/income_tax/pipeline.test.yaml",
+    ],
+)
+def test_validate_dependent_cascade_rejects_invalid_replacement_target(
+    tmp_path: Path,
+    replacement_path: str,
+) -> None:
+    repo = _repo(tmp_path)
+    _write_module(repo, "regulations/42-cfr/435/555.yaml")
+    _write_module(
+        repo,
+        "regulations/42-cfr/435/559.yaml",
+        imports=("us:regulations/42-cfr/435/555",),
+    )
+
+    with pytest.raises(ValueError, match="target RuleSpec path must be"):
+        validate_dependent_cascade(
+            repo,
+            "us/regulation/42/435/555",
+            "us/regulation/42/435/559",
+            target_rulespec_path=replacement_path,
+        )
+
+
+def test_validate_dependent_cascade_rejects_symlinked_replacement_parent(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "target.yaml").write_text(
+        "rules:\n  target_rule:\n    kind: constant\n    value: 1\n",
+        encoding="utf-8",
+    )
+    linked_parent = repo / "us" / "policies" / "linked"
+    linked_parent.parent.mkdir(parents=True)
+    linked_parent.symlink_to(outside, target_is_directory=True)
+    _write_module(
+        repo,
+        "regulations/42-cfr/435/559.yaml",
+        imports=("us:policies/linked/target#target_rule",),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="target citation has no regular baseline RuleSpec module",
+    ):
+        validate_dependent_cascade(
+            repo,
+            "us/regulation/42/435/555",
+            "us/regulation/42/435/559",
+            target_rulespec_path="us/policies/linked/target.yaml",
+        )
+
+
 def test_validate_dependent_cascade_rejects_unrelated_dependent(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1862,6 +1862,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert inputs["open_pr"]["default"] is False
     assert inputs["pr_base_branch"]["type"] == "string"
     assert inputs["pr_base_branch"]["default"] == "main"
+    assert inputs["replace_rulespec_path"]["required"] is False
     assert inputs["dependent_citation"]["required"] is False
     assert inputs["dependent_review_finding"]["required"] is False
     assert inputs["second_dependent_citation"]["required"] is False
@@ -2013,8 +2014,16 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     )
     assert (
         '"$RULESPEC_CHECKOUT" "$CITATION" "${dependent_citations[@]}"'
-        in (cascade_step["run"])
+        not in (cascade_step["run"])
     )
+    assert cascade_step["env"]["REPLACE_RULESPEC_PATH"] == (
+        "${{ inputs.replace_rulespec_path }}"
+    )
+    assert 'cascade_args+=(--target-rulespec-path "$REPLACE_RULESPEC_PATH")' in (
+        cascade_step["run"]
+    )
+    assert 'cascade_args+=("${dependent_citations[@]}")' in cascade_step["run"]
+    assert '"${cascade_args[@]}"' in cascade_step["run"]
 
     apply_step = next(
         step
@@ -2042,14 +2051,27 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "printf '%s\\n' \"$review_finding\"" in command
     assert 'args+=(--review-findings "$review_finding_path")' in command
     assert "args+=(--apply-target-only)" in command
+    assert 'args+=(--replace-rulespec-path "$replacement_path")' in command
+    assert '[ "$target_only" = "true" ]' in command
+    assert (
+        "queue-authorized re-encodes cannot override the RuleSpec target path"
+        in command
+    )
     assert '--output "$RUNNER_TEMP/generated/$output_lane"' in command
     assert '"$SECOND_DEPENDENT_CITATION"' in command
-    assert '"$SECOND_DEPENDENT_REVIEW_FINDING" false dependent-2' in command
-    assert 'run_signed_encode "$CITATION" "$REVIEW_FINDING" true target' in command
+    assert '"$SECOND_DEPENDENT_REVIEW_FINDING" false dependent-2 ""' in command
     assert (
-        '"$DEPENDENT_CITATION" "$DEPENDENT_REVIEW_FINDING" false dependent' in command
+        '"$CITATION" "$REVIEW_FINDING" true target "$REPLACE_RULESPEC_PATH"'
+        in command
     )
-    assert 'run_signed_encode "$CITATION" "$REVIEW_FINDING" false target' in command
+    assert (
+        '"$DEPENDENT_CITATION" "$DEPENDENT_REVIEW_FINDING" false dependent ""'
+        in command
+    )
+    assert (
+        '"$CITATION" "$REVIEW_FINDING" false target "$REPLACE_RULESPEC_PATH"'
+        in command
+    )
     assert "dependent review finding is required with dependent citation" in command
     assert steps.index(cascade_step) < steps.index(apply_step)
 
@@ -2069,6 +2091,9 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert 'citation = payload.get("citation")' in package_command
     assert 'applied_manifest["context_manifest_file"]' in package_command
     assert 'applied_manifest.get("context_manifest_sha256")' in package_command
+    assert "primary_paths != [normalized_replacement_path]" in package_command
+    assert "replacement apply manifest primary path does not " in package_command
+    assert "match the requested RuleSpec target" in package_command
     assert 'finding.get("content")' in package_command
     assert 'finding.get("sha256")' in package_command
     assert '"dependent-context-manifest.json"' in package_command
@@ -2539,6 +2564,97 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
             .strip()
             == "Preserve the second dependent source."
         )
+
+
+@pytest.mark.parametrize("with_dependent", [False, True])
+def test_targeted_signed_reencode_runs_replacement_target(
+    tmp_path: Path,
+    with_dependent: bool,
+) -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
+    )
+    command = next(
+        step["run"]
+        for step in workflow["jobs"]["encode"]["steps"]
+        if step.get("name") == "Encode, review, validate, and apply"
+    ).replace(
+        "/opt/axiom-verification/axiom-encode-apply-signer run",
+        '"$SIGNER_STUB"',
+    )
+    calls_path = tmp_path / "calls.jsonl"
+    signer_stub = tmp_path / "signer-stub"
+    signer_stub.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
+    stream.write(json.dumps(sys.argv[1:]) + "\\n")
+"""
+    )
+    signer_stub.chmod(0o700)
+    runner_temp = tmp_path / "runner-temp"
+    runner_temp.mkdir()
+    replacement_path = "us-nc/policies/income_tax/pilot_liability_pipeline.yaml"
+    dependent_citation = (
+        "us-nc/statute/105/105-153.5" if with_dependent else ""
+    )
+    dependent_finding = (
+        "Preserve the resident pipeline semantics." if with_dependent else ""
+    )
+
+    environment = {
+        **os.environ,
+        "AXIOM_ENCODE_APPLY_SIGNING_KEY": "test-key",
+        "CALLS_PATH": str(calls_path),
+        "CITATION": "us-nc/statute/105/105-153.7",
+        "DEPENDENT_CITATION": dependent_citation,
+        "DEPENDENT_REVIEW_FINDING": dependent_finding,
+        "GITHUB_WORKSPACE": str(tmp_path),
+        "REPLACE_RULESPEC_PATH": replacement_path,
+        "REVIEW_FINDING": "Preserve all supported existing semantics.",
+        "RULESPEC_CHECKOUT": str(tmp_path / "rulespec-us"),
+        "RUNNER_TEMP": str(runner_temp),
+        "SECOND_DEPENDENT_CITATION": "",
+        "SECOND_DEPENDENT_REVIEW_FINDING": "",
+        "SIGNER_STUB": str(signer_stub),
+    }
+    subprocess.run(
+        ["bash", "-c", command],
+        check=True,
+        env=environment,
+    )
+
+    calls = [
+        json.loads(line) for line in calls_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert len(calls) == (2 if with_dependent else 1)
+    encode_args = [call[call.index("--") + 1 :] for call in calls]
+    assert ("--apply-target-only" in encode_args[0]) is with_dependent
+    assert encode_args[0][encode_args[0].index("--replace-rulespec-path") + 1] == (
+        replacement_path
+    )
+    assert encode_args[0][-1] == "us-nc/statute/105/105-153.7"
+    if with_dependent:
+        assert "--replace-rulespec-path" not in encode_args[1]
+        assert "--apply-target-only" not in encode_args[1]
+        assert encode_args[1][-1] == dependent_citation
+
+    blocked = subprocess.run(
+        ["bash", "-c", command],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**environment, "QUEUE_ID": "us-snap-all-states-2026-07"},
+    )
+    assert blocked.returncode != 0
+    assert (
+        "queue-authorized re-encodes cannot override the RuleSpec target path"
+        in blocked.stderr
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2019,8 +2019,9 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert cascade_step["env"]["REPLACE_RULESPEC_PATH"] == (
         "${{ inputs.replace_rulespec_path }}"
     )
-    assert 'cascade_args+=(--target-rulespec-path "$REPLACE_RULESPEC_PATH")' in (
-        cascade_step["run"]
+    assert (
+        'cascade_args+=(--target-rulespec-path "$REPLACE_RULESPEC_PATH")'
+        in (cascade_step["run"])
     )
     assert 'cascade_args+=("${dependent_citations[@]}")' in cascade_step["run"]
     assert '"${cascade_args[@]}"' in cascade_step["run"]
@@ -2061,16 +2062,14 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert '"$SECOND_DEPENDENT_CITATION"' in command
     assert '"$SECOND_DEPENDENT_REVIEW_FINDING" false dependent-2 ""' in command
     assert (
-        '"$CITATION" "$REVIEW_FINDING" true target "$REPLACE_RULESPEC_PATH"'
-        in command
+        '"$CITATION" "$REVIEW_FINDING" true target "$REPLACE_RULESPEC_PATH"' in command
     )
     assert (
         '"$DEPENDENT_CITATION" "$DEPENDENT_REVIEW_FINDING" false dependent ""'
         in command
     )
     assert (
-        '"$CITATION" "$REVIEW_FINDING" false target "$REPLACE_RULESPEC_PATH"'
-        in command
+        '"$CITATION" "$REVIEW_FINDING" false target "$REPLACE_RULESPEC_PATH"' in command
     )
     assert "dependent review finding is required with dependent citation" in command
     assert steps.index(cascade_step) < steps.index(apply_step)
@@ -2599,9 +2598,7 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
     runner_temp = tmp_path / "runner-temp"
     runner_temp.mkdir()
     replacement_path = "us-nc/policies/income_tax/pilot_liability_pipeline.yaml"
-    dependent_citation = (
-        "us-nc/statute/105/105-153.5" if with_dependent else ""
-    )
+    dependent_citation = "us-nc/statute/105/105-153.5" if with_dependent else ""
     dependent_finding = (
         "Preserve the resident pipeline semantics." if with_dependent else ""
     )

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1386"
+version = "0.2.1387"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- add a constrained `encode --apply --replace-rulespec-path` path for regenerating an existing protected primary RuleSpec module from its singular official corpus source
- bind model context, output, signed manifest metadata, and workflow packaging to the exact replacement target
- support atomic target-plus-dependent signed re-encodes while rejecting queue overrides and symlinked checkout boundaries

## Review cycle
Independent review was repeated until no actionable findings remained. Fixes included dependent-cascade validation, source fallback identity binding, exact signed manifest target binding, queue isolation, workspace target classification, and rejection of intermediate-parent and jurisdiction-root symlinks. Final exact-head review of `01ec936e1dfdeef8baa572650bd62bc1c3903f63` reported no actionable findings.

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest` (5,831 passed, 119 skipped)
- focused replacement, eval workspace, signed workflow, and cascade tests
