### PR TITLE
Bundle Utah 2026 before-credit oracle mappings

### DIFF
--- a/changelog.d/ut-2026-before-credit-oracle-registry.changed.md
+++ b/changelog.d/ut-2026-before-credit-oracle-registry.changed.md
@@ -1,0 +1,1 @@
+Bundle the canonical Utah 2026 before-credit oracle mappings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1394"
+version = "0.2.1395"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@89d2a710f070a421b29f18fdec22df983250d19b",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@51d0930ed337ecbb6d345ea6f36c9fe8243ee40d",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1394"
+__version__ = "0.2.1395"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -27942,6 +27942,79 @@ mappings:
     comparison: money
     rationale: Both outputs apply the tax-year-2026 section 27-7-5 schedule to one Person's completed nonnegative Mississippi taxable income before credits. The oracle validates PolicyEngine's joint/default Person schedule branch only; this mapping excludes filing-method selection, TaxUnit aggregation, credits, payments, and final liability.
 
+  # Utah's canonical TY2026 full-year-resident surface applies section
+  # 59-10-104's rate to completed Utah taxable income, but must also honor the
+  # separate section 59-10-104.1 exemption. PolicyEngine publishes those two
+  # components separately, so the schedule comparison is explicitly derived.
+  - legal_id: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_input_domain_is_valid
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom validates the caller's nonnegative-income, aligned-filing-unit, full-year-resident interface contract. PolicyEngine exposes no one-to-one Judgment for that complete contract.
+
+  - legal_id: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_before_credit_schedule_applies
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This applicability Judgment combines Axiom's explicit interface guards with the section 59-10-104.1 exemption. PolicyEngine exposes the exemption but not the complete guarded predicate.
+
+  - legal_id: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_income_tax_rate
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ut.tax.income.rate
+    period: year
+    comparison: rate
+    rationale: Same 4.45 percent Utah individual-income-tax rate for tax year 2026.
+
+  - legal_id: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_resident_state_taxable_income_boundary
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes a fail-closed normalization of caller-supplied completed Utah taxable income. PolicyEngine's ut_taxable_income is the upstream input, not a one-to-one output with the same interface guards.
+
+  - legal_id: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_resident_income_tax_before_credits
+    country: us
+    program: tax
+    mapping_type: derived_expression
+    expression: ut_income_tax_before_credits * (1 - ut_income_tax_exempt)
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: PolicyEngine publishes section 59-10-104 tax before credits and the section 59-10-104.1 exemption separately. Multiplying by one minus the Boolean exemption reproduces the canonical exemption-aware schedule output without claiming the taxpayer credit or final liability.
+
+  - legal_id: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_taxpayer_credit_source_hold_applies
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This source-readiness hold records that the section 59-10-1018 taxpayer credit is intentionally outside the canonical schedule surface.
+
+  - legal_id: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_final_resident_liability_source_hold_applies
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This source-readiness hold records that downstream credits, payments, and final resident liability are intentionally outside the canonical schedule surface.
+
+  - legal_id: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_taxpayer_tax_credit
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This zero is an explicit fail-closed source-hold sentinel, not a computed taxpayer-credit result.
+
+  - legal_id: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_final_resident_income_tax_liability_before_payments
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This zero is an explicit fail-closed source-hold sentinel, not computed final Utah liability.
+
 prefixes:
   - legal_id_prefix: us-dc:statutes/4/4-205/49#
     country: us
@@ -30241,6 +30314,12 @@ prefixes:
     mapping_type: not_comparable
     candidate_priority: P4
     rationale: PolicyEngine-US does not model every MS statute, agency policy manual, or state regulation at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
+
+  - legal_id_prefix: "us-ut:"
+    country: us
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: PolicyEngine-US does not model every Utah statute, agency policy manual, or state regulation at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
 
   - legal_id_prefix: "us-nc:"
     country: us

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5425,8 +5425,7 @@ def test_packaged_utah_2026_before_credit_registry_is_exactly_synchronized():
     bundled_document = yaml.safe_load(bundled_path.read_text())
     runtime_document = yaml.safe_load(runtime_path.read_text())
     schedule_prefix = (
-        "us-ut:policies/income_tax/"
-        "2026_full_year_resident_before_credit_schedule#"
+        "us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#"
     )
 
     def schedule_records(document):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5120,7 +5120,7 @@ def test_packaged_alabama_2026_schedule_registry_and_fallback_are_synchronized()
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "89d2a710f070a421b29f18fdec22df983250d19b"
+    assert pin == "51d0930ed337ecbb6d345ea6f36c9fe8243ee40d"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5231,7 +5231,7 @@ def test_packaged_connecticut_2026_ordinary_tax_registry_is_exactly_synchronized
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "89d2a710f070a421b29f18fdec22df983250d19b"
+    assert pin == "51d0930ed337ecbb6d345ea6f36c9fe8243ee40d"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5315,7 +5315,7 @@ def test_packaged_georgia_2026_annual_tax_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "89d2a710f070a421b29f18fdec22df983250d19b"
+    assert pin == "51d0930ed337ecbb6d345ea6f36c9fe8243ee40d"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5410,7 +5410,108 @@ def test_packaged_mississippi_2026_schedule_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "89d2a710f070a421b29f18fdec22df983250d19b"
+    assert pin == "51d0930ed337ecbb6d345ea6f36c9fe8243ee40d"
+    assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
+
+
+def test_packaged_utah_2026_before_credit_registry_is_exactly_synchronized():
+    import axiom_oracles.bridges.registry as runtime_registry_module
+
+    root = Path(__file__).parents[1]
+    bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
+    runtime_path = (
+        Path(runtime_registry_module.__file__).with_name("mappings") / "us.yaml"
+    )
+    bundled_document = yaml.safe_load(bundled_path.read_text())
+    runtime_document = yaml.safe_load(runtime_path.read_text())
+    schedule_prefix = (
+        "us-ut:policies/income_tax/"
+        "2026_full_year_resident_before_credit_schedule#"
+    )
+
+    def schedule_records(document):
+        return {
+            item["legal_id"].removeprefix(schedule_prefix): item
+            for item in document["mappings"]
+            if item.get("legal_id", "").startswith(schedule_prefix)
+        }
+
+    bundled = schedule_records(bundled_document)
+    runtime = schedule_records(runtime_document)
+    not_comparable = {
+        "ut_pit_2026_input_domain_is_valid",
+        "ut_pit_2026_before_credit_schedule_applies",
+        "ut_pit_2026_resident_state_taxable_income_boundary",
+        "ut_pit_2026_taxpayer_credit_source_hold_applies",
+        "ut_pit_2026_final_resident_liability_source_hold_applies",
+        "ut_pit_2026_taxpayer_tax_credit",
+        "ut_pit_2026_final_resident_income_tax_liability_before_payments",
+    }
+    expected_types = {
+        **dict.fromkeys(not_comparable, "not_comparable"),
+        "ut_pit_2026_income_tax_rate": "parameter_value",
+        "ut_pit_2026_resident_income_tax_before_credits": "derived_expression",
+    }
+    assert len(expected_types) == 9
+    assert set(bundled) == set(expected_types)
+    assert {name: item["mapping_type"] for name, item in bundled.items()} == (
+        expected_types
+    )
+    assert bundled == runtime
+
+    for output_name in not_comparable:
+        assert bundled[output_name]["candidate_priority"] == "P4"
+
+    rate = bundled["ut_pit_2026_income_tax_rate"]
+    assert rate["policyengine_parameter"] == "gov.states.ut.tax.income.rate"
+    assert rate["period"] == "year"
+    assert rate["comparison"] == "rate"
+
+    before_credits = bundled["ut_pit_2026_resident_income_tax_before_credits"]
+    assert before_credits["expression"] == (
+        "ut_income_tax_before_credits * (1 - ut_income_tax_exempt)"
+    )
+    assert before_credits["entity"] == "tax_unit"
+    assert before_credits["period"] == "year"
+    assert before_credits["unit"] == "USD"
+    assert before_credits["comparison"] == "money"
+    assert "final liability" in before_credits["rationale"]
+
+    bundled_fallbacks = [
+        item
+        for item in bundled_document["prefixes"]
+        if item.get("legal_id_prefix") == "us-ut:"
+    ]
+    runtime_fallbacks = [
+        item
+        for item in runtime_document["prefixes"]
+        if item.get("legal_id_prefix") == "us-ut:"
+    ]
+    assert len(bundled_fallbacks) == 1
+    assert bundled_fallbacks == runtime_fallbacks
+
+    registry = load_policyengine_registry()
+    exact = registry.mapping_for_legal_id(
+        f"{schedule_prefix}ut_pit_2026_resident_income_tax_before_credits",
+        country="us",
+    )
+    fallback = registry.mapping_for_legal_id(
+        "us-ut:policies/income_tax/unrelated#future_output",
+        country="us",
+    )
+    assert exact is not None
+    assert exact.match_type == "exact"
+    assert exact.mapping_type == "derived_expression"
+    assert fallback is not None
+    assert fallback.match_type == "prefix"
+    assert fallback.mapping_type == "not_comparable"
+
+    dependency_pin = re.search(
+        r"axiom-oracles@[0-9a-f]{40}", (root / "pyproject.toml").read_text()
+    )
+    assert dependency_pin is not None
+    pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
+    assert pin == "51d0930ed337ecbb6d345ea6f36c9fe8243ee40d"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1394"
+version = "0.2.1395"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=89d2a710f070a421b29f18fdec22df983250d19b" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=51d0930ed337ecbb6d345ea6f36c9fe8243ee40d" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=89d2a710f070a421b29f18fdec22df983250d19b#89d2a710f070a421b29f18fdec22df983250d19b" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=51d0930ed337ecbb6d345ea6f36c9fe8243ee40d#51d0930ed337ecbb6d345ea6f36c9fe8243ee40d" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Scope

Pins `axiom-oracles` to merged Utah oracle commit `51d0930ed337ecbb6d345ea6f36c9fe8243ee40d` and bundles the canonical Utah TY2026 full-year-resident before-credit schedule mappings. This preserves the bounded schedule scope: caller-completed taxable income and exemption state, not taxpayer-credit computation, payments, or final liability.

## Changes

- Adds all 9 canonical Utah output mappings: 2 comparable and 7 explicit P4 boundaries.
- Uses the exemption-aware derived target `ut_income_tax_before_credits * (1 - ut_income_tax_exempt)` at TaxUnit/year grain.
- Adds the broad `us-ut:` P4 fallback after exact mappings.
- Updates the dependency/lock pin and releases encoder version 0.2.1395.
- Adds an exact slice/fallback synchronization and runtime-precedence regression.

The oracle 89d2a710→51d0930 mapping delta and encoder 7c02247→d51c54 mapping delta are byte-identical: 79 additions, 0 deletions, normalized added-line SHA-256 `ddfd318ba363bf2df6326f55481120658a99196644b56eb94471490faa65b43c`.

## Checks

- Focused AL/CT/GA/MS/UT registry tests: 5 passed before commit; independent review rerun plus version provenance: 6 passed.
- Ruff, compileall, `uv lock --check`, and diff check passed.
- Precommit full suite: 5,935 passed, 119 skipped, with only the expected version-provenance guard failing because the version bump was not yet committed.
- The exact provenance guard passed after commit.
- A postcommit broad rerun was stopped after accumulated pytest basetemps exhausted the local filesystem and produced an ENOSPC cascade; those basetemps were removed. Hosted CI is the clean full-suite gate.

## Review-fix cycle

Independent exact-head review is CLEAN for `d51c54fd9348b17a7b342b364cc4cde9e05acf18`. The reviewer initially flagged whole-file registry divergence, then verified it was pre-existing and outside the established delta-scoped bundle contract; exact relative-delta comparison retracted that concern and found no Utah defect.