### PR TITLE
Fix sign-applied-files routing for root-level source-root outputs (#1312)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -7,8 +7,8 @@ verified end to end. Actual checkout-root source directories use a narrow
 source-checkout admission mode without weakening normal canonical routing;
 mixed root/jurisdiction layouts and symlink rejection are covered. The
 terminal version is 0.2.1407, focused checks pass, and the independent
-review-fix cycle has no remaining actionable findings. Only the untracked
-worker report and final origin-diff handoff remain.
+review-fix cycle has no remaining actionable findings. The exact origin diff
+has been audited and the required untracked worker report is complete.
 
 ## Done
 
@@ -83,8 +83,9 @@ worker report and final origin-diff handoff remain.
 - Completed the final independent review pass after the mixed-layout fix and
   terminal version bump; both reviewers reported no remaining actionable
   findings.
+- Verified the exact `origin/main..HEAD` name-only diff and clean tracked
+  state, then wrote the required untracked `WORKER-REPORT.md`.
 
 ## Next
 
-- Verify the exact `origin/main..HEAD` name-only diff and clean tracked state.
-- Write the untracked `WORKER-REPORT.md` and deliver the final handoff.
+- No implementation work remains; deliver the local head and report.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,11 +2,11 @@
 
 ## State
 
-The root/placement/citation failure is reproduced and regression coverage is
-red before implementation. Current `main` removed the public
-`sign-applied-files` command in the signing hard cut, so the committed tests
-cover its surviving shared helpers/writer and the literal command-level
-failure/pass is being verified against a scratch copy of the pinned bridge.
+The checkout-root routing and ProgramSpec citation fix is implemented and
+passes its focused current-main regression and compatibility controls. Current
+`main` removed the public `sign-applied-files` command in the signing hard cut,
+so literal command-level failure/pass and the held-out SC change are next being
+verified against a scratch copy of the pinned bridge.
 
 ## Done
 
@@ -29,10 +29,17 @@ failure/pass is being verified against a scratch copy of the pinned bridge.
   `programs/us-sc/snap/fy-2026.yaml` writer case.
 - Recorded that `uv run` cannot access `~/.cache/uv` in the sandbox; focused
   current-main tests run with an existing compatible project environment.
+- Routed checkout-owned `policies/`, `programs/`, `regulations/`, and
+  `statutes/` outputs through the exact checkout root, taught manifest
+  placement to accept that root, and made ProgramSpec citations bare
+  `programs/...` paths.
+- Added the issue 1312 changelog entry.
+- Passed the focused current-main regression plus the jurisdiction-prefixed and
+  UK issue-1078 controls: nine tests passed; focused Ruff also passed.
 
 ## Next
 
-- Implement checkout-owned source-root placement and bare ProgramSpec citation
-  without changing jurisdiction-prefixed or UK country-monorepo behavior.
-- Add the changelog entry, rerun focused tests, and port the minimal fix into a
-  scratch pinned bridge for literal command and real-checkout verification.
+- Port the minimal fix into a scratch pinned bridge and capture literal
+  `sign-applied-files` fail/pass evidence.
+- Reconstruct the held-out SC ProgramSpec/worklist change in a scratch
+  rulespec-us checkout, sign it, and run `guard-generated`.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,11 +2,11 @@
 
 ## State
 
-The checkout-root routing and ProgramSpec citation fix is implemented and
-passes its focused current-main regression and compatibility controls. Current
-`main` removed the public `sign-applied-files` command in the signing hard cut,
-so literal command-level failure/pass and the held-out SC change are next being
-verified against a scratch copy of the pinned bridge.
+The checkout-root routing and ProgramSpec citation fix is implemented, passes
+its focused current-main regression and compatibility controls, and is
+verified end to end against the held-out SC change through a disposable
+backport to the pinned signing bridge. Full gates and the independent
+review-fix cycle remain.
 
 ## Done
 
@@ -36,10 +36,26 @@ verified against a scratch copy of the pinned bridge.
 - Added the issue 1312 changelog entry.
 - Passed the focused current-main regression plus the jurisdiction-prefixed and
   UK issue-1078 controls: nine tests passed; focused Ruff also passed.
+- Reconstructed the exact two-file SC change on rulespec-us base
+  `187d8d8e`: page 159 entered/page 369 left the ProgramSpec scope and all
+  three `SNAP-SC-UTIL` worklist rows changed to `merged`.
+- Captured the literal pinned-bridge fail-first: exit 1 at the reported
+  `path.relative_to(manifest_root)` line because the root ProgramSpec was
+  rebased against `<scratch>/us`.
+- Applied the minimal routing/citation backport to a disposable pinned checkout,
+  followed by a scratch-only version bump required by its clean-provenance
+  gate; the campaign interpreter then signed the reconstructed diff.
+- Confirmed the v1 output shape: checkout-root
+  `.axiom/encoding-manifests/programs/us-sc/snap/fy-2026.json`, bare
+  `programs/us-sc/snap/fy-2026` citation, and checkout-relative applied path.
+- Committed the manifest only in the disposable rulespec clone and passed the
+  separate external `guard-generated --roots programs` check.
+- Confirmed the source `wt-snap-sc` worktree remains unchanged apart from its
+  two pre-existing untracked report files.
 
 ## Next
 
-- Port the minimal fix into a scratch pinned bridge and capture literal
-  `sign-applied-files` fail/pass evidence.
-- Reconstruct the held-out SC ProgramSpec/worklist change in a scratch
-  rulespec-us checkout, sign it, and run `guard-generated`.
+- Run the full repository test, Ruff, compile, and changelog/version gates.
+- Complete the independent review-fix cycle and rerun affected checks.
+- Finalize this progress ledger, verify the origin/main diff, and write the
+  untracked worker report.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,12 +2,13 @@
 
 ## State
 
-The checkout-root routing and ProgramSpec citation fix is implemented,
-verified end to end, and strengthened after independent review. Actual
-checkout-root atomic directories now use a narrow source-checkout admission
-mode without weakening normal canonical routing, symlink rejection is
-preserved, and direct signer-style US/UK controls pass. Version and remaining
-broad-gate work remain.
+The checkout-root routing and ProgramSpec citation fix is implemented and
+verified end to end. Actual checkout-root source directories use a narrow
+source-checkout admission mode without weakening normal canonical routing;
+mixed root/jurisdiction layouts and symlink rejection are covered. The
+terminal version is 0.2.1407, focused checks pass, and the independent
+review-fix cycle has no remaining actionable findings. Only the untracked
+worker report and final origin-diff handoff remain.
 
 ## Done
 
@@ -62,12 +63,28 @@ broad-gate work remain.
   symlink-rejection, direct `us-sc/policies/...`, and direct `uk/statutes/...`
   coverage.
 - Passed all 14 strengthened focused routing/writer/compatibility tests.
+- The second review pass found two additional mixed-layout safety gaps:
+  jurisdiction-prefixed files failed when the same checkout also had a
+  root-level atomic source directory, and the checkout-root helper resolved a
+  symlink alias before admission. Captured both as three failing cases, then
+  fixed them with scoped direct-child routing and lexical validation.
+- Passed the final routing, writer, issue-1078, repository-routing, and version
+  provenance matrix: 57 tests passed.
+- Coordinated the terminal encoder version as 0.2.1407 in `pyproject.toml`,
+  `src/axiom_encode/__init__.py`, and `uv.lock`, after all encoder-affecting
+  commits.
+- Passed full Ruff, `compileall`, and `git diff --check`.
+- Ran all 6,091 repository tests with an available offline compatible
+  environment and writable scratch Go cache: 6,024 passed and 31 skipped.
+  Of 36 failures, the sole branch-caused version-provenance failure was fixed
+  and rerun green; the other 35 are confined to the environment's stale
+  `axiom-oracles`/editable install and sandbox-dependent system/provisioning
+  checks.
+- Completed the final independent review pass after the mixed-layout fix and
+  terminal version bump; both reviewers reported no remaining actionable
+  findings.
 
 ## Next
 
-- Commit the required coordinated encoder version bump and rerun its gate.
-- Rerun broad repository tests, Ruff, and compile checks, distinguishing
-  sandbox/dependency failures from branch-caused failures.
-- Repeat independent review after the substantive routing hardening.
-- Finalize this progress ledger, verify the origin/main diff, and write the
-  untracked worker report.
+- Verify the exact `origin/main..HEAD` name-only diff and clean tracked state.
+- Write the untracked `WORKER-REPORT.md` and deliver the final handoff.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,77 +1,21 @@
-# Receipt.sign adoption progress
+# Issue 1312 progress
 
 ## State
 
-Implementation and validation are complete within the binding allowed-file
-scope. Handoff is blocked on one repository provenance requirement: the changed
-encoder paths must be behind a version bump, but a valid bump must also change
-`src/axiom_encode/__init__.py`, which this task explicitly forbids touching.
-Independent reviewers reproduced the conflict and found no other correctness
-issue. No configured final-report output path exists, so the report will be
-written outside the repository under `/private/tmp` at handoff.
+Work has started on an isolated `fix/1312-program-spec-manifest-root`
+worktree created from `origin/main`. The reported root-level RuleSpec source
+path failure still needs to be reproduced and traced before implementation.
 
 ## Done
 
-- Confirmed the worktree and branch match the requested starting point.
-- Read the repository instructions and the GitNexus exploration/impact workflows.
-- Established the implementation, test, review, and reporting plan.
-- Traced all three production callers and every existing issue-string branch.
-- Read `signing_broker.py`, the relevant unchanged tests and fixtures, and the
-  full `receipt.sign` source at the clean local `v0.2.0` tag.
-- Ran the nine-test focused behavior baseline: 9 passed.
-- Replaced the final direct Ed25519 verification with receipt's 1-of-1 keyring;
-  signing and every preceding envelope/trust-root check remain untouched.
-- Refreshed `uv.lock` with receipt 0.2.0 using uv's offline cached resolver;
-  the wheel and sdist SHA-256 hashes exactly match the task's known-good values.
-- Installed the resolved wheel without dependencies in an isolated temporary
-  environment and read its complete 459-line `receipt.sign` source. Confirmed
-  the installed version is 0.2.0 and its `verify_threshold` API matches the
-  implementation (with no 0.3.0-only `allow_legacy` parameter).
-- Completed read-only implementation, packaging, and test-design audits; no
-  correctness defect was found in the interrupted shim.
-- Added seven dedicated receipt-adoption tests covering the real signing path,
-  four cryptographic refusal cases, exact receipt delegation inputs, and every
-  unchanged envelope/trust-root issue class and relevant check ordering.
-- Added the `ops#3` changelog fragment without claiming a trust-model change.
-- Ran the new test file against the installed receipt 0.2.0 wheel: 7 passed.
-- Ran the unchanged focused behavior oracle together with the new tests:
-  16 passed.
-- Ran repository lint, formatting, and compilation checks: Ruff check passed,
-  Ruff format check passed after applying its one-line domain-expression fix,
-  and `compileall` passed.
-- Ran the broadest locally runnable suite. After correcting an isolated test
-  environment that initially imported the parent checkout and rerunning two
-  temp-root-sensitive tests in the normal system temp directory, the runnable
-  tests total 4,427 passed and 31 skipped. Eleven host/provenance nodes cannot
-  pass locally: one task-caused version guard, one set-id semantics check, eight
-  root-owned Homebrew Git/provisioning checks, and one sandboxed `/var/tmp`
-  write check.
-- Reproduced the task-caused guard independently:
-  `test_current_encoder_affecting_changes_are_behind_version_bump` reports that
-  `pyproject.toml`, `src/axiom_encode/cli.py`, and `uv.lock` changed after
-  `fc04012d30d0`. The guard itself requires matching versions in
-  `pyproject.toml`, `src/axiom_encode/__init__.py`, and `uv.lock`.
-- Cross-checked the locked receipt wheel and sdist hashes again against the
-  supplied known-good values; both match exactly.
-- Completed independent code, packaging, and test reviews. All reviewers found
-  the receipt mechanics, domain bytes, issue behavior, tests, hashes, scope,
-  and changelog correct. The packaging review's only actionable formatting
-  finding was fixed and rechecked. The remaining version conflict was confirmed
-  by two reviewers as a blocker requiring a scope decision.
-- Reran the changed-path focused set after the review fix: 10 passed, with Ruff
-  check, Ruff format check, `compileall`, hash assertions, and `git diff --check`
-  all passing.
-- Ran the final post-review broad runnable-suite command without the temporary
-  root override: 4,427 passed, 31 skipped, 11 explicitly documented host/scope
-  checks deselected, and 12 dependency deprecation warnings in 109.06 seconds.
-- Repeated the independent review after the formatting fix. The code and
-  packaging reviewers reported no actionable findings; both retained only the
-  documented version-provenance scope blocker.
+- Created the requested local branch and isolated worktree from `origin/main`.
+- Read the repository instructions and applicable debugging/GitHub workflows.
+- Established the fail-first, implementation, real-checkout, compatibility,
+  validation, and independent-review plan.
 
 ## Next
 
-- Obtain explicit maintainer/user permission to add the required coordinated
-  version bump in `pyproject.toml`, `src/axiom_encode/__init__.py`, and `uv.lock`,
-  then rerun the provenance guard and the full suite. Without that scope
-  exception, retain this documented blocker and do not mark the branch ready or
-  merge it.
+- Inspect issue 1312, rulespec-us PR 1139, a committed root-level program
+  manifest, and the current root/citation helpers.
+- Add a regression that reproduces the `programs/us-sc/snap/fy-2026.yaml`
+  signing crash and capture its failure.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,11 +2,12 @@
 
 ## State
 
-The checkout-root routing and ProgramSpec citation fix is implemented, passes
-its focused current-main regression and compatibility controls, and is
-verified end to end against the held-out SC change through a disposable
-backport to the pinned signing bridge. Full gates and the independent
-review-fix cycle remain.
+The checkout-root routing and ProgramSpec citation fix is implemented,
+verified end to end, and strengthened after independent review. Actual
+checkout-root atomic directories now use a narrow source-checkout admission
+mode without weakening normal canonical routing, symlink rejection is
+preserved, and direct signer-style US/UK controls pass. Version and remaining
+broad-gate work remain.
 
 ## Done
 
@@ -52,10 +53,21 @@ review-fix cycle remain.
   separate external `guard-generated --roots programs` check.
 - Confirmed the source `wt-snap-sc` worktree remains unchanged apart from its
   two pre-existing untracked report files.
+- Completed the first independent review pass. It found that the initial
+  four-root test did not create real atomic roots and that resolving the input
+  path before admission weakened symlink rejection.
+- Added a narrowly scoped checkout inspection mode for manifest-owned source
+  roots while preserving the normal rule that only ProgramSpecs are admitted
+  at checkout root, restored lexical admission, and added real-file,
+  symlink-rejection, direct `us-sc/policies/...`, and direct `uk/statutes/...`
+  coverage.
+- Passed all 14 strengthened focused routing/writer/compatibility tests.
 
 ## Next
 
-- Run the full repository test, Ruff, compile, and changelog/version gates.
-- Complete the independent review-fix cycle and rerun affected checks.
+- Commit the required coordinated encoder version bump and rerun its gate.
+- Rerun broad repository tests, Ruff, and compile checks, distinguishing
+  sandbox/dependency failures from branch-caused failures.
+- Repeat independent review after the substantive routing hardening.
 - Finalize this progress ledger, verify the origin/main diff, and write the
   untracked worker report.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,9 +2,11 @@
 
 ## State
 
-Work has started on an isolated `fix/1312-program-spec-manifest-root`
-worktree created from `origin/main`. The reported root-level RuleSpec source
-path failure still needs to be reproduced and traced before implementation.
+The root/placement/citation failure is reproduced and regression coverage is
+red before implementation. Current `main` removed the public
+`sign-applied-files` command in the signing hard cut, so the committed tests
+cover its surviving shared helpers/writer and the literal command-level
+failure/pass is being verified against a scratch copy of the pinned bridge.
 
 ## Done
 
@@ -12,10 +14,25 @@ path failure still needs to be reproduced and traced before implementation.
 - Read the repository instructions and applicable debugging/GitHub workflows.
 - Established the fail-first, implementation, real-checkout, compatibility,
   validation, and independent-review plan.
+- Read issue 1312, rulespec-us PR 1139, issue 1078, and the committed Arizona
+  ProgramSpec manifest that establishes checkout-root placement and a bare
+  `programs/...` citation.
+- Confirmed the pinned bridge mechanism: the ProgramSpec has no leading
+  jurisdiction prefix, falls back to `<checkout>/us`, and fails while rebasing
+  `<checkout>/programs/...`; its anchor is also incorrectly `us:programs/...`.
+- Located the exact held-out SC change in rulespec-us reflog commit `f93f556c`:
+  add page 159/remove page 369 in the ProgramSpec and drain three worklist rows.
+- Added current-main regressions for the signed ProgramSpec manifest, the four
+  requested checkout-root source roots, and checkout-root placement while
+  retaining the UK and jurisdiction-content-root controls.
+- Captured the fail-first focused run: six failures, including the exact
+  `programs/us-sc/snap/fy-2026.yaml` writer case.
+- Recorded that `uv run` cannot access `~/.cache/uv` in the sandbox; focused
+  current-main tests run with an existing compatible project environment.
 
 ## Next
 
-- Inspect issue 1312, rulespec-us PR 1139, a committed root-level program
-  manifest, and the current root/citation helpers.
-- Add a regression that reproduces the `programs/us-sc/snap/fy-2026.yaml`
-  signing crash and capture its failure.
+- Implement checkout-owned source-root placement and bare ProgramSpec citation
+  without changing jurisdiction-prefixed or UK country-monorepo behavior.
+- Add the changelog entry, rerun focused tests, and port the minimal fix into a
+  scratch pinned bridge for literal command and real-checkout verification.

--- a/changelog.d/1312-program-spec-manifest-root.fixed.md
+++ b/changelog.d/1312-program-spec-manifest-root.fixed.md
@@ -1,0 +1,1 @@
+Resolve checkout-root RuleSpec source outputs against the checkout so ProgramSpec signing writes `.axiom/encoding-manifests/programs/...` manifests with `programs/...` citations. (`axiom-encode#1312`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1415"
+version = "0.2.1416"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1405"
+version = "0.2.1406"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1414"
+version = "0.2.1415"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1406"
+version = "0.2.1407"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1415"
+__version__ = "0.2.1416"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1406"
+__version__ = "0.2.1407"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1405"
+__version__ = "0.2.1406"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1414"
+__version__ = "0.2.1415"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -278,6 +278,7 @@ from .repo_routing import (
     find_policy_repo_root,
     inspect_canonical_rulespec_checkout,
     is_composition_policy_repo_root,
+    is_rulespec_source_checkout_root,
     jurisdiction_content_dir,
     jurisdiction_subdir_names,
     monorepo_checkout_name,
@@ -38862,11 +38863,11 @@ def _rulespec_apply_content_root(
     relative_output: Path | None = None,
 ) -> Path:
     """Return the exact content or checkout root for live generated writes."""
-    repo_path = Path(policy_repo_path).resolve()
+    repo_path = Path(policy_repo_path)
     if (
         relative_output is not None
         and _is_checkout_root_source_output(relative_output)
-        and is_composition_policy_repo_root(repo_path)
+        and is_rulespec_source_checkout_root(repo_path)
     ):
         content_root = repo_path
     elif relative_output is not None:
@@ -38887,7 +38888,7 @@ def _rulespec_apply_content_root(
         not content_root.is_dir()
         or (
             canonical_rulespec_root_identity(content_root) is None
-            and not is_composition_policy_repo_root(content_root)
+            and not is_rulespec_source_checkout_root(content_root)
         )
     ):
         raise ValueError(
@@ -38907,10 +38908,10 @@ def _rulespec_apply_checkout_root(
     content_root = _rulespec_apply_content_root(repo_path, relative_output)
     checkout_root = (
         content_root
-        if is_composition_policy_repo_root(content_root)
+        if is_rulespec_source_checkout_root(content_root)
         else content_root.parent
     )
-    if canonical_rulespec_repo_name(checkout_root) != checkout_root.name:
+    if not is_rulespec_source_checkout_root(checkout_root):
         raise ValueError(
             "RuleSpec apply target must belong to a canonical "
             f"rulespec-<country> checkout: {repo_path}"
@@ -42601,9 +42602,10 @@ def _applied_encoding_manifest_path(relative_output: Path) -> Path:
 def _rulespec_checkout_root(content_root: Path) -> Path:
     """Return the country checkout for one exact content or checkout root."""
 
-    resolved = Path(content_root).resolve()
-    if is_composition_policy_repo_root(resolved):
-        return resolved
+    root = Path(content_root)
+    if is_rulespec_source_checkout_root(root):
+        return root.resolve()
+    resolved = root.resolve()
     identity = canonical_rulespec_root_identity(resolved)
     if identity is None:
         raise ValueError(

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -42753,9 +42753,8 @@ def _source_checkout_jurisdiction_content_root(
         checkout_root = repo_path.parent
     else:
         return None
-    if (
-        checkout_root.name != expected_checkout
-        or not is_rulespec_source_checkout_root(checkout_root)
+    if checkout_root.name != expected_checkout or not is_rulespec_source_checkout_root(
+        checkout_root
     ):
         return None
     content_root = checkout_root / jurisdiction
@@ -42803,13 +42802,10 @@ def _rulespec_apply_content_root(
             repo_path,
             _repo_jurisdiction_prefix(repo_path),
         )
-    if (
-        not content_root.is_dir()
-        or (
-            canonical_rulespec_root_identity(content_root) is None
-            and not is_rulespec_source_checkout_root(content_root)
-            and not _is_source_checkout_jurisdiction_content_root(content_root)
-        )
+    if not content_root.is_dir() or (
+        canonical_rulespec_root_identity(content_root) is None
+        and not is_rulespec_source_checkout_root(content_root)
+        and not _is_source_checkout_jurisdiction_content_root(content_root)
     ):
         raise ValueError(
             "RuleSpec apply target must be an existing canonical "

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -38858,6 +38858,42 @@ def _is_checkout_root_source_output(relative_output: Path) -> bool:
     return bool(parts and parts[0] in RULESPEC_FILESYSTEM_ROOTS)
 
 
+def _source_checkout_jurisdiction_content_root(
+    policy_repo_path: Path,
+    jurisdiction: str,
+) -> Path | None:
+    """Return one direct jurisdiction root under an admitted source checkout."""
+    if re.fullmatch(r"[a-z]{2}(?:-[a-z0-9]+)*", jurisdiction) is None:
+        return None
+    repo_path = Path(policy_repo_path)
+    expected_checkout = monorepo_checkout_name(jurisdiction)
+    if repo_path.name == expected_checkout:
+        checkout_root = repo_path
+    elif repo_path.name == jurisdiction:
+        checkout_root = repo_path.parent
+    else:
+        return None
+    if (
+        checkout_root.name != expected_checkout
+        or not is_rulespec_source_checkout_root(checkout_root)
+    ):
+        return None
+    content_root = checkout_root / jurisdiction
+    if repo_path != checkout_root and repo_path != content_root:
+        return None
+    return content_root
+
+
+def _is_source_checkout_jurisdiction_content_root(path: Path) -> bool:
+    """Return whether ``path`` is a real direct child of a source checkout."""
+    path = Path(path)
+    return (
+        path.is_dir()
+        and not path.is_symlink()
+        and _source_checkout_jurisdiction_content_root(path, path.name) == path
+    )
+
+
 def _rulespec_apply_content_root(
     policy_repo_path: Path,
     relative_output: Path | None = None,
@@ -38873,7 +38909,10 @@ def _rulespec_apply_content_root(
     elif relative_output is not None:
         output_jurisdiction = _relative_output_jurisdiction_prefix(relative_output)
         if output_jurisdiction is not None:
-            content_root = jurisdiction_content_dir(repo_path, output_jurisdiction)
+            content_root = _source_checkout_jurisdiction_content_root(
+                repo_path,
+                output_jurisdiction,
+            ) or jurisdiction_content_dir(repo_path, output_jurisdiction)
         else:
             content_root = jurisdiction_content_dir(
                 repo_path,
@@ -38889,6 +38928,7 @@ def _rulespec_apply_content_root(
         or (
             canonical_rulespec_root_identity(content_root) is None
             and not is_rulespec_source_checkout_root(content_root)
+            and not _is_source_checkout_jurisdiction_content_root(content_root)
         )
     ):
         raise ValueError(
@@ -38904,7 +38944,7 @@ def _rulespec_apply_checkout_root(
     relative_output: Path | None = None,
 ) -> Path:
     """Return the canonical country checkout for an apply target."""
-    repo_path = Path(policy_repo_path).resolve()
+    repo_path = Path(policy_repo_path)
     content_root = _rulespec_apply_content_root(repo_path, relative_output)
     checkout_root = (
         content_root
@@ -38916,7 +38956,7 @@ def _rulespec_apply_checkout_root(
             "RuleSpec apply target must belong to a canonical "
             f"rulespec-<country> checkout: {repo_path}"
         )
-    return checkout_root
+    return checkout_root.resolve()
 
 
 def _relative_to_rulespec_apply_content_root(
@@ -42605,6 +42645,8 @@ def _rulespec_checkout_root(content_root: Path) -> Path:
     root = Path(content_root)
     if is_rulespec_source_checkout_root(root):
         return root.resolve()
+    if _is_source_checkout_jurisdiction_content_root(root):
+        return root.parent.resolve()
     resolved = root.resolve()
     identity = canonical_rulespec_root_identity(resolved)
     if identity is None:

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -38851,13 +38851,25 @@ def _relative_output_jurisdiction_prefix(relative_output: Path) -> str | None:
     return None
 
 
+def _is_checkout_root_source_output(relative_output: Path) -> bool:
+    """Return whether an output starts at a checkout-owned RuleSpec source root."""
+    parts = Path(relative_output).parts
+    return bool(parts and parts[0] in RULESPEC_FILESYSTEM_ROOTS)
+
+
 def _rulespec_apply_content_root(
     policy_repo_path: Path,
     relative_output: Path | None = None,
 ) -> Path:
-    """Return the jurisdiction content root for live generated writes."""
-    repo_path = Path(policy_repo_path)
-    if relative_output is not None:
+    """Return the exact content or checkout root for live generated writes."""
+    repo_path = Path(policy_repo_path).resolve()
+    if (
+        relative_output is not None
+        and _is_checkout_root_source_output(relative_output)
+        and is_composition_policy_repo_root(repo_path)
+    ):
+        content_root = repo_path
+    elif relative_output is not None:
         output_jurisdiction = _relative_output_jurisdiction_prefix(relative_output)
         if output_jurisdiction is not None:
             content_root = jurisdiction_content_dir(repo_path, output_jurisdiction)
@@ -38873,10 +38885,14 @@ def _rulespec_apply_content_root(
         )
     if (
         not content_root.is_dir()
-        or canonical_rulespec_root_identity(content_root) is None
+        or (
+            canonical_rulespec_root_identity(content_root) is None
+            and not is_composition_policy_repo_root(content_root)
+        )
     ):
         raise ValueError(
             "RuleSpec apply target must be an existing canonical "
+            "rulespec-<country> checkout or "
             f"rulespec-<country>/<jurisdiction> content root: {content_root}"
         )
     return content_root
@@ -38889,7 +38905,11 @@ def _rulespec_apply_checkout_root(
     """Return the canonical country checkout for an apply target."""
     repo_path = Path(policy_repo_path).resolve()
     content_root = _rulespec_apply_content_root(repo_path, relative_output)
-    checkout_root = content_root.parent
+    checkout_root = (
+        content_root
+        if is_composition_policy_repo_root(content_root)
+        else content_root.parent
+    )
     if canonical_rulespec_repo_name(checkout_root) != checkout_root.name:
         raise ValueError(
             "RuleSpec apply target must belong to a canonical "
@@ -42579,14 +42599,16 @@ def _applied_encoding_manifest_path(relative_output: Path) -> Path:
 
 
 def _rulespec_checkout_root(content_root: Path) -> Path:
-    """Return the country checkout for one exact canonical content root."""
+    """Return the country checkout for one exact content or checkout root."""
 
     resolved = Path(content_root).resolve()
+    if is_composition_policy_repo_root(resolved):
+        return resolved
     identity = canonical_rulespec_root_identity(resolved)
     if identity is None:
         raise ValueError(
-            "RuleSpec content root must use the canonical "
-            f"rulespec-<country>/<jurisdiction> layout: {resolved}"
+            "RuleSpec root must use the canonical rulespec-<country> checkout "
+            f"or rulespec-<country>/<jurisdiction> layout: {resolved}"
         )
     return resolved.parent
 
@@ -42598,6 +42620,8 @@ def _resolve_applied_manifest_placement(
     content_root = Path(content_root).resolve()
     checkout_root = _rulespec_checkout_root(content_root)
     relative_output = Path(relative_output)
+    if content_root == checkout_root:
+        return checkout_root, relative_output
     if relative_output.parts and relative_output.parts[0] == content_root.name:
         relative_output = Path(*relative_output.parts[1:])
     return checkout_root, Path(content_root.name) / relative_output
@@ -46416,6 +46440,8 @@ def _relative_rulespec_import_target(relative_output: Path) -> str:
 def _rulespec_anchor_base_for_output(repo_path: Path, relative_output: Path) -> str:
     target_path = relative_output.with_suffix("")
     parts = target_path.parts
+    if parts and parts[0] == RULESPEC_COMPOSITION_SPEC_ROOT:
+        return target_path.as_posix()
     if len(parts) > 1 and parts[0] not in RULESPEC_ATOMIC_MODULE_ROOTS:
         jurisdiction = parts[0]
         target = Path(*parts[1:]).as_posix()

--- a/src/axiom_encode/repo_routing.py
+++ b/src/axiom_encode/repo_routing.py
@@ -89,9 +89,9 @@ class _CheckoutAdmissionSnapshot:
 class _RuleSpecRoutingCache:
     """Successful checkout identity probes admitted for one bounded operation."""
 
-    checkout_inspections: dict[
-        tuple[Path, bool, bool], _CachedCheckoutInspection
-    ] = field(default_factory=dict)
+    checkout_inspections: dict[tuple[Path, bool, bool], _CachedCheckoutInspection] = (
+        field(default_factory=dict)
+    )
 
 
 _RULESPEC_ROUTING_CACHE: ContextVar[_RuleSpecRoutingCache | None] = ContextVar(

--- a/src/axiom_encode/repo_routing.py
+++ b/src/axiom_encode/repo_routing.py
@@ -89,9 +89,9 @@ class _CheckoutAdmissionSnapshot:
 class _RuleSpecRoutingCache:
     """Successful checkout identity probes admitted for one bounded operation."""
 
-    checkout_inspections: dict[tuple[Path, bool], _CachedCheckoutInspection] = field(
-        default_factory=dict
-    )
+    checkout_inspections: dict[
+        tuple[Path, bool, bool], _CachedCheckoutInspection
+    ] = field(default_factory=dict)
 
 
 _RULESPEC_ROUTING_CACHE: ContextVar[_RuleSpecRoutingCache | None] = ContextVar(
@@ -221,12 +221,14 @@ def _canonical_country_checkout_name(
     path: Path,
     *,
     allow_composition_specs: bool = False,
+    allow_checkout_source_roots: bool = False,
 ) -> str | None:
     """Return the exact canonical country-checkout name for ``path``."""
 
     return inspect_canonical_rulespec_checkout(
         path,
         allow_composition_specs=allow_composition_specs,
+        allow_checkout_source_roots=allow_checkout_source_roots,
     ).name
 
 
@@ -234,6 +236,7 @@ def inspect_canonical_rulespec_checkout(
     path: Path,
     *,
     allow_composition_specs: bool = False,
+    allow_checkout_source_roots: bool = False,
 ) -> CanonicalRuleSpecCheckoutInspection:
     """Inspect one exact country checkout without weakening route acceptance."""
 
@@ -241,6 +244,7 @@ def inspect_canonical_rulespec_checkout(
     cache_key = (
         Path(os.path.abspath(Path(path).expanduser())),
         allow_composition_specs,
+        allow_checkout_source_roots,
     )
     cached = cache.checkout_inspections.get(cache_key) if cache is not None else None
     if cached is not None:
@@ -256,6 +260,7 @@ def inspect_canonical_rulespec_checkout(
         return _inspect_canonical_rulespec_checkout_uncached(
             path,
             allow_composition_specs=allow_composition_specs,
+            allow_checkout_source_roots=allow_checkout_source_roots,
         )
 
     for _attempt in range(2):
@@ -263,6 +268,7 @@ def inspect_canonical_rulespec_checkout(
         inspection = _inspect_canonical_rulespec_checkout_uncached(
             path,
             allow_composition_specs=allow_composition_specs,
+            allow_checkout_source_roots=allow_checkout_source_roots,
         )
         if inspection.name is None or before is None:
             return inspection
@@ -471,6 +477,7 @@ def _inspect_canonical_rulespec_checkout_uncached(
     path: Path,
     *,
     allow_composition_specs: bool = False,
+    allow_checkout_source_roots: bool = False,
 ) -> CanonicalRuleSpecCheckoutInspection:
     """Inspect one checkout before it is admitted to an operation cache."""
 
@@ -487,7 +494,17 @@ def _inspect_canonical_rulespec_checkout_uncached(
     if re.fullmatch(r"[a-z]{2}", country) is None:
         return CanonicalRuleSpecCheckoutInspection(None, "checkout-country-name")
     blocked_roots = RULESPEC_FILESYSTEM_ROOTS
-    if allow_composition_specs:
+    if allow_checkout_source_roots:
+        for root_name in RULESPEC_FILESYSTEM_ROOTS:
+            source_root = checkout / root_name
+            if (source_root.exists() or source_root.is_symlink()) and (
+                source_root.is_symlink() or not source_root.is_dir()
+            ):
+                return CanonicalRuleSpecCheckoutInspection(
+                    None, "checkout-source-root-not-directory"
+                )
+        blocked_roots = frozenset()
+    elif allow_composition_specs:
         composition_root = checkout / RULESPEC_COMPOSITION_SPEC_ROOT
         if (composition_root.exists() or composition_root.is_symlink()) and (
             composition_root.is_symlink() or not composition_root.is_dir()
@@ -574,6 +591,18 @@ def is_composition_policy_repo_root(path: Path) -> bool:
 
     return (
         _canonical_country_checkout_name(Path(path), allow_composition_specs=True)
+        is not None
+    )
+
+
+def is_rulespec_source_checkout_root(path: Path) -> bool:
+    """Return True for an exact checkout that may own RuleSpec source roots."""
+
+    return (
+        _canonical_country_checkout_name(
+            Path(path),
+            allow_checkout_source_roots=True,
+        )
         is not None
     )
 

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1413"
+ENCODER_VERSION = "0.2.1415"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1415"
+ENCODER_VERSION = "0.2.1416"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14377,6 +14377,101 @@ rules: []
             "us/statutes/26/36B.test.yaml",
         ]
 
+    @pytest.mark.parametrize(
+        "source_root",
+        ("policies", "programs", "regulations", "statutes"),
+    )
+    def test_checkout_root_source_outputs_use_checkout_manifest_root(
+        self, tmp_path, source_root
+    ):
+        checkout = tmp_path / "rulespec-us"
+        (checkout / "us").mkdir(parents=True)
+        relative_output = Path(source_root) / "example.yaml"
+
+        content_root = _rulespec_apply_content_root(checkout, relative_output)
+        manifest_root, manifest_relative = _resolve_applied_manifest_placement(
+            content_root=content_root,
+            relative_output=relative_output,
+        )
+
+        assert content_root == checkout
+        assert manifest_root == checkout
+        assert manifest_relative == relative_output
+
+    def test_write_applied_manifest_places_checkout_root_program_spec(
+        self, tmp_path
+    ):
+        checkout = tmp_path / "rulespec-us"
+        (checkout / "us").mkdir(parents=True)
+        relative_output = Path("programs/us-sc/snap/fy-2026.yaml")
+        program = checkout / relative_output
+        program.parent.mkdir(parents=True)
+        program.write_text("program: us-sc/snap\nperiod: 2026-01\n")
+        output_root = tmp_path / "out"
+        generated = output_root / "manual-attestation" / relative_output
+        generated.parent.mkdir(parents=True)
+        generated.write_text(program.read_text())
+        result = SimpleNamespace(
+            output_file=str(generated),
+            context_manifest_file=None,
+            trace_file=None,
+            generation_prompt_sha256=None,
+            tool=APPLIED_ENCODING_MODEL_TOOL,
+            citation=_rulespec_anchor_base_for_output(checkout, relative_output),
+            runner="openai",
+            backend="openai",
+            model="program-placement-test",
+            source_attestation={},
+        )
+        setattr(
+            result,
+            _APPLY_VALIDATION_SNAPSHOT_ATTR,
+            {
+                "manifest_validation_execution": {
+                    "axiom_encode": dict(TEST_PINNED_ENCODER_IDENTITY)
+                }
+            },
+        )
+
+        with (
+            patch(
+                "axiom_encode.cli.load_rulespec_local_corpus_release",
+                return_value=object(),
+            ),
+            patch(
+                "axiom_encode.cli._resolver_owned_manifest_source_attestation",
+                return_value={"rulespec_root": "rulespec-us/us-sc"},
+            ),
+            patch(
+                "axiom_encode.cli.verify_rulespec_validation_waiver_set",
+                return_value="b" * 64,
+            ),
+        ):
+            manifest = _write_applied_encoding_manifest(
+                result,
+                output_root=output_root,
+                policy_repo_path=checkout,
+                corpus_path=tmp_path / "axiom-corpus",
+                relative_output=relative_output,
+                applied_files=[program],
+                axiom_encode_git={"commit": "a" * 40},
+                signing_broker=TEST_APPLY_SIGNING_BROKER,
+            )
+
+        assert manifest == (
+            checkout
+            / ".axiom/encoding-manifests/programs/us-sc/snap/fy-2026.json"
+        )
+        payload = json.loads(manifest.read_text())
+        assert payload["citation"] == "programs/us-sc/snap/fy-2026"
+        assert payload["applied_files"] == [
+            {
+                "path": relative_output.as_posix(),
+                "sha256": _sha256_file(program),
+            }
+        ]
+        assert payload["signature"]["value"]
+
     def test_resolve_applied_manifest_placement_always_uses_checkout_root(
         self, tmp_path
     ):
@@ -14405,10 +14500,20 @@ rules: []
         assert manifest_root == repo
         assert manifest_rel == Path("uk/statutes/26/36B.yaml")
 
-        # Flat/legacy roots have no fallback placement.
+        # A checkout-root source path remains rooted at the checkout.
+        manifest_root, manifest_rel = _resolve_applied_manifest_placement(
+            content_root=repo,
+            relative_output=Path("statutes/26/36B.yaml"),
+        )
+        assert manifest_root == repo
+        assert manifest_rel == Path("statutes/26/36B.yaml")
+
+        # Anonymous and legacy roots still have no fallback placement.
+        anonymous = tmp_path / "somewhere"
+        anonymous.mkdir()
         with pytest.raises(ValueError, match="canonical"):
             _resolve_applied_manifest_placement(
-                content_root=repo,
+                content_root=anonymous,
                 relative_output=Path("statutes/26/36B.yaml"),
             )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14387,6 +14387,9 @@ rules: []
         checkout = tmp_path / "rulespec-us"
         (checkout / "us").mkdir(parents=True)
         relative_output = Path(source_root) / "example.yaml"
+        output = checkout / relative_output
+        output.parent.mkdir(parents=True)
+        output.write_text("format: rulespec/v1\nrules: []\n")
 
         content_root = _rulespec_apply_content_root(checkout, relative_output)
         manifest_root, manifest_relative = _resolve_applied_manifest_placement(
@@ -14397,6 +14400,62 @@ rules: []
         assert content_root == checkout
         assert manifest_root == checkout
         assert manifest_relative == relative_output
+
+    @pytest.mark.parametrize(
+        ("checkout_name", "jurisdiction", "relative_output", "citation"),
+        (
+            (
+                "rulespec-us",
+                "us-sc",
+                Path("us-sc/policies/dss/snap-policy-manual/page-159.yaml"),
+                "us-sc:policies/dss/snap-policy-manual/page-159",
+            ),
+            (
+                "rulespec-uk",
+                "uk",
+                Path("uk/statutes/26/36B.yaml"),
+                "uk:statutes/26/36B",
+            ),
+        ),
+    )
+    def test_checkout_relative_jurisdiction_outputs_keep_manifest_routing(
+        self,
+        tmp_path,
+        checkout_name,
+        jurisdiction,
+        relative_output,
+        citation,
+    ):
+        checkout = tmp_path / checkout_name
+        (checkout / jurisdiction).mkdir(parents=True)
+
+        content_root = _rulespec_apply_content_root(checkout, relative_output)
+        manifest_root, manifest_relative = _resolve_applied_manifest_placement(
+            content_root=content_root,
+            relative_output=relative_output,
+        )
+
+        assert content_root == checkout / jurisdiction
+        assert manifest_root == checkout
+        assert manifest_relative == relative_output
+        assert (
+            _rulespec_anchor_base_for_output(checkout, relative_output) == citation
+        )
+
+    def test_checkout_root_source_output_rejects_symlinked_checkout(
+        self, tmp_path
+    ):
+        real_checkout = tmp_path / "real" / "rulespec-us"
+        (real_checkout / "us").mkdir(parents=True)
+        (real_checkout / "programs/us-sc/snap").mkdir(parents=True)
+        alias = tmp_path / "rulespec-us"
+        alias.symlink_to(real_checkout, target_is_directory=True)
+
+        with pytest.raises(ValueError, match="canonical"):
+            _rulespec_apply_content_root(
+                alias,
+                Path("programs/us-sc/snap/fy-2026.yaml"),
+            )
 
     def test_write_applied_manifest_places_checkout_root_program_spec(
         self, tmp_path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -162,6 +162,7 @@ from axiom_encode.cli import (
     _rewrite_judgment_conditional_formulas,
     _rewrite_judgment_numeric_comparisons,
     _rulespec_anchor_base_for_output,
+    _rulespec_apply_checkout_root,
     _rulespec_apply_content_root,
     _rulespec_base_for_file,
     _rulespec_checkout_root,
@@ -14402,17 +14403,25 @@ rules: []
         assert manifest_relative == relative_output
 
     @pytest.mark.parametrize(
-        ("checkout_name", "jurisdiction", "relative_output", "citation"),
+        (
+            "checkout_name",
+            "jurisdiction",
+            "checkout_source_root",
+            "relative_output",
+            "citation",
+        ),
         (
             (
                 "rulespec-us",
                 "us-sc",
+                "policies",
                 Path("us-sc/policies/dss/snap-policy-manual/page-159.yaml"),
                 "us-sc:policies/dss/snap-policy-manual/page-159",
             ),
             (
                 "rulespec-uk",
                 "uk",
+                "statutes",
                 Path("uk/statutes/26/36B.yaml"),
                 "uk:statutes/26/36B",
             ),
@@ -14423,11 +14432,13 @@ rules: []
         tmp_path,
         checkout_name,
         jurisdiction,
+        checkout_source_root,
         relative_output,
         citation,
     ):
         checkout = tmp_path / checkout_name
         (checkout / jurisdiction).mkdir(parents=True)
+        (checkout / checkout_source_root).mkdir()
 
         content_root = _rulespec_apply_content_root(checkout, relative_output)
         manifest_root, manifest_relative = _resolve_applied_manifest_placement(
@@ -14453,6 +14464,11 @@ rules: []
 
         with pytest.raises(ValueError, match="canonical"):
             _rulespec_apply_content_root(
+                alias,
+                Path("programs/us-sc/snap/fy-2026.yaml"),
+            )
+        with pytest.raises(ValueError, match="canonical"):
+            _rulespec_apply_checkout_root(
                 alias,
                 Path("programs/us-sc/snap/fy-2026.yaml"),
             )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15515,13 +15515,9 @@ rules: []
         assert content_root == checkout / jurisdiction
         assert manifest_root == checkout
         assert manifest_relative == relative_output
-        assert (
-            _rulespec_anchor_base_for_output(checkout, relative_output) == citation
-        )
+        assert _rulespec_anchor_base_for_output(checkout, relative_output) == citation
 
-    def test_checkout_root_source_output_rejects_symlinked_checkout(
-        self, tmp_path
-    ):
+    def test_checkout_root_source_output_rejects_symlinked_checkout(self, tmp_path):
         real_checkout = tmp_path / "real" / "rulespec-us"
         (real_checkout / "us").mkdir(parents=True)
         (real_checkout / "programs/us-sc/snap").mkdir(parents=True)
@@ -15539,9 +15535,7 @@ rules: []
                 Path("programs/us-sc/snap/fy-2026.yaml"),
             )
 
-    def test_write_applied_manifest_places_checkout_root_program_spec(
-        self, tmp_path
-    ):
+    def test_write_applied_manifest_places_checkout_root_program_spec(self, tmp_path):
         checkout = tmp_path / "rulespec-us"
         (checkout / "us").mkdir(parents=True)
         relative_output = Path("programs/us-sc/snap/fy-2026.yaml")
@@ -15600,8 +15594,7 @@ rules: []
             )
 
         assert manifest == (
-            checkout
-            / ".axiom/encoding-manifests/programs/us-sc/snap/fy-2026.json"
+            checkout / ".axiom/encoding-manifests/programs/us-sc/snap/fy-2026.json"
         )
         payload = json.loads(manifest.read_text())
         assert payload["citation"] == "programs/us-sc/snap/fy-2026"

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1413"
+ENCODER_VERSION = "0.2.1415"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1415"
+ENCODER_VERSION = "0.2.1416"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1413"
+ENCODER_VERSION = "0.2.1415"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1415"
+ENCODER_VERSION = "0.2.1416"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1415"
+ENCODER_VERSION = "0.2.1416"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1413"
+ENCODER_VERSION = "0.2.1415"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1415"
+ENCODER_VERSION = "0.2.1416"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1413"
+ENCODER_VERSION = "0.2.1415"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1413"
+ENCODER_VERSION = "0.2.1415"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1415"
+ENCODER_VERSION = "0.2.1416"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1415"
+ENCODER_VERSION = "0.2.1416"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1413"
+ENCODER_VERSION = "0.2.1415"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_repo_routing.py
+++ b/tests/test_repo_routing.py
@@ -29,6 +29,7 @@ from axiom_encode.repo_routing import (
     inspect_canonical_rulespec_checkout,
     is_composition_policy_repo_root,
     is_policy_repo_root,
+    is_rulespec_source_checkout_root,
     jurisdiction_subdir_names,
 )
 
@@ -72,6 +73,7 @@ def test_composition_checkout_identity_admits_only_top_level_programs(tmp_path):
 
     assert is_policy_repo_root(checkout) is False
     assert is_composition_policy_repo_root(checkout) is True
+    assert is_rulespec_source_checkout_root(checkout) is True
     assert inspect_canonical_rulespec_checkout(
         checkout, allow_composition_specs=True
     ) == ("rulespec-us", None)
@@ -79,6 +81,7 @@ def test_composition_checkout_identity_admits_only_top_level_programs(tmp_path):
 
     (checkout / "statutes").mkdir()
     assert is_composition_policy_repo_root(checkout) is False
+    assert is_rulespec_source_checkout_root(checkout) is True
     assert inspect_canonical_rulespec_checkout(
         checkout, allow_composition_specs=True
     ) == (None, "atomic-root-at-checkout")
@@ -92,6 +95,7 @@ def test_composition_checkout_identity_rejects_symlinked_programs(tmp_path):
     (checkout / "programs").symlink_to(external_programs, target_is_directory=True)
 
     assert is_composition_policy_repo_root(checkout) is False
+    assert is_rulespec_source_checkout_root(checkout) is False
 
 
 def test_composition_checkout_preserves_atomic_jurisdiction_identity(tmp_path):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1415"')
+        .startswith('__version__ = "0.2.1416"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1415"
+    assert encoder_package["version"] == "0.2.1416"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1415"
+    assert project["project"]["version"] == "0.2.1416"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1415"')
+        .startswith('__version__ = "0.2.1416"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1415"
+    assert encoder_package["version"] == "0.2.1416"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1415"
+    assert project["project"]["version"] == "0.2.1416"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1415"')
+        .startswith('__version__ = "0.2.1416"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1413"')
+        .startswith('__version__ = "0.2.1415"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1413"
+    assert encoder_package["version"] == "0.2.1415"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1413"
+    assert project["project"]["version"] == "0.2.1415"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1413"')
+        .startswith('__version__ = "0.2.1415"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1413"
+    assert encoder_package["version"] == "0.2.1415"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1413"
+    assert project["project"]["version"] == "0.2.1415"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1413"')
+        .startswith('__version__ = "0.2.1415"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1413"
+ENCODER_VERSION = "0.2.1415"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1415"
+ENCODER_VERSION = "0.2.1416"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1406"
+version = "0.2.1407"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1405"
+version = "0.2.1406"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1413"
+version = "0.2.1415"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1415"
+version = "0.2.1416"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
Closes #1312.

**Defect**: `sign-applied-files` crashed whenever a diff included a program spec:

```
ValueError: '.../programs/us-sc/snap/fy-2026.yaml' is not in the subpath of '.../us'
```

`_relative_output_jurisdiction_prefix("programs/us-sc/snap/fy-2026.yaml")` returns None because it expects `<jurisdiction>/<source-root>/...` and here `parts[0]` ("programs") is itself a source root. `_rulespec_apply_content_root` then fell back to `<repo>/us`, and the manifest writer rebased the `programs/...` file against it. Because groups are processed in sorted order, the crash also blocked signing every other file in the same diff.

**Fix**: root-level source-root outputs route to the checkout root, producing manifests under `.axiom/encoding-manifests/programs/...` with `programs/<...>` citations — matching the program manifests already on rulespec-us main. Jurisdiction-prefixed outputs (`us-sc/policies/...`) and country-monorepo layouts (the #1078 special cases) are covered by tests and unchanged.

**Verification**:
- Fail-first: the regression selection is **6 failed** before the fix, **6 passed** after.
- End-to-end: the literal pinned bridge build reproduced the reported crash; the equivalent backport then signed the reconstructed **SC program-spec scoping that rulespec-us#1139 had to drop because of this bug**, and `guard-generated` passed. (The original `wt-snap-sc` checkout was not modified.)
- Focused routing/version matrix: 57 passed; `tests/test_repo_routing.py` 44 passed. Ruff, compileall, version provenance, and diff checks pass.

Full-suite note: 6,024 passed / 31 skipped / 36 failed. One failure was branch-caused (a version-provenance assertion), fixed and re-run green; the other 35 come from the stale offline oracle/editable environment and sandbox-dependent system tests, not from this change.

**Unblocks**: the SC SNAP program-spec scoping and worklist drain held out of rulespec-us#1139, and program-spec signing generally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)