### PR TITLE
Bundle DC 2026 joint schedule oracle mappings

### DIFF
--- a/changelog.d/dc-2026-section-47-1806-03-oracle.changed.md
+++ b/changelog.d/dc-2026-section-47-1806-03-oracle.changed.md
@@ -1,0 +1,1 @@
+Bundle the District of Columbia canonical tax-year-2026 section 47-1806.03(a)(11) joint-method schedule-before-credits mappings and pin their durable reviewed oracle-main merge without claiming filing-method selection or complete D-40 liability.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1397"
+version = "0.2.1398"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@8d949d44d62b931a02e0e03f156af054e0ddf55e",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@9b889a27432e84804938bd3b374b4f5f7466792e",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1397"
+__version__ = "0.2.1398"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -27877,6 +27877,67 @@ mappings:
     comparison: money
     rationale: PolicyEngine computes this same pre-credit total internally and publishes after-personal-credit tax as total times one minus its personal-credit rate; the rate is strictly below one throughout the parameter domain.
 
+  # The canonical section 47-1806.03(a)(11) module is a narrow joint-method
+  # schedule-before-credits surface on completed District taxable income. It
+  # neither chooses between joint and separate-return methods nor replaces the
+  # legacy broad-liability/TAXSIM diagnostic.
+  - legal_id: us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_upper
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec stores the six finite upper bounds as one selector-indexed private table. PolicyEngine exposes its District schedule through a marginal-rate parameter scale, not a one-to-one variable or table with this internal representation.
+
+  - legal_id: us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_floor
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec stores the seven excess-over floors as one selector-indexed private table. PolicyEngine's marginal-rate scale does not expose a one-to-one output with this cumulative-schedule representation.
+
+  - legal_id: us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_base
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec preserves the seven statutory cumulative base amounts as a private table. PolicyEngine computes the schedule through its marginal scale and exposes no matching cumulative-base table output.
+
+  - legal_id: us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_rate
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec stores all seven marginal rates in one selector-indexed private table. PolicyEngine's parameter scale is not a one-to-one output with the same internal table identity, so the completed schedule is compared instead.
+
+  - legal_id: us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_taxable_income_boundary
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: dc_taxable_income_joint
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Both values represent the completed joint-method District taxable-income boundary consumed by the section 47-1806.03(a)(11) schedule. PolicyEngine labels this boundary as potentially negative, and both its exact joint-method target and the RuleSpec independently floor it at zero before applying the schedule. The runner preserves finite negative values rather than rewriting them; this mapping does not claim to construct taxable income or select the filing method.
+
+  - legal_id: us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_selector
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes its private integer selector only to index the four internal schedule tables. PolicyEngine publishes the computed joint-method tax but no one-to-one bracket-selector variable.
+
+  - legal_id: us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_schedule_before_credits
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: dc_income_tax_before_credits_joint
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Both outputs apply the post-2021 seven-band District schedule to completed joint-method District taxable income before credits. The exact joint-method target intentionally excludes PolicyEngine's broader filing-method selector dc_income_tax_before_credits.
+
   # Georgia's canonical TY2026 section 48-7-20 surface accepts completed
   # Georgia taxable net income and applies only the annual 4.99 percent rate.
   # It does not construct taxable income, credits, payments, filing mechanics,
@@ -30387,6 +30448,12 @@ prefixes:
     mapping_type: not_comparable
     candidate_priority: P4
     rationale: PolicyEngine-US does not model CT agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
+
+  - legal_id_prefix: "us-dc:"
+    country: us
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: PolicyEngine-US does not model every District statute, agency manual, regulation, or source-level output one to one; independently reviewed comparable outputs carry exact mappings which take precedence over this jurisdiction-wide fallback.
 
   - legal_id_prefix: "us-de:"
     country: us

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -512,6 +512,80 @@ outputs:
     assert fallback.candidate_priority == "P4"
 
 
+def test_policyengine_coverage_classifies_bounded_dc_2026_schedule(tmp_path):
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-dc"
+        / "policies/income_tax/"
+        "2026_section_47_1806_03_schedule_before_credits.yaml",
+        """format: rulespec/v1
+rules:
+  - name: dc_pit_2026_section_47_1806_03_bracket_upper
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0
+  - name: dc_pit_2026_section_47_1806_03_bracket_floor
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0
+  - name: dc_pit_2026_section_47_1806_03_bracket_base
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0
+  - name: dc_pit_2026_section_47_1806_03_bracket_rate
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0
+  - name: dc_pit_2026_section_47_1806_03_taxable_income_boundary
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0
+  - name: dc_pit_2026_section_47_1806_03_bracket_selector
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0
+  - name: dc_pit_2026_section_47_1806_03_schedule_before_credits
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["total_outputs"] == 7
+    assert report["status_counts"] == {
+        "comparable": 2,
+        "known_not_comparable": 5,
+    }
+    items = {item["rule_name"]: item for item in report["items"]}
+    assert items[
+        "dc_pit_2026_section_47_1806_03_taxable_income_boundary"
+    ]["policyengine_variable"] == "dc_taxable_income_joint"
+    assert items[
+        "dc_pit_2026_section_47_1806_03_schedule_before_credits"
+    ]["policyengine_variable"] == "dc_income_tax_before_credits_joint"
+    assert {
+        item["candidate_priority"]
+        for name, item in items.items()
+        if name
+        in {
+            "dc_pit_2026_section_47_1806_03_bracket_upper",
+            "dc_pit_2026_section_47_1806_03_bracket_floor",
+            "dc_pit_2026_section_47_1806_03_bracket_base",
+            "dc_pit_2026_section_47_1806_03_bracket_rate",
+            "dc_pit_2026_section_47_1806_03_bracket_selector",
+        }
+    } == {"P4"}
+
+
 def test_policyengine_coverage_classifies_new_york_tanf_program_output(tmp_path):
     checkout = tmp_path / "rulespec-us"
     _write_rulespec_file(

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -514,9 +514,7 @@ outputs:
 
 def test_policyengine_coverage_classifies_bounded_dc_2026_schedule(tmp_path):
     _write_rulespec_file(
-        tmp_path
-        / "rulespec-us-dc"
-        / "policies/income_tax/"
+        tmp_path / "rulespec-us-dc" / "policies/income_tax/"
         "2026_section_47_1806_03_schedule_before_credits.yaml",
         """format: rulespec/v1
 rules:
@@ -566,12 +564,18 @@ rules:
         "known_not_comparable": 5,
     }
     items = {item["rule_name"]: item for item in report["items"]}
-    assert items[
-        "dc_pit_2026_section_47_1806_03_taxable_income_boundary"
-    ]["policyengine_variable"] == "dc_taxable_income_joint"
-    assert items[
-        "dc_pit_2026_section_47_1806_03_schedule_before_credits"
-    ]["policyengine_variable"] == "dc_income_tax_before_credits_joint"
+    assert (
+        items["dc_pit_2026_section_47_1806_03_taxable_income_boundary"][
+            "policyengine_variable"
+        ]
+        == "dc_taxable_income_joint"
+    )
+    assert (
+        items["dc_pit_2026_section_47_1806_03_schedule_before_credits"][
+            "policyengine_variable"
+        ]
+        == "dc_income_tax_before_credits_joint"
+    )
     assert {
         item["candidate_priority"]
         for name, item in items.items()

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5577,8 +5577,7 @@ def test_packaged_kansas_2026_k40es_registry_is_exactly_synchronized():
 
 def _dc_2026_section_47_1806_03_records(document):
     schedule_prefix = (
-        "us-dc:policies/income_tax/"
-        "2026_section_47_1806_03_schedule_before_credits#"
+        "us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#"
     )
     return {
         item["legal_id"].removeprefix(schedule_prefix): item
@@ -5594,8 +5593,7 @@ def _dc_2026_shared_mapping_material(text):
         return text[start_index:end_index]
 
     schedule = exact_section(
-        "  # The canonical section 47-1806.03(a)(11) module is a narrow "
-        "joint-method",
+        "  # The canonical section 47-1806.03(a)(11) module is a narrow joint-method",
         "    rationale: Both outputs apply the post-2021 seven-band District "
         "schedule to completed joint-method District taxable income before "
         "credits. The exact joint-method target intentionally excludes "
@@ -5644,19 +5642,13 @@ def test_packaged_dc_2026_section_47_1806_03_has_exact_bounded_slice():
         assert output["candidate_priority"] == "P4"
         assert "policyengine_variable" not in output
 
-    boundary = bundled[
-        "dc_pit_2026_section_47_1806_03_taxable_income_boundary"
-    ]
+    boundary = bundled["dc_pit_2026_section_47_1806_03_taxable_income_boundary"]
     assert boundary["policyengine_variable"] == "dc_taxable_income_joint"
     assert "potentially negative" in boundary["rationale"]
     assert "independently floor it at zero" in boundary["rationale"]
 
-    schedule = bundled[
-        "dc_pit_2026_section_47_1806_03_schedule_before_credits"
-    ]
-    assert schedule["policyengine_variable"] == (
-        "dc_income_tax_before_credits_joint"
-    )
+    schedule = bundled["dc_pit_2026_section_47_1806_03_schedule_before_credits"]
+    assert schedule["policyengine_variable"] == ("dc_income_tax_before_credits_joint")
     assert "joint-method" in schedule["rationale"]
     assert "before credits" in schedule["rationale"]
     assert "broader filing-method selector" in schedule["rationale"]
@@ -5722,8 +5714,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert bundled_fallbacks == runtime_fallbacks
 
     prefix = (
-        "us-dc:policies/income_tax/"
-        "2026_section_47_1806_03_schedule_before_credits#"
+        "us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#"
     )
     registry = load_policyengine_registry()
     boundary = registry.mapping_for_legal_id(
@@ -5745,9 +5736,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert schedule is not None
     assert schedule.match_type == "exact"
     assert schedule.mapping_type == "direct_variable"
-    assert schedule.policyengine_variable == (
-        "dc_income_tax_before_credits_joint"
-    )
+    assert schedule.policyengine_variable == ("dc_income_tax_before_credits_joint")
     assert fallback is not None
     assert fallback.legal_id == "us-dc:"
     assert fallback.match_type == "prefix"
@@ -5761,8 +5750,10 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
     assert pin == durable_oracle_merge
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
-    assert (root / "src/axiom_encode/__init__.py").read_text().startswith(
-        '__version__ = "0.2.1398"'
+    assert (
+        (root / "src/axiom_encode/__init__.py")
+        .read_text()
+        .startswith('__version__ = "0.2.1398"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5120,7 +5120,7 @@ def test_packaged_alabama_2026_schedule_registry_and_fallback_are_synchronized()
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "8d949d44d62b931a02e0e03f156af054e0ddf55e"
+    assert pin == "9b889a27432e84804938bd3b374b4f5f7466792e"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5231,7 +5231,7 @@ def test_packaged_connecticut_2026_ordinary_tax_registry_is_exactly_synchronized
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "8d949d44d62b931a02e0e03f156af054e0ddf55e"
+    assert pin == "9b889a27432e84804938bd3b374b4f5f7466792e"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5315,7 +5315,7 @@ def test_packaged_georgia_2026_annual_tax_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "8d949d44d62b931a02e0e03f156af054e0ddf55e"
+    assert pin == "9b889a27432e84804938bd3b374b4f5f7466792e"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5410,7 +5410,7 @@ def test_packaged_mississippi_2026_schedule_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "8d949d44d62b931a02e0e03f156af054e0ddf55e"
+    assert pin == "9b889a27432e84804938bd3b374b4f5f7466792e"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5571,8 +5571,199 @@ def test_packaged_kansas_2026_k40es_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "8d949d44d62b931a02e0e03f156af054e0ddf55e"
+    assert pin == "9b889a27432e84804938bd3b374b4f5f7466792e"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
+
+
+def _dc_2026_section_47_1806_03_records(document):
+    schedule_prefix = (
+        "us-dc:policies/income_tax/"
+        "2026_section_47_1806_03_schedule_before_credits#"
+    )
+    return {
+        item["legal_id"].removeprefix(schedule_prefix): item
+        for item in document["mappings"]
+        if item.get("legal_id", "").startswith(schedule_prefix)
+    }
+
+
+def _dc_2026_shared_mapping_material(text):
+    def exact_section(start, end):
+        start_index = text.index(start)
+        end_index = text.index(end, start_index) + len(end)
+        return text[start_index:end_index]
+
+    schedule = exact_section(
+        "  # The canonical section 47-1806.03(a)(11) module is a narrow "
+        "joint-method",
+        "    rationale: Both outputs apply the post-2021 seven-band District "
+        "schedule to completed joint-method District taxable income before "
+        "credits. The exact joint-method target intentionally excludes "
+        "PolicyEngine's broader filing-method selector "
+        "dc_income_tax_before_credits.",
+    )
+    fallback = exact_section(
+        '  - legal_id_prefix: "us-dc:"',
+        "    rationale: PolicyEngine-US does not model every District statute, "
+        "agency manual, regulation, or source-level output one to one; "
+        "independently reviewed comparable outputs carry exact mappings which "
+        "take precedence over this jurisdiction-wide fallback.",
+    )
+    return f"{schedule}\n\n{fallback}".replace("\r\n", "\n").replace("\r", "\n")
+
+
+def test_packaged_dc_2026_section_47_1806_03_has_exact_bounded_slice():
+    root = Path(__file__).parents[1]
+    bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
+    bundled_document = yaml.safe_load(bundled_path.read_text())
+    bundled = _dc_2026_section_47_1806_03_records(bundled_document)
+    not_comparable = {
+        "dc_pit_2026_section_47_1806_03_bracket_upper",
+        "dc_pit_2026_section_47_1806_03_bracket_floor",
+        "dc_pit_2026_section_47_1806_03_bracket_base",
+        "dc_pit_2026_section_47_1806_03_bracket_rate",
+        "dc_pit_2026_section_47_1806_03_bracket_selector",
+    }
+    direct_variables = {
+        "dc_pit_2026_section_47_1806_03_taxable_income_boundary",
+        "dc_pit_2026_section_47_1806_03_schedule_before_credits",
+    }
+    expected_types = {
+        **dict.fromkeys(not_comparable, "not_comparable"),
+        **dict.fromkeys(direct_variables, "direct_variable"),
+    }
+
+    assert len(expected_types) == 7
+    assert set(bundled) == set(expected_types)
+    assert {name: item["mapping_type"] for name, item in bundled.items()} == (
+        expected_types
+    )
+    assert {item["program"] for item in bundled.values()} == {"tax"}
+    for output_name in not_comparable:
+        output = bundled[output_name]
+        assert output["candidate_priority"] == "P4"
+        assert "policyengine_variable" not in output
+
+    boundary = bundled[
+        "dc_pit_2026_section_47_1806_03_taxable_income_boundary"
+    ]
+    assert boundary["policyengine_variable"] == "dc_taxable_income_joint"
+    assert "potentially negative" in boundary["rationale"]
+    assert "independently floor it at zero" in boundary["rationale"]
+
+    schedule = bundled[
+        "dc_pit_2026_section_47_1806_03_schedule_before_credits"
+    ]
+    assert schedule["policyengine_variable"] == (
+        "dc_income_tax_before_credits_joint"
+    )
+    assert "joint-method" in schedule["rationale"]
+    assert "before credits" in schedule["rationale"]
+    assert "broader filing-method selector" in schedule["rationale"]
+    assert schedule["policyengine_variable"] != "dc_income_tax_before_credits"
+
+    for output in (boundary, schedule):
+        assert (
+            output["entity"],
+            output["period"],
+            output["unit"],
+            output["comparison"],
+        ) == ("tax_unit", "year", "USD", "money")
+
+    bundled_fallbacks = [
+        item
+        for item in bundled_document["prefixes"]
+        if item.get("legal_id_prefix") == "us-dc:"
+    ]
+    assert len(bundled_fallbacks) == 1
+    assert bundled_fallbacks[0]["mapping_type"] == "not_comparable"
+    assert bundled_fallbacks[0]["candidate_priority"] == "P4"
+    assert "take precedence" in bundled_fallbacks[0]["rationale"]
+
+
+def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
+    import axiom_oracles.bridges.registry as runtime_registry_module
+
+    durable_oracle_merge = "9b889a27432e84804938bd3b374b4f5f7466792e"
+    root = Path(__file__).parents[1]
+    bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
+    runtime_path = (
+        Path(runtime_registry_module.__file__).with_name("mappings") / "us.yaml"
+    )
+    bundled_text = bundled_path.read_text()
+    runtime_text = runtime_path.read_text()
+    bundled_document = yaml.safe_load(bundled_text)
+    runtime_document = yaml.safe_load(runtime_text)
+    bundled = _dc_2026_section_47_1806_03_records(bundled_document)
+    runtime = _dc_2026_section_47_1806_03_records(runtime_document)
+    bundled_material = _dc_2026_shared_mapping_material(bundled_text)
+    runtime_material = _dc_2026_shared_mapping_material(runtime_text)
+    encoded_material = bundled_material.encode()
+
+    assert bundled == runtime
+    assert bundled_material == runtime_material
+    assert len(bundled_material.splitlines()) == 66
+    assert len(encoded_material) == 4_340
+    assert hashlib.sha256(encoded_material).hexdigest() == (
+        "30c426331da1ded1c90ad5db9a0104d91a425c3c0e5e08bfd3375bbf239e4ebf"
+    )
+
+    bundled_fallbacks = [
+        item
+        for item in bundled_document["prefixes"]
+        if item.get("legal_id_prefix") == "us-dc:"
+    ]
+    runtime_fallbacks = [
+        item
+        for item in runtime_document["prefixes"]
+        if item.get("legal_id_prefix") == "us-dc:"
+    ]
+    assert len(bundled_fallbacks) == 1
+    assert bundled_fallbacks == runtime_fallbacks
+
+    prefix = (
+        "us-dc:policies/income_tax/"
+        "2026_section_47_1806_03_schedule_before_credits#"
+    )
+    registry = load_policyengine_registry()
+    boundary = registry.mapping_for_legal_id(
+        f"{prefix}dc_pit_2026_section_47_1806_03_taxable_income_boundary",
+        country="us",
+    )
+    schedule = registry.mapping_for_legal_id(
+        f"{prefix}dc_pit_2026_section_47_1806_03_schedule_before_credits",
+        country="us",
+    )
+    fallback = registry.mapping_for_legal_id(
+        "us-dc:policies/income_tax/unrelated#future_output",
+        country="us",
+    )
+    assert boundary is not None
+    assert boundary.match_type == "exact"
+    assert boundary.mapping_type == "direct_variable"
+    assert boundary.policyengine_variable == "dc_taxable_income_joint"
+    assert schedule is not None
+    assert schedule.match_type == "exact"
+    assert schedule.mapping_type == "direct_variable"
+    assert schedule.policyengine_variable == (
+        "dc_income_tax_before_credits_joint"
+    )
+    assert fallback is not None
+    assert fallback.legal_id == "us-dc:"
+    assert fallback.match_type == "prefix"
+    assert fallback.mapping_type == "not_comparable"
+    assert fallback.candidate_priority == "P4"
+
+    dependency_pin = re.search(
+        r"axiom-oracles@[0-9a-f]{40}", (root / "pyproject.toml").read_text()
+    )
+    assert dependency_pin is not None
+    pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
+    assert pin == durable_oracle_merge
+    assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
+    assert (root / "src/axiom_encode/__init__.py").read_text().startswith(
+        '__version__ = "0.2.1398"'
+    )
 
 
 def _ohio_2026_schedule_records(document):
@@ -5818,7 +6009,7 @@ def test_packaged_utah_2026_before_credit_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "8d949d44d62b931a02e0e03f156af054e0ddf55e"
+    assert pin == "9b889a27432e84804938bd3b374b4f5f7466792e"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1397"
+version = "0.2.1398"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=8d949d44d62b931a02e0e03f156af054e0ddf55e" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=9b889a27432e84804938bd3b374b4f5f7466792e" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=8d949d44d62b931a02e0e03f156af054e0ddf55e#8d949d44d62b931a02e0e03f156af054e0ddf55e" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=9b889a27432e84804938bd3b374b4f5f7466792e#9b889a27432e84804938bd3b374b4f5f7466792e" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary
- bundle the reviewed canonical DC 2026 section 47-1806.03(a)(11) joint-method schedule-before-credits oracle mappings
- pin `axiom-oracles` to durable merged DC evidence commit `9b889a27432e84804938bd3b374b4f5f7466792e`
- bump `axiom-encode` to `0.2.1398` and add synchronization, precedence, fallback, classifier, pin, and version tests

## Bundle integrity
- exact upstream/bundled shared DC material: 66 normalized lines, 4,340 bytes
- normalized SHA-256: `30c426331da1ded1c90ad5db9a0104d91a425c3c0e5e08bfd3375bbf239e4ebf`
- source mapping delta: 67 added lines with seven exact outputs plus `us-dc:` P4 fallback
- comparable surface is only `dc_taxable_income_joint` and `dc_income_tax_before_credits_joint`; the broader filing-method selector is explicitly excluded
- scope is the bounded joint-method schedule before credits, not method selection or complete D-40 liability

## Validation
- committed implementation-head full suite: 5,943 passed, 119 skipped
- focused DC checks: 3 passed before and after the formatting-only follow-up
- neighboring pin/synchronization regressions: 11 passed
- commit-dependent provenance: passed
- Ruff lint and format, Python 3.13 compileall, `uv lock --check`, diff, corpus, credential, and exact merge-object extraction checks passed

## Review cycle
Independent exact-head review of implementation head `db326700c796b441ad73ea768e17525c16aa0a06` found no actionable findings. Hosted CI then identified Ruff formatting in the two new test files. The formatting-only follow-up at exact head `1ffc1a24ceded0b53768c0bb0d8220e4c2f1cb90` received a second independent CLEAN review: the two old/new Python ASTs are identical, all effective strings and assertions are unchanged, and mapping/pin/version files are byte-identical.