### PR TITLE
Bundle Indiana 2026 AGI tax oracle mapping

### DIFF
--- a/changelog.d/in-2026-agi-tax-oracle.changed.md
+++ b/changelog.d/in-2026-agi-tax-oracle.changed.md
@@ -1,0 +1,1 @@
+Bundle Indiana's bounded tax-year-2026 adjusted-gross-income tax mapping and pin its durable reviewed oracle-main merge without claiming AGI construction, county tax, credits, or final annual liability.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1402"
+version = "0.2.1403"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@e81e68e054f6166a719f993d2bf5fe2841bc9fde",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@a294b8c82cc89f353134dc7d1090f158c02a539c",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1402"
+__version__ = "0.2.1403"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -28813,6 +28813,20 @@ mappings:
     candidate_priority: P4
     rationale: Axiom exposes the complete statutory rate table as one RuleSpec output; PolicyEngine's registry supports scalar scale-cell comparison but has no one-to-one whole-table oracle target.
 
+  # Indiana's bounded TY2026 adjusted-gross-income tax before credits and
+  # county tax. The completed-return AGI remains a caller boundary, so only
+  # the RuleSpec output is mapped directly.
+  - legal_id: us-in:policies/income_tax/pilot_liability_pipeline#in_pit_pilot_income_tax_liability
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: in_agi_tax
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Both outputs apply Indiana's tax-year-2026 2.95 percent state rate to completed Indiana adjusted gross income with a zero floor, before credits and excluding the separate county tax.
+
   # Illinois's bounded TY2026 annual tax before nonrefundable credits.
   # The canonical module accepts completed Illinois taxable income and
   # investment-credit recapture boundaries; it does not reconstruct either

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -7,20 +7,16 @@ import yaml
 from axiom_oracles.bridges.coverage import build_policyengine_coverage_report
 from axiom_oracles.bridges.registry import load_policyengine_registry
 
-MODULE = "us-il:policies/income_tax/pilot_liability_pipeline"
-DIRECT_VARIABLES = {
-    "il_pit_pilot_taxable_income": "il_taxable_income",
-    "il_pit_pilot_income_tax_liability": (
-        "il_income_tax_before_non_refundable_credits"
-    ),
-}
+MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
+OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
+POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "a294b8c82cc89f353134dc7d1090f158c02a539c"
 ENCODER_VERSION = "0.2.1403"
-FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
+FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable
     candidate_priority: P4
-    rationale: PolicyEngine-US does not model IL statutes, agency policy manuals, or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix."""
+    rationale: PolicyEngine-US does not model IN agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix."""
 
 
 def _module_mappings(document):
@@ -34,13 +30,12 @@ def _module_mappings(document):
 
 def _shared_material(text: str) -> str:
     start = text.index(
-        "  # Illinois's bounded TY2026 annual tax before nonrefundable credits."
+        "  # Indiana's bounded TY2026 adjusted-gross-income tax before credits and"
     )
     exact_end_marker = (
-        "    rationale: Both outputs apply the 4.95 percent tax to completed "
-        "Illinois taxable income and add completed investment-credit recapture "
-        "before nonrefundable credits; this mapping excludes taxable-income "
-        "construction, credit computation, payments, and final annual liability."
+        "    rationale: Both outputs apply Indiana's tax-year-2026 2.95 percent "
+        "state rate to completed Indiana adjusted gross income with a zero floor, "
+        "before credits and excluding the separate county tax."
     )
     exact_end = text.index(exact_end_marker, start) + len(exact_end_marker)
     fallback_start = text.index(FALLBACK_TEXT)
@@ -49,52 +44,44 @@ def _shared_material(text: str) -> str:
 
 
 def _write_synthetic_module(root: Path) -> None:
-    path = root / "us-il/policies/income_tax/pilot_liability_pipeline.yaml"
+    path = root / "us-in/policies/income_tax/pilot_liability_pipeline.yaml"
     path.parent.mkdir(parents=True)
-    rules = "\n".join(
-        "  - name: "
-        f"{name}\n"
+    path.write_text(
+        "format: rulespec/v1\n"
+        "rules:\n"
+        f"  - name: {OUTPUT_NAME}\n"
         "    kind: derived\n"
         "    versions:\n"
         "      - effective_from: '2026-01-01'\n"
-        "        formula: 0"
-        for name in DIRECT_VARIABLES
+        "        formula: 0\n"
     )
-    path.write_text(f"format: rulespec/v1\nrules:\n{rules}\n")
 
 
-def test_packaged_il_2026_registry_has_exact_two_direct_mappings() -> None:
+def test_packaged_in_2026_registry_has_exact_bounded_direct_mapping() -> None:
     root = Path(__file__).parents[1]
     path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     document = yaml.safe_load(path.read_text())
     mappings = _module_mappings(document)
 
-    assert len(mappings) == 2
-    assert set(mappings) == set(DIRECT_VARIABLES)
-    for output_name, variable in DIRECT_VARIABLES.items():
-        mapping = mappings[output_name]
-        assert mapping["mapping_type"] == "direct_variable"
-        assert mapping["policyengine_variable"] == variable
-        assert (
-            mapping["program"],
-            mapping["entity"],
-            mapping["period"],
-            mapping["unit"],
-            mapping["comparison"],
-        ) == ("tax", "tax_unit", "year", "USD", "money")
-        assert "candidate_priority" not in mapping
-
-    liability = mappings["il_pit_pilot_income_tax_liability"]
-    for excluded_scope in (
-        "taxable-income construction",
-        "credit computation",
-        "payments",
-        "final annual liability",
-    ):
-        assert excluded_scope in liability["rationale"]
+    assert set(mappings) == {OUTPUT_NAME}
+    mapping = mappings[OUTPUT_NAME]
+    assert mapping["mapping_type"] == "direct_variable"
+    assert mapping["policyengine_variable"] == POLICYENGINE_VARIABLE
+    assert (
+        mapping["program"],
+        mapping["entity"],
+        mapping["period"],
+        mapping["unit"],
+        mapping["comparison"],
+    ) == ("tax", "tax_unit", "year", "USD", "money")
+    assert "candidate_priority" not in mapping
+    assert "completed Indiana adjusted gross income" in mapping["rationale"]
+    assert "before credits" in mapping["rationale"]
+    assert "excluding the separate county tax" in mapping["rationale"]
+    assert "final" not in mapping["rationale"].lower()
 
 
-def test_packaged_il_2026_runtime_pin_version_and_precedence_are_exact() -> None:
+def test_packaged_in_2026_runtime_pin_version_and_precedence_are_exact() -> None:
     import axiom_oracles.bridges.registry as runtime_registry_module
 
     root = Path(__file__).parents[1]
@@ -112,30 +99,26 @@ def test_packaged_il_2026_runtime_pin_version_and_precedence_are_exact() -> None
     assert bundled_text.count(FALLBACK_TEXT) == 1
     assert runtime_text.count(FALLBACK_TEXT) == 1
     assert hashlib.sha256(_shared_material(bundled_text).encode()).hexdigest() == (
-        "dd8f49a26f8eb5186f90fcf15bc8c5d230ca6cc10590166c228736638d057ab8"
+        "52a78f849cdab4bc9de9f4f3caffade7a6f4af161fb7e199f32fb1685b8aa342"
     )
 
     registry = load_policyengine_registry()
-    for output_name, variable in DIRECT_VARIABLES.items():
-        mapping = registry.mapping_for_legal_id(
-            f"{MODULE}#{output_name}",
-            country="us",
-        )
-        assert mapping is not None
-        assert mapping.match_type == "exact"
-        assert mapping.mapping_type == "direct_variable"
-        assert mapping.policyengine_variable == variable
-        assert mapping.entity == "tax_unit"
-        assert mapping.period == "year"
-        assert mapping.unit == "USD"
-        assert mapping.comparison == "money"
+    mapping = registry.mapping_for_legal_id(f"{MODULE}#{OUTPUT_NAME}", country="us")
+    assert mapping is not None
+    assert mapping.match_type == "exact"
+    assert mapping.mapping_type == "direct_variable"
+    assert mapping.policyengine_variable == POLICYENGINE_VARIABLE
+    assert mapping.entity == "tax_unit"
+    assert mapping.period == "year"
+    assert mapping.unit == "USD"
+    assert mapping.comparison == "money"
 
     fallback = registry.mapping_for_legal_id(
-        f"{MODULE}#future_unmapped_output",
+        f"{MODULE}#completed_indiana_adjusted_gross_income",
         country="us",
     )
     assert fallback is not None
-    assert fallback.legal_id == "us-il:"
+    assert fallback.legal_id == "us-in:"
     assert fallback.match_type == "prefix"
     assert fallback.mapping_type == "not_comparable"
     assert fallback.candidate_priority == "P4"
@@ -163,7 +146,7 @@ def test_packaged_il_2026_runtime_pin_version_and_precedence_are_exact() -> None
     )
 
 
-def test_policyengine_coverage_classifies_only_bounded_il_2026_outputs(
+def test_policyengine_coverage_classifies_only_bounded_in_2026_output(
     tmp_path: Path,
 ) -> None:
     rulespec_root = tmp_path / "rulespec-us"
@@ -171,10 +154,9 @@ def test_policyengine_coverage_classifies_only_bounded_il_2026_outputs(
 
     report = build_policyengine_coverage_report(rulespec_root, program="tax")
 
-    assert report["total_outputs"] == 2
-    assert report["status_counts"] == {"comparable": 2}
-    items = {item["rule_name"]: item for item in report["items"]}
-    assert set(items) == set(DIRECT_VARIABLES)
-    assert {
-        name: item["policyengine_variable"] for name, item in items.items()
-    } == DIRECT_VARIABLES
+    assert report["total_outputs"] == 1
+    assert report["status_counts"] == {"comparable": 1}
+    assert len(report["items"]) == 1
+    item = report["items"][0]
+    assert item["rule_name"] == OUTPUT_NAME
+    assert item["policyengine_variable"] == POLICYENGINE_VARIABLE

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -10,8 +10,8 @@ from axiom_oracles.bridges.registry import load_policyengine_registry
 MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
-ORACLE_MERGE = "e81e68e054f6166a719f993d2bf5fe2841bc9fde"
-ENCODER_VERSION = "0.2.1402"
+ORACLE_MERGE = "a294b8c82cc89f353134dc7d1090f158c02a539c"
+ENCODER_VERSION = "0.2.1403"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5120,7 +5120,7 @@ def test_packaged_alabama_2026_schedule_registry_and_fallback_are_synchronized()
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "e81e68e054f6166a719f993d2bf5fe2841bc9fde"
+    assert pin == "a294b8c82cc89f353134dc7d1090f158c02a539c"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5231,7 +5231,7 @@ def test_packaged_connecticut_2026_ordinary_tax_registry_is_exactly_synchronized
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "e81e68e054f6166a719f993d2bf5fe2841bc9fde"
+    assert pin == "a294b8c82cc89f353134dc7d1090f158c02a539c"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5315,7 +5315,7 @@ def test_packaged_georgia_2026_annual_tax_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "e81e68e054f6166a719f993d2bf5fe2841bc9fde"
+    assert pin == "a294b8c82cc89f353134dc7d1090f158c02a539c"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5410,7 +5410,7 @@ def test_packaged_mississippi_2026_schedule_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "e81e68e054f6166a719f993d2bf5fe2841bc9fde"
+    assert pin == "a294b8c82cc89f353134dc7d1090f158c02a539c"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5571,7 +5571,7 @@ def test_packaged_kansas_2026_k40es_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "e81e68e054f6166a719f993d2bf5fe2841bc9fde"
+    assert pin == "a294b8c82cc89f353134dc7d1090f158c02a539c"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5676,7 +5676,7 @@ def test_packaged_dc_2026_section_47_1806_03_has_exact_bounded_slice():
 def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "e81e68e054f6166a719f993d2bf5fe2841bc9fde"
+    durable_oracle_merge = "a294b8c82cc89f353134dc7d1090f158c02a539c"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1402"')
+        .startswith('__version__ = "0.2.1403"')
     )
 
 
@@ -5879,7 +5879,7 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
 
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "e81e68e054f6166a719f993d2bf5fe2841bc9fde"
+    durable_oracle_merge = "a294b8c82cc89f353134dc7d1090f158c02a539c"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1402"
+    assert encoder_package["version"] == "0.2.1403"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1402"
+    assert project["project"]["version"] == "0.2.1403"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1402"')
+        .startswith('__version__ = "0.2.1403"')
     )
 
 
@@ -6155,7 +6155,7 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
 
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "e81e68e054f6166a719f993d2bf5fe2841bc9fde"
+    durable_oracle_merge = "a294b8c82cc89f353134dc7d1090f158c02a539c"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1402"
+    assert encoder_package["version"] == "0.2.1403"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1402"
+    assert project["project"]["version"] == "0.2.1403"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1402"')
+        .startswith('__version__ = "0.2.1403"')
     )
 
 
@@ -6506,7 +6506,7 @@ def test_packaged_utah_2026_before_credit_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "e81e68e054f6166a719f993d2bf5fe2841bc9fde"
+    assert pin == "a294b8c82cc89f353134dc7d1090f158c02a539c"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1402"
+version = "0.2.1403"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=e81e68e054f6166a719f993d2bf5fe2841bc9fde" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=a294b8c82cc89f353134dc7d1090f158c02a539c" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=e81e68e054f6166a719f993d2bf5fe2841bc9fde#e81e68e054f6166a719f993d2bf5fe2841bc9fde" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=a294b8c82cc89f353134dc7d1090f158c02a539c#a294b8c82cc89f353134dc7d1090f158c02a539c" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Outcome

Advances axiom-encode to v0.2.1403 on top of the merged Minnesota release and bundles the reviewed Indiana TY2026 adjusted-gross-income tax oracle surface.

- pins exact durable axiom-oracles merge `a294b8c82cc89f353134dc7d1090f158c02a539c`
- maps exactly `in_pit_pilot_income_tax_liability` to PolicyEngine `in_agi_tax`
- adds no input mapping and preserves the existing `us-in:` fallback byte-identically
- preserves Minnesota, Illinois, and every earlier state mapping
- explicitly limits the surface to completed Indiana AGI, before credits and excluding county tax/final liability

## Independent review cycle

Independent review completed on exact staged patch `c03c863f1948d615d1ead954ad78855ddc43dc0d734d37d93dc220478c679f5e` with no actionable findings. The reviewer confirmed the mapping-file diff is insertion-only, the fallback SHA remains `605944048f191867fd1e35f7c7f1e93d1a1652591b98ae5546bce386c3bafe4c` across base/bundle/runtime, all inherited mapping bytes are preserved, and current version/pin assertions contain no stale values.

## Checks

- `uv lock --check`: green
- focused Ruff: green
- compileall: green
- IN + IL + MN registry and changed current-pin/version nodes: 18 passed
- cached diff check: green

All acceptance checks ran on project-compatible Python 3.13.