### PR TITLE
Bundle Connecticut 2026 ordinary-tax oracle mappings

### DIFF
--- a/changelog.d/ct-2026-ordinary-tax-oracle-registry.changed.md
+++ b/changelog.d/ct-2026-ordinary-tax-oracle-registry.changed.md
@@ -1,1 +1,1 @@
-Bundle Connecticut's 45 exact TY2026 ordinary-tax-before-personal-credit oracle mappings and pin the reviewed component oracle without claiming complete annual liability.
+Bundle Connecticut's 45 exact TY2026 ordinary-tax-before-personal-credit oracle mappings and pin their durable reviewed oracle-main merge without claiming complete annual liability.

--- a/changelog.d/ct-2026-ordinary-tax-oracle-registry.changed.md
+++ b/changelog.d/ct-2026-ordinary-tax-oracle-registry.changed.md
@@ -1,0 +1,1 @@
+Bundle Connecticut's 45 exact TY2026 ordinary-tax-before-personal-credit oracle mappings and pin the reviewed component oracle without claiming complete annual liability.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1390"
+version = "0.2.1391"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@67fea9c9a7afdb5d8eaf7a99971cfd9be578d7f3",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@525cd57166283db01810798ed89ca0c75449a6d4",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1391"
+version = "0.2.1392"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@525cd57166283db01810798ed89ca0c75449a6d4",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@abe2520193439467d5fd1ada46476fc7f05d0611",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1391"
+__version__ = "0.2.1392"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1390"
+__version__ = "0.2.1391"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -27397,6 +27397,486 @@ mappings:
     comparison: money
     rationale: Both outputs apply the Alabama section 40-18-5 schedule to completed Alabama taxable income before nonrefundable credits; neither mapping claims final annual liability.
 
+  # Canonical Connecticut TY2026 full-year-resident ordinary section 12-700
+  # tax before the personal credit. PolicyEngine publishes every statutory
+  # component and the after-personal-credit result, so the pre-credit total is
+  # recovered exactly from PE's own formula rather than reimplemented here.
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_filing_status_is_valid
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom validates exactly one of four schedule flags; PolicyEngine uses a categorical filing-status input and exposes no one-to-one validation judgment.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_input_domain_is_valid
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom validates its bounded full-year-resident completed-return input contract; PolicyEngine exposes no equivalent domain judgment.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_schedule_scale
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes an internal schedule-normalization scale; PolicyEngine's filing-status-indexed rate parameters require no one-to-one output with this helper.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_head_first_ceiling
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.rates.head_of_household
+    parameter_key_path: [thresholds, 1]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same first-bracket ceiling in PolicyEngine's Connecticut head-of-household rate scale.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_joint_first_ceiling
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.rates.joint
+    parameter_key_path: [thresholds, 1]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same first-bracket ceiling in PolicyEngine's Connecticut joint rate scale.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_rate_1
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.rates.single
+    parameter_key_path: [rates, 0]
+    period: year
+    comparison: rate
+    rationale: Same first marginal rate in PolicyEngine's Connecticut rate scale.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_rate_2
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.rates.single
+    parameter_key_path: [rates, 1]
+    period: year
+    comparison: rate
+    rationale: Same second marginal rate in PolicyEngine's Connecticut rate scale.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_rate_3
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.rates.single
+    parameter_key_path: [rates, 2]
+    period: year
+    comparison: rate
+    rationale: Same third marginal rate in PolicyEngine's Connecticut rate scale.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_rate_4
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.rates.single
+    parameter_key_path: [rates, 3]
+    period: year
+    comparison: rate
+    rationale: Same fourth marginal rate in PolicyEngine's Connecticut rate scale.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_rate_5
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.rates.single
+    parameter_key_path: [rates, 4]
+    period: year
+    comparison: rate
+    rationale: Same fifth marginal rate in PolicyEngine's Connecticut rate scale.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_rate_6
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.rates.single
+    parameter_key_path: [rates, 5]
+    period: year
+    comparison: rate
+    rationale: Same sixth marginal rate in PolicyEngine's Connecticut rate scale.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_rate_7
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.rates.single
+    parameter_key_path: [rates, 6]
+    period: year
+    comparison: rate
+    rationale: Same seventh marginal rate in PolicyEngine's Connecticut rate scale.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_single_floor_2
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.rates.single
+    parameter_key_path: [thresholds, 1]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same second-bracket floor in PolicyEngine's Connecticut single rate scale.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_single_floor_3
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.rates.single
+    parameter_key_path: [thresholds, 2]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same third-bracket floor in PolicyEngine's Connecticut single rate scale.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_single_floor_4
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.rates.single
+    parameter_key_path: [thresholds, 3]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same fourth-bracket floor in PolicyEngine's Connecticut single rate scale.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_single_floor_5
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.rates.single
+    parameter_key_path: [thresholds, 4]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same fifth-bracket floor in PolicyEngine's Connecticut single rate scale.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_single_floor_6
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.rates.single
+    parameter_key_path: [thresholds, 5]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same sixth-bracket floor in PolicyEngine's Connecticut single rate scale.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_single_floor_7
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.rates.single
+    parameter_key_path: [thresholds, 6]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same seventh-bracket floor in PolicyEngine's Connecticut single rate scale.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_single_phaseout_start
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.add_back.start
+    parameter_key_path: [SINGLE]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same single-filer low-rate phaseout start in PolicyEngine.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_head_phaseout_start
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.add_back.start
+    parameter_key_path: [HEAD_OF_HOUSEHOLD]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same head-of-household low-rate phaseout start in PolicyEngine.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_joint_phaseout_start
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.add_back.start
+    parameter_key_path: [JOINT]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same joint-filer low-rate phaseout start in PolicyEngine.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_separate_phaseout_start
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.add_back.start
+    parameter_key_path: [SEPARATE]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same married-separate low-rate phaseout start in PolicyEngine.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_single_phaseout_increment
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.add_back.increment
+    parameter_key_path: [SINGLE]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same single-filer low-rate phaseout increment in PolicyEngine.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_head_phaseout_increment
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.add_back.increment
+    parameter_key_path: [HEAD_OF_HOUSEHOLD]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same head-of-household low-rate phaseout increment in PolicyEngine.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_separate_phaseout_increment
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.add_back.increment
+    parameter_key_path: [SEPARATE]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same married-separate low-rate phaseout increment in PolicyEngine.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_single_phaseout_amount
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.add_back.amount
+    parameter_key_path: [SINGLE]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same single-filer low-rate phaseout amount in PolicyEngine.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_single_phaseout_maximum
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.add_back.max_amount
+    parameter_key_path: [SINGLE]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same single-filer low-rate phaseout maximum in PolicyEngine.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_single_low_recapture_start
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.recapture.low.start
+    parameter_key_path: [SINGLE]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same single-filer low-tier recapture start in PolicyEngine.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_single_middle_recapture_start
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.recapture.middle.start
+    parameter_key_path: [SINGLE]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same single-filer middle-tier recapture start in PolicyEngine.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_single_high_recapture_start
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.recapture.high.start
+    parameter_key_path: [SINGLE]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same single-filer high-tier recapture start in PolicyEngine.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_single_recapture_increment
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.recapture.low.increment
+    parameter_key_path: [SINGLE]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same statutory recapture increment used by PolicyEngine's Connecticut tiers.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_single_low_recapture_amount
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.recapture.low.amount
+    parameter_key_path: [SINGLE]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same single-filer low-tier recapture amount in PolicyEngine.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_single_middle_recapture_amount
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.recapture.middle.amount
+    parameter_key_path: [SINGLE]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same single-filer middle-tier recapture amount in PolicyEngine.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_single_high_recapture_amount
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.recapture.high.amount
+    parameter_key_path: [SINGLE]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same single-filer high-tier recapture amount in PolicyEngine.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_single_low_recapture_maximum
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.recapture.low.max_amount
+    parameter_key_path: [SINGLE]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same single-filer low-tier recapture maximum in PolicyEngine.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_single_middle_recapture_maximum
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.recapture.middle.max_amount
+    parameter_key_path: [SINGLE]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same single-filer middle-tier recapture maximum in PolicyEngine.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_single_high_recapture_maximum
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.recapture.high.max_amount
+    parameter_key_path: [SINGLE]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same single-filer high-tier recapture maximum in PolicyEngine.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_head_middle_recapture_amount
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.recapture.middle.amount
+    parameter_key_path: [HEAD_OF_HOUSEHOLD]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same head-of-household middle-tier recapture amount in PolicyEngine.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_tax_head_middle_recapture_maximum
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.tax.income.recapture.middle.max_amount
+    parameter_key_path: [HEAD_OF_HOUSEHOLD]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same head-of-household middle-tier recapture maximum in PolicyEngine.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_schedule_tax
+    country: us
+    program: tax
+    mapping_type: derived_expression
+    expression: ct_income_tax_after_personal_credits / (1 - ct_personal_credit_rate) - ct_income_tax_phase_out_add_back - ct_income_tax_low_tax_recapture - ct_income_tax_middle_tax_recapture - ct_income_tax_high_tax_recapture
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: PolicyEngine's own pre-credit total, recovered algebraically, less its four separately published section 12-700 addback and recapture components.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_low_rate_phaseout_addback
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: ct_income_tax_phase_out_add_back
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Connecticut low-rate phaseout addback component.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_low_recapture
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: ct_income_tax_low_tax_recapture
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Connecticut low-tier recapture component.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_middle_recapture
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: ct_income_tax_middle_tax_recapture
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Connecticut middle-tier recapture component.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_ordinary_high_recapture
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: ct_income_tax_high_tax_recapture
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Connecticut high-tier recapture component.
+
+  - legal_id: us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#ct_pit_2026_resident_ordinary_tax_before_personal_credit
+    country: us
+    program: tax
+    mapping_type: derived_expression
+    expression: ct_income_tax_after_personal_credits / (1 - ct_personal_credit_rate)
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: PolicyEngine computes this same pre-credit total internally and publishes after-personal-credit tax as total times one minus its personal-credit rate; the rate is strictly below one throughout the parameter domain.
+
 prefixes:
   - legal_id_prefix: us-dc:statutes/4/4-205/49#
     country: us

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5128,17 +5128,14 @@ def test_packaged_connecticut_2026_ordinary_tax_registry_is_exactly_synchronized
     import axiom_oracles.bridges.registry as runtime_registry_module
 
     root = Path(__file__).parents[1]
-    bundled_path = (
-        root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
-    )
+    bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
         Path(runtime_registry_module.__file__).with_name("mappings") / "us.yaml"
     )
     bundled_document = yaml.safe_load(bundled_path.read_text())
     runtime_document = yaml.safe_load(runtime_path.read_text())
     schedule_prefix = (
-        "us-ct:policies/income_tax/"
-        "2026_resident_ordinary_tax_before_personal_credit#"
+        "us-ct:policies/income_tax/2026_resident_ordinary_tax_before_personal_credit#"
     )
 
     def schedule_records(document):
@@ -5212,8 +5209,7 @@ def test_packaged_connecticut_2026_ordinary_tax_registry_is_exactly_synchronized
         country="us",
     )
     final_component = registry.mapping_for_legal_id(
-        f"{schedule_prefix}"
-        "ct_pit_2026_resident_ordinary_tax_before_personal_credit",
+        f"{schedule_prefix}ct_pit_2026_resident_ordinary_tax_before_personal_credit",
         country="us",
     )
     fallback = registry.mapping_for_legal_id(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5120,7 +5120,122 @@ def test_packaged_alabama_2026_schedule_registry_and_fallback_are_synchronized()
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "67fea9c9a7afdb5d8eaf7a99971cfd9be578d7f3"
+    assert pin == "525cd57166283db01810798ed89ca0c75449a6d4"
+    assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
+
+
+def test_packaged_connecticut_2026_ordinary_tax_registry_is_exactly_synchronized():
+    import axiom_oracles.bridges.registry as runtime_registry_module
+
+    root = Path(__file__).parents[1]
+    bundled_path = (
+        root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
+    )
+    runtime_path = (
+        Path(runtime_registry_module.__file__).with_name("mappings") / "us.yaml"
+    )
+    bundled_document = yaml.safe_load(bundled_path.read_text())
+    runtime_document = yaml.safe_load(runtime_path.read_text())
+    schedule_prefix = (
+        "us-ct:policies/income_tax/"
+        "2026_resident_ordinary_tax_before_personal_credit#"
+    )
+
+    def schedule_records(document):
+        return {
+            item["legal_id"].removeprefix(schedule_prefix): item
+            for item in document["mappings"]
+            if item.get("legal_id", "").startswith(schedule_prefix)
+        }
+
+    bundled = schedule_records(bundled_document)
+    runtime = schedule_records(runtime_document)
+    not_comparable = {
+        "ct_pit_2026_ordinary_tax_filing_status_is_valid",
+        "ct_pit_2026_ordinary_tax_input_domain_is_valid",
+        "ct_pit_2026_ordinary_tax_schedule_scale",
+    }
+    parameter_values = {
+        "ct_pit_2026_ordinary_tax_head_first_ceiling",
+        "ct_pit_2026_ordinary_tax_joint_first_ceiling",
+        *(f"ct_pit_2026_ordinary_tax_rate_{index}" for index in range(1, 8)),
+        *(f"ct_pit_2026_ordinary_tax_single_floor_{index}" for index in range(2, 8)),
+        "ct_pit_2026_ordinary_tax_single_phaseout_start",
+        "ct_pit_2026_ordinary_tax_head_phaseout_start",
+        "ct_pit_2026_ordinary_tax_joint_phaseout_start",
+        "ct_pit_2026_ordinary_tax_separate_phaseout_start",
+        "ct_pit_2026_ordinary_tax_single_phaseout_increment",
+        "ct_pit_2026_ordinary_tax_head_phaseout_increment",
+        "ct_pit_2026_ordinary_tax_separate_phaseout_increment",
+        "ct_pit_2026_ordinary_tax_single_phaseout_amount",
+        "ct_pit_2026_ordinary_tax_single_phaseout_maximum",
+        "ct_pit_2026_ordinary_tax_single_low_recapture_start",
+        "ct_pit_2026_ordinary_tax_single_middle_recapture_start",
+        "ct_pit_2026_ordinary_tax_single_high_recapture_start",
+        "ct_pit_2026_ordinary_tax_single_recapture_increment",
+        "ct_pit_2026_ordinary_tax_single_low_recapture_amount",
+        "ct_pit_2026_ordinary_tax_single_middle_recapture_amount",
+        "ct_pit_2026_ordinary_tax_single_high_recapture_amount",
+        "ct_pit_2026_ordinary_tax_single_low_recapture_maximum",
+        "ct_pit_2026_ordinary_tax_single_middle_recapture_maximum",
+        "ct_pit_2026_ordinary_tax_single_high_recapture_maximum",
+        "ct_pit_2026_ordinary_tax_head_middle_recapture_amount",
+        "ct_pit_2026_ordinary_tax_head_middle_recapture_maximum",
+    }
+    direct_variables = {
+        "ct_pit_2026_ordinary_low_rate_phaseout_addback",
+        "ct_pit_2026_ordinary_low_recapture",
+        "ct_pit_2026_ordinary_middle_recapture",
+        "ct_pit_2026_ordinary_high_recapture",
+    }
+    derived_expressions = {
+        "ct_pit_2026_ordinary_schedule_tax",
+        "ct_pit_2026_resident_ordinary_tax_before_personal_credit",
+    }
+    expected_types = {
+        **dict.fromkeys(not_comparable, "not_comparable"),
+        **dict.fromkeys(parameter_values, "parameter_value"),
+        **dict.fromkeys(direct_variables, "direct_variable"),
+        **dict.fromkeys(derived_expressions, "derived_expression"),
+    }
+
+    assert len(expected_types) == 45
+    assert set(bundled) == set(expected_types)
+    assert {name: item["mapping_type"] for name, item in bundled.items()} == (
+        expected_types
+    )
+    assert bundled == runtime
+
+    registry = load_policyengine_registry()
+    exact = registry.mapping_for_legal_id(
+        f"{schedule_prefix}ct_pit_2026_ordinary_tax_rate_1",
+        country="us",
+    )
+    final_component = registry.mapping_for_legal_id(
+        f"{schedule_prefix}"
+        "ct_pit_2026_resident_ordinary_tax_before_personal_credit",
+        country="us",
+    )
+    fallback = registry.mapping_for_legal_id(
+        "us-ct:policies/income_tax/unrelated#future_output",
+        country="us",
+    )
+    assert exact is not None
+    assert exact.match_type == "exact"
+    assert exact.mapping_type == "parameter_value"
+    assert final_component is not None
+    assert final_component.match_type == "exact"
+    assert final_component.mapping_type == "derived_expression"
+    assert fallback is not None
+    assert fallback.match_type == "prefix"
+    assert fallback.mapping_type == "not_comparable"
+
+    dependency_pin = re.search(
+        r"axiom-oracles@[0-9a-f]{40}", (root / "pyproject.toml").read_text()
+    )
+    assert dependency_pin is not None
+    pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
+    assert pin == "525cd57166283db01810798ed89ca0c75449a6d4"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5120,7 +5120,7 @@ def test_packaged_alabama_2026_schedule_registry_and_fallback_are_synchronized()
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "525cd57166283db01810798ed89ca0c75449a6d4"
+    assert pin == "abe2520193439467d5fd1ada46476fc7f05d0611"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5231,7 +5231,7 @@ def test_packaged_connecticut_2026_ordinary_tax_registry_is_exactly_synchronized
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "525cd57166283db01810798ed89ca0c75449a6d4"
+    assert pin == "abe2520193439467d5fd1ada46476fc7f05d0611"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1391"
+version = "0.2.1392"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=525cd57166283db01810798ed89ca0c75449a6d4" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=abe2520193439467d5fd1ada46476fc7f05d0611" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=525cd57166283db01810798ed89ca0c75449a6d4#525cd57166283db01810798ed89ca0c75449a6d4" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=abe2520193439467d5fd1ada46476fc7f05d0611#abe2520193439467d5fd1ada46476fc7f05d0611" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1390"
+version = "0.2.1391"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=67fea9c9a7afdb5d8eaf7a99971cfd9be578d7f3" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=525cd57166283db01810798ed89ca0c75449a6d4" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=67fea9c9a7afdb5d8eaf7a99971cfd9be578d7f3#67fea9c9a7afdb5d8eaf7a99971cfd9be578d7f3" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=525cd57166283db01810798ed89ca0c75449a6d4#525cd57166283db01810798ed89ca0c75449a6d4" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- bundle all 45 exact Connecticut TY2026 full-year-resident ordinary-tax-before-personal-credit mappings from the reviewed component oracle
- pin `axiom-oracles` to the durable reviewed oracle-main merge `abe2520193439467d5fd1ada46476fc7f05d0611`
- bump axiom-encode from base version `0.2.1390` to `0.2.1392` (`0.2.1391` for the registry integration and `0.2.1392` for the durable dependency-pin change required by version provenance)
- add exact-set, mapping-type, runtime-equality, exact-precedence, fallback, and dependency-pin regression coverage
- preserve the general `us-ct:` non-comparable fallback for unrelated outputs

This is deliberately a narrow component integration. It does not claim complete Connecticut annual income-tax liability.

## Mapping inventory

- 36 `parameter_value`
- 4 `direct_variable`
- 2 `derived_expression`
- 3 `not_comparable`
- 45 total, with bundled records exactly equal to the runtime records installed from `abe2520193439467d5fd1ada46476fc7f05d0611`
- exact mappings take precedence; one `us-ct:` prefix fallback remains for unrelated outputs

## Dependencies

- TheAxiomFoundation/axiom-oracles#371 — merged as `abe2520193439467d5fd1ada46476fc7f05d0611`; post-merge `test` and `gettsim-live` checks succeeded
- TheAxiomFoundation/rulespec-us#1121 — merged as `c3f0992433398517110883226ed2c6a4329c243f`
- TheAxiomFoundation/rulespec-us#1122 — merged as `d0263e3419bac4020ab4932eea760c452c0fe05d`

All dependency merges are durable and complete. This PR remains draft pending fresh independent review of the post-merge pin/version update and a no-actionable-findings review-fix cycle.

## Provenance fix cycle

The first committed-state full run at `c002b7c35a6c9ff061270bc3dd570397be6c18f5` reported one failure: the durable `pyproject.toml`/`uv.lock` dependency-pin change followed the `0.2.1391` version commit. The repository's provenance guard correctly required a new version. The encoder version was advanced consistently to `0.2.1392` in `pyproject.toml`, the package, and `uv.lock`, committed as `1df0cf975e925b29ae7af46429e1b30ffd386cf8`, and both focused and full suites then passed.

## Validation

- `uv run --no-sync pytest -q tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_rulespec_validation.py -k 'test_current_encoder_affecting_changes_are_behind_version_bump or packaged_connecticut_2026_ordinary_tax_registry or packaged_alabama_2026_schedule_registry or packaged_kentucky_2026_whole_tax_registry'` — 3 passed, 1344 deselected
- `uv run --no-sync pytest -q` — 5933 passed, 119 skipped
- `uv run --no-sync ruff check pyproject.toml src/axiom_encode scripts tests` — passed
- `uv run --no-sync ruff format --check src/ tests/` — 130 files already formatted
- `.venv/bin/python -m compileall -q src/axiom_encode scripts` — passed
- `git diff --check` — passed
- exact registry audit — 45 bundled, 45 runtime, exact equality, expected 36/4/2/3 mapping-type counts, one preserved `us-ct:` fallback

Validated from clean committed head `1df0cf975e925b29ae7af46429e1b30ffd386cf8`.