### PR TITLE
Bundle Alabama 2026 schedule oracle mappings

### DIFF
--- a/changelog.d/al-2026-section-40-18-5-oracle-registry.changed.md
+++ b/changelog.d/al-2026-section-40-18-5-oracle-registry.changed.md
@@ -1,0 +1,1 @@
+Bundle Alabama's nine exact TY2026 section 40-18-5 schedule oracle mappings and pin the reviewed oracle implementation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1389"
+version = "0.2.1390"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@53f3b3f42c33d22b9e5e45397489119b45a644c5",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@67fea9c9a7afdb5d8eaf7a99971cfd9be578d7f3",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1389"
+__version__ = "0.2.1390"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -27298,6 +27298,105 @@ mappings:
     comparison: money
     rationale: Both outputs apply Kentucky's annual income-tax rate to completed nonnegative Kentucky net or taxable income before subtracting any allowable nonrefundable or refundable credits.
 
+  # Alabama Code section 40-18-5 is a narrow schedule-before-credits surface.
+  # These exact entries override the jurisdiction-wide Alabama fallback without
+  # claiming that the separate source-held annual-return pipeline is complete.
+  - legal_id: us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_first_rate
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.al.tax.income.rates.single
+    parameter_key_path: [rates, 0]
+    period: year
+    comparison: rate
+    rationale: Same two percent first-bracket rate; PolicyEngine's Alabama joint and nonjoint scales share all three marginal rates, so the single scale is the exact canonical parameter target.
+
+  - legal_id: us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_second_rate
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.al.tax.income.rates.single
+    parameter_key_path: [rates, 1]
+    period: year
+    comparison: rate
+    rationale: Same four percent second-bracket rate; PolicyEngine's Alabama joint and nonjoint scales share all three marginal rates, so the single scale is the exact canonical parameter target.
+
+  - legal_id: us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_third_rate
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.al.tax.income.rates.single
+    parameter_key_path: [rates, 2]
+    period: year
+    comparison: rate
+    rationale: Same five percent third-bracket rate; PolicyEngine's Alabama joint and nonjoint scales share all three marginal rates, so the single scale is the exact canonical parameter target.
+
+  - legal_id: us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_nonjoint_first_bracket_ceiling
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.al.tax.income.rates.single
+    parameter_key_path: [thresholds, 1]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same 500 dollar first-bracket ceiling in PolicyEngine's Alabama nonjoint schedule.
+
+  - legal_id: us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_nonjoint_second_bracket_ceiling
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.al.tax.income.rates.single
+    parameter_key_path: [thresholds, 2]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same 3,000 dollar second-bracket ceiling in PolicyEngine's Alabama nonjoint schedule.
+
+  - legal_id: us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_joint_first_bracket_ceiling
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.al.tax.income.rates.joint
+    parameter_key_path: [thresholds, 1]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same 1,000 dollar first-bracket ceiling in PolicyEngine's Alabama joint schedule.
+
+  - legal_id: us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_joint_second_bracket_ceiling
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.al.tax.income.rates.joint
+    parameter_key_path: [thresholds, 2]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same 6,000 dollar second-bracket ceiling in PolicyEngine's Alabama joint schedule.
+
+  - legal_id: us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_taxable_income_boundary
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: al_taxable_income
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: RuleSpec preserves the completed Alabama taxable-income boundary supplied by the validated Populace projection before applying the nonnegative schedule floor.
+
+  - legal_id: us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_schedule_before_credits
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: al_income_tax_before_non_refundable_credits
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Both outputs apply the Alabama section 40-18-5 schedule to completed Alabama taxable income before nonrefundable credits; neither mapping claims final annual liability.
+
 prefixes:
   - legal_id_prefix: us-dc:statutes/4/4-205/49#
     country: us

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5058,6 +5058,79 @@ def test_packaged_kentucky_2026_oracle_registry_and_pin_are_synchronized():
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
+def test_packaged_alabama_2026_schedule_registry_and_fallback_are_synchronized():
+    root = Path(__file__).parents[1]
+    document = yaml.safe_load(
+        (root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml").read_text()
+    )
+    schedule_prefix = (
+        "us-al:policies/income_tax/"
+        "2026_section_40_18_5_schedule_before_credits#"
+    )
+    schedule = {
+        item["legal_id"].removeprefix(schedule_prefix): item
+        for item in document["mappings"]
+        if item.get("legal_id", "").startswith(schedule_prefix)
+    }
+
+    assert set(schedule) == {
+        "al_pit_2026_section_40_18_5_first_rate",
+        "al_pit_2026_section_40_18_5_second_rate",
+        "al_pit_2026_section_40_18_5_third_rate",
+        "al_pit_2026_section_40_18_5_nonjoint_first_bracket_ceiling",
+        "al_pit_2026_section_40_18_5_nonjoint_second_bracket_ceiling",
+        "al_pit_2026_section_40_18_5_joint_first_bracket_ceiling",
+        "al_pit_2026_section_40_18_5_joint_second_bracket_ceiling",
+        "al_pit_2026_section_40_18_5_taxable_income_boundary",
+        "al_pit_2026_section_40_18_5_schedule_before_credits",
+    }
+    assert {
+        name: item["mapping_type"] for name, item in schedule.items()
+    } == {
+        "al_pit_2026_section_40_18_5_first_rate": "parameter_value",
+        "al_pit_2026_section_40_18_5_second_rate": "parameter_value",
+        "al_pit_2026_section_40_18_5_third_rate": "parameter_value",
+        "al_pit_2026_section_40_18_5_nonjoint_first_bracket_ceiling": (
+            "parameter_value"
+        ),
+        "al_pit_2026_section_40_18_5_nonjoint_second_bracket_ceiling": (
+            "parameter_value"
+        ),
+        "al_pit_2026_section_40_18_5_joint_first_bracket_ceiling": (
+            "parameter_value"
+        ),
+        "al_pit_2026_section_40_18_5_joint_second_bracket_ceiling": (
+            "parameter_value"
+        ),
+        "al_pit_2026_section_40_18_5_taxable_income_boundary": "direct_variable",
+        "al_pit_2026_section_40_18_5_schedule_before_credits": "direct_variable",
+    }
+
+    registry = load_policyengine_registry()
+    exact = registry.mapping_for_legal_id(
+        f"{schedule_prefix}al_pit_2026_section_40_18_5_first_rate",
+        country="us",
+    )
+    fallback = registry.mapping_for_legal_id(
+        "us-al:policies/income_tax/unrelated#future_output",
+        country="us",
+    )
+    assert exact is not None
+    assert exact.match_type == "exact"
+    assert exact.mapping_type == "parameter_value"
+    assert fallback is not None
+    assert fallback.match_type == "prefix"
+    assert fallback.mapping_type == "not_comparable"
+
+    dependency_pin = re.search(
+        r"axiom-oracles@[0-9a-f]{40}", (root / "pyproject.toml").read_text()
+    )
+    assert dependency_pin is not None
+    pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
+    assert pin == "67fea9c9a7afdb5d8eaf7a99971cfd9be578d7f3"
+    assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
+
+
 def test_policyengine_registry_classifies_medicaid_435_120_helpers_not_comparable():
     registry = load_policyengine_registry()
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5064,8 +5064,7 @@ def test_packaged_alabama_2026_schedule_registry_and_fallback_are_synchronized()
         (root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml").read_text()
     )
     schedule_prefix = (
-        "us-al:policies/income_tax/"
-        "2026_section_40_18_5_schedule_before_credits#"
+        "us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#"
     )
     schedule = {
         item["legal_id"].removeprefix(schedule_prefix): item
@@ -5084,9 +5083,7 @@ def test_packaged_alabama_2026_schedule_registry_and_fallback_are_synchronized()
         "al_pit_2026_section_40_18_5_taxable_income_boundary",
         "al_pit_2026_section_40_18_5_schedule_before_credits",
     }
-    assert {
-        name: item["mapping_type"] for name, item in schedule.items()
-    } == {
+    assert {name: item["mapping_type"] for name, item in schedule.items()} == {
         "al_pit_2026_section_40_18_5_first_rate": "parameter_value",
         "al_pit_2026_section_40_18_5_second_rate": "parameter_value",
         "al_pit_2026_section_40_18_5_third_rate": "parameter_value",
@@ -5096,12 +5093,8 @@ def test_packaged_alabama_2026_schedule_registry_and_fallback_are_synchronized()
         "al_pit_2026_section_40_18_5_nonjoint_second_bracket_ceiling": (
             "parameter_value"
         ),
-        "al_pit_2026_section_40_18_5_joint_first_bracket_ceiling": (
-            "parameter_value"
-        ),
-        "al_pit_2026_section_40_18_5_joint_second_bracket_ceiling": (
-            "parameter_value"
-        ),
+        "al_pit_2026_section_40_18_5_joint_first_bracket_ceiling": ("parameter_value"),
+        "al_pit_2026_section_40_18_5_joint_second_bracket_ceiling": ("parameter_value"),
         "al_pit_2026_section_40_18_5_taxable_income_boundary": "direct_variable",
         "al_pit_2026_section_40_18_5_schedule_before_credits": "direct_variable",
     }

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1389"
+version = "0.2.1390"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=53f3b3f42c33d22b9e5e45397489119b45a644c5" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=67fea9c9a7afdb5d8eaf7a99971cfd9be578d7f3" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=53f3b3f42c33d22b9e5e45397489119b45a644c5#53f3b3f42c33d22b9e5e45397489119b45a644c5" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=67fea9c9a7afdb5d8eaf7a99971cfd9be578d7f3#67fea9c9a7afdb5d8eaf7a99971cfd9be578d7f3" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- mirror the nine reviewed Alabama TY2026 section 40-18-5 exact oracle mappings into the packaged encoder registry
- retain the jurisdiction-wide `us-al:` not-comparable fallback for unrelated Alabama outputs
- pin axiom-oracles to merged Alabama oracle commit `67fea9c9` and bump axiom-encode to `0.2.1390`
- add exact-set, mapping-type, precedence, and dependency-lock regression coverage

This is a narrow schedule-before-credits surface. It does not claim the source-held Alabama annual-return liability pipeline is complete.

## Validation

- focused registry/version tests: passed
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`: passed
- `python -m compileall -q src/axiom_encode scripts`: passed
- full `uv run pytest`: running; draft remains blocked until terminal green and independent review cycle completes

## Dependency

- axiom-oracles #370 merged at `67fea9c9`; post-merge CI green