### PR TITLE
Bundle Georgia 2026 annual-tax oracle mappings

### DIFF
--- a/changelog.d/ga-2026-annual-tax-oracle-registry.changed.md
+++ b/changelog.d/ga-2026-annual-tax-oracle-registry.changed.md
@@ -1,0 +1,1 @@
+Bundle Georgia's two exact TY2026 section 48-7-20 annual-tax-before-nonrefundable-credits oracle mappings and pin their durable reviewed oracle-main merge without claiming taxable-income construction or final Form 500 liability.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1392"
+version = "0.2.1393"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@abe2520193439467d5fd1ada46476fc7f05d0611",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@c33a805098cb7a7c7f0dfada68b2f24cf67f588e",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1392"
+__version__ = "0.2.1393"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -27877,6 +27877,28 @@ mappings:
     comparison: money
     rationale: PolicyEngine computes this same pre-credit total internally and publishes after-personal-credit tax as total times one minus its personal-credit rate; the rate is strictly below one throughout the parameter domain.
 
+  # Georgia's canonical TY2026 section 48-7-20 surface accepts completed
+  # Georgia taxable net income and applies only the annual 4.99 percent rate.
+  # It does not construct taxable income, credits, payments, filing mechanics,
+  # or final Form 500 liability.
+  - legal_id: us-ga:policies/income_tax/2026_annual_tax_before_nonrefundable_credits#ga_pit_2026_annual_input_is_nonnegative
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom validates the caller-supplied completed Georgia taxable-net-income boundary. PolicyEngine exposes no one-to-one validation Judgment for this interface contract.
+
+  - legal_id: us-ga:policies/income_tax/2026_annual_tax_before_nonrefundable_credits#ga_pit_2026_annual_tax_before_nonrefundable_credits
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: ga_income_tax_before_non_refundable_credits
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Both outputs apply O.C.G.A. section 48-7-20 tax to completed Georgia taxable income before nonrefundable credits. This mapping excludes taxable-income construction, filing mechanics, credits, payments, and final Form 500 liability.
+
 prefixes:
   - legal_id_prefix: us-dc:statutes/4/4-205/49#
     country: us

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5120,7 +5120,7 @@ def test_packaged_alabama_2026_schedule_registry_and_fallback_are_synchronized()
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "abe2520193439467d5fd1ada46476fc7f05d0611"
+    assert pin == "c33a805098cb7a7c7f0dfada68b2f24cf67f588e"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5231,7 +5231,91 @@ def test_packaged_connecticut_2026_ordinary_tax_registry_is_exactly_synchronized
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "abe2520193439467d5fd1ada46476fc7f05d0611"
+    assert pin == "c33a805098cb7a7c7f0dfada68b2f24cf67f588e"
+    assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
+
+
+def test_packaged_georgia_2026_annual_tax_registry_is_exactly_synchronized():
+    import axiom_oracles.bridges.registry as runtime_registry_module
+
+    root = Path(__file__).parents[1]
+    bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
+    runtime_path = (
+        Path(runtime_registry_module.__file__).with_name("mappings") / "us.yaml"
+    )
+    bundled_document = yaml.safe_load(bundled_path.read_text())
+    runtime_document = yaml.safe_load(runtime_path.read_text())
+    schedule_prefix = (
+        "us-ga:policies/income_tax/2026_annual_tax_before_nonrefundable_credits#"
+    )
+
+    def schedule_records(document):
+        return {
+            item["legal_id"].removeprefix(schedule_prefix): item
+            for item in document["mappings"]
+            if item.get("legal_id", "").startswith(schedule_prefix)
+        }
+
+    bundled = schedule_records(bundled_document)
+    runtime = schedule_records(runtime_document)
+
+    assert set(bundled) == {
+        "ga_pit_2026_annual_input_is_nonnegative",
+        "ga_pit_2026_annual_tax_before_nonrefundable_credits",
+    }
+    assert bundled == runtime
+
+    private = bundled["ga_pit_2026_annual_input_is_nonnegative"]
+    assert private["mapping_type"] == "not_comparable"
+    assert private["candidate_priority"] == "P4"
+    assert "policyengine_variable" not in private
+
+    public = bundled["ga_pit_2026_annual_tax_before_nonrefundable_credits"]
+    assert public["mapping_type"] == "direct_variable"
+    assert (
+        public["policyengine_variable"] == "ga_income_tax_before_non_refundable_credits"
+    )
+    assert public["entity"] == "tax_unit"
+    assert public["period"] == "year"
+    assert public["unit"] == "USD"
+    assert public["comparison"] == "money"
+    assert "candidate_priority" not in public
+    assert "final Form 500 liability" in public["rationale"]
+
+    registry = load_policyengine_registry()
+    exact_private = registry.mapping_for_legal_id(
+        f"{schedule_prefix}ga_pit_2026_annual_input_is_nonnegative",
+        country="us",
+    )
+    exact_public = registry.mapping_for_legal_id(
+        f"{schedule_prefix}ga_pit_2026_annual_tax_before_nonrefundable_credits",
+        country="us",
+    )
+    fallback = registry.mapping_for_legal_id(
+        "us-ga:policies/income_tax/unrelated#future_output",
+        country="us",
+    )
+    assert exact_private is not None
+    assert exact_private.match_type == "exact"
+    assert exact_private.mapping_type == "not_comparable"
+    assert exact_private.candidate_priority == "P4"
+    assert exact_public is not None
+    assert exact_public.match_type == "exact"
+    assert exact_public.mapping_type == "direct_variable"
+    assert (
+        exact_public.policyengine_variable
+        == "ga_income_tax_before_non_refundable_credits"
+    )
+    assert fallback is not None
+    assert fallback.match_type == "prefix"
+    assert fallback.mapping_type == "not_comparable"
+
+    dependency_pin = re.search(
+        r"axiom-oracles@[0-9a-f]{40}", (root / "pyproject.toml").read_text()
+    )
+    assert dependency_pin is not None
+    pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
+    assert pin == "c33a805098cb7a7c7f0dfada68b2f24cf67f588e"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1392"
+version = "0.2.1393"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=abe2520193439467d5fd1ada46476fc7f05d0611" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=c33a805098cb7a7c7f0dfada68b2f24cf67f588e" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=abe2520193439467d5fd1ada46476fc7f05d0611#abe2520193439467d5fd1ada46476fc7f05d0611" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=c33a805098cb7a7c7f0dfada68b2f24cf67f588e#c33a805098cb7a7c7f0dfada68b2f24cf67f588e" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- package the two exact Georgia TY2026 section 48-7-20 annual-tax-before-nonrefundable-credits mappings from reviewed oracle merge `c33a805098cb7a7c7f0dfada68b2f24cf67f588e`
- preserve exact-before-`us-ga:` prefix precedence: the private nonnegative-input Judgment is explicit P4 `not_comparable`, while the public amount maps directly to `ga_income_tax_before_non_refundable_credits`
- pin axiom-oracles to the durable merge, update the lock, and bump axiom-encode to `0.2.1393`
- add bundled/runtime equality, mapping-shape, prefix-fallback, and pin synchronization regression coverage

## Truthful scope

This package exposes only O.C.G.A. §48-7-20 tax on caller-completed Georgia taxable net income before nonrefundable credits. It does not claim taxable-income construction, filing mechanics, credits, payments, or final Form 500 liability.

## Checks

- Ruff check: pass
- Ruff format check: pass
- compileall: pass
- Towncrier draft: pass
- focused AL/CT/GA registry and committed-version guards: 4 passed
- full local suite before commit: 5,933 passed, 119 skipped; the sole failure was the intentional version-provenance guard reading the old `HEAD` while the version bump was uncommitted
- the exact committed-version guard passed after commit
- oracle merge post-merge CI: terminal green (`test`, `gettsim-live`)

Hosted encoder CI is the authoritative full-suite check on the committed head.