### PR TITLE
Bundle California 2026 BHST oracle mappings

### DIFF
--- a/changelog.d/ca-2026-bhst-oracle.changed.md
+++ b/changelog.d/ca-2026-bhst-oracle.changed.md
@@ -1,0 +1,1 @@
+Bundle California's bounded tax-year-2026 Behavioral Health Services Tax component mappings and pin their durable reviewed oracle-main merge without claiming the separate rate-schedule branch or complete Form 540 liability.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1398"
+version = "0.2.1399"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@9b889a27432e84804938bd3b374b4f5f7466792e",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@076ad9d458e5539db8d71cd4a06a43ad9b632d19",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1398"
+__version__ = "0.2.1399"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -28203,6 +28203,228 @@ mappings:
     candidate_priority: P4
     rationale: This zero is an explicit fail-closed source-hold sentinel, not computed final Utah liability.
 
+  # California's TY2026 pilot contains one independently comparable subgraph:
+  # the 1 percent Behavioral Health Services Tax on completed California
+  # taxable income above $1 million. These records deliberately do not promote
+  # the pilot's separate rate-schedule branch or broad liability surface.
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_rate_schedule_threshold
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec's $100,000 threshold selects the official California rate-schedule branch instead of the tax table. PolicyEngine exposes completed California income-tax results, not this source-specific routing threshold as a one-to-one parameter or variable.
+
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_schedule_x_upper
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec stores the Schedule X finite upper bounds as a selector-indexed private table. PolicyEngine's marginal scale does not expose a one-to-one output with that internal representation.
+
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_schedule_x_floor
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec stores the Schedule X excess-over floors as a selector-indexed private table. PolicyEngine's marginal scale does not expose a one-to-one output with that cumulative-schedule representation.
+
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_schedule_x_base
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec preserves the published Schedule X cumulative base amounts. PolicyEngine computes tax through a marginal scale and exposes no matching cumulative-base table output.
+
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_schedule_x_rate
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec stores the Schedule X rates in one selector-indexed private table. PolicyEngine's filing-status-specific marginal scale is not a one-to-one output with this table identity.
+
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_schedule_y_upper
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec stores the Schedule Y finite upper bounds as a selector-indexed private table. PolicyEngine's marginal scale does not expose a one-to-one output with that internal representation.
+
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_schedule_y_floor
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec stores the Schedule Y excess-over floors as a selector-indexed private table. PolicyEngine's marginal scale does not expose a one-to-one output with that cumulative-schedule representation.
+
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_schedule_y_base
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec preserves the published Schedule Y cumulative base amounts. PolicyEngine computes tax through a marginal scale and exposes no matching cumulative-base table output.
+
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_schedule_y_rate
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec stores the Schedule Y rates in one selector-indexed private table. PolicyEngine's filing-status-specific marginal scale is not a one-to-one output with this table identity.
+
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_schedule_z_upper
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec stores the Schedule Z finite upper bounds as a selector-indexed private table. PolicyEngine's marginal scale does not expose a one-to-one output with that internal representation.
+
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_schedule_z_floor
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec stores the Schedule Z excess-over floors as a selector-indexed private table. PolicyEngine's marginal scale does not expose a one-to-one output with that cumulative-schedule representation.
+
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_schedule_z_base
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec preserves the published Schedule Z cumulative base amounts. PolicyEngine computes tax through a marginal scale and exposes no matching cumulative-base table output.
+
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_schedule_z_rate
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec stores the Schedule Z rates in one selector-indexed private table. PolicyEngine's filing-status-specific marginal scale is not a one-to-one output with this table identity.
+
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_behavioral_health_services_tax_threshold
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ca.tax.income.mental_health_services
+    parameter_key_path: [thresholds, 1]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Both sources set the additional California tax threshold at $1 million of completed California taxable income. The second threshold in PolicyEngine's marginal scale is the first dollar at which the 1 percent rate applies.
+
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_behavioral_health_services_tax_rate
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ca.tax.income.mental_health_services
+    parameter_key_path: [rates, 1]
+    period: year
+    comparison: rate
+    rationale: Both sources apply a 1 percent additional California tax rate to completed California taxable income above $1 million.
+
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_completed_taxable_income
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: ca_taxable_income
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: RuleSpec preserves the nonnegative boundary derived from caller-supplied completed California taxable income. It does not construct taxable income, and the campaign supplies the distinct upstream PolicyEngine ca_taxable_income value directly.
+
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_rate_schedule_applicable
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This Boolean selects the official greater-than-$100,000 rate-schedule branch instead of the tax table. PolicyEngine does not expose that source-specific applicability judgment as a one-to-one variable.
+
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_schedule_x_bracket
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This private integer selects RuleSpec's internal Schedule X tables. PolicyEngine publishes computed tax but no one-to-one bracket-selector variable.
+
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_schedule_y_bracket
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This private integer selects RuleSpec's internal Schedule Y tables. PolicyEngine publishes computed tax but no one-to-one bracket-selector variable.
+
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_schedule_z_bracket
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This private integer selects RuleSpec's internal Schedule Z tables. PolicyEngine publishes computed tax but no one-to-one bracket-selector variable.
+
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_schedule_x_top_bracket_base
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This internal Schedule X top-bracket base is derived from RuleSpec's published cumulative schedule representation. PolicyEngine exposes no one-to-one variable with that representation.
+
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_schedule_y_top_bracket_base
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This internal Schedule Y top-bracket base is derived from RuleSpec's published cumulative schedule representation. PolicyEngine exposes no one-to-one variable with that representation.
+
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_schedule_z_top_bracket_base
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This internal Schedule Z top-bracket base is derived from RuleSpec's published cumulative schedule representation. PolicyEngine exposes no one-to-one variable with that representation.
+
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_schedule_x_tax
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This branch-specific Schedule X amount is a non-applicable zero sentinel for other filing classifications and for the tax-table domain. PolicyEngine's broader California schedule variables do not have the same one-to-one branch contract.
+
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_schedule_y_tax
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This branch-specific Schedule Y amount is a non-applicable zero sentinel for other filing classifications and for the tax-table domain. PolicyEngine's broader California schedule variables do not have the same one-to-one branch contract.
+
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_schedule_z_tax
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This branch-specific Schedule Z amount is a non-applicable zero sentinel for other filing classifications and for the tax-table domain. PolicyEngine's broader California schedule variables do not have the same one-to-one branch contract.
+
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_estimated_tax_rate_schedule_amount
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This output is only the Form 540-ES greater-than-$100,000 rate-schedule branch and returns a non-applicable zero sentinel in the tax-table domain. PolicyEngine does not expose that bounded estimated-tax worksheet branch one to one.
+
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_behavioral_health_services_tax
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: ca_mental_health_services_tax
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Both outputs impose the 1 percent additional California tax on the portion of completed California taxable income above $1 million. This exact subgraph comparison makes no claim about the separate rate-schedule branch or full California liability.
+
+  - legal_id: us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_estimated_tax_schedule_branch_total
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This estimated-tax worksheet total combines RuleSpec's bounded rate-schedule branch with Behavioral Health Services Tax. PolicyEngine exposes broader California income-tax totals with different tax-table, credit, and liability scope, so only the BHST component is directly comparable.
+
 prefixes:
   - legal_id_prefix: us-dc:statutes/4/4-205/49#
     country: us

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -590,6 +590,90 @@ rules:
     } == {"P4"}
 
 
+def test_policyengine_coverage_classifies_bounded_ca_2026_bhst(tmp_path):
+    output_names = (
+        "ca_pit_pilot_rate_schedule_threshold",
+        "ca_pit_pilot_schedule_x_upper",
+        "ca_pit_pilot_schedule_x_floor",
+        "ca_pit_pilot_schedule_x_base",
+        "ca_pit_pilot_schedule_x_rate",
+        "ca_pit_pilot_schedule_y_upper",
+        "ca_pit_pilot_schedule_y_floor",
+        "ca_pit_pilot_schedule_y_base",
+        "ca_pit_pilot_schedule_y_rate",
+        "ca_pit_pilot_schedule_z_upper",
+        "ca_pit_pilot_schedule_z_floor",
+        "ca_pit_pilot_schedule_z_base",
+        "ca_pit_pilot_schedule_z_rate",
+        "ca_pit_pilot_behavioral_health_services_tax_threshold",
+        "ca_pit_pilot_behavioral_health_services_tax_rate",
+        "ca_pit_pilot_completed_taxable_income",
+        "ca_pit_pilot_rate_schedule_applicable",
+        "ca_pit_pilot_schedule_x_bracket",
+        "ca_pit_pilot_schedule_y_bracket",
+        "ca_pit_pilot_schedule_z_bracket",
+        "ca_pit_pilot_schedule_x_top_bracket_base",
+        "ca_pit_pilot_schedule_y_top_bracket_base",
+        "ca_pit_pilot_schedule_z_top_bracket_base",
+        "ca_pit_pilot_schedule_x_tax",
+        "ca_pit_pilot_schedule_y_tax",
+        "ca_pit_pilot_schedule_z_tax",
+        "ca_pit_pilot_estimated_tax_rate_schedule_amount",
+        "ca_pit_pilot_behavioral_health_services_tax",
+        "ca_pit_pilot_estimated_tax_schedule_branch_total",
+    )
+    rules = "\n".join(
+        "  - name: "
+        f"{name}\n"
+        "    kind: derived\n"
+        "    versions:\n"
+        "      - effective_from: '2026-01-01'\n"
+        "        formula: 0"
+        for name in output_names
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-ca"
+        / "policies/income_tax/pilot_liability_pipeline.yaml",
+        f"format: rulespec/v1\nrules:\n{rules}\n",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["total_outputs"] == 29
+    assert report["status_counts"] == {
+        "comparable": 4,
+        "known_not_comparable": 25,
+    }
+    items = {item["rule_name"]: item for item in report["items"]}
+    assert set(items) == set(output_names)
+    assert {name for name, item in items.items() if item["status"] == "comparable"} == {
+        "ca_pit_pilot_behavioral_health_services_tax_threshold",
+        "ca_pit_pilot_behavioral_health_services_tax_rate",
+        "ca_pit_pilot_completed_taxable_income",
+        "ca_pit_pilot_behavioral_health_services_tax",
+    }
+    assert (
+        items["ca_pit_pilot_behavioral_health_services_tax_threshold"][
+            "policyengine_parameter"
+        ]
+        == "gov.states.ca.tax.income.mental_health_services"
+    )
+    assert (
+        items["ca_pit_pilot_completed_taxable_income"]["policyengine_variable"]
+        == "ca_taxable_income"
+    )
+    assert (
+        items["ca_pit_pilot_behavioral_health_services_tax"]["policyengine_variable"]
+        == "ca_mental_health_services_tax"
+    )
+    assert {
+        item["candidate_priority"]
+        for item in items.values()
+        if item["status"] == "known_not_comparable"
+    } == {"P4"}
+
+
 def test_policyengine_coverage_classifies_new_york_tanf_program_output(tmp_path):
     checkout = tmp_path / "rulespec-us"
     _write_rulespec_file(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5120,7 +5120,7 @@ def test_packaged_alabama_2026_schedule_registry_and_fallback_are_synchronized()
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "9b889a27432e84804938bd3b374b4f5f7466792e"
+    assert pin == "076ad9d458e5539db8d71cd4a06a43ad9b632d19"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5231,7 +5231,7 @@ def test_packaged_connecticut_2026_ordinary_tax_registry_is_exactly_synchronized
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "9b889a27432e84804938bd3b374b4f5f7466792e"
+    assert pin == "076ad9d458e5539db8d71cd4a06a43ad9b632d19"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5315,7 +5315,7 @@ def test_packaged_georgia_2026_annual_tax_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "9b889a27432e84804938bd3b374b4f5f7466792e"
+    assert pin == "076ad9d458e5539db8d71cd4a06a43ad9b632d19"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5410,7 +5410,7 @@ def test_packaged_mississippi_2026_schedule_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "9b889a27432e84804938bd3b374b4f5f7466792e"
+    assert pin == "076ad9d458e5539db8d71cd4a06a43ad9b632d19"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5571,7 +5571,7 @@ def test_packaged_kansas_2026_k40es_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "9b889a27432e84804938bd3b374b4f5f7466792e"
+    assert pin == "076ad9d458e5539db8d71cd4a06a43ad9b632d19"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5676,7 +5676,7 @@ def test_packaged_dc_2026_section_47_1806_03_has_exact_bounded_slice():
 def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "9b889a27432e84804938bd3b374b4f5f7466792e"
+    durable_oracle_merge = "076ad9d458e5539db8d71cd4a06a43ad9b632d19"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -5753,7 +5753,245 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1398"')
+        .startswith('__version__ = "0.2.1399"')
+    )
+
+
+def _ca_2026_bhst_records(document):
+    module_prefix = "us-ca:policies/income_tax/pilot_liability_pipeline#"
+    return {
+        item["legal_id"].removeprefix(module_prefix): item
+        for item in document["mappings"]
+        if item.get("legal_id", "").startswith(module_prefix)
+    }
+
+
+def _ca_2026_bhst_shared_mapping_material(text):
+    def exact_section(start, end):
+        start_index = text.index(start)
+        end_index = text.index(end, start_index) + len(end)
+        return text[start_index:end_index]
+
+    exact_records = exact_section(
+        "  # California's TY2026 pilot contains one independently comparable subgraph:",
+        "    rationale: This estimated-tax worksheet total combines RuleSpec's "
+        "bounded rate-schedule branch with Behavioral Health Services Tax. "
+        "PolicyEngine exposes broader California income-tax totals with "
+        "different tax-table, credit, and liability scope, so only the BHST "
+        "component is directly comparable.",
+    )
+    fallback = exact_section(
+        '  - legal_id_prefix: "us-ca:"',
+        "    rationale: PolicyEngine-US does not model CA agency policy manuals "
+        "or state regulations at output granularity; comparable state outputs "
+        "carry exact mappings which take precedence over this prefix.",
+    )
+    return f"{exact_records}\n\n{fallback}".replace("\r\n", "\n").replace("\r", "\n")
+
+
+def test_packaged_ca_2026_bhst_registry_has_exact_bounded_slice():
+    root = Path(__file__).parents[1]
+    bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
+    bundled_document = yaml.safe_load(bundled_path.read_text())
+    bundled = _ca_2026_bhst_records(bundled_document)
+    expected_parameter_values = {
+        "ca_pit_pilot_behavioral_health_services_tax_threshold": (
+            "gov.states.ca.tax.income.mental_health_services",
+            ["thresholds", 1],
+            "money",
+        ),
+        "ca_pit_pilot_behavioral_health_services_tax_rate": (
+            "gov.states.ca.tax.income.mental_health_services",
+            ["rates", 1],
+            "rate",
+        ),
+    }
+    expected_direct_variables = {
+        "ca_pit_pilot_completed_taxable_income": "ca_taxable_income",
+        "ca_pit_pilot_behavioral_health_services_tax": (
+            "ca_mental_health_services_tax"
+        ),
+    }
+    comparable = {
+        name: item
+        for name, item in bundled.items()
+        if item["mapping_type"] != "not_comparable"
+    }
+    not_comparable = {
+        name: item
+        for name, item in bundled.items()
+        if item["mapping_type"] == "not_comparable"
+    }
+
+    assert len(bundled) == 29
+    assert set(comparable) == {
+        *expected_parameter_values,
+        *expected_direct_variables,
+    }
+    assert len(not_comparable) == 25
+    assert {item["candidate_priority"] for item in not_comparable.values()} == {"P4"}
+    assert {item["program"] for item in bundled.values()} == {"tax"}
+    for output in not_comparable.values():
+        assert "policyengine_variable" not in output
+        assert "policyengine_parameter" not in output
+        assert output["rationale"]
+
+    for output_name, (
+        parameter,
+        key_path,
+        comparison,
+    ) in expected_parameter_values.items():
+        output = bundled[output_name]
+        assert output["mapping_type"] == "parameter_value"
+        assert output["policyengine_parameter"] == parameter
+        assert output["parameter_key_path"] == key_path
+        assert output["period"] == "year"
+        assert output["comparison"] == comparison
+    assert (
+        bundled["ca_pit_pilot_behavioral_health_services_tax_threshold"]["unit"]
+        == "USD"
+    )
+
+    for output_name, variable in expected_direct_variables.items():
+        output = bundled[output_name]
+        assert output["mapping_type"] == "direct_variable"
+        assert output["policyengine_variable"] == variable
+        assert (
+            output["entity"],
+            output["period"],
+            output["unit"],
+            output["comparison"],
+        ) == ("tax_unit", "year", "USD", "money")
+
+    bundled_fallbacks = [
+        item
+        for item in bundled_document["prefixes"]
+        if item.get("legal_id_prefix") == "us-ca:"
+    ]
+    assert len(bundled_fallbacks) == 1
+    assert bundled_fallbacks[0]["mapping_type"] == "not_comparable"
+    assert bundled_fallbacks[0]["candidate_priority"] == "P4"
+    assert "take precedence" in bundled_fallbacks[0]["rationale"]
+
+
+def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
+    import tomllib
+
+    import axiom_oracles.bridges.registry as runtime_registry_module
+
+    durable_oracle_merge = "076ad9d458e5539db8d71cd4a06a43ad9b632d19"
+    root = Path(__file__).parents[1]
+    bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
+    runtime_path = (
+        Path(runtime_registry_module.__file__).with_name("mappings") / "us.yaml"
+    )
+    bundled_text = bundled_path.read_text()
+    runtime_text = runtime_path.read_text()
+    bundled_document = yaml.safe_load(bundled_text)
+    runtime_document = yaml.safe_load(runtime_text)
+    bundled = _ca_2026_bhst_records(bundled_document)
+    runtime = _ca_2026_bhst_records(runtime_document)
+    bundled_material = _ca_2026_bhst_shared_mapping_material(bundled_text)
+    runtime_material = _ca_2026_bhst_shared_mapping_material(runtime_text)
+    encoded_material = bundled_material.encode()
+
+    assert bundled == runtime
+    assert bundled_material == runtime_material
+    assert len(bundled_material.splitlines()) == 227
+    assert len(encoded_material) == 12_886
+    assert hashlib.sha256(encoded_material).hexdigest() == (
+        "5d6b30fed74d8f16dbd8296b997a9f4bddca4a3de2ff052f297e196ba7757ec3"
+    )
+
+    bundled_fallbacks = [
+        item
+        for item in bundled_document["prefixes"]
+        if item.get("legal_id_prefix") == "us-ca:"
+    ]
+    runtime_fallbacks = [
+        item
+        for item in runtime_document["prefixes"]
+        if item.get("legal_id_prefix") == "us-ca:"
+    ]
+    assert len(bundled_fallbacks) == 1
+    assert bundled_fallbacks == runtime_fallbacks
+
+    prefix = "us-ca:policies/income_tax/pilot_liability_pipeline#"
+    registry = load_policyengine_registry()
+    threshold = registry.mapping_for_legal_id(
+        f"{prefix}ca_pit_pilot_behavioral_health_services_tax_threshold",
+        country="us",
+    )
+    rate = registry.mapping_for_legal_id(
+        f"{prefix}ca_pit_pilot_behavioral_health_services_tax_rate",
+        country="us",
+    )
+    completed_income = registry.mapping_for_legal_id(
+        f"{prefix}ca_pit_pilot_completed_taxable_income",
+        country="us",
+    )
+    bhst = registry.mapping_for_legal_id(
+        f"{prefix}ca_pit_pilot_behavioral_health_services_tax",
+        country="us",
+    )
+    internal = registry.mapping_for_legal_id(
+        f"{prefix}ca_pit_pilot_rate_schedule_threshold",
+        country="us",
+    )
+    fallback = registry.mapping_for_legal_id(
+        f"{prefix}future_unmapped_output",
+        country="us",
+    )
+
+    assert threshold is not None
+    assert threshold.match_type == "exact"
+    assert threshold.mapping_type == "parameter_value"
+    assert threshold.policyengine_parameter == (
+        "gov.states.ca.tax.income.mental_health_services"
+    )
+    assert threshold.parameter_key_path == ("thresholds", 1)
+    assert rate is not None
+    assert rate.match_type == "exact"
+    assert rate.mapping_type == "parameter_value"
+    assert rate.parameter_key_path == ("rates", 1)
+    assert completed_income is not None
+    assert completed_income.match_type == "exact"
+    assert completed_income.mapping_type == "direct_variable"
+    assert completed_income.policyengine_variable == "ca_taxable_income"
+    assert bhst is not None
+    assert bhst.match_type == "exact"
+    assert bhst.mapping_type == "direct_variable"
+    assert bhst.policyengine_variable == "ca_mental_health_services_tax"
+    assert internal is not None
+    assert internal.match_type == "exact"
+    assert internal.mapping_type == "not_comparable"
+    assert internal.candidate_priority == "P4"
+    assert fallback is not None
+    assert fallback.legal_id == "us-ca:"
+    assert fallback.match_type == "prefix"
+    assert fallback.mapping_type == "not_comparable"
+    assert fallback.candidate_priority == "P4"
+
+    dependency_pin = re.search(
+        r"axiom-oracles@[0-9a-f]{40}", (root / "pyproject.toml").read_text()
+    )
+    assert dependency_pin is not None
+    pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
+    assert pin == durable_oracle_merge
+    lock_text = (root / "uv.lock").read_text()
+    assert lock_text.count(f"?rev={pin}") == 2
+    assert f"?rev={pin}#{pin}" in lock_text
+    lock = tomllib.loads(lock_text)
+    encoder_package = next(
+        package for package in lock["package"] if package["name"] == "axiom-encode"
+    )
+    assert encoder_package["version"] == "0.2.1399"
+    project = tomllib.loads((root / "pyproject.toml").read_text())
+    assert project["project"]["version"] == "0.2.1399"
+    assert (
+        (root / "src/axiom_encode/__init__.py")
+        .read_text()
+        .startswith('__version__ = "0.2.1399"')
     )
 
 
@@ -6000,7 +6238,7 @@ def test_packaged_utah_2026_before_credit_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "9b889a27432e84804938bd3b374b4f5f7466792e"
+    assert pin == "076ad9d458e5539db8d71cd4a06a43ad9b632d19"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1398"
+version = "0.2.1399"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=9b889a27432e84804938bd3b374b4f5f7466792e" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=076ad9d458e5539db8d71cd4a06a43ad9b632d19" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=9b889a27432e84804938bd3b374b4f5f7466792e#9b889a27432e84804938bd3b374b4f5f7466792e" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=076ad9d458e5539db8d71cd4a06a43ad9b632d19#076ad9d458e5539db8d71cd4a06a43ad9b632d19" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary
- bundle the reviewed California 2026 Behavioral Health Services Tax oracle mappings
- pin `axiom-oracles` to durable merged California evidence commit `076ad9d458e5539db8d71cd4a06a43ad9b632d19`
- bump `axiom-encode` to `0.2.1399` and add exact synchronization, precedence, fallback, classifier, pin, and version tests

## Bundle integrity
- exact CA block: 221 normalized lines, 12,578 bytes, SHA-256 `f40cc687ce54a627c07d750febf3c6cce5e77ea9a09c06a1725cfbcec4e278bb`
- existing single `us-ca:` fallback: 5 lines, 306 bytes, SHA-256 `e4a85981b315f0d977b8bf63a31f993927f1ee2de2e7973816fc77d8a9a66875`
- combined normalized material: 227 lines, 12,886 bytes, SHA-256 `5d6b30fed74d8f16dbd8296b997a9f4bddca4a3de2ff052f297e196ba7757ec3`
- 29 exact outputs: 4 comparable and 25 explicit P4; exact records precede the existing fallback
- comparable scope is BHST threshold/rate, completed `ca_taxable_income`, and `ca_mental_health_services_tax`; no complete California liability claim

## Validation
- committed-head full suite: 5,946 passed, 119 skipped
- focused implementation/neighbor checks: 12 independently passed
- commit-dependent provenance: passed
- Ruff lint and format, Python 3.13 compileall, `uv lock --check`, diff, wheel/sdist build, corpus, credential, and exact merge-object extraction checks passed

## Review cycle
Independent exact-head review of `b5c1c2fafa48d79b0377f90e93fa0595dcb2a9c0` found no actionable findings. It independently confirmed the two-parent oracle merge pin, byte identity and all three hashes, version/lock synchronization, exact precedence/fallback behavior, 4 comparable plus 25 known-not-comparable outputs, bounded wording, neighboring-state preservation, and a clean seven-file scope.