### PR TITLE
Bundle Mississippi 2026 schedule oracle mappings

### DIFF
--- a/changelog.d/ms-2026-schedule-oracle-registry.changed.md
+++ b/changelog.d/ms-2026-schedule-oracle-registry.changed.md
@@ -1,0 +1,1 @@
+Bundle Mississippi's canonical TY2026 section 27-7-5 schedule mappings and pin the merged oracle registry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1393"
+version = "0.2.1394"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@c33a805098cb7a7c7f0dfada68b2f24cf67f588e",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@89d2a710f070a421b29f18fdec22df983250d19b",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1393"
+__version__ = "0.2.1394"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -27899,6 +27899,49 @@ mappings:
     comparison: money
     rationale: Both outputs apply O.C.G.A. section 48-7-20 tax to completed Georgia taxable income before nonrefundable credits. This mapping excludes taxable-income construction, filing mechanics, credits, payments, and final Form 500 liability.
 
+  # Mississippi's canonical TY2026 section 27-7-5 surface applies the enacted
+  # Person-grain schedule to one caller-completed Mississippi taxable-income
+  # amount. It does not select a filing method, construct taxable income,
+  # aggregate an annual return, apply credits, or claim final liability.
+  - legal_id: us-ms:policies/income_tax/2026_section_27_7_5_schedule#ms_pit_2026_zero_tax_ceiling
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ms.tax.income.rate
+    parameter_key_path: [thresholds, 1]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same $10,000 zero-tax ceiling in PolicyEngine's Mississippi marginal-rate scale for tax year 2026.
+
+  - legal_id: us-ms:policies/income_tax/2026_section_27_7_5_schedule#ms_pit_2026_rate
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ms.tax.income.rate
+    parameter_key_path: [rates, 1]
+    period: year
+    comparison: rate
+    rationale: Same four percent marginal rate above $10,000 in PolicyEngine's Mississippi income-tax scale for tax year 2026.
+
+  - legal_id: us-ms:policies/income_tax/2026_section_27_7_5_schedule#ms_pit_2026_schedule_taxable_income
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes one normalized generic caller-supplied taxable-income boundary. PolicyEngine exposes filing-method-specific joint and separate Person candidates, not a one-to-one generic interface output.
+
+  - legal_id: us-ms:policies/income_tax/2026_section_27_7_5_schedule#ms_pit_2026_section_27_7_5_schedule_tax
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: ms_income_tax_before_credits_joint
+    entity: person
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Both outputs apply the tax-year-2026 section 27-7-5 schedule to one Person's completed nonnegative Mississippi taxable income before credits. The oracle validates PolicyEngine's joint/default Person schedule branch only; this mapping excludes filing-method selection, TaxUnit aggregation, credits, payments, and final liability.
+
 prefixes:
   - legal_id_prefix: us-dc:statutes/4/4-205/49#
     country: us
@@ -30192,6 +30235,12 @@ prefixes:
     mapping_type: not_comparable
     candidate_priority: P4
     rationale: PolicyEngine-US does not model MD agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
+
+  - legal_id_prefix: "us-ms:"
+    country: us
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: PolicyEngine-US does not model every MS statute, agency policy manual, or state regulation at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
 
   - legal_id_prefix: "us-nc:"
     country: us

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5120,7 +5120,7 @@ def test_packaged_alabama_2026_schedule_registry_and_fallback_are_synchronized()
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "c33a805098cb7a7c7f0dfada68b2f24cf67f588e"
+    assert pin == "89d2a710f070a421b29f18fdec22df983250d19b"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5231,7 +5231,7 @@ def test_packaged_connecticut_2026_ordinary_tax_registry_is_exactly_synchronized
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "c33a805098cb7a7c7f0dfada68b2f24cf67f588e"
+    assert pin == "89d2a710f070a421b29f18fdec22df983250d19b"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5315,7 +5315,104 @@ def test_packaged_georgia_2026_annual_tax_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "c33a805098cb7a7c7f0dfada68b2f24cf67f588e"
+    assert pin == "89d2a710f070a421b29f18fdec22df983250d19b"
+    assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
+
+
+def test_packaged_mississippi_2026_schedule_registry_is_exactly_synchronized():
+    import axiom_oracles.bridges.registry as runtime_registry_module
+
+    root = Path(__file__).parents[1]
+    bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
+    runtime_path = (
+        Path(runtime_registry_module.__file__).with_name("mappings") / "us.yaml"
+    )
+    bundled_document = yaml.safe_load(bundled_path.read_text())
+    runtime_document = yaml.safe_load(runtime_path.read_text())
+    schedule_prefix = (
+        "us-ms:policies/income_tax/2026_section_27_7_5_schedule#"
+    )
+
+    def schedule_records(document):
+        return {
+            item["legal_id"].removeprefix(schedule_prefix): item
+            for item in document["mappings"]
+            if item.get("legal_id", "").startswith(schedule_prefix)
+        }
+
+    bundled = schedule_records(bundled_document)
+    runtime = schedule_records(runtime_document)
+    assert set(bundled) == {
+        "ms_pit_2026_zero_tax_ceiling",
+        "ms_pit_2026_rate",
+        "ms_pit_2026_schedule_taxable_income",
+        "ms_pit_2026_section_27_7_5_schedule_tax",
+    }
+    assert bundled == runtime
+    bundled_fallbacks = [
+        item
+        for item in bundled_document["prefixes"]
+        if item.get("legal_id_prefix") == "us-ms:"
+    ]
+    runtime_fallbacks = [
+        item
+        for item in runtime_document["prefixes"]
+        if item.get("legal_id_prefix") == "us-ms:"
+    ]
+    assert len(bundled_fallbacks) == 1
+    assert bundled_fallbacks == runtime_fallbacks
+
+    ceiling = bundled["ms_pit_2026_zero_tax_ceiling"]
+    assert ceiling["mapping_type"] == "parameter_value"
+    assert ceiling["policyengine_parameter"] == "gov.states.ms.tax.income.rate"
+    assert ceiling["parameter_key_path"] == ["thresholds", 1]
+    assert ceiling["comparison"] == "money"
+
+    rate = bundled["ms_pit_2026_rate"]
+    assert rate["mapping_type"] == "parameter_value"
+    assert rate["policyengine_parameter"] == "gov.states.ms.tax.income.rate"
+    assert rate["parameter_key_path"] == ["rates", 1]
+    assert rate["comparison"] == "rate"
+
+    taxable_income = bundled["ms_pit_2026_schedule_taxable_income"]
+    assert taxable_income["mapping_type"] == "not_comparable"
+    assert taxable_income["candidate_priority"] == "P4"
+    assert "policyengine_variable" not in taxable_income
+
+    schedule_tax = bundled["ms_pit_2026_section_27_7_5_schedule_tax"]
+    assert schedule_tax["mapping_type"] == "direct_variable"
+    assert schedule_tax["policyengine_variable"] == (
+        "ms_income_tax_before_credits_joint"
+    )
+    assert schedule_tax["entity"] == "person"
+    assert schedule_tax["period"] == "year"
+    assert schedule_tax["unit"] == "USD"
+    assert schedule_tax["comparison"] == "money"
+    assert "final liability" in schedule_tax["rationale"]
+
+    registry = load_policyengine_registry()
+    exact = registry.mapping_for_legal_id(
+        f"{schedule_prefix}ms_pit_2026_section_27_7_5_schedule_tax",
+        country="us",
+    )
+    fallback = registry.mapping_for_legal_id(
+        "us-ms:policies/income_tax/unrelated#future_output",
+        country="us",
+    )
+    assert exact is not None
+    assert exact.match_type == "exact"
+    assert exact.mapping_type == "direct_variable"
+    assert exact.policyengine_variable == "ms_income_tax_before_credits_joint"
+    assert fallback is not None
+    assert fallback.match_type == "prefix"
+    assert fallback.mapping_type == "not_comparable"
+
+    dependency_pin = re.search(
+        r"axiom-oracles@[0-9a-f]{40}", (root / "pyproject.toml").read_text()
+    )
+    assert dependency_pin is not None
+    pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
+    assert pin == "89d2a710f070a421b29f18fdec22df983250d19b"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5329,9 +5329,7 @@ def test_packaged_mississippi_2026_schedule_registry_is_exactly_synchronized():
     )
     bundled_document = yaml.safe_load(bundled_path.read_text())
     runtime_document = yaml.safe_load(runtime_path.read_text())
-    schedule_prefix = (
-        "us-ms:policies/income_tax/2026_section_27_7_5_schedule#"
-    )
+    schedule_prefix = "us-ms:policies/income_tax/2026_section_27_7_5_schedule#"
 
     def schedule_records(document):
         return {

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1393"
+version = "0.2.1394"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=c33a805098cb7a7c7f0dfada68b2f24cf67f588e" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=89d2a710f070a421b29f18fdec22df983250d19b" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=c33a805098cb7a7c7f0dfada68b2f24cf67f588e#c33a805098cb7a7c7f0dfada68b2f24cf67f588e" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=89d2a710f070a421b29f18fdec22df983250d19b#89d2a710f070a421b29f18fdec22df983250d19b" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Scope

- pin the merged oracle registry at `89d2a710f070a421b29f18fdec22df983250d19b`
- bundle the four exact TY2026 Mississippi section 27-7-5 schedule mappings and the fail-closed `us-ms:` fallback
- bump axiom-encode to `0.2.1394` and refresh the lockfile
- add exact bundled/runtime synchronization and precedence coverage

This is the narrow Person-grain schedule on caller-completed Mississippi taxable income: zero through $10,000, then 4%. It does not select filing method, construct taxable income, aggregate a return, apply credits, or claim final liability.

## Validation

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest` — 5,935 passed, 119 skipped
- focused registry/version tests — 5 passed
- live local classifier against RuleSpec PR #1124 — three tested comparables and one known P4 non-comparable; zero pending classifications
- Ruff 0.15 and CI Ruff 0.16 format/lint checks
- `uv lock --check`
- `git diff --check`

## Review-fix cycle

Independent semantic review completed at `59dd94fd24227869433f9596b1c42f5f572da0fd` with no actionable findings. The reviewer independently verified the merged oracle provenance, exact registry and fallback synchronization, exact-before-prefix behavior, PolicyEngine Person/year semantics, the $10,000 threshold, the 4% rate, version metadata, lockfile, and focused checks.

Hosted lint then requested one Ruff 0.16 line-wrap normalization. That formatting-only change was applied and rechecked. Independent exact-head follow-up review at `b898dbebd2a970d7ca2e78333be1b10006e14684` confirmed no semantic change and no actionable findings.