### PR TITLE
Map Arkansas TY2026 individual tax before nonrefundable credits

### DIFF
--- a/changelog.d/ar-2026-before-nonrefundable-oracle.changed.md
+++ b/changelog.d/ar-2026-before-nonrefundable-oracle.changed.md
@@ -1,0 +1,1 @@
+Bundle Arkansas's bounded tax-year-2026 Person-grain individual schedule component before nonrefundable credits and pin its durable reviewed oracle-main merge without claiming taxable-income construction, filing-unit aggregation or method selection, low-income tables, credits, payments, or final liability.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1407"
+version = "0.2.1408"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@cee703f34ad367534b2d50debc2bcd9dfdf9c29e",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@678dd840b4c64e54c63805b0183f05c0f769b399",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1407"
+__version__ = "0.2.1408"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -28871,6 +28871,20 @@ mappings:
     comparison: money
     rationale: Both outputs compose Montana's complete temporary tax-year-2026 ordinary-income and net-long-term-capital-gain schedules under MCA 15-30-2103 from the same completed-return boundaries, before nonrefundable credits; this narrow mapping excludes credits, payments, and final annual liability.
 
+  # Arkansas Act 2 of 2026 supplies this bounded Person-grain individual
+  # schedule component. Person-to-TaxUnit summation belongs only to the
+  # reviewed Populace comparison accounting and does not change its entity.
+  - legal_id: us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: ar_income_tax_before_non_refundable_credits_indiv
+    entity: person
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Both outputs apply Arkansas Act 2 of 2026 section 1's complete tax-year-2026 individual schedule, including the high-income bracket-adjustment table, to completed-return individual taxable income at Person grain before nonrefundable credits; this narrow mapping excludes taxable-income construction, filing-unit aggregation or method selection, low-income tables, credits, payments, and final liability.
+
   # Pennsylvania's bounded TY2026 resident tax before forgiveness. The
   # completed-return adjusted-taxable-income input remains a caller boundary;
   # these exact output mappings are promoted only with a runtime proof that the

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -7,17 +7,16 @@ import yaml
 from axiom_oracles.bridges.coverage import build_policyengine_coverage_report
 from axiom_oracles.bridges.registry import load_policyengine_registry
 
-MODULE = "us-sc:policies/income_tax/pilot_liability_pipeline"
-OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
-INPUT_NAME = "sc_pit_pilot_state_taxable_income"
-POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
+MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
+OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
+POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
 ENCODER_VERSION = "0.2.1408"
-FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
+FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable
     candidate_priority: P4
-    rationale: PolicyEngine-US does not model SC agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix."""
+    rationale: PolicyEngine-US does not model AR agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix."""
 
 
 def _module_mappings(document):
@@ -31,13 +30,16 @@ def _module_mappings(document):
 
 def _shared_material(text: str) -> str:
     start = text.index(
-        "  # South Carolina's bounded TY2026 individual income tax before"
+        "  # Arkansas Act 2 of 2026 supplies this bounded Person-grain individual"
     )
     exact_end_marker = (
-        "    rationale: On the reviewed nonnegative completed-return boundary, "
-        "both outputs apply South Carolina's enacted tax-year-2026 1.99 percent "
-        "and 5.21 percent-minus-$966 schedule to South Carolina taxable income "
-        "before nonrefundable credits, payments, or final annual liability."
+        "    rationale: Both outputs apply Arkansas Act 2 of 2026 section 1's "
+        "complete tax-year-2026 individual schedule, including the high-income "
+        "bracket-adjustment table, to completed-return individual taxable "
+        "income at Person grain before nonrefundable credits; this narrow "
+        "mapping excludes taxable-income construction, filing-unit aggregation "
+        "or method selection, low-income tables, credits, payments, and final "
+        "liability."
     )
     exact_end = text.index(exact_end_marker, start) + len(exact_end_marker)
     fallback_start = text.index(FALLBACK_TEXT)
@@ -46,7 +48,7 @@ def _shared_material(text: str) -> str:
 
 
 def _write_synthetic_module(root: Path) -> None:
-    path = root / "us-sc/policies/income_tax/pilot_liability_pipeline.yaml"
+    path = root / "us-ar/policies/income_tax/pilot_liability_pipeline.yaml"
     path.parent.mkdir(parents=True)
     path.write_text(
         "format: rulespec/v1\n"
@@ -59,7 +61,7 @@ def _write_synthetic_module(root: Path) -> None:
     )
 
 
-def test_packaged_sc_2026_registry_has_one_exact_direct_mapping() -> None:
+def test_packaged_ar_2026_registry_has_one_exact_person_mapping() -> None:
     root = Path(__file__).parents[1]
     path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     document = yaml.safe_load(path.read_text())
@@ -75,22 +77,37 @@ def test_packaged_sc_2026_registry_has_one_exact_direct_mapping() -> None:
         mapping["period"],
         mapping["unit"],
         mapping["comparison"],
-    ) == ("tax", "tax_unit", "year", "USD", "money")
+    ) == ("tax", "person", "year", "USD", "money")
     assert "candidate_priority" not in mapping
-    assert "reviewed nonnegative completed-return boundary" in mapping["rationale"]
     for bounded_scope in (
-        "tax-year-2026",
+        "Arkansas Act 2 of 2026 section 1",
+        "high-income bracket-adjustment table",
+        "completed-return individual taxable income",
+        "Person grain",
         "before nonrefundable credits",
+        "taxable-income construction",
+        "filing-unit aggregation or method selection",
+        "low-income tables",
+        "credits",
         "payments",
-        "final annual liability",
+        "final liability",
     ):
         assert bounded_scope in mapping["rationale"]
-    assert f"input.{INPUT_NAME}" not in mappings
-    assert "sc_pit_pilot_taxable_income" not in mappings
-    assert "sc_pit_pilot_schedule_tax" not in mappings
+    for excluded_name in (
+        "input.ar_pit_pilot_individual_taxable_income",
+        "ar_pit_pilot_taxable_income",
+        "ar_pit_pilot_uses_high_income_schedule",
+        "ar_pit_pilot_schedule_a_bracket",
+        "ar_pit_pilot_schedule_b_bracket",
+        "ar_pit_pilot_adjustment_lower_half_bracket",
+        "ar_pit_pilot_adjustment_upper_half_bracket",
+        "ar_pit_pilot_bracket_adjustment",
+        "ar_pit_pilot_schedule_tax",
+    ):
+        assert excluded_name not in mappings
 
 
-def test_packaged_sc_2026_runtime_pin_version_and_precedence_are_exact() -> None:
+def test_packaged_ar_2026_runtime_pin_version_and_precedence_are_exact() -> None:
     import axiom_oracles.bridges.registry as runtime_registry_module
 
     root = Path(__file__).parents[1]
@@ -108,10 +125,10 @@ def test_packaged_sc_2026_runtime_pin_version_and_precedence_are_exact() -> None
     assert bundled_text.count(FALLBACK_TEXT) == 1
     assert runtime_text.count(FALLBACK_TEXT) == 1
     assert hashlib.sha256(FALLBACK_TEXT.encode()).hexdigest() == (
-        "31484c10dd215ae94df62a526db8d6d5e5276967ba4094ab8c19cb1dc8c218dd"
+        "ddd27d33e34c93be2750aae0ff47afb6ccec7bf291737f3bfcb58ed07e55ca7b"
     )
     assert hashlib.sha256(_shared_material(bundled_text).encode()).hexdigest() == (
-        "933fda9c31f5450ac251865b31943cc100490ff4d394723fb520e2e9cebd73f4"
+        "2db4827d0961ad95dcccfd98debcac823404d95e742e97a8589d3571a9e74a74"
     )
 
     registry = load_policyengine_registry()
@@ -123,14 +140,22 @@ def test_packaged_sc_2026_runtime_pin_version_and_precedence_are_exact() -> None
     assert mapping.match_type == "exact"
     assert mapping.mapping_type == "direct_variable"
     assert mapping.policyengine_variable == POLICYENGINE_VARIABLE
-    assert mapping.entity == "tax_unit"
+    assert mapping.entity == "person"
     assert mapping.period == "year"
     assert mapping.unit == "USD"
     assert mapping.comparison == "money"
 
     for output_name in (
-        "sc_pit_pilot_taxable_income",
-        "sc_pit_pilot_schedule_tax",
+        "input.ar_pit_pilot_individual_taxable_income",
+        "ar_pit_pilot_taxable_income",
+        "ar_pit_pilot_uses_high_income_schedule",
+        "ar_pit_pilot_schedule_a_bracket",
+        "ar_pit_pilot_schedule_b_bracket",
+        "ar_pit_pilot_adjustment_lower_half_bracket",
+        "ar_pit_pilot_adjustment_upper_half_bracket",
+        "ar_pit_pilot_bracket_adjustment",
+        "ar_pit_pilot_schedule_tax",
+        "ar_pit_pilot_final_annual_liability",
         "future_unmapped_output",
     ):
         fallback = registry.mapping_for_legal_id(
@@ -138,7 +163,7 @@ def test_packaged_sc_2026_runtime_pin_version_and_precedence_are_exact() -> None
             country="us",
         )
         assert fallback is not None
-        assert fallback.legal_id == "us-sc:"
+        assert fallback.legal_id == "us-ar:"
         assert fallback.match_type == "prefix"
         assert fallback.mapping_type == "not_comparable"
         assert fallback.candidate_priority == "P4"
@@ -166,7 +191,7 @@ def test_packaged_sc_2026_runtime_pin_version_and_precedence_are_exact() -> None
     )
 
 
-def test_policyengine_coverage_classifies_only_bounded_sc_2026_output(
+def test_policyengine_coverage_classifies_only_bounded_ar_2026_output(
     tmp_path: Path,
 ) -> None:
     rulespec_root = tmp_path / "rulespec-us"

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -14,8 +14,8 @@ DIRECT_VARIABLES = {
         "il_income_tax_before_non_refundable_credits"
     ),
 }
-ORACLE_MERGE = "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
-ENCODER_VERSION = "0.2.1407"
+ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
+ENCODER_VERSION = "0.2.1408"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -10,8 +10,8 @@ from axiom_oracles.bridges.registry import load_policyengine_registry
 MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
-ORACLE_MERGE = "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
-ENCODER_VERSION = "0.2.1407"
+ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
+ENCODER_VERSION = "0.2.1408"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -10,8 +10,8 @@ from axiom_oracles.bridges.registry import load_policyengine_registry
 MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
-ORACLE_MERGE = "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
-ENCODER_VERSION = "0.2.1407"
+ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
+ENCODER_VERSION = "0.2.1408"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -10,8 +10,8 @@ from axiom_oracles.bridges.registry import load_policyengine_registry
 MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
-ORACLE_MERGE = "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
-ENCODER_VERSION = "0.2.1407"
+ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
+ENCODER_VERSION = "0.2.1408"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -10,8 +10,8 @@ from axiom_oracles.bridges.registry import load_policyengine_registry
 MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
-ORACLE_MERGE = "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
-ENCODER_VERSION = "0.2.1407"
+ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
+ENCODER_VERSION = "0.2.1408"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -13,8 +13,8 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_taxable_income": "pa_adjusted_taxable_income",
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
-ORACLE_MERGE = "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
-ENCODER_VERSION = "0.2.1407"
+ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
+ENCODER_VERSION = "0.2.1408"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5120,7 +5120,7 @@ def test_packaged_alabama_2026_schedule_registry_and_fallback_are_synchronized()
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
+    assert pin == "678dd840b4c64e54c63805b0183f05c0f769b399"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5231,7 +5231,7 @@ def test_packaged_connecticut_2026_ordinary_tax_registry_is_exactly_synchronized
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
+    assert pin == "678dd840b4c64e54c63805b0183f05c0f769b399"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5315,7 +5315,7 @@ def test_packaged_georgia_2026_annual_tax_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
+    assert pin == "678dd840b4c64e54c63805b0183f05c0f769b399"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5410,7 +5410,7 @@ def test_packaged_mississippi_2026_schedule_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
+    assert pin == "678dd840b4c64e54c63805b0183f05c0f769b399"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5571,7 +5571,7 @@ def test_packaged_kansas_2026_k40es_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
+    assert pin == "678dd840b4c64e54c63805b0183f05c0f769b399"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5676,7 +5676,7 @@ def test_packaged_dc_2026_section_47_1806_03_has_exact_bounded_slice():
 def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
+    durable_oracle_merge = "678dd840b4c64e54c63805b0183f05c0f769b399"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1407"')
+        .startswith('__version__ = "0.2.1408"')
     )
 
 
@@ -5879,7 +5879,7 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
 
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
+    durable_oracle_merge = "678dd840b4c64e54c63805b0183f05c0f769b399"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1407"
+    assert encoder_package["version"] == "0.2.1408"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1407"
+    assert project["project"]["version"] == "0.2.1408"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1407"')
+        .startswith('__version__ = "0.2.1408"')
     )
 
 
@@ -6155,7 +6155,7 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
 
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
+    durable_oracle_merge = "678dd840b4c64e54c63805b0183f05c0f769b399"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1407"
+    assert encoder_package["version"] == "0.2.1408"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1407"
+    assert project["project"]["version"] == "0.2.1408"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1407"')
+        .startswith('__version__ = "0.2.1408"')
     )
 
 
@@ -6506,7 +6506,7 @@ def test_packaged_utah_2026_before_credit_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "cee703f34ad367534b2d50debc2bcd9dfdf9c29e"
+    assert pin == "678dd840b4c64e54c63805b0183f05c0f769b399"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1407"
+version = "0.2.1408"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=cee703f34ad367534b2d50debc2bcd9dfdf9c29e" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=678dd840b4c64e54c63805b0183f05c0f769b399" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=cee703f34ad367534b2d50debc2bcd9dfdf9c29e#cee703f34ad367534b2d50debc2bcd9dfdf9c29e" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=678dd840b4c64e54c63805b0183f05c0f769b399#678dd840b4c64e54c63805b0183f05c0f769b399" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- pin axiom-oracles to reviewed main merge `678dd840b4c64e54c63805b0183f05c0f769b399`
- bundle the exact Arkansas Act 2 TY2026 Person-grain mapping for `ar_pit_pilot_income_tax_before_non_refundable_credits_indiv` to `ar_income_tax_before_non_refundable_credits_indiv`
- retain the byte-identical `us-ar:` P4 not-comparable fallback so the direct mapping wins only by exact precedence
- bump axiom-encode to `0.2.1408` and update the lock, changelog, and durable pin/version assertions

## Scope

This promotes only the completed-return individual schedule component before nonrefundable credits at Person grain. Person-to-TaxUnit summation remains comparison accounting only. Taxable-income construction, filing-unit aggregation or method selection, low-income tables, credits, payments, and final liability remain unpromoted boundaries routed through the unchanged fallback.

## Validation

- focused Arkansas registry/runtime/entity/fallback/coverage/pin suite — 3 passed
- promoted 2026 state registry suites plus `tests/test_rulespec_validation.py` — 1,352 passed, 31 skipped
- full repository suite — 5,973 passed, 119 skipped
- `ruff check pyproject.toml src/axiom_encode scripts tests` — passed
- `ruff format --check src/ tests/` — 138 files already formatted
- `python -m compileall -q src/axiom_encode scripts` — passed
- `uv lock --check` — passed
- `git diff --check` and explicit pin/version/fallback hash checks — passed

Tests used a clean archive of exact oracle commit `678dd840b4c64e54c63805b0183f05c0f769b399` on `PYTHONPATH` to avoid mutating the shared development environment.

## Review cycle

- independent review of commit `4694893eb1d22a19af38ccef586d372a1ae515c8` returned CLEAN with no actionable findings
- reviewer independently verified byte-identical exact mapping and fallback material, Person entity, scope exclusions, pin/version/lock propagation, and focused checks
