### PR TITLE
Add authenticated RuleSpec path migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
 # Changelog
 
 All notable changes to Axiom Encode will be documented here.
+
+- Add a broker-authenticated `migrate-rulespec-paths` workflow for
+  current-v5 model encodings. It permits only deterministic engine-safe path
+  normalization and exact durable-reference rewrites, preserves legal corpus
+  citations and nested model provenance, binds the clean repository base/tree,
+  corpus, waiver set, plan, paths, and hashes in a signed receipt, and installs
+  the complete migration transactionally. Persisted verification recomputes
+  every move and dependent rewrite from the receipt-bound Git base, enforces the
+  current encoder identity, uses no-follow bounded reads and sanitized Git
+  inspection, preserves path-only `0644` file semantics in live verification,
+  and reuses one digest-bound receipt proof per multi-manifest operation.

--- a/README.md
+++ b/README.md
@@ -262,6 +262,43 @@ build/axiom-encode-signing-supervisor \
 `retire` accepts only a module already covered by a verified model
 `encode --apply` manifest and includes its companion test automatically.
 
+Canonicalize paths of already-authenticated v5 model encodings with the
+separate path-only workflow. The plan is deliberately minimal and binds one
+clean RuleSpec HEAD:
+
+```json
+{
+  "schema_version": "axiom-encode/rulespec-path-migration-plan/v1",
+  "base_commit": "0123456789abcdef0123456789abcdef01234567",
+  "moves": [
+    {
+      "from": "us-la/statutes/47:32.yaml",
+      "to": "us-la/statutes/47/32.yaml"
+    }
+  ]
+}
+```
+
+Run it under the same protected apply-signing supervisor:
+
+```bash
+axiom-encode migrate-rulespec-paths \
+  --plan /tmp/canonical-paths.json \
+  --policy-repo-path ~/TheAxiomFoundation/rulespec-us \
+  --corpus-path ~/TheAxiomFoundation/axiom-corpus
+```
+
+The destination must be the command's unique normalization of colon, whitespace,
+case, or non-ASCII-dash path components. Companion tests and exact durable
+RuleSpec references are derived rather than caller-authored. Legal
+`corpus_citation_path` strings are preserved. The command accepts only files
+with exactly one valid current-v5 model owner; legacy HMAC, manual,
+deterministic, unmanifested, overlapping, or stale provenance fails closed.
+It signs a plan/HEAD/tree/corpus/waiver/hash-bound receipt under
+`.axiom/path-migrations/`, embeds the prior signed model manifest in each
+replacement manifest, and installs moves, reference rewrites, receipts, and
+manifests in one recoverable transaction.
+
 Repository CI should run:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1408"
+version = "0.2.1409"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1409"
+version = "0.2.1410"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1408"
+__version__ = "0.2.1409"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1409"
+__version__ = "0.2.1410"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -6433,26 +6433,20 @@ def _manifest_census(
             raise
         entries, coverage = {}, {}
     else:
-        path_migration_receipt_proof_cache: dict[
-            tuple[str, str], tuple[str, ...]
-        ] = {}
+        path_migration_receipt_proof_cache: dict[tuple[str, str], tuple[str, ...]] = {}
         entries, _issues = _load_applied_encoding_manifest_entries(
             repo_path,
             surviving,
             roots=roots,
             expected_encoder_identity=expected_encoder_identity,
-            path_migration_receipt_proof_cache=(
-                path_migration_receipt_proof_cache
-            ),
+            path_migration_receipt_proof_cache=(path_migration_receipt_proof_cache),
         )
         coverage = _manifest_coverage_by_file(
             repo_path,
             surviving,
             roots=roots,
             expected_encoder_identity=expected_encoder_identity,
-            path_migration_receipt_proof_cache=(
-                path_migration_receipt_proof_cache
-            ),
+            path_migration_receipt_proof_cache=(path_migration_receipt_proof_cache),
         )
     encoder = unmanifested = 0
     unmanifested_paths: list[str] = []
@@ -10232,18 +10226,14 @@ def _applied_manifest_paths_for_files(
         expected_encoder_identity = _current_guard_encoder_execution_identity()
     except RuntimeError:
         return manifest_paths
-    path_migration_receipt_proof_cache: dict[
-        tuple[str, str], tuple[str, ...]
-    ] = {}
+    path_migration_receipt_proof_cache: dict[tuple[str, str], tuple[str, ...]] = {}
     for relative_manifest_path in _all_applied_encoding_manifest_paths(repo_path):
         payload, _root_prefix, _manifest_sha256, issues = (
             _load_verified_applied_encoding_manifest_payload(
                 repo_path,
                 relative_manifest_path,
                 expected_encoder_identity=expected_encoder_identity,
-                path_migration_receipt_proof_cache=(
-                    path_migration_receipt_proof_cache
-                ),
+                path_migration_receipt_proof_cache=(path_migration_receipt_proof_cache),
             )
         )
         if issues or payload is None:
@@ -17322,9 +17312,7 @@ def _cmd_migrate_rulespec_paths(args) -> None:
         raise SystemExit("Migration plan produces no file changes")
 
     all_manifest_paths = _all_applied_encoding_manifest_paths(repo_path, roots=roots)
-    planning_receipt_proof_cache: dict[
-        tuple[str, str], tuple[str, ...]
-    ] = {}
+    planning_receipt_proof_cache: dict[tuple[str, str], tuple[str, ...]] = {}
     coverage = _manifest_coverage_by_file(
         repo_path,
         all_manifest_paths,
@@ -17545,9 +17533,7 @@ def _cmd_migrate_rulespec_paths(args) -> None:
         locked_head, locked_tree = _rulespec_migration_base_identity(repo_path)
         if (locked_head, locked_tree) != (head_commit, base_tree):
             raise RuntimeError("RuleSpec base identity changed after planning")
-        pre_install_receipt_proof_cache: dict[
-            tuple[str, str], tuple[str, ...]
-        ] = {}
+        pre_install_receipt_proof_cache: dict[tuple[str, str], tuple[str, ...]] = {}
         for owner_path, (
             expected_payload,
             expected_digest,
@@ -17574,9 +17560,7 @@ def _cmd_migrate_rulespec_paths(args) -> None:
 
     def post_install_check() -> None:
         locked_release = locked_contract()
-        post_install_receipt_proof_cache: dict[
-            tuple[str, str], tuple[str, ...]
-        ] = {}
+        post_install_receipt_proof_cache: dict[tuple[str, str], tuple[str, ...]] = {}
         verified_receipt, digest, issues = _load_verified_path_migration_receipt(
             repo_path,
             receipt_relative.as_posix(),
@@ -17675,9 +17659,7 @@ def cmd_retire(args):
             unique_selected_targets.append(target)
 
     all_manifest_paths = _all_applied_encoding_manifest_paths(repo_path, roots=roots)
-    planning_receipt_proof_cache: dict[
-        tuple[str, str], tuple[str, ...]
-    ] = {}
+    planning_receipt_proof_cache: dict[tuple[str, str], tuple[str, ...]] = {}
     retirement_groups: dict[
         Path,
         tuple[list[Path], dict[str, object], str],
@@ -17713,9 +17695,7 @@ def cmd_retire(args):
                     expected_waiver_set_sha256=waiver_sha256,
                     local_corpus_release=local_corpus_release,
                     expected_encoder_identity=expected_encoder_identity,
-                    path_migration_receipt_proof_cache=(
-                        planning_receipt_proof_cache
-                    ),
+                    path_migration_receipt_proof_cache=(planning_receipt_proof_cache),
                 )
             )
             if issues or payload is None or manifest_sha256 is None:
@@ -17875,9 +17855,7 @@ def cmd_retire(args):
 
     def pre_install_check() -> None:
         locked_waiver, locked_release = locked_retirement_contract()
-        pre_install_receipt_proof_cache: dict[
-            tuple[str, str], tuple[str, ...]
-        ] = {}
+        pre_install_receipt_proof_cache: dict[tuple[str, str], tuple[str, ...]] = {}
         for manifest_path, (
             _covered,
             expected_payload,
@@ -17904,9 +17882,7 @@ def cmd_retire(args):
 
     def post_install_check() -> None:
         locked_waiver, locked_release = locked_retirement_contract()
-        post_install_receipt_proof_cache: dict[
-            tuple[str, str], tuple[str, ...]
-        ] = {}
+        post_install_receipt_proof_cache: dict[tuple[str, str], tuple[str, ...]] = {}
         for manifest_path in manifest_paths:
             verified, _root_prefix, _digest, issues = (
                 _load_verified_applied_encoding_manifest_payload(
@@ -18071,9 +18047,7 @@ def guard_generated_change_issues(
     # immutable-base/live-file proof is intentionally snapshotted once for
     # this guard operation; the cache is discarded before the next operation,
     # and its digest key invalidates a changed receipt within this operation.
-    path_migration_receipt_proof_cache: dict[
-        tuple[str, str], tuple[str, ...]
-    ] = {}
+    path_migration_receipt_proof_cache: dict[tuple[str, str], tuple[str, ...]] = {}
     manifest_entries, manifest_issues = _load_applied_encoding_manifest_entries(
         repo_path,
         surviving_manifest_paths,
@@ -18125,9 +18099,7 @@ def guard_generated_change_issues(
             local_corpus_release=local_corpus_release,
             expected_encoder_identity=expected_encoder_identity,
             expected_waiver_set_sha256=expected_manifest_waiver_set_sha256,
-            path_migration_receipt_proof_cache=(
-                path_migration_receipt_proof_cache
-            ),
+            path_migration_receipt_proof_cache=(path_migration_receipt_proof_cache),
         )
     )
 
@@ -18262,9 +18234,7 @@ def _generated_provenance_gate_issues(
     local_corpus_release: LocalCorpusRelease,
     expected_encoder_identity: Mapping[str, str],
     expected_waiver_set_sha256: str,
-    path_migration_receipt_proof_cache: dict[
-        tuple[str, str], tuple[str, ...]
-    ],
+    path_migration_receipt_proof_cache: dict[tuple[str, str], tuple[str, ...]],
 ) -> list[str]:
     """Reject protected files authorized only by manual attestations."""
 
@@ -18473,9 +18443,7 @@ def _manifest_coverage_by_file(
     local_corpus_release: LocalCorpusRelease | None = None,
     expected_encoder_identity: Mapping[str, str] | None = None,
     expected_waiver_set_sha256: str | None = None,
-    path_migration_receipt_proof_cache: dict[
-        tuple[str, str], tuple[str, ...]
-    ]
+    path_migration_receipt_proof_cache: dict[tuple[str, str], tuple[str, ...]]
     | None = None,
 ) -> dict[str, list[dict[str, object]]]:
     """Map each non-deleted covered file to a list of covering-manifest records.
@@ -18502,9 +18470,7 @@ def _manifest_coverage_by_file(
                 local_corpus_release=local_corpus_release,
                 expected_encoder_identity=expected_encoder_identity,
                 expected_waiver_set_sha256=expected_waiver_set_sha256,
-                path_migration_receipt_proof_cache=(
-                    path_migration_receipt_proof_cache
-                ),
+                path_migration_receipt_proof_cache=(path_migration_receipt_proof_cache),
             )
         )
         if issues or payload is None or root_prefix is None:
@@ -19942,10 +19908,7 @@ def _migrated_model_manifest_issues(
     signing_broker: SigningBroker | Ed25519PublicKey,
     expected_waiver_set_sha256: str,
     local_corpus_release: LocalCorpusRelease | None,
-    path_migration_receipt_proof_cache: dict[
-        tuple[str, str], tuple[str, ...]
-    ]
-    | None,
+    path_migration_receipt_proof_cache: dict[tuple[str, str], tuple[str, ...]] | None,
 ) -> list[str]:
     """Verify nested model provenance and the signed path-only receipt."""
 
@@ -20161,9 +20124,7 @@ def _load_verified_applied_encoding_manifest_payload(
     expected_waiver_set_sha256: str | None = None,
     local_corpus_release: LocalCorpusRelease | None = None,
     expected_encoder_identity: Mapping[str, str] | None = None,
-    path_migration_receipt_proof_cache: dict[
-        tuple[str, str], tuple[str, ...]
-    ]
+    path_migration_receipt_proof_cache: dict[tuple[str, str], tuple[str, ...]]
     | None = None,
 ) -> tuple[dict[str, object] | None, str | None, str | None, list[str]]:
     """Load one canonical v5 apply manifest and verify every binding."""
@@ -20388,9 +20349,7 @@ def _load_verified_applied_encoding_manifest_payload(
             signing_broker=signing_broker,
             expected_waiver_set_sha256=expected_waiver_set_sha256,
             local_corpus_release=local_corpus_release,
-            path_migration_receipt_proof_cache=(
-                path_migration_receipt_proof_cache
-            ),
+            path_migration_receipt_proof_cache=(path_migration_receipt_proof_cache),
         )
     )
     issues.extend(
@@ -20440,9 +20399,7 @@ def _load_applied_encoding_manifest_entries(
     local_corpus_release: LocalCorpusRelease | None = None,
     expected_encoder_identity: Mapping[str, str] | None = None,
     expected_waiver_set_sha256: str | None = None,
-    path_migration_receipt_proof_cache: dict[
-        tuple[str, str], tuple[str, ...]
-    ]
+    path_migration_receipt_proof_cache: dict[tuple[str, str], tuple[str, ...]]
     | None = None,
 ) -> tuple[dict[str, set[str]], list[str]]:
     entries: dict[str, set[str]] = defaultdict(set)
@@ -20486,9 +20443,7 @@ def _load_applied_encoding_manifest_entries(
                 expected_waiver_set_sha256=expected_waiver_set_sha256,
                 local_corpus_release=local_corpus_release,
                 expected_encoder_identity=expected_encoder_identity,
-                path_migration_receipt_proof_cache=(
-                    path_migration_receipt_proof_cache
-                ),
+                path_migration_receipt_proof_cache=(path_migration_receipt_proof_cache),
             )
         )
         issues.extend(manifest_issues)

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -34,7 +34,7 @@ from base64 import b64decode, b64encode
 from binascii import Error as BinasciiError
 from calendar import monthrange
 from collections import Counter, defaultdict
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import asdict, is_dataclass
 from datetime import date, datetime, timezone
 from decimal import Decimal, InvalidOperation, localcontext
@@ -283,6 +283,22 @@ from .repo_routing import (
     monorepo_checkout_name,
 )
 from .rules_engine_compat import run_rulespec_compile
+from .rulespec_path_migration import (
+    MIGRATION_TOOL as APPLIED_ENCODING_PATH_MIGRATION_TOOL,
+)
+from .rulespec_path_migration import (
+    RECEIPT_DIR as APPLIED_ENCODING_PATH_MIGRATION_RECEIPT_DIR,
+)
+from .rulespec_path_migration import (
+    RECEIPT_SCHEMA as APPLIED_ENCODING_PATH_MIGRATION_RECEIPT_SCHEMA,
+)
+from .rulespec_path_migration import (
+    PathMigrationPlanError,
+    companion_path,
+    exact_reference_replacements,
+    load_plan_bytes,
+    rewrite_exact_references,
+)
 from .signing_broker import (
     _SIGNATURE_DOMAIN_PREFIX,
     SigningBroker,
@@ -373,8 +389,25 @@ _RETIRE_APPLY_MANIFEST_FIELDS = frozenset(
         "signature",
     }
 )
+_PATH_MIGRATION_APPLY_MANIFEST_FIELDS = frozenset(
+    {
+        "schema_version",
+        "generated_at",
+        "tool",
+        "axiom_encode_version",
+        "axiom_encode_git",
+        VALIDATION_WAIVER_SET_SHA256_FIELD,
+        "applied_files",
+        "migrated_manifest",
+        "migration",
+        "source_attestation",
+        "signature",
+    }
+)
 _MODEL_APPLIED_FILE_FIELDS = frozenset({"path", "sha256"})
 _RETIRED_APPLIED_FILE_FIELDS = frozenset({"path", "deleted"})
+_PATH_MIGRATION_LIVE_FILE_FIELDS = frozenset({"path", "sha256"})
+_PATH_MIGRATION_DELETED_FILE_FIELDS = frozenset({"path", "deleted"})
 
 
 def _resolve_explicit_existing_directory(raw_path: Path, *, label: str) -> Path:
@@ -1797,6 +1830,27 @@ def main():
     )
     _add_required_corpus_path_argument(retire_parser)
 
+    path_migration_parser = subparsers.add_parser(
+        "migrate-rulespec-paths",
+        help=(
+            "Transactionally normalize authenticated v5 RuleSpec paths and "
+            "their exact durable references"
+        ),
+    )
+    path_migration_parser.add_argument(
+        "--plan",
+        type=Path,
+        required=True,
+        help="Exact-schema JSON move plan bound to the current RuleSpec HEAD",
+    )
+    path_migration_parser.add_argument(
+        "--policy-repo-path",
+        type=Path,
+        required=True,
+        help="Exact canonical rulespec-<country> checkout",
+    )
+    _add_required_corpus_path_argument(path_migration_parser)
+
     # test command
     test_parser = subparsers.add_parser(
         "test", help="Execute RuleSpec companion .test.yaml cases"
@@ -2585,6 +2639,8 @@ def main():
         cmd_program_scope_sync(args)
     elif args.command == "retire":
         cmd_retire(args)
+    elif args.command == "migrate-rulespec-paths":
+        cmd_migrate_rulespec_paths(args)
     elif args.command == "guard-generated":
         cmd_guard_generated(args)
     elif args.command == "manifest-census":
@@ -6377,17 +6433,26 @@ def _manifest_census(
             raise
         entries, coverage = {}, {}
     else:
+        path_migration_receipt_proof_cache: dict[
+            tuple[str, str], tuple[str, ...]
+        ] = {}
         entries, _issues = _load_applied_encoding_manifest_entries(
             repo_path,
             surviving,
             roots=roots,
             expected_encoder_identity=expected_encoder_identity,
+            path_migration_receipt_proof_cache=(
+                path_migration_receipt_proof_cache
+            ),
         )
         coverage = _manifest_coverage_by_file(
             repo_path,
             surviving,
             roots=roots,
             expected_encoder_identity=expected_encoder_identity,
+            path_migration_receipt_proof_cache=(
+                path_migration_receipt_proof_cache
+            ),
         )
     encoder = unmanifested = 0
     unmanifested_paths: list[str] = []
@@ -6401,8 +6466,7 @@ def _manifest_census(
             and _sha256_file(current) in expected_hashes
         )
         if covered and any(
-            record["backend"] in APPLIED_ENCODING_ENCODER_BACKENDS
-            for record in coverage.get(path, [])
+            record["is_generated"] is True for record in coverage.get(path, [])
         ):
             encoder += 1
         else:
@@ -10168,12 +10232,18 @@ def _applied_manifest_paths_for_files(
         expected_encoder_identity = _current_guard_encoder_execution_identity()
     except RuntimeError:
         return manifest_paths
+    path_migration_receipt_proof_cache: dict[
+        tuple[str, str], tuple[str, ...]
+    ] = {}
     for relative_manifest_path in _all_applied_encoding_manifest_paths(repo_path):
         payload, _root_prefix, _manifest_sha256, issues = (
             _load_verified_applied_encoding_manifest_payload(
                 repo_path,
                 relative_manifest_path,
                 expected_encoder_identity=expected_encoder_identity,
+                path_migration_receipt_proof_cache=(
+                    path_migration_receipt_proof_cache
+                ),
             )
         )
         if issues or payload is None:
@@ -16808,6 +16878,753 @@ def _is_generated_zero_expected_value(value: object) -> bool:
     return False
 
 
+def _rulespec_migration_git_environment() -> dict[str, str]:
+    """Return an environment unable to redirect Git away from the checkout."""
+
+    environment = dict(os.environ)
+    for name in tuple(environment):
+        if name.startswith("GIT_"):
+            environment.pop(name)
+    environment.update(
+        {
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_SYSTEM": os.devnull,
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_LITERAL_PATHSPECS": "1",
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_NO_REPLACE_OBJECTS": "1",
+            "GIT_OPTIONAL_LOCKS": "0",
+        }
+    )
+    return environment
+
+
+def _rulespec_migration_git_bytes(repo_path: Path, *arguments: str) -> bytes:
+    """Run one read-only Git query with repository-routing authority removed."""
+
+    completed = subprocess.run(
+        ["git", "-C", str(repo_path), *arguments],
+        capture_output=True,
+        env=_rulespec_migration_git_environment(),
+        check=False,
+    )
+    if completed.returncode != 0:
+        stderr = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(
+            f"Cannot inspect RuleSpec Git identity ({' '.join(arguments)}): {stderr}"
+        )
+    return completed.stdout
+
+
+def _rulespec_migration_git(repo_path: Path, *arguments: str) -> str:
+    return _rulespec_migration_git_bytes(repo_path, *arguments).decode("utf-8")
+
+
+def _rulespec_migration_base_blob(
+    repo_path: Path,
+    commit: str,
+    relative: Path,
+) -> bytes:
+    """Read one regular 0644 blob from a receipt-bound Git base."""
+
+    path_text = relative.as_posix()
+    if (
+        relative.is_absolute()
+        or path_text != str(relative)
+        or any(part in {"", ".", ".."} for part in relative.parts)
+    ):
+        raise RuntimeError("Migration receipt contains a noncanonical repository path")
+    listing = _rulespec_migration_git_bytes(
+        repo_path,
+        "ls-tree",
+        "-z",
+        "--full-tree",
+        commit,
+        "--",
+        path_text,
+    )
+    records = [record for record in listing.split(b"\0") if record]
+    if len(records) != 1:
+        raise RuntimeError(f"Migration base does not contain exactly one {path_text}")
+    try:
+        metadata, encoded_path = records[0].split(b"\t", 1)
+        mode, object_type, _object_id = metadata.decode("ascii").split(" ")
+        listed_path = encoded_path.decode("utf-8")
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise RuntimeError("Migration base tree entry is malformed") from exc
+    if mode != "100644" or object_type != "blob" or listed_path != path_text:
+        raise RuntimeError(
+            f"Migration base path is not a regular 0644 file: {path_text}"
+        )
+    return _rulespec_migration_git_bytes(repo_path, "show", f"{commit}:{path_text}")
+
+
+def _rulespec_migration_base_identity(repo_path: Path) -> tuple[str, str]:
+    head = _rulespec_migration_git(repo_path, "rev-parse", "HEAD").strip()
+    tree = _rulespec_migration_git(repo_path, "rev-parse", "HEAD^{tree}").strip()
+    if (
+        re.fullmatch(r"[0-9a-f]{40}", head) is None
+        or re.fullmatch(r"[0-9a-f]{40}", tree) is None
+    ):
+        raise RuntimeError("RuleSpec checkout has a malformed HEAD or tree identity")
+    status = _rulespec_migration_git(
+        repo_path,
+        "status",
+        "--porcelain",
+        "--untracked-files=no",
+    )
+    if status.strip():
+        raise RuntimeError(
+            "Canonical path migration requires a clean tracked RuleSpec checkout"
+        )
+    return head, tree
+
+
+def _rulespec_migration_tracked_files(repo_path: Path) -> dict[Path, str]:
+    """Return exact tracked regular-file modes, rejecting ambiguous Git stages."""
+
+    raw = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo_path),
+            "-c",
+            "core.quotepath=false",
+            "ls-files",
+            "--stage",
+            "-z",
+        ],
+        capture_output=True,
+        env=_rulespec_migration_git_environment(),
+        check=False,
+    )
+    if raw.returncode != 0:
+        raise RuntimeError("Cannot enumerate tracked RuleSpec files")
+    result: dict[Path, str] = {}
+    for record in raw.stdout.split(b"\0"):
+        if not record:
+            continue
+        try:
+            metadata, encoded_path = record.split(b"\t", 1)
+            mode, _object_id, stage = metadata.decode("ascii").split(" ")
+            path_text = encoded_path.decode("utf-8")
+        except (ValueError, UnicodeDecodeError) as exc:
+            raise RuntimeError("RuleSpec tracked-file index is malformed") from exc
+        path = Path(path_text)
+        if (
+            stage != "0"
+            or path.is_absolute()
+            or path.as_posix() != path_text
+            or any(part in {"", ".", ".."} for part in path.parts)
+            or path in result
+        ):
+            raise RuntimeError("RuleSpec tracked-file index is ambiguous")
+        result[path] = mode
+    return result
+
+
+def _migration_corpus_citations(raw: bytes) -> tuple[str, ...]:
+    """Collect legal corpus identities so path normalization cannot mutate them."""
+
+    try:
+        payload = yaml.safe_load(raw.decode("utf-8"))
+    except (UnicodeDecodeError, yaml.YAMLError):
+        return ()
+    values: list[str] = []
+
+    def walk(value: object) -> None:
+        if isinstance(value, dict):
+            for key, child in value.items():
+                if key == "corpus_citation_path" and isinstance(child, str):
+                    values.append(child)
+                walk(child)
+        elif isinstance(value, list):
+            for child in value:
+                walk(child)
+
+    walk(payload)
+    return tuple(values)
+
+
+def _migration_manifest_destination(
+    manifest_path: Path,
+    replacements: Mapping[str, str],
+) -> Path:
+    raw, counts = rewrite_exact_references(
+        manifest_path.as_posix().encode("utf-8"),
+        replacements,
+    )
+    if any(not str(item.get("from", "")).endswith(".yaml") for item in counts):
+        raise RuntimeError("Manifest path migration used a non-path replacement")
+    destination = Path(raw.decode("utf-8"))
+    if (
+        destination.is_absolute()
+        or destination.suffix != ".json"
+        or any(part in {"", ".", ".."} for part in destination.parts)
+        or _applied_encoding_manifest_root_prefix(
+            destination,
+            roots=tuple(sorted(RULESPEC_ATOMIC_MODULE_ROOTS)),
+        )
+        is None
+    ):
+        raise RuntimeError("Path migration produced a noncanonical manifest path")
+    return destination
+
+
+@contextlib.contextmanager
+def _rulespec_migration_clean_ambient_git() -> Iterator[None]:
+    """Remove all ambient Git authority for the complete migration command."""
+
+    saved = {
+        name: value for name, value in os.environ.items() if name.startswith("GIT_")
+    }
+    for name in saved:
+        os.environ.pop(name, None)
+    try:
+        yield
+    finally:
+        for name in tuple(os.environ):
+            if name.startswith("GIT_"):
+                os.environ.pop(name)
+        os.environ.update(saved)
+
+
+def cmd_migrate_rulespec_paths(args) -> None:
+    """Apply one broker-authenticated, path-only v5 RuleSpec migration."""
+
+    with _rulespec_migration_clean_ambient_git():
+        _cmd_migrate_rulespec_paths(args)
+
+
+def _cmd_migrate_rulespec_paths(args) -> None:
+    """Implementation under a command-wide sanitized Git environment."""
+
+    repo_path = _resolve_canonical_rulespec_checkout(
+        args.policy_repo_path,
+        label="RuleSpec checkout",
+    )
+    _recover_apply_transaction(repo_path)
+    signing_broker = _require_applied_encoding_manifest_signer()
+    local_corpus_release = load_rulespec_local_corpus_release(
+        repo_path,
+        Path(args.corpus_path),
+    )
+    waiver_sha256 = verify_rulespec_validation_waiver_set(repo_path)
+    expected_encoder_identity = _current_guard_encoder_execution_identity()
+    encoder_provenance = _require_clean_axiom_encode_git_provenance()
+    head_commit, base_tree = _rulespec_migration_base_identity(repo_path)
+
+    try:
+        plan_path = Path(os.path.abspath(Path(args.plan).expanduser()))
+        resolved_plan = plan_path.resolve(strict=True)
+        if resolved_plan != plan_path:
+            raise UnsafeCorpusPathError(
+                "migration plan or one of its ancestors is a symlink"
+            )
+        plan_raw = read_bounded_regular_file(
+            Path(plan_path.anchor),
+            plan_path,
+            label="RuleSpec path migration plan",
+            max_bytes=1024 * 1024,
+        )
+    except (OSError, UnsafeCorpusPathError) as exc:
+        raise SystemExit(f"Cannot read migration plan safely: {exc}") from exc
+    try:
+        plan = load_plan_bytes(plan_raw)
+    except PathMigrationPlanError as exc:
+        raise SystemExit(f"Invalid migration plan: {exc}") from exc
+    if plan.base_commit != head_commit:
+        raise SystemExit(
+            f"Migration plan base_commit {plan.base_commit} does not match "
+            f"RuleSpec HEAD {head_commit}"
+        )
+
+    tracked = _rulespec_migration_tracked_files(repo_path)
+    roots = tuple(sorted(RULESPEC_ATOMIC_MODULE_ROOTS))
+    primary_moves = {move.source: move.destination for move in plan.moves}
+    file_moves: dict[Path, Path] = {}
+    existing_companions: set[Path] = set()
+    for source, destination in primary_moves.items():
+        if source not in tracked:
+            raise SystemExit(f"Migration source is not tracked: {source.as_posix()}")
+        if tracked[source] != "100644":
+            raise SystemExit(
+                f"Migration source is not a regular 0644 file: {source.as_posix()}"
+            )
+        if (repo_path / source).is_symlink():
+            raise SystemExit(f"Migration source is a symlink: {source.as_posix()}")
+        if (
+            destination in tracked
+            or (repo_path / destination).exists()
+            or (repo_path / destination).is_symlink()
+        ):
+            raise SystemExit(
+                f"Migration destination collides with an existing path: "
+                f"{destination.as_posix()}"
+            )
+        file_moves[source] = destination
+        old_companion = companion_path(source)
+        if old_companion in tracked:
+            if (
+                tracked[old_companion] != "100644"
+                or (repo_path / old_companion).is_symlink()
+            ):
+                raise SystemExit(
+                    f"Migration companion is not a regular 0644 file: "
+                    f"{old_companion.as_posix()}"
+                )
+            new_companion = companion_path(destination)
+            if (
+                new_companion in tracked
+                or (repo_path / new_companion).exists()
+                or (repo_path / new_companion).is_symlink()
+            ):
+                raise SystemExit(
+                    f"Migration companion destination collides: "
+                    f"{new_companion.as_posix()}"
+                )
+            existing_companions.add(old_companion)
+            file_moves[old_companion] = new_companion
+
+    try:
+        replacements = exact_reference_replacements(
+            plan.moves,
+            existing_companions=existing_companions,
+        )
+    except PathMigrationPlanError as exc:
+        raise SystemExit(f"Invalid migration replacement set: {exc}") from exc
+
+    manifest_prefix = APPLIED_ENCODING_MANIFEST_DIR.parts
+    receipt_prefix = APPLIED_ENCODING_PATH_MIGRATION_RECEIPT_DIR.parts
+    planned_files: dict[Path, bytes | None] = {}
+    expected_originals: dict[Path, str | None] = {}
+    rewrite_records: list[dict[str, object]] = []
+    move_records: list[dict[str, object]] = []
+    protected_changed: set[Path] = set()
+    skipped_manifest_matches: list[Path] = []
+    for relative, mode in sorted(tracked.items(), key=lambda item: item[0].as_posix()):
+        absolute = repo_path / relative
+        if relative.parts[: len(manifest_prefix)] == manifest_prefix:
+            if mode != "100644":
+                raise SystemExit(
+                    f"Tracked migration manifest is not a regular 0644 file: "
+                    f"{relative.as_posix()}"
+                )
+            try:
+                raw = read_bounded_regular_file(
+                    repo_path,
+                    absolute,
+                    label=f"tracked migration manifest {relative.as_posix()}",
+                    max_bytes=4 * 1024 * 1024,
+                )
+            except UnsafeCorpusPathError as exc:
+                raise SystemExit(str(exc)) from exc
+            if any(old.encode("utf-8") in raw for old in replacements):
+                skipped_manifest_matches.append(relative)
+            continue
+        if relative.parts[: len(receipt_prefix)] == receipt_prefix:
+            if mode != "100644":
+                raise SystemExit(
+                    f"Prior migration receipt is not a regular 0644 file: "
+                    f"{relative.as_posix()}"
+                )
+            try:
+                prior_receipt_raw = read_bounded_regular_file(
+                    repo_path,
+                    absolute,
+                    label=f"prior migration receipt {relative.as_posix()}",
+                    max_bytes=4 * 1024 * 1024,
+                )
+            except UnsafeCorpusPathError as exc:
+                raise SystemExit(str(exc)) from exc
+            if any(old.encode("utf-8") in prior_receipt_raw for old in replacements):
+                raise SystemExit(
+                    f"Prior migration receipt still references a moved identity: "
+                    f"{relative.as_posix()}"
+                )
+            continue
+        if mode not in {"100644", "100755"}:
+            raw = _rulespec_migration_git_bytes(
+                repo_path,
+                "show",
+                f"HEAD:{relative.as_posix()}",
+            )
+            if any(old.encode("utf-8") in raw for old in replacements):
+                raise SystemExit(
+                    f"Durable reference occurs in non-regular tracked path: "
+                    f"{relative.as_posix()}"
+                )
+            continue
+        if absolute.is_symlink() or not absolute.is_file():
+            raise SystemExit(
+                f"Tracked migration input is not a trusted regular file: "
+                f"{relative.as_posix()}"
+            )
+        raw = read_bounded_regular_file(
+            repo_path,
+            absolute,
+            label=f"tracked migration input {relative.as_posix()}",
+            max_bytes=16 * 1024 * 1024,
+        )
+        try:
+            rewritten, counts = rewrite_exact_references(raw, replacements)
+        except PathMigrationPlanError as exc:
+            raise SystemExit(f"Cannot rewrite {relative.as_posix()}: {exc}") from exc
+        destination = file_moves.get(relative, relative)
+        if relative in file_moves:
+            planned_files[relative] = None
+            expected_originals[absolute] = hashlib.sha256(raw).hexdigest()
+            planned_files[destination] = rewritten
+            expected_originals[repo_path / destination] = None
+            move_records.append(
+                {
+                    "from": relative.as_posix(),
+                    "to": destination.as_posix(),
+                    "from_sha256": hashlib.sha256(raw).hexdigest(),
+                    "to_sha256": hashlib.sha256(rewritten).hexdigest(),
+                    "kind": (
+                        "companion"
+                        if relative.name.endswith(".test.yaml")
+                        else "primary"
+                    ),
+                }
+            )
+            protected_changed.add(relative)
+        elif counts:
+            planned_files[relative] = rewritten
+            expected_originals[absolute] = hashlib.sha256(raw).hexdigest()
+        if counts:
+            if mode != "100644":
+                raise SystemExit(
+                    f"Migration cannot rewrite non-0644 tracked file: "
+                    f"{relative.as_posix()}"
+                )
+            if relative.suffix in {".yaml", ".yml"} and (
+                _migration_corpus_citations(raw)
+                != _migration_corpus_citations(rewritten)
+            ):
+                raise SystemExit(
+                    f"Migration would alter legal corpus citations in "
+                    f"{relative.as_posix()}"
+                )
+            rewrite_records.append(
+                {
+                    "path": destination.as_posix(),
+                    "before_sha256": hashlib.sha256(raw).hexdigest(),
+                    "after_sha256": hashlib.sha256(rewritten).hexdigest(),
+                    "replacements": list(counts),
+                }
+            )
+            if _is_protected_rulespec_yaml_path(relative, roots=roots):
+                protected_changed.add(relative)
+
+    if not planned_files:
+        raise SystemExit("Migration plan produces no file changes")
+
+    all_manifest_paths = _all_applied_encoding_manifest_paths(repo_path, roots=roots)
+    planning_receipt_proof_cache: dict[
+        tuple[str, str], tuple[str, ...]
+    ] = {}
+    coverage = _manifest_coverage_by_file(
+        repo_path,
+        all_manifest_paths,
+        roots=roots,
+        local_corpus_release=local_corpus_release,
+        expected_encoder_identity=expected_encoder_identity,
+        expected_waiver_set_sha256=waiver_sha256,
+        path_migration_receipt_proof_cache=planning_receipt_proof_cache,
+    )
+    owner_paths: set[str] = set()
+    for protected in sorted(protected_changed):
+        owners = coverage.get(protected.as_posix(), [])
+        generated_owners = [
+            owner for owner in owners if owner.get("is_generated") is True
+        ]
+        if len(owners) != 1 or len(generated_owners) != 1:
+            labels = sorted(str(owner.get("manifest")) for owner in owners)
+            detail = ", ".join(labels) if labels else "none"
+            raise SystemExit(
+                f"Cannot migrate {protected.as_posix()}: expected exactly one "
+                f"authenticated generated v5 owner, found {detail}"
+            )
+        owner_paths.add(str(generated_owners[0]["manifest"]))
+
+    unmatched_manifest_refs = sorted(
+        set(skipped_manifest_matches) - {Path(path) for path in owner_paths}
+    )
+    if unmatched_manifest_refs:
+        raise SystemExit(
+            "Migration would leave partial durable references in unrelated signed "
+            "manifests: "
+            + ", ".join(path.as_posix() for path in unmatched_manifest_refs)
+        )
+
+    prior_groups: dict[str, tuple[dict[str, object], str, Path]] = {}
+    manifest_receipt_records: list[dict[str, object]] = []
+    for owner_path in sorted(owner_paths):
+        if tracked.get(Path(owner_path)) != "100644":
+            raise SystemExit(
+                f"Prior migration manifest is not a regular 0644 file: {owner_path}"
+            )
+        payload, _root_prefix, digest, issues = (
+            _load_verified_applied_encoding_manifest_payload(
+                repo_path,
+                owner_path,
+                roots=roots,
+                signing_broker=signing_broker,
+                expected_waiver_set_sha256=waiver_sha256,
+                local_corpus_release=local_corpus_release,
+                expected_encoder_identity=expected_encoder_identity,
+                path_migration_receipt_proof_cache=planning_receipt_proof_cache,
+            )
+        )
+        if issues or payload is None or digest is None:
+            raise SystemExit(
+                f"Cannot migrate invalid prior manifest {owner_path}: "
+                + "; ".join(issues)
+            )
+        if _normalized_manifest_backend(payload) not in (
+            APPLIED_ENCODING_GENERATED_BACKENDS
+        ):
+            raise SystemExit(f"Cannot migrate non-model provenance in {owner_path}")
+        destination = next(
+            (
+                _applied_encoding_manifest_path(new_primary)
+                for old_primary, new_primary in primary_moves.items()
+                if Path(owner_path) == _applied_encoding_manifest_path(old_primary)
+            ),
+            _migration_manifest_destination(Path(owner_path), replacements),
+        )
+        if destination != Path(owner_path) and (
+            destination in tracked
+            or (repo_path / destination).exists()
+            or (repo_path / destination).is_symlink()
+        ):
+            raise SystemExit(
+                f"Replacement manifest destination collides: {destination.as_posix()}"
+            )
+        prior_groups[owner_path] = (payload, digest, destination)
+        manifest_receipt_records.append(
+            {
+                "prior_path": owner_path,
+                "prior_sha256": digest,
+                "replacement_path": destination.as_posix(),
+            }
+        )
+
+    receipt_relative = (
+        APPLIED_ENCODING_PATH_MIGRATION_RECEIPT_DIR / f"{plan.sha256}.json"
+    )
+    if (
+        receipt_relative in tracked
+        or (repo_path / receipt_relative).exists()
+        or (repo_path / receipt_relative).is_symlink()
+    ):
+        raise SystemExit(
+            f"Migration receipt already exists: {receipt_relative.as_posix()}"
+        )
+    receipt_payload: dict[str, object] = {
+        "schema_version": APPLIED_ENCODING_PATH_MIGRATION_RECEIPT_SCHEMA,
+        "generated_at": _utc_now_iso(),
+        "tool": APPLIED_ENCODING_PATH_MIGRATION_TOOL,
+        "plan_sha256": plan.sha256,
+        "plan": dict(plan.payload),
+        "repository": {
+            "base_commit": plan.base_commit,
+            "head_commit": head_commit,
+            "base_tree": base_tree,
+        },
+        "axiom_encode_version": __version__,
+        "axiom_encode_git": encoder_provenance,
+        VALIDATION_WAIVER_SET_SHA256_FIELD: waiver_sha256,
+        "corpus_release": {
+            "name": local_corpus_release.name,
+            "content_sha256": local_corpus_release.content_sha256,
+            "selector_sha256": local_corpus_release.selector_sha256,
+        },
+        "moves": sorted(move_records, key=lambda item: str(item["from"])),
+        "rewrites": sorted(rewrite_records, key=lambda item: str(item["path"])),
+        "manifests": manifest_receipt_records,
+    }
+    _sign_applied_encoding_manifest(receipt_payload, signing_broker)
+    receipt_bytes = (
+        json.dumps(receipt_payload, indent=2, sort_keys=True) + "\n"
+    ).encode()
+    receipt_sha256 = hashlib.sha256(receipt_bytes).hexdigest()
+    planned_files[receipt_relative] = receipt_bytes
+    expected_originals[repo_path / receipt_relative] = None
+
+    for owner_path, (prior, prior_digest, destination) in prior_groups.items():
+        prior_entries = prior.get("applied_files")
+        assert isinstance(prior_entries, list)
+        new_entries: list[dict[str, object]] = []
+        for item in prior_entries:
+            assert isinstance(item, dict)
+            old_path = Path(str(item["path"]))
+            live_path = file_moves.get(old_path, old_path)
+            if old_path in file_moves:
+                new_entries.append({"path": old_path.as_posix(), "deleted": True})
+            live_bytes = planned_files.get(live_path)
+            if live_bytes is None:
+                live_bytes = read_bounded_regular_file(
+                    repo_path,
+                    repo_path / live_path,
+                    label=f"migration manifest file {live_path.as_posix()}",
+                    max_bytes=10 * 1024 * 1024,
+                )
+            new_entries.append(
+                {
+                    "path": live_path.as_posix(),
+                    "sha256": hashlib.sha256(live_bytes).hexdigest(),
+                }
+            )
+        replacement_payload: dict[str, object] = {
+            "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+            "generated_at": _utc_now_iso(),
+            "tool": APPLIED_ENCODING_PATH_MIGRATION_TOOL,
+            "axiom_encode_version": __version__,
+            "axiom_encode_git": encoder_provenance,
+            VALIDATION_WAIVER_SET_SHA256_FIELD: waiver_sha256,
+            "applied_files": new_entries,
+            "migrated_manifest": prior,
+            "migration": {
+                "receipt_path": receipt_relative.as_posix(),
+                "receipt_sha256": receipt_sha256,
+                "plan_sha256": plan.sha256,
+                "prior_manifest_path": owner_path,
+                "prior_manifest_sha256": prior_digest,
+            },
+            "source_attestation": prior["source_attestation"],
+        }
+        _sign_applied_encoding_manifest(replacement_payload, signing_broker)
+        replacement_bytes = (
+            json.dumps(replacement_payload, indent=2, sort_keys=True) + "\n"
+        ).encode()
+        old_manifest = Path(owner_path)
+        if old_manifest != destination:
+            planned_files[old_manifest] = None
+        planned_files[destination] = replacement_bytes
+        expected_originals[repo_path / old_manifest] = prior_digest
+        if old_manifest != destination:
+            expected_originals[repo_path / destination] = None
+
+    transaction_files = [
+        (repo_path / relative, raw)
+        for relative, raw in sorted(
+            planned_files.items(), key=lambda item: item[0].as_posix()
+        )
+    ]
+    for target, _raw in transaction_files:
+        _ensure_safe_apply_target(repo_path, target)
+
+    expected_release_identity = (
+        local_corpus_release.root,
+        local_corpus_release.name,
+        local_corpus_release.content_sha256,
+        local_corpus_release.selector_sha256,
+    )
+
+    def locked_contract() -> LocalCorpusRelease:
+        if verify_rulespec_validation_waiver_set(repo_path) != waiver_sha256:
+            raise RuntimeError("Migration waiver set changed after validation")
+        locked_release = load_rulespec_local_corpus_release(
+            repo_path,
+            Path(args.corpus_path),
+        )
+        if (
+            locked_release.root,
+            locked_release.name,
+            locked_release.content_sha256,
+            locked_release.selector_sha256,
+        ) != expected_release_identity:
+            raise RuntimeError("Migration corpus release changed after validation")
+        return locked_release
+
+    def pre_install_check() -> None:
+        locked_contract()
+        locked_head, locked_tree = _rulespec_migration_base_identity(repo_path)
+        if (locked_head, locked_tree) != (head_commit, base_tree):
+            raise RuntimeError("RuleSpec base identity changed after planning")
+        pre_install_receipt_proof_cache: dict[
+            tuple[str, str], tuple[str, ...]
+        ] = {}
+        for owner_path, (
+            expected_payload,
+            expected_digest,
+            _destination,
+        ) in prior_groups.items():
+            verified, _prefix, digest, issues = (
+                _load_verified_applied_encoding_manifest_payload(
+                    repo_path,
+                    owner_path,
+                    roots=roots,
+                    signing_broker=signing_broker,
+                    expected_waiver_set_sha256=waiver_sha256,
+                    local_corpus_release=local_corpus_release,
+                    expected_encoder_identity=expected_encoder_identity,
+                    path_migration_receipt_proof_cache=(
+                        pre_install_receipt_proof_cache
+                    ),
+                )
+            )
+            if issues or verified != expected_payload or digest != expected_digest:
+                raise RuntimeError(
+                    f"Migration manifest changed after validation: {owner_path}"
+                )
+
+    def post_install_check() -> None:
+        locked_release = locked_contract()
+        post_install_receipt_proof_cache: dict[
+            tuple[str, str], tuple[str, ...]
+        ] = {}
+        verified_receipt, digest, issues = _load_verified_path_migration_receipt(
+            repo_path,
+            receipt_relative.as_posix(),
+            signing_broker=signing_broker,
+            expected_waiver_set_sha256=waiver_sha256,
+            local_corpus_release=locked_release,
+            proof_cache=post_install_receipt_proof_cache,
+        )
+        if issues or verified_receipt != receipt_payload or digest != receipt_sha256:
+            raise RuntimeError(
+                "Migration receipt failed post-install verification: "
+                + "; ".join(issues)
+            )
+        for _owner, (_prior, _digest, destination) in prior_groups.items():
+            verified, _prefix, _manifest_digest, manifest_issues = (
+                _load_verified_applied_encoding_manifest_payload(
+                    repo_path,
+                    destination.as_posix(),
+                    roots=roots,
+                    signing_broker=signing_broker,
+                    expected_waiver_set_sha256=waiver_sha256,
+                    local_corpus_release=locked_release,
+                    expected_encoder_identity=expected_encoder_identity,
+                    path_migration_receipt_proof_cache=(
+                        post_install_receipt_proof_cache
+                    ),
+                )
+            )
+            if verified is None or manifest_issues:
+                raise RuntimeError(
+                    f"Migration manifest failed post-install verification: "
+                    f"{destination}: {'; '.join(manifest_issues)}"
+                )
+
+    _install_apply_transaction(
+        transaction_files,
+        checkout_root=repo_path,
+        expected_originals=expected_originals,
+        pre_install_check=pre_install_check,
+        post_install_check=post_install_check,
+    )
+    for record in sorted(move_records, key=lambda item: str(item["from"])):
+        print(f"migrated {record['from']} -> {record['to']}")
+    print(f"signed {receipt_relative.as_posix()}")
+    for _owner, (_prior, _digest, destination) in prior_groups.items():
+        print(f"signed {destination.as_posix()}")
+
+
 def cmd_retire(args):
     """Delete live RuleSpec files and sign deletion entries for the guard."""
     repo_path = _resolve_canonical_rulespec_checkout(
@@ -16858,6 +17675,9 @@ def cmd_retire(args):
             unique_selected_targets.append(target)
 
     all_manifest_paths = _all_applied_encoding_manifest_paths(repo_path, roots=roots)
+    planning_receipt_proof_cache: dict[
+        tuple[str, str], tuple[str, ...]
+    ] = {}
     retirement_groups: dict[
         Path,
         tuple[list[Path], dict[str, object], str],
@@ -16893,6 +17713,9 @@ def cmd_retire(args):
                     expected_waiver_set_sha256=waiver_sha256,
                     local_corpus_release=local_corpus_release,
                     expected_encoder_identity=expected_encoder_identity,
+                    path_migration_receipt_proof_cache=(
+                        planning_receipt_proof_cache
+                    ),
                 )
             )
             if issues or payload is None or manifest_sha256 is None:
@@ -16958,6 +17781,7 @@ def cmd_retire(args):
         roots=roots,
         local_corpus_release=local_corpus_release,
         expected_encoder_identity=expected_encoder_identity,
+        path_migration_receipt_proof_cache=planning_receipt_proof_cache,
     )
     for manifest_path, (covered, _payload, _digest) in retirement_groups.items():
         expected_owner = manifest_path.relative_to(repo_path).as_posix()
@@ -17051,6 +17875,9 @@ def cmd_retire(args):
 
     def pre_install_check() -> None:
         locked_waiver, locked_release = locked_retirement_contract()
+        pre_install_receipt_proof_cache: dict[
+            tuple[str, str], tuple[str, ...]
+        ] = {}
         for manifest_path, (
             _covered,
             expected_payload,
@@ -17065,6 +17892,9 @@ def cmd_retire(args):
                     expected_waiver_set_sha256=locked_waiver,
                     local_corpus_release=locked_release,
                     expected_encoder_identity=expected_encoder_identity,
+                    path_migration_receipt_proof_cache=(
+                        pre_install_receipt_proof_cache
+                    ),
                 )
             )
             if verified != expected_payload or digest != expected_digest or issues:
@@ -17074,6 +17904,9 @@ def cmd_retire(args):
 
     def post_install_check() -> None:
         locked_waiver, locked_release = locked_retirement_contract()
+        post_install_receipt_proof_cache: dict[
+            tuple[str, str], tuple[str, ...]
+        ] = {}
         for manifest_path in manifest_paths:
             verified, _root_prefix, _digest, issues = (
                 _load_verified_applied_encoding_manifest_payload(
@@ -17083,6 +17916,9 @@ def cmd_retire(args):
                     expected_waiver_set_sha256=locked_waiver,
                     local_corpus_release=locked_release,
                     expected_encoder_identity=expected_encoder_identity,
+                    path_migration_receipt_proof_cache=(
+                        post_install_receipt_proof_cache
+                    ),
                 )
             )
             if verified is None or issues:
@@ -17122,7 +17958,8 @@ def guard_generated_change_issues(
     if pending_transaction.exists() or pending_transaction.is_symlink():
         return [
             "RuleSpec checkout has an incomplete apply/retire transaction; "
-            "rerun encode --apply or retire to recover it before validation"
+            "rerun encode --apply, retire, or migrate-rulespec-paths to recover "
+            "it before validation"
         ]
     try:
         load_rulespec_toolchain(repo_path)
@@ -17230,6 +18067,13 @@ def guard_generated_change_issues(
     missing_manifest_paths = [
         path for path in manifest_paths if not (repo_path / path).exists()
     ]
+    # A migration receipt may authorize many replacement manifests. Its
+    # immutable-base/live-file proof is intentionally snapshotted once for
+    # this guard operation; the cache is discarded before the next operation,
+    # and its digest key invalidates a changed receipt within this operation.
+    path_migration_receipt_proof_cache: dict[
+        tuple[str, str], tuple[str, ...]
+    ] = {}
     manifest_entries, manifest_issues = _load_applied_encoding_manifest_entries(
         repo_path,
         surviving_manifest_paths,
@@ -17237,6 +18081,7 @@ def guard_generated_change_issues(
         local_corpus_release=local_corpus_release,
         expected_encoder_identity=expected_encoder_identity,
         expected_waiver_set_sha256=expected_manifest_waiver_set_sha256,
+        path_migration_receipt_proof_cache=path_migration_receipt_proof_cache,
     )
     if manifest_issues:
         return manifest_issues
@@ -17280,6 +18125,9 @@ def guard_generated_change_issues(
             local_corpus_release=local_corpus_release,
             expected_encoder_identity=expected_encoder_identity,
             expected_waiver_set_sha256=expected_manifest_waiver_set_sha256,
+            path_migration_receipt_proof_cache=(
+                path_migration_receipt_proof_cache
+            ),
         )
     )
 
@@ -17414,6 +18262,9 @@ def _generated_provenance_gate_issues(
     local_corpus_release: LocalCorpusRelease,
     expected_encoder_identity: Mapping[str, str],
     expected_waiver_set_sha256: str,
+    path_migration_receipt_proof_cache: dict[
+        tuple[str, str], tuple[str, ...]
+    ],
 ) -> list[str]:
     """Reject protected files authorized only by manual attestations."""
 
@@ -17424,6 +18275,7 @@ def _generated_provenance_gate_issues(
         local_corpus_release=local_corpus_release,
         expected_encoder_identity=expected_encoder_identity,
         expected_waiver_set_sha256=expected_waiver_set_sha256,
+        path_migration_receipt_proof_cache=path_migration_receipt_proof_cache,
     )
     issues: list[str] = []
     for path in protected:
@@ -17621,6 +18473,10 @@ def _manifest_coverage_by_file(
     local_corpus_release: LocalCorpusRelease | None = None,
     expected_encoder_identity: Mapping[str, str] | None = None,
     expected_waiver_set_sha256: str | None = None,
+    path_migration_receipt_proof_cache: dict[
+        tuple[str, str], tuple[str, ...]
+    ]
+    | None = None,
 ) -> dict[str, list[dict[str, object]]]:
     """Map each non-deleted covered file to a list of covering-manifest records.
 
@@ -17634,6 +18490,8 @@ def _manifest_coverage_by_file(
             expected_encoder_identity = _current_guard_encoder_execution_identity()
         except RuntimeError:
             return {}
+    if path_migration_receipt_proof_cache is None:
+        path_migration_receipt_proof_cache = {}
     result: dict[str, list[dict[str, object]]] = defaultdict(list)
     for manifest_path in manifest_paths:
         payload, root_prefix, _manifest_sha256, issues = (
@@ -17644,12 +18502,21 @@ def _manifest_coverage_by_file(
                 local_corpus_release=local_corpus_release,
                 expected_encoder_identity=expected_encoder_identity,
                 expected_waiver_set_sha256=expected_waiver_set_sha256,
+                path_migration_receipt_proof_cache=(
+                    path_migration_receipt_proof_cache
+                ),
             )
         )
         if issues or payload is None or root_prefix is None:
             continue
         backend = _normalized_manifest_backend(payload)
-        is_generated = backend in APPLIED_ENCODING_GENERATED_BACKENDS
+        migrated_manifest = payload.get("migrated_manifest")
+        is_generated = backend in APPLIED_ENCODING_GENERATED_BACKENDS or (
+            payload.get("tool") == APPLIED_ENCODING_PATH_MIGRATION_TOOL
+            and isinstance(migrated_manifest, dict)
+            and _normalized_manifest_backend(migrated_manifest)
+            in APPLIED_ENCODING_GENERATED_BACKENDS
+        )
         applied_files = payload.get("applied_files")
         if not isinstance(applied_files, list):
             continue
@@ -18154,6 +19021,48 @@ def _applied_manifest_tool_execution_issues(
         return issues
     if backend is None:
         applied_files = payload.get("applied_files")
+        if tool == APPLIED_ENCODING_PATH_MIGRATION_TOOL:
+            if not isinstance(applied_files, list) or any(
+                not isinstance(item, dict)
+                or (
+                    item.get("deleted") is not True
+                    and not isinstance(item.get("sha256"), str)
+                )
+                for item in applied_files
+            ):
+                issues.append(
+                    f"{manifest_label} path migration has malformed file entries"
+                )
+            migrated_manifest = payload.get("migrated_manifest")
+            if (
+                not isinstance(migrated_manifest, dict)
+                or migrated_manifest.get("backend")
+                not in APPLIED_ENCODING_ENCODER_BACKENDS
+                or migrated_manifest.get("tool") != APPLIED_ENCODING_MODEL_TOOL
+            ):
+                issues.append(
+                    f"{manifest_label} path migration must preserve a model "
+                    "encode --apply manifest"
+                )
+            if (
+                "deterministic_execution" in payload
+                or "validation_execution" in payload
+            ):
+                issues.append(
+                    f"{manifest_label} path migration must preserve prior provenance "
+                    "instead of claiming new execution"
+                )
+            provenance = payload.get("axiom_encode_git")
+            if not isinstance(provenance, dict) or (
+                provenance.get("commit") != expected_encoder_identity.get("commit")
+                or provenance.get("version") != expected_encoder_identity.get("version")
+                or provenance.get("dirty_tracked") is not False
+            ):
+                issues.append(
+                    f"{manifest_label} path migration does not match the running "
+                    "pinned encoder"
+                )
+            return issues
         if tool != APPLIED_ENCODING_RETIRE_TOOL or not isinstance(applied_files, list):
             issues.append(f"{manifest_label} has no allowlisted tool/backend contract")
         elif any(
@@ -18208,6 +19117,10 @@ def _applied_manifest_exact_schema_issues(
         expected_fields = _RETIRE_APPLY_MANIFEST_FIELDS
         expected_item_fields = _RETIRED_APPLIED_FILE_FIELDS
         contract = "retirement"
+    elif backend is None and tool == APPLIED_ENCODING_PATH_MIGRATION_TOOL:
+        expected_fields = _PATH_MIGRATION_APPLY_MANIFEST_FIELDS
+        expected_item_fields = None
+        contract = "path migration"
     else:
         return []
 
@@ -18309,7 +19222,18 @@ def _applied_manifest_exact_schema_issues(
     applied_files = payload.get("applied_files")
     if isinstance(applied_files, list):
         for index, item in enumerate(applied_files):
-            if isinstance(item, dict) and set(item) != expected_item_fields:
+            allowed_item_fields = (
+                _PATH_MIGRATION_DELETED_FILE_FIELDS
+                if contract == "path migration"
+                and isinstance(item, dict)
+                and item.get("deleted") is True
+                else (
+                    _PATH_MIGRATION_LIVE_FILE_FIELDS
+                    if contract == "path migration"
+                    else expected_item_fields
+                )
+            )
+            if isinstance(item, dict) and set(item) != allowed_item_fields:
                 issues.append(
                     f"{manifest_label} applied_files[{index}] does not match "
                     f"the exact {contract} file schema"
@@ -18446,6 +19370,788 @@ def _retired_model_manifest_issues(
     return issues
 
 
+_PATH_MIGRATION_RECEIPT_FIELDS = frozenset(
+    {
+        "schema_version",
+        "generated_at",
+        "tool",
+        "plan_sha256",
+        "plan",
+        "repository",
+        "axiom_encode_version",
+        "axiom_encode_git",
+        VALIDATION_WAIVER_SET_SHA256_FIELD,
+        "corpus_release",
+        "moves",
+        "rewrites",
+        "manifests",
+        "signature",
+    }
+)
+_PATH_MIGRATION_BINDING_FIELDS = frozenset(
+    {
+        "receipt_path",
+        "receipt_sha256",
+        "plan_sha256",
+        "prior_manifest_path",
+        "prior_manifest_sha256",
+    }
+)
+
+
+def _canonical_migration_receipt_repo_path(raw: object) -> Path | None:
+    if not isinstance(raw, str) or not raw:
+        return None
+    path = Path(raw)
+    if (
+        path.is_absolute()
+        or path.as_posix() != raw
+        or any(part in {"", ".", ".."} for part in path.parts)
+    ):
+        return None
+    return path
+
+
+def _path_migration_receipt_content_issues(
+    payload: Mapping[str, object],
+    *,
+    repo_path: Path,
+    parsed_plan: object,
+) -> list[str]:
+    """Re-prove every signed move/rewrite from the receipt-bound Git base."""
+
+    if not hasattr(parsed_plan, "moves"):
+        return []
+    repository = payload.get("repository")
+    moves = payload.get("moves")
+    rewrites = payload.get("rewrites")
+    if (
+        not isinstance(repository, dict)
+        or not isinstance(moves, list)
+        or not isinstance(rewrites, list)
+    ):
+        return []
+    base_commit = repository.get("base_commit")
+    base_tree = repository.get("base_tree")
+    if not isinstance(base_commit, str) or not isinstance(base_tree, str):
+        return []
+
+    issues: list[str] = []
+    try:
+        actual_tree = _rulespec_migration_git(
+            repo_path,
+            "rev-parse",
+            f"{base_commit}^{{tree}}",
+        ).strip()
+    except (OSError, RuntimeError, UnicodeDecodeError) as exc:
+        return [f"migration receipt base commit cannot be verified: {exc}"]
+    if actual_tree != base_tree:
+        issues.append("migration receipt base tree does not match its base commit")
+
+    valid_moves = [
+        item
+        for item in moves
+        if isinstance(item, dict)
+        and set(item) == {"from", "to", "from_sha256", "to_sha256", "kind"}
+        and _canonical_migration_receipt_repo_path(item.get("from")) is not None
+        and _canonical_migration_receipt_repo_path(item.get("to")) is not None
+    ]
+    existing_companions = {
+        Path(str(item["from"]))
+        for item in valid_moves
+        if item.get("kind") == "companion"
+    }
+    try:
+        allowed_replacements = exact_reference_replacements(
+            parsed_plan.moves,
+            existing_companions=existing_companions,
+        )
+    except PathMigrationPlanError as exc:
+        return [f"migration receipt replacement authority is invalid: {exc}"]
+
+    valid_rewrites = [
+        item
+        for item in rewrites
+        if isinstance(item, dict)
+        and set(item) == {"path", "before_sha256", "after_sha256", "replacements"}
+        and _canonical_migration_receipt_repo_path(item.get("path")) is not None
+    ]
+    rewrite_by_path = {str(item["path"]): item for item in valid_rewrites}
+    move_sources = {str(item["from"]) for item in valid_moves}
+    move_destinations = {str(item["to"]) for item in valid_moves}
+    verified_rewrites: set[str] = set()
+    try:
+        tracked_modes = _rulespec_migration_tracked_files(repo_path)
+    except RuntimeError as exc:
+        return [f"migration receipt cannot inspect the live Git index: {exc}"]
+
+    def verify_transformation(
+        *,
+        base_path: Path,
+        live_path: Path,
+        expected_before: object,
+        expected_after: object,
+    ) -> None:
+        try:
+            before = _rulespec_migration_base_blob(
+                repo_path,
+                base_commit,
+                base_path,
+            )
+            after, counts = rewrite_exact_references(before, allowed_replacements)
+        except (OSError, RuntimeError, PathMigrationPlanError) as exc:
+            issues.append(
+                f"migration receipt cannot re-prove {live_path.as_posix()}: {exc}"
+            )
+            return
+        before_sha256 = hashlib.sha256(before).hexdigest()
+        after_sha256 = hashlib.sha256(after).hexdigest()
+        if before_sha256 != expected_before or after_sha256 != expected_after:
+            issues.append(
+                f"migration receipt hashes are not the exact path-only result for "
+                f"{live_path.as_posix()}"
+            )
+        rewrite = rewrite_by_path.get(live_path.as_posix())
+        expected_rewrite = (
+            {
+                "path": live_path.as_posix(),
+                "before_sha256": before_sha256,
+                "after_sha256": after_sha256,
+                "replacements": list(counts),
+            }
+            if counts
+            else None
+        )
+        if rewrite != expected_rewrite:
+            issues.append(
+                f"migration receipt rewrite proof is not exact for "
+                f"{live_path.as_posix()}"
+            )
+        if rewrite is not None:
+            verified_rewrites.add(live_path.as_posix())
+        try:
+            live = read_bounded_regular_file(
+                repo_path,
+                repo_path / live_path,
+                label=f"migrated live file {live_path.as_posix()}",
+                max_bytes=16 * 1024 * 1024,
+                required_mode=0o644,
+            )
+        except (OSError, UnsafeCorpusPathError) as exc:
+            issues.append(
+                f"migration receipt live file cannot be read safely: "
+                f"{live_path.as_posix()}: {exc}"
+            )
+        else:
+            if live != after:
+                issues.append(
+                    f"migration receipt live bytes are not the exact path-only "
+                    f"result for {live_path.as_posix()}"
+                )
+        index_mode = tracked_modes.get(live_path)
+        if index_mode is not None and index_mode != "100644":
+            issues.append(
+                f"migration receipt live index mode for {live_path.as_posix()} "
+                f"must be 100644, found {index_mode}"
+            )
+
+    for item in valid_moves:
+        source = Path(str(item["from"]))
+        destination = Path(str(item["to"]))
+        verify_transformation(
+            base_path=source,
+            live_path=destination,
+            expected_before=item.get("from_sha256"),
+            expected_after=item.get("to_sha256"),
+        )
+        source_absolute = repo_path / source
+        if source_absolute.exists() or source_absolute.is_symlink():
+            issues.append(f"migration receipt source still exists: {source.as_posix()}")
+
+    for item in valid_rewrites:
+        path = Path(str(item["path"]))
+        if path.as_posix() in move_destinations:
+            continue
+        if path.as_posix() in move_sources:
+            issues.append(
+                f"migration receipt rewrite uses a deleted source path: "
+                f"{path.as_posix()}"
+            )
+            continue
+        verify_transformation(
+            base_path=path,
+            live_path=path,
+            expected_before=item.get("before_sha256"),
+            expected_after=item.get("after_sha256"),
+        )
+    if verified_rewrites != set(rewrite_by_path):
+        issues.append("migration receipt contains an unproved rewrite record")
+    return issues
+
+
+def _load_verified_path_migration_receipt(
+    repo_path: Path,
+    receipt_path: str,
+    *,
+    signing_broker: SigningBroker | Ed25519PublicKey,
+    expected_waiver_set_sha256: str,
+    local_corpus_release: LocalCorpusRelease | None,
+    proof_cache: dict[tuple[str, str], tuple[str, ...]] | None = None,
+) -> tuple[dict[str, object] | None, str | None, list[str]]:
+    """Verify one exact broker-signed canonical path-migration receipt."""
+
+    label = Path(receipt_path).as_posix()
+    relative = Path(receipt_path)
+    if (
+        relative.is_absolute()
+        or relative.as_posix() != receipt_path
+        or any(part in {"", ".", ".."} for part in relative.parts)
+        or relative.parent != APPLIED_ENCODING_PATH_MIGRATION_RECEIPT_DIR
+        or relative.suffix != ".json"
+    ):
+        return None, None, [f"{label} is not a canonical migration receipt path"]
+    repo_root = Path(repo_path).resolve()
+    try:
+        raw = read_bounded_regular_file(
+            repo_root,
+            repo_root / relative,
+            label="RuleSpec path migration receipt",
+            max_bytes=4 * 1024 * 1024,
+        )
+        digest = hashlib.sha256(raw).hexdigest()
+        payload = json.loads(raw.decode("utf-8"))
+    except UnsafeCorpusPathError as exc:
+        return None, None, [f"{label} cannot be read safely: {exc}"]
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, RecursionError):
+        return None, None, [f"{label} is not valid JSON"]
+    if not isinstance(payload, dict):
+        return None, digest, [f"{label} is not a JSON object"]
+    issues: list[str] = []
+    if set(payload) != _PATH_MIGRATION_RECEIPT_FIELDS:
+        issues.append(f"{label} does not match the exact migration receipt schema")
+    if (
+        payload.get("schema_version") != APPLIED_ENCODING_PATH_MIGRATION_RECEIPT_SCHEMA
+        or payload.get("tool") != APPLIED_ENCODING_PATH_MIGRATION_TOOL
+    ):
+        issues.append(f"{label} is not a canonical migration receipt")
+    generated_at = payload.get("generated_at")
+    try:
+        parsed_generated_at = (
+            datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+            if isinstance(generated_at, str)
+            else None
+        )
+    except ValueError:
+        parsed_generated_at = None
+    if parsed_generated_at is None or parsed_generated_at.tzinfo is None:
+        issues.append(f"{label} generated_at is not an RFC3339 timestamp")
+    version = payload.get("axiom_encode_version")
+    if not isinstance(version, str) or not version:
+        issues.append(f"{label} axiom_encode_version is invalid")
+    provenance = payload.get("axiom_encode_git")
+    expected_provenance_fields = {
+        "root",
+        "commit",
+        "dirty_tracked",
+        "version",
+        "version_commit",
+        "identity_source",
+    }
+    if (
+        not isinstance(provenance, dict)
+        or set(provenance) != expected_provenance_fields
+    ):
+        issues.append(f"{label} axiom_encode_git is malformed")
+    else:
+        if not isinstance(provenance.get("root"), str) or not provenance["root"]:
+            issues.append(f"{label} axiom_encode_git.root is invalid")
+        for field in ("commit", "version_commit"):
+            if (
+                not isinstance(provenance.get(field), str)
+                or re.fullmatch(r"[0-9a-f]{40}", str(provenance[field])) is None
+            ):
+                issues.append(f"{label} axiom_encode_git.{field} is invalid")
+        if provenance.get("dirty_tracked") is not False:
+            issues.append(f"{label} axiom_encode_git must be clean")
+        if provenance.get("version") != version:
+            issues.append(f"{label} axiom_encode_git.version disagrees with receipt")
+        if provenance.get("identity_source") not in _APPLY_IDENTITY_SOURCES:
+            issues.append(f"{label} axiom_encode_git.identity_source is invalid")
+    signature_issue = _applied_encoding_manifest_signature_issue(
+        payload, signing_broker
+    )
+    if signature_issue:
+        issues.append(f"{label} {signature_issue}")
+
+    plan = payload.get("plan")
+    try:
+        parsed_plan = load_plan_bytes(
+            json.dumps(
+                plan,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+            ).encode("ascii")
+        )
+    except (PathMigrationPlanError, UnicodeEncodeError, TypeError):
+        parsed_plan = None
+        issues.append(f"{label} contains an invalid canonical migration plan")
+    if parsed_plan is not None and (
+        payload.get("plan_sha256") != parsed_plan.sha256
+        or relative.stem != parsed_plan.sha256
+    ):
+        issues.append(f"{label} plan identity is inconsistent")
+
+    repository = payload.get("repository")
+    if not isinstance(repository, dict) or set(repository) != {
+        "base_commit",
+        "head_commit",
+        "base_tree",
+    }:
+        issues.append(f"{label} repository identity is malformed")
+    else:
+        for field in ("base_commit", "head_commit"):
+            if (
+                not isinstance(repository.get(field), str)
+                or re.fullmatch(r"[0-9a-f]{40}", str(repository[field])) is None
+            ):
+                issues.append(f"{label} repository.{field} is invalid")
+        if (
+            not isinstance(repository.get("base_tree"), str)
+            or re.fullmatch(r"[0-9a-f]{40}", str(repository["base_tree"])) is None
+        ):
+            issues.append(f"{label} repository.base_tree is invalid")
+        if parsed_plan is not None and (
+            repository.get("base_commit") != parsed_plan.base_commit
+            or repository.get("head_commit") != parsed_plan.base_commit
+        ):
+            issues.append(f"{label} repository identity disagrees with its plan")
+
+    if payload.get(VALIDATION_WAIVER_SET_SHA256_FIELD) != (expected_waiver_set_sha256):
+        issues.append(f"{label} waiver-set binding is stale")
+    release = payload.get("corpus_release")
+    if not isinstance(release, dict) or set(release) != {
+        "name",
+        "content_sha256",
+        "selector_sha256",
+    }:
+        issues.append(f"{label} corpus release binding is malformed")
+    elif local_corpus_release is not None and release != {
+        "name": local_corpus_release.name,
+        "content_sha256": local_corpus_release.content_sha256,
+        "selector_sha256": local_corpus_release.selector_sha256,
+    }:
+        issues.append(f"{label} corpus release binding is stale")
+
+    moves = payload.get("moves")
+    if not isinstance(moves, list) or not moves:
+        issues.append(f"{label} moves are malformed")
+    else:
+        seen_from: set[str] = set()
+        seen_to: set[str] = set()
+        for index, item in enumerate(moves):
+            if not isinstance(item, dict) or set(item) != {
+                "from",
+                "to",
+                "from_sha256",
+                "to_sha256",
+                "kind",
+            }:
+                issues.append(f"{label} moves[{index}] is malformed")
+                continue
+            old = item.get("from")
+            new = item.get("to")
+            if (
+                not isinstance(old, str)
+                or not isinstance(new, str)
+                or _canonical_migration_receipt_repo_path(old) is None
+                or _canonical_migration_receipt_repo_path(new) is None
+                or old in seen_from
+                or new in seen_to
+                or item.get("kind") not in {"primary", "companion"}
+            ):
+                issues.append(f"{label} moves[{index}] identity is invalid")
+            else:
+                seen_from.add(old)
+                seen_to.add(new)
+            for field in ("from_sha256", "to_sha256"):
+                if (
+                    not isinstance(item.get(field), str)
+                    or _SHA256_HEX_PATTERN.fullmatch(str(item[field])) is None
+                ):
+                    issues.append(f"{label} moves[{index}].{field} is invalid")
+        if parsed_plan is not None:
+            primary_pairs = {
+                (str(item.get("from")), str(item.get("to")))
+                for item in moves
+                if isinstance(item, dict) and item.get("kind") == "primary"
+            }
+            expected_primary_pairs = {
+                (move.source.as_posix(), move.destination.as_posix())
+                for move in parsed_plan.moves
+            }
+            if primary_pairs != expected_primary_pairs:
+                issues.append(f"{label} primary moves disagree with its plan")
+            allowed_companions = {
+                (
+                    companion_path(move.source).as_posix(),
+                    companion_path(move.destination).as_posix(),
+                )
+                for move in parsed_plan.moves
+            }
+            actual_companions = {
+                (str(item.get("from")), str(item.get("to")))
+                for item in moves
+                if isinstance(item, dict) and item.get("kind") == "companion"
+            }
+            if not actual_companions <= allowed_companions:
+                issues.append(f"{label} contains an unauthorized companion move")
+
+    rewrites = payload.get("rewrites")
+    if not isinstance(rewrites, list):
+        issues.append(f"{label} rewrites are malformed")
+    else:
+        seen_paths: set[str] = set()
+        allowed_replacements: dict[str, str] = {}
+        if parsed_plan is not None and isinstance(moves, list):
+            existing_companions = {
+                Path(str(item["from"]))
+                for item in moves
+                if isinstance(item, dict)
+                and item.get("kind") == "companion"
+                and isinstance(item.get("from"), str)
+            }
+            try:
+                allowed_replacements = exact_reference_replacements(
+                    parsed_plan.moves,
+                    existing_companions=existing_companions,
+                )
+            except PathMigrationPlanError:
+                issues.append(f"{label} replacement authority is invalid")
+        for index, item in enumerate(rewrites):
+            if not isinstance(item, dict) or set(item) != {
+                "path",
+                "before_sha256",
+                "after_sha256",
+                "replacements",
+            }:
+                issues.append(f"{label} rewrites[{index}] is malformed")
+                continue
+            path = item.get("path")
+            replacements = item.get("replacements")
+            if (
+                not isinstance(path, str)
+                or _canonical_migration_receipt_repo_path(path) is None
+                or path in seen_paths
+                or not isinstance(replacements, list)
+                or not replacements
+            ):
+                issues.append(f"{label} rewrites[{index}] identity is invalid")
+            else:
+                seen_paths.add(path)
+            for field in ("before_sha256", "after_sha256"):
+                if (
+                    not isinstance(item.get(field), str)
+                    or _SHA256_HEX_PATTERN.fullmatch(str(item[field])) is None
+                ):
+                    issues.append(f"{label} rewrites[{index}].{field} is invalid")
+            for replacement in replacements if isinstance(replacements, list) else []:
+                if (
+                    not isinstance(replacement, dict)
+                    or set(replacement) != {"from", "to", "count"}
+                    or not isinstance(replacement.get("from"), str)
+                    or not isinstance(replacement.get("to"), str)
+                    or isinstance(replacement.get("count"), bool)
+                    or not isinstance(replacement.get("count"), int)
+                    or replacement["count"] <= 0
+                ):
+                    issues.append(
+                        f"{label} rewrites[{index}] has a malformed replacement"
+                    )
+                elif (
+                    allowed_replacements.get(str(replacement["from"]))
+                    != (replacement["to"])
+                ):
+                    issues.append(
+                        f"{label} rewrites[{index}] contains an unauthorized replacement"
+                    )
+
+    manifests = payload.get("manifests")
+    if not isinstance(manifests, list) or not manifests:
+        issues.append(f"{label} manifests are malformed")
+    else:
+        prior_paths: set[str] = set()
+        replacement_paths: set[str] = set()
+        for index, item in enumerate(manifests):
+            if not isinstance(item, dict) or set(item) != {
+                "prior_path",
+                "prior_sha256",
+                "replacement_path",
+            }:
+                issues.append(f"{label} manifests[{index}] is malformed")
+                continue
+            prior = item.get("prior_path")
+            replacement = item.get("replacement_path")
+            if (
+                not isinstance(prior, str)
+                or not isinstance(replacement, str)
+                or _applied_encoding_manifest_root_prefix(
+                    Path(prior),
+                    roots=tuple(sorted(RULESPEC_ATOMIC_MODULE_ROOTS)),
+                )
+                is None
+                or _applied_encoding_manifest_root_prefix(
+                    Path(replacement),
+                    roots=tuple(sorted(RULESPEC_ATOMIC_MODULE_ROOTS)),
+                )
+                is None
+                or prior in prior_paths
+                or replacement in replacement_paths
+                or not isinstance(item.get("prior_sha256"), str)
+                or _SHA256_HEX_PATTERN.fullmatch(str(item["prior_sha256"])) is None
+            ):
+                issues.append(f"{label} manifests[{index}] identity is invalid")
+            else:
+                prior_paths.add(prior)
+                replacement_paths.add(replacement)
+    if parsed_plan is not None:
+        proof_key = (str(repo_root), digest)
+        cached_proof = proof_cache.get(proof_key) if proof_cache is not None else None
+        if cached_proof is None:
+            cached_proof = tuple(
+                _path_migration_receipt_content_issues(
+                    payload,
+                    repo_path=repo_root,
+                    parsed_plan=parsed_plan,
+                )
+            )
+            if proof_cache is not None:
+                proof_cache[proof_key] = cached_proof
+        issues.extend(f"{label} {issue}" for issue in cached_proof)
+    if issues:
+        return None, digest, issues
+    return payload, digest, []
+
+
+def _migrated_model_manifest_issues(
+    payload: Mapping[str, object],
+    *,
+    repo_path: Path,
+    root_prefix: str,
+    manifest_label: str,
+    signing_broker: SigningBroker | Ed25519PublicKey,
+    expected_waiver_set_sha256: str,
+    local_corpus_release: LocalCorpusRelease | None,
+    path_migration_receipt_proof_cache: dict[
+        tuple[str, str], tuple[str, ...]
+    ]
+    | None,
+) -> list[str]:
+    """Verify nested model provenance and the signed path-only receipt."""
+
+    if (
+        payload.get("backend") is not None
+        or payload.get("tool") != APPLIED_ENCODING_PATH_MIGRATION_TOOL
+    ):
+        return []
+    migrated = payload.get("migrated_manifest")
+    migrated_label = f"{manifest_label}.migrated_manifest"
+    binding = payload.get("migration")
+    if not isinstance(migrated, dict):
+        return [f"{migrated_label} must be a signed model apply manifest"]
+    issues = _applied_manifest_exact_schema_issues(
+        migrated,
+        manifest_label=migrated_label,
+    )
+    signature_issue = _applied_encoding_manifest_signature_issue(
+        migrated, signing_broker
+    )
+    if signature_issue:
+        issues.append(f"{migrated_label} {signature_issue}")
+    if not isinstance(binding, dict) or set(binding) != _PATH_MIGRATION_BINDING_FIELDS:
+        return [*issues, f"{manifest_label} migration binding is malformed"]
+    for field in ("receipt_sha256", "plan_sha256", "prior_manifest_sha256"):
+        if (
+            not isinstance(binding.get(field), str)
+            or _SHA256_HEX_PATTERN.fullmatch(str(binding[field])) is None
+        ):
+            issues.append(f"{manifest_label} migration.{field} is invalid")
+    receipt_path = binding.get("receipt_path")
+    if not isinstance(receipt_path, str):
+        issues.append(f"{manifest_label} migration.receipt_path is invalid")
+        return issues
+    receipt, receipt_sha256, receipt_issues = _load_verified_path_migration_receipt(
+        repo_path,
+        receipt_path,
+        signing_broker=signing_broker,
+        expected_waiver_set_sha256=expected_waiver_set_sha256,
+        local_corpus_release=local_corpus_release,
+        proof_cache=path_migration_receipt_proof_cache,
+    )
+    issues.extend(receipt_issues)
+    if receipt is None:
+        return issues
+    if receipt_sha256 != binding.get("receipt_sha256") or receipt.get(
+        "plan_sha256"
+    ) != binding.get("plan_sha256"):
+        issues.append(f"{manifest_label} migration receipt binding is stale")
+    receipt_manifests = receipt.get("manifests")
+    expected_receipt_entry = {
+        "prior_path": binding.get("prior_manifest_path"),
+        "prior_sha256": binding.get("prior_manifest_sha256"),
+        "replacement_path": manifest_label,
+    }
+    if (
+        not isinstance(receipt_manifests, list)
+        or expected_receipt_entry not in receipt_manifests
+    ):
+        issues.append(f"{manifest_label} is not authorized by its migration receipt")
+    if receipt.get("axiom_encode_version") != payload.get(
+        "axiom_encode_version"
+    ) or receipt.get("axiom_encode_git") != payload.get("axiom_encode_git"):
+        issues.append(
+            f"{manifest_label} encoder provenance disagrees with its migration receipt"
+        )
+
+    migrated_raw = (json.dumps(migrated, indent=2, sort_keys=True) + "\n").encode()
+    if hashlib.sha256(migrated_raw).hexdigest() != binding.get("prior_manifest_sha256"):
+        issues.append(f"{migrated_label} bytes do not match the prior manifest digest")
+
+    receipt_provenance = receipt.get("axiom_encode_git")
+    expected_nested_encoder = {
+        "repository": APPLIED_ENCODING_OFFICIAL_REPOSITORY,
+        "commit": (
+            receipt_provenance.get("commit")
+            if isinstance(receipt_provenance, dict)
+            else None
+        ),
+        "version": receipt.get("axiom_encode_version"),
+    }
+    issues.extend(
+        _applied_manifest_tool_execution_issues(
+            migrated,
+            manifest_label=migrated_label,
+            expected_encoder_identity=expected_nested_encoder,
+        )
+    )
+    issues.extend(
+        _model_apply_validation_execution_issues(
+            migrated,
+            manifest_label=migrated_label,
+            expected_waiver_set_sha256=expected_waiver_set_sha256,
+            expected_encoder_identity=expected_nested_encoder,
+        )
+    )
+    if migrated.get(VALIDATION_WAIVER_SET_SHA256_FIELD) != (expected_waiver_set_sha256):
+        issues.append(f"{migrated_label} waiver-set binding is stale")
+    if payload.get("source_attestation") != migrated.get("source_attestation"):
+        issues.append(f"{migrated_label} source_attestation differs from the migration")
+
+    nested_entries_raw = migrated.get("applied_files")
+    outer_entries_raw = payload.get("applied_files")
+    nested_entries = nested_entries_raw if isinstance(nested_entries_raw, list) else []
+    outer_entries = outer_entries_raw if isinstance(outer_entries_raw, list) else []
+    nested_paths = {
+        str(item.get("path"))
+        for item in nested_entries
+        if isinstance(item, dict) and isinstance(item.get("path"), str)
+    }
+    moved_pairs = {
+        str(item["from"]): str(item["to"])
+        for item in receipt.get("moves", [])
+        if isinstance(item, dict)
+        and isinstance(item.get("from"), str)
+        and isinstance(item.get("to"), str)
+    }
+    rewrite_by_path = {
+        str(item["path"]): item
+        for item in receipt.get("rewrites", [])
+        if isinstance(item, dict) and isinstance(item.get("path"), str)
+    }
+    expected_live = {moved_pairs.get(path, path) for path in nested_paths}
+    expected_deleted = nested_paths & set(moved_pairs)
+    actual_live = {
+        str(item.get("path"))
+        for item in outer_entries
+        if isinstance(item, dict)
+        and isinstance(item.get("path"), str)
+        and item.get("deleted") is not True
+    }
+    actual_deleted = {
+        str(item.get("path"))
+        for item in outer_entries
+        if isinstance(item, dict)
+        and isinstance(item.get("path"), str)
+        and item.get("deleted") is True
+    }
+    if actual_live != expected_live or actual_deleted != expected_deleted:
+        issues.append(
+            f"{migrated_label} applied files do not exactly match the path migration"
+        )
+    nested_hashes = {
+        str(item["path"]): str(item["sha256"])
+        for item in nested_entries
+        if isinstance(item, dict)
+        and isinstance(item.get("path"), str)
+        and isinstance(item.get("sha256"), str)
+    }
+    outer_hashes = {
+        str(item["path"]): str(item["sha256"])
+        for item in outer_entries
+        if isinstance(item, dict)
+        and item.get("deleted") is not True
+        and isinstance(item.get("path"), str)
+        and isinstance(item.get("sha256"), str)
+    }
+    move_by_source = {
+        str(item["from"]): item
+        for item in receipt.get("moves", [])
+        if isinstance(item, dict) and isinstance(item.get("from"), str)
+    }
+    for old_path in sorted(nested_paths):
+        live_path = moved_pairs.get(old_path, old_path)
+        old_hash = nested_hashes.get(old_path)
+        live_hash = outer_hashes.get(live_path)
+        move = move_by_source.get(old_path)
+        if move is not None and (
+            old_hash != move.get("from_sha256") or live_hash != move.get("to_sha256")
+        ):
+            issues.append(
+                f"{migrated_label} file hashes disagree with the migration receipt"
+            )
+        rewrite = rewrite_by_path.get(live_path)
+        if old_hash != live_hash:
+            if rewrite is None or (
+                rewrite.get("before_sha256") != old_hash
+                or rewrite.get("after_sha256") != live_hash
+            ):
+                issues.append(
+                    f"{migrated_label} changed file is not hash-bound to an exact "
+                    "migration rewrite"
+                )
+        elif rewrite is not None and (
+            rewrite.get("before_sha256") != old_hash
+            or rewrite.get("after_sha256") != live_hash
+        ):
+            issues.append(
+                f"{migrated_label} unchanged file disagrees with its migration rewrite"
+            )
+
+    structural_migrated = copy.deepcopy(migrated)
+    structural_migrated["applied_files"] = [
+        {"path": path, "deleted": True} for path in sorted(nested_paths)
+    ]
+    issues.extend(
+        _applied_manifest_source_attestation_issues(
+            structural_migrated,
+            repo_path=repo_path,
+            root_prefix=root_prefix,
+            manifest_label=migrated_label,
+        )
+    )
+    return issues
+
+
 def _load_verified_applied_encoding_manifest_payload(
     repo_path: Path,
     manifest_path: str,
@@ -18455,6 +20161,10 @@ def _load_verified_applied_encoding_manifest_payload(
     expected_waiver_set_sha256: str | None = None,
     local_corpus_release: LocalCorpusRelease | None = None,
     expected_encoder_identity: Mapping[str, str] | None = None,
+    path_migration_receipt_proof_cache: dict[
+        tuple[str, str], tuple[str, ...]
+    ]
+    | None = None,
 ) -> tuple[dict[str, object] | None, str | None, str | None, list[str]]:
     """Load one canonical v5 apply manifest and verify every binding."""
 
@@ -18670,6 +20380,20 @@ def _load_verified_applied_encoding_manifest_payload(
         )
     )
     issues.extend(
+        _migrated_model_manifest_issues(
+            payload,
+            repo_path=repo_path,
+            root_prefix=root_prefix,
+            manifest_label=manifest_label,
+            signing_broker=signing_broker,
+            expected_waiver_set_sha256=expected_waiver_set_sha256,
+            local_corpus_release=local_corpus_release,
+            path_migration_receipt_proof_cache=(
+                path_migration_receipt_proof_cache
+            ),
+        )
+    )
+    issues.extend(
         _applied_manifest_source_attestation_issues(
             payload,
             repo_path=repo_path,
@@ -18716,6 +20440,10 @@ def _load_applied_encoding_manifest_entries(
     local_corpus_release: LocalCorpusRelease | None = None,
     expected_encoder_identity: Mapping[str, str] | None = None,
     expected_waiver_set_sha256: str | None = None,
+    path_migration_receipt_proof_cache: dict[
+        tuple[str, str], tuple[str, ...]
+    ]
+    | None = None,
 ) -> tuple[dict[str, set[str]], list[str]]:
     entries: dict[str, set[str]] = defaultdict(set)
     issues: list[str] = []
@@ -18745,6 +20473,8 @@ def _load_applied_encoding_manifest_entries(
             return entries, [
                 f"Cannot verify the running pinned encoder identity: {exc}"
             ]
+    if path_migration_receipt_proof_cache is None:
+        path_migration_receipt_proof_cache = {}
 
     for manifest_path in manifest_paths:
         payload, root_prefix, _manifest_sha256, manifest_issues = (
@@ -18756,6 +20486,9 @@ def _load_applied_encoding_manifest_entries(
                 expected_waiver_set_sha256=expected_waiver_set_sha256,
                 local_corpus_release=local_corpus_release,
                 expected_encoder_identity=expected_encoder_identity,
+                path_migration_receipt_proof_cache=(
+                    path_migration_receipt_proof_cache
+                ),
             )
         )
         issues.extend(manifest_issues)
@@ -19828,7 +21561,8 @@ def _run_encode_attempt(
         if pending_transaction.exists() or pending_transaction.is_symlink():
             raise RuntimeError(
                 "RuleSpec checkout has an incomplete apply/retire transaction; "
-                "rerun encode --apply or retire to recover it before encoding"
+                "rerun encode --apply, retire, or migrate-rulespec-paths to "
+                "recover it before encoding"
             )
     corpus_release = load_rulespec_local_corpus_release(
         policy_checkout_path,
@@ -41237,6 +42971,14 @@ def _is_canonical_apply_transaction_target(
 
     if canonical_tail(relative, suffix=RULESPEC_FILE_SUFFIX):
         return True
+    receipt_prefix = APPLIED_ENCODING_PATH_MIGRATION_RECEIPT_DIR.parts
+    if relative.parts[: len(receipt_prefix)] == receipt_prefix:
+        receipt_tail = relative.parts[len(receipt_prefix) :]
+        return (
+            len(receipt_tail) == 1
+            and relative.suffix == ".json"
+            and _SHA256_HEX_PATTERN.fullmatch(Path(receipt_tail[0]).stem) is not None
+        )
     manifest_prefix = APPLIED_ENCODING_MANIFEST_DIR.parts
     if relative.parts[: len(manifest_prefix)] != manifest_prefix:
         return False

--- a/src/axiom_encode/corpus_resolver.py
+++ b/src/axiom_encode/corpus_resolver.py
@@ -3762,6 +3762,7 @@ def read_bounded_regular_file(
     *,
     label: str,
     max_bytes: int,
+    required_mode: int | None = None,
 ) -> bytes:
     """Atomically open a contained regular file without following symlinks.
 
@@ -3807,6 +3808,12 @@ def read_bounded_regular_file(
         file_stat = os.fstat(file_descriptor)
         if not stat.S_ISREG(file_stat.st_mode):
             raise UnsafeCorpusPathError(f"{label} is not a regular file: {candidate}")
+        actual_mode = stat.S_IMODE(file_stat.st_mode)
+        if required_mode is not None and actual_mode != required_mode:
+            raise UnsafeCorpusPathError(
+                f"{label} must have mode {required_mode:04o}, found "
+                f"{actual_mode:04o}: {candidate}"
+            )
         if file_stat.st_size > max_bytes:
             raise UnsafeCorpusPathError(
                 f"{label} exceeds the {max_bytes}-byte safety limit: {candidate}"

--- a/src/axiom_encode/rulespec_path_migration.py
+++ b/src/axiom_encode/rulespec_path_migration.py
@@ -1,0 +1,269 @@
+"""Pure planning helpers for authenticated canonical RuleSpec path migrations.
+
+This module deliberately cannot sign or install files.  It turns a minimal,
+exact-schema move plan into deterministic path and durable-reference
+replacements.  The CLI owns provenance verification and the journaled install.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import unicodedata
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final, Mapping, Sequence
+
+PLAN_SCHEMA: Final = "axiom-encode/rulespec-path-migration-plan/v1"
+RECEIPT_SCHEMA: Final = "axiom-encode/rulespec-path-migration-receipt/v1"
+MIGRATION_TOOL: Final = "axiom-encode migrate-rulespec-paths"
+RECEIPT_DIR: Final = Path(".axiom") / "path-migrations"
+
+_SHA256 = re.compile(r"[0-9a-f]{64}")
+_JURISDICTION = re.compile(r"[a-z]{2}(?:-[a-z0-9_]+)*")
+_SAFE_COMPONENT = re.compile(r"[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?")
+_DURABLE_REFERENCE_CHARACTER = r"A-Za-z0-9._:/-"
+_NON_ASCII_DASHES = str.maketrans(
+    {
+        "\N{HYPHEN}": "-",
+        "\N{NON-BREAKING HYPHEN}": "-",
+        "\N{FIGURE DASH}": "-",
+        "\N{EN DASH}": "-",
+        "\N{EM DASH}": "-",
+        "\N{HORIZONTAL BAR}": "-",
+        "\N{SMALL EM DASH}": "-",
+        "\N{SMALL HYPHEN-MINUS}": "-",
+        "\N{FULLWIDTH HYPHEN-MINUS}": "-",
+    }
+)
+
+
+class PathMigrationPlanError(ValueError):
+    """The caller supplied a noncanonical or over-broad migration plan."""
+
+
+@dataclass(frozen=True, slots=True)
+class PlannedMove:
+    """One primary RuleSpec path move admitted by the exact plan."""
+
+    source: Path
+    destination: Path
+
+
+@dataclass(frozen=True, slots=True)
+class PathMigrationPlan:
+    """Parsed and canonically serialized path-migration authority."""
+
+    base_commit: str
+    moves: tuple[PlannedMove, ...]
+    payload: Mapping[str, object]
+    canonical_bytes: bytes
+    sha256: str
+
+
+def _canonical_json_bytes(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("ascii")
+
+
+def _safe_repo_path(raw: object, *, field: str) -> Path:
+    if not isinstance(raw, str) or not raw:
+        raise PathMigrationPlanError(f"{field} must be a non-empty string")
+    path = Path(raw)
+    if (
+        path.is_absolute()
+        or path.as_posix() != raw
+        or any(part in {"", ".", ".."} for part in path.parts)
+    ):
+        raise PathMigrationPlanError(f"{field} is not a canonical repository path")
+    return path
+
+
+def _normalize_component(component: str) -> tuple[str, ...]:
+    normalized = unicodedata.normalize("NFKC", component).translate(_NON_ASCII_DASHES)
+    normalized = normalized.replace(":", "/")
+    normalized = re.sub(r"\s+", "-", normalized)
+    normalized = normalized.lower()
+    pieces = tuple(piece for piece in normalized.split("/") if piece)
+    if not pieces or any(_SAFE_COMPONENT.fullmatch(piece) is None for piece in pieces):
+        raise PathMigrationPlanError(
+            f"path component {component!r} cannot be normalized safely"
+        )
+    return pieces
+
+
+def canonical_destination(source: Path) -> Path:
+    """Return the sole engine-safe identity allowed for ``source``."""
+
+    parts: list[str] = []
+    for component in source.parts:
+        parts.extend(_normalize_component(component))
+    return Path(*parts)
+
+
+def _validate_primary_path(path: Path, *, field: str) -> None:
+    if len(path.parts) < 3:
+        raise PathMigrationPlanError(
+            f"{field} must be jurisdiction-prefixed and under a content root"
+        )
+    if _JURISDICTION.fullmatch(path.parts[0]) is None:
+        raise PathMigrationPlanError(f"{field} has an invalid jurisdiction root")
+    if path.parts[1] not in {"forms", "policies", "regulations", "statutes"}:
+        raise PathMigrationPlanError(f"{field} is outside a protected RuleSpec root")
+    if path.suffix != ".yaml" or path.name.endswith(".test.yaml"):
+        raise PathMigrationPlanError(f"{field} must name a primary .yaml RuleSpec")
+
+
+def load_plan_bytes(raw: bytes) -> PathMigrationPlan:
+    """Parse one exact, canonical JSON migration plan."""
+
+    if len(raw) > 1024 * 1024:
+        raise PathMigrationPlanError("migration plan exceeds 1 MiB")
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
+        raise PathMigrationPlanError("migration plan is not valid UTF-8 JSON") from exc
+    if not isinstance(payload, dict):
+        raise PathMigrationPlanError("migration plan must be a JSON object")
+    if set(payload) != {"schema_version", "base_commit", "moves"}:
+        raise PathMigrationPlanError(
+            "migration plan must contain exactly schema_version, base_commit, moves"
+        )
+    if payload.get("schema_version") != PLAN_SCHEMA:
+        raise PathMigrationPlanError("migration plan schema_version is unsupported")
+    base_commit = payload.get("base_commit")
+    # This repository still uses SHA-1 object IDs.  Refuse abbreviations and
+    # algorithm-ambiguous strings rather than silently resolving a prefix.
+    if (
+        not isinstance(base_commit, str)
+        or re.fullmatch(r"[0-9a-f]{40}", base_commit) is None
+    ):
+        raise PathMigrationPlanError(
+            "migration plan base_commit must be one full Git object ID"
+        )
+    raw_moves = payload.get("moves")
+    if not isinstance(raw_moves, list) or not raw_moves:
+        raise PathMigrationPlanError("migration plan moves must be a non-empty list")
+    if len(raw_moves) > 256:
+        raise PathMigrationPlanError("migration plan contains too many moves")
+
+    moves: list[PlannedMove] = []
+    sources: set[str] = set()
+    destinations: set[str] = set()
+    for index, item in enumerate(raw_moves):
+        field = f"moves[{index}]"
+        if not isinstance(item, dict) or set(item) != {"from", "to"}:
+            raise PathMigrationPlanError(f"{field} must contain exactly from and to")
+        source = _safe_repo_path(item.get("from"), field=f"{field}.from")
+        destination = _safe_repo_path(item.get("to"), field=f"{field}.to")
+        _validate_primary_path(source, field=f"{field}.from")
+        _validate_primary_path(destination, field=f"{field}.to")
+        if destination != canonical_destination(source):
+            raise PathMigrationPlanError(
+                f"{field}.to is not the unique canonical normalization of "
+                f"{source.as_posix()}"
+            )
+        if source == destination:
+            raise PathMigrationPlanError(f"{field} is a no-op")
+        if source.as_posix() in sources:
+            raise PathMigrationPlanError(f"{field}.from is duplicated")
+        if destination.as_posix() in destinations:
+            raise PathMigrationPlanError(f"{field}.to collides with another move")
+        sources.add(source.as_posix())
+        destinations.add(destination.as_posix())
+        moves.append(PlannedMove(source=source, destination=destination))
+
+    if sources & destinations:
+        raise PathMigrationPlanError(
+            "migration plan cannot chain or swap paths in one transaction"
+        )
+    canonical_bytes = _canonical_json_bytes(payload)
+    return PathMigrationPlan(
+        base_commit=base_commit,
+        moves=tuple(moves),
+        payload=payload,
+        canonical_bytes=canonical_bytes,
+        sha256=hashlib.sha256(canonical_bytes).hexdigest(),
+    )
+
+
+def companion_path(primary: Path) -> Path:
+    """Return the mechanically coupled companion test path."""
+
+    return primary.with_name(f"{primary.stem}.test.yaml")
+
+
+def rulespec_identity(path: Path) -> str:
+    """Convert a protected RuleSpec path to its durable module identity."""
+
+    _validate_primary_path(path, field="path")
+    without_suffix = path.with_suffix("")
+    jurisdiction, content_root, *remainder = without_suffix.parts
+    return f"{jurisdiction}:{content_root}/{'/'.join(remainder)}"
+
+
+def exact_reference_replacements(
+    moves: Sequence[PlannedMove],
+    *,
+    existing_companions: set[Path],
+) -> dict[str, str]:
+    """Return every exact durable identity/path rewrite implied by ``moves``."""
+
+    replacements: dict[str, str] = {}
+
+    def add(old: str, new: str) -> None:
+        prior = replacements.get(old)
+        if prior is not None and prior != new:
+            raise PathMigrationPlanError(f"conflicting replacement for {old!r}")
+        replacements[old] = new
+
+    for move in moves:
+        add(
+            move.source.as_posix(),
+            move.destination.as_posix(),
+        )
+        add(
+            rulespec_identity(move.source),
+            rulespec_identity(move.destination),
+        )
+        old_test = companion_path(move.source)
+        if old_test in existing_companions:
+            add(old_test.as_posix(), companion_path(move.destination).as_posix())
+    return replacements
+
+
+def rewrite_exact_references(
+    raw: bytes,
+    replacements: Mapping[str, str],
+) -> tuple[bytes, tuple[dict[str, object], ...]]:
+    """Apply exact UTF-8 token rewrites and return an auditable count record."""
+
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        matching = [old for old in replacements if old.encode("utf-8") in raw]
+        if matching:
+            raise PathMigrationPlanError(
+                "a durable reference occurs in a non-UTF-8 tracked file"
+            ) from exc
+        return raw, ()
+
+    counts: list[dict[str, object]] = []
+    for old in sorted(replacements, key=lambda item: (-len(item), item)):
+        pattern = re.compile(
+            rf"(?<![{_DURABLE_REFERENCE_CHARACTER}])"
+            rf"{re.escape(old)}"
+            rf"(?![{_DURABLE_REFERENCE_CHARACTER}])"
+        )
+        count = len(pattern.findall(text))
+        if not count:
+            continue
+        new = replacements[old]
+        text = pattern.sub(lambda _match: new, text)
+        counts.append({"from": old, "to": new, "count": count})
+    return text.encode("utf-8"), tuple(counts)

--- a/src/axiom_encode/run_log_export.py
+++ b/src/axiom_encode/run_log_export.py
@@ -301,6 +301,9 @@ def build_manifest_index(repo_paths: Iterable[Path]) -> dict[str, dict[str, Any]
         root = repo_path / APPLY_MANIFEST_GLOB
         if not root.is_dir():
             continue
+        path_migration_receipt_proof_cache: dict[
+            tuple[str, str], tuple[str, ...]
+        ] = {}
         for manifest_path in root.rglob("*.json"):
             from .cli import _load_verified_applied_encoding_manifest_payload
 
@@ -308,6 +311,9 @@ def build_manifest_index(repo_paths: Iterable[Path]) -> dict[str, dict[str, Any]
                 _load_verified_applied_encoding_manifest_payload(
                     repo_path,
                     manifest_path.relative_to(repo_path).as_posix(),
+                    path_migration_receipt_proof_cache=(
+                        path_migration_receipt_proof_cache
+                    ),
                 )
             )
             if issues or payload is None:

--- a/src/axiom_encode/run_log_export.py
+++ b/src/axiom_encode/run_log_export.py
@@ -301,9 +301,7 @@ def build_manifest_index(repo_paths: Iterable[Path]) -> dict[str, dict[str, Any]
         root = repo_path / APPLY_MANIFEST_GLOB
         if not root.is_dir():
             continue
-        path_migration_receipt_proof_cache: dict[
-            tuple[str, str], tuple[str, ...]
-        ] = {}
+        path_migration_receipt_proof_cache: dict[tuple[str, str], tuple[str, ...]] = {}
         for manifest_path in root.rglob("*.json"):
             from .cli import _load_verified_applied_encoding_manifest_payload
 

--- a/src/axiom_encode/supabase_sync.py
+++ b/src/axiom_encode/supabase_sync.py
@@ -418,9 +418,7 @@ def sync_applied_manifest_runs(
     runs: list["EncodingRun"] = []
     for repo_path in repo_paths:
         repo_path = Path(repo_path).resolve()
-        path_migration_receipt_proof_cache: dict[
-            tuple[str, str], tuple[str, ...]
-        ] = {}
+        path_migration_receipt_proof_cache: dict[tuple[str, str], tuple[str, ...]] = {}
         for manifest_path in find_apply_manifests(repo_path):
             stats["total"] += 1
             try:

--- a/src/axiom_encode/supabase_sync.py
+++ b/src/axiom_encode/supabase_sync.py
@@ -418,6 +418,9 @@ def sync_applied_manifest_runs(
     runs: list["EncodingRun"] = []
     for repo_path in repo_paths:
         repo_path = Path(repo_path).resolve()
+        path_migration_receipt_proof_cache: dict[
+            tuple[str, str], tuple[str, ...]
+        ] = {}
         for manifest_path in find_apply_manifests(repo_path):
             stats["total"] += 1
             try:
@@ -427,6 +430,9 @@ def sync_applied_manifest_runs(
                     _load_verified_applied_encoding_manifest_payload(
                         repo_path,
                         manifest_path.relative_to(repo_path).as_posix(),
+                        path_migration_receipt_proof_cache=(
+                            path_migration_receipt_proof_cache
+                        ),
                     )
                 )
                 if issues or payload is None:

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1408"
+ENCODER_VERSION = "0.2.1410"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33280,8 +33280,7 @@ class TestGuardGenerated:
         )
 
         assert any(
-            "migrated live file us/statutes/26/1.yaml must have mode 0644"
-            in issue
+            "migrated live file us/statutes/26/1.yaml must have mode 0644" in issue
             for issue in issues
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,6 +39,7 @@ from axiom_encode.cli import (
     APPLIED_ENCODING_OFFICIAL_REPOSITORY,
     APPLIED_ENCODING_RETIRE_TOOL,
     APPLIED_ENCODING_SIGNATURE_ALGORITHM,
+    _all_applied_encoding_manifest_paths,
     _append_exception_positive_companion_tests_if_missing,
     _append_generated_derived_output_tests_if_missing,
     _append_generated_judgment_positive_tests_if_missing,
@@ -89,6 +90,7 @@ from axiom_encode.cli import (
     _load_verified_applied_encoding_manifest_payload,
     _local_factual_input_names_from_rules_content,
     _looks_like_absolute_rulespec_output_target,
+    _manifest_coverage_by_file,
     _medicaid_magi_income_helper_issue_names,
     _normalize_invalid_proof_atom_kinds,
     _normalize_invalid_proof_atom_kinds_file,
@@ -240,6 +242,7 @@ from axiom_encode.cli import (
     cmd_log,
     cmd_log_event,
     cmd_manifest_census,
+    cmd_migrate_rulespec_paths,
     cmd_normalize_proof_atom_kinds,
     cmd_oracle_candidates,
     cmd_oracle_coverage,
@@ -33025,6 +33028,586 @@ class TestGuardGenerated:
                 ],
             }
         )
+
+    def _path_migration_repo(
+        self,
+        tmp_path: Path,
+    ) -> tuple[Path, Path, str]:
+        repo = self._canonical_guard_repo(tmp_path)
+        _git(repo, "init")
+        _git(repo, "config", "user.email", "test@example.com")
+        _git(repo, "config", "user.name", "Test User")
+        primary = repo / "us/statutes/26:1.yaml"
+        companion = repo / "us/statutes/26:1.test.yaml"
+        dependent = repo / "us/policies/example.yaml"
+        self._source_backed_rule(primary)
+        self._source_backed_rule(companion)
+        self._source_backed_rule(dependent)
+        dependent.write_text(
+            dependent.read_text() + "imports:\n" + "  - us:statutes/26:1#test_output\n"
+        )
+        manifest = repo / ".axiom/encoding-manifests/us/statutes/26:1.json"
+        manifest.parent.mkdir(parents=True)
+        payload = self._model_manifest(
+            [
+                {
+                    "path": "us/statutes/26:1.yaml",
+                    "sha256": _sha256_file(primary),
+                },
+                {
+                    "path": "us/statutes/26:1.test.yaml",
+                    "sha256": _sha256_file(companion),
+                },
+            ]
+        )
+        manifest.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+        dependent_manifest = repo / ".axiom/encoding-manifests/us/policies/example.json"
+        dependent_manifest.parent.mkdir(parents=True, exist_ok=True)
+        dependent_payload = self._model_manifest(
+            [
+                {
+                    "path": "us/policies/example.yaml",
+                    "sha256": _sha256_file(dependent),
+                }
+            ]
+        )
+        dependent_manifest.write_text(
+            json.dumps(dependent_payload, indent=2, sort_keys=True) + "\n"
+        )
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "add v5 encoded rules")
+        head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+        plan = repo.parent / "migration-plan.json"
+        plan.write_text(
+            json.dumps(
+                {
+                    "schema_version": ("axiom-encode/rulespec-path-migration-plan/v1"),
+                    "base_commit": head,
+                    "moves": [
+                        {
+                            "from": "us/statutes/26:1.yaml",
+                            "to": "us/statutes/26/1.yaml",
+                        }
+                    ],
+                }
+            )
+        )
+        return repo, plan, head
+
+    def _enable_path_migration(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "axiom_encode.cli._require_applied_encoding_manifest_signer",
+            lambda: TEST_APPLY_SIGNING_BROKER,
+        )
+        monkeypatch.setattr(
+            "axiom_encode.cli._current_guard_encoder_execution_identity",
+            lambda: TEST_PINNED_ENCODER_IDENTITY,
+        )
+        monkeypatch.setattr(
+            "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+            lambda: {
+                "root": "/repo/axiom-encode",
+                "commit": TEST_PINNED_ENCODER_IDENTITY["commit"],
+                "dirty_tracked": False,
+                "version": AXIOM_ENCODE_TEST_VERSION,
+                "version_commit": "b" * 40,
+                "identity_source": "git",
+            },
+        )
+
+    def test_authenticated_v5_path_migration_is_transactional_and_generated(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        repo, plan, _head = self._path_migration_repo(tmp_path)
+        provenance = {
+            "root": "/repo/axiom-encode",
+            "commit": TEST_PINNED_ENCODER_IDENTITY["commit"],
+            "dirty_tracked": False,
+            "version": AXIOM_ENCODE_TEST_VERSION,
+            "version_commit": "b" * 40,
+            "identity_source": "git",
+        }
+        monkeypatch.setattr(
+            "axiom_encode.cli._require_applied_encoding_manifest_signer",
+            lambda: TEST_APPLY_SIGNING_BROKER,
+        )
+        monkeypatch.setattr(
+            "axiom_encode.cli._current_guard_encoder_execution_identity",
+            lambda: TEST_PINNED_ENCODER_IDENTITY,
+        )
+        monkeypatch.setattr(
+            "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+            lambda: provenance,
+        )
+        monkeypatch.setenv("GIT_DIR", str(repo / "redirected.git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(repo.parent / "redirected-tree"))
+        monkeypatch.setenv("GIT_INDEX_FILE", str(repo / "redirected.index"))
+
+        cmd_migrate_rulespec_paths(
+            SimpleNamespace(
+                policy_repo_path=repo,
+                corpus_path=self.corpus_path,
+                plan=plan,
+            )
+        )
+        monkeypatch.delenv("GIT_DIR")
+        monkeypatch.delenv("GIT_WORK_TREE")
+        monkeypatch.delenv("GIT_INDEX_FILE")
+
+        assert not (repo / "us/statutes/26:1.yaml").exists()
+        assert not (repo / "us/statutes/26:1.test.yaml").exists()
+        assert (repo / "us/statutes/26/1.yaml").is_file()
+        assert (repo / "us/statutes/26/1.test.yaml").is_file()
+        dependent = repo / "us/policies/example.yaml"
+        assert "us:statutes/26/1#test_output" in dependent.read_text()
+        assert "us:statutes/26:1" not in dependent.read_text()
+        migrated_manifest = repo / ".axiom/encoding-manifests/us/statutes/26/1.json"
+        assert migrated_manifest.is_file()
+        assert not (repo / ".axiom/encoding-manifests/us/statutes/26:1.json").exists()
+        payload = json.loads(migrated_manifest.read_text())
+        assert payload["tool"] == "axiom-encode migrate-rulespec-paths"
+        assert payload["backend"] if "backend" in payload else None is None
+        assert payload["migrated_manifest"]["backend"] == "codex"
+        receipt_path = repo / payload["migration"]["receipt_path"]
+        assert receipt_path.is_file()
+        receipt = json.loads(receipt_path.read_text())
+        assert (
+            receipt["repository"]["base_commit"]
+            == _git(repo, "rev-parse", "HEAD").stdout.strip()
+        )
+        coverage = _manifest_coverage_by_file(
+            repo,
+            _all_applied_encoding_manifest_paths(repo),
+            local_corpus_release=self.corpus_release,
+            expected_encoder_identity=TEST_PINNED_ENCODER_IDENTITY,
+            expected_waiver_set_sha256=TEST_VALIDATION_WAIVER_SHA256,
+        )
+        assert coverage["us/statutes/26/1.yaml"][0]["is_generated"] is True
+        assert coverage["us/policies/example.yaml"][0]["is_generated"] is True
+        receipt["moves"][0]["to_sha256"] = "f" * 64
+        receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n")
+        forged_coverage = _manifest_coverage_by_file(
+            repo,
+            _all_applied_encoding_manifest_paths(repo),
+            local_corpus_release=self.corpus_release,
+            expected_encoder_identity=TEST_PINNED_ENCODER_IDENTITY,
+            expected_waiver_set_sha256=TEST_VALIDATION_WAIVER_SHA256,
+        )
+        assert "us/statutes/26/1.yaml" not in forged_coverage
+        assert "us/policies/example.yaml" not in forged_coverage
+
+    def test_path_migration_recomputes_signed_dependent_rewrite_from_base(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        repo, plan, _head = self._path_migration_repo(tmp_path)
+        self._enable_path_migration(monkeypatch)
+        cmd_migrate_rulespec_paths(
+            SimpleNamespace(
+                policy_repo_path=repo,
+                corpus_path=self.corpus_path,
+                plan=plan,
+            )
+        )
+
+        dependent = repo / "us/policies/example.yaml"
+        dependent.write_text(dependent.read_text() + "arbitrary: injected\n")
+        dependent_hash = _sha256_file(dependent)
+        dependent_manifest = repo / ".axiom/encoding-manifests/us/policies/example.json"
+        manifest_payload = json.loads(dependent_manifest.read_text())
+        receipt_path = repo / manifest_payload["migration"]["receipt_path"]
+        receipt_payload = json.loads(receipt_path.read_text())
+        dependent_rewrite = next(
+            item
+            for item in receipt_payload["rewrites"]
+            if item["path"] == "us/policies/example.yaml"
+        )
+        dependent_rewrite["after_sha256"] = dependent_hash
+        _sign_applied_encoding_manifest(
+            receipt_payload,
+            TEST_APPLY_SIGNING_BROKER,
+        )
+        receipt_path.write_text(
+            json.dumps(receipt_payload, indent=2, sort_keys=True) + "\n"
+        )
+        manifest_payload["migration"]["receipt_sha256"] = _sha256_file(receipt_path)
+        manifest_payload["applied_files"][0]["sha256"] = dependent_hash
+        _sign_applied_encoding_manifest(
+            manifest_payload,
+            TEST_APPLY_SIGNING_BROKER,
+        )
+        dependent_manifest.write_text(
+            json.dumps(manifest_payload, indent=2, sort_keys=True) + "\n"
+        )
+
+        coverage = _manifest_coverage_by_file(
+            repo,
+            _all_applied_encoding_manifest_paths(repo),
+            local_corpus_release=self.corpus_release,
+            expected_encoder_identity=TEST_PINNED_ENCODER_IDENTITY,
+            expected_waiver_set_sha256=TEST_VALIDATION_WAIVER_SHA256,
+        )
+        assert "us/policies/example.yaml" not in coverage
+
+    def test_path_migration_guard_rejects_live_mode_change_after_migration(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        repo, plan, _head = self._path_migration_repo(tmp_path)
+        self._enable_path_migration(monkeypatch)
+        cmd_migrate_rulespec_paths(
+            SimpleNamespace(
+                policy_repo_path=repo,
+                corpus_path=self.corpus_path,
+                plan=plan,
+            )
+        )
+
+        destination = repo / "us/statutes/26/1.yaml"
+        destination.chmod(0o755)
+
+        issues = guard_generated_change_issues(
+            repo,
+            corpus_path=self.corpus_path,
+            all_files=True,
+        )
+
+        assert any(
+            "migrated live file us/statutes/26/1.yaml must have mode 0644"
+            in issue
+            for issue in issues
+        )
+
+        destination.chmod(0o644)
+        _git(repo, "add", "-A")
+        _git(repo, "update-index", "--chmod=+x", "us/statutes/26/1.yaml")
+        issues = guard_generated_change_issues(
+            repo,
+            corpus_path=self.corpus_path,
+            all_files=True,
+        )
+        assert any(
+            "live index mode for us/statutes/26/1.yaml must be 100644, found 100755"
+            in issue
+            for issue in issues
+        )
+
+    def test_path_migration_guard_reuses_one_receipt_content_proof(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        import axiom_encode.cli as cli_module
+
+        repo, plan, _head = self._path_migration_repo(tmp_path)
+        self._enable_path_migration(monkeypatch)
+        cmd_migrate_rulespec_paths(
+            SimpleNamespace(
+                policy_repo_path=repo,
+                corpus_path=self.corpus_path,
+                plan=plan,
+            )
+        )
+        original = cli_module._path_migration_receipt_content_issues
+        proof_calls = 0
+
+        def counted_proof(*args, **kwargs):
+            nonlocal proof_calls
+            proof_calls += 1
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(
+            cli_module,
+            "_path_migration_receipt_content_issues",
+            counted_proof,
+        )
+
+        issues = guard_generated_change_issues(
+            repo,
+            corpus_path=self.corpus_path,
+            all_files=True,
+        )
+
+        assert issues == []
+        assert proof_calls == 1
+
+    def test_path_migration_postcheck_reuses_one_receipt_content_proof(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        import axiom_encode.cli as cli_module
+
+        repo, plan, _head = self._path_migration_repo(tmp_path)
+        self._enable_path_migration(monkeypatch)
+        original = cli_module._path_migration_receipt_content_issues
+        proof_calls = 0
+
+        def counted_proof(*args, **kwargs):
+            nonlocal proof_calls
+            proof_calls += 1
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(
+            cli_module,
+            "_path_migration_receipt_content_issues",
+            counted_proof,
+        )
+
+        cmd_migrate_rulespec_paths(
+            SimpleNamespace(
+                policy_repo_path=repo,
+                corpus_path=self.corpus_path,
+                plan=plan,
+            )
+        )
+
+        assert proof_calls == 1
+
+    def test_path_migration_census_reuses_one_receipt_content_proof(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        import axiom_encode.cli as cli_module
+
+        repo, plan, _head = self._path_migration_repo(tmp_path)
+        self._enable_path_migration(monkeypatch)
+        cmd_migrate_rulespec_paths(
+            SimpleNamespace(
+                policy_repo_path=repo,
+                corpus_path=self.corpus_path,
+                plan=plan,
+            )
+        )
+        original = cli_module._path_migration_receipt_content_issues
+        proof_calls = 0
+
+        def counted_proof(*args, **kwargs):
+            nonlocal proof_calls
+            proof_calls += 1
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(
+            cli_module,
+            "_path_migration_receipt_content_issues",
+            counted_proof,
+        )
+
+        census = cli_module._manifest_census(
+            repo,
+            roots=tuple(sorted(RULESPEC_ATOMIC_MODULE_ROOTS)),
+        )
+
+        assert census["unmanifested"] == 0
+        assert proof_calls == 1
+
+    def test_path_migration_rejects_resigned_historical_nested_model(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        repo, plan, _head = self._path_migration_repo(tmp_path)
+        self._enable_path_migration(monkeypatch)
+        cmd_migrate_rulespec_paths(
+            SimpleNamespace(
+                policy_repo_path=repo,
+                corpus_path=self.corpus_path,
+                plan=plan,
+            )
+        )
+
+        dependent_manifest = repo / ".axiom/encoding-manifests/us/policies/example.json"
+        manifest_payload = json.loads(dependent_manifest.read_text())
+        nested = manifest_payload["migrated_manifest"]
+        historical_version = "0.1.0"
+        historical_commit = "c" * 40
+        nested["axiom_encode_version"] = historical_version
+        nested["axiom_encode_git"]["commit"] = historical_commit
+        nested["axiom_encode_git"]["version"] = historical_version
+        nested["validation_execution"]["axiom_encode"]["commit"] = historical_commit
+        nested["validation_execution"]["axiom_encode"]["version"] = historical_version
+        _sign_applied_encoding_manifest(nested, TEST_APPLY_SIGNING_BROKER)
+        nested_bytes = (json.dumps(nested, indent=2, sort_keys=True) + "\n").encode()
+        nested_hash = hashlib.sha256(nested_bytes).hexdigest()
+
+        receipt_path = repo / manifest_payload["migration"]["receipt_path"]
+        receipt_payload = json.loads(receipt_path.read_text())
+        receipt_entry = next(
+            item
+            for item in receipt_payload["manifests"]
+            if item["replacement_path"]
+            == ".axiom/encoding-manifests/us/policies/example.json"
+        )
+        receipt_entry["prior_sha256"] = nested_hash
+        _sign_applied_encoding_manifest(
+            receipt_payload,
+            TEST_APPLY_SIGNING_BROKER,
+        )
+        receipt_path.write_text(
+            json.dumps(receipt_payload, indent=2, sort_keys=True) + "\n"
+        )
+        manifest_payload["migration"]["prior_manifest_sha256"] = nested_hash
+        manifest_payload["migration"]["receipt_sha256"] = _sha256_file(receipt_path)
+        _sign_applied_encoding_manifest(
+            manifest_payload,
+            TEST_APPLY_SIGNING_BROKER,
+        )
+        dependent_manifest.write_text(
+            json.dumps(manifest_payload, indent=2, sort_keys=True) + "\n"
+        )
+
+        coverage = _manifest_coverage_by_file(
+            repo,
+            _all_applied_encoding_manifest_paths(repo),
+            local_corpus_release=self.corpus_release,
+            expected_encoder_identity=TEST_PINNED_ENCODER_IDENTITY,
+            expected_waiver_set_sha256=TEST_VALIDATION_WAIVER_SHA256,
+        )
+        assert "us/policies/example.yaml" not in coverage
+
+    def test_path_migration_rejects_symlinked_plan_ancestor_and_executable_source(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        repo, plan, _head = self._path_migration_repo(tmp_path)
+        self._enable_path_migration(monkeypatch)
+        real_plan_dir = tmp_path / "real-plan"
+        real_plan_dir.mkdir()
+        real_plan = real_plan_dir / plan.name
+        plan.replace(real_plan)
+        linked_plan_dir = tmp_path / "linked-plan"
+        linked_plan_dir.symlink_to(real_plan_dir, target_is_directory=True)
+
+        with pytest.raises(SystemExit, match="Cannot read migration plan safely"):
+            cmd_migrate_rulespec_paths(
+                SimpleNamespace(
+                    policy_repo_path=repo,
+                    corpus_path=self.corpus_path,
+                    plan=linked_plan_dir / real_plan.name,
+                )
+            )
+        assert (repo / "us/statutes/26:1.yaml").is_file()
+
+        source = repo / "us/statutes/26:1.yaml"
+        source.chmod(source.stat().st_mode | stat.S_IXUSR)
+        _git(repo, "add", "us/statutes/26:1.yaml")
+        _git(repo, "commit", "-m", "make source executable")
+        plan_payload = json.loads(real_plan.read_text())
+        plan_payload["base_commit"] = _git(repo, "rev-parse", "HEAD").stdout.strip()
+        real_plan.write_text(json.dumps(plan_payload))
+        with pytest.raises(SystemExit, match="regular 0644"):
+            cmd_migrate_rulespec_paths(
+                SimpleNamespace(
+                    policy_repo_path=repo,
+                    corpus_path=self.corpus_path,
+                    plan=real_plan,
+                )
+            )
+        assert (repo / "us/statutes/26:1.yaml").is_file()
+        assert not (repo / "us/statutes/26/1.yaml").exists()
+
+    def test_path_migration_rejects_missing_generated_owner_without_mutation(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        repo, plan, _head = self._path_migration_repo(tmp_path)
+        (repo / ".axiom/encoding-manifests/us/statutes/26:1.json").unlink()
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "remove source provenance")
+        payload = json.loads(plan.read_text())
+        payload["base_commit"] = _git(repo, "rev-parse", "HEAD").stdout.strip()
+        plan.write_text(json.dumps(payload))
+        monkeypatch.setattr(
+            "axiom_encode.cli._require_applied_encoding_manifest_signer",
+            lambda: TEST_APPLY_SIGNING_BROKER,
+        )
+        monkeypatch.setattr(
+            "axiom_encode.cli._current_guard_encoder_execution_identity",
+            lambda: TEST_PINNED_ENCODER_IDENTITY,
+        )
+        monkeypatch.setattr(
+            "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+            lambda: {
+                "root": "/repo/axiom-encode",
+                "commit": TEST_PINNED_ENCODER_IDENTITY["commit"],
+                "dirty_tracked": False,
+                "version": AXIOM_ENCODE_TEST_VERSION,
+                "version_commit": "b" * 40,
+                "identity_source": "git",
+            },
+        )
+
+        with pytest.raises(SystemExit, match="exactly one authenticated generated"):
+            cmd_migrate_rulespec_paths(
+                SimpleNamespace(
+                    policy_repo_path=repo,
+                    corpus_path=self.corpus_path,
+                    plan=plan,
+                )
+            )
+
+        assert (repo / "us/statutes/26:1.yaml").is_file()
+        assert not (repo / "us/statutes/26/1.yaml").exists()
+        assert not (repo / ".axiom/path-migrations").exists()
+
+    def test_path_migration_rolls_back_when_receipt_postcheck_fails(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        repo, plan, _head = self._path_migration_repo(tmp_path)
+        monkeypatch.setattr(
+            "axiom_encode.cli._require_applied_encoding_manifest_signer",
+            lambda: TEST_APPLY_SIGNING_BROKER,
+        )
+        monkeypatch.setattr(
+            "axiom_encode.cli._current_guard_encoder_execution_identity",
+            lambda: TEST_PINNED_ENCODER_IDENTITY,
+        )
+        monkeypatch.setattr(
+            "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+            lambda: {
+                "root": "/repo/axiom-encode",
+                "commit": TEST_PINNED_ENCODER_IDENTITY["commit"],
+                "dirty_tracked": False,
+                "version": AXIOM_ENCODE_TEST_VERSION,
+                "version_commit": "b" * 40,
+                "identity_source": "git",
+            },
+        )
+        monkeypatch.setattr(
+            "axiom_encode.cli._load_verified_path_migration_receipt",
+            lambda *_args, **_kwargs: (None, None, ["injected receipt failure"]),
+        )
+
+        with pytest.raises(
+            RuntimeError,
+            match="Migration receipt failed post-install verification",
+        ):
+            cmd_migrate_rulespec_paths(
+                SimpleNamespace(
+                    policy_repo_path=repo,
+                    corpus_path=self.corpus_path,
+                    plan=plan,
+                )
+            )
+
+        assert (repo / "us/statutes/26:1.yaml").is_file()
+        assert (repo / "us/statutes/26:1.test.yaml").is_file()
+        assert not (repo / "us/statutes/26/1.yaml").exists()
+        assert not (repo / ".axiom/path-migrations").exists()
+        assert (repo / ".axiom/encoding-manifests/us/statutes/26:1.json").is_file()
+        assert not (repo / ".axiom/.apply-transaction").exists()
 
     def test_empty_diff_still_verifies_signed_release_binding(self, tmp_path):
         toolchain = tmp_path / ".axiom/toolchain.toml"

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1408"
+ENCODER_VERSION = "0.2.1410"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1408"
+ENCODER_VERSION = "0.2.1410"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1408"
+ENCODER_VERSION = "0.2.1410"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1408"
+ENCODER_VERSION = "0.2.1410"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1408"
+ENCODER_VERSION = "0.2.1410"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1408"
+ENCODER_VERSION = "0.2.1410"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_path_migration.py
+++ b/tests/test_rulespec_path_migration.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from axiom_encode.rulespec_path_migration import (
+    PLAN_SCHEMA,
+    PathMigrationPlanError,
+    PlannedMove,
+    canonical_destination,
+    companion_path,
+    exact_reference_replacements,
+    load_plan_bytes,
+    rewrite_exact_references,
+    rulespec_identity,
+)
+
+BASE = "a" * 40
+
+
+def _plan(*moves: tuple[str, str], **extra: object) -> bytes:
+    payload: dict[str, object] = {
+        "schema_version": PLAN_SCHEMA,
+        "base_commit": BASE,
+        "moves": [{"from": old, "to": new} for old, new in moves],
+        **extra,
+    }
+    return json.dumps(payload).encode()
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("us-la/statutes/47:294.yaml", "us-la/statutes/47/294.yaml"),
+        (
+            "us-nh/regulations/he-w-700/He-W 704/04.yaml",
+            "us-nh/regulations/he-w-700/he-w-704/04.yaml",
+        ),
+        (
+            "us/statutes/42/1437c\u20131.yaml",
+            "us/statutes/42/1437c-1.yaml",
+        ),
+    ],
+)
+def test_unique_canonical_destination(source: str, expected: str) -> None:
+    assert canonical_destination(Path(source)) == Path(expected)
+
+
+def test_loads_minimal_exact_plan_and_hashes_canonical_payload() -> None:
+    loaded = load_plan_bytes(
+        _plan(("us-la/statutes/47:294.yaml", "us-la/statutes/47/294.yaml"))
+    )
+
+    assert loaded.base_commit == BASE
+    assert loaded.moves == (
+        PlannedMove(
+            source=Path("us-la/statutes/47:294.yaml"),
+            destination=Path("us-la/statutes/47/294.yaml"),
+        ),
+    )
+    assert len(loaded.sha256) == 64
+    assert loaded.canonical_bytes == (
+        b'{"base_commit":"' + BASE.encode() + b'","moves":[{"from":'
+        b'"us-la/statutes/47:294.yaml","to":"us-la/statutes/47/294.yaml"}],'
+        b'"schema_version":"axiom-encode/rulespec-path-migration-plan/v1"}'
+    )
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        _plan(
+            ("us-la/statutes/47:294.yaml", "us-la/statutes/47/294.yaml"),
+            reason="too much authority",
+        ),
+        _plan(("us-la/statutes/47:294.yaml", "us-la/statutes/47-294.yaml")),
+        _plan(("us-la/statutes/47/294.yaml", "us-la/statutes/47/294.yaml")),
+        _plan(("us-la/statutes/47:294.test.yaml", "us-la/statutes/47/294.test.yaml")),
+        _plan(("us-la/statutes/../47:294.yaml", "us-la/statutes/47/294.yaml")),
+        _plan(
+            ("us-la/statutes/47:294.yaml", "us-la/statutes/47/294.yaml"),
+            ("us-la/statutes/47:295.yaml", "us-la/statutes/47/294.yaml"),
+        ),
+    ],
+)
+def test_rejects_overbroad_unsafe_or_colliding_plan(raw: bytes) -> None:
+    with pytest.raises(PathMigrationPlanError):
+        load_plan_bytes(raw)
+
+
+def test_derives_companion_and_only_plural_rulespec_identity_rewrites() -> None:
+    move = PlannedMove(
+        Path("us-la/statutes/47:32.yaml"),
+        Path("us-la/statutes/47/32.yaml"),
+    )
+
+    replacements = exact_reference_replacements(
+        [move],
+        existing_companions={companion_path(move.source)},
+    )
+
+    assert replacements == {
+        "us-la/statutes/47:32.yaml": "us-la/statutes/47/32.yaml",
+        "us-la:statutes/47:32": "us-la:statutes/47/32",
+        "us-la/statutes/47:32.test.yaml": "us-la/statutes/47/32.test.yaml",
+    }
+    assert rulespec_identity(move.source) == "us-la:statutes/47:32"
+    assert "us-la/statute/47:32" not in replacements
+
+
+def test_rewrites_exact_durable_references_but_preserves_legal_citation() -> None:
+    raw = (
+        b"import: us-la:statutes/47:32#rate\n"
+        b"path: us-la/statutes/47:32.yaml\n"
+        b"other_import: us-la:statutes/47:320#rate\n"
+        b"other_path: archive-us-la/statutes/47:32.yaml.bak\n"
+        b"corpus_citation_path: us-la/statute/47:32\n"
+    )
+
+    rewritten, counts = rewrite_exact_references(
+        raw,
+        {
+            "us-la:statutes/47:32": "us-la:statutes/47/32",
+            "us-la/statutes/47:32.yaml": "us-la/statutes/47/32.yaml",
+        },
+    )
+
+    assert rewritten == (
+        b"import: us-la:statutes/47/32#rate\n"
+        b"path: us-la/statutes/47/32.yaml\n"
+        b"other_import: us-la:statutes/47:320#rate\n"
+        b"other_path: archive-us-la/statutes/47:32.yaml.bak\n"
+        b"corpus_citation_path: us-la/statute/47:32\n"
+    )
+    assert counts == (
+        {
+            "from": "us-la/statutes/47:32.yaml",
+            "to": "us-la/statutes/47/32.yaml",
+            "count": 1,
+        },
+        {
+            "from": "us-la:statutes/47:32",
+            "to": "us-la:statutes/47/32",
+            "count": 1,
+        },
+    )
+
+
+def test_non_utf8_without_reference_is_ignored_but_match_fails_closed() -> None:
+    replacements = {"old/path": "new/path"}
+    assert rewrite_exact_references(b"\xff", replacements) == (b"\xff", ())
+    with pytest.raises(PathMigrationPlanError, match="non-UTF-8"):
+        rewrite_exact_references(b"\xffold/path", replacements)

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1408"')
+        .startswith('__version__ = "0.2.1410"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1408"
+    assert encoder_package["version"] == "0.2.1410"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1408"
+    assert project["project"]["version"] == "0.2.1410"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1408"')
+        .startswith('__version__ = "0.2.1410"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1408"
+    assert encoder_package["version"] == "0.2.1410"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1408"
+    assert project["project"]["version"] == "0.2.1410"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1408"')
+        .startswith('__version__ = "0.2.1410"')
     )
 
 

--- a/tests/test_run_log.py
+++ b/tests/test_run_log.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import sqlite3
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -743,6 +744,40 @@ def test_build_manifest_index_accepts_verified_v4(tmp_path, monkeypatch):
 
     assert set(index) == {"abc12345"}
     assert len(index["abc12345"]["_manifest_sha256"]) == 64
+
+
+def test_build_manifest_index_reuses_one_receipt_proof_cache(tmp_path, monkeypatch):
+    import axiom_encode.cli as cli_module
+
+    repo, _rule, manifest = _write_verified_run_log_manifest(tmp_path, monkeypatch)
+    second = manifest.with_name("second.json")
+    second.write_bytes(manifest.read_bytes())
+    original = cli_module._load_verified_applied_encoding_manifest_payload
+    proof_calls = 0
+
+    def counted_loader(*args, **kwargs):
+        nonlocal proof_calls
+        cache = kwargs["path_migration_receipt_proof_cache"]
+        proof_key = (str(repo), "shared-receipt")
+        if proof_key not in cache:
+            proof_calls += 1
+            cache[proof_key] = ()
+        payload, root_prefix, digest, issues = original(*args, **kwargs)
+        if payload is not None and Path(args[1]).name == "second.json":
+            payload = dict(payload)
+            payload["run_id"] = "second-run"
+        return payload, root_prefix, digest, issues
+
+    monkeypatch.setattr(
+        cli_module,
+        "_load_verified_applied_encoding_manifest_payload",
+        counted_loader,
+    )
+
+    index = rx.build_manifest_index([repo])
+
+    assert set(index) == {"abc12345", "second-run"}
+    assert proof_calls == 1
 
 
 def test_build_manifest_index_rejects_stale_or_tampered_manifest(tmp_path, monkeypatch):

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1408"
+ENCODER_VERSION = "0.2.1410"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_supabase_sync.py
+++ b/tests/test_supabase_sync.py
@@ -1237,6 +1237,35 @@ class TestSyncAppliedManifestRuns:
         assert "5c8705fb" in output
         assert "aa11bb22" in output
 
+    def test_scan_reuses_one_receipt_proof_cache(self, tmp_path, monkeypatch):
+        import axiom_encode.cli as cli_module
+        from axiom_encode.supabase_sync import sync_applied_manifest_runs
+
+        repo = self._write_repo(tmp_path)
+        original = cli_module._load_verified_applied_encoding_manifest_payload
+        proof_calls = 0
+
+        def counted_loader(*args, **kwargs):
+            nonlocal proof_calls
+            cache = kwargs["path_migration_receipt_proof_cache"]
+            proof_key = (str(repo.resolve()), "shared-receipt")
+            if proof_key not in cache:
+                proof_calls += 1
+                cache[proof_key] = ()
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(
+            cli_module,
+            "_load_verified_applied_encoding_manifest_payload",
+            counted_loader,
+        )
+
+        stats = sync_applied_manifest_runs([repo], dry_run=True)
+
+        assert stats["total"] == 2
+        assert stats["failed"] == 0
+        assert proof_calls == 1
+
     def test_syncs_manifest_runs_with_apply_manifest_source(self, tmp_path):
         from axiom_encode.supabase_sync import sync_applied_manifest_runs
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1408"
+version = "0.2.1409"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1409"
+version = "0.2.1410"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

Adds the authenticated `axiom-encode migrate-rulespec-paths` workflow for deterministic canonical path migration of current-v5, model-generated RuleSpec encodings.

This is the structural migration primitive required before the separate fresh-reencode replacement contract. It does not claim or migrate legacy/manual owners.

## Design and security invariants

- Accepts an exact minimal `axiom-encode/rulespec-path-migration-plan/v1` plan bound to a clean 40-character Git base commit.
- Permits only the unique canonical normalization of a path while preserving the jurisdiction and protected RuleSpec root.
- Derives companion-test moves mechanically; callers cannot grant arbitrary companion authority.
- Rewrites only exact, token-bounded durable RuleSpec path/identity references and preserves singular legal corpus citations.
- Requires every changed protected module to have exactly one authenticated current-v5 model-generated owner.
- Produces a broker-signed `axiom-encode/rulespec-path-migration-receipt/v1` receipt and signed replacement manifests embedding the prior signed model manifest.
- Installs the complete move/rewrite/manifest/receipt set transactionally with pre-install validation, rollback, and post-install verification.
- Recomputes the receipt-bound base tree and every move/dependent rewrite from Git base blobs during persistent verification.
- Verifies receipt, plan, repository, corpus release, waiver set, hashes, timestamps, encoder provenance, nested model provenance, and live destination bytes.
- Rejects stale/historical nested encoder identities instead of trusting receipt self-claims.
- Uses bounded no-follow reads for plans, manifests, receipts, and live migrated files, including rejection of symlinked plan ancestors.
- Removes ambient `GIT_*` routing/configuration authority for migration Git inspection and uses literal pathspec behavior.
- Requires source/base/live/index file semantics to remain regular `0644`/Git `100644`; chmod-only filesystem and index changes are rejected.
- Caches one immutable-base/live-snapshot receipt content proof per operation/repository and receipt digest, while every manifest still rereads, signature-verifies, and digest-binds the receipt. This prevents `O(N×R)` Git/file reproof across guard, census, migration, retirement, export, and applied-run sync scans.
- Bumps `axiom-encode` from `0.2.1408` to `0.2.1409` and documents the contract.

## Independent review-fix cycle

The change completed repeated independent review cycles before publication.

Initial review findings, all fixed with adversarial tests:

1. Dependent rewrites were not independently recomputed from the receipt-bound Git base.
2. Nested model provenance could be self-claimed and receipt encoder identity was insufficiently validated.
3. Plan/manifest reads needed bounded no-follow handling and symlink-ancestor rejection.
4. Non-`0644` tracked inputs could be silently downgraded.
5. Ambient Git routing/configuration variables were not fully removed.

Subsequent review findings, all fixed with adversarial or call-count tests:

1. Persisted verification needed live filesystem and Git-index mode enforcement.
2. Shared receipt verification needed operation-scoped caching.
3. Cache scope needed to cover migration postchecks, census, retirement, manifest path scans, run-log export, and applied-run sync—not only `guard-generated`.

Final independent review result on exact head `e298f612e04a88ee2b4f99ad98db1a34c0245897`: **CLEAN, no actionable findings**.

## Exact local checks

Run from the repository's Python 3.13 environment on exact head `e298f612e04a88ee2b4f99ad98db1a34c0245897`:

- Expanded focused suite covering migration, guard, receipt signing/adoption, version provenance, run-log export, and applied-run sync: **166 passed**.
- `ruff check pyproject.toml src/axiom_encode scripts tests`: **passed**.
- `python -m compileall -q src/axiom_encode scripts`: **passed**.
- `git diff --check`: **passed**.
- Worktree: **clean**.
- Full suite: **5967 passed, 119 skipped, 31 failed** in 279.42s.

The 31 full-suite failures are identical pre-existing root-environment/runtime mismatches, not migration failures:

- 30 packaged PolicyEngine oracle registry/coverage synchronization failures because the installed `axiom_oracles` runtime mappings are empty/out of sync with this checkout.
- 1 `tests/test_cli.py::test_ci_entrypoint_is_registered` failure because the subprocess resolves the installed/runtime CLI rather than this checkout and that installed CLI lacks the current `ci` entrypoint.

Before the version bump/provenance fix, the same environment had 32 failures; the migration-related version-provenance failure is fixed. No migration/path test failed in the final full run.

## Merge gate

Do not merge while any hosted CI or signing check is failed, stale, or pending. Merge only if the exact PR head is fully green, then verify exact post-merge CI/signing before beginning replacement-contract work.
