### PR TITLE
Map South Carolina 2026 pre-credit income tax oracle

### DIFF
--- a/changelog.d/sc-2026-before-nonrefundable-credits-oracle.changed.md
+++ b/changelog.d/sc-2026-before-nonrefundable-credits-oracle.changed.md
@@ -1,0 +1,1 @@
+Bundle South Carolina's bounded tax-year-2026 income-tax-before-nonrefundable-credits mapping and pin its durable reviewed oracle-main merge without claiming taxable-income construction, credits, payments, or final annual liability.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1404"
+version = "0.2.1405"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@8a49395fb38f748c72733e05bdbf8d768b2bf77d",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@c95aac78835375d31390d1e430d1608fee2b3b93",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1404"
+__version__ = "0.2.1405"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -28827,6 +28827,21 @@ mappings:
     comparison: money
     rationale: Both outputs apply Indiana's tax-year-2026 2.95 percent state rate to completed Indiana adjusted gross income with a zero floor, before credits and excluding the separate county tax.
 
+  # South Carolina's bounded TY2026 individual income tax before
+  # nonrefundable credits. The completed-return taxable-income input remains a
+  # caller boundary; promotion is limited to the enacted 2026 schedule and a
+  # runtime-proved nonnegative population domain.
+  - legal_id: us-sc:policies/income_tax/pilot_liability_pipeline#sc_pit_pilot_income_tax_liability
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: sc_income_tax_before_non_refundable_credits
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: On the reviewed nonnegative completed-return boundary, both outputs apply South Carolina's enacted tax-year-2026 1.99 percent and 5.21 percent-minus-$966 schedule to South Carolina taxable income before nonrefundable credits, payments, or final annual liability.
+
   # Pennsylvania's bounded TY2026 resident tax before forgiveness. The
   # completed-return adjusted-taxable-income input remains a caller boundary;
   # these exact output mappings are promoted only with a runtime proof that the

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -14,8 +14,8 @@ DIRECT_VARIABLES = {
         "il_income_tax_before_non_refundable_credits"
     ),
 }
-ORACLE_MERGE = "8a49395fb38f748c72733e05bdbf8d768b2bf77d"
-ENCODER_VERSION = "0.2.1404"
+ORACLE_MERGE = "c95aac78835375d31390d1e430d1608fee2b3b93"
+ENCODER_VERSION = "0.2.1405"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -10,8 +10,8 @@ from axiom_oracles.bridges.registry import load_policyengine_registry
 MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
-ORACLE_MERGE = "8a49395fb38f748c72733e05bdbf8d768b2bf77d"
-ENCODER_VERSION = "0.2.1404"
+ORACLE_MERGE = "c95aac78835375d31390d1e430d1608fee2b3b93"
+ENCODER_VERSION = "0.2.1405"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -13,8 +13,8 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_taxable_income": "pa_adjusted_taxable_income",
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
-ORACLE_MERGE = "8a49395fb38f748c72733e05bdbf8d768b2bf77d"
-ENCODER_VERSION = "0.2.1404"
+ORACLE_MERGE = "c95aac78835375d31390d1e430d1608fee2b3b93"
+ENCODER_VERSION = "0.2.1405"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5120,7 +5120,7 @@ def test_packaged_alabama_2026_schedule_registry_and_fallback_are_synchronized()
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "8a49395fb38f748c72733e05bdbf8d768b2bf77d"
+    assert pin == "c95aac78835375d31390d1e430d1608fee2b3b93"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5231,7 +5231,7 @@ def test_packaged_connecticut_2026_ordinary_tax_registry_is_exactly_synchronized
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "8a49395fb38f748c72733e05bdbf8d768b2bf77d"
+    assert pin == "c95aac78835375d31390d1e430d1608fee2b3b93"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5315,7 +5315,7 @@ def test_packaged_georgia_2026_annual_tax_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "8a49395fb38f748c72733e05bdbf8d768b2bf77d"
+    assert pin == "c95aac78835375d31390d1e430d1608fee2b3b93"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5410,7 +5410,7 @@ def test_packaged_mississippi_2026_schedule_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "8a49395fb38f748c72733e05bdbf8d768b2bf77d"
+    assert pin == "c95aac78835375d31390d1e430d1608fee2b3b93"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5571,7 +5571,7 @@ def test_packaged_kansas_2026_k40es_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "8a49395fb38f748c72733e05bdbf8d768b2bf77d"
+    assert pin == "c95aac78835375d31390d1e430d1608fee2b3b93"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5676,7 +5676,7 @@ def test_packaged_dc_2026_section_47_1806_03_has_exact_bounded_slice():
 def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "8a49395fb38f748c72733e05bdbf8d768b2bf77d"
+    durable_oracle_merge = "c95aac78835375d31390d1e430d1608fee2b3b93"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1404"')
+        .startswith('__version__ = "0.2.1405"')
     )
 
 
@@ -5879,7 +5879,7 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
 
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "8a49395fb38f748c72733e05bdbf8d768b2bf77d"
+    durable_oracle_merge = "c95aac78835375d31390d1e430d1608fee2b3b93"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1404"
+    assert encoder_package["version"] == "0.2.1405"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1404"
+    assert project["project"]["version"] == "0.2.1405"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1404"')
+        .startswith('__version__ = "0.2.1405"')
     )
 
 
@@ -6155,7 +6155,7 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
 
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "8a49395fb38f748c72733e05bdbf8d768b2bf77d"
+    durable_oracle_merge = "c95aac78835375d31390d1e430d1608fee2b3b93"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1404"
+    assert encoder_package["version"] == "0.2.1405"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1404"
+    assert project["project"]["version"] == "0.2.1405"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1404"')
+        .startswith('__version__ = "0.2.1405"')
     )
 
 
@@ -6506,7 +6506,7 @@ def test_packaged_utah_2026_before_credit_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "8a49395fb38f748c72733e05bdbf8d768b2bf77d"
+    assert pin == "c95aac78835375d31390d1e430d1608fee2b3b93"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -7,16 +7,17 @@ import yaml
 from axiom_oracles.bridges.coverage import build_policyengine_coverage_report
 from axiom_oracles.bridges.registry import load_policyengine_registry
 
-MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
-OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
-POLICYENGINE_VARIABLE = "in_agi_tax"
+MODULE = "us-sc:policies/income_tax/pilot_liability_pipeline"
+OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
+INPUT_NAME = "sc_pit_pilot_state_taxable_income"
+POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "c95aac78835375d31390d1e430d1608fee2b3b93"
 ENCODER_VERSION = "0.2.1405"
-FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
+FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable
     candidate_priority: P4
-    rationale: PolicyEngine-US does not model IN agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix."""
+    rationale: PolicyEngine-US does not model SC agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix."""
 
 
 def _module_mappings(document):
@@ -30,12 +31,13 @@ def _module_mappings(document):
 
 def _shared_material(text: str) -> str:
     start = text.index(
-        "  # Indiana's bounded TY2026 adjusted-gross-income tax before credits and"
+        "  # South Carolina's bounded TY2026 individual income tax before"
     )
     exact_end_marker = (
-        "    rationale: Both outputs apply Indiana's tax-year-2026 2.95 percent "
-        "state rate to completed Indiana adjusted gross income with a zero floor, "
-        "before credits and excluding the separate county tax."
+        "    rationale: On the reviewed nonnegative completed-return boundary, "
+        "both outputs apply South Carolina's enacted tax-year-2026 1.99 percent "
+        "and 5.21 percent-minus-$966 schedule to South Carolina taxable income "
+        "before nonrefundable credits, payments, or final annual liability."
     )
     exact_end = text.index(exact_end_marker, start) + len(exact_end_marker)
     fallback_start = text.index(FALLBACK_TEXT)
@@ -44,7 +46,7 @@ def _shared_material(text: str) -> str:
 
 
 def _write_synthetic_module(root: Path) -> None:
-    path = root / "us-in/policies/income_tax/pilot_liability_pipeline.yaml"
+    path = root / "us-sc/policies/income_tax/pilot_liability_pipeline.yaml"
     path.parent.mkdir(parents=True)
     path.write_text(
         "format: rulespec/v1\n"
@@ -57,7 +59,7 @@ def _write_synthetic_module(root: Path) -> None:
     )
 
 
-def test_packaged_in_2026_registry_has_exact_bounded_direct_mapping() -> None:
+def test_packaged_sc_2026_registry_has_one_exact_direct_mapping() -> None:
     root = Path(__file__).parents[1]
     path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     document = yaml.safe_load(path.read_text())
@@ -75,13 +77,20 @@ def test_packaged_in_2026_registry_has_exact_bounded_direct_mapping() -> None:
         mapping["comparison"],
     ) == ("tax", "tax_unit", "year", "USD", "money")
     assert "candidate_priority" not in mapping
-    assert "completed Indiana adjusted gross income" in mapping["rationale"]
-    assert "before credits" in mapping["rationale"]
-    assert "excluding the separate county tax" in mapping["rationale"]
-    assert "final" not in mapping["rationale"].lower()
+    assert "reviewed nonnegative completed-return boundary" in mapping["rationale"]
+    for bounded_scope in (
+        "tax-year-2026",
+        "before nonrefundable credits",
+        "payments",
+        "final annual liability",
+    ):
+        assert bounded_scope in mapping["rationale"]
+    assert f"input.{INPUT_NAME}" not in mappings
+    assert "sc_pit_pilot_taxable_income" not in mappings
+    assert "sc_pit_pilot_schedule_tax" not in mappings
 
 
-def test_packaged_in_2026_runtime_pin_version_and_precedence_are_exact() -> None:
+def test_packaged_sc_2026_runtime_pin_version_and_precedence_are_exact() -> None:
     import axiom_oracles.bridges.registry as runtime_registry_module
 
     root = Path(__file__).parents[1]
@@ -98,12 +107,18 @@ def test_packaged_in_2026_runtime_pin_version_and_precedence_are_exact() -> None
     assert _shared_material(bundled_text) == _shared_material(runtime_text)
     assert bundled_text.count(FALLBACK_TEXT) == 1
     assert runtime_text.count(FALLBACK_TEXT) == 1
+    assert hashlib.sha256(FALLBACK_TEXT.encode()).hexdigest() == (
+        "31484c10dd215ae94df62a526db8d6d5e5276967ba4094ab8c19cb1dc8c218dd"
+    )
     assert hashlib.sha256(_shared_material(bundled_text).encode()).hexdigest() == (
-        "52a78f849cdab4bc9de9f4f3caffade7a6f4af161fb7e199f32fb1685b8aa342"
+        "933fda9c31f5450ac251865b31943cc100490ff4d394723fb520e2e9cebd73f4"
     )
 
     registry = load_policyengine_registry()
-    mapping = registry.mapping_for_legal_id(f"{MODULE}#{OUTPUT_NAME}", country="us")
+    mapping = registry.mapping_for_legal_id(
+        f"{MODULE}#{OUTPUT_NAME}",
+        country="us",
+    )
     assert mapping is not None
     assert mapping.match_type == "exact"
     assert mapping.mapping_type == "direct_variable"
@@ -113,15 +128,20 @@ def test_packaged_in_2026_runtime_pin_version_and_precedence_are_exact() -> None
     assert mapping.unit == "USD"
     assert mapping.comparison == "money"
 
-    fallback = registry.mapping_for_legal_id(
-        f"{MODULE}#completed_indiana_adjusted_gross_income",
-        country="us",
-    )
-    assert fallback is not None
-    assert fallback.legal_id == "us-in:"
-    assert fallback.match_type == "prefix"
-    assert fallback.mapping_type == "not_comparable"
-    assert fallback.candidate_priority == "P4"
+    for output_name in (
+        "sc_pit_pilot_taxable_income",
+        "sc_pit_pilot_schedule_tax",
+        "future_unmapped_output",
+    ):
+        fallback = registry.mapping_for_legal_id(
+            f"{MODULE}#{output_name}",
+            country="us",
+        )
+        assert fallback is not None
+        assert fallback.legal_id == "us-sc:"
+        assert fallback.match_type == "prefix"
+        assert fallback.mapping_type == "not_comparable"
+        assert fallback.candidate_priority == "P4"
 
     dependency_pin = re.search(
         r"axiom-oracles@[0-9a-f]{40}",
@@ -146,7 +166,7 @@ def test_packaged_in_2026_runtime_pin_version_and_precedence_are_exact() -> None
     )
 
 
-def test_policyengine_coverage_classifies_only_bounded_in_2026_output(
+def test_policyengine_coverage_classifies_only_bounded_sc_2026_output(
     tmp_path: Path,
 ) -> None:
     rulespec_root = tmp_path / "rulespec-us"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1404"
+version = "0.2.1405"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=8a49395fb38f748c72733e05bdbf8d768b2bf77d" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=c95aac78835375d31390d1e430d1608fee2b3b93" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=8a49395fb38f748c72733e05bdbf8d768b2bf77d#8a49395fb38f748c72733e05bdbf8d768b2bf77d" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=c95aac78835375d31390d1e430d1608fee2b3b93#c95aac78835375d31390d1e430d1608fee2b3b93" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- pin the reviewed South Carolina oracle merge `c95aac78835375d31390d1e430d1608fee2b3b93`
- add exactly one direct RuleSpec mapping: `sc_pit_pilot_income_tax_liability` to `sc_income_tax_before_non_refundable_credits`
- preserve the existing `us-sc` prefix fallback byte-for-byte and intentionally leave taxable income, schedule tax, resident core, and final liability unmapped
- advance the package to `0.2.1405` and add focused registry/runtime coverage

## Validation

- 15 focused SC/PA/IN/IL/MN registry tests passed
- 9 affected RuleSpec pin/version tests passed
- `uvx --from ruff==0.16.0 ruff check src tests`
- `uvx --from ruff==0.16.0 ruff format --check src tests`
- `uv lock --check`
- `git diff --check`

## Review cycle

Independent review completed with no actionable findings. The reviewer reproduced the staged path and patch digests, audited the one-output boundary and fallback preservation, verified exact pins, and reran all focused checks above. Hosted CI and a post-merge check are still required before this layer is considered complete.