### PR TITLE
Bundle Minnesota 2026 basic tax oracle mapping

### DIFF
--- a/changelog.d/mn-2026-basic-tax-oracle.changed.md
+++ b/changelog.d/mn-2026-basic-tax-oracle.changed.md
@@ -1,0 +1,1 @@
+Bundle Minnesota's bounded tax-year-2026 section 290.06 continuous schedule mapping and pin its durable reviewed oracle-main merge without claiming taxable-income construction, tax-table rounding, alternative minimum tax, credits, payments, or final liability.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1401"
+version = "0.2.1402"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@3ab8efe9cbf38ff20df88e24468b7f249946eca3",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@e81e68e054f6166a719f993d2bf5fe2841bc9fde",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1401"
+__version__ = "0.2.1402"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -28425,6 +28425,20 @@ mappings:
     candidate_priority: P4
     rationale: This estimated-tax worksheet total combines RuleSpec's bounded rate-schedule branch with Behavioral Health Services Tax. PolicyEngine exposes broader California income-tax totals with different tax-table, credit, and liability scope, so only the BHST component is directly comparable.
 
+  # Minnesota's tax-year-2026 pilot exposes a source-faithful continuous
+  # section 290.06 rate schedule. The exact mapping deliberately does not
+  # promote the pilot's historical broad-liability concept.
+  - legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: mn_basic_tax
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Both outputs apply Minnesota's four-rate individual schedule to completed Minnesota taxable income selected by filing status. The final official tax-year-2026 RuleSpec thresholds are $10 to $30 above PolicyEngine-US 1.752.2's thresholds, producing only a reviewed sub-dollar residual under the preserved $1 absolute tolerance. This narrow mapping makes no claim about taxable-income construction, tax-table rounding, alternative minimum tax, net investment income tax, credits, payments, or final liability.
+
   # New York Tax Law section 601's bounded TY2026 main resident schedule.
   # These exact records cover every output in the canonical RuleSpec module
   # and take precedence over the jurisdiction-wide fallback below. They do not
@@ -31131,6 +31145,12 @@ prefixes:
     mapping_type: not_comparable
     candidate_priority: P4
     rationale: PolicyEngine-US does not model MD agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
+
+  - legal_id_prefix: "us-mn:"
+    country: us
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: PolicyEngine-US does not model every Minnesota statute, agency policy manual, or state regulation at output granularity; independently reviewed comparable outputs carry exact mappings which take precedence over this jurisdiction-wide fallback.
 
   - legal_id_prefix: "us-ms:"
     country: us

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -7,20 +7,16 @@ import yaml
 from axiom_oracles.bridges.coverage import build_policyengine_coverage_report
 from axiom_oracles.bridges.registry import load_policyengine_registry
 
-MODULE = "us-il:policies/income_tax/pilot_liability_pipeline"
-DIRECT_VARIABLES = {
-    "il_pit_pilot_taxable_income": "il_taxable_income",
-    "il_pit_pilot_income_tax_liability": (
-        "il_income_tax_before_non_refundable_credits"
-    ),
-}
+MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
+OUTPUT = "mn_pit_pilot_schedule_tax"
+POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e81e68e054f6166a719f993d2bf5fe2841bc9fde"
 ENCODER_VERSION = "0.2.1402"
-FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
+FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable
     candidate_priority: P4
-    rationale: PolicyEngine-US does not model IL statutes, agency policy manuals, or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix."""
+    rationale: PolicyEngine-US does not model every Minnesota statute, agency policy manual, or state regulation at output granularity; independently reviewed comparable outputs carry exact mappings which take precedence over this jurisdiction-wide fallback."""
 
 
 def _module_mappings(document):
@@ -34,13 +30,17 @@ def _module_mappings(document):
 
 def _shared_material(text: str) -> str:
     start = text.index(
-        "  # Illinois's bounded TY2026 annual tax before nonrefundable credits."
+        "  # Minnesota's tax-year-2026 pilot exposes a source-faithful continuous"
     )
     exact_end_marker = (
-        "    rationale: Both outputs apply the 4.95 percent tax to completed "
-        "Illinois taxable income and add completed investment-credit recapture "
-        "before nonrefundable credits; this mapping excludes taxable-income "
-        "construction, credit computation, payments, and final annual liability."
+        "    rationale: Both outputs apply Minnesota's four-rate individual "
+        "schedule to completed Minnesota taxable income selected by filing "
+        "status. The final official tax-year-2026 RuleSpec thresholds are $10 "
+        "to $30 above PolicyEngine-US 1.752.2's thresholds, producing only a "
+        "reviewed sub-dollar residual under the preserved $1 absolute "
+        "tolerance. This narrow mapping makes no claim about taxable-income "
+        "construction, tax-table rounding, alternative minimum tax, net "
+        "investment income tax, credits, payments, or final liability."
     )
     exact_end = text.index(exact_end_marker, start) + len(exact_end_marker)
     fallback_start = text.index(FALLBACK_TEXT)
@@ -49,52 +49,50 @@ def _shared_material(text: str) -> str:
 
 
 def _write_synthetic_module(root: Path) -> None:
-    path = root / "us-il/policies/income_tax/pilot_liability_pipeline.yaml"
+    path = root / "us-mn/policies/income_tax/pilot_liability_pipeline.yaml"
     path.parent.mkdir(parents=True)
-    rules = "\n".join(
-        "  - name: "
-        f"{name}\n"
+    path.write_text(
+        "format: rulespec/v1\n"
+        "rules:\n"
+        f"  - name: {OUTPUT}\n"
         "    kind: derived\n"
         "    versions:\n"
         "      - effective_from: '2026-01-01'\n"
-        "        formula: 0"
-        for name in DIRECT_VARIABLES
+        "        formula: 0\n"
     )
-    path.write_text(f"format: rulespec/v1\nrules:\n{rules}\n")
 
 
-def test_packaged_il_2026_registry_has_exact_two_direct_mappings() -> None:
+def test_packaged_mn_2026_registry_has_one_exact_direct_mapping() -> None:
     root = Path(__file__).parents[1]
     path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     document = yaml.safe_load(path.read_text())
     mappings = _module_mappings(document)
 
-    assert len(mappings) == 2
-    assert set(mappings) == set(DIRECT_VARIABLES)
-    for output_name, variable in DIRECT_VARIABLES.items():
-        mapping = mappings[output_name]
-        assert mapping["mapping_type"] == "direct_variable"
-        assert mapping["policyengine_variable"] == variable
-        assert (
-            mapping["program"],
-            mapping["entity"],
-            mapping["period"],
-            mapping["unit"],
-            mapping["comparison"],
-        ) == ("tax", "tax_unit", "year", "USD", "money")
-        assert "candidate_priority" not in mapping
-
-    liability = mappings["il_pit_pilot_income_tax_liability"]
+    assert set(mappings) == {OUTPUT}
+    mapping = mappings[OUTPUT]
+    assert mapping["mapping_type"] == "direct_variable"
+    assert mapping["policyengine_variable"] == POLICYENGINE_VARIABLE
+    assert (
+        mapping["program"],
+        mapping["entity"],
+        mapping["period"],
+        mapping["unit"],
+        mapping["comparison"],
+    ) == ("tax", "tax_unit", "year", "USD", "money")
+    assert "candidate_priority" not in mapping
     for excluded_scope in (
         "taxable-income construction",
-        "credit computation",
+        "tax-table rounding",
+        "alternative minimum tax",
+        "net investment income tax",
+        "credits",
         "payments",
-        "final annual liability",
+        "final liability",
     ):
-        assert excluded_scope in liability["rationale"]
+        assert excluded_scope in mapping["rationale"]
 
 
-def test_packaged_il_2026_runtime_pin_version_and_precedence_are_exact() -> None:
+def test_packaged_mn_2026_runtime_pin_version_and_precedence_are_exact() -> None:
     import axiom_oracles.bridges.registry as runtime_registry_module
 
     root = Path(__file__).parents[1]
@@ -111,31 +109,30 @@ def test_packaged_il_2026_runtime_pin_version_and_precedence_are_exact() -> None
     assert _shared_material(bundled_text) == _shared_material(runtime_text)
     assert bundled_text.count(FALLBACK_TEXT) == 1
     assert runtime_text.count(FALLBACK_TEXT) == 1
+    assert hashlib.sha256(FALLBACK_TEXT.encode()).hexdigest() == (
+        "a1922806d932ae93464931b656c5e38db6cf808ec10a3e85694ffc5831956f2b"
+    )
     assert hashlib.sha256(_shared_material(bundled_text).encode()).hexdigest() == (
-        "dd8f49a26f8eb5186f90fcf15bc8c5d230ca6cc10590166c228736638d057ab8"
+        "8e4b30d18da4483a19a6d641244f70b806eebdc952efdd8fcba0beb6a83cf74d"
     )
 
     registry = load_policyengine_registry()
-    for output_name, variable in DIRECT_VARIABLES.items():
-        mapping = registry.mapping_for_legal_id(
-            f"{MODULE}#{output_name}",
-            country="us",
-        )
-        assert mapping is not None
-        assert mapping.match_type == "exact"
-        assert mapping.mapping_type == "direct_variable"
-        assert mapping.policyengine_variable == variable
-        assert mapping.entity == "tax_unit"
-        assert mapping.period == "year"
-        assert mapping.unit == "USD"
-        assert mapping.comparison == "money"
+    mapping = registry.mapping_for_legal_id(f"{MODULE}#{OUTPUT}", country="us")
+    assert mapping is not None
+    assert mapping.match_type == "exact"
+    assert mapping.mapping_type == "direct_variable"
+    assert mapping.policyengine_variable == POLICYENGINE_VARIABLE
+    assert mapping.entity == "tax_unit"
+    assert mapping.period == "year"
+    assert mapping.unit == "USD"
+    assert mapping.comparison == "money"
 
     fallback = registry.mapping_for_legal_id(
         f"{MODULE}#future_unmapped_output",
         country="us",
     )
     assert fallback is not None
-    assert fallback.legal_id == "us-il:"
+    assert fallback.legal_id == "us-mn:"
     assert fallback.match_type == "prefix"
     assert fallback.mapping_type == "not_comparable"
     assert fallback.candidate_priority == "P4"
@@ -163,7 +160,7 @@ def test_packaged_il_2026_runtime_pin_version_and_precedence_are_exact() -> None
     )
 
 
-def test_policyengine_coverage_classifies_only_bounded_il_2026_outputs(
+def test_policyengine_coverage_classifies_only_bounded_mn_2026_output(
     tmp_path: Path,
 ) -> None:
     rulespec_root = tmp_path / "rulespec-us"
@@ -171,10 +168,8 @@ def test_policyengine_coverage_classifies_only_bounded_il_2026_outputs(
 
     report = build_policyengine_coverage_report(rulespec_root, program="tax")
 
-    assert report["total_outputs"] == 2
-    assert report["status_counts"] == {"comparable": 2}
-    items = {item["rule_name"]: item for item in report["items"]}
-    assert set(items) == set(DIRECT_VARIABLES)
-    assert {
-        name: item["policyengine_variable"] for name, item in items.items()
-    } == DIRECT_VARIABLES
+    assert report["total_outputs"] == 1
+    assert report["status_counts"] == {"comparable": 1}
+    item = report["items"][0]
+    assert item["rule_name"] == OUTPUT
+    assert item["policyengine_variable"] == POLICYENGINE_VARIABLE

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5120,7 +5120,7 @@ def test_packaged_alabama_2026_schedule_registry_and_fallback_are_synchronized()
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "3ab8efe9cbf38ff20df88e24468b7f249946eca3"
+    assert pin == "e81e68e054f6166a719f993d2bf5fe2841bc9fde"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5231,7 +5231,7 @@ def test_packaged_connecticut_2026_ordinary_tax_registry_is_exactly_synchronized
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "3ab8efe9cbf38ff20df88e24468b7f249946eca3"
+    assert pin == "e81e68e054f6166a719f993d2bf5fe2841bc9fde"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5315,7 +5315,7 @@ def test_packaged_georgia_2026_annual_tax_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "3ab8efe9cbf38ff20df88e24468b7f249946eca3"
+    assert pin == "e81e68e054f6166a719f993d2bf5fe2841bc9fde"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5410,7 +5410,7 @@ def test_packaged_mississippi_2026_schedule_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "3ab8efe9cbf38ff20df88e24468b7f249946eca3"
+    assert pin == "e81e68e054f6166a719f993d2bf5fe2841bc9fde"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5571,7 +5571,7 @@ def test_packaged_kansas_2026_k40es_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "3ab8efe9cbf38ff20df88e24468b7f249946eca3"
+    assert pin == "e81e68e054f6166a719f993d2bf5fe2841bc9fde"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5676,7 +5676,7 @@ def test_packaged_dc_2026_section_47_1806_03_has_exact_bounded_slice():
 def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "3ab8efe9cbf38ff20df88e24468b7f249946eca3"
+    durable_oracle_merge = "e81e68e054f6166a719f993d2bf5fe2841bc9fde"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1401"')
+        .startswith('__version__ = "0.2.1402"')
     )
 
 
@@ -5879,7 +5879,7 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
 
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "3ab8efe9cbf38ff20df88e24468b7f249946eca3"
+    durable_oracle_merge = "e81e68e054f6166a719f993d2bf5fe2841bc9fde"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1401"
+    assert encoder_package["version"] == "0.2.1402"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1401"
+    assert project["project"]["version"] == "0.2.1402"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1401"')
+        .startswith('__version__ = "0.2.1402"')
     )
 
 
@@ -6155,7 +6155,7 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
 
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "3ab8efe9cbf38ff20df88e24468b7f249946eca3"
+    durable_oracle_merge = "e81e68e054f6166a719f993d2bf5fe2841bc9fde"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1401"
+    assert encoder_package["version"] == "0.2.1402"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1401"
+    assert project["project"]["version"] == "0.2.1402"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1401"')
+        .startswith('__version__ = "0.2.1402"')
     )
 
 
@@ -6506,7 +6506,7 @@ def test_packaged_utah_2026_before_credit_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "3ab8efe9cbf38ff20df88e24468b7f249946eca3"
+    assert pin == "e81e68e054f6166a719f993d2bf5fe2841bc9fde"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1401"
+version = "0.2.1402"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=3ab8efe9cbf38ff20df88e24468b7f249946eca3" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=e81e68e054f6166a719f993d2bf5fe2841bc9fde" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=3ab8efe9cbf38ff20df88e24468b7f249946eca3#3ab8efe9cbf38ff20df88e24468b7f249946eca3" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=e81e68e054f6166a719f993d2bf5fe2841bc9fde#e81e68e054f6166a719f993d2bf5fe2841bc9fde" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Outcome

Advances axiom-encode to v0.2.1402 on top of the merged Illinois release and bundles the reviewed Minnesota TY2026 continuous basic-tax schedule oracle surface.

- pins exact durable axiom-oracles merge `e81e68e054f6166a719f993d2bf5fe2841bc9fde`
- maps exactly `mn_pit_pilot_schedule_tax` to PolicyEngine `mn_basic_tax`
- adds the independently reviewed `us-mn:` fallback without promoting the historical broad-liability concept
- preserves the Illinois mappings and every prior state mapping
- explicitly excludes taxable-income construction, tax-table rounding, AMT, NIIT, credits, payments, and final liability

## Independent review cycle

Independent review completed on exact staged patch `441ae629d9d239884c41cc06d1401df7a9f1e27b3ae33233554cedd613845b66` with no actionable findings. The reviewer confirmed byte-identical bundled/runtime Minnesota material, semantic identity of the rest of the base registry after removing the two new Minnesota records, exact IL preservation, consistent v0.2.1402 versioning, and no stale `3ab8...` or v0.2.1401 assertions.

## Checks

- `uv lock --check`: green, 101 packages
- Ruff on applicable repo paths: green
- compileall for `src/axiom_encode` and `scripts`: green
- MN + IL registry suites: 6 passed
- full `tests/test_rulespec_validation.py`: 1,328 passed, 31 skipped
- independent combined focused/shared rerun: 1,334 passed, 31 skipped
- cached diff check: green

A system-Python 3.14 attempt was discarded because the pinned pyroaring dependency does not build on that interpreter; all acceptance checks ran on the project-compatible Python 3.13 environment.