### PR TITLE
Bump the axiom-oracles pin for the additional Medicare pipeline mappings

### DIFF
--- a/changelog.d/bump-axiom-oracles-addmed-mappings.changed.md
+++ b/changelog.d/bump-axiom-oracles-addmed-mappings.changed.md
@@ -1,0 +1,1 @@
+Bump the pinned axiom-oracles commit to pick up the additional Medicare tax pipeline oracle mappings (axiom-oracles#409), so the changed-file oracle-coverage classifier reads them instead of reporting the outputs as unclassified.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@3ab8efe9cbf38ff20df88e24468b7f249946eca3",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@4cb8a142dfd8f390225a4f2a16b94ebd74a07e62",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/uv.lock
+++ b/uv.lock
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=3ab8efe9cbf38ff20df88e24468b7f249946eca3" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=4cb8a142dfd8f390225a4f2a16b94ebd74a07e62" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=3ab8efe9cbf38ff20df88e24468b7f249946eca3#3ab8efe9cbf38ff20df88e24468b7f249946eca3" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=4cb8a142dfd8f390225a4f2a16b94ebd74a07e62#4cb8a142dfd8f390225a4f2a16b94ebd74a07e62" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
Pin-only bump: `axiom-oracles` `3ab8efe9` → `4cb8a142` (axiom-oracles main, including **axiom-oracles#409**).

**Why**: the shared validate workflow installs this repo at the classifier ref, then force-reinstalls *the axiom-oracles pin declared in this pyproject* so the changed-file oracle-coverage gate reads bridge mappings from it. #409 classifies all fourteen outputs of rulespec-us's `additional_medicare_tax_pipeline` (5 comparable, 9 known-not-comparable); until this pin moves, the classifier still reports them as unclassified and **rulespec-us#1143** (the §1401(b)(2) self-employment-leg restore) cannot merge.

`uv.lock` regenerated by `uv lock` (single dependency delta). No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)