### PR TITLE
Bundle Ohio 2026 schedule oracle mappings

### DIFF
--- a/changelog.d/oh-2026-schedule-oracle-registry.changed.md
+++ b/changelog.d/oh-2026-schedule-oracle-registry.changed.md
@@ -1,0 +1,1 @@
+Bundle Ohio's bounded TY2026 nonbusiness-income schedule mappings and pin their durable reviewed oracle-main merge without claiming complete IT 1040 liability.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1395"
+version = "0.2.1396"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@51d0930ed337ecbb6d345ea6f36c9fe8243ee40d",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@5dbc6ecaae03897e6a1d3598fe6c41f07af1b8c6",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1395"
+__version__ = "0.2.1396"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -27942,6 +27942,72 @@ mappings:
     comparison: money
     rationale: Both outputs apply the tax-year-2026 section 27-7-5 schedule to one Person's completed nonnegative Mississippi taxable income before credits. The oracle validates PolicyEngine's joint/default Person schedule branch only; this mapping excludes filing-method selection, TaxUnit aggregation, credits, payments, and final liability.
 
+  # Ohio's bounded TY2026 nonbusiness-income module accepts one completed
+  # Ohio taxable-income boundary and applies only section 5747.02(A)(3)(c)'s
+  # schedule before credits. PolicyEngine-US 1.752.2 incorrectly treats the
+  # $26,050 equality point as taxable, so the comparable schedule records
+  # explicitly restore the statute's inclusive no-tax gate.
+  - legal_id: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_nonbusiness_taxable_income_construction_source_hold_applies
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This Judgment records that Ohio adjusted-gross-income, business-income separation, and exemption construction remain outside the bounded completed-income schedule. PolicyEngine exposes no equivalent source-readiness hold.
+
+  - legal_id: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_business_income_and_excess_exemption_source_hold_applies
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This Judgment records that the separate Ohio business-income tax and excess-exemption allocation remain outside the bounded nonbusiness schedule. PolicyEngine exposes no equivalent source-readiness hold.
+
+  - legal_id: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_credit_surface_source_hold_applies
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This Judgment records that the complete Ohio credit inventory, limitations, and ordering remain outside the bounded schedule. PolicyEngine exposes no equivalent source-readiness hold.
+
+  - legal_id: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_final_return_ordering_source_hold_applies
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This Judgment records that final Ohio IT 1040 ordering and liability remain outside the bounded schedule. PolicyEngine exposes no equivalent source-readiness hold.
+
+  - legal_id: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_taxable_income
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: oh_taxable_income
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Both values are the completed nonnegative Ohio taxable-income boundary used by the nonbusiness-income schedule; this mapping does not claim to construct that amount from return components.
+
+  - legal_id: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_schedule_tax
+    country: us
+    program: tax
+    mapping_type: derived_expression
+    expression: oh_income_tax_before_non_refundable_credits * (oh_taxable_income > 26050)
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: PolicyEngine's published before-credit schedule is preserved above the authoritative 2026 Ohio no-tax threshold and set to zero at or below $26,050, correcting PolicyEngine-US 1.752.2's strict-inequality defect to match section 5747.02(A)(3)(c). The campaign runner reads the threshold from PolicyEngine's own statutory parameter and validates exact TaxUnit identity before applying this gate.
+
+  - legal_id: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_income_tax_liability
+    country: us
+    program: tax
+    mapping_type: derived_expression
+    expression: oh_income_tax_before_non_refundable_credits * (oh_taxable_income > 26050)
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Within this bounded module this legacy-named output is exactly the nonbusiness-income schedule before nonrefundable credits, not final Ohio IT 1040 liability. The derived oracle preserves PolicyEngine's schedule above the statutory threshold while correcting its equality defect.
+
   # Utah's canonical TY2026 full-year-resident surface applies section
   # 59-10-104's rate to completed Utah taxable income, but must also honor the
   # separate section 59-10-104.1 exemption. PolicyEngine publishes those two
@@ -30344,6 +30410,12 @@ prefixes:
     mapping_type: not_comparable
     candidate_priority: P4
     rationale: PolicyEngine-US does not model NY agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
+
+  - legal_id_prefix: "us-oh:"
+    country: us
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: PolicyEngine-US does not model every Ohio statute, agency policy manual, or state regulation at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
 
   - legal_id_prefix: "us-ok:"
     country: us

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5120,7 +5120,7 @@ def test_packaged_alabama_2026_schedule_registry_and_fallback_are_synchronized()
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "51d0930ed337ecbb6d345ea6f36c9fe8243ee40d"
+    assert pin == "5dbc6ecaae03897e6a1d3598fe6c41f07af1b8c6"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5231,7 +5231,7 @@ def test_packaged_connecticut_2026_ordinary_tax_registry_is_exactly_synchronized
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "51d0930ed337ecbb6d345ea6f36c9fe8243ee40d"
+    assert pin == "5dbc6ecaae03897e6a1d3598fe6c41f07af1b8c6"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5315,7 +5315,7 @@ def test_packaged_georgia_2026_annual_tax_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "51d0930ed337ecbb6d345ea6f36c9fe8243ee40d"
+    assert pin == "5dbc6ecaae03897e6a1d3598fe6c41f07af1b8c6"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5410,7 +5410,154 @@ def test_packaged_mississippi_2026_schedule_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "51d0930ed337ecbb6d345ea6f36c9fe8243ee40d"
+    assert pin == "5dbc6ecaae03897e6a1d3598fe6c41f07af1b8c6"
+    assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
+
+
+def _ohio_2026_schedule_records(document):
+    schedule_prefix = "us-oh:policies/income_tax/pilot_liability_pipeline#"
+    return {
+        item["legal_id"].removeprefix(schedule_prefix): item
+        for item in document["mappings"]
+        if item.get("legal_id", "").startswith(schedule_prefix)
+    }
+
+
+def test_packaged_ohio_2026_schedule_registry_has_exact_bounded_slice():
+    root = Path(__file__).parents[1]
+    bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
+    bundled_document = yaml.safe_load(bundled_path.read_text())
+    bundled = _ohio_2026_schedule_records(bundled_document)
+    not_comparable = {
+        "oh_pit_pilot_nonbusiness_taxable_income_construction_source_hold_applies",
+        "oh_pit_pilot_business_income_and_excess_exemption_source_hold_applies",
+        "oh_pit_pilot_credit_surface_source_hold_applies",
+        "oh_pit_pilot_final_return_ordering_source_hold_applies",
+    }
+    expected_types = {
+        **dict.fromkeys(not_comparable, "not_comparable"),
+        "oh_pit_pilot_taxable_income": "direct_variable",
+        "oh_pit_pilot_schedule_tax": "derived_expression",
+        "oh_pit_pilot_income_tax_liability": "derived_expression",
+    }
+
+    assert len(expected_types) == 7
+    assert set(bundled) == set(expected_types)
+    assert {name: item["mapping_type"] for name, item in bundled.items()} == (
+        expected_types
+    )
+    for output_name in not_comparable:
+        assert bundled[output_name]["candidate_priority"] == "P4"
+
+    taxable_income = bundled["oh_pit_pilot_taxable_income"]
+    assert taxable_income["policyengine_variable"] == "oh_taxable_income"
+    assert (
+        taxable_income["entity"],
+        taxable_income["period"],
+        taxable_income["unit"],
+        taxable_income["comparison"],
+    ) == ("tax_unit", "year", "USD", "money")
+
+    expression = (
+        "oh_income_tax_before_non_refundable_credits * (oh_taxable_income > 26050)"
+    )
+    for output_name in (
+        "oh_pit_pilot_schedule_tax",
+        "oh_pit_pilot_income_tax_liability",
+    ):
+        schedule = bundled[output_name]
+        assert schedule["expression"] == expression
+        assert (
+            schedule["entity"],
+            schedule["period"],
+            schedule["unit"],
+            schedule["comparison"],
+        ) == ("tax_unit", "year", "USD", "money")
+
+    bundled_fallbacks = [
+        item
+        for item in bundled_document["prefixes"]
+        if item.get("legal_id_prefix") == "us-oh:"
+    ]
+    assert len(bundled_fallbacks) == 1
+    assert bundled_fallbacks[0]["mapping_type"] == "not_comparable"
+    assert bundled_fallbacks[0]["candidate_priority"] == "P4"
+
+
+def test_packaged_ohio_2026_schedule_registry_is_exactly_synchronized():
+    import axiom_oracles.bridges.registry as runtime_registry_module
+
+    root = Path(__file__).parents[1]
+    bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
+    runtime_path = (
+        Path(runtime_registry_module.__file__).with_name("mappings") / "us.yaml"
+    )
+    bundled_text = bundled_path.read_text()
+    runtime_text = runtime_path.read_text()
+    bundled_document = yaml.safe_load(bundled_text)
+    runtime_document = yaml.safe_load(runtime_text)
+    bundled = _ohio_2026_schedule_records(bundled_document)
+    runtime = _ohio_2026_schedule_records(runtime_document)
+
+    assert bundled == runtime
+
+    def exact_slice(text, start, end):
+        return text[text.index(start) : text.index(end)]
+
+    assert exact_slice(
+        bundled_text,
+        "  # Ohio's bounded TY2026",
+        "  # Utah's canonical TY2026",
+    ) == exact_slice(
+        runtime_text,
+        "  # Ohio's bounded TY2026",
+        "  # Utah's canonical TY2026",
+    )
+    assert exact_slice(
+        bundled_text,
+        '  - legal_id_prefix: "us-oh:"',
+        '  - legal_id_prefix: "us-ok:"',
+    ) == exact_slice(
+        runtime_text,
+        '  - legal_id_prefix: "us-oh:"',
+        '  - legal_id_prefix: "us-ok:"',
+    )
+
+    bundled_fallbacks = [
+        item
+        for item in bundled_document["prefixes"]
+        if item.get("legal_id_prefix") == "us-oh:"
+    ]
+    runtime_fallbacks = [
+        item
+        for item in runtime_document["prefixes"]
+        if item.get("legal_id_prefix") == "us-oh:"
+    ]
+    assert len(bundled_fallbacks) == 1
+    assert bundled_fallbacks == runtime_fallbacks
+
+    schedule_prefix = "us-oh:policies/income_tax/pilot_liability_pipeline#"
+    registry = load_policyengine_registry()
+    exact = registry.mapping_for_legal_id(
+        f"{schedule_prefix}oh_pit_pilot_schedule_tax",
+        country="us",
+    )
+    fallback = registry.mapping_for_legal_id(
+        "us-oh:policies/income_tax/unrelated#future_output",
+        country="us",
+    )
+    assert exact is not None
+    assert exact.match_type == "exact"
+    assert exact.mapping_type == "derived_expression"
+    assert fallback is not None
+    assert fallback.match_type == "prefix"
+    assert fallback.mapping_type == "not_comparable"
+
+    dependency_pin = re.search(
+        r"axiom-oracles@[0-9a-f]{40}", (root / "pyproject.toml").read_text()
+    )
+    assert dependency_pin is not None
+    pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5510,7 +5657,7 @@ def test_packaged_utah_2026_before_credit_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "51d0930ed337ecbb6d345ea6f36c9fe8243ee40d"
+    assert pin == "5dbc6ecaae03897e6a1d3598fe6c41f07af1b8c6"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1395"
+version = "0.2.1396"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=51d0930ed337ecbb6d345ea6f36c9fe8243ee40d" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=5dbc6ecaae03897e6a1d3598fe6c41f07af1b8c6" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=51d0930ed337ecbb6d345ea6f36c9fe8243ee40d#51d0930ed337ecbb6d345ea6f36c9fe8243ee40d" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=5dbc6ecaae03897e6a1d3598fe6c41f07af1b8c6#5dbc6ecaae03897e6a1d3598fe6c41f07af1b8c6" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- pin `axiom-oracles` to merged Ohio oracle repair `5dbc6ecaae03897e6a1d3598fe6c41f07af1b8c6`
- bundle the exact seven Ohio RuleSpec mappings plus the `us-oh:` P4 fallback
- preserve the bounded nonbusiness-income schedule scope while using the oracle structural fix for the inclusive $26,050 no-tax boundary
- release encoder version `0.2.1396`

The oracle and encoder mapping deltas are byte-identical after normalization: `b8699136a4074fc4f4ab67223f764d5c44012b69a83da0ebed97dc7ac0604fbf`.

## Validation

- `1064 passed, 10 skipped` — `tests/test_cli.py`
- `4874 passed, 109 skipped` — all remaining tests
- focused Ohio/static/runtime registry tests pass
- Ruff lint and format checks pass
- `compileall`, `uv lock --check`, and `git diff --check` pass
- independent exact-head review CLEAN at `97c4d55592a29704eeb9f24e79571c67033ef40e`

## Scope

This is a legitimate oracle/registry correction, not a tolerance workaround. The derived oracle target uses the authoritative Ohio threshold and returns zero at or below it while preserving PolicyEngine schedule values above it. Final annual liability remains explicitly source-held outside the encoded bounded schedule.