### PR TITLE
Wave-2 class fixes: stated conversions, German word-number lexicon, structural labels, excerpt re-anchoring, retry steering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1387"
+version = "0.2.1388"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1387"
+__version__ = "0.2.1388"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -29,6 +29,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import unicodedata
 from base64 import b64decode, b64encode
 from binascii import Error as BinasciiError
 from calendar import monthrange
@@ -28859,6 +28860,92 @@ def _source_excerpt_preserving_whitespace(
     return next(iter(matches)) if len(matches) == 1 else None
 
 
+_PROOF_EXCERPT_CANONICAL_PUNCTUATION = {
+    "'": "'",
+    "\u2018": "'",
+    "\u2019": "'",
+    "\u201a": "'",
+    "\u201b": "'",
+    '"': '"',
+    "\u201c": '"',
+    "\u201d": '"',
+    "\u201e": '"',
+    "\u201f": '"',
+    "-": "-",
+    "\u2010": "-",
+    "\u2011": "-",
+    "\u2012": "-",
+    "\u2013": "-",
+    "\u2014": "-",
+    "\u2015": "-",
+    "\u2212": "-",
+    "*": "*",
+    "\u00b7": "*",
+    "\u2022": "*",
+    "\u2219": "*",
+    "\u22c5": "*",
+    "\u00d7": "*",
+}
+
+
+def _canonical_proof_excerpt_with_raw_coordinates(
+    value: str,
+) -> tuple[str, tuple[tuple[int, int], ...]]:
+    """Build a matching-only view while retaining exact source coordinates."""
+    canonical: list[str] = []
+    raw_coordinates: list[tuple[int, int]] = []
+    for raw_index, raw_character in enumerate(str(value)):
+        if raw_character.isspace() or unicodedata.category(raw_character) == "Cf":
+            continue
+        character = _PROOF_EXCERPT_CANONICAL_PUNCTUATION.get(
+            raw_character,
+            raw_character,
+        )
+        for normalized_character in unicodedata.normalize(
+            "NFD",
+            character.casefold(),
+        ):
+            if normalized_character.isspace() or unicodedata.category(
+                normalized_character
+            ) in {"Cf", "Mn"}:
+                continue
+            canonical.append(
+                _PROOF_EXCERPT_CANONICAL_PUNCTUATION.get(
+                    normalized_character,
+                    normalized_character,
+                )
+            )
+            raw_coordinates.append((raw_index, raw_index + 1))
+    return "".join(canonical), tuple(raw_coordinates)
+
+
+def _canonical_source_excerpt_matches(
+    *,
+    source_text: str,
+    excerpt: str,
+) -> tuple[str, ...]:
+    """Return every source span equivalent under narrow display normalization."""
+    canonical_query, _ = _canonical_proof_excerpt_with_raw_coordinates(excerpt)
+    if not canonical_query:
+        return ()
+    matches: list[str] = []
+    for segment in split_proof_evidence_text(source_text):
+        canonical_source, coordinates = _canonical_proof_excerpt_with_raw_coordinates(
+            segment
+        )
+        search_from = 0
+        while True:
+            match_start = canonical_source.find(canonical_query, search_from)
+            if match_start < 0:
+                break
+            match_end = match_start + len(canonical_query)
+            raw_start = coordinates[match_start][0]
+            raw_end = coordinates[match_end - 1][1]
+            matches.append(segment[raw_start:raw_end])
+            search_from = match_start + 1
+    return tuple(matches)
+
+
 def _try_repair_generated_nonexact_proof_excerpts_for_apply(
     result,
     *,
@@ -29055,6 +29142,18 @@ def _closest_exact_source_excerpt(
     if not source or not query:
         return None
     segments = split_proof_evidence_text(source)
+    whitespace_pattern = r"\s+".join(re.escape(part) for part in query.split())
+    has_whitespace_match = any(
+        re.search(whitespace_pattern, segment, flags=re.IGNORECASE) is not None
+        for segment in segments
+    )
+    if not has_whitespace_match:
+        canonical_matches = _canonical_source_excerpt_matches(
+            source_text=source,
+            excerpt=query,
+        )
+        if canonical_matches:
+            return canonical_matches[0] if len(canonical_matches) == 1 else None
     if len(segments) > 1:
         matches = {
             candidate
@@ -29070,7 +29169,6 @@ def _closest_exact_source_excerpt(
         return next(iter(matches)) if len(matches) == 1 else None
 
     candidates = _exact_source_excerpt_candidate_spans(source)
-    whitespace_pattern = r"\s+".join(re.escape(part) for part in query.split())
     direct_match = re.search(whitespace_pattern, source, flags=re.IGNORECASE)
     if direct_match is not None:
         enclosing = [
@@ -29121,7 +29219,7 @@ def _closest_exact_source_excerpt(
             )
         )
         shared_numbers = query_numbers & candidate_numbers
-        if query_numbers and not shared_numbers:
+        if query_numbers and not query_numbers.issubset(candidate_numbers):
             continue
         if len(shared_tokens) < 2 and not (shared_numbers and shared_tokens):
             continue

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -29155,7 +29155,7 @@ def _closest_exact_source_excerpt(
         if canonical_matches:
             return canonical_matches[0] if len(canonical_matches) == 1 else None
     if len(segments) > 1:
-        matches = {
+        matches = [
             candidate
             for segment in segments
             if (
@@ -29165,8 +29165,8 @@ def _closest_exact_source_excerpt(
                     numeric_profile=numeric_profile,
                 )
             )
-        }
-        return next(iter(matches)) if len(matches) == 1 else None
+        ]
+        return matches[0] if len(matches) == 1 else None
 
     candidates = _exact_source_excerpt_candidate_spans(source)
     direct_match = re.search(whitespace_pattern, source, flags=re.IGNORECASE)

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -19412,6 +19412,36 @@ class _FailedEncodeAttempt(NamedTuple):
     error: str
 
 
+def _encode_validation_retry_feedback(
+    prior_attempts: Sequence[_FailedEncodeAttempt],
+) -> tuple[str, ...]:
+    """Return bounded, deduplicated validator guidance for the next attempt."""
+
+    feedback: list[str] = []
+    seen: set[str] = set()
+
+    def add(raw_item: object) -> None:
+        if len(feedback) >= 12 or not isinstance(raw_item, str):
+            return
+        item = raw_item.strip()[:2000]
+        if not item or item in seen:
+            return
+        seen.add(item)
+        feedback.append(item)
+
+    for failed_attempt in reversed(prior_attempts):
+        add(failed_attempt.error)
+        metrics = getattr(failed_attempt.result, "metrics", None)
+        for attribute in ("compile_issues", "ci_issues"):
+            issues = getattr(metrics, attribute, ())
+            if isinstance(issues, Sequence) and not isinstance(issues, (str, bytes)):
+                for issue in issues:
+                    add(issue)
+        if len(feedback) >= 12:
+            break
+    return tuple(feedback)
+
+
 class _EncodeAttemptExecution(NamedTuple):
     result: Any
     outcome: dict[str, Any]
@@ -19868,6 +19898,7 @@ def _run_encode_attempt(
             if replacement_target is not None
             else None
         ),
+        validation_retry_feedback=_encode_validation_retry_feedback(prior_attempts),
     )
 
     result = results[0]

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -246,7 +246,6 @@ from .harness.validator_pipeline import (
     _rulespec_rule_formula_rule_records,
     _rulespec_target_is_descendant_of,
     extract_embedded_source_text,
-    extract_numbers_from_text,
     extract_typed_numeric_occurrences_from_text,
     find_interval_table_reencoding_candidates,
     find_structured_scale_parameter_issue_records,
@@ -28851,13 +28850,14 @@ def _source_excerpt_preserving_whitespace(
     parts = str(excerpt).split()
     if not parts:
         return None
-    matches: set[str] = set()
+    matches: list[str] = []
     pattern = r"\s+".join(re.escape(part) for part in parts)
     for segment in split_proof_evidence_text(source_text):
-        match = re.search(pattern, segment, flags=re.IGNORECASE)
-        if match is not None:
-            matches.add(segment[match.start() : match.end()].strip())
-    return next(iter(matches)) if len(matches) == 1 else None
+        matches.extend(
+            segment[match.start() : match.end()]
+            for match in re.finditer(pattern, segment, flags=re.IGNORECASE)
+        )
+    return matches[0] if len(matches) == 1 else None
 
 
 _PROOF_EXCERPT_CANONICAL_PUNCTUATION = {
@@ -28941,6 +28941,13 @@ def _canonical_source_excerpt_matches(
             match_end = match_start + len(canonical_query)
             raw_start = coordinates[match_start][0]
             raw_end = coordinates[match_end - 1][1]
+            while raw_end < len(segment) and unicodedata.category(segment[raw_end]) in {
+                "Cf",
+                "Mc",
+                "Me",
+                "Mn",
+            }:
+                raw_end += 1
             matches.append(segment[raw_start:raw_end])
             search_from = match_start + 1
     return tuple(matches)
@@ -29149,13 +29156,15 @@ def _closest_exact_source_excerpt(
         re.search(whitespace_pattern, segment, flags=re.IGNORECASE) is not None
         for segment in segments
     )
+    canonical_matches = _canonical_source_excerpt_matches(
+        source_text=source,
+        excerpt=query,
+    )
+    if len(canonical_matches) > 1:
+        return None
     if not has_whitespace_match:
-        canonical_matches = _canonical_source_excerpt_matches(
-            source_text=source,
-            excerpt=query,
-        )
         if canonical_matches:
-            return canonical_matches[0] if len(canonical_matches) == 1 else None
+            return canonical_matches[0]
     if len(segments) > 1:
         matches = [
             candidate
@@ -29205,7 +29214,10 @@ def _closest_exact_source_excerpt(
         return _safe_wrapped_direct_source_match(source, direct_match)
 
     query_tokens = _proof_excerpt_match_tokens(query)
-    query_numbers = set(extract_numbers_from_text(query, profile=numeric_profile))
+    query_numbers = _proof_excerpt_numeric_occurrence_counter(
+        query,
+        profile=numeric_profile,
+    )
     if _has_malformed_profiled_numeric_envelope(
         query,
         profile=numeric_profile,
@@ -29218,17 +29230,18 @@ def _closest_exact_source_excerpt(
         normalized_candidate = re.sub(r"\s+", " ", candidate.text).strip()
         candidate_tokens = _proof_excerpt_match_tokens(candidate.text)
         shared_tokens = query_tokens & candidate_tokens
-        candidate_numbers = set(
-            extract_numbers_from_text(
-                candidate.text,
-                profile=numeric_profile,
-            )
+        candidate_numbers = _proof_excerpt_numeric_occurrence_counter(
+            candidate.text,
+            profile=numeric_profile,
         )
         shared_numbers = query_numbers & candidate_numbers
         if query_numbers and (
             not (query_numbers & candidate_numbers)
             if not require_all_query_numbers
-            else not query_numbers.issubset(candidate_numbers)
+            else any(
+                candidate_numbers[value] < count
+                for value, count in query_numbers.items()
+            )
         ):
             continue
         if len(shared_tokens) < 2 and not (shared_numbers and shared_tokens):
@@ -29241,18 +29254,27 @@ def _closest_exact_source_excerpt(
         token_coverage = len(shared_tokens) / max(1, len(query_tokens))
         if similarity < 0.55 and token_coverage < 0.6:
             continue
-        score = similarity + (1.25 * token_coverage) + (0.1 * len(shared_numbers))
+        score = (
+            similarity + (1.25 * token_coverage) + (0.1 * sum(shared_numbers.values()))
+        )
         scored.append((score, candidate))
     if not scored:
         return None
-    selected = max(
-        scored,
-        key=lambda item: (
+
+    def selection_key(
+        item: tuple[float, _SourceExcerptCandidate],
+    ) -> tuple[float, bool, int]:
+        return (
             item[0],
             item[1].kind == "paragraph",
             -len(re.sub(r"\s+", " ", item[1].text)),
-        ),
-    )[1]
+        )
+
+    best_key = max(selection_key(item) for item in scored)
+    best_candidates = [item[1] for item in scored if selection_key(item) == best_key]
+    if len({(candidate.start, candidate.end) for candidate in best_candidates}) > 1:
+        return None
+    selected = best_candidates[0]
     if selected.kind == "table_row":
         return selected.text
     return _governing_source_excerpt_candidate(
@@ -29260,6 +29282,28 @@ def _closest_exact_source_excerpt(
         candidates,
         allow_complete_conditional_fallback=True,
     )
+
+
+def _proof_excerpt_numeric_occurrence_counter(
+    text: str,
+    *,
+    profile: str,
+) -> Counter[float]:
+    """Count one source-facing numeric value per exact token coordinate."""
+    values_by_span: dict[tuple[int, int], float] = {}
+    for occurrence in extract_typed_numeric_occurrences_from_text(
+        text,
+        profile=profile,
+    ):
+        values_by_span.setdefault(
+            (occurrence.start, occurrence.end),
+            (
+                occurrence.value
+                if occurrence.source_value is None
+                else occurrence.source_value
+            ),
+        )
+    return Counter(values_by_span.values())
 
 
 def _safe_wrapped_direct_source_match(

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -29046,6 +29046,7 @@ def _try_repair_generated_nonexact_proof_excerpts_for_apply(
                     source_text=source_text,
                     excerpt=excerpt,
                     numeric_profile=numeric_profile,
+                    require_all_query_numbers=not targets[target],
                 )
             if exact_excerpt is None or exact_excerpt == excerpt:
                 continue
@@ -29136,6 +29137,7 @@ def _closest_exact_source_excerpt(
     source_text: str,
     excerpt: str,
     numeric_profile: str = "legacy",
+    require_all_query_numbers: bool = True,
 ) -> str | None:
     source = str(source_text)
     query = re.sub(r"\s+", " ", str(excerpt)).strip()
@@ -29163,6 +29165,7 @@ def _closest_exact_source_excerpt(
                     source_text=segment,
                     excerpt=excerpt,
                     numeric_profile=numeric_profile,
+                    require_all_query_numbers=require_all_query_numbers,
                 )
             )
         ]
@@ -29222,7 +29225,11 @@ def _closest_exact_source_excerpt(
             )
         )
         shared_numbers = query_numbers & candidate_numbers
-        if query_numbers and not query_numbers.issubset(candidate_numbers):
+        if query_numbers and (
+            not (query_numbers & candidate_numbers)
+            if not require_all_query_numbers
+            else not query_numbers.issubset(candidate_numbers)
+        ):
             continue
         if len(shared_tokens) < 2 and not (shared_numbers and shared_tokens):
             continue

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -29169,7 +29169,10 @@ def _closest_exact_source_excerpt(
         return matches[0] if len(matches) == 1 else None
 
     candidates = _exact_source_excerpt_candidate_spans(source)
-    direct_match = re.search(whitespace_pattern, source, flags=re.IGNORECASE)
+    direct_matches = list(re.finditer(whitespace_pattern, source, flags=re.IGNORECASE))
+    if len(direct_matches) > 1:
+        return None
+    direct_match = direct_matches[0] if direct_matches else None
     if direct_match is not None:
         enclosing = [
             candidate
@@ -48178,6 +48181,7 @@ def _cmd_eval_suite_revalidate_with_signer(args, evidence_signing_key):
             source_citation_path=source_citation_path,
             rulespec_dependency_roots=manifest.rulespec_dependency_roots,
             require_complete_source_unit=case.require_complete_source_unit,
+            amendment_documents=source_unit.amendment_documents,
         )
         validation_error = _eval_artifact_validation_error(
             result.metrics,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -6924,10 +6924,19 @@ def _evaluate_artifact_in_scope(
             half_up_recall_source_text or "",
         ),
     )
-    counted_numeric_source_text = _numeric_occurrence_source_text(
-        numeric_recall_source_text or "",
-        suppress_source_backed_half_up_increment=bool(half_up_helper_count),
-    )
+    if require_complete_source_unit:
+        counted_numeric_source_text = numeric_recall_source_text or ""
+        if half_up_helper_count:
+            counted_numeric_source_text = (
+                normalize_source_backed_half_up_rounding_occurrence_text(
+                    counted_numeric_source_text
+                )
+            )
+    else:
+        counted_numeric_source_text = _numeric_occurrence_source_text(
+            numeric_recall_source_text or "",
+            suppress_source_backed_half_up_increment=bool(half_up_helper_count),
+        )
     typed_source_numeric_occurrences = (
         extract_typed_numeric_inventory_occurrences_from_text(
             counted_numeric_source_text,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -1361,6 +1361,7 @@ def run_model_eval(
     review_findings_paths: list[Path] | None = None,
     require_complete_source_unit: bool = False,
     target_relative_output: Path | None = None,
+    validation_retry_feedback: Sequence[str] = (),
 ) -> list[EvalResult]:
     """Run a deterministic comparison over one or more citations."""
     _validate_eval_oracle_runtime(oracle, policyengine_runtime, policy_path)
@@ -1399,6 +1400,7 @@ def run_model_eval(
                         review_findings_paths=review_findings_paths or [],
                         require_complete_source_unit=require_complete_source_unit,
                         target_relative_output=target_relative_output,
+                        validation_retry_feedback=validation_retry_feedback,
                     )
                 )
 
@@ -7027,6 +7029,7 @@ def _evaluate_artifact_in_scope(
         module_citation_path=numeric_source_citation_path,
         proof_source_texts=numeric_proof_source_texts,
         require_body_bound_proof_evidence=False,
+        require_complete_source_unit=require_complete_source_unit,
     )
     admin_agency_aggregate_issues = find_admin_agency_aggregate_entity_issues(
         content,
@@ -7857,6 +7860,7 @@ def _run_single_eval(
     review_findings_paths: list[Path] | None = None,
     require_complete_source_unit: bool = False,
     target_relative_output: Path | None = None,
+    validation_retry_feedback: Sequence[str] = (),
 ) -> EvalResult:
     include_tests = include_tests or require_complete_source_unit
     if source_unit is None:
@@ -7919,6 +7923,7 @@ def _run_single_eval(
         runner_backend=runner.backend,
         policyengine_rule_hint=policyengine_rule_hint,
         require_complete_source_unit=require_complete_source_unit,
+        validation_retry_feedback=validation_retry_feedback,
     )
     generation_prompt_sha256 = _sha256_text(prompt)
     output_file = _contained_eval_output_file(output_root, runner.name, relative_output)
@@ -8770,6 +8775,33 @@ Mandatory independent-review corrections:
 """
 
 
+def _format_validation_retry_feedback(feedback: Sequence[str]) -> str:
+    """Render bounded prior-attempt validator output as non-authority guidance."""
+
+    rendered_items: list[str] = []
+    seen: set[str] = set()
+    for raw_item in feedback[:12]:
+        item = str(raw_item).strip()[:2000]
+        if not item or item in seen:
+            continue
+        seen.add(item)
+        rendered_items.append(f"- {json.dumps(item, ensure_ascii=False)}")
+    if not rendered_items:
+        return ""
+    return f"""
+Deterministic validation feedback from prior generation attempts:
+- This is repair guidance from the validator, not legal authority. Keep the
+  authoritative source and release-bound corpus evidence as the sole basis for
+  legal facts and values.
+- Correct every listed issue in this attempt. Do not repeat the rejected
+  pattern.
+
+=== BEGIN PRIOR VALIDATION FEEDBACK ===
+{chr(10).join(rendered_items)}
+=== END PRIOR VALIDATION FEEDBACK ===
+"""
+
+
 def _build_rulespec_eval_prompt(
     citation: str,
     mode: EvalMode,
@@ -8782,6 +8814,7 @@ def _build_rulespec_eval_prompt(
     policyengine_rule_hint: str | None,
     include_corpus_context_injection: bool = True,
     require_complete_source_unit: bool = False,
+    validation_retry_feedback: Sequence[str] = (),
 ) -> str:
     """Build the RuleSpec authoring prompt used by current evals."""
     source_text = workspace.source_text_file.read_text()
@@ -9304,6 +9337,9 @@ Preferred principal output:
 """
 
     mandatory_review_findings_section = _format_mandatory_review_findings(workspace)
+    validation_retry_feedback_section = _format_validation_retry_feedback(
+        validation_retry_feedback
+    )
     complete_source_unit_section = ""
     if require_complete_source_unit:
         complete_source_unit_section = """
@@ -9355,7 +9391,7 @@ Primary legal authority:
 {legal_authority_instruction}
 {corpus_source_section.rstrip()}
 {inline_source}
-{source_metadata_section}{provision_metadata_section}{amendment_section}{context_section}{missing_cited_source_section}{mandatory_review_findings_section}
+{source_metadata_section}{provision_metadata_section}{amendment_section}{context_section}{missing_cited_source_section}{mandatory_review_findings_section}{validation_retry_feedback_section}
 {backend_section}
 {canonical_concept_section}{complete_source_unit_section}
 RuleSpec requirements:
@@ -10175,6 +10211,7 @@ def _build_eval_prompt(
     policyengine_rule_hint: str | None = None,
     include_corpus_context_injection: bool = True,
     require_complete_source_unit: bool = False,
+    validation_retry_feedback: Sequence[str] = (),
 ) -> str:
     """Build a prompt-only eval request with explicit provenance rules."""
     return _build_rulespec_eval_prompt(
@@ -10189,6 +10226,7 @@ def _build_eval_prompt(
         policyengine_rule_hint=policyengine_rule_hint,
         include_corpus_context_injection=include_corpus_context_injection,
         require_complete_source_unit=require_complete_source_unit,
+        validation_retry_feedback=validation_retry_feedback,
     )
 
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -9314,6 +9314,15 @@ Complete-source-unit mode is enabled for this request:
 - Every explicit computation stated in the source unit must have a principal
   `kind: derived` or `kind: derived_relation` output. Naming its constants as
   parameters without encoding the stated formula is invalid.
+- When the source states both a base value and its converted result, encode both
+  values as separate grounded `kind: parameter` rules. Result wording such as
+  "converted to the month, this gives ..." states a scalar result; it does not
+  mandate deriving one parameter from the other.
+- Never introduce calendar constants `12`, `52`, `365`, `4`, or `24` as module
+  literals unless that literal appears in the authoritative source text.
+  Express a stated conversion through companion-test assertions on both
+  parameter outputs; literals used only in companion tests do not require
+  source grounding.
 - Encode every structural paragraph and list branch, including Absatz markers
   such as `(1)` and `(2)`, `Abs. 5`, numbered items such as `1.` and `1a.`, and
   Satz enumerations. If a branch cannot be encoded, use a precise typed

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -6780,27 +6780,25 @@ def _evaluate_artifact_in_scope(
             policy_repo_root=policy_repo_root,
             rulespec_dependency_roots=rulespec_dependency_roots,
         )
-        pipeline_options: dict[str, Any] = {
-            "policy_repo_path": validation_policy_repo_root,
-            "axiom_rules_path": axiom_rules_path,
-            "enable_oracles": oracle != "none",
-            "policyengine_runtime": policyengine_runtime,
-            "policyengine_rule_hint": policyengine_rule_hint,
-            "require_policy_proofs": True,
-            "source_text": source_text,
-            "source_metadata": source_metadata,
-            "local_corpus_release": local_corpus_release,
-            "source_citation_path": source_citation_path,
-            "rulespec_dependency_roots": validation_dependency_roots,
-            "validation_staging_root": validation_staging_root,
-            "require_complete_source_unit": require_complete_source_unit,
-        }
-        if amendment_documents:
-            pipeline_options["amendment_source_texts"] = {
+        pipeline = ValidatorPipeline(
+            policy_repo_path=validation_policy_repo_root,
+            axiom_rules_path=axiom_rules_path,
+            enable_oracles=oracle != "none",
+            policyengine_runtime=policyengine_runtime,
+            policyengine_rule_hint=policyengine_rule_hint,
+            require_policy_proofs=True,
+            source_text=source_text,
+            source_metadata=source_metadata,
+            local_corpus_release=local_corpus_release,
+            source_citation_path=source_citation_path,
+            rulespec_dependency_roots=validation_dependency_roots,
+            validation_staging_root=validation_staging_root,
+            require_complete_source_unit=require_complete_source_unit,
+            amendment_source_texts={
                 document.citation_path: document.body
                 for document in amendment_documents
-            }
-        pipeline = ValidatorPipeline(**pipeline_options)
+            },
+        )
         compile_result = pipeline._run_compile_check(validation_file)
         ci_result = pipeline._run_ci(validation_file)
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -99,7 +99,6 @@ from .policyengine_runtime import (
 )
 from .pricing import estimate_usage_cost_usd
 from .source_completeness import (
-    authoritative_numeric_recall_text,
     collect_artifact_numeric_values,
 )
 from .validator_pipeline import (
@@ -4097,6 +4096,7 @@ def _revalidate_persisted_eval_suite_case_results(
                 source_citation_path=source_citation_path,
                 rulespec_dependency_roots=rulespec_dependency_roots,
                 require_complete_source_unit=case.require_complete_source_unit,
+                amendment_documents=source_unit.amendment_documents,
             )
         fresh_success = bool(
             fresh_metrics is not None
@@ -6676,6 +6676,7 @@ def evaluate_artifact(
     source_citation_path: str | None = None,
     rulespec_dependency_roots: Sequence[Path] = (),
     require_complete_source_unit: bool = False,
+    amendment_documents: Sequence[CorpusAmendmentDocument] = (),
 ) -> EvalArtifactMetrics:
     """Evaluate an artifact inside one exact named corpus release."""
 
@@ -6706,6 +6707,7 @@ def evaluate_artifact(
             source_citation_path=source_citation_path,
             rulespec_dependency_roots=rulespec_dependency_roots,
             require_complete_source_unit=require_complete_source_unit,
+            amendment_documents=amendment_documents,
         )
 
 
@@ -6761,6 +6763,7 @@ def _evaluate_artifact_in_scope(
     source_citation_path: str | None = None,
     rulespec_dependency_roots: Sequence[Path] = (),
     require_complete_source_unit: bool = False,
+    amendment_documents: Sequence[CorpusAmendmentDocument] = (),
 ) -> EvalArtifactMetrics:
     """Evaluate one RuleSpec artifact with deterministic checks plus optional oracles."""
     with _rulespec_validation_target(
@@ -6777,21 +6780,27 @@ def _evaluate_artifact_in_scope(
             policy_repo_root=policy_repo_root,
             rulespec_dependency_roots=rulespec_dependency_roots,
         )
-        pipeline = ValidatorPipeline(
-            policy_repo_path=validation_policy_repo_root,
-            axiom_rules_path=axiom_rules_path,
-            enable_oracles=oracle != "none",
-            policyengine_runtime=policyengine_runtime,
-            policyengine_rule_hint=policyengine_rule_hint,
-            require_policy_proofs=True,
-            source_text=source_text,
-            source_metadata=source_metadata,
-            local_corpus_release=local_corpus_release,
-            source_citation_path=source_citation_path,
-            rulespec_dependency_roots=validation_dependency_roots,
-            validation_staging_root=validation_staging_root,
-            require_complete_source_unit=require_complete_source_unit,
-        )
+        pipeline_options: dict[str, Any] = {
+            "policy_repo_path": validation_policy_repo_root,
+            "axiom_rules_path": axiom_rules_path,
+            "enable_oracles": oracle != "none",
+            "policyengine_runtime": policyengine_runtime,
+            "policyengine_rule_hint": policyengine_rule_hint,
+            "require_policy_proofs": True,
+            "source_text": source_text,
+            "source_metadata": source_metadata,
+            "local_corpus_release": local_corpus_release,
+            "source_citation_path": source_citation_path,
+            "rulespec_dependency_roots": validation_dependency_roots,
+            "validation_staging_root": validation_staging_root,
+            "require_complete_source_unit": require_complete_source_unit,
+        }
+        if amendment_documents:
+            pipeline_options["amendment_source_texts"] = {
+                document.citation_path: document.body
+                for document in amendment_documents
+            }
+        pipeline = ValidatorPipeline(**pipeline_options)
         compile_result = pipeline._run_compile_check(validation_file)
         ci_result = pipeline._run_ci(validation_file)
 
@@ -6880,7 +6889,7 @@ def _evaluate_artifact_in_scope(
     # separately parsed proof evidence below — never in module.summary.
     numeric_validation_source_text = embedded_source or numeric_source_text or ""
     numeric_recall_source_text = (
-        authoritative_numeric_recall_text(evaluation_source_text)
+        evaluation_source_text
         if require_complete_source_unit
         else numeric_validation_source_text
     )
@@ -7030,6 +7039,9 @@ def _evaluate_artifact_in_scope(
         proof_source_texts=numeric_proof_source_texts,
         require_body_bound_proof_evidence=False,
         require_complete_source_unit=require_complete_source_unit,
+        amendment_source_texts={
+            document.citation_path: document.body for document in amendment_documents
+        },
     )
     admin_agency_aggregate_issues = find_admin_agency_aggregate_entity_issues(
         content,
@@ -7115,6 +7127,7 @@ def _evaluate_generated_artifact_with_repairs(
     source_citation_path: str | None = None,
     rulespec_dependency_roots: Sequence[Path] = (),
     require_complete_source_unit: bool = False,
+    amendment_documents: Sequence[CorpusAmendmentDocument] = (),
 ) -> EvalArtifactMetrics | None:
     metrics = evaluate_artifact(
         rulespec_file=rulespec_file,
@@ -7130,6 +7143,7 @@ def _evaluate_generated_artifact_with_repairs(
         source_citation_path=source_citation_path,
         rulespec_dependency_roots=rulespec_dependency_roots,
         require_complete_source_unit=require_complete_source_unit,
+        amendment_documents=amendment_documents,
     )
     if metrics is None:
         return None
@@ -7156,6 +7170,7 @@ def _evaluate_generated_artifact_with_repairs(
         source_citation_path=source_citation_path,
         rulespec_dependency_roots=rulespec_dependency_roots,
         require_complete_source_unit=require_complete_source_unit,
+        amendment_documents=amendment_documents,
     )
 
 
@@ -7976,6 +7991,7 @@ def _run_single_eval(
             ),
             rulespec_dependency_roots=rulespec_dependency_roots,
             require_complete_source_unit=require_complete_source_unit,
+            amendment_documents=source_unit.amendment_documents,
         )
     validation_error = _eval_artifact_validation_error(
         metrics,
@@ -8200,6 +8216,7 @@ def _run_single_source_eval(
             ),
             rulespec_dependency_roots=rulespec_dependency_roots,
             require_complete_source_unit=require_complete_source_unit,
+            amendment_documents=amendment_documents,
         )
     validation_error = _eval_artifact_validation_error(
         metrics,

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -302,7 +302,8 @@ _STATED_CONVERSION_DATE = re.compile(
     rf"(?:st|nd|rd|th)?\s*,?\s*(?:18|19|20)\d{{2}}|"
     rf"(?<!\w)\d{{1,2}}(?:st|nd|rd|th)?\s+"
     rf"{_STATED_CONVERSION_ENGLISH_MONTH}\s+(?:18|19|20)\d{{2}}|"
-    rf"(?<!\w)\d{{1,2}}[./]\d{{1,2}}[./]\d{{2,4}}(?!\w)"
+    rf"(?<!\w)\d{{1,2}}[./]\d{{1,2}}[./]\d{{2,4}}(?!\w)|"
+    rf"(?<!\w)(?:18|19|20)\d{{2}}-\d{{2}}-\d{{2}}(?!\w)"
     rf")",
     flags=re.IGNORECASE,
 )
@@ -389,7 +390,7 @@ _BUCHSTABE_REFERENCE = re.compile(
 _GERMAN_LEGAL_CITATION = re.compile(
     r"§{1,2}\s*\d+[a-z]?"
     r"(?:\s*,\s*\d+[a-z]?)*"
-    r"(?:\s*(?:und|bis)\s*\d+[a-z]?)*",
+    r"(?:\s*(?:und|bis|[-–—])\s*\d+[a-z]?)*",
     flags=re.IGNORECASE,
 )
 _EXPLICIT_LEGAL_SECTION_REFERENCE = re.compile(
@@ -398,17 +399,18 @@ _EXPLICIT_LEGAL_SECTION_REFERENCE = re.compile(
     flags=re.IGNORECASE,
 )
 _ENGLISH_LEGAL_CITATION = re.compile(
-    r"\b(?:sections?|secs?\.?|regulations?|paragraphs?)\s+"
-    r"\d+(?:\.\d+)*(?:\s*(?:through|to|-|and|,)\s*\d+(?:\.\d+)*)*",
+    r"\b(?:articles?|sections?|secs?\.?|regulations?|paragraphs?)\s+"
+    r"\d+(?:\.\d+)*(?:\s*(?:through|to|[-–—]|and|,)\s*\d+(?:\.\d+)*)*",
     flags=re.IGNORECASE,
 )
 _STRUCTURAL_REFERENCE = re.compile(
     r"\b(?:"
+    r"Artikel(?:s|n)?|Art\.|"
     r"Absatz(?:es)?|Absätze(?:n)?|Abs\.|"
     r"Satz(?:es)?|Sätze(?:n)?|"
     r"Nummer(?:n)?|Nr\.|Buchstabe(?:n)?|Buchst\."
     r")\s*\d*[a-z]?"
-    r"(?:\s*(?:,|und|bis)\s*\d+[a-z]?)*\b",
+    r"(?:\s*(?:,|und|bis|[-–—])\s*\d+[a-z]?)*\b",
     flags=re.IGNORECASE,
 )
 _FORMULA_IDENTIFIER = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\b")
@@ -588,7 +590,7 @@ def _stated_conversion_candidate_contains_formula(
     start = cue.start()
     suffix_limit = min(len(source_text), result.end("value") + 160)
     clause_suffix = source_text[result.end("value") : suffix_limit]
-    clause_boundary = re.search(r"[.!?\n]", clause_suffix)
+    clause_boundary = re.search(r"[.;!?\n]", clause_suffix)
     end = (
         result.end("value") + clause_boundary.start()
         if clause_boundary is not None

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -262,6 +262,7 @@ _COMPUTATION_LANGUAGE = re.compile(
     r"splitting-verfahren|verfahren\s+nach\s+absatz|"
     r"calculated|computed|computation|multiplied|divided|"
     r"sum\s+of|difference\s+between|product\s+of|twice|half\s+of|"
+    r"\d+(?:[.,]\d+)?\s+times\b|"
     r"percentage\s+of|in\s+excess\s+of|"
     r"equals?[^.;]{0,100}\b(?:plus|minus|times)\b"
     r")\b",
@@ -282,6 +283,28 @@ _STATED_CONVERSION_RESULT = re.compile(
 )
 _STATED_CONVERSION_BASE_VALUE = re.compile(
     r"\d{1,3}(?:[ .]\d{3})+(?:,\d+)?|\d+(?:[.,]\d+)?"
+)
+_STATED_CONVERSION_GERMAN_MONTH = (
+    r"(?:jan(?:uar)?|feb(?:ruar)?|märz|maerz|mrz|apr(?:il)?|mai|"
+    r"jun(?:i)?|jul(?:i)?|aug(?:ust)?|sep(?:t(?:ember)?)?|"
+    r"okt(?:ober)?|nov(?:ember)?|dez(?:ember)?)\.?"
+)
+_STATED_CONVERSION_ENGLISH_MONTH = (
+    r"(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|"
+    r"jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t(?:ember)?)?|"
+    r"oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\.?"
+)
+_STATED_CONVERSION_DATE = re.compile(
+    rf"(?:"
+    rf"(?<!\w)\d{{1,2}}\.\s*{_STATED_CONVERSION_GERMAN_MONTH}\s+"
+    rf"(?:des\s+Jahres\s+)?(?:18|19|20)\d{{2}}|"
+    rf"\b{_STATED_CONVERSION_ENGLISH_MONTH}\s+\d{{1,2}}"
+    rf"(?:st|nd|rd|th)?\s*,?\s*(?:18|19|20)\d{{2}}|"
+    rf"(?<!\w)\d{{1,2}}(?:st|nd|rd|th)?\s+"
+    rf"{_STATED_CONVERSION_ENGLISH_MONTH}\s+(?:18|19|20)\d{{2}}|"
+    rf"(?<!\w)\d{{1,2}}[./]\d{{1,2}}[./]\d{{2,4}}(?!\w)"
+    rf")",
+    flags=re.IGNORECASE,
 )
 _ROUNDING_LANGUAGE = re.compile(
     r"\b(?:"
@@ -563,7 +586,14 @@ def _stated_conversion_candidate_contains_formula(
     """Keep arithmetic inside a conversion clause out of the scalar exemption."""
 
     start = cue.start()
-    end = result.start("value")
+    suffix_limit = min(len(source_text), result.end("value") + 160)
+    clause_suffix = source_text[result.end("value") : suffix_limit]
+    clause_boundary = re.search(r"[.!?\n]", clause_suffix)
+    end = (
+        result.end("value") + clause_boundary.start()
+        if clause_boundary is not None
+        else suffix_limit
+    )
     characters = list(source_text[start:end])
     verb_start = result.start("verb") - start
     verb_end = result.end("verb") - start
@@ -581,6 +611,18 @@ def _looks_like_temporal_or_structural_number(
     match: re.Match[str],
 ) -> bool:
     """Return whether a prospective base value is only metadata or structure."""
+
+    for pattern in (
+        _STATED_CONVERSION_DATE,
+        _GERMAN_LEGAL_CITATION,
+        _ENGLISH_LEGAL_CITATION,
+        _STRUCTURAL_REFERENCE,
+    ):
+        if any(
+            metadata.start() <= match.start() and match.end() <= metadata.end()
+            for metadata in pattern.finditer(text)
+        ):
+            return True
 
     raw = match.group(0).replace(" ", "").replace(".", "").replace(",", ".")
     with contextlib.suppress(ValueError):

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -32,6 +32,8 @@ class NumericOccurrenceLike(Protocol):
     has_temporal_context: bool
     source_value: float | None
     requires_rate_context: bool
+    is_word_number: bool
+    alternative_values: tuple[float, ...]
 
 
 @dataclass(frozen=True)
@@ -46,6 +48,8 @@ class _NumericOccurrenceView:
     has_temporal_context: bool
     source_value: float | None
     requires_rate_context: bool
+    is_word_number: bool
+    alternative_values: tuple[float, ...]
 
 
 NumericOccurrenceExtractor = Callable[[str], Sequence[NumericOccurrenceLike]]
@@ -3389,6 +3393,8 @@ def _numeric_occurrences_are_equivalent(
         and left.has_temporal_context == right.has_temporal_context
         and left.source_value == right.source_value
         and left.requires_rate_context == right.requires_rate_context
+        and left.is_word_number == right.is_word_number
+        and left.alternative_values == right.alternative_values
     )
 
 
@@ -4704,6 +4710,8 @@ def _shift_numeric_occurrence(
         has_temporal_context=occurrence.has_temporal_context,
         source_value=occurrence.source_value,
         requires_rate_context=occurrence.requires_rate_context,
+        is_word_number=occurrence.is_word_number,
+        alternative_values=occurrence.alternative_values,
     )
 
 
@@ -6994,6 +7002,8 @@ def _source_boundary_obligations(
                 occurrence.has_rate_context,
                 occurrence.source_value,
                 occurrence.requires_rate_context,
+                occurrence.is_word_number,
+                occurrence.alternative_values,
                 occurrence.start,
                 occurrence.end,
             ): (branch, occurrence)

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -377,6 +377,14 @@ _MISSING_DEPENDENCY_LANGUAGE = re.compile(
     r")\b",
     flags=re.IGNORECASE,
 )
+_IMPRECISE_DEFERRAL_RETRY_SHAPE = """\
+Required shape (adapt the output and cited dependency to the omitted branch):
+module:
+  deferred_outputs:
+    - output: de:statutes/estg/32a/6#surviving_spouse_splitting_tax
+      reason: Cannot be computed until the joint-assessment conditions cited in EStG § 26 are encoded.
+`output` and `reason` are required; `blocked_by` is optional and, when present, \
+must list exact absolute upstream RuleSpec outputs."""
 _ABSATZ_REFERENCE = re.compile(
     r"\b(?:Absatz(?:es)?|Absätze(?:n)?|Abs\.)\s*(?P<label>\d+[a-z]?)\b",
     flags=re.IGNORECASE,
@@ -1355,7 +1363,7 @@ def _deferred_coverage(
                 f"`module.deferred_outputs[{index}]` identifies source branch "
                 f"({branch_label}) (`{rendered_path}`) but its deferral does not "
                 "name an exact missing "
-                "dependency/citation."
+                f"dependency/citation.\n{_IMPRECISE_DEFERRAL_RETRY_SHAPE}"
             )
     return covered, issues
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -267,6 +267,22 @@ _COMPUTATION_LANGUAGE = re.compile(
     r")\b",
     flags=re.IGNORECASE,
 )
+_STATED_CONVERSION_CUE = re.compile(
+    r"\b(?:umgerechnet|converted)\b",
+    flags=re.IGNORECASE,
+)
+_STATED_CONVERSION_RESULT = re.compile(
+    r"\b(?:"
+    r"ergibt\s+sich|ergeben\s+sich|entspricht|entsprechen|beträgt|betragen|"
+    r"equals?|results?\s+in|is|are"
+    r")\b"
+    r"[^.!?\n]{0,80}?"
+    r"(?P<value>\d{1,3}(?:[ .]\d{3})+(?:,\d+)?|\d+(?:[.,]\d+)?)",
+    flags=re.IGNORECASE,
+)
+_STATED_CONVERSION_BASE_VALUE = re.compile(
+    r"\d{1,3}(?:[ .]\d{3})+(?:,\d+)?|\d+(?:[.,]\d+)?"
+)
 _ROUNDING_LANGUAGE = re.compile(
     r"\b(?:"
     r"abgerundet(?:e|en|er|es)?|abzurunden|aufgerundet(?:e|en|er|es)?|"
@@ -492,11 +508,68 @@ def _is_editorial_omission(text: str) -> bool:
 def source_states_explicit_computation(source_text: str) -> bool:
     """Return whether text states a computation rather than only a scalar."""
 
+    computation_text = _without_stated_conversion_results(source_text)
     return bool(
-        _has_substantive_arithmetic_expression(source_text)
-        or _COMPUTATION_LANGUAGE.search(source_text)
-        or _ROUNDING_LANGUAGE.search(source_text)
+        _has_substantive_arithmetic_expression(computation_text)
+        or _COMPUTATION_LANGUAGE.search(computation_text)
+        or _ROUNDING_LANGUAGE.search(computation_text)
     )
+
+
+def source_states_stated_conversion_result(source_text: str) -> bool:
+    """Return whether text states both a base scalar and its converted result."""
+
+    return bool(_stated_conversion_result_spans(source_text))
+
+
+def _stated_conversion_result_spans(source_text: str) -> tuple[tuple[int, int], ...]:
+    """Locate result clauses such as ``Umgerechnet ... ergibt sich 6 150``."""
+
+    spans: list[tuple[int, int]] = []
+    for cue in _STATED_CONVERSION_CUE.finditer(source_text):
+        result = _STATED_CONVERSION_RESULT.search(
+            source_text,
+            cue.end(),
+            min(len(source_text), cue.end() + 180),
+        )
+        if result is None:
+            continue
+        base_window = source_text[max(0, cue.start() - 300) : cue.start()]
+        paragraph_break = base_window.rfind("\n\n")
+        if paragraph_break >= 0:
+            base_window = base_window[paragraph_break + 2 :]
+        base_values = list(_STATED_CONVERSION_BASE_VALUE.finditer(base_window))
+        if not base_values:
+            continue
+        last_base = base_values[-1]
+        if _looks_like_temporal_year(base_window, last_base):
+            continue
+        spans.append((cue.start(), result.end("value")))
+    return tuple(spans)
+
+
+def _looks_like_temporal_year(text: str, match: re.Match[str]) -> bool:
+    """Return whether a prospective base value is only a nearby calendar year."""
+
+    raw = match.group(0).replace(" ", "").replace(".", "").replace(",", ".")
+    with contextlib.suppress(ValueError):
+        value = float(raw)
+        if value.is_integer() and 1900 <= value <= 2100:
+            prefix = text[max(0, match.start() - 24) : match.start()]
+            return bool(re.search(r"\b(?:jahr(?:es)?|year)\s*$", prefix, re.IGNORECASE))
+    return False
+
+
+def _without_stated_conversion_results(source_text: str) -> str:
+    """Blank stated-result clauses without hiding other source computations."""
+
+    spans = _stated_conversion_result_spans(source_text)
+    if not spans:
+        return source_text
+    characters = list(source_text)
+    for start, end in spans:
+        characters[start:end] = " " * (end - start)
+    return "".join(characters)
 
 
 def _has_substantive_arithmetic_expression(source_text: str) -> bool:

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -272,7 +272,7 @@ _STATED_CONVERSION_CUE = re.compile(
     flags=re.IGNORECASE,
 )
 _STATED_CONVERSION_RESULT = re.compile(
-    r"\b(?:"
+    r"\b(?P<verb>"
     r"ergibt\s+sich|ergeben\s+sich|entspricht|entsprechen|beträgt|betragen|"
     r"equals?|results?\s+in|is|are"
     r")\b"
@@ -534,30 +534,79 @@ def _stated_conversion_result_spans(source_text: str) -> tuple[tuple[int, int], 
         )
         if result is None:
             continue
+        if _stated_conversion_candidate_contains_formula(source_text, cue, result):
+            continue
         base_window = source_text[max(0, cue.start() - 300) : cue.start()]
         paragraph_break = base_window.rfind("\n\n")
         if paragraph_break >= 0:
             base_window = base_window[paragraph_break + 2 :]
         base_values = list(_STATED_CONVERSION_BASE_VALUE.finditer(base_window))
-        if not base_values:
-            continue
-        last_base = base_values[-1]
-        if _looks_like_temporal_year(base_window, last_base):
+        substantive_base = next(
+            (
+                match
+                for match in reversed(base_values)
+                if not _looks_like_temporal_or_structural_number(base_window, match)
+            ),
+            None,
+        )
+        if substantive_base is None:
             continue
         spans.append((cue.start(), result.end("value")))
     return tuple(spans)
 
 
-def _looks_like_temporal_year(text: str, match: re.Match[str]) -> bool:
-    """Return whether a prospective base value is only a nearby calendar year."""
+def _stated_conversion_candidate_contains_formula(
+    source_text: str,
+    cue: re.Match[str],
+    result: re.Match[str],
+) -> bool:
+    """Keep arithmetic inside a conversion clause out of the scalar exemption."""
+
+    start = cue.start()
+    end = result.start("value")
+    characters = list(source_text[start:end])
+    verb_start = result.start("verb") - start
+    verb_end = result.end("verb") - start
+    characters[verb_start:verb_end] = " " * (verb_end - verb_start)
+    candidate = "".join(characters)
+    return bool(
+        _has_substantive_arithmetic_expression(candidate)
+        or _COMPUTATION_LANGUAGE.search(candidate)
+        or _ROUNDING_LANGUAGE.search(candidate)
+    )
+
+
+def _looks_like_temporal_or_structural_number(
+    text: str,
+    match: re.Match[str],
+) -> bool:
+    """Return whether a prospective base value is only metadata or structure."""
 
     raw = match.group(0).replace(" ", "").replace(".", "").replace(",", ".")
     with contextlib.suppress(ValueError):
         value = float(raw)
         if value.is_integer() and 1900 <= value <= 2100:
             prefix = text[max(0, match.start() - 24) : match.start()]
-            return bool(re.search(r"\b(?:jahr(?:es)?|year)\s*$", prefix, re.IGNORECASE))
-    return False
+            if re.search(
+                r"\b(?:jahr(?:es)?|year|in|for|für(?:\s+das)?)\s*$",
+                prefix,
+                re.IGNORECASE,
+            ):
+                return True
+
+    prefix = text[max(0, match.start() - 32) : match.start()]
+    suffix = text[match.end() : min(len(text), match.end() + 8)]
+    if re.search(
+        r"(?:§+|artikel|art\.?|absatz|abs\.?|satz|nummer|nr\.?|"
+        r"section|sec\.?|subsection|paragraph|clause|item)\s*$",
+        prefix,
+        re.IGNORECASE,
+    ):
+        return True
+    if prefix.endswith("(") and re.match(r"\s*\)", suffix):
+        return True
+    line_prefix = prefix.rsplit("\n", 1)[-1]
+    return bool(not line_prefix.strip() and re.match(r"\s*\.", suffix))
 
 
 def _without_stated_conversion_results(source_text: str) -> str:

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -30,6 +30,7 @@ class NumericOccurrenceLike(Protocol):
     raw: str
     has_rate_context: bool
     has_temporal_context: bool
+    has_structural_context: bool
     source_value: float | None
     requires_rate_context: bool
     is_word_number: bool
@@ -46,6 +47,7 @@ class _NumericOccurrenceView:
     raw: str
     has_rate_context: bool
     has_temporal_context: bool
+    has_structural_context: bool
     source_value: float | None
     requires_rate_context: bool
     is_word_number: bool
@@ -842,9 +844,7 @@ def _analyze_rulespec_payload(
             "parameter-only representation is invalid."
         )
 
-    source_occurrences = tuple(
-        extract_numeric_occurrences(authoritative_numeric_recall_text(source_text))
-    )
+    source_occurrences = tuple(extract_numeric_occurrences(source_text))
     named_values = (
         tuple(float(value) for value in artifact_numeric_values)
         if artifact_numeric_values is not None
@@ -3391,6 +3391,7 @@ def _numeric_occurrences_are_equivalent(
         math.isclose(float(left.value), float(right.value))
         and left.has_rate_context == right.has_rate_context
         and left.has_temporal_context == right.has_temporal_context
+        and left.has_structural_context == right.has_structural_context
         and left.source_value == right.source_value
         and left.requires_rate_context == right.requires_rate_context
         and left.is_word_number == right.is_word_number
@@ -4708,6 +4709,7 @@ def _shift_numeric_occurrence(
         raw=occurrence.raw,
         has_rate_context=occurrence.has_rate_context,
         has_temporal_context=occurrence.has_temporal_context,
+        has_structural_context=occurrence.has_structural_context,
         source_value=occurrence.source_value,
         requires_rate_context=occurrence.requires_rate_context,
         is_word_number=occurrence.is_word_number,
@@ -7000,6 +7002,8 @@ def _source_boundary_obligations(
                 branch.path,
                 float(occurrence.value),
                 occurrence.has_rate_context,
+                occurrence.has_temporal_context,
+                occurrence.has_structural_context,
                 occurrence.source_value,
                 occurrence.requires_rate_context,
                 occurrence.is_word_number,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -7343,6 +7343,7 @@ def find_ungrounded_numeric_issues(
             content,
             source,
             value,
+            source_citation_path=source_citation_path,
             require_complete_source_unit=require_complete_source_unit,
         )
         issues.append(
@@ -7358,6 +7359,7 @@ def _stated_conversion_ungrounded_literal_hint(
     source_text: str,
     value: float,
     *,
+    source_citation_path: str | None,
     require_complete_source_unit: bool,
 ) -> str:
     """Return targeted retry guidance for a complete-mode calendar conversion."""
@@ -7376,6 +7378,11 @@ def _stated_conversion_ungrounded_literal_hint(
         return ""
     citation_path = _module_numeric_citation_path(payload)
     if not isinstance(citation_path, str) or not citation_path.strip():
+        return ""
+    if (
+        source_citation_path is not None
+        and citation_path.strip() != source_citation_path.strip()
+    ):
         return ""
     return f" {_STATED_CONVERSION_UNGROUNDED_HINT}"
 
@@ -7603,6 +7610,7 @@ def find_ungrounded_numeric_issues_scoped(
                     content,
                     module_source,
                     value,
+                    source_citation_path=module_citation_path,
                     require_complete_source_unit=require_complete_source_unit,
                 )
             }"

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -116,9 +116,19 @@ from .proof_validator import (
 from .source_completeness import (
     analyze_complete_source_unit,
     collect_artifact_numeric_bindings,
+    source_states_stated_conversion_result,
 )
 
 logger = logging.getLogger(__name__)
+
+_STATED_CONVERSION_CALENDAR_CONSTANTS = frozenset({4.0, 12.0, 24.0, 52.0, 365.0})
+_STATED_CONVERSION_UNGROUNDED_HINT = (
+    "Complete-source stated-conversion hint: encode the source-stated base and "
+    "converted result as separate grounded `kind: parameter` rules (for example, "
+    "annual and monthly amounts); do not derive one with an ungrounded calendar "
+    "constant. Assert both parameter outputs and their stated arithmetic relation "
+    "in companion tests."
+)
 
 _SENSITIVE_ENV_NAME_MARKERS = (
     "AUTH",
@@ -7301,6 +7311,7 @@ def find_ungrounded_numeric_issues(
     *,
     authoritative_source_text: str | None = None,
     source_citation_path: str | None = None,
+    require_complete_source_unit: bool = False,
 ) -> list[str]:
     """Return issues for generated numeric literals absent from source text."""
     grounding_values = extract_grounding_values(content)
@@ -7328,11 +7339,45 @@ def find_ungrounded_numeric_issues(
         if grounded:
             continue
         display = raw if raw == f"{value:g}" else f"{raw} ({value:g})"
+        hint = _stated_conversion_ungrounded_literal_hint(
+            content,
+            source,
+            value,
+            require_complete_source_unit=require_complete_source_unit,
+        )
         issues.append(
             "Ungrounded generated numeric literal: "
             f"{display} does not appear as a substantive numeric value in the source text."
+            f"{hint}"
         )
     return issues
+
+
+def _stated_conversion_ungrounded_literal_hint(
+    content: str,
+    source_text: str,
+    value: float,
+    *,
+    require_complete_source_unit: bool,
+) -> str:
+    """Return targeted retry guidance for a complete-mode calendar conversion."""
+
+    if (
+        not require_complete_source_unit
+        or value not in _STATED_CONVERSION_CALENDAR_CONSTANTS
+        or not source_states_stated_conversion_result(source_text)
+    ):
+        return ""
+    try:
+        payload = yaml.safe_load(content)
+    except (yaml.YAMLError, ValueError):
+        return ""
+    if not isinstance(payload, dict):
+        return ""
+    citation_path = _module_numeric_citation_path(payload)
+    if not isinstance(citation_path, str) or not citation_path.strip():
+        return ""
+    return f" {_STATED_CONVERSION_UNGROUNDED_HINT}"
 
 
 def evaluate_numeric_grounding_values_scoped(
@@ -7479,6 +7524,7 @@ def find_ungrounded_numeric_issues_scoped(
     module_citation_path: str | None = None,
     proof_source_texts: Mapping[str, str | None] | None = None,
     require_body_bound_proof_evidence: bool = True,
+    require_complete_source_unit: bool = False,
 ) -> list[str]:
     """Ground each rule's literals against the provisions that rule actually cites.
 
@@ -7505,6 +7551,7 @@ def find_ungrounded_numeric_issues_scoped(
             content,
             source_text=module_source_text,
             source_citation_path=module_citation_path,
+            require_complete_source_unit=require_complete_source_unit,
         )
 
     if not extract_grounding_values(content):
@@ -7551,6 +7598,14 @@ def find_ungrounded_numeric_issues_scoped(
         issue = (
             "Ungrounded generated numeric literal: "
             f"{display} does not appear as a substantive numeric value in the source text."
+            f"{
+                _stated_conversion_ungrounded_literal_hint(
+                    content,
+                    module_source,
+                    value,
+                    require_complete_source_unit=require_complete_source_unit,
+                )
+            }"
         )
         if issue not in seen:
             seen.add(issue)
@@ -25233,6 +25288,7 @@ class ValidatorPipeline:
                     content,
                     source_text=validation_source_text,
                     source_citation_path=self.source_citation_path,
+                    require_complete_source_unit=self.require_complete_source_unit,
                 )
             )
         else:
@@ -25242,6 +25298,7 @@ class ValidatorPipeline:
                     module_source_text=validation_source_text,
                     module_citation_path=self.source_citation_path,
                     proof_source_texts=numeric_source_texts,
+                    require_complete_source_unit=self.require_complete_source_unit,
                 )
             )
         issues.extend(find_deprecated_source_url_issues(content))

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -1791,9 +1791,14 @@ _GERMAN_STRUCTURAL_REFERENCE_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _ENGLISH_STRUCTURAL_REFERENCE_PATTERN = re.compile(
-    r"\b(?:articles?|sections?|secs?\.?|subsections?|paragraphs?|regulations?)"
+    r"\b(?:articles?|sections?|secs?\.?|subsections?|paragraphs?|"
+    r"regs?\.?|regulations?)"
     r"\s+\d+(?:\.\d+)*(?:\s*(?:,|and|through|to|[-–—])\s*"
     r"\d+(?:\.\d+)*)*",
+    re.IGNORECASE,
+)
+_ENGLISH_STRUCTURAL_DIGIT_LABEL_PATTERN = re.compile(
+    r"\b(?:2nd|3rd)\s+digit\b",
     re.IGNORECASE,
 )
 _STRUCTURAL_LINE_MARKER_PATTERN = re.compile(
@@ -6379,6 +6384,7 @@ def _structural_numeric_component_spans(
             _GERMAN_STRUCTURAL_LABEL_PATTERN,
             _GERMAN_STRUCTURAL_REFERENCE_PATTERN,
             _ENGLISH_STRUCTURAL_REFERENCE_PATTERN,
+            _ENGLISH_STRUCTURAL_DIGIT_LABEL_PATTERN,
             _STRUCTURAL_LINE_MARKER_PATTERN,
             _STRUCTURAL_GLUED_SENTENCE_MARKER_PATTERN,
         )

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -1778,6 +1778,33 @@ _TEMPORAL_PREPOSITION_YEAR_PATTERN = re.compile(
     rf"(?P<year>{_TEMPORAL_YEAR_BODY}){_TEMPORAL_YEAR_END}",
     re.IGNORECASE,
 )
+_GERMAN_STRUCTURAL_LABEL_PATTERN = re.compile(
+    r"\b(?:Regelbedarfsstufe(?:n)?|Stufe(?:n)?|Anlage(?:n)?)\s+"
+    r"\d+[a-z]?(?:\s*(?:,|und|bis|[-–—])\s*\d+[a-z]?)*",
+    re.IGNORECASE,
+)
+_GERMAN_STRUCTURAL_REFERENCE_PATTERN = re.compile(
+    r"(?:§{1,2}\s*|"
+    r"\b(?:Artikel(?:s|n)?|Art\.|Absatz(?:es)?|Absätze(?:n)?|Abs\.|"
+    r"Satz(?:es)?|Sätze(?:n)?|Nummer(?:n)?|Nr\.)\s*)"
+    r"\d+[a-z]?(?:\s*(?:,|und|bis|[-–—])\s*\d+[a-z]?)*",
+    re.IGNORECASE,
+)
+_ENGLISH_STRUCTURAL_REFERENCE_PATTERN = re.compile(
+    r"\b(?:articles?|sections?|secs?\.?|subsections?|paragraphs?|regulations?)"
+    r"\s+\d+(?:\.\d+)*(?:\s*(?:,|and|through|to|[-–—])\s*"
+    r"\d+(?:\.\d+)*)*",
+    re.IGNORECASE,
+)
+_STRUCTURAL_LINE_MARKER_PATTERN = re.compile(
+    r"(?m)^[ \t]*(?:"
+    r"\(\d+[a-z]?\)(?:[ \t]+bis[ \t]+\(\d+[a-z]?\))?"
+    r"|\d+[a-z]?\.)",
+    re.IGNORECASE,
+)
+_STRUCTURAL_GLUED_SENTENCE_MARKER_PATTERN = re.compile(
+    r"(?<![\w])(?:[1-9]\d?)(?=[A-ZÄÖÜ])"
+)
 _CURRENCY_MARKER_BEFORE_NUMBER_PATTERN = re.compile(
     r"(?:[$£€¥₹]|(?:euros?|eur|usd|gbp|cad|aud|chf)\b)\s*$",
     re.IGNORECASE,
@@ -1874,6 +1901,7 @@ class NumericOccurrence:
     raw: str
     has_rate_context: bool = False
     has_temporal_context: bool = False
+    has_structural_context: bool = False
     source_value: float | None = None
     requires_rate_context: bool = False
     is_word_number: bool = False
@@ -5755,11 +5783,15 @@ class _LegacyNumericCollector:
     rate_table_cell_spans: tuple[tuple[int, int], ...] = field(init=False)
     shared_rate_spans: tuple[tuple[int, int], ...] = field(init=False)
     temporal_component_spans: tuple[tuple[int, int], ...] = field(init=False)
+    structural_component_spans: tuple[tuple[int, int], ...] = field(init=False)
     money_spans: tuple[tuple[int, int], ...] = field(init=False)
 
     def __post_init__(self) -> None:
         self.rate_table_cell_spans = _pipe_table_rate_cell_spans(self.source)
         self.temporal_component_spans = _temporal_numeric_component_spans(self.source)
+        self.structural_component_spans = _structural_numeric_component_spans(
+            self.source
+        )
         money_spans = {
             span for span, _value in _iter_raw_european_money_value_matches(self.source)
         }
@@ -5846,6 +5878,14 @@ class _LegacyNumericCollector:
                 for temporal_start, temporal_end in self.temporal_component_spans
             )
         )
+        has_structural_context = (
+            not has_rate_context
+            and not has_money_context
+            and any(
+                start >= structural_start and end <= structural_end
+                for structural_start, structural_end in self.structural_component_spans
+            )
+        )
         return NumericOccurrence(
             value=value,
             start=start,
@@ -5853,6 +5893,7 @@ class _LegacyNumericCollector:
             raw=self.source[start:end],
             has_rate_context=has_rate_context,
             has_temporal_context=has_temporal_context,
+            has_structural_context=has_structural_context,
             source_value=value if source_value is None else source_value,
             requires_rate_context=requires_rate_context,
             is_word_number=is_word_number,
@@ -6328,6 +6369,24 @@ def _temporal_numeric_component_spans(
     return tuple(sorted(spans))
 
 
+def _structural_numeric_component_spans(
+    text: str,
+) -> tuple[tuple[int, int], ...]:
+    """Classify source spans whose numbers are only legal structural labels."""
+    spans = {
+        match.span()
+        for pattern in (
+            _GERMAN_STRUCTURAL_LABEL_PATTERN,
+            _GERMAN_STRUCTURAL_REFERENCE_PATTERN,
+            _ENGLISH_STRUCTURAL_REFERENCE_PATTERN,
+            _STRUCTURAL_LINE_MARKER_PATTERN,
+            _STRUCTURAL_GLUED_SENTENCE_MARKER_PATTERN,
+        )
+        for match in pattern.finditer(text)
+    }
+    return tuple(sorted(spans))
+
+
 def _has_malformed_profiled_numeric_envelope(
     text: str,
     *,
@@ -6456,12 +6515,14 @@ def _german_word_number_occurrences(
     return grounding, inventory
 
 
-def _non_temporal_numeric_inventory(
+def _scalar_recall_numeric_inventory(
     occurrences: Iterable[NumericOccurrence],
 ) -> tuple[NumericOccurrence, ...]:
     """Project typed grounding evidence into scalar-recall obligations."""
     return tuple(
-        occurrence for occurrence in occurrences if not occurrence.has_temporal_context
+        occurrence
+        for occurrence in occurrences
+        if not occurrence.has_temporal_context and not occurrence.has_structural_context
     )
 
 
@@ -6568,7 +6629,7 @@ def _tokenize_profiled_numeric_occurrences(
     )
     return _NumericTokenization(
         grounding=tuple(grounding_occurrences),
-        inventory=_non_temporal_numeric_inventory(inventory_occurrences),
+        inventory=_scalar_recall_numeric_inventory(inventory_occurrences),
     )
 
 
@@ -7185,7 +7246,7 @@ def _tokenize_numeric_occurrences_from_text(
         _complete_typed_year_occurrences(collector, collector.inventory)
     )
     occurrence_counts = Counter(occurrence.value for occurrence in collector.inventory)
-    normalized_inventory = _non_temporal_numeric_inventory(
+    normalized_inventory = _scalar_recall_numeric_inventory(
         occurrence
         for occurrence in collector.inventory
         if not (

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -7506,6 +7506,51 @@ def _numeric_value_grounded_in_source(
     )
 
 
+def _attached_amendment_citations_for_numeric_value(
+    value: float,
+    amendment_source_texts: Mapping[str, str] | None,
+) -> tuple[str, ...]:
+    """Return exact attached citations containing ``value`` as typed evidence."""
+    if not amendment_source_texts:
+        return ()
+    matches: list[str] = []
+    for raw_citation_path, source_text in sorted(amendment_source_texts.items()):
+        if not isinstance(raw_citation_path, str) or not isinstance(source_text, str):
+            continue
+        with contextlib.suppress(InvalidCorpusCitationError):
+            citation_path = require_canonical_corpus_citation_path(raw_citation_path)
+            if _source_text_contains_numeric_value_equivalent(
+                source_text,
+                value,
+                profile=_numeric_profile_for_citation_path(citation_path),
+            ):
+                matches.append(citation_path)
+    return tuple(matches)
+
+
+def _attached_amendment_ungrounded_literal_hint(
+    value: float,
+    amendment_source_texts: Mapping[str, str] | None,
+) -> str:
+    """Point retries to attached evidence while leaving the value ungrounded."""
+    citations = _attached_amendment_citations_for_numeric_value(
+        value,
+        amendment_source_texts,
+    )
+    if not citations:
+        return ""
+    citation_display = ", ".join(f"`{citation}`" for citation in citations)
+    return (
+        " Attached-amendment grounding hint: this value appears in attached "
+        f"corpus document {citation_display}, but the attachment alone does not "
+        "ground it. Add a source proof atom to the owning scalar/formula with "
+        "the exact owning literal `path` (for a scalar parameter, for example, "
+        "`path: versions[0].formula`), an appropriate `kind`, and nested "
+        f"`source: {{corpus_citation_path: {citations[0]}, excerpt: <exact "
+        "verbatim source span>}}`."
+    )
+
+
 def _ungrounded_from_values(
     grounding_values: Sequence[tuple[int, str, float]],
     source: str,
@@ -7646,6 +7691,7 @@ def find_ungrounded_numeric_issues(
     authoritative_source_text: str | None = None,
     source_citation_path: str | None = None,
     require_complete_source_unit: bool = False,
+    amendment_source_texts: Mapping[str, str] | None = None,
 ) -> list[str]:
     """Return issues for generated numeric literals absent from source text."""
     grounding_values = extract_grounding_values(content)
@@ -7680,10 +7726,14 @@ def find_ungrounded_numeric_issues(
             source_citation_path=source_citation_path,
             require_complete_source_unit=require_complete_source_unit,
         )
+        amendment_hint = _attached_amendment_ungrounded_literal_hint(
+            value,
+            amendment_source_texts,
+        )
         issues.append(
             "Ungrounded generated numeric literal: "
             f"{display} does not appear as a substantive numeric value in the source text."
-            f"{hint}"
+            f"{hint}{amendment_hint}"
         )
     return issues
 
@@ -7866,6 +7916,7 @@ def find_ungrounded_numeric_issues_scoped(
     proof_source_texts: Mapping[str, str | None] | None = None,
     require_body_bound_proof_evidence: bool = True,
     require_complete_source_unit: bool = False,
+    amendment_source_texts: Mapping[str, str] | None = None,
 ) -> list[str]:
     """Ground each rule's literals against the provisions that rule actually cites.
 
@@ -7893,6 +7944,7 @@ def find_ungrounded_numeric_issues_scoped(
             source_text=module_source_text,
             source_citation_path=module_citation_path,
             require_complete_source_unit=require_complete_source_unit,
+            amendment_source_texts=amendment_source_texts,
         )
 
     if not extract_grounding_values(content):
@@ -7936,18 +7988,21 @@ def find_ungrounded_numeric_issues_scoped(
         if grounded:
             continue
         display = raw if raw == f"{value:g}" else f"{raw} ({value:g})"
+        stated_conversion_hint = _stated_conversion_ungrounded_literal_hint(
+            content,
+            module_source,
+            value,
+            source_citation_path=module_citation_path,
+            require_complete_source_unit=require_complete_source_unit,
+        )
+        amendment_hint = _attached_amendment_ungrounded_literal_hint(
+            value,
+            amendment_source_texts,
+        )
         issue = (
             "Ungrounded generated numeric literal: "
             f"{display} does not appear as a substantive numeric value in the source text."
-            f"{
-                _stated_conversion_ungrounded_literal_hint(
-                    content,
-                    module_source,
-                    value,
-                    source_citation_path=module_citation_path,
-                    require_complete_source_unit=require_complete_source_unit,
-                )
-            }"
+            f"{stated_conversion_hint}{amendment_hint}"
         )
         if issue not in seen:
             seen.add(issue)
@@ -23803,6 +23858,7 @@ class ValidatorPipeline:
         source_text: str | None = None,
         source_metadata: dict[str, object] | None = None,
         source_citation_path: str | None = None,
+        amendment_source_texts: Mapping[str, str] | None = None,
         rulespec_dependency_roots: Iterable[Path] = (),
         validation_staging_root: Path | None = None,
     ):
@@ -23871,6 +23927,18 @@ class ValidatorPipeline:
             if source_citation_path is not None
             else None
         )
+        if amendment_source_texts is None:
+            amendment_source_texts = {}
+        if not isinstance(amendment_source_texts, Mapping):
+            raise TypeError("amendment_source_texts must be a mapping when provided")
+        self.amendment_source_texts: dict[str, str] = {}
+        for raw_citation_path, raw_source_text in amendment_source_texts.items():
+            if not isinstance(raw_citation_path, str):
+                raise TypeError("amendment source citation paths must be strings")
+            if not isinstance(raw_source_text, str):
+                raise TypeError("amendment source bodies must be strings")
+            citation_path = require_canonical_corpus_citation_path(raw_citation_path)
+            self.amendment_source_texts[citation_path] = raw_source_text
         source_attestation = (
             self.source_metadata.get("source_attestation")
             if isinstance(self.source_metadata, dict)
@@ -25065,6 +25133,85 @@ class ValidatorPipeline:
         """Format a scalar value spec with its kind for failure messages."""
         return f"{value.get('kind')} {value.get('value')}"
 
+    def _complete_mode_effective_version_mismatch_hint(
+        self,
+        *,
+        expected_scalar: dict[str, Any],
+        actual_scalar: dict[str, Any],
+        period: Mapping[str, Any] | None,
+    ) -> str:
+        """Steer amendment-backed mismatches toward distinct effective versions."""
+        if (
+            not self.require_complete_source_unit
+            or not self.amendment_source_texts
+            or not self.source_text
+            or period is None
+        ):
+            return ""
+        numeric_kinds = {"integer", "decimal"}
+        if (
+            expected_scalar.get("kind") not in numeric_kinds
+            or actual_scalar.get("kind") not in numeric_kinds
+        ):
+            return ""
+        try:
+            expected_value = float(self._rulespec_decimal(expected_scalar.get("value")))
+            actual_value = float(self._rulespec_decimal(actual_scalar.get("value")))
+        except (ValueError, OverflowError):
+            return ""
+        if not math.isfinite(expected_value) or not math.isfinite(actual_value):
+            return ""
+        source_profile = _numeric_profile_for_citation_path(self.source_citation_path)
+        if _source_text_contains_numeric_value_equivalent(
+            self.source_text,
+            expected_value,
+            profile=source_profile,
+        ) or not _source_text_contains_numeric_value_equivalent(
+            self.source_text,
+            actual_value,
+            profile=source_profile,
+        ):
+            return ""
+        citations = _attached_amendment_citations_for_numeric_value(
+            expected_value,
+            self.amendment_source_texts,
+        )
+        if not citations:
+            return ""
+
+        citation_display = ", ".join(f"`{citation}`" for citation in citations)
+        period_start = str(period.get("start") or "")
+        year_match = re.match(r"(?P<year>\d{4})-", period_start)
+        version_shape = (
+            f"`{expected_value:g}` for the test period beginning {period_start} "
+            f"and `{actual_value:g}` as the later consolidated value"
+        )
+        if year_match is not None:
+            period_year = int(year_match.group("year"))
+            next_year = period_year + 1
+            matching_amendment_text = "\n".join(
+                self.amendment_source_texts[citation] for citation in citations
+            )
+            if re.search(
+                rf"(?<!\d){period_year}(?!\d)",
+                matching_amendment_text,
+            ) and re.search(
+                rf"(?<!\d){next_year}(?!\d)",
+                matching_amendment_text,
+            ):
+                version_shape = (
+                    f"`{expected_value:g}` for {period_year} from the amendment "
+                    f"and `{actual_value:g}` for the {next_year} consolidated version"
+                )
+
+        return (
+            " Complete-source effective-version hint: the expected value appears "
+            f"in attached amendment document {citation_display}, while the actual "
+            "value appears in the authoritative consolidated source. Encode dual "
+            f"effective versions—{version_shape}—and give each version a source "
+            "proof atom citing its own authoritative document."
+        )
+
     def _compare_rulespec_output(
         self,
         *,
@@ -25072,6 +25219,7 @@ class ValidatorPipeline:
         output_name: str,
         expected_value: Any,
         actual_output: Any,
+        period: Mapping[str, Any] | None = None,
     ) -> str | None:
         """Compare a single expected output; return an issue string on mismatch."""
         if isinstance(expected_value, list):
@@ -25100,6 +25248,7 @@ class ValidatorPipeline:
                     output_name=output_name,
                     expected_value=expected_item,
                     actual_output=actual_item,
+                    period=period,
                 )
                 if mismatch:
                     return f"{mismatch} (row #{row_index})"
@@ -25150,10 +25299,15 @@ class ValidatorPipeline:
                 expected_value = Decimal(expected_numeric_text)
         expected_scalar = self._rulespec_expected_scalar_value(expected_value)
         if not self._rulespec_scalar_values_equal(actual_scalar, expected_scalar):
-            return (
+            mismatch = (
                 f"Test case `{case_name}` output `{output_name}` expected "
                 f"{self._format_rulespec_scalar_value(expected_scalar)}, got "
                 f"{self._format_rulespec_actual_value(actual_output)}."
+            )
+            return mismatch + self._complete_mode_effective_version_mismatch_hint(
+                expected_scalar=expected_scalar,
+                actual_scalar=actual_scalar,
+                period=period,
             )
         return None
 
@@ -25562,6 +25716,7 @@ class ValidatorPipeline:
                     output_name=output_key,
                     expected_value=expected_value,
                     actual_output=actual_output,
+                    period=period,
                 )
                 if mismatch:
                     issues.append(mismatch)
@@ -25625,15 +25780,19 @@ class ValidatorPipeline:
         # (module source ∪ its own proof-atom sources), not the single
         # module-level source: a benefit/tax module legitimately draws its
         # rate, thresholds, and conversions from several provisions of one Act.
-        # When an explicit override source is supplied, keep single-source
-        # behavior for that caller.
-        if self.source_text is not None:
+        # When an explicit override source is supplied without amendment
+        # context, keep single-source behavior for that caller. Attached
+        # amendments remain hint-only unless an owning proof atom cites them;
+        # when attachments exist, scoped grounding is required so a valid
+        # citation can resolve and ground that exact literal path.
+        if self.source_text is not None and not self.amendment_source_texts:
             issues.extend(
                 find_ungrounded_numeric_issues(
                     content,
                     source_text=validation_source_text,
                     source_citation_path=self.source_citation_path,
                     require_complete_source_unit=self.require_complete_source_unit,
+                    amendment_source_texts=self.amendment_source_texts,
                 )
             )
         else:
@@ -25644,6 +25803,7 @@ class ValidatorPipeline:
                     module_citation_path=self.source_citation_path,
                     proof_source_texts=numeric_source_texts,
                     require_complete_source_unit=self.require_complete_source_unit,
+                    amendment_source_texts=self.amendment_source_texts,
                 )
             )
         issues.extend(find_deprecated_source_url_issues(content))

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -1698,6 +1698,7 @@ _LOCAL_RATE_CONTEXT_AFTER_NUMBER_PATTERN = re.compile(
     r"\bpercent\b|"
     r"\bper[ \t-]+cent(?:um)?\b|"
     r"\bProzent\b|"
+    r"\b(?:Beitragssatz|Prozent)punkt(?:e|en|es|s)?\b|"
     r"\bvom[ \t]+Hundert\b"
     r")",
     re.IGNORECASE,
@@ -1707,6 +1708,7 @@ _TABLE_RATE_HEADER_PATTERN = re.compile(
     r"\bpercent(?:age)?\b|"
     r"\bper[ \t-]+cent(?:um)?\b|"
     r"\bProzent\b|"
+    r"\b(?:Beitragssatz|Prozent)punkt(?:e|en|es|s)?\b|"
     r"\bvom[ \t]+Hundert\b"
     r")",
     re.IGNORECASE,
@@ -1874,6 +1876,8 @@ class NumericOccurrence:
     has_temporal_context: bool = False
     source_value: float | None = None
     requires_rate_context: bool = False
+    is_word_number: bool = False
+    alternative_values: tuple[float, ...] = ()
 
     @property
     def span(self) -> tuple[int, int]:
@@ -5800,6 +5804,8 @@ class _LegacyNumericCollector:
         source_value: float | None = None,
         force_rate_context: bool = False,
         requires_rate_context: bool = False,
+        is_word_number: bool = False,
+        alternative_values: tuple[float, ...] = (),
     ) -> NumericOccurrence:
         source_span = view.source_span(span)
         start, end = source_span
@@ -5849,6 +5855,8 @@ class _LegacyNumericCollector:
             has_temporal_context=has_temporal_context,
             source_value=value if source_value is None else source_value,
             requires_rate_context=requires_rate_context,
+            is_word_number=is_word_number,
+            alternative_values=alternative_values,
         )
 
     def add_grounding(
@@ -5884,7 +5892,7 @@ _LOCALE_UNARY_PREFIXES = frozenset(
     "\u2264"  # less than or equal
     "\u2265"  # greater than or equal
 )
-_GERMAN_LEXICAL_SCALE_VALUES = {
+_GERMAN_FRACTION_DENOMINATOR_VALUES = {
     "Einhundertzwanzigstel": 120.0,
     "Dreihundertsechzigstel": 360.0,
     "Vierhundertfünfzigstel": 450.0,
@@ -5911,17 +5919,158 @@ _GERMAN_LEXICAL_SCALE_VALUES = {
     "Drittel": 3.0,
     "Zehntel": 10.0,
     "Achtel": 8.0,
+    "Hälfte": 2.0,
 }
-_GERMAN_LEXICAL_SCALE_VALUES_CASEFOLD = {
-    word.casefold(): value for word, value in _GERMAN_LEXICAL_SCALE_VALUES.items()
+_GERMAN_FRACTION_DENOMINATOR_VALUES_CASEFOLD = {
+    word.casefold(): value
+    for word, value in _GERMAN_FRACTION_DENOMINATOR_VALUES.items()
 }
-_GERMAN_LEXICAL_SCALE_PATTERN = re.compile(
-    r"(?<!\w)(?P<denominator>"
+_GERMAN_FRACTION_WORD_PATTERN = re.compile(
+    r"(?<!\w)(?P<fraction>"
     + "|".join(
         re.escape(word)
-        for word in sorted(_GERMAN_LEXICAL_SCALE_VALUES, key=len, reverse=True)
+        for word in sorted(
+            _GERMAN_FRACTION_DENOMINATOR_VALUES,
+            key=len,
+            reverse=True,
+        )
     )
-    + r")(?:n)?(?!\w)",
+    + r")(?:n|s)?(?!\w)",
+    re.IGNORECASE,
+)
+_GERMAN_QUANTITATIVE_CARDINAL_VALUES = {
+    "null": 0.0,
+    "zwei": 2.0,
+    "drei": 3.0,
+    "vier": 4.0,
+    "fünf": 5.0,
+    "sechs": 6.0,
+    "sieben": 7.0,
+    "acht": 8.0,
+    "neun": 9.0,
+    "zehn": 10.0,
+    "elf": 11.0,
+    "zwölf": 12.0,
+    "dreißig": 30.0,
+    "dreihundertsechzig": 360.0,
+}
+_GERMAN_QUANTITATIVE_CARDINAL_VALUES_CASEFOLD = {
+    word.casefold(): value
+    for word, value in _GERMAN_QUANTITATIVE_CARDINAL_VALUES.items()
+}
+_GERMAN_QUANTITATIVE_CARDINAL_BODY = "|".join(
+    re.escape(word)
+    for word in sorted(_GERMAN_QUANTITATIVE_CARDINAL_VALUES, key=len, reverse=True)
+)
+_GERMAN_FRACTION_NUMERATOR_CARDINAL_BODY = "|".join(
+    re.escape(word)
+    for word in sorted(
+        (
+            word
+            for word, value in _GERMAN_QUANTITATIVE_CARDINAL_VALUES.items()
+            if value != 1
+        ),
+        key=len,
+        reverse=True,
+    )
+)
+_GERMAN_QUANTITATIVE_UNIT_BODY = (
+    r"(?:[A-Za-zÄÖÜäöüß]+)?"
+    r"(?:stunde|stunden|tag|tage|tagen|woche|wochen|monat|monate|monaten|"
+    r"jahr|jahre|jahren|teil|teile|teilen|kind|kinder|kindern|person|"
+    r"personen|partner|partnern|monatswert|monatswerte|monatswerten|"
+    r"haushaltsmitglied|haushaltsmitglieder|haushaltsmitgliedern|euro|prozent)"
+)
+_GERMAN_CARDINAL_BEFORE_UNIT_PATTERN = re.compile(
+    rf"(?<!\w)(?P<cardinal>{_GERMAN_QUANTITATIVE_CARDINAL_BODY})(?!\w)"
+    rf"(?=[ \t]+{_GERMAN_QUANTITATIVE_UNIT_BODY}\b)",
+    re.IGNORECASE,
+)
+_GERMAN_CARDINAL_BEFORE_MODIFIED_UNIT_PATTERN = re.compile(
+    rf"(?<!\w)(?P<cardinal>{_GERMAN_QUANTITATIVE_CARDINAL_BODY})(?!\w)"
+    rf"(?=[ \t]+zu[ \t]+berücksichtigende[ \t]+"
+    rf"{_GERMAN_QUANTITATIVE_UNIT_BODY}\b)",
+    re.IGNORECASE,
+)
+_GERMAN_CARDINAL_BEFORE_FRACTION_PATTERN = re.compile(
+    rf"(?<!\w)(?P<cardinal>{_GERMAN_FRACTION_NUMERATOR_CARDINAL_BODY})(?!\w)"
+    r"(?=[ \t]+(?:"
+    + "|".join(
+        re.escape(word)
+        for word in sorted(
+            _GERMAN_FRACTION_DENOMINATOR_VALUES,
+            key=len,
+            reverse=True,
+        )
+    )
+    + r")(?:n|s)?(?!\w))",
+    re.IGNORECASE,
+)
+_GERMAN_PRORATION_CARDINAL_PATTERN = re.compile(
+    rf"\b(?:Woche|Monat|Jahr)\s+zu[ \t]+"
+    rf"(?P<cardinal>{_GERMAN_QUANTITATIVE_CARDINAL_BODY})(?!\w)",
+    re.IGNORECASE,
+)
+_GERMAN_DIVISOR_CARDINAL_PATTERN = re.compile(
+    rf"\bdurch[ \t]+(?P<cardinal>{_GERMAN_QUANTITATIVE_CARDINAL_BODY})"
+    r"(?!\w)[ \t]+geteilt\b",
+    re.IGNORECASE,
+)
+_GERMAN_MULTIPLIER_VALUES = {
+    "ein": 1.0,
+    "zwei": 2.0,
+    "drei": 3.0,
+    "vier": 4.0,
+    "fünf": 5.0,
+    "sechs": 6.0,
+    "sieben": 7.0,
+    "acht": 8.0,
+    "neun": 9.0,
+    "zehn": 10.0,
+    "elf": 11.0,
+    "zwölf": 12.0,
+}
+_GERMAN_MULTIPLIER_VALUES_CASEFOLD = {
+    word.casefold(): value for word, value in _GERMAN_MULTIPLIER_VALUES.items()
+}
+_GERMAN_WORD_MULTIPLIER_PATTERN = re.compile(
+    r"(?<!\w)(?P<multiplier>"
+    + "|".join(
+        re.escape(word)
+        for word in sorted(_GERMAN_MULTIPLIER_VALUES, key=len, reverse=True)
+    )
+    + r")(?:-)?fache(?:n|r|s|m)?(?!\w)",
+    re.IGNORECASE,
+)
+_GERMAN_DOUBLE_MULTIPLIER_PATTERN = re.compile(
+    r"(?<!\w)doppelt(?:e|en|er|es|em)?(?!\w)",
+    re.IGNORECASE,
+)
+_GERMAN_ORDINAL_PART_VALUES = {
+    "erste": 1.0,
+    "zweite": 2.0,
+    "dritte": 3.0,
+    "vierte": 4.0,
+    "fünfte": 5.0,
+    "sechste": 6.0,
+    "siebte": 7.0,
+    "achte": 8.0,
+    "neunte": 9.0,
+    "zehnte": 10.0,
+    "elfte": 11.0,
+    "zwölfte": 12.0,
+}
+_GERMAN_ORDINAL_PART_VALUES_CASEFOLD = {
+    word.casefold(): value for word, value in _GERMAN_ORDINAL_PART_VALUES.items()
+}
+_GERMAN_ORDINAL_PART_PATTERN = re.compile(
+    r"\b(?:der|die|das|den|dem|des|ein(?:e[nsrm]?)?)\s+"
+    r"(?P<ordinal>"
+    + "|".join(
+        re.escape(word)
+        for word in sorted(_GERMAN_ORDINAL_PART_VALUES, key=len, reverse=True)
+    )
+    + r")(?:n|r|s|m)?\s+Teil(?:s|e|en)?\b",
     re.IGNORECASE,
 )
 
@@ -6197,6 +6346,116 @@ def _has_malformed_profiled_numeric_envelope(
     )
 
 
+def _german_word_number_occurrences(
+    cleaned: str,
+    *,
+    view: _NumericTextView,
+    collector: _LegacyNumericCollector,
+) -> tuple[list[NumericOccurrence], list[NumericOccurrence]]:
+    """Extract German word-number candidates and one recall item per phrase."""
+
+    grounding: list[NumericOccurrence] = []
+    inventory: list[NumericOccurrence] = []
+
+    def add_unambiguous(span: tuple[int, int], value: float) -> None:
+        occurrence = collector.occurrence(
+            view,
+            span,
+            value,
+            is_word_number=True,
+        )
+        grounding.append(occurrence)
+
+    def add_fraction_alternatives(
+        span: tuple[int, int],
+        denominator: float,
+        *,
+        fraction_is_primary: bool = False,
+        include_in_inventory: bool = True,
+    ) -> None:
+        reciprocal = 1.0 / denominator
+        denominator_occurrence = collector.occurrence(
+            view,
+            span,
+            denominator,
+            is_word_number=True,
+            alternative_values=(reciprocal,),
+        )
+        reciprocal_occurrence = collector.occurrence(
+            view,
+            span,
+            reciprocal,
+            is_word_number=True,
+            alternative_values=(denominator,),
+        )
+        alternatives = (
+            (reciprocal_occurrence, denominator_occurrence)
+            if fraction_is_primary
+            else (denominator_occurrence, reciprocal_occurrence)
+        )
+        grounding.extend(alternatives)
+        # Complete-source recall treats the two readings as alternatives for one
+        # lexical occurrence rather than demanding two named scalar definitions.
+        if include_in_inventory:
+            inventory.append(alternatives[0])
+
+    for match in _GERMAN_FRACTION_WORD_PATTERN.finditer(cleaned):
+        normalized_fraction = match.group("fraction").casefold()
+        denominator = _GERMAN_FRACTION_DENOMINATOR_VALUES_CASEFOLD.get(
+            normalized_fraction
+        )
+        if denominator is not None:
+            add_fraction_alternatives(
+                match.span(),
+                denominator,
+                fraction_is_primary=normalized_fraction == "hälfte".casefold(),
+                include_in_inventory=normalized_fraction != "hälfte".casefold(),
+            )
+
+    seen_cardinal_spans: set[tuple[int, int]] = set()
+    for pattern in (
+        _GERMAN_CARDINAL_BEFORE_UNIT_PATTERN,
+        _GERMAN_CARDINAL_BEFORE_MODIFIED_UNIT_PATTERN,
+        _GERMAN_CARDINAL_BEFORE_FRACTION_PATTERN,
+        _GERMAN_PRORATION_CARDINAL_PATTERN,
+        _GERMAN_DIVISOR_CARDINAL_PATTERN,
+    ):
+        for match in pattern.finditer(cleaned):
+            span = match.span("cardinal")
+            if span in seen_cardinal_spans:
+                continue
+            value = _GERMAN_QUANTITATIVE_CARDINAL_VALUES_CASEFOLD.get(
+                match.group("cardinal").casefold()
+            )
+            if value is None:
+                continue
+            add_unambiguous(span, value)
+            seen_cardinal_spans.add(span)
+
+    for match in _GERMAN_WORD_MULTIPLIER_PATTERN.finditer(cleaned):
+        value = _GERMAN_MULTIPLIER_VALUES_CASEFOLD.get(
+            match.group("multiplier").casefold()
+        )
+        if value is not None:
+            add_unambiguous(match.span(), value)
+    for match in _GERMAN_DOUBLE_MULTIPLIER_PATTERN.finditer(cleaned):
+        add_unambiguous(match.span(), 2.0)
+
+    for match in _GERMAN_ORDINAL_PART_PATTERN.finditer(cleaned):
+        denominator = _GERMAN_ORDINAL_PART_VALUES_CASEFOLD.get(
+            match.group("ordinal").casefold()
+        )
+        if denominator is not None:
+            add_fraction_alternatives(
+                match.span("ordinal"),
+                denominator,
+                fraction_is_primary=True,
+                include_in_inventory=False,
+            )
+
+    return grounding, inventory
+
+
 def _non_temporal_numeric_inventory(
     occurrences: Iterable[NumericOccurrence],
 ) -> tuple[NumericOccurrence, ...]:
@@ -6273,7 +6532,8 @@ def _tokenize_profiled_numeric_occurrences(
     cleaned = _clean_source_text_for_numeric_extraction(text)
     view = _NumericTextView.aligned(text, cleaned)
     collector = _LegacyNumericCollector(text)
-    occurrences: list[NumericOccurrence] = []
+    grounding_occurrences: list[NumericOccurrence] = []
+    inventory_occurrences: list[NumericOccurrence] = []
 
     for span in _iter_locale_numeric_envelopes(cleaned, profile=profile):
         if not _locale_numeric_envelope_has_token_boundaries(cleaned, span):
@@ -6281,21 +6541,34 @@ def _tokenize_profiled_numeric_occurrences(
         value = _parse_locale_numeric_envelope(cleaned[span[0] : span[1]], profile)
         if value is None:
             continue
-        occurrences.append(collector.occurrence(view, span, value))
+        occurrence = collector.occurrence(view, span, value)
+        grounding_occurrences.append(occurrence)
+        inventory_occurrences.append(occurrence)
 
     if profile == "de-DE":
-        for match in _GERMAN_LEXICAL_SCALE_PATTERN.finditer(cleaned):
-            value = _GERMAN_LEXICAL_SCALE_VALUES_CASEFOLD.get(
-                match.group("denominator").casefold()
-            )
-            if value is not None:
-                occurrences.append(collector.occurrence(view, match.span(), value))
+        word_grounding, word_inventory = _german_word_number_occurrences(
+            cleaned,
+            view=view,
+            collector=collector,
+        )
+        grounding_occurrences.extend(word_grounding)
+        inventory_occurrences.extend(word_inventory)
 
-    occurrences = list(_complete_typed_year_occurrences(collector, occurrences))
-    occurrences.sort(key=lambda occurrence: (occurrence.start, occurrence.end))
+    grounding_occurrences = list(
+        _complete_typed_year_occurrences(collector, grounding_occurrences)
+    )
+    inventory_occurrences = list(
+        _complete_typed_year_occurrences(collector, inventory_occurrences)
+    )
+    grounding_occurrences.sort(
+        key=lambda occurrence: (occurrence.start, occurrence.end)
+    )
+    inventory_occurrences.sort(
+        key=lambda occurrence: (occurrence.start, occurrence.end)
+    )
     return _NumericTokenization(
-        grounding=tuple(occurrences),
-        inventory=_non_temporal_numeric_inventory(occurrences),
+        grounding=tuple(grounding_occurrences),
+        inventory=_non_temporal_numeric_inventory(inventory_occurrences),
     )
 
 
@@ -22906,12 +23179,15 @@ def numeric_value_is_grounded(
     evidence; an unrelated integer can never authorize the conversion.
     """
     for occurrence in source_occurrences:
-        source_value = occurrence.value
-        if math.isclose(
-            value,
-            source_value,
-            rel_tol=0,
-            abs_tol=NUMERIC_GROUNDING_ABS_TOLERANCE,
+        source_values = (occurrence.value, *occurrence.alternative_values)
+        if any(
+            math.isclose(
+                value,
+                source_value,
+                rel_tol=0,
+                abs_tol=NUMERIC_GROUNDING_ABS_TOLERANCE,
+            )
+            for source_value in source_values
         ) and not (
             occurrence.requires_rate_context and not occurrence.has_rate_context
         ):
@@ -22923,7 +23199,7 @@ def numeric_value_is_grounded(
                 value * 100,
                 occurrence.source_value
                 if occurrence.source_value is not None
-                else source_value,
+                else occurrence.value,
                 rel_tol=0,
                 abs_tol=NUMERIC_GROUNDING_ABS_TOLERANCE,
             )

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -1631,6 +1631,15 @@ Complete-source-unit mode is enabled for this request:
 - Every explicit computation stated in the source unit must have a principal
   `kind: derived` or `kind: derived_relation` output. Naming its constants as
   parameters without encoding the stated formula is invalid.
+- When the source states both a base value and its converted result, encode both
+  values as separate grounded `kind: parameter` rules. Result wording such as
+  "converted to the month, this gives ..." states a scalar result; it does not
+  mandate deriving one parameter from the other.
+- Never introduce calendar constants `12`, `52`, `365`, `4`, or `24` as module
+  literals unless that literal appears in the authoritative source text.
+  Express a stated conversion through companion-test assertions on both
+  parameter outputs; literals used only in companion tests do not require
+  source grounding.
 - Encode every structural paragraph and list branch, including Absatz markers
   such as `(1)` and `(2)`, `Abs. 5`, numbered items such as `1.` and `1a.`, and
   Satz enumerations. If a branch cannot be encoded, use a precise typed

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8500,7 +8500,7 @@ must use a reasonable allocation method.
 
 def test_closest_exact_source_excerpt_uses_direct_match_source_coordinates():
     source_text = """(a) If household income is below the threshold and all documentation requirements are satisfied, the agency shall pay $500.
-(b) If fraud is found, the agency shall pay $500.
+(b) If fraud is found, the agency shall pay $600.
 """
 
     repaired = _closest_exact_source_excerpt(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4160,6 +4160,7 @@ class TestCmdEvalSuiteRevalidate:
                     body="authoritative source text",
                     citation_path="us/statute/7/2014/e/6/A",
                     requested="us/statute/7/2014/e/6/A",
+                    amendment_documents=("attached-amendment",),
                     source_attestation=_complete_source_attestation(
                         "us/statute/7/2014/e/6/A"
                     ),
@@ -4194,6 +4195,9 @@ class TestCmdEvalSuiteRevalidate:
             dependency_root
         ]
         assert mock_eval.call_args.kwargs["require_complete_source_unit"] is True
+        assert mock_eval.call_args.kwargs["amendment_documents"] == (
+            "attached-amendment",
+        )
         ledger = json.loads((source_output / "suite-results.jsonl").read_text())
         assert ledger["result"]["metrics"]["compile_pass"] is compile_pass
         assert ledger["result"]["metrics"]["ci_pass"] is ci_pass
@@ -7861,6 +7865,17 @@ def test_closest_exact_source_excerpt_rejects_identical_cross_record_matches():
     excerpt = "Der Wert beträgt 25 Euro."
     repaired = _closest_exact_source_excerpt(
         source_text=(excerpt + PROOF_EVIDENCE_SEGMENT_SEPARATOR + excerpt),
+        excerpt=excerpt,
+        numeric_profile="de-DE",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_rejects_repeated_direct_match():
+    excerpt = "Der Wert beträgt 25 Euro."
+    repaired = _closest_exact_source_excerpt(
+        source_text=f"{excerpt} Eine Ausnahme gilt. {excerpt}",
         excerpt=excerpt,
         numeric_profile="de-DE",
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7861,6 +7861,18 @@ def test_closest_exact_source_excerpt_rejects_ambiguous_canonical_span():
     assert repaired is None
 
 
+def test_closest_exact_source_excerpt_rejects_mixed_direct_and_canonical_spans():
+    repaired = _closest_exact_source_excerpt(
+        source_text=(
+            "Der Wert beträgt 25 Euro. Eine zweite Zeile sagt: DerWert beträgt 25 Euro."
+        ),
+        excerpt="Der Wert beträgt 25 Euro.",
+        numeric_profile="de-DE",
+    )
+
+    assert repaired is None
+
+
 def test_closest_exact_source_excerpt_rejects_identical_cross_record_matches():
     excerpt = "Der Wert beträgt 25 Euro."
     repaired = _closest_exact_source_excerpt(
@@ -7900,6 +7912,38 @@ def test_closest_exact_source_excerpt_rejects_changed_number_in_near_match():
     )
 
     assert repaired is None
+
+
+def test_closest_exact_source_excerpt_preserves_numeric_multiplicity():
+    repaired = _closest_exact_source_excerpt(
+        source_text=("Die Angabe „20 Euro“ wird durch die Angabe „25 Euro“ ersetzt."),
+        excerpt=('Die Angabe "20 Euro" wird durch die Angabe "20 Euro" geändert.'),
+        numeric_profile="de-DE",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_rejects_tied_fuzzy_spans():
+    repaired = _closest_exact_source_excerpt(
+        source_text=("Alpha Betrag ist 20 Euro. Alpha Betrag ist 20 Euro."),
+        excerpt="Delta Betrag ist 20 Euro.",
+        numeric_profile="de-DE",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_preserves_decomposed_grapheme():
+    source_text = "Ho\u0308he"
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt="Höhe",
+        numeric_profile="de-DE",
+    )
+
+    assert repaired == source_text
 
 
 def test_repair_generated_undeclared_money_unit(tmp_path):
@@ -10882,6 +10926,18 @@ def test_declared_subsection_source_keeps_corpus_evidence_segments_separate():
     assert (
         _source_excerpt_preserving_whitespace(
             source_text=scoped,
+            excerpt=excerpt,
+        )
+        is None
+    )
+
+
+def test_protected_source_excerpt_rejects_repeated_coordinates():
+    excerpt = "The amount is 25 Euro."
+
+    assert (
+        _source_excerpt_preserving_whitespace(
+            source_text=f"{excerpt} An exception applies. {excerpt}",
             excerpt=excerpt,
         )
         is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7857,6 +7857,17 @@ def test_closest_exact_source_excerpt_rejects_ambiguous_canonical_span():
     assert repaired is None
 
 
+def test_closest_exact_source_excerpt_rejects_identical_cross_record_matches():
+    excerpt = "Der Wert beträgt 25 Euro."
+    repaired = _closest_exact_source_excerpt(
+        source_text=(excerpt + PROOF_EVIDENCE_SEGMENT_SEPARATOR + excerpt),
+        excerpt=excerpt,
+        numeric_profile="de-DE",
+    )
+
+    assert repaired is None
+
+
 def test_closest_exact_source_excerpt_rejects_changed_number_in_near_match():
     source_text = (
         "In § 6a Absatz 2 Satz 4 werden die Wörter „ab 1. Juli 2022“ gestrichen "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11670,6 +11670,13 @@ class TestCmdEncode:
         ]
         assert validated == generated
         assert mock_run.call_count == 3
+        assert [
+            call.kwargs["validation_retry_feedback"] for call in mock_run.call_args_list
+        ] == [
+            (),
+            ("validator rejected generated section",),
+            ("validator rejected generated section",),
+        ]
         assert mock_validate.call_count == 3
         mock_apply.assert_called_once()
         assert mock_apply.call_args.args[0].model == DEFAULT_OPENAI_ESCALATION_MODEL
@@ -11687,6 +11694,29 @@ class TestCmdEncode:
             "initial_model": DEFAULT_OPENAI_MODEL,
             "escalation_model": DEFAULT_OPENAI_ESCALATION_MODEL,
         }
+
+    def test_encode_retry_feedback_includes_actionable_ci_issue(self):
+        import axiom_encode.cli as cli_module
+
+        hint = (
+            "Ungrounded generated numeric literal: 12 does not appear as a "
+            "substantive numeric value in the source text. Complete-source "
+            "stated-conversion hint: encode separate grounded parameters."
+        )
+        failed_attempt = cli_module._FailedEncodeAttempt(
+            result=SimpleNamespace(
+                metrics=SimpleNamespace(
+                    compile_issues=[],
+                    ci_issues=[hint],
+                )
+            ),
+            error="Generated RuleSpec failed CI validation",
+        )
+
+        assert cli_module._encode_validation_retry_feedback([failed_attempt]) == (
+            "Generated RuleSpec failed CI validation",
+            hint,
+        )
 
     def test_encode_rejects_incompatible_escalation_model_before_generation(
         self, tmp_path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7800,6 +7800,82 @@ def test_closest_exact_source_excerpt_rejects_malformed_de_span_with_valid_numbe
     assert repaired is None
 
 
+@pytest.mark.parametrize(
+    ("citation_path", "source_text", "generated_excerpt"),
+    [
+        (
+            "de/statute/estg/32a",
+            (
+                "5. von 277 826 Euro an:0,45 • x – 19 470,38.3Die Größe „y“ "
+                "ist ein Zehntausendstel"
+            ),
+            (
+                '5. von 277 826 Euro an: 0,45 * x - 19 470,38. 3 Die Grosse "y" '
+                "ist ein Zehntausendstel"
+            ),
+        ),
+        (
+            "de/statute/estg/9a",
+            (
+                "3. von den Einnahmen im Sinne des § 22 Nummer 1, 1a und 5:ein "
+                "Pauschbetrag von insgesamt 102 Euro.2Der Pauschbetrag nach Satz 1 "
+                "Nummer 1 Buchstabe b"
+            ),
+            (
+                "3. von den Einnahmen im Sinne des § 22 Nummer 1, 1a und 5: ein "
+                "Pauschbetrag von insgesamt 102 Euro. 2 Der Pauschbetrag nach Satz "
+                "1 Nummer 1 Buchstabe b"
+            ),
+        ),
+        (
+            "de/statute/sgb-2/20",
+            "monatlich ein Betrag in Höhe der Regelbedarfsstufe 1 anerkannt.",
+            "monatlich ein Betrag in Ho\u0308he der Regelbedarfsstufe1 anerkannt.",
+        ),
+    ],
+)
+def test_closest_exact_source_excerpt_reanchors_live_german_glue_variants(
+    citation_path, source_text, generated_excerpt
+):
+    # Exact slices from the 2026-07-16 German wave corpus release.
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=generated_excerpt,
+        numeric_profile="de-DE",
+    )
+
+    assert repaired == source_text, citation_path
+
+
+def test_closest_exact_source_excerpt_rejects_ambiguous_canonical_span():
+    repaired = _closest_exact_source_excerpt(
+        source_text="Der Wert:25 Euro gilt.\n\nDer Wert :25 Euro gilt.",
+        excerpt="Der Wert: 25 Euro gilt.",
+        numeric_profile="de-DE",
+    )
+
+    assert repaired is None
+
+
+def test_closest_exact_source_excerpt_rejects_changed_number_in_near_match():
+    source_text = (
+        "In § 6a Absatz 2 Satz 4 werden die Wörter „ab 1. Juli 2022“ gestrichen "
+        "und wird die Angabe „20 Euro“ durch die Angabe „25 Euro“ ersetzt."
+    )
+
+    repaired = _closest_exact_source_excerpt(
+        source_text=source_text,
+        excerpt=(
+            'In § 6a Absatz 2 Satz 4 werden die Wörter "ab 1. Juli 2022" '
+            'gestrichen und wird die Angabe "20 Euro" durch die Angabe '
+            '"26 Euro" ersetzt.'
+        ),
+        numeric_profile="de-DE",
+    )
+
+    assert repaired is None
+
+
 def test_repair_generated_undeclared_money_unit(tmp_path):
     output_root = tmp_path / "out"
     rules_file = output_root / "model" / "policies" / "benefit.yaml"
@@ -8190,6 +8266,75 @@ rules:
         payload["rules"][0]["metadata"]["proof"]["atoms"][0]["source"]["excerpt"]
         == "The maximum amount for age is $6,100."
     )
+
+
+def test_repair_generated_nonexact_proof_excerpt_reanchors_amendment_document(
+    tmp_path, monkeypatch
+):
+    citation_path = "de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1"
+    source_text = (
+        "In § 6a Absatz 2 Satz 4 werden die Wörter „ab 1. Juli 2022“ gestrichen "
+        "und wird die Angabe „20 Euro“ durch die Angabe „25 Euro“ ersetzt."
+    )
+    generated_excerpt = (
+        'In § 6a Absatz 2 Satz 4 werden die Wörter "ab 1. Juli 2022" gestrichen '
+        'und wird die Angabe "20 Euro" durch die Angabe "25 Euro" ersetzt.'
+    )
+    output_root = tmp_path / "out"
+    rules_file = output_root / "model" / "statutes" / "bkgg" / "6a.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(
+        f"""format: rulespec/v1
+module:
+  summary: Current consolidated BKGG source.
+rules:
+- name: child_supplement_immediate_supplement
+  kind: parameter
+  dtype: Money
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: {citation_path}
+          excerpt: {generated_excerpt!r}
+  versions:
+  - effective_from: '2025-01-01'
+    formula: 25
+"""
+    )
+    requested_paths = []
+
+    def source_for_citation(requested_path, *, corpus_release):
+        requested_paths.append((requested_path, corpus_release))
+        return source_text
+
+    monkeypatch.setattr(
+        "axiom_encode.cli._local_source_text_for_corpus_path",
+        source_for_citation,
+    )
+    corpus_release = SimpleNamespace(name="german-wave-release")
+
+    repaired = _try_repair_generated_nonexact_proof_excerpts_for_apply(
+        SimpleNamespace(output_file=str(rules_file)),
+        output_root=output_root,
+        corpus_release=corpus_release,
+        issues=[
+            "Proof source evidence not found: rule "
+            "`child_supplement_immediate_supplement` proof atom 0 "
+            "`source.excerpt` does not appear in "
+            f"`{citation_path}`."
+        ],
+    )
+
+    payload = yaml.safe_load(rules_file.read_text())
+    repaired_source = payload["rules"][0]["metadata"]["proof"]["atoms"][0]["source"]
+    assert repaired == ["child_supplement_immediate_supplement[0]"]
+    assert requested_paths == [(citation_path, corpus_release)]
+    assert repaired_source["corpus_citation_path"] == citation_path
+    assert repaired_source["excerpt"] == source_text
+    assert repaired_source["excerpt"] in source_text
 
 
 def test_closest_exact_source_excerpt_reflows_wrapped_regulatory_paragraph():

--- a/tests/test_complete_source_mode_plumbing.py
+++ b/tests/test_complete_source_mode_plumbing.py
@@ -96,6 +96,13 @@ def test_generic_encoder_prompt_adds_completeness_only_when_enabled():
     assert (
         "parameters without encoding the stated formula is invalid" in complete_prompt
     )
+    assert (
+        "encode both\n  values as separate grounded `kind: parameter` rules"
+        in complete_prompt
+    )
+    assert "calendar constants `12`, `52`, `365`, `4`, or `24`" in complete_prompt
+    assert "companion-test assertions on both\n  parameter outputs" in complete_prompt
+    assert "separate grounded `kind: parameter` rules" not in default_prompt
     assert "missing dependency or citation" in complete_prompt
     assert "exact missing RuleSpec targets under `blocked_by`" not in complete_prompt
     assert (
@@ -215,6 +222,13 @@ def test_eval_prompt_adds_completeness_only_when_enabled(tmp_path):
     assert (
         "parameters without encoding the stated formula is invalid" in complete_prompt
     )
+    assert (
+        "encode both\n  values as separate grounded `kind: parameter` rules"
+        in complete_prompt
+    )
+    assert "calendar constants `12`, `52`, `365`, `4`, or `24`" in complete_prompt
+    assert "companion-test assertions on both\n  parameter outputs" in complete_prompt
+    assert "separate grounded `kind: parameter` rules" not in default_prompt
     assert "exact missing RuleSpec targets under `blocked_by`" not in complete_prompt
     assert (
         "Only include `blocked_by` entries when you know the exact" in complete_prompt

--- a/tests/test_complete_source_mode_plumbing.py
+++ b/tests/test_complete_source_mode_plumbing.py
@@ -235,6 +235,41 @@ def test_eval_prompt_adds_completeness_only_when_enabled(tmp_path):
     )
 
 
+def test_eval_prompt_adds_prior_validation_feedback_only_when_supplied(tmp_path):
+    source_file = tmp_path / "source.txt"
+    source_file.write_text("The annual amount is 73 800.")
+    workspace = EvalWorkspace(
+        root=tmp_path,
+        source_text_file=source_file,
+        manifest_file=tmp_path / "context-manifest.json",
+    )
+    kwargs = {
+        "citation": "de/regulation/example/1",
+        "mode": "cold",
+        "workspace": workspace,
+        "context_files": [],
+        "target_file_name": "1.yaml",
+        "include_tests": True,
+        "runner_backend": "openai",
+    }
+    feedback = (
+        "Ungrounded generated numeric literal: 12 does not appear as a "
+        "substantive numeric value in the source text. Complete-source "
+        "stated-conversion hint: encode separate grounded parameters.",
+    )
+
+    default_prompt = evals._build_eval_prompt(**kwargs)
+    retry_prompt = evals._build_eval_prompt(
+        **kwargs,
+        validation_retry_feedback=feedback,
+    )
+
+    assert "PRIOR VALIDATION FEEDBACK" not in default_prompt
+    assert "PRIOR VALIDATION FEEDBACK" in retry_prompt
+    assert "repair guidance from the validator, not legal authority" in retry_prompt
+    assert feedback[0] in retry_prompt
+
+
 def test_run_model_eval_forces_tests_and_forwards_complete_mode(tmp_path):
     source_unit = object()
     result = object()
@@ -257,11 +292,15 @@ def test_run_model_eval_forces_tests_and_forwards_complete_mode(tmp_path):
             corpus_release=object(),
             include_tests=False,
             require_complete_source_unit=True,
+            validation_retry_feedback=("prior validator issue",),
         )
 
     assert actual == [result]
     assert run_single.call_args.kwargs["include_tests"] is True
     assert run_single.call_args.kwargs["require_complete_source_unit"] is True
+    assert run_single.call_args.kwargs["validation_retry_feedback"] == (
+        "prior validator issue",
+    )
 
 
 def test_repair_revalidation_keeps_complete_mode(tmp_path):

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -7703,6 +7703,12 @@ rules:
                 "_run_ci",
                 return_value=ValidationResult("ci", passed=True),
             ),
+            patch(
+                "axiom_encode.harness.evals._numeric_occurrence_source_text",
+                side_effect=AssertionError(
+                    "complete-mode recall must use the typed raw-source path"
+                ),
+            ),
         ):
             metrics = evaluate_artifact(
                 rulespec_file=rulespec_file,

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -6875,6 +6875,84 @@ class TestEvaluateArtifact:
             for issue in metrics.ci_issues
         )
 
+    def test_attached_amendment_value_stays_ungrounded_with_citation_hint(
+        self,
+        tmp_path,
+    ):
+        source_citation = "de/statute/solzg-1995/3"
+        source_text = "Die konsolidierte Freigrenze beträgt 40 700 Euro."
+        amendment_citation = (
+            "de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1"
+        )
+        amendment_source = (
+            "aa) In Nummer 1 wird die Angabe „36 260 Euro“ durch die Angabe "
+            "„39 900 Euro“ ersetzt."
+        )
+        rulespec_file = _generated_rulespec_file_path(
+            tmp_path,
+            "statutes/solzg-1995/3.yaml",
+        )
+        rulespec_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/solzg-1995/3
+rules:
+  - name: exemption_threshold
+    kind: parameter
+    dtype: Money
+    unit: EUR
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 39900
+""",
+            encoding="utf-8",
+        )
+        amendment = CorpusAmendmentDocument(
+            citation_path=amendment_citation,
+            title="Steuerfortentwicklungsgesetz – SteFeG",
+            expression_date="2024-12-23",
+            metadata={},
+            body=amendment_source,
+        )
+
+        with (
+            patch.object(
+                ValidatorPipeline,
+                "_run_compile_check",
+                return_value=ValidationResult("compile", passed=True),
+            ),
+            patch.object(
+                ValidatorPipeline,
+                "_run_ci",
+                return_value=ValidationResult("ci", passed=True),
+            ),
+        ):
+            metrics = evaluate_artifact(
+                local_corpus_release=_write_test_corpus_provision(
+                    tmp_path / "bound-release",
+                    citation_path=source_citation,
+                    body=source_text,
+                ),
+                rulespec_file=rulespec_file,
+                policy_repo_root=_canonical_rulespec_content_root(tmp_path, "de"),
+                axiom_rules_path=tmp_path / "axiom-rules-engine",
+                source_text=source_text,
+                source_citation_path=source_citation,
+                amendment_documents=(amendment,),
+                skip_reviewers=True,
+            )
+
+        assert not metrics.ci_pass
+        assert metrics.ungrounded_numeric_count == 1
+        amendment_issues = [
+            issue
+            for issue in metrics.ci_issues
+            if "Attached-amendment grounding hint" in issue
+        ]
+        assert len(amendment_issues) == 1
+        assert amendment_citation in amendment_issues[0]
+
     def test_evaluate_artifact_skips_reviewers_when_requested(self, tmp_path):
         rulespec_file = _generated_rulespec_file_path(tmp_path, "statutes/24/a.yaml")
         rulespec_file.write_text(
@@ -6919,6 +6997,47 @@ class TestEvaluateArtifact:
         assert metrics.generalist_review_pass
         assert metrics.generalist_review_score is None
         assert metrics.generalist_review_issues == []
+
+    def test_generated_eval_revalidation_keeps_attached_amendments(self, tmp_path):
+        amendment = CorpusAmendmentDocument(
+            citation_path=(
+                "de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1"
+            ),
+            title="Steuerfortentwicklungsgesetz – SteFeG",
+            expression_date="2024-12-23",
+            metadata={},
+            body=(
+                "In § 3 Absatz 3 Satz 1 wird die Angabe „36 260 Euro“ durch "
+                "die Angabe „39 900 Euro“ ersetzt."
+            ),
+        )
+        metrics = SimpleNamespace(ci_issues=["repairable"])
+        with (
+            patch(
+                "axiom_encode.harness.evals.evaluate_artifact",
+                return_value=metrics,
+            ) as mock_evaluate,
+            patch(
+                "axiom_encode.harness.evals._apply_generated_eval_repairs",
+                return_value=["companion-test-repair"],
+            ),
+        ):
+            result = _evaluate_generated_artifact_with_repairs(
+                rulespec_file=tmp_path / "artifact.yaml",
+                policy_repo_root=tmp_path / "rulespec-de",
+                axiom_rules_path=tmp_path / "axiom-rules-engine",
+                source_text="Source body",
+                local_corpus_release=object(),
+                require_complete_source_unit=True,
+                amendment_documents=(amendment,),
+            )
+
+        assert result is metrics
+        assert mock_evaluate.call_count == 2
+        assert all(
+            call.kwargs["amendment_documents"] == (amendment,)
+            for call in mock_evaluate.call_args_list
+        )
 
     def test_generated_eval_repairs_unreferenced_proof_imports(self, tmp_path):
         rulespec_file = tmp_path / "regulations" / "example.yaml"
@@ -7539,6 +7658,70 @@ rules:
         assert metrics.covered_source_numeric_occurrence_count == 1
         assert metrics.missing_source_numeric_occurrence_count == 1
         assert any("73" in issue for issue in metrics.numeric_occurrence_issues)
+
+    def test_complete_mode_typed_recall_excludes_stage_labels_but_demands_one_euro(
+        self,
+        tmp_path,
+    ):
+        citation_path = "de/statute/rbeg-2021/8"
+        source_text = (
+            "1. in der Regelbedarfsstufe 1 auf 446 Euro für jede erwachsene "
+            "Person. Ein Eigenanteil von 1 Euro wird verlangt."
+        )
+        corpus_release = _write_test_corpus_provision(
+            tmp_path,
+            citation_path=citation_path,
+            body=source_text,
+        )
+        rulespec_file = tmp_path / "statutes/rbeg-2021/8.yaml"
+        rulespec_file.parent.mkdir(parents=True)
+        rulespec_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/rbeg-2021/8
+rules:
+  - name: regelbedarfsstufe_one_amount
+    kind: parameter
+    dtype: Money
+    unit: EUR
+    versions:
+      - effective_from: '2021-01-01'
+        formula: 446
+""",
+            encoding="utf-8",
+        )
+
+        with (
+            patch.object(
+                ValidatorPipeline,
+                "_run_compile_check",
+                return_value=ValidationResult("compile", passed=True),
+            ),
+            patch.object(
+                ValidatorPipeline,
+                "_run_ci",
+                return_value=ValidationResult("ci", passed=True),
+            ),
+        ):
+            metrics = evaluate_artifact(
+                rulespec_file=rulespec_file,
+                policy_repo_root=_canonical_rulespec_content_root(tmp_path, "de"),
+                axiom_rules_path=tmp_path / "axiom-rules-engine",
+                source_text=source_text,
+                local_corpus_release=corpus_release,
+                source_citation_path=citation_path,
+                require_complete_source_unit=True,
+                skip_reviewers=True,
+            )
+
+        assert metrics.source_numeric_occurrence_count == 2
+        assert metrics.covered_source_numeric_occurrence_count == 1
+        assert metrics.missing_source_numeric_occurrence_count == 1
+        assert metrics.numeric_occurrence_issues == [
+            "Source numeric value 1 appears 1 time(s), but only 0 named scalar "
+            "definition(s) with that value were found."
+        ]
 
     def test_complete_mode_numeric_recall_is_summary_invariant(self, tmp_path):
         source_text = "If the 3rd digit is 5 or more, increase the 2nd digit by 1."
@@ -19353,6 +19536,86 @@ rules: []
     mock_scope.assert_called_once_with(corpus_release)
 
 
+def test_evaluate_artifact_passes_exact_attached_amendment_sources(
+    tmp_path, monkeypatch
+):
+    source_citation_path = "de/statute/estg/66"
+    source_text = "Das Kindergeld beträgt monatlich für jedes Kind 259 Euro."
+    corpus_release = _write_test_corpus_provision(
+        tmp_path,
+        citation_path=source_citation_path,
+        body=source_text,
+    )
+    policy_repo = _canonical_rulespec_content_root(tmp_path, "de")
+    rules_file = policy_repo / "statutes/estg/66.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/66
+rules: []
+""",
+        encoding="utf-8",
+    )
+    amendment_citation_path = (
+        "de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1"
+    )
+    amendment_body = (
+        "4. In § 66 Absatz 1 wird die Angabe „250 Euro“ durch die Angabe "
+        "„255 Euro“ ersetzt."
+    )
+    amendment = CorpusAmendmentDocument(
+        citation_path=amendment_citation_path,
+        title="Steuerfortentwicklungsgesetz – SteFeG",
+        expression_date="2024-12-23",
+        metadata={},
+        body=amendment_body,
+    )
+    observed_amendment_sources: list[dict[str, str] | None] = []
+    original_init = ValidatorPipeline.__init__
+
+    def recording_init(
+        pipeline,
+        *args,
+        amendment_source_texts=None,
+        **kwargs,
+    ):
+        observed_amendment_sources.append(amendment_source_texts)
+        original_init(
+            pipeline,
+            *args,
+            amendment_source_texts=amendment_source_texts,
+            **kwargs,
+        )
+
+    monkeypatch.setattr(ValidatorPipeline, "__init__", recording_init)
+    monkeypatch.setattr(
+        ValidatorPipeline,
+        "_run_compile_check",
+        lambda _self, _path: ValidationResult("compile", passed=True),
+    )
+    monkeypatch.setattr(
+        ValidatorPipeline,
+        "_run_ci",
+        lambda _self, _path: ValidationResult("ci", passed=True),
+    )
+
+    evaluate_artifact(
+        rulespec_file=rules_file,
+        policy_repo_root=policy_repo,
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        source_text=source_text,
+        skip_reviewers=True,
+        local_corpus_release=corpus_release,
+        source_citation_path=source_citation_path,
+        require_complete_source_unit=True,
+        amendment_documents=(amendment,),
+    )
+
+    assert observed_amendment_sources == [{amendment_citation_path: amendment_body}]
+
+
 class TestSourceEval:
     def test_run_model_eval_passes_validation_options_to_evaluate_artifact(
         self,
@@ -20276,7 +20539,10 @@ def _run_case_revalidation(
         corpus_citation_path="uk/statute/ukpga/1994/23/2",
         require_complete_source_unit=require_complete_source_unit,
     )
-    source_unit = SimpleNamespace(body="The rate of VAT is 20 percent.")
+    source_unit = SimpleNamespace(
+        body="The rate of VAT is 20 percent.",
+        amendment_documents=(),
+    )
     with (
         patch.object(
             evals_module, "resolve_corpus_source_unit", return_value=source_unit

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -8063,6 +8063,7 @@ def test_de_numeric_profile_terminates_at_released_juris_sentence_marker():
         (0.45, "0,45"),
         (19470.38, "19 470,38"),
         (10000.0, "Zehntausendstel"),
+        (0.0001, "Zehntausendstel"),
     ]
     assert {3.0, 38.3, 470.38}.isdisjoint({item.value for item in occurrences})
 
@@ -8471,11 +8472,179 @@ def test_de_numeric_profile_reads_german_lexical_denominators(
     source_text,
     expected,
 ):
-    assert extract_numbers_from_text(source_text, profile="de-DE") == {expected}
+    reciprocal = 1 / expected
+    assert extract_numbers_from_text(source_text, profile="de-DE") == {
+        expected,
+        reciprocal,
+    }
     assert extract_numeric_occurrences_from_text(
         source_text,
         profile="de-DE",
     ) == [expected]
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        source_text,
+        profile="de-DE",
+    )
+    assert len(inventory) == 1
+    assert inventory[0].is_word_number
+    assert inventory[0].alternative_values == (reciprocal,)
+
+
+@pytest.mark.parametrize(
+    (
+        "source_text",
+        "expected_primary",
+        "expected_alternative",
+        "expected_inventory_count",
+    ),
+    (
+        # Exact released wave-2 corpus bytes from the cited bodies.
+        (
+            "für die Hälfte ihres gemeinsam zu versteuernden Einkommens",
+            0.5,
+            2.0,
+            0,
+        ),
+        ("ein Fünftel der monatlichen Bezugsgröße", 5.0, 0.2, 1),
+        ("abzüglich eines Zwölftels des Kinderfreibetrags", 12.0, 1 / 12, 1),
+        (
+            "von einem Dreihundertsechzigstel der Beitragsbemessungsgrenze",
+            360.0,
+            1 / 360,
+            1,
+        ),
+        (
+            "ein Zehntausendstel des den Grundfreibetrag übersteigenden Teils",
+            10000,
+            0.0001,
+            1,
+        ),
+    ),
+)
+def test_de_word_fraction_candidates_do_not_duplicate_recall_obligation(
+    source_text,
+    expected_primary,
+    expected_alternative,
+    expected_inventory_count,
+):
+    grounding = extract_typed_numeric_occurrences_from_text(
+        source_text,
+        profile="de-DE",
+    )
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        source_text,
+        profile="de-DE",
+    )
+    word_grounding = [item for item in grounding if item.is_word_number]
+
+    assert [item.value for item in word_grounding] == [
+        expected_primary,
+        expected_alternative,
+    ]
+    assert len(inventory) == expected_inventory_count
+    if inventory:
+        assert inventory[0].value == expected_primary
+        assert inventory[0].alternative_values == (expected_alternative,)
+    assert numeric_value_is_grounded(expected_primary, grounding)
+    assert numeric_value_is_grounded(expected_alternative, grounding)
+
+
+@pytest.mark.parametrize(
+    ("source_text", "expected"),
+    (
+        ("Haben zwei Partner Anspruch auf Leistungen", 2.0),
+        ("in nicht mehr als zwei Kalendermonaten", 2.0),
+        ("nach Ablauf von drei Sitzungswochen", 3.0),
+        ("durch drei geteilt", 3.0),
+        ("für sechs Monate", 6.0),
+        ("sieben Dreihundertsechzigstel", 7.0),
+        ("bei einer Arbeitszeit von zehn Wochenstunden", 10.0),
+        ("nicht mit mehr als zwölf Monatswerten", 12.0),
+        ("für bis zu zwölf zu berücksichtigende Haushaltsmitglieder", 12.0),
+    ),
+)
+def test_de_quantitative_cardinals_use_exact_released_wave_phrases(
+    source_text,
+    expected,
+):
+    occurrences = extract_typed_numeric_occurrences_from_text(
+        source_text,
+        profile="de-DE",
+    )
+
+    assert any(
+        item.value == expected and item.is_word_number for item in occurrences
+    ), occurrences
+
+
+def test_de_proration_cardinals_use_exact_sgb_3_341_sentence():
+    # Exact sentence from body sha256
+    # cc18498f1bbf534679b14937e8750c38098112cd8c1bfab98a956b6a58b5378f.
+    source_text = (
+        "Für die Berechnung der Beiträge ist die Woche zu sieben, der Monat zu "
+        "dreißig und das Jahr zu dreihundertsechzig Tagen anzusetzen, soweit "
+        "dieses Buch nichts anderes bestimmt."
+    )
+
+    word_values = {
+        item.value
+        for item in extract_typed_numeric_occurrences_from_text(
+            source_text,
+            profile="de-DE",
+        )
+        if item.is_word_number
+    }
+
+    assert {7.0, 30.0, 360.0} <= word_values
+
+
+@pytest.mark.parametrize(
+    "source_text",
+    (
+        "das Zweifache des Steuerbetrags",
+        "den doppelten Kinderfreibetrag",
+    ),
+)
+def test_de_multiplier_words_emit_typed_numeric_candidates(source_text):
+    occurrences = extract_typed_numeric_occurrences_from_text(
+        source_text,
+        profile="de-DE",
+    )
+
+    assert [(item.value, item.is_word_number) for item in occurrences] == [(2.0, True)]
+
+
+def test_de_ordinal_part_emits_divisor_and_fraction_candidates():
+    occurrences = extract_typed_numeric_occurrences_from_text(
+        "der siebte Teil des Betrags",
+        profile="de-DE",
+    )
+
+    assert [item.value for item in occurrences] == [1 / 7, 7.0]
+    assert all(item.is_word_number for item in occurrences)
+
+
+@pytest.mark.parametrize(
+    ("source_text", "expected_rate"),
+    (
+        ("um 0,1 Prozentpunkte für je 2 Euro", 0.001),
+        ("nicht höher als 0,5 Beitragssatzpunkte über dem Beitragssatz", 0.005),
+        ("um 0,6 Beitragssatzpunkten", 0.006),
+        ("in Höhe von 0,25 Beitragssatzpunkten", 0.0025),
+    ),
+)
+def test_de_point_units_supply_rate_context_from_exact_wave_phrases(
+    source_text,
+    expected_rate,
+):
+    occurrences = extract_typed_numeric_occurrences_from_text(
+        source_text,
+        profile="de-DE",
+    )
+    point_occurrence = next(item for item in occurrences if item.raw.startswith("0,"))
+
+    assert point_occurrence.has_rate_context
+    assert numeric_value_is_grounded(expected_rate, occurrences)
 
 
 def test_numeric_extraction_handles_uganda_shilling_suffix():

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -700,6 +700,158 @@ def test_rulespec_numeric_output_comparison_accepts_quoted_decimal(tmp_path):
     )
 
 
+def test_complete_mode_test_mismatch_steers_estg_dual_effective_versions(tmp_path):
+    amendment_citation = (
+        "de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1"
+    )
+    amendment_source = (
+        "4. In § 66 Absatz 1 wird die Angabe „250 Euro“ durch die Angabe "
+        "„255 Euro“ ersetzt. "
+        "4. § 66 wird wie folgt geändert: a) In Absatz 1 wird die Angabe "
+        "„255 Euro“ durch die Angabe „259 Euro“ ersetzt. "
+        "Artikel 10 Inkrafttreten (1) Dieses Gesetz tritt vorbehaltlich des "
+        "Absatzes 2 am 1. Januar 2025 in Kraft. (2) Die Artikel 2, 4 und 6 "
+        "treten am 1. Januar 2026 in Kraft."
+    )
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path / "rulespec-de/de",
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+        require_complete_source_unit=True,
+        source_text=(
+            "(1) Das Kindergeld beträgt monatlich für jedes Kind 259 Euro.\n"
+            "(2) Das Kindergeld wird monatlich vom Beginn des Monats an gezahlt."
+        ),
+        source_citation_path="de/statute/estg/66",
+        amendment_source_texts={amendment_citation: amendment_source},
+    )
+
+    output_name = "de:statutes/estg/66#child_benefit_amount"
+    issues = pipeline._run_rulespec_test_cases(
+        rules_file=tmp_path / "rulespec-de/de/statutes/estg/66.yaml",
+        compiled_path=tmp_path / "compiled.json",
+        compiled_payload={
+            "program": {
+                "derived": [],
+                "parameters": [
+                    {
+                        "name": "child_benefit_amount",
+                        "id": output_name,
+                        "versions": [
+                            {
+                                "effective_from": "2025-01-01",
+                                "values": {"0": {"kind": "integer", "value": "259"}},
+                            }
+                        ],
+                    }
+                ],
+            }
+        },
+        cases=[
+            {
+                "name": "kindergeld_2025",
+                "period": {
+                    "period_kind": "tax_year",
+                    "start": "2025-01-01",
+                    "end": "2025-12-31",
+                },
+                "input": {},
+                "output": {output_name: 255},
+            }
+        ],
+    )
+
+    assert len(issues) == 1
+    issue = issues[0]
+    assert "expected integer 255, got integer 259" in issue
+    assert "Complete-source effective-version hint" in issue
+    assert amendment_citation in issue
+    assert "dual effective versions" in issue
+    assert "`255` for 2025 from the amendment" in issue
+    assert "`259` for the 2026 consolidated version" in issue
+
+
+@pytest.mark.parametrize(
+    ("require_complete_source_unit", "primary_source", "amendment_sources"),
+    (
+        (
+            False,
+            "Das Kindergeld beträgt monatlich für jedes Kind 259 Euro.",
+            {
+                "de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1": (
+                    "Die Angabe „250 Euro“ wird durch „255 Euro“ ersetzt. "
+                    "Das Gesetz gilt 2025 und 2026."
+                )
+            },
+        ),
+        (
+            True,
+            "2025 betrug das Kindergeld 255 Euro; nun beträgt es 259 Euro.",
+            {
+                "de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1": (
+                    "Die Angabe „250 Euro“ wird durch „255 Euro“ ersetzt. "
+                    "Das Gesetz gilt 2025 und 2026."
+                )
+            },
+        ),
+        (
+            True,
+            "Das Kindergeld beträgt monatlich für jedes Kind 259 Euro.",
+            {
+                "de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1": (
+                    "Die Angabe „250 Euro“ wird durch „254 Euro“ ersetzt. "
+                    "Das Gesetz gilt 2025 und 2026."
+                )
+            },
+        ),
+        (
+            True,
+            "Das Kindergeld beträgt monatlich für jedes Kind 260 Euro.",
+            {
+                "de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1": (
+                    "Die Angabe „250 Euro“ wird durch „255 Euro“ ersetzt. "
+                    "Das Gesetz gilt 2025 und 2026."
+                )
+            },
+        ),
+    ),
+)
+def test_effective_version_hint_requires_complete_amendment_primary_split(
+    tmp_path,
+    require_complete_source_unit,
+    primary_source,
+    amendment_sources,
+):
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path / "rulespec-de/de",
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+        require_complete_source_unit=require_complete_source_unit,
+        source_text=primary_source,
+        source_citation_path="de/statute/estg/66",
+        amendment_source_texts=amendment_sources,
+    )
+
+    issue = pipeline._compare_rulespec_output(
+        case_name="kindergeld_2025",
+        output_name="de:statutes/estg/66#child_benefit_amount",
+        expected_value=255,
+        actual_output={
+            "kind": "scalar",
+            "value": {"kind": "integer", "value": 259},
+        },
+        period={
+            "period_kind": "tax_year",
+            "start": "2025-01-01",
+            "end": "2025-12-31",
+        },
+    )
+
+    assert issue is not None
+    assert "expected integer 255, got integer 259" in issue
+    assert "Complete-source effective-version hint" not in issue
+
+
 def test_rulespec_compile_roots_use_only_explicit_checkouts(monkeypatch, tmp_path):
     repo_parent = tmp_path / "repos"
     policy_repo = _canonical_rulespec_content_root(repo_parent, "us-ny")
@@ -8645,6 +8797,181 @@ def test_de_point_units_supply_rate_context_from_exact_wave_phrases(
 
     assert point_occurrence.has_rate_context
     assert numeric_value_is_grounded(expected_rate, occurrences)
+
+
+def test_ungrounded_literal_names_attached_amendment_without_grounding_it():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/solzg-1995/3
+rules:
+  - name: exemption_threshold
+    kind: parameter
+    dtype: Money
+    unit: EUR
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 39900
+"""
+    primary_source = "Die Freigrenze beträgt 40 700 Euro."
+    amendment_citation = (
+        "de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1"
+    )
+    amendment_source = (
+        "aa) In Nummer 1 wird die Angabe „36 260 Euro“ durch die Angabe "
+        "„39 900 Euro“ ersetzt."
+    )
+    single_source_issues = find_ungrounded_numeric_issues(
+        content,
+        source_text=primary_source,
+        source_citation_path="de/statute/solzg-1995/3",
+        amendment_source_texts={amendment_citation: amendment_source},
+    )
+    scoped_issues = find_ungrounded_numeric_issues_scoped(
+        content,
+        module_source_text=primary_source,
+        module_citation_path="de/statute/solzg-1995/3",
+        amendment_source_texts={amendment_citation: amendment_source},
+    )
+
+    for issues in (single_source_issues, scoped_issues):
+        assert len(issues) == 1
+        assert "Ungrounded generated numeric literal" in issues[0]
+        assert amendment_citation in issues[0]
+        assert "attachment alone does not ground it" in issues[0]
+        assert "exact owning literal `path`" in issues[0]
+        assert "`path: versions[0].formula`" in issues[0]
+        assert f"source: {{corpus_citation_path: {amendment_citation}" in issues[0]
+
+    cited_content = f"""format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/solzg-1995/3
+rules:
+  - name: exemption_threshold
+    kind: parameter
+    dtype: Money
+    unit: EUR
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: {amendment_citation}
+              excerpt: {amendment_source}
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 39900
+"""
+    cited_issues = find_ungrounded_numeric_issues_scoped(
+        cited_content,
+        module_source_text=primary_source,
+        module_citation_path="de/statute/solzg-1995/3",
+        proof_source_texts={amendment_citation: amendment_source},
+        amendment_source_texts={amendment_citation: amendment_source},
+    )
+
+    assert cited_issues == []
+
+
+def test_ungrounded_literal_omits_amendment_hint_when_value_is_absent():
+    content = """format: rulespec/v1
+rules:
+  - name: exemption_threshold
+    kind: parameter
+    dtype: Money
+    unit: EUR
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 39900
+"""
+    issues = find_ungrounded_numeric_issues(
+        content,
+        source_text="Die konsolidierte Freigrenze beträgt 40 700 Euro.",
+        source_citation_path="de/statute/solzg-1995/3",
+        amendment_source_texts={
+            "de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1": (
+                "Die frühere Freigrenze beträgt 39 901 Euro."
+            )
+        },
+    )
+
+    assert len(issues) == 1
+    assert "Attached-amendment grounding hint" not in issues[0]
+
+
+def test_rulespec_ci_uses_scoped_grounding_when_amendments_are_attached(
+    tmp_path,
+):
+    amendment_citation = (
+        "de/statute/bgbl-2024-i-449/steuerfortentwicklungsgesetz/document-1"
+    )
+    amendment_source = (
+        "aa) In Nummer 1 wird die Angabe „36 260 Euro“ durch die Angabe "
+        "„39 900 Euro“ ersetzt."
+    )
+    primary_source = "Die konsolidierte Freigrenze beträgt 40 700 Euro."
+    release = _write_local_corpus_provision(
+        tmp_path / "release",
+        "de/statute/solzg-1995/3",
+        primary_source,
+    )
+    rules_file = tmp_path / "rulespec-de/de/statutes/solzg-1995/3.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+rules:
+  - name: exemption_threshold
+    kind: parameter
+    dtype: Money
+    unit: EUR
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 39900
+""",
+        encoding="utf-8",
+    )
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path / "rulespec-de/de",
+        axiom_rules_path=tmp_path / "missing-rules-engine",
+        enable_oracles=False,
+        local_corpus_release=release,
+        source_text=primary_source,
+        source_citation_path="de/statute/solzg-1995/3",
+        amendment_source_texts={amendment_citation: amendment_source},
+    )
+    failed_compile = subprocess.CompletedProcess(
+        args=[],
+        returncode=1,
+        stdout="",
+        stderr="synthetic compile failure",
+    )
+
+    with (
+        patch.object(
+            pipeline,
+            "_compile_rulespec_to_artifact",
+            return_value=(failed_compile, None),
+        ),
+        patch.object(
+            validator_pipeline,
+            "find_ungrounded_numeric_issues",
+            return_value=[],
+        ) as single_source,
+        patch.object(
+            validator_pipeline,
+            "find_ungrounded_numeric_issues_scoped",
+            return_value=[],
+        ) as scoped,
+    ):
+        pipeline._run_ci(rules_file)
+
+    single_source.assert_not_called()
+    assert scoped.call_args.kwargs["module_source_text"] == pipeline.source_text
+    assert scoped.call_args.kwargs["amendment_source_texts"] == {
+        amendment_citation: amendment_source
+    }
 
 
 def test_numeric_extraction_handles_uganda_shilling_suffix():

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -21,6 +21,8 @@ from axiom_encode.harness.validator_pipeline import (
     ValidatorPipeline,
     extract_named_scalar_occurrences,
     extract_typed_numeric_inventory_occurrences_from_text,
+    find_ungrounded_numeric_issues,
+    find_ungrounded_numeric_issues_scoped,
     numeric_value_is_grounded,
 )
 
@@ -450,6 +452,41 @@ MINUHV_SECTION_1_BODY = (
 )
 
 
+def _stated_conversion_rulespec_with_divisor(
+    citation_path: str,
+    parameters: tuple[tuple[str, str], ...],
+    *,
+    annual_parameter: str,
+    divisor: str,
+) -> str:
+    parameter_rules = "\n".join(
+        f"""\
+  - name: {name}
+    kind: parameter
+    dtype: Money
+    source: {citation_path}
+    versions:
+      - effective_from: '2025-01-01'
+        formula: {value}"""
+        for name, value in parameters
+    )
+    return f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: {citation_path}
+rules:
+{parameter_rules}
+  - name: derived_monthly_amount
+    kind: derived
+    dtype: Money
+    source: {citation_path}
+    versions:
+      - effective_from: '2025-01-01'
+        formula: {annual_parameter} / {divisor}
+"""
+
+
 def test_exact_svbezgrv_2025_section_1_excludes_temporal_year_from_recall():
     citation_path = "de/regulation/svbezgrv-2025/1"
     assert (
@@ -559,6 +596,178 @@ rules:
         SVBEZGRV_2025_SECTION_2_BODY,
         corpus_citation_path=citation_path,
         test_cases=[],
+    )
+
+
+@pytest.mark.parametrize(
+    ("citation_path", "source_body", "parameters", "annual_parameter"),
+    (
+        (
+            "de/regulation/svbezgrv-2025/1",
+            SVBEZGRV_2025_SECTION_1_BODY,
+            (
+                ("annual_reference_amount", "44940"),
+                ("monthly_reference_amount", "3745"),
+            ),
+            "annual_reference_amount",
+        ),
+        (
+            "de/regulation/svbezgrv-2025/2",
+            SVBEZGRV_2025_SECTION_2_BODY,
+            (
+                ("general_annual_income_limit", "73800"),
+                ("general_monthly_income_limit", "6150"),
+                ("special_annual_income_limit", "66150"),
+                ("special_monthly_income_limit", "5512.5"),
+            ),
+            "general_annual_income_limit",
+        ),
+    ),
+)
+def test_exact_svbezgrv_bare_calendar_divisor_gets_complete_mode_hint(
+    citation_path,
+    source_body,
+    parameters,
+    annual_parameter,
+):
+    content = _stated_conversion_rulespec_with_divisor(
+        citation_path,
+        parameters,
+        annual_parameter=annual_parameter,
+        divisor="12",
+    )
+
+    issues = find_ungrounded_numeric_issues_scoped(
+        content,
+        module_source_text=source_body,
+        module_citation_path=citation_path,
+        require_complete_source_unit=True,
+    )
+
+    assert len(issues) == 1
+    assert issues[0].startswith(
+        "Ungrounded generated numeric literal: 12 does not appear as a "
+        "substantive numeric value in the source text."
+    )
+    assert "separate grounded `kind: parameter` rules" in issues[0]
+    assert "annual and monthly amounts" in issues[0]
+    assert "companion tests" in issues[0]
+
+
+def test_stated_conversion_other_ungrounded_literal_keeps_original_error():
+    content = _stated_conversion_rulespec_with_divisor(
+        "de/regulation/svbezgrv-2025/1",
+        (
+            ("annual_reference_amount", "44940"),
+            ("monthly_reference_amount", "3745"),
+        ),
+        annual_parameter="annual_reference_amount",
+        divisor="13",
+    )
+
+    assert find_ungrounded_numeric_issues(
+        content,
+        source_text=SVBEZGRV_2025_SECTION_1_BODY,
+        require_complete_source_unit=True,
+    ) == [
+        "Ungrounded generated numeric literal: 13 does not appear as a "
+        "substantive numeric value in the source text."
+    ]
+
+
+def test_stated_conversion_calendar_hint_is_complete_mode_only():
+    content = _stated_conversion_rulespec_with_divisor(
+        "de/regulation/svbezgrv-2025/1",
+        (
+            ("annual_reference_amount", "44940"),
+            ("monthly_reference_amount", "3745"),
+        ),
+        annual_parameter="annual_reference_amount",
+        divisor="12",
+    )
+
+    assert find_ungrounded_numeric_issues(
+        content,
+        source_text=SVBEZGRV_2025_SECTION_1_BODY,
+    ) == [
+        "Ungrounded generated numeric literal: 12 does not appear as a "
+        "substantive numeric value in the source text."
+    ]
+
+
+@pytest.mark.parametrize("calendar_constant", ("4", "12", "24", "52", "365"))
+def test_complete_mode_stated_conversion_hint_covers_calendar_constants(
+    calendar_constant,
+):
+    content = _stated_conversion_rulespec_with_divisor(
+        "de/regulation/svbezgrv-2025/1",
+        (
+            ("annual_reference_amount", "44940"),
+            ("monthly_reference_amount", "3745"),
+        ),
+        annual_parameter="annual_reference_amount",
+        divisor=calendar_constant,
+    )
+
+    issues = find_ungrounded_numeric_issues(
+        content,
+        source_text=SVBEZGRV_2025_SECTION_1_BODY,
+        require_complete_source_unit=True,
+    )
+
+    assert len(issues) == 1
+    assert "Complete-source stated-conversion hint" in issues[0]
+
+
+def test_stated_conversion_hint_requires_module_source_citation():
+    content = """\
+format: rulespec/v1
+module:
+  summary: Annual and monthly amounts.
+rules:
+  - name: derived_monthly_amount
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '2025-01-01'
+        formula: annual_reference_amount / 12
+"""
+
+    assert find_ungrounded_numeric_issues(
+        content,
+        source_text=SVBEZGRV_2025_SECTION_1_BODY,
+        require_complete_source_unit=True,
+    ) == [
+        "Ungrounded generated numeric literal: 12 does not appear as a "
+        "substantive numeric value in the source text."
+    ]
+
+
+def test_explicit_calendar_literal_in_source_grounds_normally():
+    citation_path = "de/regulation/example/1"
+    source = "Der Jahresbetrag ist das 12-Fache des Monatsbetrags."
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: {citation_path}
+rules:
+  - name: annual_amount
+    kind: derived
+    dtype: Money
+    source: {citation_path}
+    versions:
+      - effective_from: '2025-01-01'
+        formula: monthly_amount * 12
+"""
+
+    assert (
+        find_ungrounded_numeric_issues(
+            content,
+            source_text=source,
+            require_complete_source_unit=True,
+        )
+        == []
     )
 
 

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -1192,7 +1192,8 @@ module:
 rules: []
 """
 
-    result = _analyze(content, ABSATZ_6, test_cases=[])
+    released_absatz_6 = "(6) " + RELEASED_ESTG_32A_BODY.split("\n(6) ", 1)[1]
+    result = _analyze(content, released_absatz_6, test_cases=[])
 
     assert _has_issue(result, "(6)", "deferral")
     issue = next(

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -1862,6 +1862,28 @@ def test_structural_labels_are_typed_grounding_only(source_text):
     assert not inventory
 
 
+@pytest.mark.parametrize(
+    "source_text",
+    (
+        "The details appear in regs. 123.45.",
+        "Use the 2nd digit and inspect the 3rd digit.",
+    ),
+)
+def test_english_structural_labels_are_typed_grounding_only(source_text):
+    grounding = extract_typed_numeric_occurrences_from_text(
+        source_text,
+        profile="legacy",
+    )
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        source_text,
+        profile="legacy",
+    )
+
+    assert grounding
+    assert all(occurrence.has_structural_context for occurrence in grounding)
+    assert not inventory
+
+
 def test_structural_range_markers_stay_out_of_numeric_recall():
     inventory = extract_typed_numeric_inventory_occurrences_from_text(
         "(1) bis (3) gelten entsprechend.",

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -21,6 +21,7 @@ from axiom_encode.harness.validator_pipeline import (
     ValidatorPipeline,
     extract_named_scalar_occurrences,
     extract_typed_numeric_inventory_occurrences_from_text,
+    extract_typed_numeric_occurrences_from_text,
     find_ungrounded_numeric_issues,
     find_ungrounded_numeric_issues_scoped,
     numeric_value_is_grounded,
@@ -1765,6 +1766,133 @@ rules:
     result = _analyze(content, source, test_cases=[])
 
     assert _has_issue(result, "73", "numeric-recall")
+
+
+RELEASED_RBEG_2021_8_BODY = """\
+Die Regelbedarfsstufen nach der Anlage zu § 28 des Zwölften Buches Sozialgesetzbuch belaufen sich zum 1. Januar 2021
+1. in der Regelbedarfsstufe 1 auf 446 Euro für jede erwachsene Person, die in einer Wohnung nach § 42a Absatz 2 Satz 2 des Zwölften Buches Sozialgesetzbuch lebt und für die nicht Nummer 2 gilt,
+2. in der Regelbedarfsstufe 2 auf 401 Euro für jede erwachsene Person, die
+a) in einer Wohnung nach § 42a Absatz 2 Satz 2 des Zwölften Buches Sozialgesetzbuch mit einem Ehegatten oder Lebenspartner oder in eheähnlicher oder lebenspartnerschaftsähnlicher Gemeinschaft mit einem Partner zusammenlebt oder
+b) nicht in einer Wohnung lebt, weil ihr allein oder mit einer weiteren Person ein persönlicher Wohnraum und mit weiteren Personen zusätzliche Räumlichkeiten nach § 42a Absatz 2 Satz 3 des Zwölften Buches Sozialgesetzbuch zur gemeinschaftlichen Nutzung überlassen sind,
+3. in der Regelbedarfsstufe 3 auf 357 Euro für eine erwachsene Person, deren notwendiger Lebensunterhalt sich nach § 27b des Zwölften Buches Sozialgesetzbuch bestimmt (Unterbringung in einer stationären Einrichtung),
+4. in der Regelbedarfsstufe 4 auf 373 Euro für eine Jugendliche oder einen Jugendlichen vom Beginn des 15. bis zur Vollendung des 18. Lebensjahres,
+5. in der Regelbedarfsstufe 5 auf 309 Euro für ein Kind vom Beginn des siebten bis zur Vollendung des 14. Lebensjahres und
+6. in der Regelbedarfsstufe 6 auf 283 Euro für ein Kind bis zur Vollendung des sechsten Lebensjahres."""
+
+
+def test_released_rbeg_stage_and_reference_labels_stay_out_of_numeric_recall():
+    assert (
+        hashlib.sha256(RELEASED_RBEG_2021_8_BODY.encode()).hexdigest()
+        == "0783343f3ce3c3b691ea8bee3047e3a818af42b0da4902c6ff3b28c372e4a964"
+    )
+    grounding = extract_typed_numeric_occurrences_from_text(
+        RELEASED_RBEG_2021_8_BODY,
+        profile="de-DE",
+    )
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        RELEASED_RBEG_2021_8_BODY,
+        profile="de-DE",
+    )
+
+    assert any(
+        occurrence.raw == "1" and occurrence.has_structural_context
+        for occurrence in grounding
+    )
+    assert [occurrence.value for occurrence in inventory] == [
+        446.0,
+        401.0,
+        357.0,
+        373.0,
+        15.0,
+        18.0,
+        309.0,
+        14.0,
+        283.0,
+    ]
+
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/rbeg-2021/8
+rules: []
+"""
+    result = _analyze(
+        content,
+        RELEASED_RBEG_2021_8_BODY,
+        corpus_citation_path="de/statute/rbeg-2021/8",
+        artifact_numeric_values=tuple(occurrence.value for occurrence in inventory),
+    )
+
+    assert not _has_issue(result, "numeric-recall")
+
+
+@pytest.mark.parametrize(
+    "source_text",
+    (
+        "Die Leistung richtet sich nach Stufe 1.",
+        "Die Einzelheiten stehen in Anlage 1.",
+        "Die Verweisung lautet §1 Absatz 2 Satz 3 Nummer 4.",
+    ),
+)
+def test_structural_labels_are_typed_grounding_only(source_text):
+    grounding = extract_typed_numeric_occurrences_from_text(
+        source_text,
+        profile="de-DE",
+    )
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        source_text,
+        profile="de-DE",
+    )
+
+    assert grounding
+    assert all(occurrence.has_structural_context for occurrence in grounding)
+    assert not inventory
+
+
+def test_structural_range_markers_stay_out_of_numeric_recall():
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        "(1) bis (3) gelten entsprechend.",
+        profile="de-DE",
+    )
+
+    assert not inventory
+
+
+def test_structural_stage_label_does_not_exempt_one_euro_from_numeric_recall():
+    source = "Regelbedarfsstufe 1: Die Leistung beträgt 1 Euro."
+    grounding = extract_typed_numeric_occurrences_from_text(source, profile="de-DE")
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        source,
+        profile="de-DE",
+    )
+
+    assert [
+        (occurrence.value, occurrence.has_structural_context)
+        for occurrence in grounding
+    ] == [
+        (1.0, True),
+        (1.0, False),
+    ]
+    assert [(occurrence.value, occurrence.raw) for occurrence in inventory] == [
+        (1.0, "1")
+    ]
+
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/rbeg-2021/8
+rules: []
+"""
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="de/statute/rbeg-2021/8",
+        artifact_numeric_values=(),
+    )
+
+    assert _has_issue(result, "numeric-recall", "value 1")
 
 
 def test_imported_numeric_recall_only_credits_explicit_imported_scalar():

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -15,6 +15,7 @@ from axiom_encode.harness.source_completeness import (
     collect_artifact_numeric_values,
     recognize_source_structure,
     source_states_explicit_computation,
+    source_states_stated_conversion_result,
 )
 from axiom_encode.harness.validator_pipeline import (
     ValidatorPipeline,
@@ -1246,6 +1247,33 @@ rules:
     ],
 )
 def test_additional_formula_language_is_computation(source: str):
+    assert source_states_explicit_computation(source)
+
+
+@pytest.mark.parametrize("result_phrase", ["ergibt sich", "ergeben sich"])
+def test_stated_conversion_result_is_not_a_formula_mandate(result_phrase: str):
+    source = (
+        "Der Jahresbetrag beträgt 73 800 Euro. "
+        f"Umgerechnet auf den Monat {result_phrase} 6 150 Euro."
+    )
+
+    assert source_states_stated_conversion_result(source)
+    assert not source_states_explicit_computation(source)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "Der Monatsbetrag ergibt sich aus dem Jahresbetrag geteilt durch 12.",
+        "Der Jahresbetrag beträgt das 12-Fache des Monatsbetrags.",
+        (
+            "Der Jahresbetrag beträgt 73 800 Euro. "
+            "Umgerechnet auf den Monat ergibt sich 6 150 Euro. "
+            "Der Zuschlag ergibt sich aus dem Monatsbetrag plus 10 Euro."
+        ),
+    ],
+)
+def test_stated_conversion_exemption_preserves_actual_formulas(source: str):
     assert source_states_explicit_computation(source)
 
 

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -743,6 +743,41 @@ rules:
     ]
 
 
+def test_stated_conversion_hint_requires_exact_source_citation_binding():
+    content = _stated_conversion_rulespec_with_divisor(
+        "de/regulation/wrong/9",
+        (
+            ("annual_reference_amount", "44940"),
+            ("monthly_reference_amount", "3745"),
+        ),
+        annual_parameter="annual_reference_amount",
+        divisor="12",
+    )
+    expected = [
+        "Ungrounded generated numeric literal: 12 does not appear as a "
+        "substantive numeric value in the source text."
+    ]
+
+    assert (
+        find_ungrounded_numeric_issues(
+            content,
+            source_text=SVBEZGRV_2025_SECTION_1_BODY,
+            source_citation_path="de/regulation/right/1",
+            require_complete_source_unit=True,
+        )
+        == expected
+    )
+    assert (
+        find_ungrounded_numeric_issues_scoped(
+            content,
+            module_source_text=SVBEZGRV_2025_SECTION_1_BODY,
+            module_citation_path="de/regulation/right/1",
+            require_complete_source_unit=True,
+        )
+        == expected
+    )
+
+
 def test_explicit_calendar_literal_in_source_grounds_normally():
     citation_path = "de/regulation/example/1"
     source = "Der Jahresbetrag ist das 12-Fache des Monatsbetrags."
@@ -1476,6 +1511,15 @@ def test_stated_conversion_result_is_not_a_formula_mandate(result_phrase: str):
         "Der Monatsbetrag ergibt sich aus dem Jahresbetrag geteilt durch 12.",
         "Der Jahresbetrag beträgt das 12-Fache des Monatsbetrags.",
         (
+            "Der Jahresbetrag beträgt 73 800 Euro. Umgerechnet auf den Monat "
+            "ergibt sich aus dem Jahresbetrag geteilt durch 12 ein Monatsbetrag "
+            "von 6 150 Euro."
+        ),
+        (
+            "The annual amount is 73,800 dollars. Converted to a monthly amount, "
+            "it is the annual amount divided by 12, or 6,150 dollars."
+        ),
+        (
             "Der Jahresbetrag beträgt 73 800 Euro. "
             "Umgerechnet auf den Monat ergibt sich 6 150 Euro. "
             "Der Zuschlag ergibt sich aus dem Monatsbetrag plus 10 Euro."
@@ -1484,6 +1528,72 @@ def test_stated_conversion_result_is_not_a_formula_mandate(result_phrase: str):
 )
 def test_stated_conversion_exemption_preserves_actual_formulas(source: str):
     assert source_states_explicit_computation(source)
+
+
+def test_stated_conversion_pair_scans_past_trailing_year():
+    source = (
+        "Der Jahresbetrag beträgt 73 800 Euro im Jahr 2025. "
+        "Umgerechnet auf den Monat ergibt sich 6 150 Euro."
+    )
+
+    assert source_states_stated_conversion_result(source)
+    assert not source_states_explicit_computation(source)
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "Nach § 12 umgerechnet auf den Monat ergibt sich 6 150 Euro.",
+        "(1) Umgerechnet auf den Monat ergibt sich 6 150 Euro.",
+    ),
+)
+def test_stated_conversion_pair_rejects_structural_number_as_base(source: str):
+    assert not source_states_stated_conversion_result(source)
+    assert source_states_explicit_computation(source)
+
+
+def test_same_clause_stated_conversion_formula_requires_derived_output():
+    source = (
+        "Der Jahresbetrag beträgt 73 800 Euro. Umgerechnet auf den Monat ergibt "
+        "sich aus dem Jahresbetrag geteilt durch 12 ein Monatsbetrag von "
+        "6 150 Euro."
+    )
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: annual_amount
+    kind: parameter
+    dtype: Money
+    source: de/statute/estg/32a
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 73800
+  - name: monthly_amount
+    kind: parameter
+    dtype: Money
+    source: de/statute/estg/32a
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 6150
+  - name: months_per_year
+    kind: parameter
+    dtype: Decimal
+    source: de/statute/estg/32a
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 12
+"""
+
+    result = _analyze(content, source, test_cases=[])
+
+    assert _has_issue(result, "formula-output", "parameter-only")
+    assert any(
+        "formula-output" in issue and "parameter-only" in issue
+        for issue in _pipeline_issues(content, source, test_cases=[])
+    )
 
 
 def test_scalar_amount_language_is_not_computation():

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -1544,6 +1544,8 @@ def test_stated_conversion_pair_scans_past_trailing_year():
     "source",
     (
         "Nach § 12 umgerechnet auf den Monat ergibt sich 6 150 Euro.",
+        "Nach den §§ 10 bis 12 umgerechnet auf den Monat ergibt sich 6 150 Euro.",
+        "Am 1. Januar 2025 gilt: Umgerechnet auf den Monat ergibt sich 6 150 Euro.",
         "(1) Umgerechnet auf den Monat ergibt sich 6 150 Euro.",
     ),
 )
@@ -1552,12 +1554,29 @@ def test_stated_conversion_pair_rejects_structural_number_as_base(source: str):
     assert source_states_explicit_computation(source)
 
 
-def test_same_clause_stated_conversion_formula_requires_derived_output():
-    source = (
-        "Der Jahresbetrag beträgt 73 800 Euro. Umgerechnet auf den Monat ergibt "
-        "sich aus dem Jahresbetrag geteilt durch 12 ein Monatsbetrag von "
-        "6 150 Euro."
-    )
+@pytest.mark.parametrize(
+    "source",
+    (
+        (
+            "Der Jahresbetrag beträgt 73 800 Euro. Umgerechnet auf den Monat "
+            "ergibt sich aus dem Jahresbetrag geteilt durch 12 ein Monatsbetrag "
+            "von 6 150 Euro."
+        ),
+        (
+            "Der Jahresbetrag beträgt 73 800 Euro. Umgerechnet auf den Monat "
+            "ergibt sich 1/12 des Jahresbetrags, nämlich 6 150 Euro."
+        ),
+        (
+            "Der Monatsbetrag beträgt 6 150 Euro. Umgerechnet auf das Jahr "
+            "ergibt sich das 12-Fache des Monatsbetrags, also 73 800 Euro."
+        ),
+        (
+            "The monthly amount is 6,150 dollars. Converted to an annual amount, "
+            "it is 12 times the monthly amount, or 73,800 dollars."
+        ),
+    ),
+)
+def test_same_clause_stated_conversion_formula_requires_derived_output(source: str):
     content = """\
 format: rulespec/v1
 module:
@@ -1594,6 +1613,33 @@ rules:
         "formula-output" in issue and "parameter-only" in issue
         for issue in _pipeline_issues(content, source, test_cases=[])
     )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "Nach den §§ 10 bis 12 umgerechnet auf den Monat ergeben sich 6 150 Euro.",
+        "Am 1. Januar 2025 gilt: Umgerechnet auf den Monat ergeben sich 6 150 Euro.",
+    ),
+)
+def test_metadata_only_numbers_do_not_activate_stated_conversion_hint(source: str):
+    citation_path = "de/regulation/example/1"
+    content = _stated_conversion_rulespec_with_divisor(
+        citation_path,
+        (("monthly_amount", "6150"),),
+        annual_parameter="annual_amount",
+        divisor="52",
+    )
+
+    assert find_ungrounded_numeric_issues(
+        content,
+        source_text=source,
+        source_citation_path=citation_path,
+        require_complete_source_unit=True,
+    ) == [
+        "Ungrounded generated numeric literal: 52 does not appear as a "
+        "substantive numeric value in the source text."
+    ]
 
 
 def test_scalar_amount_language_is_not_computation():

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -1545,13 +1545,17 @@ def test_stated_conversion_pair_scans_past_trailing_year():
     (
         "Nach § 12 umgerechnet auf den Monat ergibt sich 6 150 Euro.",
         "Nach den §§ 10 bis 12 umgerechnet auf den Monat ergibt sich 6 150 Euro.",
+        "Nach den §§ 10–12 umgerechnet auf den Monat ergibt sich 6 150 Euro.",
+        "Nach Artikel 10 bis 12 umgerechnet ergibt sich 6 150 Euro.",
+        "Nach Art. 10 bis 12 umgerechnet ergibt sich 6 150 Euro.",
+        "Under Articles 10 to 12, converted monthly, it is 6150 dollars.",
         "Am 1. Januar 2025 gilt: Umgerechnet auf den Monat ergibt sich 6 150 Euro.",
+        "Ab 2025-01-01 gilt: Umgerechnet auf den Monat ergibt sich 6 150 Euro.",
         "(1) Umgerechnet auf den Monat ergibt sich 6 150 Euro.",
     ),
 )
 def test_stated_conversion_pair_rejects_structural_number_as_base(source: str):
     assert not source_states_stated_conversion_result(source)
-    assert source_states_explicit_computation(source)
 
 
 @pytest.mark.parametrize(
@@ -1615,11 +1619,43 @@ rules:
     )
 
 
+def test_stated_conversion_pair_stops_formula_guard_at_semicolon():
+    source = (
+        "Der Jahresbetrag beträgt 73 800 Euro. Umgerechnet auf den Monat ergibt "
+        "sich 6 150 Euro; der Zuschlag ergibt sich aus dem Monatsbetrag plus "
+        "10 Euro."
+    )
+
+    assert source_states_stated_conversion_result(source)
+    assert source_states_explicit_computation(source)
+
+
+def test_stated_conversion_metadata_filter_retains_real_amounts():
+    source = (
+        "Nach § 12 beträgt der Jahresbetrag 73 800 Euro im Jahr 2025. "
+        "Umgerechnet auf den Monat ergibt sich 6 150 Euro."
+    )
+    year_sized_amount = (
+        "Der Jahresbetrag beträgt 2 025 Euro. Umgerechnet auf den Monat ergibt "
+        "sich 168,75 Euro."
+    )
+
+    assert source_states_stated_conversion_result(source)
+    assert not source_states_explicit_computation(source)
+    assert source_states_stated_conversion_result(year_sized_amount)
+    assert not source_states_explicit_computation(year_sized_amount)
+
+
 @pytest.mark.parametrize(
     "source",
     (
         "Nach den §§ 10 bis 12 umgerechnet auf den Monat ergeben sich 6 150 Euro.",
+        "Nach den §§ 10–12 umgerechnet auf den Monat ergeben sich 6 150 Euro.",
+        "Nach Artikel 10 bis 12 umgerechnet ergeben sich 6 150 Euro.",
+        "Nach Art. 10 bis 12 umgerechnet ergeben sich 6 150 Euro.",
+        "Under Articles 10 to 12, converted monthly, it is 6150 dollars.",
         "Am 1. Januar 2025 gilt: Umgerechnet auf den Monat ergeben sich 6 150 Euro.",
+        "Ab 2025-01-01 gilt: Umgerechnet auf den Monat ergeben sich 6 150 Euro.",
     ),
 )
 def test_metadata_only_numbers_do_not_activate_stated_conversion_hint(source: str):

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -1195,6 +1195,17 @@ rules: []
     result = _analyze(content, ABSATZ_6, test_cases=[])
 
     assert _has_issue(result, "(6)", "deferral")
+    issue = next(
+        issue
+        for issue in result.issues
+        if issue.startswith("[complete-source-unit:deferral]")
+    )
+    assert "Required shape" in issue
+    assert "module:\n  deferred_outputs:" in issue
+    assert "output: de:statutes/estg/32a/6#surviving_spouse_splitting_tax" in issue
+    assert "reason: Cannot be computed until" in issue
+    assert "EStG § 26" in issue
+    assert "`blocked_by` is optional" in issue
 
 
 def test_deferral_cannot_name_its_own_branch_as_missing_dependency():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1387"
+version = "0.2.1388"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
Consolidated fixes for every failure class from the first two production signed-apply dispatches on rulespec-de (runs 30193739949 / 30196429700 — 22 failed legs, all diagnosed, zero unexplained). 18 commits, built cross-family and verified by direct probes against the released corpus bodies.

## Stated conversion results (svbezgrv legs; even sol-tier fabricated `/12`)
"…auf 73 800 Euro festgesetzt. Umgerechnet auf den Monat ergeben sich 6 150 Euro" is a stated conversion **result** — the correct complete encoding is both values as grounded parameters. The classifier now treats singular `ergibt sich` like the plural (that inconsistency was the bug); complete-mode prompts guide the parameter pattern; and the ungrounded-literal error for calendar constants (12/52/365/…) carries an actionable hint the retry ladder feeds back. Genuine formula clauses (`1/12`, `12-Fache`) still demand derived outputs.

## German word-number lexicon (evidence-driven from all 24 wave bodies)
Sweep-derived table (report in ops): `Hälfte` ×16 across seven provisions, `Dreihundertsechzigstel` ×5, `Zwölftel` ×4, cardinals (`zehn Stunden`), multipliers (`Zweifache`, `doppelten`), `vom Hundert` ×9. Fraction/-stel forms emit **both** divisor and reciprocal candidates (either encoding style grounds); `Prozentpunkte`/`Beitragssatzpunkte` word forms now carry **rate context** (so `0,1 Prozentpunkte` grounds a generated `0.001`). Probes: `Hälfte`→{0.5, 2}; `0,1 Prozentpunkte`→(0.1, rate=True).

## Structural labels (gate residual, rbeg-2021/8)
"Regelbedarfsstufe 1" no longer demands a named scalar (typed `has_structural_context` on the shared occurrence machinery, filtered only from complete-mode recall); money context wins — "1 Euro" stays demanded (probed).

## Excerpt re-anchoring (dominant statute failure, incl. sol-tier attempts)
When a proof excerpt fails verbatim lookup, the repair fuzzy-locates the intended span (normalization for **matching only**) and replaces the excerpt with the **exact raw source bytes** — repair-toward-the-source, strengthening the verbatim contract. Ambiguity/ties/cross-record matches fail closed. Works for amendment documents too.

## Retry steering
Imprecise-deferral errors now show the exact required YAML shape; ungrounded literals that appear in an attached amendment document get a citation-path hint (solzg/3's `39900` = the SteFeG 2025 value); test-failure errors hint dual effective versions when the expected value lives only in the amendment (estg/66's 255/259).

## Verification
Rebased onto current main (resolving one conflict with #1298, both sides' semantics preserved — replacement-path validation AND bounded retry feedback; independently reviewed). Matrices: 424 + 259 + 416 + 2051 passed; ruff/compileall clean; full suite: failure/error node sets identical to baseline (zero new). Version 0.2.1388.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
