### PR TITLE
Bundle Illinois 2026 pre-credit income tax oracle

### DIFF
--- a/changelog.d/il-2026-before-nonrefundable-credits-oracle.changed.md
+++ b/changelog.d/il-2026-before-nonrefundable-credits-oracle.changed.md
@@ -1,0 +1,1 @@
+Bundle Illinois's bounded tax-year-2026 annual income tax before nonrefundable credits mappings and pin their durable reviewed oracle-main merge without claiming broader exemptions, credits, payments, or final annual liability.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1400"
+version = "0.2.1401"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@9e6d93662da32ad423c177b8265720eed40e6660",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@3ab8efe9cbf38ff20df88e24468b7f249946eca3",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1400"
+__version__ = "0.2.1401"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -28799,6 +28799,32 @@ mappings:
     candidate_priority: P4
     rationale: Axiom exposes the complete statutory rate table as one RuleSpec output; PolicyEngine's registry supports scalar scale-cell comparison but has no one-to-one whole-table oracle target.
 
+  # Illinois's bounded TY2026 annual tax before nonrefundable credits.
+  # The canonical module accepts completed Illinois taxable income and
+  # investment-credit recapture boundaries; it does not reconstruct either
+  # upstream chain or claim credits, payments, or final annual liability.
+  - legal_id: us-il:policies/income_tax/pilot_liability_pipeline#il_pit_pilot_taxable_income
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: il_taxable_income
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: RuleSpec preserves the completed Illinois taxable-income boundary after a nonnegative floor; PolicyEngine exposes the same completed TaxUnit boundary as il_taxable_income.
+
+  - legal_id: us-il:policies/income_tax/pilot_liability_pipeline#il_pit_pilot_income_tax_liability
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: il_income_tax_before_non_refundable_credits
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Both outputs apply the 4.95 percent tax to completed Illinois taxable income and add completed investment-credit recapture before nonrefundable credits; this mapping excludes taxable-income construction, credit computation, payments, and final annual liability.
+
 
 prefixes:
   - legal_id_prefix: us-dc:statutes/4/4-205/49#

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -1,0 +1,180 @@
+import hashlib
+import re
+import tomllib
+from pathlib import Path
+
+import yaml
+from axiom_oracles.bridges.coverage import build_policyengine_coverage_report
+from axiom_oracles.bridges.registry import load_policyengine_registry
+
+MODULE = "us-il:policies/income_tax/pilot_liability_pipeline"
+DIRECT_VARIABLES = {
+    "il_pit_pilot_taxable_income": "il_taxable_income",
+    "il_pit_pilot_income_tax_liability": (
+        "il_income_tax_before_non_refundable_credits"
+    ),
+}
+ORACLE_MERGE = "3ab8efe9cbf38ff20df88e24468b7f249946eca3"
+ENCODER_VERSION = "0.2.1401"
+FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
+    country: us
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: PolicyEngine-US does not model IL statutes, agency policy manuals, or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix."""
+
+
+def _module_mappings(document):
+    prefix = f"{MODULE}#"
+    return {
+        item["legal_id"].removeprefix(prefix): item
+        for item in document["mappings"]
+        if item.get("legal_id", "").startswith(prefix)
+    }
+
+
+def _shared_material(text: str) -> str:
+    start = text.index(
+        "  # Illinois's bounded TY2026 annual tax before nonrefundable credits."
+    )
+    exact_end_marker = (
+        "    rationale: Both outputs apply the 4.95 percent tax to completed "
+        "Illinois taxable income and add completed investment-credit recapture "
+        "before nonrefundable credits; this mapping excludes taxable-income "
+        "construction, credit computation, payments, and final annual liability."
+    )
+    exact_end = text.index(exact_end_marker, start) + len(exact_end_marker)
+    fallback_start = text.index(FALLBACK_TEXT)
+    fallback_end = fallback_start + len(FALLBACK_TEXT)
+    return f"{text[start:exact_end]}\n\n{text[fallback_start:fallback_end]}"
+
+
+def _write_synthetic_module(root: Path) -> None:
+    path = root / "us-il/policies/income_tax/pilot_liability_pipeline.yaml"
+    path.parent.mkdir(parents=True)
+    rules = "\n".join(
+        "  - name: "
+        f"{name}\n"
+        "    kind: derived\n"
+        "    versions:\n"
+        "      - effective_from: '2026-01-01'\n"
+        "        formula: 0"
+        for name in DIRECT_VARIABLES
+    )
+    path.write_text(f"format: rulespec/v1\nrules:\n{rules}\n")
+
+
+def test_packaged_il_2026_registry_has_exact_two_direct_mappings() -> None:
+    root = Path(__file__).parents[1]
+    path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
+    document = yaml.safe_load(path.read_text())
+    mappings = _module_mappings(document)
+
+    assert len(mappings) == 2
+    assert set(mappings) == set(DIRECT_VARIABLES)
+    for output_name, variable in DIRECT_VARIABLES.items():
+        mapping = mappings[output_name]
+        assert mapping["mapping_type"] == "direct_variable"
+        assert mapping["policyengine_variable"] == variable
+        assert (
+            mapping["program"],
+            mapping["entity"],
+            mapping["period"],
+            mapping["unit"],
+            mapping["comparison"],
+        ) == ("tax", "tax_unit", "year", "USD", "money")
+        assert "candidate_priority" not in mapping
+
+    liability = mappings["il_pit_pilot_income_tax_liability"]
+    for excluded_scope in (
+        "taxable-income construction",
+        "credit computation",
+        "payments",
+        "final annual liability",
+    ):
+        assert excluded_scope in liability["rationale"]
+
+
+def test_packaged_il_2026_runtime_pin_version_and_precedence_are_exact() -> None:
+    import axiom_oracles.bridges.registry as runtime_registry_module
+
+    root = Path(__file__).parents[1]
+    bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
+    runtime_path = (
+        Path(runtime_registry_module.__file__).with_name("mappings") / "us.yaml"
+    )
+    bundled_text = bundled_path.read_text()
+    runtime_text = runtime_path.read_text()
+    bundled_document = yaml.safe_load(bundled_text)
+    runtime_document = yaml.safe_load(runtime_text)
+
+    assert _module_mappings(bundled_document) == _module_mappings(runtime_document)
+    assert _shared_material(bundled_text) == _shared_material(runtime_text)
+    assert bundled_text.count(FALLBACK_TEXT) == 1
+    assert runtime_text.count(FALLBACK_TEXT) == 1
+    assert hashlib.sha256(_shared_material(bundled_text).encode()).hexdigest() == (
+        "dd8f49a26f8eb5186f90fcf15bc8c5d230ca6cc10590166c228736638d057ab8"
+    )
+
+    registry = load_policyengine_registry()
+    for output_name, variable in DIRECT_VARIABLES.items():
+        mapping = registry.mapping_for_legal_id(
+            f"{MODULE}#{output_name}",
+            country="us",
+        )
+        assert mapping is not None
+        assert mapping.match_type == "exact"
+        assert mapping.mapping_type == "direct_variable"
+        assert mapping.policyengine_variable == variable
+        assert mapping.entity == "tax_unit"
+        assert mapping.period == "year"
+        assert mapping.unit == "USD"
+        assert mapping.comparison == "money"
+
+    fallback = registry.mapping_for_legal_id(
+        f"{MODULE}#future_unmapped_output",
+        country="us",
+    )
+    assert fallback is not None
+    assert fallback.legal_id == "us-il:"
+    assert fallback.match_type == "prefix"
+    assert fallback.mapping_type == "not_comparable"
+    assert fallback.candidate_priority == "P4"
+
+    dependency_pin = re.search(
+        r"axiom-oracles@[0-9a-f]{40}",
+        (root / "pyproject.toml").read_text(),
+    )
+    assert dependency_pin is not None
+    assert dependency_pin.group(0).removeprefix("axiom-oracles@") == ORACLE_MERGE
+    lock_text = (root / "uv.lock").read_text()
+    assert lock_text.count(f"?rev={ORACLE_MERGE}") == 2
+    assert f"?rev={ORACLE_MERGE}#{ORACLE_MERGE}" in lock_text
+    lock = tomllib.loads(lock_text)
+    encoder_package = next(
+        package for package in lock["package"] if package["name"] == "axiom-encode"
+    )
+    assert encoder_package["version"] == ENCODER_VERSION
+    project = tomllib.loads((root / "pyproject.toml").read_text())
+    assert project["project"]["version"] == ENCODER_VERSION
+    assert (
+        (root / "src/axiom_encode/__init__.py")
+        .read_text()
+        .startswith(f'__version__ = "{ENCODER_VERSION}"')
+    )
+
+
+def test_policyengine_coverage_classifies_only_bounded_il_2026_outputs(
+    tmp_path: Path,
+) -> None:
+    rulespec_root = tmp_path / "rulespec-us"
+    _write_synthetic_module(rulespec_root)
+
+    report = build_policyengine_coverage_report(rulespec_root, program="tax")
+
+    assert report["total_outputs"] == 2
+    assert report["status_counts"] == {"comparable": 2}
+    items = {item["rule_name"]: item for item in report["items"]}
+    assert set(items) == set(DIRECT_VARIABLES)
+    assert {
+        name: item["policyengine_variable"] for name, item in items.items()
+    } == DIRECT_VARIABLES

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5120,7 +5120,7 @@ def test_packaged_alabama_2026_schedule_registry_and_fallback_are_synchronized()
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "9e6d93662da32ad423c177b8265720eed40e6660"
+    assert pin == "3ab8efe9cbf38ff20df88e24468b7f249946eca3"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5231,7 +5231,7 @@ def test_packaged_connecticut_2026_ordinary_tax_registry_is_exactly_synchronized
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "9e6d93662da32ad423c177b8265720eed40e6660"
+    assert pin == "3ab8efe9cbf38ff20df88e24468b7f249946eca3"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5315,7 +5315,7 @@ def test_packaged_georgia_2026_annual_tax_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "9e6d93662da32ad423c177b8265720eed40e6660"
+    assert pin == "3ab8efe9cbf38ff20df88e24468b7f249946eca3"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5410,7 +5410,7 @@ def test_packaged_mississippi_2026_schedule_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "9e6d93662da32ad423c177b8265720eed40e6660"
+    assert pin == "3ab8efe9cbf38ff20df88e24468b7f249946eca3"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5571,7 +5571,7 @@ def test_packaged_kansas_2026_k40es_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "9e6d93662da32ad423c177b8265720eed40e6660"
+    assert pin == "3ab8efe9cbf38ff20df88e24468b7f249946eca3"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5676,7 +5676,7 @@ def test_packaged_dc_2026_section_47_1806_03_has_exact_bounded_slice():
 def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "9e6d93662da32ad423c177b8265720eed40e6660"
+    durable_oracle_merge = "3ab8efe9cbf38ff20df88e24468b7f249946eca3"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1400"')
+        .startswith('__version__ = "0.2.1401"')
     )
 
 
@@ -5879,7 +5879,7 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
 
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "9e6d93662da32ad423c177b8265720eed40e6660"
+    durable_oracle_merge = "3ab8efe9cbf38ff20df88e24468b7f249946eca3"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1400"
+    assert encoder_package["version"] == "0.2.1401"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1400"
+    assert project["project"]["version"] == "0.2.1401"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1400"')
+        .startswith('__version__ = "0.2.1401"')
     )
 
 
@@ -6155,7 +6155,7 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
 
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "9e6d93662da32ad423c177b8265720eed40e6660"
+    durable_oracle_merge = "3ab8efe9cbf38ff20df88e24468b7f249946eca3"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1400"
+    assert encoder_package["version"] == "0.2.1401"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1400"
+    assert project["project"]["version"] == "0.2.1401"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1400"')
+        .startswith('__version__ = "0.2.1401"')
     )
 
 
@@ -6506,7 +6506,7 @@ def test_packaged_utah_2026_before_credit_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "9e6d93662da32ad423c177b8265720eed40e6660"
+    assert pin == "3ab8efe9cbf38ff20df88e24468b7f249946eca3"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1400"
+version = "0.2.1401"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=9e6d93662da32ad423c177b8265720eed40e6660" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=3ab8efe9cbf38ff20df88e24468b7f249946eca3" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=9e6d93662da32ad423c177b8265720eed40e6660#9e6d93662da32ad423c177b8265720eed40e6660" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=3ab8efe9cbf38ff20df88e24468b7f249946eca3#3ab8efe9cbf38ff20df88e24468b7f249946eca3" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- pin axiom-oracles to reviewed Illinois merge `3ab8efe9cbf38ff20df88e24468b7f249946eca3`
- bundle exactly two Illinois TY2026 mappings: completed taxable income and annual income tax before nonrefundable credits
- preserve the broad `us-il:` P4 fallback byte-for-byte and bump axiom-encode to `0.2.1401`

Base: `1c0fce6bd311063bbbc7686fce84c104da74b2df`
Head: `207aad32c33dffacf507fc57f40b7abff5131796`

## Validation

- full deterministic inventory: 6,071 nodes accounted for
- pre-commit: 5,948 passed, 120 skipped, 2 managed-macOS environment blocks, 1 committed-HEAD provenance gate deferred, 0 branch-caused failures
- post-commit provenance gate: passed
- focused Illinois registry tests: 3 passed
- Ruff: passed
- compileall: passed
- `uv lock --check --offline --python 3.13`: passed
- cached/worktree diff checks: passed

The two pre-commit environment blocks were independently proven against the exact clean base and require hosted CI:

1. macOS system path alias test cannot create its intentional `/var/tmp` fixture under the managed sandbox.
2. setid hardening test cannot set mode 4755 under the managed filesystem (`Operation not permitted`); the exact clean base reproduces.

## Review cycle

Independent staged review was clean with no actionable findings. Reviewed patch SHA-256: `3d8d40fe7ab83a089cf7b183c55be439fa62d2ad56feecdff70d115c2f5f86e6`. Exact seven-file name-set SHA-256: `ccede59d653d0f62a1d163738497f6e55bd125777b08ca186f6c0c7e688c266a`.