### PR TITLE
Map Montana TY2026 tax before nonrefundable credits

### DIFF
--- a/changelog.d/mt-2026-before-credits-oracle.changed.md
+++ b/changelog.d/mt-2026-before-credits-oracle.changed.md
@@ -1,0 +1,1 @@
+Bundle Montana's bounded tax-year-2026 income-tax-before-nonrefundable-credits mapping and pin its durable reviewed oracle-main merge without claiming taxable-income construction, section 1222 net-long-term-capital-gain inputs, filing-status classification, schedule internals, credits, payments, or final annual liability.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1406"
+version = "0.2.1407"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@a62340d2f1e2873b43404478835de5577e685736",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@cee703f34ad367534b2d50debc2bcd9dfdf9c29e",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1406"
+__version__ = "0.2.1407"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -28856,6 +28856,21 @@ mappings:
     comparison: money
     rationale: On the reviewed nonnegative completed-return boundary, both outputs apply Oklahoma's enacted tax-year-2026 four-band schedule to Oklahoma taxable income using the statutory single-or-separate versus joint, surviving-spouse, or head-of-household schedule branch, before credits, payments, or final annual liability.
 
+  # Montana's bounded TY2026 tax before nonrefundable credits. Completed
+  # taxable income, section 1222 net long-term capital gain, and filing-status
+  # classification remain reviewed caller boundaries; credits, payments, and
+  # final annual liability are not promoted.
+  - legal_id: us-mt:policies/income_tax/pilot_liability_pipeline#mt_pit_pilot_income_tax_liability
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: mt_income_tax_before_non_refundable_credits_joint
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Both outputs compose Montana's complete temporary tax-year-2026 ordinary-income and net-long-term-capital-gain schedules under MCA 15-30-2103 from the same completed-return boundaries, before nonrefundable credits; this narrow mapping excludes credits, payments, and final annual liability.
+
   # Pennsylvania's bounded TY2026 resident tax before forgiveness. The
   # completed-return adjusted-taxable-income input remains a caller boundary;
   # these exact output mappings are promoted only with a runtime proof that the
@@ -31226,6 +31241,12 @@ prefixes:
     mapping_type: not_comparable
     candidate_priority: P4
     rationale: PolicyEngine-US does not model every MS statute, agency policy manual, or state regulation at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
+
+  - legal_id_prefix: "us-mt:"
+    country: us
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: PolicyEngine-US does not model every Montana statute, agency policy manual, or state regulation at output granularity; independently reviewed comparable outputs carry exact mappings which take precedence over this jurisdiction-wide fallback.
 
   - legal_id_prefix: "us-ut:"
     country: us

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -14,8 +14,8 @@ DIRECT_VARIABLES = {
         "il_income_tax_before_non_refundable_credits"
     ),
 }
-ORACLE_MERGE = "a62340d2f1e2873b43404478835de5577e685736"
-ENCODER_VERSION = "0.2.1406"
+ORACLE_MERGE = "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
+ENCODER_VERSION = "0.2.1407"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -10,8 +10,8 @@ from axiom_oracles.bridges.registry import load_policyengine_registry
 MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
-ORACLE_MERGE = "a62340d2f1e2873b43404478835de5577e685736"
-ENCODER_VERSION = "0.2.1406"
+ORACLE_MERGE = "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
+ENCODER_VERSION = "0.2.1407"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -7,16 +7,16 @@ import yaml
 from axiom_oracles.bridges.coverage import build_policyengine_coverage_report
 from axiom_oracles.bridges.registry import load_policyengine_registry
 
-MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
-OUTPUT = "mn_pit_pilot_schedule_tax"
-POLICYENGINE_VARIABLE = "mn_basic_tax"
+MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
+OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
+POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
 ENCODER_VERSION = "0.2.1407"
-FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
+FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable
     candidate_priority: P4
-    rationale: PolicyEngine-US does not model every Minnesota statute, agency policy manual, or state regulation at output granularity; independently reviewed comparable outputs carry exact mappings which take precedence over this jurisdiction-wide fallback."""
+    rationale: PolicyEngine-US does not model every Montana statute, agency policy manual, or state regulation at output granularity; independently reviewed comparable outputs carry exact mappings which take precedence over this jurisdiction-wide fallback."""
 
 
 def _module_mappings(document):
@@ -29,18 +29,13 @@ def _module_mappings(document):
 
 
 def _shared_material(text: str) -> str:
-    start = text.index(
-        "  # Minnesota's tax-year-2026 pilot exposes a source-faithful continuous"
-    )
+    start = text.index("  # Montana's bounded TY2026 tax before nonrefundable credits.")
     exact_end_marker = (
-        "    rationale: Both outputs apply Minnesota's four-rate individual "
-        "schedule to completed Minnesota taxable income selected by filing "
-        "status. The final official tax-year-2026 RuleSpec thresholds are $10 "
-        "to $30 above PolicyEngine-US 1.752.2's thresholds, producing only a "
-        "reviewed sub-dollar residual under the preserved $1 absolute "
-        "tolerance. This narrow mapping makes no claim about taxable-income "
-        "construction, tax-table rounding, alternative minimum tax, net "
-        "investment income tax, credits, payments, or final liability."
+        "    rationale: Both outputs compose Montana's complete temporary "
+        "tax-year-2026 ordinary-income and net-long-term-capital-gain schedules "
+        "under MCA 15-30-2103 from the same completed-return boundaries, before "
+        "nonrefundable credits; this narrow mapping excludes credits, payments, "
+        "and final annual liability."
     )
     exact_end = text.index(exact_end_marker, start) + len(exact_end_marker)
     fallback_start = text.index(FALLBACK_TEXT)
@@ -49,12 +44,12 @@ def _shared_material(text: str) -> str:
 
 
 def _write_synthetic_module(root: Path) -> None:
-    path = root / "us-mn/policies/income_tax/pilot_liability_pipeline.yaml"
+    path = root / "us-mt/policies/income_tax/pilot_liability_pipeline.yaml"
     path.parent.mkdir(parents=True)
     path.write_text(
         "format: rulespec/v1\n"
         "rules:\n"
-        f"  - name: {OUTPUT}\n"
+        f"  - name: {OUTPUT_NAME}\n"
         "    kind: derived\n"
         "    versions:\n"
         "      - effective_from: '2026-01-01'\n"
@@ -62,14 +57,14 @@ def _write_synthetic_module(root: Path) -> None:
     )
 
 
-def test_packaged_mn_2026_registry_has_one_exact_direct_mapping() -> None:
+def test_packaged_mt_2026_registry_has_one_exact_direct_mapping() -> None:
     root = Path(__file__).parents[1]
     path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     document = yaml.safe_load(path.read_text())
     mappings = _module_mappings(document)
 
-    assert set(mappings) == {OUTPUT}
-    mapping = mappings[OUTPUT]
+    assert set(mappings) == {OUTPUT_NAME}
+    mapping = mappings[OUTPUT_NAME]
     assert mapping["mapping_type"] == "direct_variable"
     assert mapping["policyengine_variable"] == POLICYENGINE_VARIABLE
     assert (
@@ -80,19 +75,35 @@ def test_packaged_mn_2026_registry_has_one_exact_direct_mapping() -> None:
         mapping["comparison"],
     ) == ("tax", "tax_unit", "year", "USD", "money")
     assert "candidate_priority" not in mapping
-    for excluded_scope in (
-        "taxable-income construction",
-        "tax-table rounding",
-        "alternative minimum tax",
-        "net investment income tax",
+    for bounded_scope in (
+        "complete temporary tax-year-2026",
+        "ordinary-income",
+        "net-long-term-capital-gain",
+        "MCA 15-30-2103",
+        "completed-return boundaries",
+        "before nonrefundable credits",
         "credits",
         "payments",
-        "final liability",
+        "final annual liability",
     ):
-        assert excluded_scope in mapping["rationale"]
+        assert bounded_scope in mapping["rationale"]
+    for excluded_name in (
+        "input.mt_pit_pilot_state_taxable_income",
+        "input.mt_pit_pilot_section_1222_net_long_term_capital_gain",
+        "input.mt_pit_pilot_filing_status_joint_or_surviving_spouse",
+        "input.mt_pit_pilot_filing_status_head_of_household",
+        "mt_pit_pilot_taxable_income",
+        "mt_pit_pilot_net_long_term_capital_gain",
+        "mt_pit_pilot_nonqualified_taxable_income",
+        "mt_pit_pilot_filing_status_threshold",
+        "mt_pit_pilot_ordinary_income_tax",
+        "mt_pit_pilot_capital_gain_lower_band",
+        "mt_pit_pilot_capital_gains_tax",
+    ):
+        assert excluded_name not in mappings
 
 
-def test_packaged_mn_2026_runtime_pin_version_and_precedence_are_exact() -> None:
+def test_packaged_mt_2026_runtime_pin_version_and_precedence_are_exact() -> None:
     import axiom_oracles.bridges.registry as runtime_registry_module
 
     root = Path(__file__).parents[1]
@@ -110,14 +121,17 @@ def test_packaged_mn_2026_runtime_pin_version_and_precedence_are_exact() -> None
     assert bundled_text.count(FALLBACK_TEXT) == 1
     assert runtime_text.count(FALLBACK_TEXT) == 1
     assert hashlib.sha256(FALLBACK_TEXT.encode()).hexdigest() == (
-        "a1922806d932ae93464931b656c5e38db6cf808ec10a3e85694ffc5831956f2b"
+        "e87e011316a69dac2f45fee3e33d3340d57e0b5d9bb8f3a74f2fe719d4211efb"
     )
     assert hashlib.sha256(_shared_material(bundled_text).encode()).hexdigest() == (
-        "8e4b30d18da4483a19a6d641244f70b806eebdc952efdd8fcba0beb6a83cf74d"
+        "9c92210f6d6e63d7dfe46c22da19c8fc7a9149640efcb0cadd6b86d73f7a2cf0"
     )
 
     registry = load_policyengine_registry()
-    mapping = registry.mapping_for_legal_id(f"{MODULE}#{OUTPUT}", country="us")
+    mapping = registry.mapping_for_legal_id(
+        f"{MODULE}#{OUTPUT_NAME}",
+        country="us",
+    )
     assert mapping is not None
     assert mapping.match_type == "exact"
     assert mapping.mapping_type == "direct_variable"
@@ -127,15 +141,29 @@ def test_packaged_mn_2026_runtime_pin_version_and_precedence_are_exact() -> None
     assert mapping.unit == "USD"
     assert mapping.comparison == "money"
 
-    fallback = registry.mapping_for_legal_id(
-        f"{MODULE}#future_unmapped_output",
-        country="us",
-    )
-    assert fallback is not None
-    assert fallback.legal_id == "us-mn:"
-    assert fallback.match_type == "prefix"
-    assert fallback.mapping_type == "not_comparable"
-    assert fallback.candidate_priority == "P4"
+    for output_name in (
+        "input.mt_pit_pilot_state_taxable_income",
+        "input.mt_pit_pilot_section_1222_net_long_term_capital_gain",
+        "input.mt_pit_pilot_filing_status_joint_or_surviving_spouse",
+        "input.mt_pit_pilot_filing_status_head_of_household",
+        "mt_pit_pilot_taxable_income",
+        "mt_pit_pilot_net_long_term_capital_gain",
+        "mt_pit_pilot_nonqualified_taxable_income",
+        "mt_pit_pilot_filing_status_threshold",
+        "mt_pit_pilot_ordinary_income_tax",
+        "mt_pit_pilot_capital_gain_lower_band",
+        "mt_pit_pilot_capital_gains_tax",
+        "future_unmapped_output",
+    ):
+        fallback = registry.mapping_for_legal_id(
+            f"{MODULE}#{output_name}",
+            country="us",
+        )
+        assert fallback is not None
+        assert fallback.legal_id == "us-mt:"
+        assert fallback.match_type == "prefix"
+        assert fallback.mapping_type == "not_comparable"
+        assert fallback.candidate_priority == "P4"
 
     dependency_pin = re.search(
         r"axiom-oracles@[0-9a-f]{40}",
@@ -160,7 +188,7 @@ def test_packaged_mn_2026_runtime_pin_version_and_precedence_are_exact() -> None
     )
 
 
-def test_policyengine_coverage_classifies_only_bounded_mn_2026_output(
+def test_policyengine_coverage_classifies_only_bounded_mt_2026_output(
     tmp_path: Path,
 ) -> None:
     rulespec_root = tmp_path / "rulespec-us"
@@ -170,6 +198,7 @@ def test_policyengine_coverage_classifies_only_bounded_mn_2026_output(
 
     assert report["total_outputs"] == 1
     assert report["status_counts"] == {"comparable": 1}
+    assert len(report["items"]) == 1
     item = report["items"][0]
-    assert item["rule_name"] == OUTPUT
+    assert item["rule_name"] == OUTPUT_NAME
     assert item["policyengine_variable"] == POLICYENGINE_VARIABLE

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -10,8 +10,8 @@ from axiom_oracles.bridges.registry import load_policyengine_registry
 MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
-ORACLE_MERGE = "a62340d2f1e2873b43404478835de5577e685736"
-ENCODER_VERSION = "0.2.1406"
+ORACLE_MERGE = "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
+ENCODER_VERSION = "0.2.1407"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -13,8 +13,8 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_taxable_income": "pa_adjusted_taxable_income",
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
-ORACLE_MERGE = "a62340d2f1e2873b43404478835de5577e685736"
-ENCODER_VERSION = "0.2.1406"
+ORACLE_MERGE = "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
+ENCODER_VERSION = "0.2.1407"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5120,7 +5120,7 @@ def test_packaged_alabama_2026_schedule_registry_and_fallback_are_synchronized()
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "a62340d2f1e2873b43404478835de5577e685736"
+    assert pin == "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5231,7 +5231,7 @@ def test_packaged_connecticut_2026_ordinary_tax_registry_is_exactly_synchronized
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "a62340d2f1e2873b43404478835de5577e685736"
+    assert pin == "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5315,7 +5315,7 @@ def test_packaged_georgia_2026_annual_tax_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "a62340d2f1e2873b43404478835de5577e685736"
+    assert pin == "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5410,7 +5410,7 @@ def test_packaged_mississippi_2026_schedule_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "a62340d2f1e2873b43404478835de5577e685736"
+    assert pin == "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5571,7 +5571,7 @@ def test_packaged_kansas_2026_k40es_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "a62340d2f1e2873b43404478835de5577e685736"
+    assert pin == "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5676,7 +5676,7 @@ def test_packaged_dc_2026_section_47_1806_03_has_exact_bounded_slice():
 def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "a62340d2f1e2873b43404478835de5577e685736"
+    durable_oracle_merge = "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1406"')
+        .startswith('__version__ = "0.2.1407"')
     )
 
 
@@ -5879,7 +5879,7 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
 
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "a62340d2f1e2873b43404478835de5577e685736"
+    durable_oracle_merge = "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1406"
+    assert encoder_package["version"] == "0.2.1407"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1406"
+    assert project["project"]["version"] == "0.2.1407"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1406"')
+        .startswith('__version__ = "0.2.1407"')
     )
 
 
@@ -6155,7 +6155,7 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
 
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "a62340d2f1e2873b43404478835de5577e685736"
+    durable_oracle_merge = "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1406"
+    assert encoder_package["version"] == "0.2.1407"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1406"
+    assert project["project"]["version"] == "0.2.1407"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1406"')
+        .startswith('__version__ = "0.2.1407"')
     )
 
 
@@ -6506,7 +6506,7 @@ def test_packaged_utah_2026_before_credit_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "a62340d2f1e2873b43404478835de5577e685736"
+    assert pin == "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -11,8 +11,8 @@ MODULE = "us-sc:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
-ORACLE_MERGE = "a62340d2f1e2873b43404478835de5577e685736"
-ENCODER_VERSION = "0.2.1406"
+ORACLE_MERGE = "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
+ENCODER_VERSION = "0.2.1407"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1406"
+version = "0.2.1407"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=a62340d2f1e2873b43404478835de5577e685736" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=cee703f34ad367534b2d50debc2bcd9dfdf9c29e" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=a62340d2f1e2873b43404478835de5577e685736#a62340d2f1e2873b43404478835de5577e685736" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=cee703f34ad367534b2d50debc2bcd9dfdf9c29e#cee703f34ad367534b2d50debc2bcd9dfdf9c29e" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- pin axiom-oracles to reviewed main merge `cee703f34ad367534b2d50debc2bcd9dfdf9c29e`
- bundle the exact Montana TY2026 mapping for `mt_pit_pilot_income_tax_liability` to `mt_income_tax_before_non_refundable_credits_joint`
- bundle the exact `us-mt:` P4 not-comparable fallback so the direct mapping wins by exact precedence
- bump axiom-encode to `0.2.1407` and update the lock, changelog, and durable pin/version assertions

## Scope

This promotes only the completed-return tax before nonrefundable credits. Montana taxable income, section 1222 net long-term capital gain, filing-status classification, schedule internals, credits, payments, and final annual liability remain unpromoted caller or downstream boundaries.

## Validation

- `uv run pytest -q tests/test_mt_2026_oracle_registry.py` — 3 passed
- promoted 2026 state registry tests plus `tests/test_rulespec_validation.py` — 1349 passed, 31 skipped
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests` — passed
- `uv run ruff format --check src/ tests/` — 137 files already formatted
- `python -m compileall -q src/axiom_encode scripts` — passed
- `uv lock --check` — passed
- `git diff --check` and explicit pin/version checks — passed

## Review cycle

- independent review of original commit `8bc2aa48edbb8be508d161910a11fa3c4ea5ac4c` returned CLEAN
- after the CI-requested canonical Ruff formatting-only amendment, independent delta review of current commit `f323c2ac9513df20c1c1ff2a61fb3815226f2790` returned CLEAN