### PR TITLE
Bundle Kansas 2026 K-40ES oracle mappings

### DIFF
--- a/changelog.d/ks-2026-k40es-oracle.changed.md
+++ b/changelog.d/ks-2026-k40es-oracle.changed.md
@@ -1,0 +1,1 @@
+Bundle Kansas's canonical tax-year-2026 K-40ES joint and all-other-filer schedule-before-credits mappings and pin their durable reviewed oracle-main merge without claiming complete K-40 liability.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1396"
+version = "0.2.1397"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@5dbc6ecaae03897e6a1d3598fe6c41f07af1b8c6",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@8d949d44d62b931a02e0e03f156af054e0ddf55e",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1396"
+__version__ = "0.2.1397"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -27899,6 +27899,67 @@ mappings:
     comparison: money
     rationale: Both outputs apply O.C.G.A. section 48-7-20 tax to completed Georgia taxable income before nonrefundable credits. This mapping excludes taxable-income construction, filing mechanics, credits, payments, and final Form 500 liability.
 
+  # The official Kansas K-40ES module is a narrow schedule-before-credits
+  # surface on completed Kansas taxable income. It does not claim the complete
+  # annual-return liability chain or replace the legacy TAXSIM diagnostic.
+  - legal_id: us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_lower_rate
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ks.tax.income.rates.joint
+    parameter_key_path: [rates, 0]
+    period: year
+    comparison: rate
+    rationale: The official 2026 K-40ES and PolicyEngine's joint and all-other Kansas schedules use the same 5.2 percent lower marginal rate; the joint scale is the canonical exact parameter target.
+
+  - legal_id: us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_upper_rate
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ks.tax.income.rates.joint
+    parameter_key_path: [rates, 1]
+    period: year
+    comparison: rate
+    rationale: The official 2026 K-40ES and PolicyEngine's joint and all-other Kansas schedules use the same 5.58 percent upper marginal rate; the joint scale is the canonical exact parameter target.
+
+  - legal_id: us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_joint_lower_bracket_ceiling
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.states.ks.tax.income.rates.joint
+    candidate_priority: P4
+    rationale: RuleSpec stores the official K-40ES last dollar in the joint lower bracket, $46,000. PolicyEngine's marginal scale stores the first dollar of the upper bracket, $46,001, so the two boundary representations intentionally differ by one dollar and are not direct parameter values.
+
+  - legal_id: us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_other_lower_bracket_ceiling
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.states.ks.tax.income.rates.other
+    candidate_priority: P4
+    rationale: RuleSpec stores the official K-40ES last dollar in the all-other-filer lower bracket, $23,000. PolicyEngine's marginal scale stores the first dollar of the upper bracket, $23,001, so the two boundary representations intentionally differ by one dollar and are not direct parameter values.
+
+  - legal_id: us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_taxable_income_boundary
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: ks_taxable_income
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: RuleSpec preserves the nonnegative boundary derived from the caller-supplied completed Kansas taxable income before selecting and applying the K-40ES schedule; it does not claim to reconstruct taxable income.
+
+  - legal_id: us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_schedule_before_credits
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: ks_income_tax_before_credits
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Both outputs select the joint or all-other Kansas schedule and apply it to completed Kansas taxable income before credits. The Populace runner fails closed if PolicyEngine's separate adjusted-gross-income gate would suppress an otherwise positive K-40ES schedule domain.
+
   # Mississippi's canonical TY2026 section 27-7-5 surface applies the enacted
   # Person-grain schedule to one caller-completed Mississippi taxable-income
   # amount. It does not select a filing method, construct taxable income,
@@ -30362,6 +30423,12 @@ prefixes:
     mapping_type: not_comparable
     candidate_priority: P4
     rationale: PolicyEngine-US does not model IN agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
+
+  - legal_id_prefix: "us-ks:"
+    country: us
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: PolicyEngine-US does not model every Kansas statute, agency manual, regulation, or source-level output one to one; independently reviewed comparable outputs carry exact mappings which take precedence over this jurisdiction-wide fallback.
 
   - legal_id_prefix: "us-ma:"
     country: us

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -501,13 +501,15 @@ outputs:
         country="us",
     )
     assert final_mapping.match_type == "exact"
-    assert (
-        registry.mapping_for_legal_id(
-            "us-ks:programs/tanf/fy-2026#ks_tanf_extra",
-            country="us",
-        )
-        is None
+    fallback = registry.mapping_for_legal_id(
+        "us-ks:programs/tanf/fy-2026#ks_tanf_extra",
+        country="us",
     )
+    assert fallback is not None
+    assert fallback.legal_id == "us-ks:"
+    assert fallback.match_type == "prefix"
+    assert fallback.mapping_type == "not_comparable"
+    assert fallback.candidate_priority == "P4"
 
 
 def test_policyengine_coverage_classifies_new_york_tanf_program_output(tmp_path):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5120,7 +5120,7 @@ def test_packaged_alabama_2026_schedule_registry_and_fallback_are_synchronized()
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "5dbc6ecaae03897e6a1d3598fe6c41f07af1b8c6"
+    assert pin == "8d949d44d62b931a02e0e03f156af054e0ddf55e"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5231,7 +5231,7 @@ def test_packaged_connecticut_2026_ordinary_tax_registry_is_exactly_synchronized
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "5dbc6ecaae03897e6a1d3598fe6c41f07af1b8c6"
+    assert pin == "8d949d44d62b931a02e0e03f156af054e0ddf55e"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5315,7 +5315,7 @@ def test_packaged_georgia_2026_annual_tax_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "5dbc6ecaae03897e6a1d3598fe6c41f07af1b8c6"
+    assert pin == "8d949d44d62b931a02e0e03f156af054e0ddf55e"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5410,7 +5410,168 @@ def test_packaged_mississippi_2026_schedule_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "5dbc6ecaae03897e6a1d3598fe6c41f07af1b8c6"
+    assert pin == "8d949d44d62b931a02e0e03f156af054e0ddf55e"
+    assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
+
+
+def _kansas_2026_k40es_records(document):
+    schedule_prefix = "us-ks:policies/income_tax/2026_k40es_schedule_before_credits#"
+    return {
+        item["legal_id"].removeprefix(schedule_prefix): item
+        for item in document["mappings"]
+        if item.get("legal_id", "").startswith(schedule_prefix)
+    }
+
+
+def _kansas_2026_shared_mapping_material(text):
+    def exact_section(start, end):
+        start_index = text.index(start)
+        end_index = text.index(end, start_index) + len(end)
+        return text[start_index:end_index]
+
+    schedule = exact_section(
+        "  # The official Kansas K-40ES",
+        "    rationale: Both outputs select the joint or all-other Kansas "
+        "schedule and apply it to completed Kansas taxable income before "
+        "credits. The Populace runner fails closed if PolicyEngine's separate "
+        "adjusted-gross-income gate would suppress an otherwise positive "
+        "K-40ES schedule domain.",
+    )
+    fallback = exact_section(
+        '  - legal_id_prefix: "us-ks:"',
+        "    rationale: PolicyEngine-US does not model every Kansas statute, "
+        "agency manual, regulation, or source-level output one to one; "
+        "independently reviewed comparable outputs carry exact mappings which "
+        "take precedence over this jurisdiction-wide fallback.",
+    )
+    return f"{schedule}\n\n{fallback}".replace("\r\n", "\n").replace("\r", "\n")
+
+
+def test_packaged_kansas_2026_k40es_registry_has_exact_bounded_slice():
+    root = Path(__file__).parents[1]
+    bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
+    bundled_document = yaml.safe_load(bundled_path.read_text())
+    bundled = _kansas_2026_k40es_records(bundled_document)
+    expected_types = {
+        "ks_pit_2026_k40es_lower_rate": "parameter_value",
+        "ks_pit_2026_k40es_upper_rate": "parameter_value",
+        "ks_pit_2026_k40es_joint_lower_bracket_ceiling": "not_comparable",
+        "ks_pit_2026_k40es_other_lower_bracket_ceiling": "not_comparable",
+        "ks_pit_2026_k40es_taxable_income_boundary": "direct_variable",
+        "ks_pit_2026_k40es_schedule_before_credits": "direct_variable",
+    }
+
+    assert set(bundled) == set(expected_types)
+    assert {name: item["mapping_type"] for name, item in bundled.items()} == (
+        expected_types
+    )
+
+    for output_name, index in (
+        ("ks_pit_2026_k40es_lower_rate", 0),
+        ("ks_pit_2026_k40es_upper_rate", 1),
+    ):
+        rate = bundled[output_name]
+        assert rate["policyengine_parameter"] == (
+            "gov.states.ks.tax.income.rates.joint"
+        )
+        assert rate["parameter_key_path"] == ["rates", index]
+        assert rate["period"] == "year"
+        assert rate["comparison"] == "rate"
+
+    for output_name, scale in (
+        ("ks_pit_2026_k40es_joint_lower_bracket_ceiling", "joint"),
+        ("ks_pit_2026_k40es_other_lower_bracket_ceiling", "other"),
+    ):
+        ceiling = bundled[output_name]
+        assert ceiling["candidate_priority"] == "P4"
+        assert ceiling["policyengine_parameter"] == (
+            f"gov.states.ks.tax.income.rates.{scale}"
+        )
+        assert "first dollar of the upper bracket" in ceiling["rationale"]
+
+    for output_name, variable in (
+        ("ks_pit_2026_k40es_taxable_income_boundary", "ks_taxable_income"),
+        (
+            "ks_pit_2026_k40es_schedule_before_credits",
+            "ks_income_tax_before_credits",
+        ),
+    ):
+        output = bundled[output_name]
+        assert output["policyengine_variable"] == variable
+        assert (
+            output["entity"],
+            output["period"],
+            output["unit"],
+            output["comparison"],
+        ) == ("tax_unit", "year", "USD", "money")
+
+    bundled_fallbacks = [
+        item
+        for item in bundled_document["prefixes"]
+        if item.get("legal_id_prefix") == "us-ks:"
+    ]
+    assert len(bundled_fallbacks) == 1
+    assert bundled_fallbacks[0]["mapping_type"] == "not_comparable"
+    assert bundled_fallbacks[0]["candidate_priority"] == "P4"
+
+
+def test_packaged_kansas_2026_k40es_registry_is_exactly_synchronized():
+    import axiom_oracles.bridges.registry as runtime_registry_module
+
+    root = Path(__file__).parents[1]
+    bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
+    runtime_path = (
+        Path(runtime_registry_module.__file__).with_name("mappings") / "us.yaml"
+    )
+    bundled_text = bundled_path.read_text()
+    runtime_text = runtime_path.read_text()
+    bundled_document = yaml.safe_load(bundled_text)
+    runtime_document = yaml.safe_load(runtime_text)
+    bundled = _kansas_2026_k40es_records(bundled_document)
+    runtime = _kansas_2026_k40es_records(runtime_document)
+
+    assert bundled == runtime
+    assert _kansas_2026_shared_mapping_material(
+        bundled_text
+    ) == _kansas_2026_shared_mapping_material(runtime_text)
+
+    bundled_fallbacks = [
+        item
+        for item in bundled_document["prefixes"]
+        if item.get("legal_id_prefix") == "us-ks:"
+    ]
+    runtime_fallbacks = [
+        item
+        for item in runtime_document["prefixes"]
+        if item.get("legal_id_prefix") == "us-ks:"
+    ]
+    assert len(bundled_fallbacks) == 1
+    assert bundled_fallbacks == runtime_fallbacks
+
+    registry = load_policyengine_registry()
+    exact = registry.mapping_for_legal_id(
+        "us-ks:policies/income_tax/2026_k40es_schedule_before_credits"
+        "#ks_pit_2026_k40es_schedule_before_credits",
+        country="us",
+    )
+    fallback = registry.mapping_for_legal_id(
+        "us-ks:policies/income_tax/unrelated#future_output",
+        country="us",
+    )
+    assert exact is not None
+    assert exact.match_type == "exact"
+    assert exact.mapping_type == "direct_variable"
+    assert exact.policyengine_variable == "ks_income_tax_before_credits"
+    assert fallback is not None
+    assert fallback.match_type == "prefix"
+    assert fallback.mapping_type == "not_comparable"
+
+    dependency_pin = re.search(
+        r"axiom-oracles@[0-9a-f]{40}", (root / "pyproject.toml").read_text()
+    )
+    assert dependency_pin is not None
+    pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
+    assert pin == "8d949d44d62b931a02e0e03f156af054e0ddf55e"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5657,7 +5818,7 @@ def test_packaged_utah_2026_before_credit_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "5dbc6ecaae03897e6a1d3598fe6c41f07af1b8c6"
+    assert pin == "8d949d44d62b931a02e0e03f156af054e0ddf55e"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1396"
+version = "0.2.1397"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=5dbc6ecaae03897e6a1d3598fe6c41f07af1b8c6" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=8d949d44d62b931a02e0e03f156af054e0ddf55e" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=5dbc6ecaae03897e6a1d3598fe6c41f07af1b8c6#5dbc6ecaae03897e6a1d3598fe6c41f07af1b8c6" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=8d949d44d62b931a02e0e03f156af054e0ddf55e#8d949d44d62b931a02e0e03f156af054e0ddf55e" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary
- bundle the reviewed canonical Kansas 2026 K-40ES schedule-before-credits oracle mappings
- pin `axiom-oracles` to merged Kansas evidence commit `8d949d44d62b931a02e0e03f156af054e0ddf55e`
- bump `axiom-encode` to `0.2.1397` and add synchronization, precedence, pin, and version tests

## Bundle integrity
- exact upstream/bundled Kansas material: 67 lines, 3,892 bytes
- normalized SHA-256: `47bf81b9177c97fb5da47321e8c999a0303413bc5fb281b3ec07832dd1914b06`
- scope is the bounded K-40ES schedule before credits, not complete annual Kansas liability

## Validation
- exact full suite: 5,940 passed, 119 skipped
- full CLI partition: 1,064 passed, 10 skipped
- non-CLI partition: 4,876 passed, 109 skipped
- Ruff, compileall, `uv lock --check`, diff, and commit-dependent provenance tests passed

## Review cycle
Independent exact-head review of `99f62e667c1d84565653a3d9775225dfdd4e74b8` found no actionable findings and independently confirmed byte identity, pin/version synchronization, mapping precedence, bounded wording, and a clean seven-file scope.