### PR TITLE
Map Oklahoma 2026 pre-credit income tax oracle

### DIFF
--- a/changelog.d/ok-2026-before-credits-oracle.changed.md
+++ b/changelog.d/ok-2026-before-credits-oracle.changed.md
@@ -1,0 +1,1 @@
+Bundle Oklahoma's bounded tax-year-2026 income-tax-before-credits mapping and pin its durable reviewed oracle-main merge without claiming taxable-income construction, schedule internals, credits, payments, or final annual liability.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1405"
+version = "0.2.1406"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@c95aac78835375d31390d1e430d1608fee2b3b93",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@a62340d2f1e2873b43404478835de5577e685736",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1405"
+__version__ = "0.2.1406"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -28842,6 +28842,20 @@ mappings:
     comparison: money
     rationale: On the reviewed nonnegative completed-return boundary, both outputs apply South Carolina's enacted tax-year-2026 1.99 percent and 5.21 percent-minus-$966 schedule to South Carolina taxable income before nonrefundable credits, payments, or final annual liability.
 
+  # Oklahoma's bounded TY2026 individual income tax before credits. Completed
+  # taxable income and filing-status classification remain caller boundaries;
+  # no credit, payment, or final-liability surface is promoted here.
+  - legal_id: us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_income_tax_liability
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: ok_income_tax_before_credits
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: On the reviewed nonnegative completed-return boundary, both outputs apply Oklahoma's enacted tax-year-2026 four-band schedule to Oklahoma taxable income using the statutory single-or-separate versus joint, surviving-spouse, or head-of-household schedule branch, before credits, payments, or final annual liability.
+
   # Pennsylvania's bounded TY2026 resident tax before forgiveness. The
   # completed-return adjusted-taxable-income input remains a caller boundary;
   # these exact output mappings are promoted only with a runtime proof that the

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -14,8 +14,8 @@ DIRECT_VARIABLES = {
         "il_income_tax_before_non_refundable_credits"
     ),
 }
-ORACLE_MERGE = "c95aac78835375d31390d1e430d1608fee2b3b93"
-ENCODER_VERSION = "0.2.1405"
+ORACLE_MERGE = "a62340d2f1e2873b43404478835de5577e685736"
+ENCODER_VERSION = "0.2.1406"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -10,8 +10,8 @@ from axiom_oracles.bridges.registry import load_policyengine_registry
 MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
-ORACLE_MERGE = "c95aac78835375d31390d1e430d1608fee2b3b93"
-ENCODER_VERSION = "0.2.1405"
+ORACLE_MERGE = "a62340d2f1e2873b43404478835de5577e685736"
+ENCODER_VERSION = "0.2.1406"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -10,8 +10,8 @@ from axiom_oracles.bridges.registry import load_policyengine_registry
 MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
-ORACLE_MERGE = "c95aac78835375d31390d1e430d1608fee2b3b93"
-ENCODER_VERSION = "0.2.1405"
+ORACLE_MERGE = "a62340d2f1e2873b43404478835de5577e685736"
+ENCODER_VERSION = "0.2.1406"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -7,17 +7,16 @@ import yaml
 from axiom_oracles.bridges.coverage import build_policyengine_coverage_report
 from axiom_oracles.bridges.registry import load_policyengine_registry
 
-MODULE = "us-sc:policies/income_tax/pilot_liability_pipeline"
-OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
-INPUT_NAME = "sc_pit_pilot_state_taxable_income"
-POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
+MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
+OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
+POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "a62340d2f1e2873b43404478835de5577e685736"
 ENCODER_VERSION = "0.2.1406"
-FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
+FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable
     candidate_priority: P4
-    rationale: PolicyEngine-US does not model SC agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix."""
+    rationale: PolicyEngine-US does not model OK agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix."""
 
 
 def _module_mappings(document):
@@ -31,13 +30,14 @@ def _module_mappings(document):
 
 def _shared_material(text: str) -> str:
     start = text.index(
-        "  # South Carolina's bounded TY2026 individual income tax before"
+        "  # Oklahoma's bounded TY2026 individual income tax before credits."
     )
     exact_end_marker = (
         "    rationale: On the reviewed nonnegative completed-return boundary, "
-        "both outputs apply South Carolina's enacted tax-year-2026 1.99 percent "
-        "and 5.21 percent-minus-$966 schedule to South Carolina taxable income "
-        "before nonrefundable credits, payments, or final annual liability."
+        "both outputs apply Oklahoma's enacted tax-year-2026 four-band schedule "
+        "to Oklahoma taxable income using the statutory single-or-separate "
+        "versus joint, surviving-spouse, or head-of-household schedule branch, "
+        "before credits, payments, or final annual liability."
     )
     exact_end = text.index(exact_end_marker, start) + len(exact_end_marker)
     fallback_start = text.index(FALLBACK_TEXT)
@@ -46,7 +46,7 @@ def _shared_material(text: str) -> str:
 
 
 def _write_synthetic_module(root: Path) -> None:
-    path = root / "us-sc/policies/income_tax/pilot_liability_pipeline.yaml"
+    path = root / "us-ok/policies/income_tax/pilot_liability_pipeline.yaml"
     path.parent.mkdir(parents=True)
     path.write_text(
         "format: rulespec/v1\n"
@@ -59,7 +59,7 @@ def _write_synthetic_module(root: Path) -> None:
     )
 
 
-def test_packaged_sc_2026_registry_has_one_exact_direct_mapping() -> None:
+def test_packaged_ok_2026_registry_has_one_exact_direct_mapping() -> None:
     root = Path(__file__).parents[1]
     path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     document = yaml.safe_load(path.read_text())
@@ -80,17 +80,22 @@ def test_packaged_sc_2026_registry_has_one_exact_direct_mapping() -> None:
     assert "reviewed nonnegative completed-return boundary" in mapping["rationale"]
     for bounded_scope in (
         "tax-year-2026",
-        "before nonrefundable credits",
+        "four-band schedule",
+        "before credits",
         "payments",
         "final annual liability",
     ):
         assert bounded_scope in mapping["rationale"]
-    assert f"input.{INPUT_NAME}" not in mappings
-    assert "sc_pit_pilot_taxable_income" not in mappings
-    assert "sc_pit_pilot_schedule_tax" not in mappings
+    for excluded_name in (
+        "input.ok_pit_pilot_state_taxable_income",
+        "input.ok_pit_pilot_filing_status_uses_wide_schedule",
+        "ok_pit_pilot_taxable_income",
+        "ok_pit_pilot_schedule_tax",
+    ):
+        assert excluded_name not in mappings
 
 
-def test_packaged_sc_2026_runtime_pin_version_and_precedence_are_exact() -> None:
+def test_packaged_ok_2026_runtime_pin_version_and_precedence_are_exact() -> None:
     import axiom_oracles.bridges.registry as runtime_registry_module
 
     root = Path(__file__).parents[1]
@@ -108,10 +113,10 @@ def test_packaged_sc_2026_runtime_pin_version_and_precedence_are_exact() -> None
     assert bundled_text.count(FALLBACK_TEXT) == 1
     assert runtime_text.count(FALLBACK_TEXT) == 1
     assert hashlib.sha256(FALLBACK_TEXT.encode()).hexdigest() == (
-        "31484c10dd215ae94df62a526db8d6d5e5276967ba4094ab8c19cb1dc8c218dd"
+        "1c977a456afdb80469308da94b9dda0e630c53f79e504706ae11ebd8f5a3057a"
     )
     assert hashlib.sha256(_shared_material(bundled_text).encode()).hexdigest() == (
-        "933fda9c31f5450ac251865b31943cc100490ff4d394723fb520e2e9cebd73f4"
+        "971de99c5084eda2a4de0ebc1fd763605d58524d81279033128c3b8d1db70fde"
     )
 
     registry = load_policyengine_registry()
@@ -129,8 +134,10 @@ def test_packaged_sc_2026_runtime_pin_version_and_precedence_are_exact() -> None
     assert mapping.comparison == "money"
 
     for output_name in (
-        "sc_pit_pilot_taxable_income",
-        "sc_pit_pilot_schedule_tax",
+        "input.ok_pit_pilot_state_taxable_income",
+        "input.ok_pit_pilot_filing_status_uses_wide_schedule",
+        "ok_pit_pilot_taxable_income",
+        "ok_pit_pilot_schedule_tax",
         "future_unmapped_output",
     ):
         fallback = registry.mapping_for_legal_id(
@@ -138,7 +145,7 @@ def test_packaged_sc_2026_runtime_pin_version_and_precedence_are_exact() -> None
             country="us",
         )
         assert fallback is not None
-        assert fallback.legal_id == "us-sc:"
+        assert fallback.legal_id == "us-ok:"
         assert fallback.match_type == "prefix"
         assert fallback.mapping_type == "not_comparable"
         assert fallback.candidate_priority == "P4"
@@ -166,7 +173,7 @@ def test_packaged_sc_2026_runtime_pin_version_and_precedence_are_exact() -> None
     )
 
 
-def test_policyengine_coverage_classifies_only_bounded_sc_2026_output(
+def test_policyengine_coverage_classifies_only_bounded_ok_2026_output(
     tmp_path: Path,
 ) -> None:
     rulespec_root = tmp_path / "rulespec-us"

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -13,8 +13,8 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_taxable_income": "pa_adjusted_taxable_income",
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
-ORACLE_MERGE = "c95aac78835375d31390d1e430d1608fee2b3b93"
-ENCODER_VERSION = "0.2.1405"
+ORACLE_MERGE = "a62340d2f1e2873b43404478835de5577e685736"
+ENCODER_VERSION = "0.2.1406"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5120,7 +5120,7 @@ def test_packaged_alabama_2026_schedule_registry_and_fallback_are_synchronized()
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "c95aac78835375d31390d1e430d1608fee2b3b93"
+    assert pin == "a62340d2f1e2873b43404478835de5577e685736"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5231,7 +5231,7 @@ def test_packaged_connecticut_2026_ordinary_tax_registry_is_exactly_synchronized
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "c95aac78835375d31390d1e430d1608fee2b3b93"
+    assert pin == "a62340d2f1e2873b43404478835de5577e685736"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5315,7 +5315,7 @@ def test_packaged_georgia_2026_annual_tax_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "c95aac78835375d31390d1e430d1608fee2b3b93"
+    assert pin == "a62340d2f1e2873b43404478835de5577e685736"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5410,7 +5410,7 @@ def test_packaged_mississippi_2026_schedule_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "c95aac78835375d31390d1e430d1608fee2b3b93"
+    assert pin == "a62340d2f1e2873b43404478835de5577e685736"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5571,7 +5571,7 @@ def test_packaged_kansas_2026_k40es_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "c95aac78835375d31390d1e430d1608fee2b3b93"
+    assert pin == "a62340d2f1e2873b43404478835de5577e685736"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5676,7 +5676,7 @@ def test_packaged_dc_2026_section_47_1806_03_has_exact_bounded_slice():
 def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "c95aac78835375d31390d1e430d1608fee2b3b93"
+    durable_oracle_merge = "a62340d2f1e2873b43404478835de5577e685736"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1405"')
+        .startswith('__version__ = "0.2.1406"')
     )
 
 
@@ -5879,7 +5879,7 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
 
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "c95aac78835375d31390d1e430d1608fee2b3b93"
+    durable_oracle_merge = "a62340d2f1e2873b43404478835de5577e685736"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1405"
+    assert encoder_package["version"] == "0.2.1406"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1405"
+    assert project["project"]["version"] == "0.2.1406"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1405"')
+        .startswith('__version__ = "0.2.1406"')
     )
 
 
@@ -6155,7 +6155,7 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
 
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "c95aac78835375d31390d1e430d1608fee2b3b93"
+    durable_oracle_merge = "a62340d2f1e2873b43404478835de5577e685736"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1405"
+    assert encoder_package["version"] == "0.2.1406"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1405"
+    assert project["project"]["version"] == "0.2.1406"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1405"')
+        .startswith('__version__ = "0.2.1406"')
     )
 
 
@@ -6506,7 +6506,7 @@ def test_packaged_utah_2026_before_credit_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "c95aac78835375d31390d1e430d1608fee2b3b93"
+    assert pin == "a62340d2f1e2873b43404478835de5577e685736"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1405"
+version = "0.2.1406"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=c95aac78835375d31390d1e430d1608fee2b3b93" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=a62340d2f1e2873b43404478835de5577e685736" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=c95aac78835375d31390d1e430d1608fee2b3b93#c95aac78835375d31390d1e430d1608fee2b3b93" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=a62340d2f1e2873b43404478835de5577e685736#a62340d2f1e2873b43404478835de5577e685736" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- pin fully verified Oklahoma oracle merge `a62340d2f1e2873b43404478835de5577e685736`
- add exactly one direct RuleSpec mapping from `ok_pit_pilot_income_tax_liability` to `ok_income_tax_before_credits`
- preserve the existing `us-ok:` fallback byte-for-byte; taxable income, schedule internals, inputs, credits, payments, and final liability remain intentionally unmapped
- advance the package to `0.2.1406` and add focused registry/runtime/fallback/coverage tests

## Validation

- 18 Oklahoma/SC/PA/IN/IL/MN registry tests passed against an archive of exact oracle merge `a62340d…`
- 9 affected RuleSpec pin/version tests passed
- `uvx --from ruff==0.16.0 ruff check src tests`
- `uvx --from ruff==0.16.0 ruff format --check src tests`
- `uv lock --python 3.13 --check`
- `git diff --cached --check`

## Review cycle

Independent review completed with no actionable findings. It reproduced both staged hashes, confirmed the 14-line mapping is byte-identical to the pinned oracle runtime, verified the fallback is unchanged, audited all excluded surfaces, and reran every focused check above. Hosted CI and exact post-merge checks remain required before this layer is complete.