### PR TITLE
ci: bump signed-apply encoder pin to d8d4f1bf (wave-2 class fixes)

### DIFF
--- a/.github/workflows/signed-apply-reusable.yml
+++ b/.github/workflows/signed-apply-reusable.yml
@@ -61,7 +61,7 @@ env:
   # wave pin 185b2457). The validate workflow's encode-ref is bumped to the
   # same sha in this PR so the signed PRs' CI verifies manifests with the
   # same encoder generation that produced them.
-  AXIOM_ENCODE_REF: d662c5cbc45afb65fcaec7678bb153d49a4deee2
+  AXIOM_ENCODE_REF: d8d4f1bf211b7640120e88a1055bc67c68134109
   AXIOM_RULES_ENGINE_REF: 05eac9d2f89dabe5c6673176260762cef3a58f47
 
 jobs:


### PR DESCRIPTION
One-line pin bump so signed-apply provisions encoder 0.2.1388 with the #1299 wave-2 class fixes. Lockstep rulespec-de bump follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)