### PR TITLE
Bundle Pennsylvania 2026 income tax oracle mappings

### DIFF
--- a/changelog.d/pa-2026-before-forgiveness-oracle.changed.md
+++ b/changelog.d/pa-2026-before-forgiveness-oracle.changed.md
@@ -1,0 +1,1 @@
+Bundle Pennsylvania's bounded tax-year-2026 adjusted-taxable-income and income-tax-before-forgiveness mappings and pin their durable reviewed oracle-main merge without claiming input construction, tax forgiveness, credits, payments, or final annual liability.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1403"
+version = "0.2.1404"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@a294b8c82cc89f353134dc7d1090f158c02a539c",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@8a49395fb38f748c72733e05bdbf8d768b2bf77d",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1403"
+__version__ = "0.2.1404"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -28827,6 +28827,32 @@ mappings:
     comparison: money
     rationale: Both outputs apply Indiana's tax-year-2026 2.95 percent state rate to completed Indiana adjusted gross income with a zero floor, before credits and excluding the separate county tax.
 
+  # Pennsylvania's bounded TY2026 resident tax before forgiveness. The
+  # completed-return adjusted-taxable-income input remains a caller boundary;
+  # these exact output mappings are promoted only with a runtime proof that the
+  # selected certified population stays in RuleSpec's nonnegative domain.
+  - legal_id: us-pa:policies/income_tax/pilot_liability_pipeline#pa_pit_pilot_taxable_income
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: pa_adjusted_taxable_income
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: On the reviewed nonnegative completed-return boundary, RuleSpec's taxable-income output and PolicyEngine's pa_adjusted_taxable_income expose the same Pennsylvania adjusted taxable income before tax forgiveness and credits.
+
+  - legal_id: us-pa:policies/income_tax/pilot_liability_pipeline#pa_pit_pilot_income_tax_liability
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: pa_income_tax_before_forgiveness
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: On the reviewed nonnegative completed-return boundary, both outputs apply Pennsylvania's tax-year-2026 3.07 percent rate to adjusted taxable income before tax forgiveness, credits, payments, or final annual liability.
+
   # Illinois's bounded TY2026 annual tax before nonrefundable credits.
   # The canonical module accepts completed Illinois taxable income and
   # investment-credit recapture boundaries; it does not reconstruct either
@@ -31213,6 +31239,12 @@ prefixes:
     mapping_type: not_comparable
     candidate_priority: P4
     rationale: PolicyEngine-US does not model OK agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
+
+  - legal_id_prefix: "us-pa:"
+    country: us
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: PolicyEngine-US does not model PA agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
 
   - legal_id_prefix: "us-sc:"
     country: us

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -14,8 +14,8 @@ DIRECT_VARIABLES = {
         "il_income_tax_before_non_refundable_credits"
     ),
 }
-ORACLE_MERGE = "a294b8c82cc89f353134dc7d1090f158c02a539c"
-ENCODER_VERSION = "0.2.1403"
+ORACLE_MERGE = "8a49395fb38f748c72733e05bdbf8d768b2bf77d"
+ENCODER_VERSION = "0.2.1404"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -10,8 +10,8 @@ from axiom_oracles.bridges.registry import load_policyengine_registry
 MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
-ORACLE_MERGE = "a294b8c82cc89f353134dc7d1090f158c02a539c"
-ENCODER_VERSION = "0.2.1403"
+ORACLE_MERGE = "8a49395fb38f748c72733e05bdbf8d768b2bf77d"
+ENCODER_VERSION = "0.2.1404"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -7,16 +7,19 @@ import yaml
 from axiom_oracles.bridges.coverage import build_policyengine_coverage_report
 from axiom_oracles.bridges.registry import load_policyengine_registry
 
-MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
-OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
-POLICYENGINE_VARIABLE = "in_agi_tax"
+MODULE = "us-pa:policies/income_tax/pilot_liability_pipeline"
+INPUT_NAME = "pa_pit_pilot_state_taxable_income"
+DIRECT_VARIABLES = {
+    "pa_pit_pilot_taxable_income": "pa_adjusted_taxable_income",
+    "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
+}
 ORACLE_MERGE = "8a49395fb38f748c72733e05bdbf8d768b2bf77d"
 ENCODER_VERSION = "0.2.1404"
-FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
+FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable
     candidate_priority: P4
-    rationale: PolicyEngine-US does not model IN agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix."""
+    rationale: PolicyEngine-US does not model PA agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix."""
 
 
 def _module_mappings(document):
@@ -30,12 +33,13 @@ def _module_mappings(document):
 
 def _shared_material(text: str) -> str:
     start = text.index(
-        "  # Indiana's bounded TY2026 adjusted-gross-income tax before credits and"
+        "  # Pennsylvania's bounded TY2026 resident tax before forgiveness."
     )
     exact_end_marker = (
-        "    rationale: Both outputs apply Indiana's tax-year-2026 2.95 percent "
-        "state rate to completed Indiana adjusted gross income with a zero floor, "
-        "before credits and excluding the separate county tax."
+        "    rationale: On the reviewed nonnegative completed-return boundary, "
+        "both outputs apply Pennsylvania's tax-year-2026 3.07 percent rate to "
+        "adjusted taxable income before tax forgiveness, credits, payments, or "
+        "final annual liability."
     )
     exact_end = text.index(exact_end_marker, start) + len(exact_end_marker)
     fallback_start = text.index(FALLBACK_TEXT)
@@ -44,44 +48,56 @@ def _shared_material(text: str) -> str:
 
 
 def _write_synthetic_module(root: Path) -> None:
-    path = root / "us-in/policies/income_tax/pilot_liability_pipeline.yaml"
+    path = root / "us-pa/policies/income_tax/pilot_liability_pipeline.yaml"
     path.parent.mkdir(parents=True)
-    path.write_text(
-        "format: rulespec/v1\n"
-        "rules:\n"
-        f"  - name: {OUTPUT_NAME}\n"
+    rules = "\n".join(
+        "  - name: "
+        f"{name}\n"
         "    kind: derived\n"
         "    versions:\n"
         "      - effective_from: '2026-01-01'\n"
-        "        formula: 0\n"
+        "        formula: 0"
+        for name in DIRECT_VARIABLES
     )
+    path.write_text(f"format: rulespec/v1\nrules:\n{rules}\n")
 
 
-def test_packaged_in_2026_registry_has_exact_bounded_direct_mapping() -> None:
+def test_packaged_pa_2026_registry_has_exact_two_direct_mappings() -> None:
     root = Path(__file__).parents[1]
     path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     document = yaml.safe_load(path.read_text())
     mappings = _module_mappings(document)
 
-    assert set(mappings) == {OUTPUT_NAME}
-    mapping = mappings[OUTPUT_NAME]
-    assert mapping["mapping_type"] == "direct_variable"
-    assert mapping["policyengine_variable"] == POLICYENGINE_VARIABLE
-    assert (
-        mapping["program"],
-        mapping["entity"],
-        mapping["period"],
-        mapping["unit"],
-        mapping["comparison"],
-    ) == ("tax", "tax_unit", "year", "USD", "money")
-    assert "candidate_priority" not in mapping
-    assert "completed Indiana adjusted gross income" in mapping["rationale"]
-    assert "before credits" in mapping["rationale"]
-    assert "excluding the separate county tax" in mapping["rationale"]
-    assert "final" not in mapping["rationale"].lower()
+    assert set(mappings) == set(DIRECT_VARIABLES)
+    for output_name, variable in DIRECT_VARIABLES.items():
+        mapping = mappings[output_name]
+        assert mapping["mapping_type"] == "direct_variable"
+        assert mapping["policyengine_variable"] == variable
+        assert (
+            mapping["program"],
+            mapping["entity"],
+            mapping["period"],
+            mapping["unit"],
+            mapping["comparison"],
+        ) == ("tax", "tax_unit", "year", "USD", "money")
+        assert "candidate_priority" not in mapping
+        assert "reviewed nonnegative completed-return boundary" in (
+            mapping["rationale"]
+        )
+
+    liability = mappings["pa_pit_pilot_income_tax_liability"]
+    for bounded_scope in (
+        "3.07 percent",
+        "before tax forgiveness",
+        "credits",
+        "payments",
+        "final annual liability",
+    ):
+        assert bounded_scope in liability["rationale"]
+    assert f"input.{INPUT_NAME}" not in mappings
 
 
-def test_packaged_in_2026_runtime_pin_version_and_precedence_are_exact() -> None:
+def test_packaged_pa_2026_runtime_pin_version_and_precedence_are_exact() -> None:
     import axiom_oracles.bridges.registry as runtime_registry_module
 
     root = Path(__file__).parents[1]
@@ -98,27 +114,34 @@ def test_packaged_in_2026_runtime_pin_version_and_precedence_are_exact() -> None
     assert _shared_material(bundled_text) == _shared_material(runtime_text)
     assert bundled_text.count(FALLBACK_TEXT) == 1
     assert runtime_text.count(FALLBACK_TEXT) == 1
+    assert hashlib.sha256(FALLBACK_TEXT.encode()).hexdigest() == (
+        "36c34549d21576398741ca559e0d923b09126364b22cb1f7bdc5c3da025c6111"
+    )
     assert hashlib.sha256(_shared_material(bundled_text).encode()).hexdigest() == (
-        "52a78f849cdab4bc9de9f4f3caffade7a6f4af161fb7e199f32fb1685b8aa342"
+        "a81fd41cefe8ae15c991d29c4676bce3aa970e8d850c3d1cefd90ef590f3ac97"
     )
 
     registry = load_policyengine_registry()
-    mapping = registry.mapping_for_legal_id(f"{MODULE}#{OUTPUT_NAME}", country="us")
-    assert mapping is not None
-    assert mapping.match_type == "exact"
-    assert mapping.mapping_type == "direct_variable"
-    assert mapping.policyengine_variable == POLICYENGINE_VARIABLE
-    assert mapping.entity == "tax_unit"
-    assert mapping.period == "year"
-    assert mapping.unit == "USD"
-    assert mapping.comparison == "money"
+    for output_name, variable in DIRECT_VARIABLES.items():
+        mapping = registry.mapping_for_legal_id(
+            f"{MODULE}#{output_name}",
+            country="us",
+        )
+        assert mapping is not None
+        assert mapping.match_type == "exact"
+        assert mapping.mapping_type == "direct_variable"
+        assert mapping.policyengine_variable == variable
+        assert mapping.entity == "tax_unit"
+        assert mapping.period == "year"
+        assert mapping.unit == "USD"
+        assert mapping.comparison == "money"
 
     fallback = registry.mapping_for_legal_id(
-        f"{MODULE}#completed_indiana_adjusted_gross_income",
+        f"{MODULE}#future_unmapped_output",
         country="us",
     )
     assert fallback is not None
-    assert fallback.legal_id == "us-in:"
+    assert fallback.legal_id == "us-pa:"
     assert fallback.match_type == "prefix"
     assert fallback.mapping_type == "not_comparable"
     assert fallback.candidate_priority == "P4"
@@ -146,7 +169,7 @@ def test_packaged_in_2026_runtime_pin_version_and_precedence_are_exact() -> None
     )
 
 
-def test_policyengine_coverage_classifies_only_bounded_in_2026_output(
+def test_policyengine_coverage_classifies_only_bounded_pa_2026_outputs(
     tmp_path: Path,
 ) -> None:
     rulespec_root = tmp_path / "rulespec-us"
@@ -154,9 +177,10 @@ def test_policyengine_coverage_classifies_only_bounded_in_2026_output(
 
     report = build_policyengine_coverage_report(rulespec_root, program="tax")
 
-    assert report["total_outputs"] == 1
-    assert report["status_counts"] == {"comparable": 1}
-    assert len(report["items"]) == 1
-    item = report["items"][0]
-    assert item["rule_name"] == OUTPUT_NAME
-    assert item["policyengine_variable"] == POLICYENGINE_VARIABLE
+    assert report["total_outputs"] == 2
+    assert report["status_counts"] == {"comparable": 2}
+    items = {item["rule_name"]: item for item in report["items"]}
+    assert set(items) == set(DIRECT_VARIABLES)
+    assert {
+        name: item["policyengine_variable"] for name, item in items.items()
+    } == DIRECT_VARIABLES

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -81,8 +81,8 @@ def test_packaged_pa_2026_registry_has_exact_two_direct_mappings() -> None:
             mapping["comparison"],
         ) == ("tax", "tax_unit", "year", "USD", "money")
         assert "candidate_priority" not in mapping
-        assert "reviewed nonnegative completed-return boundary" in (
-            mapping["rationale"]
+        assert (
+            "reviewed nonnegative completed-return boundary" in (mapping["rationale"])
         )
 
     liability = mappings["pa_pit_pilot_income_tax_liability"]

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5120,7 +5120,7 @@ def test_packaged_alabama_2026_schedule_registry_and_fallback_are_synchronized()
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "a294b8c82cc89f353134dc7d1090f158c02a539c"
+    assert pin == "8a49395fb38f748c72733e05bdbf8d768b2bf77d"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5231,7 +5231,7 @@ def test_packaged_connecticut_2026_ordinary_tax_registry_is_exactly_synchronized
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "a294b8c82cc89f353134dc7d1090f158c02a539c"
+    assert pin == "8a49395fb38f748c72733e05bdbf8d768b2bf77d"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5315,7 +5315,7 @@ def test_packaged_georgia_2026_annual_tax_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "a294b8c82cc89f353134dc7d1090f158c02a539c"
+    assert pin == "8a49395fb38f748c72733e05bdbf8d768b2bf77d"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5410,7 +5410,7 @@ def test_packaged_mississippi_2026_schedule_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "a294b8c82cc89f353134dc7d1090f158c02a539c"
+    assert pin == "8a49395fb38f748c72733e05bdbf8d768b2bf77d"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5571,7 +5571,7 @@ def test_packaged_kansas_2026_k40es_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "a294b8c82cc89f353134dc7d1090f158c02a539c"
+    assert pin == "8a49395fb38f748c72733e05bdbf8d768b2bf77d"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5676,7 +5676,7 @@ def test_packaged_dc_2026_section_47_1806_03_has_exact_bounded_slice():
 def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "a294b8c82cc89f353134dc7d1090f158c02a539c"
+    durable_oracle_merge = "8a49395fb38f748c72733e05bdbf8d768b2bf77d"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1403"')
+        .startswith('__version__ = "0.2.1404"')
     )
 
 
@@ -5879,7 +5879,7 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
 
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "a294b8c82cc89f353134dc7d1090f158c02a539c"
+    durable_oracle_merge = "8a49395fb38f748c72733e05bdbf8d768b2bf77d"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1403"
+    assert encoder_package["version"] == "0.2.1404"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1403"
+    assert project["project"]["version"] == "0.2.1404"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1403"')
+        .startswith('__version__ = "0.2.1404"')
     )
 
 
@@ -6155,7 +6155,7 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
 
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "a294b8c82cc89f353134dc7d1090f158c02a539c"
+    durable_oracle_merge = "8a49395fb38f748c72733e05bdbf8d768b2bf77d"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1403"
+    assert encoder_package["version"] == "0.2.1404"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1403"
+    assert project["project"]["version"] == "0.2.1404"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1403"')
+        .startswith('__version__ = "0.2.1404"')
     )
 
 
@@ -6506,7 +6506,7 @@ def test_packaged_utah_2026_before_credit_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "a294b8c82cc89f353134dc7d1090f158c02a539c"
+    assert pin == "8a49395fb38f748c72733e05bdbf8d768b2bf77d"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1403"
+version = "0.2.1404"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=a294b8c82cc89f353134dc7d1090f158c02a539c" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=8a49395fb38f748c72733e05bdbf8d768b2bf77d" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=a294b8c82cc89f353134dc7d1090f158c02a539c#a294b8c82cc89f353134dc7d1090f158c02a539c" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=8a49395fb38f748c72733e05bdbf8d768b2bf77d#8a49395fb38f748c72733e05bdbf8d768b2bf77d" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Outcome

Advances axiom-encode to v0.2.1404 on top of the merged Indiana release and bundles the reviewed Pennsylvania TY2026 adjusted-taxable-income and tax-before-forgiveness surfaces.

- pins exact durable axiom-oracles merge `8a49395fb38f748c72733e05bdbf8d768b2bf77d`
- maps exactly `pa_pit_pilot_taxable_income` to `pa_adjusted_taxable_income` and `pa_pit_pilot_income_tax_liability` to `pa_income_tax_before_forgiveness`
- adds no input mapping and inherits one exact `us-pa:` P4 fallback from the oracle registry
- preserves Indiana, Minnesota, Illinois, and every earlier state mapping
- explicitly excludes input construction, tax forgiveness, credits, payments, and final annual liability

## Independent review cycle

Independent review completed CLEAN on exact staged patch `af5ff2b31714b0f286224576fb5525c8852688614705118bbd4d5c3b5f458a95` with no actionable findings. The reviewer confirmed exactly ten intended paths, consistent v0.2.1404/8a49395 pins, no stale prior current pin/version, exactly two PA direct mappings plus one fallback, bundled/runtime byte synchronization, bounded rationale, and no unrelated mapping drift.

## Checks

- `uv lock --check`: green
- focused Ruff and compileall: green
- PA + IN + MN + IL registry and changed current-pin/version nodes: 21 passed
- `git diff --check`: green

All focused tests ran on project-compatible Python 3.13 with the exact reviewed oracle tree.