### PR TITLE
Bundle New York 2026 main income tax oracle mappings

### DIFF
--- a/changelog.d/ny-2026-main-income-tax-oracle.changed.md
+++ b/changelog.d/ny-2026-main-income-tax-oracle.changed.md
@@ -1,0 +1,1 @@
+Bundle New York's bounded tax-year-2026 Tax Law section 601 main resident income-tax schedule mappings and pin their durable reviewed oracle-main merge without claiming supplemental tax, credits, local taxes, payments, or final annual liability.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1399"
+version = "0.2.1400"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@076ad9d458e5539db8d71cd4a06a43ad9b632d19",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@9e6d93662da32ad423c177b8265720eed40e6660",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1399"
+__version__ = "0.2.1400"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -28425,6 +28425,381 @@ mappings:
     candidate_priority: P4
     rationale: This estimated-tax worksheet total combines RuleSpec's bounded rate-schedule branch with Behavioral Health Services Tax. PolicyEngine exposes broader California income-tax totals with different tax-table, credit, and liability scope, so only the BHST component is directly comparable.
 
+  # New York Tax Law section 601's bounded TY2026 main resident schedule.
+  # These exact records cover every output in the canonical RuleSpec module
+  # and take precedence over the jurisdiction-wide fallback below. They do not
+  # claim supplemental tax, credits, local taxes, or final annual liability.
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: ny_taxable_income
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: RuleSpec preserves the completed New York taxable-income boundary supplied to the section 601 main schedule; PolicyEngine exposes that same completed boundary as ny_taxable_income.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: ny_main_income_tax
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Both outputs apply the 2026 section 601 main resident schedule to completed New York taxable income before supplemental tax, credits, local taxes, payments, or final liability.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_bracket_selector
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the internal integer row selected from the joint-or-surviving statutory table; PolicyEngine applies a marginal scale and exposes no one-to-one selector output.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_bracket_selector
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the internal integer row selected from the head-of-household statutory table; PolicyEngine applies a marginal scale and exposes no one-to-one selector output.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_selector
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the internal integer row selected from the single-or-separate statutory table; PolicyEngine applies a marginal scale and exposes no one-to-one selector output.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_first_upper_bound
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ny.tax.income.main.joint
+    parameter_key_path: [thresholds, 1]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same first upper bound in the 2026 joint and surviving-spouse section 601 schedule; PolicyEngine's joint and surviving-spouse scales are identical.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_second_upper_bound
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ny.tax.income.main.joint
+    parameter_key_path: [thresholds, 2]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same second upper bound in the 2026 joint and surviving-spouse section 601 schedule; PolicyEngine's joint and surviving-spouse scales are identical.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_third_upper_bound
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ny.tax.income.main.joint
+    parameter_key_path: [thresholds, 3]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same third upper bound in the 2026 joint and surviving-spouse section 601 schedule; PolicyEngine's joint and surviving-spouse scales are identical.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_fourth_upper_bound
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ny.tax.income.main.joint
+    parameter_key_path: [thresholds, 4]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same fourth upper bound in the 2026 joint and surviving-spouse section 601 schedule; PolicyEngine's joint and surviving-spouse scales are identical.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_fifth_upper_bound
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ny.tax.income.main.joint
+    parameter_key_path: [thresholds, 5]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same fifth upper bound in the 2026 joint and surviving-spouse section 601 schedule; PolicyEngine's joint and surviving-spouse scales are identical.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_sixth_upper_bound
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ny.tax.income.main.joint
+    parameter_key_path: [thresholds, 6]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same sixth upper bound in the 2026 joint and surviving-spouse section 601 schedule; PolicyEngine's joint and surviving-spouse scales are identical.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_seventh_upper_bound
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ny.tax.income.main.joint
+    parameter_key_path: [thresholds, 7]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same seventh upper bound in the 2026 joint and surviving-spouse section 601 schedule; PolicyEngine's joint and surviving-spouse scales are identical.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_eighth_upper_bound
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ny.tax.income.main.joint
+    parameter_key_path: [thresholds, 8]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same eighth upper bound in the 2026 joint and surviving-spouse section 601 schedule; PolicyEngine's joint and surviving-spouse scales are identical.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_first_upper_bound
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ny.tax.income.main.head_of_household
+    parameter_key_path: [thresholds, 1]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same first upper bound in the 2026 head-of-household section 601 schedule.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_second_upper_bound
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ny.tax.income.main.head_of_household
+    parameter_key_path: [thresholds, 2]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same second upper bound in the 2026 head-of-household section 601 schedule.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_third_upper_bound
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ny.tax.income.main.head_of_household
+    parameter_key_path: [thresholds, 3]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same third upper bound in the 2026 head-of-household section 601 schedule.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_fourth_upper_bound
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ny.tax.income.main.head_of_household
+    parameter_key_path: [thresholds, 4]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same fourth upper bound in the 2026 head-of-household section 601 schedule.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_fifth_upper_bound
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ny.tax.income.main.head_of_household
+    parameter_key_path: [thresholds, 5]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same fifth upper bound in the 2026 head-of-household section 601 schedule.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_sixth_upper_bound
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ny.tax.income.main.head_of_household
+    parameter_key_path: [thresholds, 6]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same sixth upper bound in the 2026 head-of-household section 601 schedule.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_seventh_upper_bound
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ny.tax.income.main.head_of_household
+    parameter_key_path: [thresholds, 7]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same seventh upper bound in the 2026 head-of-household section 601 schedule.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_eighth_upper_bound
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ny.tax.income.main.head_of_household
+    parameter_key_path: [thresholds, 8]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same eighth upper bound in the 2026 head-of-household section 601 schedule.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_first_upper_bound
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ny.tax.income.main.single
+    parameter_key_path: [thresholds, 1]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same first upper bound in the 2026 single and married-separate section 601 schedule; PolicyEngine's single and separate scales are identical.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_second_upper_bound
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ny.tax.income.main.single
+    parameter_key_path: [thresholds, 2]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same second upper bound in the 2026 single and married-separate section 601 schedule; PolicyEngine's single and separate scales are identical.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_third_upper_bound
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ny.tax.income.main.single
+    parameter_key_path: [thresholds, 3]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same third upper bound in the 2026 single and married-separate section 601 schedule; PolicyEngine's single and separate scales are identical.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_fourth_upper_bound
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ny.tax.income.main.single
+    parameter_key_path: [thresholds, 4]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same fourth upper bound in the 2026 single and married-separate section 601 schedule; PolicyEngine's single and separate scales are identical.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_fifth_upper_bound
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ny.tax.income.main.single
+    parameter_key_path: [thresholds, 5]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same fifth upper bound in the 2026 single and married-separate section 601 schedule; PolicyEngine's single and separate scales are identical.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_sixth_upper_bound
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ny.tax.income.main.single
+    parameter_key_path: [thresholds, 6]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same sixth upper bound in the 2026 single and married-separate section 601 schedule; PolicyEngine's single and separate scales are identical.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_seventh_upper_bound
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ny.tax.income.main.single
+    parameter_key_path: [thresholds, 7]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same seventh upper bound in the 2026 single and married-separate section 601 schedule; PolicyEngine's single and separate scales are identical.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_eighth_upper_bound
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ny.tax.income.main.single
+    parameter_key_path: [thresholds, 8]
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same eighth upper bound in the 2026 single and married-separate section 601 schedule; PolicyEngine's single and separate scales are identical.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_bracket_floor
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the complete statutory floor table as one RuleSpec output; PolicyEngine's registry supports scalar scale-cell comparison but has no one-to-one whole-table oracle target.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_bracket_base
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the statute's rounded cumulative-base table; PolicyEngine computes a continuous marginal scale and has no one-to-one published-base table target.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_bracket_rate
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the complete statutory rate table as one RuleSpec output; PolicyEngine's registry supports scalar scale-cell comparison but has no one-to-one whole-table oracle target.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_bracket_floor
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the complete statutory floor table as one RuleSpec output; PolicyEngine's registry supports scalar scale-cell comparison but has no one-to-one whole-table oracle target.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_bracket_base
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the statute's rounded cumulative-base table; PolicyEngine computes a continuous marginal scale and has no one-to-one published-base table target.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_bracket_rate
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the complete statutory rate table as one RuleSpec output; PolicyEngine's registry supports scalar scale-cell comparison but has no one-to-one whole-table oracle target.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_floor
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the complete statutory floor table as one RuleSpec output; PolicyEngine's registry supports scalar scale-cell comparison but has no one-to-one whole-table oracle target.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_base
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the statute's rounded cumulative-base table; PolicyEngine computes a continuous marginal scale and has no one-to-one published-base table target.
+
+  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_rate
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the complete statutory rate table as one RuleSpec output; PolicyEngine's registry supports scalar scale-cell comparison but has no one-to-one whole-table oracle target.
+
+
 prefixes:
   - legal_id_prefix: us-dc:statutes/4/4-205/49#
     country: us

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -674,6 +674,106 @@ def test_policyengine_coverage_classifies_bounded_ca_2026_bhst(tmp_path):
     } == {"P4"}
 
 
+def test_policyengine_coverage_classifies_bounded_ny_2026_main_income_tax(tmp_path):
+    filing_statuses = (
+        "joint_or_surviving",
+        "head_of_household",
+        "single_or_separate",
+    )
+    ordinals = (
+        "first",
+        "second",
+        "third",
+        "fourth",
+        "fifth",
+        "sixth",
+        "seventh",
+        "eighth",
+    )
+    direct_variables = {
+        "ny_pit_pilot_taxable_income": "ny_taxable_income",
+        "ny_pit_pilot_main_income_tax": "ny_main_income_tax",
+    }
+    parameter_outputs = {
+        f"ny_pit_pilot_{filing_status}_{ordinal}_upper_bound"
+        for filing_status in filing_statuses
+        for ordinal in ordinals
+    }
+    not_comparable_outputs = {
+        *(
+            f"ny_pit_pilot_{filing_status}_bracket_selector"
+            for filing_status in filing_statuses
+        ),
+        *(
+            f"ny_pit_pilot_{filing_status}_bracket_{table}"
+            for filing_status in filing_statuses
+            for table in ("floor", "base", "rate")
+        ),
+    }
+    output_names = (
+        *direct_variables,
+        *sorted(parameter_outputs),
+        *sorted(not_comparable_outputs),
+    )
+    rules = "\n".join(
+        "  - name: "
+        f"{name}\n"
+        "    kind: derived\n"
+        "    versions:\n"
+        "      - effective_from: '2026-01-01'\n"
+        "        formula: 0"
+        for name in output_names
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-ny"
+        / "policies/income_tax/pilot_liability_pipeline.yaml",
+        f"format: rulespec/v1\nrules:\n{rules}\n",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["total_outputs"] == 38
+    assert report["status_counts"] == {
+        "comparable": 26,
+        "known_not_comparable": 12,
+    }
+    items = {item["rule_name"]: item for item in report["items"]}
+    assert set(items) == set(output_names)
+    assert {name for name, item in items.items() if item["status"] == "comparable"} == {
+        *direct_variables,
+        *parameter_outputs,
+    }
+    for output_name, variable in direct_variables.items():
+        assert items[output_name]["policyengine_variable"] == variable
+    assert (
+        items["ny_pit_pilot_joint_or_surviving_first_upper_bound"][
+            "policyengine_parameter"
+        ]
+        == "gov.states.ny.tax.income.main.joint"
+    )
+    assert (
+        items["ny_pit_pilot_head_of_household_eighth_upper_bound"][
+            "policyengine_parameter"
+        ]
+        == "gov.states.ny.tax.income.main.head_of_household"
+    )
+    assert (
+        items["ny_pit_pilot_single_or_separate_fourth_upper_bound"][
+            "policyengine_parameter"
+        ]
+        == "gov.states.ny.tax.income.main.single"
+    )
+    assert {
+        name for name, item in items.items() if item["status"] == "known_not_comparable"
+    } == not_comparable_outputs
+    assert {
+        item["candidate_priority"]
+        for item in items.values()
+        if item["status"] == "known_not_comparable"
+    } == {"P4"}
+
+
 def test_policyengine_coverage_classifies_new_york_tanf_program_output(tmp_path):
     checkout = tmp_path / "rulespec-us"
     _write_rulespec_file(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5120,7 +5120,7 @@ def test_packaged_alabama_2026_schedule_registry_and_fallback_are_synchronized()
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "076ad9d458e5539db8d71cd4a06a43ad9b632d19"
+    assert pin == "9e6d93662da32ad423c177b8265720eed40e6660"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5231,7 +5231,7 @@ def test_packaged_connecticut_2026_ordinary_tax_registry_is_exactly_synchronized
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "076ad9d458e5539db8d71cd4a06a43ad9b632d19"
+    assert pin == "9e6d93662da32ad423c177b8265720eed40e6660"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5315,7 +5315,7 @@ def test_packaged_georgia_2026_annual_tax_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "076ad9d458e5539db8d71cd4a06a43ad9b632d19"
+    assert pin == "9e6d93662da32ad423c177b8265720eed40e6660"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5410,7 +5410,7 @@ def test_packaged_mississippi_2026_schedule_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "076ad9d458e5539db8d71cd4a06a43ad9b632d19"
+    assert pin == "9e6d93662da32ad423c177b8265720eed40e6660"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5571,7 +5571,7 @@ def test_packaged_kansas_2026_k40es_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "076ad9d458e5539db8d71cd4a06a43ad9b632d19"
+    assert pin == "9e6d93662da32ad423c177b8265720eed40e6660"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5676,7 +5676,7 @@ def test_packaged_dc_2026_section_47_1806_03_has_exact_bounded_slice():
 def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "076ad9d458e5539db8d71cd4a06a43ad9b632d19"
+    durable_oracle_merge = "9e6d93662da32ad423c177b8265720eed40e6660"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1399"')
+        .startswith('__version__ = "0.2.1400"')
     )
 
 
@@ -5879,7 +5879,7 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
 
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "076ad9d458e5539db8d71cd4a06a43ad9b632d19"
+    durable_oracle_merge = "9e6d93662da32ad423c177b8265720eed40e6660"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -5985,13 +5985,281 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1399"
+    assert encoder_package["version"] == "0.2.1400"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1399"
+    assert project["project"]["version"] == "0.2.1400"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1399"')
+        .startswith('__version__ = "0.2.1400"')
+    )
+
+
+def _ny_2026_main_income_tax_records(document):
+    module_prefix = "us-ny:policies/income_tax/pilot_liability_pipeline#"
+    return {
+        item["legal_id"].removeprefix(module_prefix): item
+        for item in document["mappings"]
+        if item.get("legal_id", "").startswith(module_prefix)
+    }
+
+
+def _ny_2026_main_income_tax_expected_parameters():
+    ordinals = (
+        "first",
+        "second",
+        "third",
+        "fourth",
+        "fifth",
+        "sixth",
+        "seventh",
+        "eighth",
+    )
+    filing_scales = {
+        "joint_or_surviving": "gov.states.ny.tax.income.main.joint",
+        "head_of_household": "gov.states.ny.tax.income.main.head_of_household",
+        "single_or_separate": "gov.states.ny.tax.income.main.single",
+    }
+    return {
+        f"ny_pit_pilot_{filing_status}_{ordinal}_upper_bound": (
+            parameter,
+            ["thresholds", index],
+        )
+        for filing_status, parameter in filing_scales.items()
+        for index, ordinal in enumerate(ordinals, start=1)
+    }
+
+
+def _ny_2026_main_income_tax_shared_mapping_material(text):
+    def exact_section(start, end):
+        start_index = text.index(start)
+        end_index = text.index(end, start_index) + len(end)
+        return text[start_index:end_index]
+
+    exact_records = exact_section(
+        "  # New York Tax Law section 601's bounded TY2026 main resident schedule.",
+        "  - legal_id: us-ny:policies/income_tax/pilot_liability_pipeline"
+        "#ny_pit_pilot_single_or_separate_bracket_rate\n"
+        "    country: us\n"
+        "    program: tax\n"
+        "    mapping_type: not_comparable\n"
+        "    candidate_priority: P4\n"
+        "    rationale: Axiom exposes the complete statutory rate table as one "
+        "RuleSpec output; PolicyEngine's registry supports scalar scale-cell "
+        "comparison but has no one-to-one whole-table oracle target.",
+    )
+    fallback = exact_section(
+        '  - legal_id_prefix: "us-ny:"',
+        "    rationale: PolicyEngine-US does not model NY agency policy manuals "
+        "or state regulations at output granularity; comparable state outputs "
+        "carry exact mappings which take precedence over this prefix.",
+    )
+    return f"{exact_records}\n\n{fallback}".replace("\r\n", "\n").replace("\r", "\n")
+
+
+def test_packaged_ny_2026_main_income_tax_registry_has_exact_bounded_slice():
+    root = Path(__file__).parents[1]
+    bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
+    bundled_document = yaml.safe_load(bundled_path.read_text())
+    bundled = _ny_2026_main_income_tax_records(bundled_document)
+    expected_parameters = _ny_2026_main_income_tax_expected_parameters()
+    expected_direct_variables = {
+        "ny_pit_pilot_taxable_income": "ny_taxable_income",
+        "ny_pit_pilot_main_income_tax": "ny_main_income_tax",
+    }
+    filing_statuses = (
+        "joint_or_surviving",
+        "head_of_household",
+        "single_or_separate",
+    )
+    expected_not_comparable = {
+        *(
+            f"ny_pit_pilot_{filing_status}_bracket_selector"
+            for filing_status in filing_statuses
+        ),
+        *(
+            f"ny_pit_pilot_{filing_status}_bracket_{table}"
+            for filing_status in filing_statuses
+            for table in ("floor", "base", "rate")
+        ),
+    }
+    comparable = {
+        name: item
+        for name, item in bundled.items()
+        if item["mapping_type"] != "not_comparable"
+    }
+    not_comparable = {
+        name: item
+        for name, item in bundled.items()
+        if item["mapping_type"] == "not_comparable"
+    }
+
+    assert len(bundled) == 38
+    assert set(comparable) == {*expected_parameters, *expected_direct_variables}
+    assert set(not_comparable) == expected_not_comparable
+    assert len(comparable) == 26
+    assert len(not_comparable) == 12
+    assert {item["program"] for item in bundled.values()} == {"tax"}
+
+    for output_name, (parameter, key_path) in expected_parameters.items():
+        output = bundled[output_name]
+        assert output["mapping_type"] == "parameter_value"
+        assert output["policyengine_parameter"] == parameter
+        assert output["parameter_key_path"] == key_path
+        assert (output["period"], output["unit"], output["comparison"]) == (
+            "year",
+            "USD",
+            "money",
+        )
+
+    for output_name, variable in expected_direct_variables.items():
+        output = bundled[output_name]
+        assert output["mapping_type"] == "direct_variable"
+        assert output["policyengine_variable"] == variable
+        assert (
+            output["entity"],
+            output["period"],
+            output["unit"],
+            output["comparison"],
+        ) == ("tax_unit", "year", "USD", "money")
+
+    for output in not_comparable.values():
+        assert output["candidate_priority"] == "P4"
+        assert "policyengine_variable" not in output
+        assert "policyengine_parameter" not in output
+        assert output["rationale"]
+
+    main_tax = bundled["ny_pit_pilot_main_income_tax"]
+    for excluded_scope in (
+        "supplemental tax",
+        "credits",
+        "local taxes",
+        "payments",
+        "final liability",
+    ):
+        assert excluded_scope in main_tax["rationale"]
+
+    bundled_fallbacks = [
+        item
+        for item in bundled_document["prefixes"]
+        if item.get("legal_id_prefix") == "us-ny:"
+    ]
+    assert len(bundled_fallbacks) == 1
+    assert bundled_fallbacks[0]["mapping_type"] == "not_comparable"
+    assert bundled_fallbacks[0]["candidate_priority"] == "P4"
+    assert "take precedence" in bundled_fallbacks[0]["rationale"]
+
+
+def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
+    import tomllib
+
+    import axiom_oracles.bridges.registry as runtime_registry_module
+
+    durable_oracle_merge = "9e6d93662da32ad423c177b8265720eed40e6660"
+    root = Path(__file__).parents[1]
+    bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
+    runtime_path = (
+        Path(runtime_registry_module.__file__).with_name("mappings") / "us.yaml"
+    )
+    bundled_text = bundled_path.read_text()
+    runtime_text = runtime_path.read_text()
+    bundled_document = yaml.safe_load(bundled_text)
+    runtime_document = yaml.safe_load(runtime_text)
+    bundled = _ny_2026_main_income_tax_records(bundled_document)
+    runtime = _ny_2026_main_income_tax_records(runtime_document)
+    bundled_material = _ny_2026_main_income_tax_shared_mapping_material(bundled_text)
+    runtime_material = _ny_2026_main_income_tax_shared_mapping_material(runtime_text)
+    encoded_material = bundled_material.encode()
+
+    assert bundled == runtime
+    assert bundled_material == runtime_material
+    assert len(bundled_material.splitlines()) == 379
+    assert len(encoded_material) == 17_869
+    assert hashlib.sha256(encoded_material).hexdigest() == (
+        "843aab529936dd09cfbdba58a2ff8857a3ffefa7df28369fd28dbed7d89aed61"
+    )
+
+    bundled_fallbacks = [
+        item
+        for item in bundled_document["prefixes"]
+        if item.get("legal_id_prefix") == "us-ny:"
+    ]
+    runtime_fallbacks = [
+        item
+        for item in runtime_document["prefixes"]
+        if item.get("legal_id_prefix") == "us-ny:"
+    ]
+    assert len(bundled_fallbacks) == 1
+    assert bundled_fallbacks == runtime_fallbacks
+
+    prefix = "us-ny:policies/income_tax/pilot_liability_pipeline#"
+    registry = load_policyengine_registry()
+    taxable_income = registry.mapping_for_legal_id(
+        f"{prefix}ny_pit_pilot_taxable_income",
+        country="us",
+    )
+    main_tax = registry.mapping_for_legal_id(
+        f"{prefix}ny_pit_pilot_main_income_tax",
+        country="us",
+    )
+    joint_eighth_upper = registry.mapping_for_legal_id(
+        f"{prefix}ny_pit_pilot_joint_or_surviving_eighth_upper_bound",
+        country="us",
+    )
+    selector = registry.mapping_for_legal_id(
+        f"{prefix}ny_pit_pilot_head_of_household_bracket_selector",
+        country="us",
+    )
+    fallback = registry.mapping_for_legal_id(
+        f"{prefix}future_unmapped_output",
+        country="us",
+    )
+
+    assert taxable_income is not None
+    assert taxable_income.match_type == "exact"
+    assert taxable_income.mapping_type == "direct_variable"
+    assert taxable_income.policyengine_variable == "ny_taxable_income"
+    assert main_tax is not None
+    assert main_tax.match_type == "exact"
+    assert main_tax.mapping_type == "direct_variable"
+    assert main_tax.policyengine_variable == "ny_main_income_tax"
+    assert joint_eighth_upper is not None
+    assert joint_eighth_upper.match_type == "exact"
+    assert joint_eighth_upper.mapping_type == "parameter_value"
+    assert joint_eighth_upper.policyengine_parameter == (
+        "gov.states.ny.tax.income.main.joint"
+    )
+    assert joint_eighth_upper.parameter_key_path == ("thresholds", 8)
+    assert selector is not None
+    assert selector.match_type == "exact"
+    assert selector.mapping_type == "not_comparable"
+    assert selector.candidate_priority == "P4"
+    assert fallback is not None
+    assert fallback.legal_id == "us-ny:"
+    assert fallback.match_type == "prefix"
+    assert fallback.mapping_type == "not_comparable"
+    assert fallback.candidate_priority == "P4"
+
+    dependency_pin = re.search(
+        r"axiom-oracles@[0-9a-f]{40}", (root / "pyproject.toml").read_text()
+    )
+    assert dependency_pin is not None
+    pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
+    assert pin == durable_oracle_merge
+    lock_text = (root / "uv.lock").read_text()
+    assert lock_text.count(f"?rev={pin}") == 2
+    assert f"?rev={pin}#{pin}" in lock_text
+    lock = tomllib.loads(lock_text)
+    encoder_package = next(
+        package for package in lock["package"] if package["name"] == "axiom-encode"
+    )
+    assert encoder_package["version"] == "0.2.1400"
+    project = tomllib.loads((root / "pyproject.toml").read_text())
+    assert project["project"]["version"] == "0.2.1400"
+    assert (
+        (root / "src/axiom_encode/__init__.py")
+        .read_text()
+        .startswith('__version__ = "0.2.1400"')
     )
 
 
@@ -6238,7 +6506,7 @@ def test_packaged_utah_2026_before_credit_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "076ad9d458e5539db8d71cd4a06a43ad9b632d19"
+    assert pin == "9e6d93662da32ad423c177b8265720eed40e6660"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1399"
+version = "0.2.1400"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=076ad9d458e5539db8d71cd4a06a43ad9b632d19" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=9e6d93662da32ad423c177b8265720eed40e6660" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=076ad9d458e5539db8d71cd4a06a43ad9b632d19#076ad9d458e5539db8d71cd4a06a43ad9b632d19" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=9e6d93662da32ad423c177b8265720eed40e6660#9e6d93662da32ad423c177b8265720eed40e6660" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- bump `axiom-encode` coherently from `0.2.1399` to `0.2.1400`
- pin merged `axiom-oracles` commit `9e6d93662da32ad423c177b8265720eed40e6660`
- bundle the exact reviewed 38-record New York TY2026 Tax Law §601 main resident income-tax mapping block plus the existing `us-ny:` fallback
- add focused mapping, runtime byte-parity, exact-over-prefix precedence, pin/version, and coverage regression tests

## Bounded scope

This propagation covers completed New York taxable income and the §601 main resident schedule exposed as `ny_main_income_tax`. It does not claim §601(d-5) supplemental tax, credits, local taxes, payments, or final annual liability. Existing legacy encoder and registry surfaces are preserved.

## Provenance and parity

- encoder base: `acdb75593bb6506270310a675c75a32ac24b50eb`
- encoder head: `cf223f0dd5565e5d5ea9c590a52a632da677b5b1`
- oracle merge: `9e6d93662da32ad423c177b8265720eed40e6660`
- exact shared mapping material: 379 lines, 17,869 bytes, SHA-256 `843aab529936dd09cfbdba58a2ff8857a3ffefa7df28369fd28dbed7d89aed61`
- mapping classification: 38 total = 26 comparable (2 direct variables + 24 scalar thresholds) + 12 P4 not-comparable outputs
- upstream oracle campaign: 3,741 compared cases, 0 mismatches, max absolute difference `2.1199999973`, tolerance unchanged at absolute `2.25` / relative `1e-7`
- two upstream full campaigns canonicalized to SHA-256 `9946ff188613827a09187397c8ca4274f1e7d944d8c19e04cbde9b1651dd57a6`

## Validation

- full 6,068-test inventory in deterministic disk-safe batches: 5,949 passed, 119 skipped, 0 failed
- post-commit provenance gate and NY focused tests: 4 passed
- independent staged review: CLEAN, no actionable findings; reviewer independently ran 1,731 passed / 31 skipped
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv lock --check`
- `git diff --check`
- staged review patch SHA-256 `ad04bde34c6a6e2ee9f339bd3cf81c7aaa1dec347812de9a8a031e554402e833`
- security scan clean; no corpus or secret material included
