### PR TITLE
Synchronize Kentucky PolicyEngine oracle registry

### DIFF
--- a/changelog.d/ky-2026-oracle-registry.changed.md
+++ b/changelog.d/ky-2026-oracle-registry.changed.md
@@ -1,0 +1,1 @@
+Pin axiom-oracles to the reviewed Kentucky tax-year-2026 schedule-before-credits mapping while preserving the full-year return outputs as explicit source-held, not-comparable sentinels.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1388"
+version = "0.2.1389"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@eeca677b4bbce143fb0a109e4b63bcce59453e3d",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@53f3b3f42c33d22b9e5e45397489119b45a644c5",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1388"
+__version__ = "0.2.1389"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -27157,6 +27157,147 @@ mappings:
     candidate_priority: P4
     rationale: Axiom exposes the household-level work-expense allowance deduction allowed by R986-200-239 when the gross-income test is satisfied. PolicyEngine exposes person-level earned income after the work-expense allowance, not this household aggregate deduction as a one-to-one oracle target.
 
+  # Kentucky's TY2026 full-year-resident module is a source-readiness
+  # boundary. Exact P4 mappings keep its source holds and fail-closed
+  # sentinels from being treated as completed Kentucky tax results or compared
+  # with PolicyEngine's projected state-tax outputs.
+  - legal_id: us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_input_domain_is_valid
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom validates the bounded Kentucky full-year-resident and aligned-filing-unit contract; PolicyEngine exposes no one-to-one predicate.
+
+  - legal_id: us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_final_return_source_hold_applies
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This source-readiness hold records that the operative TY2026 Kentucky Form 740 final-return package is absent from the pinned corpus.
+
+  - legal_id: us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_income_and_modification_source_hold_applies
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This source-readiness hold records that the complete TY2026 Kentucky income-base, addition, and subtraction chain is not pinned.
+
+  - legal_id: us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_deduction_and_exemption_source_hold_applies
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This source-readiness hold records that the complete TY2026 Kentucky final-return deduction, election, and exemption chain is not pinned.
+
+  - legal_id: us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_tax_and_surtax_source_hold_applies
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: The regular 3.5 percent rate is official, but this hold records that final-return net income and the complete Kentucky statewide tax surface remain incomplete.
+
+  - legal_id: us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_nonrefundable_credit_source_hold_applies
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This source-readiness hold records that complete TY2026 Kentucky nonrefundable-credit eligibility, limitations, ordering, recaptures, and carryforwards are not pinned.
+
+  - legal_id: us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_refundable_credit_source_hold_applies
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This source-readiness hold records that complete TY2026 Kentucky refundable-credit eligibility, limitations, ordering, recaptures, and refundability are not pinned.
+
+  - legal_id: us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_complete_liability_source_hold_applies
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This completion-state predicate combines Axiom's Kentucky final-return, income, deduction, tax, surtax, and credit source holds.
+
+  - legal_id: us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_state_income_after_modifications
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This zero is a fail-closed sentinel while the TY2026 Kentucky income, addition, and subtraction chain is held, not completed state income after modifications.
+
+  - legal_id: us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_deductions_and_exemptions
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This zero is a fail-closed sentinel while the Kentucky final-return deduction, election, and exemption chain is held, not a completed deduction amount.
+
+  - legal_id: us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_taxable_income
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This zero is a fail-closed sentinel while Kentucky income, deductions, and exemptions are held, not completed Kentucky taxable or net income.
+
+  - legal_id: us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_tax_before_credits_including_statewide_surtaxes
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This zero is a fail-closed sentinel while final-return net income and statewide tax applicability are held, not completed before-credit Kentucky tax.
+
+  - legal_id: us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_tax_after_nonrefundable_credits
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This zero is a fail-closed sentinel while Kentucky nonrefundable-credit authority and ordering are held, not completed after-credit tax.
+
+  - legal_id: us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_refundable_credits
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This zero is a fail-closed sentinel while the Kentucky refundable-credit inventory and ordering are held, not a completed credit amount.
+
+  - legal_id: us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_net_income_tax_liability_before_payments
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This signed-liability zero is a fail-closed sentinel while the annual Kentucky chain is held and must not be interpreted as zero tax.
+
+  # KRS 141.020 is a narrow schedule-before-credits surface, separate from the
+  # annual-return source hold above. The caller supplies completed Kentucky net
+  # income; the module applies only the official 2026 rate and claims neither
+  # upstream return construction nor any post-credit liability.
+  - legal_id: us-ky:policies/income_tax/2026_krs_141_020_schedule_before_credits#ky_pit_2026_krs_141_020_rate
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ky.tax.income.rate
+    period: year
+    unit: rate
+    comparison: rate
+    rationale: KRS 141.020(2)(f) and PolicyEngine's Kentucky income-tax rate parameter both supply the 3.5 percent rate for tax year 2026.
+
+  - legal_id: us-ky:policies/income_tax/2026_krs_141_020_schedule_before_credits#ky_pit_2026_krs_141_020_net_income_boundary
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes its nonnegative caller-supplied completed-net-income boundary as a private diagnostic. PolicyEngine splits Kentucky taxable income between joint and separate-return Person variables and does not expose this selected TaxUnit boundary as one standalone variable; the reviewed Populace bridge follows PolicyEngine's upstream ky_files_separately branch to select the corresponding Person-summed boundary.
+
+  - legal_id: us-ky:policies/income_tax/2026_krs_141_020_schedule_before_credits#ky_pit_2026_krs_141_020_schedule_before_credits
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: ky_income_tax_before_non_refundable_credits_unit
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Both outputs apply Kentucky's annual income-tax rate to completed nonnegative Kentucky net or taxable income before subtracting any allowable nonrefundable or refundable credits.
+
 prefixes:
   - legal_id_prefix: us-dc:statutes/4/4-205/49#
     country: us

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5002,6 +5002,62 @@ def test_policyengine_registry_is_legal_id_keyed():
     )
 
 
+def test_packaged_kentucky_2026_oracle_registry_and_pin_are_synchronized():
+    root = Path(__file__).parents[1]
+    document = yaml.safe_load(
+        (root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml").read_text()
+    )
+    records = {
+        item["legal_id"]: item
+        for item in document["mappings"]
+        if item.get("legal_id", "").startswith("us-ky:policies/income_tax/2026_")
+    }
+    source_hold_prefix = (
+        "us-ky:policies/income_tax/2026_full_year_resident_source_hold#"
+    )
+    source_holds = {
+        legal_id: item
+        for legal_id, item in records.items()
+        if legal_id.startswith(source_hold_prefix)
+    }
+    schedule_prefix = (
+        "us-ky:policies/income_tax/2026_krs_141_020_schedule_before_credits#"
+    )
+    schedule = {
+        legal_id.removeprefix(schedule_prefix): item
+        for legal_id, item in records.items()
+        if legal_id.startswith(schedule_prefix)
+    }
+
+    assert len(source_holds) == 15
+    assert {item["mapping_type"] for item in source_holds.values()} == {
+        "not_comparable"
+    }
+    assert {item["candidate_priority"] for item in source_holds.values()} == {"P4"}
+    assert set(schedule) == {
+        "ky_pit_2026_krs_141_020_rate",
+        "ky_pit_2026_krs_141_020_net_income_boundary",
+        "ky_pit_2026_krs_141_020_schedule_before_credits",
+    }
+    assert (
+        schedule["ky_pit_2026_krs_141_020_rate"]["policyengine_parameter"]
+        == "gov.states.ky.tax.income.rate"
+    )
+    assert (
+        schedule["ky_pit_2026_krs_141_020_schedule_before_credits"][
+            "policyengine_variable"
+        ]
+        == "ky_income_tax_before_non_refundable_credits_unit"
+    )
+
+    dependency_pin = re.search(
+        r"axiom-oracles@[0-9a-f]{40}", (root / "pyproject.toml").read_text()
+    )
+    assert dependency_pin is not None
+    pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
+    assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
+
+
 def test_policyengine_registry_classifies_medicaid_435_120_helpers_not_comparable():
     registry = load_policyengine_registry()
 

--- a/uv.lock
+++ b/uv.lock
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=eeca677b4bbce143fb0a109e4b63bcce59453e3d" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=53f3b3f42c33d22b9e5e45397489119b45a644c5" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=eeca677b4bbce143fb0a109e4b63bcce59453e3d#eeca677b4bbce143fb0a109e4b63bcce59453e3d" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=53f3b3f42c33d22b9e5e45397489119b45a644c5#53f3b3f42c33d22b9e5e45397489119b45a644c5" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1388"
+version = "0.2.1389"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Outcome

Synchronizes axiom-encode with the Kentucky canonical schedule oracle in axiom-oracles PR #369 and pins the exact runtime commit.

The bundled registry gains 18 Kentucky records: the canonical 3.5% rate, canonical schedule-before-credits direct comparison, explicit completed-net-income boundary disposition, and the 15 existing full-year source-hold classifications that were missing from the encoder mirror.

## Semantics

- public schedule -> `ky_income_tax_before_non_refundable_credits_unit`
- statutory rate -> `gov.states.ky.tax.income.rate`
- caller-supplied completed-net-income boundary -> explicit `not_comparable`
- source-held annual outputs remain explicit sentinels/not-comparable; no final annual liability claim

## Verification

- ruff passed
- compileall passed
- focused synchronized-registry tests: 2/2 passed
- exact encoder/oracle YAML mirror: 18/18 records identical
- full pytest: 5,931 passed, 119 skipped
- `uv lock --check` passes now that oracle commit `53f3b3f4` is published on the draft branch

## Integration blocker under audit

Using the new oracle pin against the current rulespec-us tree also identifies 189 non-Kentucky pending declarations as stale. Those are not being blindly drained: the campaign already found broad state-prefix fallbacks that can falsely classify canonical tax outputs. A read-only exact-vs-prefix audit is underway, and this PR remains draft until that whole-ECPS impact is categorized and the review-fix cycle is clean.

## Review cycle

Requires independent exact-head review before ready/merge, including the dependency pin, bundled/runtime registry parity, and global pending-coverage impact.