### PR TITLE
Replace legacy RuleSpecs with fresh signed v5 encodings

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -35,7 +35,11 @@ on:
         required: false
         type: string
       replace_rulespec_path:
-        description: Existing checkout-relative RuleSpec path sourced by citation
+        description: Existing target, or unique canonical destination for a legacy replacement
+        required: false
+        type: string
+      replace_legacy_rulespec_path:
+        description: Exact noncanonical legacy primary replaced by a fresh model encode
         required: false
         type: string
       dependent_citation:
@@ -511,6 +515,7 @@ jobs:
         env:
           CITATION: ${{ inputs.citation }}
           REPLACE_RULESPEC_PATH: ${{ inputs.replace_rulespec_path }}
+          REPLACE_LEGACY_RULESPEC_PATH: ${{ inputs.replace_legacy_rulespec_path }}
           DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
           SECOND_DEPENDENT_CITATION: ${{ inputs.second_dependent_citation }}
           RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
@@ -530,8 +535,12 @@ jobs:
             validate-dependent-cascade
             "$RULESPEC_CHECKOUT" "$CITATION"
           )
-          if [ -n "$REPLACE_RULESPEC_PATH" ]; then
-            cascade_args+=(--target-rulespec-path "$REPLACE_RULESPEC_PATH")
+          cascade_target="$REPLACE_RULESPEC_PATH"
+          if [ -n "$REPLACE_LEGACY_RULESPEC_PATH" ]; then
+            cascade_target="$REPLACE_LEGACY_RULESPEC_PATH"
+          fi
+          if [ -n "$cascade_target" ]; then
+            cascade_args+=(--target-rulespec-path "$cascade_target")
           fi
           cascade_args+=("${dependent_citations[@]}")
           "${cascade_args[@]}"
@@ -543,6 +552,7 @@ jobs:
           CITATION: ${{ inputs.citation }}
           REVIEW_FINDING: ${{ inputs.review_finding }}
           REPLACE_RULESPEC_PATH: ${{ inputs.replace_rulespec_path }}
+          REPLACE_LEGACY_RULESPEC_PATH: ${{ inputs.replace_legacy_rulespec_path }}
           QUEUE_ID: ${{ inputs.queue_id }}
           DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
           DEPENDENT_REVIEW_FINDING: ${{ inputs.dependent_review_finding }}
@@ -553,8 +563,11 @@ jobs:
           set -euo pipefail
           : "${QUEUE_ID:=}"
           : "${REPLACE_RULESPEC_PATH:=}"
+          : "${REPLACE_LEGACY_RULESPEC_PATH:=}"
           : "${SECOND_DEPENDENT_CITATION:=}"
           : "${SECOND_DEPENDENT_REVIEW_FINDING:=}"
+          dependent_rulespec_path=""
+          second_dependent_rulespec_path=""
 
           run_signed_encode() {
             local citation="$1"
@@ -562,6 +575,7 @@ jobs:
             local target_only="$3"
             local output_lane="$4"
             local replacement_path="$5"
+            local legacy_source_path="$6"
             local review_finding_path=""
             local -a args=(
               /opt/axiom-verification/axiom-encode encode
@@ -580,6 +594,20 @@ jobs:
             fi
             if [ -n "$replacement_path" ]; then
               args+=(--replace-rulespec-path "$replacement_path")
+            fi
+            if [ -n "$legacy_source_path" ]; then
+              args+=(--replace-legacy-rulespec-path "$legacy_source_path")
+              if [ -n "$dependent_rulespec_path" ]; then
+                args+=(
+                  --legacy-dependent-rulespec-path "$dependent_rulespec_path"
+                )
+              fi
+              if [ -n "$second_dependent_rulespec_path" ]; then
+                args+=(
+                  --legacy-dependent-rulespec-path \
+                  "$second_dependent_rulespec_path"
+                )
+              fi
             fi
             if [ -n "$review_finding" ]; then
               review_finding_dir="$(mktemp -d "$RUNNER_TEMP/axiom-targeted-review-finding.XXXXXX")"
@@ -607,8 +635,15 @@ jobs:
             echo "dependent citation is required with dependent review finding" >&2
             exit 1
           fi
-          if [ -n "$QUEUE_ID" ] && [ -n "$REPLACE_RULESPEC_PATH" ]; then
+          if [ -n "$QUEUE_ID" ] && \
+            { [ -n "$REPLACE_RULESPEC_PATH" ] || \
+              [ -n "$REPLACE_LEGACY_RULESPEC_PATH" ]; }; then
             echo "queue-authorized re-encodes cannot override the RuleSpec target path" >&2
+            exit 1
+          fi
+          if [ -n "$REPLACE_LEGACY_RULESPEC_PATH" ] && \
+            [ -z "$REPLACE_RULESPEC_PATH" ]; then
+            echo "legacy source and canonical destination must be paired" >&2
             exit 1
           fi
           if [ -n "$DEPENDENT_CITATION" ] && [ -z "$DEPENDENT_REVIEW_FINDING" ]; then
@@ -640,19 +675,43 @@ jobs:
             exit 1
           fi
 
+          backfill_helper="axiom-encode/scripts/prepare_signed_backfill.py"
+          if [ ! -f "$backfill_helper" ]; then
+            backfill_helper="scripts/prepare_signed_backfill.py"
+          fi
+          workflow_python="/opt/axiom-verification/python/bin/python"
+          if [ ! -x "$workflow_python" ]; then
+            workflow_python="${AXIOM_TEST_PYTHON:-python}"
+          fi
+          if [ -n "$DEPENDENT_CITATION" ]; then
+            dependent_rulespec_path="$("$workflow_python" "$backfill_helper" \
+              citation-rulespec-path "$DEPENDENT_CITATION")"
+          fi
+          if [ -n "$SECOND_DEPENDENT_CITATION" ]; then
+            second_dependent_rulespec_path="$("$workflow_python" "$backfill_helper" \
+              citation-rulespec-path "$SECOND_DEPENDENT_CITATION")"
+          fi
+
           if [ -n "$DEPENDENT_CITATION" ]; then
             run_signed_encode \
-              "$CITATION" "$REVIEW_FINDING" true target "$REPLACE_RULESPEC_PATH"
+              "$CITATION" "$REVIEW_FINDING" true target \
+              "$REPLACE_RULESPEC_PATH" "$REPLACE_LEGACY_RULESPEC_PATH"
+            dependent_target_only=false
+            if [ -n "$SECOND_DEPENDENT_CITATION" ]; then
+              dependent_target_only=true
+            fi
             run_signed_encode \
-              "$DEPENDENT_CITATION" "$DEPENDENT_REVIEW_FINDING" false dependent ""
+              "$DEPENDENT_CITATION" "$DEPENDENT_REVIEW_FINDING" \
+              "$dependent_target_only" dependent "" ""
             if [ -n "$SECOND_DEPENDENT_CITATION" ]; then
               run_signed_encode \
                 "$SECOND_DEPENDENT_CITATION" \
-                "$SECOND_DEPENDENT_REVIEW_FINDING" false dependent-2 ""
+                "$SECOND_DEPENDENT_REVIEW_FINDING" false dependent-2 "" ""
             fi
           else
             run_signed_encode \
-              "$CITATION" "$REVIEW_FINDING" false target "$REPLACE_RULESPEC_PATH"
+              "$CITATION" "$REVIEW_FINDING" false target \
+              "$REPLACE_RULESPEC_PATH" "$REPLACE_LEGACY_RULESPEC_PATH"
           fi
 
       - name: Verify generated provenance
@@ -685,8 +744,13 @@ jobs:
           QUEUE_MANIFEST_SHA256: ${{ inputs.queue_manifest_sha256 }}
           REVIEW_FINDING_PRESENT: ${{ inputs.review_finding != '' }}
           REPLACE_RULESPEC_PATH: ${{ inputs.replace_rulespec_path }}
+          REPLACE_LEGACY_RULESPEC_PATH: ${{ inputs.replace_legacy_rulespec_path }}
           RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
         run: |
+          workflow_python=(/opt/axiom-verification/python/bin/python -I)
+          if [ ! -x "${workflow_python[0]}" ]; then
+            workflow_python=("${AXIOM_TEST_PYTHON:-python}")
+          fi
           artifact="$RUNNER_TEMP/targeted-reencode"
           mkdir -p "$artifact"
           git -C "$RULESPEC_CHECKOUT" diff --binary --full-index HEAD > "$artifact/tracked.patch"
@@ -694,15 +758,21 @@ jobs:
             | tar -C "$RULESPEC_CHECKOUT" --null -czf "$artifact/untracked.tar.gz" --files-from -
           git -C "$RULESPEC_CHECKOUT" status --short > "$artifact/status.txt"
           cp "$RUNNER_TEMP/guard-generated.json" "$artifact/guard-generated.json"
-          python - \
+          "${workflow_python[@]}" - \
             "$artifact/context-manifest.json" \
             "$artifact/apply-manifests.json" <<'PY'
           import hashlib
           import json
           import os
+          import re
           import subprocess
           import sys
           from pathlib import Path
+
+          from axiom_encode.corpus_resolver import (
+              UnsafeCorpusPathError,
+              read_bounded_regular_file,
+          )
 
           def git_paths(*args):
               output = subprocess.check_output(
@@ -714,8 +784,32 @@ jobs:
                   if value
               }
 
+          def read_bounded_regular(root, relative, *, label, max_bytes):
+              relative = Path(relative)
+              if (
+                  relative.is_absolute()
+                  or not relative.parts
+                  or any(part in {"", ".", ".."} for part in relative.parts)
+              ):
+                  raise SystemExit(f"{label} path is not canonical")
+              root = Path(root).resolve(strict=True)
+              try:
+                  return read_bounded_regular_file(
+                      root,
+                      root / relative,
+                      label=label,
+                      max_bytes=max_bytes,
+                      required_mode=0o644,
+                  )
+              except UnsafeCorpusPathError as exc:
+                  raise SystemExit(str(exc)) from exc
+
           manifest_paths = git_paths(
-              "diff", "--name-only", "-z", "HEAD", "--",
+              "diff", "--name-only", "--diff-filter=AM", "-z", "HEAD", "--",
+              ".axiom/encoding-manifests",
+          )
+          deleted_manifest_paths = git_paths(
+              "diff", "--name-only", "--diff-filter=D", "-z", "HEAD", "--",
               ".axiom/encoding-manifests",
           )
           manifest_paths.update(
@@ -729,6 +823,9 @@ jobs:
               os.environ.get("SECOND_DEPENDENT_CITATION") or ""
           )
           replacement_path = os.environ.get("REPLACE_RULESPEC_PATH") or ""
+          legacy_source_path = (
+              os.environ.get("REPLACE_LEGACY_RULESPEC_PATH") or ""
+          )
           normalized_replacement_path = ""
           if replacement_path:
               candidate = Path(replacement_path)
@@ -749,15 +846,33 @@ jobs:
 
           matches = {}
           for relative_path in sorted(manifest_paths):
-              manifest_path = Path(os.environ["RULESPEC_CHECKOUT"]) / relative_path
-              payload = json.loads(manifest_path.read_text(encoding="utf-8"))
-              citation = payload.get("citation")
+              payload = json.loads(
+                  read_bounded_regular(
+                      os.environ["RULESPEC_CHECKOUT"],
+                      relative_path,
+                      label="changed apply manifest",
+                      max_bytes=1024 * 1024,
+                  ).decode("utf-8")
+              )
+              effective = payload
+              if (
+                  payload.get("tool")
+                  == "axiom-encode encode --apply --replace-legacy-rulespec-path"
+              ):
+                  effective = payload.get("replacement_manifest")
+                  if not isinstance(effective, dict):
+                      raise SystemExit(
+                          "legacy replacement omits nested model manifest"
+                      )
+              citation = effective.get("citation")
               if (
                   payload.get("schema_version")
                   == "axiom-encode/applied-rulespec/v5"
                   and citation in expected_citations
               ):
-                  matches.setdefault(citation, []).append((relative_path, payload))
+                  matches.setdefault(citation, []).append(
+                      (relative_path, payload, effective)
+                  )
 
           expected = [
               (
@@ -800,9 +915,145 @@ jobs:
                       "expected exactly one changed signed apply manifest for "
                       f"{citation}; found {len(citation_matches)}"
                   )
-              relative_path, applied_manifest = citation_matches[0]
+              relative_path, applied_manifest, evidence_manifest = (
+                  citation_matches[0]
+              )
               manifest_path = Path(os.environ["RULESPEC_CHECKOUT"]) / relative_path
-              if lane == "target" and normalized_replacement_path:
+              if lane == "target" and legacy_source_path:
+                  if (
+                      applied_manifest.get("tool")
+                      != "axiom-encode encode --apply "
+                      "--replace-legacy-rulespec-path"
+                  ):
+                      raise SystemExit(
+                          "legacy replacement target is not the dedicated v5 contract"
+                      )
+                  replacement = applied_manifest.get("replacement")
+                  if not isinstance(replacement, dict):
+                      raise SystemExit("legacy replacement binding is malformed")
+                  receipt_path_raw = replacement.get("receipt_path")
+                  if not isinstance(receipt_path_raw, str):
+                      raise SystemExit("legacy replacement receipt path is malformed")
+                  receipt_path = Path(receipt_path_raw)
+                  if (
+                      receipt_path.is_absolute()
+                      or receipt_path.as_posix() != receipt_path_raw
+                      or any(part in {"", ".", ".."} for part in receipt_path.parts)
+                      or receipt_path.parent
+                      != Path(".axiom/legacy-replacements")
+                      or receipt_path.suffix != ".json"
+                      or re.fullmatch(r"[0-9a-f]{64}", receipt_path.stem) is None
+                  ):
+                      raise SystemExit(
+                          "legacy replacement receipt path is not canonical"
+                      )
+                  receipt_bytes = read_bounded_regular(
+                      os.environ["RULESPEC_CHECKOUT"],
+                      receipt_path,
+                      label="legacy replacement receipt",
+                      max_bytes=4 * 1024 * 1024,
+                  )
+                  if (
+                      hashlib.sha256(receipt_bytes).hexdigest()
+                      != replacement.get("receipt_sha256")
+                  ):
+                      raise SystemExit(
+                          "legacy replacement receipt digest does not match"
+                      )
+                  receipt = json.loads(receipt_bytes)
+                  receipt_replacement = receipt.get("replacement")
+                  if (
+                      receipt.get("schema_version")
+                      != "axiom-encode/legacy-fresh-reencode-receipt/v1"
+                      or not isinstance(receipt_replacement, dict)
+                      or receipt_replacement.get("source")
+                      != legacy_source_path
+                      or receipt_replacement.get("destination")
+                      != normalized_replacement_path
+                  ):
+                      raise SystemExit("legacy replacement receipt paths differ")
+                  scheduled = receipt_replacement.get("scheduled_dependents")
+                  if not isinstance(scheduled, list):
+                      raise SystemExit(
+                          "legacy replacement scheduled dependents are malformed"
+                      )
+                  from axiom_encode.rulespec_path_migration import (
+                      rewrite_exact_references,
+                  )
+                  for dependent in scheduled:
+                      if (
+                          not isinstance(dependent, dict)
+                          or not isinstance(dependent.get("primary"), str)
+                          or not isinstance(dependent.get("files"), list)
+                      ):
+                          raise SystemExit(
+                              "legacy replacement scheduled dependent is malformed"
+                          )
+                      dependent_manifest = (
+                          Path(".axiom/encoding-manifests")
+                          / Path(dependent["primary"]).with_suffix(".json")
+                      )
+                      if dependent_manifest not in manifest_paths:
+                          raise SystemExit(
+                              "legacy replacement scheduled dependent lacks "
+                              "a changed signed manifest"
+                          )
+                      for evidence in dependent["files"]:
+                          if not isinstance(evidence, dict):
+                              raise SystemExit(
+                                  "legacy replacement scheduled file is malformed"
+                              )
+                          pending_relative = Path(
+                              str(evidence.get("path") or "")
+                          )
+                          pending_bytes = read_bounded_regular(
+                              os.environ["RULESPEC_CHECKOUT"],
+                              pending_relative,
+                              label="legacy replacement scheduled dependent",
+                              max_bytes=16 * 1024 * 1024,
+                          )
+                          if (
+                              hashlib.sha256(pending_bytes).hexdigest()
+                              == evidence.get("before_sha256")
+                          ):
+                              raise SystemExit(
+                                  "legacy replacement scheduled dependent "
+                                  "is still pending"
+                              )
+                          replacements = {
+                              str(item["from"]): str(item["to"])
+                              for item in evidence.get("replacements", [])
+                              if isinstance(item, dict)
+                              and set(item) == {"from", "to", "count"}
+                          }
+                          _rewritten, remaining = rewrite_exact_references(
+                              pending_bytes, replacements
+                          )
+                          if (
+                              len(replacements)
+                              != len(evidence.get("replacements", []))
+                              or remaining
+                          ):
+                              raise SystemExit(
+                                  "legacy replacement scheduled dependent "
+                                  "retains an old reference"
+                              )
+                  expected_old_manifest = Path(
+                      ".axiom/encoding-manifests"
+                  ) / Path(legacy_source_path).with_suffix(".json")
+                  if deleted_manifest_paths != {expected_old_manifest}:
+                      raise SystemExit(
+                          "legacy replacement must delete exactly its old manifest"
+                      )
+                  if (
+                      Path(os.environ["RULESPEC_CHECKOUT"]) / legacy_source_path
+                  ).exists():
+                      raise SystemExit("legacy replacement old primary still exists")
+                  receipt_artifact = Path(sys.argv[1]).with_name(
+                      "legacy-replacement-receipt.json"
+                  )
+                  receipt_artifact.write_bytes(receipt_bytes)
+              elif lane == "target" and normalized_replacement_path:
                   applied_files = applied_manifest.get("applied_files")
                   if not isinstance(applied_files, list):
                       raise SystemExit(
@@ -821,16 +1072,25 @@ jobs:
                           "replacement apply manifest primary path does not "
                           "match the requested RuleSpec target"
                       )
-              context_path = Path(applied_manifest["context_manifest_file"]).resolve()
+              context_path = Path(
+                  evidence_manifest["context_manifest_file"]
+              ).resolve()
               try:
                   context_path.relative_to(generated_root / lane)
               except ValueError as exc:
                   raise SystemExit(
                       f"signed context manifest is outside assigned {lane} lane"
                   ) from exc
-              context_bytes = context_path.read_bytes()
+              context_bytes = read_bounded_regular(
+                  generated_root,
+                  context_path.relative_to(generated_root),
+                  label="signed context manifest",
+                  max_bytes=16 * 1024 * 1024,
+              )
               context_digest = hashlib.sha256(context_bytes).hexdigest()
-              if context_digest != applied_manifest.get("context_manifest_sha256"):
+              if context_digest != evidence_manifest.get(
+                  "context_manifest_sha256"
+              ):
                   raise SystemExit("signed context manifest digest does not match")
 
               context_payload = json.loads(context_bytes)
@@ -868,7 +1128,14 @@ jobs:
                   {
                       "citation": citation,
                       "path": relative_path.as_posix(),
-                      "sha256": hashlib.sha256(manifest_path.read_bytes()).hexdigest(),
+                      "sha256": hashlib.sha256(
+                          read_bounded_regular(
+                              os.environ["RULESPEC_CHECKOUT"],
+                              relative_path,
+                              label="packaged apply manifest",
+                              max_bytes=1024 * 1024,
+                          )
+                      ).hexdigest(),
                   }
               )
           Path(sys.argv[2]).write_text(
@@ -884,7 +1151,7 @@ jobs:
               encoding="utf-8",
           )
           PY
-          python - "$artifact/metadata.json" <<'PY'
+          "${workflow_python[@]}" - "$artifact/metadata.json" <<'PY'
           import json
           import os
           import subprocess
@@ -904,6 +1171,9 @@ jobs:
               ),
               "replace_rulespec_path": (
                   os.environ.get("REPLACE_RULESPEC_PATH") or None
+              ),
+              "replace_legacy_rulespec_path": (
+                  os.environ.get("REPLACE_LEGACY_RULESPEC_PATH") or None
               ),
               "pr_base_branch": os.environ["PR_BASE_BRANCH"],
               "queue_id": os.environ.get("QUEUE_ID") or None,
@@ -935,10 +1205,16 @@ jobs:
           RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
         run: |
           set -euo pipefail
-          branch="$(python axiom-encode/scripts/prepare_signed_backfill.py branch-name \
+          workflow_python=(/opt/axiom-verification/python/bin/python -I)
+          if [ ! -x "${workflow_python[0]}" ]; then
+            workflow_python=("${AXIOM_TEST_PYTHON:-python}")
+          fi
+          branch="$("${workflow_python[@]}" \
+            axiom-encode/scripts/prepare_signed_backfill.py branch-name \
             "$COUNTRY" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT")"
           git -C "$RULESPEC_CHECKOUT" switch -c "$branch"
-          python axiom-encode/scripts/prepare_signed_backfill.py stage \
+          "${workflow_python[@]}" \
+            axiom-encode/scripts/prepare_signed_backfill.py stage \
             "$RULESPEC_CHECKOUT"
           git -C "$RULESPEC_CHECKOUT" \
             -c core.hooksPath=/dev/null \
@@ -964,12 +1240,17 @@ jobs:
         run: |
           set -euo pipefail
           test -n "$GH_TOKEN"
+          workflow_python=(/opt/axiom-verification/python/bin/python -I)
+          if [ ! -x "${workflow_python[0]}" ]; then
+            workflow_python=("${AXIOM_TEST_PYTHON:-python}")
+          fi
           repo="TheAxiomFoundation/rulespec-${COUNTRY}"
           git -C "$RULESPEC_CHECKOUT" fetch --no-tags origin \
             "+refs/heads/${PR_BASE_BRANCH}:refs/remotes/origin/${PR_BASE_BRANCH}"
           test "$(git -C "$RULESPEC_CHECKOUT" rev-parse \
             "refs/remotes/origin/${PR_BASE_BRANCH}")" = "$RULESPEC_REF"
-          branch="$(python axiom-encode/scripts/prepare_signed_backfill.py branch-name \
+          branch="$("${workflow_python[@]}" \
+            axiom-encode/scripts/prepare_signed_backfill.py branch-name \
             "$COUNTRY" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT")"
           body="$(printf '%s\n' \
             '## Signed apply manifest' \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1410"
+version = "0.2.1411"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import re
 import subprocess
@@ -14,6 +15,16 @@ COMMIT_PATTERN = re.compile(r"[0-9a-f]{40}")
 DIGEST_PATTERN = re.compile(r"[0-9a-f]{64}")
 QUEUE_TRACKING_PATTERN = re.compile(r"[a-z0-9][a-z0-9-]{0,63}")
 MANIFEST_ROOT = PurePosixPath(".axiom/encoding-manifests")
+LEGACY_REPLACEMENT_RECEIPT_ROOT = PurePosixPath(".axiom/legacy-replacements")
+LEGACY_REPLACEMENT_TOOL = "axiom-encode encode --apply --replace-legacy-rulespec-path"
+MODEL_APPLY_TOOL = "axiom-encode encode --apply"
+MODEL_APPLY_BACKENDS = frozenset({"claude", "codex", "openai"})
+LEGACY_REPLACEMENT_METADATA_PATHS = frozenset(
+    {
+        PurePosixPath(".axiom/index/provisions_to_rules.json"),
+        PurePosixPath("oracle-coverage-pending.yaml"),
+    }
+)
 RULESPEC_ATOMIC_ROOTS = frozenset(
     {"legislation", "policies", "regulations", "statutes"}
 )
@@ -34,6 +45,39 @@ REVIEWED_RULESPEC_PR_BASE_BRANCHES = frozenset(
         ("us", "hard-cut/canonical-layout-us"),
     }
 )
+
+
+def _read_bounded_regular(
+    repo: Path,
+    relative: PurePosixPath,
+    *,
+    label: str,
+    max_bytes: int,
+) -> bytes:
+    """Read one canonical in-repo 0644 file without following symlinks."""
+
+    from axiom_encode.corpus_resolver import (
+        UnsafeCorpusPathError,
+        read_bounded_regular_file,
+    )
+
+    if (
+        relative.is_absolute()
+        or not relative.parts
+        or any(part in {"", ".", ".."} for part in relative.parts)
+    ):
+        raise ValueError(f"{label} path is not canonical: {relative}")
+    root = repo.resolve(strict=True)
+    try:
+        return read_bounded_regular_file(
+            root,
+            root.joinpath(*relative.parts),
+            label=label,
+            max_bytes=max_bytes,
+            required_mode=0o644,
+        )
+    except UnsafeCorpusPathError as exc:
+        raise ValueError(str(exc)) from exc
 
 
 def validate_country(value: str) -> str:
@@ -161,6 +205,11 @@ def _citation_rulespec_path(citation: str) -> tuple[str, PurePosixPath]:
     ):
         raise ValueError("citation does not resolve to a canonical RuleSpec path")
     return jurisdiction, relative
+
+
+def citation_rulespec_path(citation: str) -> PurePosixPath:
+    jurisdiction, relative = _citation_rulespec_path(citation)
+    return PurePosixPath(jurisdiction) / relative
 
 
 def _is_regular_file_beneath(root: Path, relative: PurePosixPath) -> bool:
@@ -308,7 +357,12 @@ def _safe_relative_path(value: object, *, label: str) -> PurePosixPath:
     if not isinstance(value, str):
         raise ValueError(f"{label} must be a string")
     path = PurePosixPath(value)
-    if path.is_absolute() or ".." in path.parts or not path.parts:
+    if (
+        path.is_absolute()
+        or path.as_posix() != value
+        or any(part in {"", ".", ".."} for part in path.parts)
+        or not path.parts
+    ):
         raise ValueError(f"{label} is not a safe repository-relative path")
     return path
 
@@ -334,19 +388,425 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
         for path in changed
         if path.is_relative_to(MANIFEST_ROOT) and path.suffix == ".json"
     }
-    if not manifests:
+    live_manifests = {path for path in manifests if (repo / path).is_file()}
+    deleted_manifests = manifests - live_manifests
+    if not live_manifests:
         raise ValueError(
             "no changed signed apply manifest is available to authorize publication"
         )
 
-    authorized = set(manifests)
-    for relative in manifests:
-        manifest_path = repo / relative
-        if not manifest_path.is_file() or manifest_path.is_symlink():
-            raise ValueError(f"changed manifest is not a regular file: {relative}")
-        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest_payloads: dict[PurePosixPath, dict[str, object]] = {}
+    for relative in live_manifests:
+        payload = json.loads(
+            _read_bounded_regular(
+                repo,
+                relative,
+                label="changed manifest",
+                max_bytes=1024 * 1024,
+            ).decode("utf-8")
+        )
+        if not isinstance(payload, dict):
+            raise ValueError(f"changed manifest is malformed: {relative}")
         if payload.get("schema_version") != "axiom-encode/applied-rulespec/v5":
             raise ValueError(f"changed manifest has an unsupported schema: {relative}")
+        manifest_payloads[relative] = payload
+    legacy_manifests = {
+        relative
+        for relative, payload in manifest_payloads.items()
+        if payload.get("tool") == LEGACY_REPLACEMENT_TOOL
+    }
+    if len(legacy_manifests) > 1 or (deleted_manifests and len(legacy_manifests) != 1):
+        raise ValueError(
+            "deleted manifests require exactly one receipt-linked legacy replacement"
+        )
+
+    authorized = set(live_manifests)
+    for relative, payload in manifest_payloads.items():
+        replacement = payload.get("replacement")
+        receipt_rewrites: set[PurePosixPath] = set()
+        if payload.get("tool") == LEGACY_REPLACEMENT_TOOL:
+            if not isinstance(replacement, dict):
+                raise ValueError(f"legacy replacement binding is malformed: {relative}")
+            receipt_relative = _safe_relative_path(
+                replacement.get("receipt_path"),
+                label=f"{relative} replacement.receipt_path",
+            )
+            if (
+                receipt_relative.parent != LEGACY_REPLACEMENT_RECEIPT_ROOT
+                or receipt_relative.suffix != ".json"
+                or DIGEST_PATTERN.fullmatch(receipt_relative.stem) is None
+            ):
+                raise ValueError(
+                    f"legacy replacement receipt path is invalid: {relative}"
+                )
+            receipt_raw = _read_bounded_regular(
+                repo,
+                receipt_relative,
+                label="legacy replacement receipt",
+                max_bytes=4 * 1024 * 1024,
+            )
+            if hashlib.sha256(receipt_raw).hexdigest() != replacement.get(
+                "receipt_sha256"
+            ):
+                raise ValueError(
+                    f"legacy replacement receipt digest differs: {relative}"
+                )
+            receipt = json.loads(receipt_raw.decode("utf-8"))
+            if (
+                receipt.get("schema_version")
+                != "axiom-encode/legacy-fresh-reencode-receipt/v1"
+                or receipt.get("tool") != LEGACY_REPLACEMENT_TOOL
+            ):
+                raise ValueError(
+                    f"legacy replacement receipt schema differs: {relative}"
+                )
+            legacy = receipt.get("legacy")
+            receipt_replacement = receipt.get("replacement")
+            if not isinstance(legacy, dict) or not isinstance(
+                receipt_replacement, dict
+            ):
+                raise ValueError(f"legacy replacement receipt is malformed: {relative}")
+            old_manifest = legacy.get("manifest")
+            if not isinstance(old_manifest, dict):
+                raise ValueError(
+                    f"legacy replacement old manifest evidence is malformed: {relative}"
+                )
+            old_manifest_path = _safe_relative_path(
+                old_manifest.get("path"),
+                label=f"{relative} legacy.manifest.path",
+            )
+            if (
+                old_manifest_path not in deleted_manifests
+                or replacement.get("legacy_manifest_path")
+                != old_manifest_path.as_posix()
+                or replacement.get("legacy_manifest_sha256")
+                != old_manifest.get("sha256")
+            ):
+                raise ValueError(
+                    f"legacy replacement old manifest deletion differs: {relative}"
+                )
+            raw_rewrites = receipt_replacement.get("rewrites")
+            live_files = receipt_replacement.get("live_files")
+            legacy_files = legacy.get("files")
+            scheduled_dependents = receipt_replacement.get("scheduled_dependents")
+            if not isinstance(raw_rewrites, list):
+                raise ValueError(
+                    f"legacy replacement receipt rewrites are malformed: {relative}"
+                )
+            if (
+                not isinstance(live_files, list)
+                or not isinstance(legacy_files, list)
+                or not isinstance(scheduled_dependents, list)
+            ):
+                raise ValueError(
+                    f"legacy replacement receipt file sets are malformed: {relative}"
+                )
+            nested_manifest = payload.get("replacement_manifest")
+            if (
+                not isinstance(nested_manifest, dict)
+                or live_files != nested_manifest.get("applied_files")
+                or receipt.get("replacement_manifest") != nested_manifest
+            ):
+                raise ValueError(
+                    f"legacy replacement live files differ from fresh model "
+                    f"manifest: {relative}"
+                )
+            repository = receipt.get("repository")
+            base_commit = (
+                repository.get("base_commit") if isinstance(repository, dict) else None
+            )
+            from axiom_encode.cli import (
+                _legacy_replacement_authoritative_map,
+                _legacy_replacement_reference_inventory_issues,
+                _strict_legacy_replacement_map,
+            )
+
+            authoritative_replacements, authority_issues = (
+                _legacy_replacement_authoritative_map(
+                    repo,
+                    base_commit=str(base_commit or ""),
+                    manifest_label=relative.as_posix(),
+                    legacy=legacy,
+                    replacement=receipt_replacement,
+                )
+            )
+            if authoritative_replacements is None or authority_issues:
+                raise ValueError(
+                    f"legacy replacement authority differs: {relative}: "
+                    + "; ".join(authority_issues)
+                )
+            from axiom_encode.rulespec_path_migration import (
+                PathMigrationPlanError,
+                rewrite_exact_references,
+            )
+
+            for index, rewrite in enumerate(raw_rewrites):
+                if not isinstance(rewrite, dict) or set(rewrite) != {
+                    "path",
+                    "before_sha256",
+                    "after_sha256",
+                    "replacements",
+                }:
+                    raise ValueError(
+                        f"legacy replacement rewrite[{index}] is malformed"
+                    )
+                rewrite_path = _safe_relative_path(
+                    rewrite.get("path"),
+                    label=f"{relative} rewrite[{index}].path",
+                )
+                if (
+                    rewrite_path not in LEGACY_REPLACEMENT_METADATA_PATHS
+                    or rewrite_path in receipt_rewrites
+                ):
+                    raise ValueError(
+                        f"legacy replacement rewrite[{index}] path is unauthorized"
+                    )
+                before = rewrite.get("before_sha256")
+                after = rewrite.get("after_sha256")
+                base_raw = _git(
+                    repo,
+                    "show",
+                    f"HEAD:{rewrite_path.as_posix()}",
+                )
+                live_raw = _read_bounded_regular(
+                    repo,
+                    rewrite_path,
+                    label="legacy replacement metadata rewrite",
+                    max_bytes=16 * 1024 * 1024,
+                )
+                replacement_records = rewrite["replacements"]
+                if _strict_legacy_replacement_map(replacement_records) is None:
+                    raise ValueError(
+                        f"legacy replacement rewrite[{index}] records are malformed"
+                    )
+                try:
+                    expected_live, observed_counts = rewrite_exact_references(
+                        base_raw,
+                        authoritative_replacements,
+                    )
+                except PathMigrationPlanError as exc:
+                    raise ValueError(
+                        f"legacy replacement rewrite[{index}] is unreadable"
+                    ) from exc
+                if (
+                    not isinstance(before, str)
+                    or DIGEST_PATTERN.fullmatch(before) is None
+                    or not isinstance(after, str)
+                    or DIGEST_PATTERN.fullmatch(after) is None
+                    or hashlib.sha256(base_raw).hexdigest() != before
+                    or hashlib.sha256(live_raw).hexdigest() != after
+                    or expected_live != live_raw
+                    or list(observed_counts) != replacement_records
+                ):
+                    raise ValueError(
+                        f"legacy replacement rewrite[{index}] state differs"
+                    )
+                receipt_rewrites.add(rewrite_path)
+            expected_applied_files = [
+                *live_files,
+                *[
+                    {
+                        "path": rewrite.get("path"),
+                        "sha256": rewrite.get("after_sha256"),
+                    }
+                    for rewrite in raw_rewrites
+                    if isinstance(rewrite, dict)
+                ],
+                *[
+                    {"path": item.get("path"), "deleted": True}
+                    for item in legacy_files
+                    if isinstance(item, dict)
+                ],
+            ]
+            if payload.get("applied_files") != expected_applied_files:
+                raise ValueError(
+                    f"legacy replacement outer applied_files differ from receipt: "
+                    f"{relative}"
+                )
+            for index, item in enumerate(live_files):
+                if (
+                    not isinstance(item, dict)
+                    or set(item) != {"path", "sha256"}
+                    or not isinstance(item.get("sha256"), str)
+                    or DIGEST_PATTERN.fullmatch(item["sha256"]) is None
+                ):
+                    raise ValueError(
+                        f"legacy replacement live_files[{index}] is malformed"
+                    )
+                live_path = _safe_relative_path(
+                    item.get("path"),
+                    label=f"{relative} live_files[{index}].path",
+                )
+                if (
+                    hashlib.sha256(
+                        _read_bounded_regular(
+                            repo,
+                            live_path,
+                            label="legacy replacement live file",
+                            max_bytes=16 * 1024 * 1024,
+                        )
+                    ).hexdigest()
+                    != item["sha256"]
+                ):
+                    raise ValueError(
+                        f"legacy replacement live file differs: {live_path}"
+                    )
+            for index, item in enumerate(legacy_files):
+                if (
+                    not isinstance(item, dict)
+                    or set(item) != {"path", "sha256"}
+                    or not isinstance(item.get("sha256"), str)
+                    or DIGEST_PATTERN.fullmatch(item["sha256"]) is None
+                ):
+                    raise ValueError(
+                        f"legacy replacement legacy.files[{index}] is malformed"
+                    )
+                deleted_path = _safe_relative_path(
+                    item.get("path"),
+                    label=f"{relative} legacy.files[{index}].path",
+                )
+                if (repo / deleted_path).exists() or (repo / deleted_path).is_symlink():
+                    raise ValueError(
+                        f"legacy replacement deleted file still exists: {deleted_path}"
+                    )
+                base_raw = _git(repo, "show", f"HEAD:{deleted_path.as_posix()}")
+                if hashlib.sha256(base_raw).hexdigest() != item["sha256"]:
+                    raise ValueError(
+                        f"legacy replacement deleted file base differs: {deleted_path}"
+                    )
+            for index, dependent in enumerate(scheduled_dependents):
+                if (
+                    not isinstance(dependent, dict)
+                    or set(dependent) != {"primary", "files"}
+                    or not isinstance(dependent.get("files"), list)
+                    or not dependent["files"]
+                ):
+                    raise ValueError(
+                        f"legacy scheduled dependent[{index}] is malformed"
+                    )
+                primary = _safe_relative_path(
+                    dependent.get("primary"),
+                    label=f"{relative} scheduled[{index}].primary",
+                )
+                dependent_manifest = MANIFEST_ROOT / primary.with_suffix(".json")
+                if dependent_manifest not in live_manifests:
+                    raise ValueError(
+                        f"legacy scheduled dependent lacks changed manifest: {primary}"
+                    )
+                dependent_payload = manifest_payloads[dependent_manifest]
+                dependent_applied_files = dependent_payload.get("applied_files")
+                dependent_hashes = (
+                    {
+                        str(item["path"]): str(item["sha256"])
+                        for item in dependent_applied_files
+                        if isinstance(item, dict)
+                        and set(item) == {"path", "sha256"}
+                        and isinstance(item.get("path"), str)
+                        and isinstance(item.get("sha256"), str)
+                        and DIGEST_PATTERN.fullmatch(item["sha256"]) is not None
+                    }
+                    if isinstance(dependent_applied_files, list)
+                    else {}
+                )
+                if (
+                    dependent_payload.get("tool") != MODEL_APPLY_TOOL
+                    or dependent_payload.get("backend") not in MODEL_APPLY_BACKENDS
+                    or primary.as_posix() not in dependent_hashes
+                    or len(dependent_hashes) != len(dependent_applied_files or [])
+                ):
+                    raise ValueError(
+                        f"legacy scheduled dependent lacks a fresh model manifest: "
+                        f"{primary}"
+                    )
+                for file_index, evidence in enumerate(dependent["files"]):
+                    if (
+                        not isinstance(evidence, dict)
+                        or set(evidence) != {"path", "before_sha256", "replacements"}
+                        or not isinstance(evidence.get("replacements"), list)
+                    ):
+                        raise ValueError(
+                            f"legacy scheduled dependent file is malformed: {primary}"
+                        )
+                    pending_path = _safe_relative_path(
+                        evidence.get("path"),
+                        label=(
+                            f"{relative} scheduled[{index}].files[{file_index}].path"
+                        ),
+                    )
+                    if pending_path not in changed:
+                        raise ValueError(
+                            f"legacy scheduled dependent was not freshly changed: "
+                            f"{pending_path}"
+                        )
+                    base_raw = _git(repo, "show", f"HEAD:{pending_path.as_posix()}")
+                    if hashlib.sha256(base_raw).hexdigest() != evidence.get(
+                        "before_sha256"
+                    ):
+                        raise ValueError(
+                            f"legacy scheduled dependent base differs: {pending_path}"
+                        )
+                    if _strict_legacy_replacement_map(evidence["replacements"]) is None:
+                        raise ValueError(
+                            "legacy scheduled dependent replacement records "
+                            f"are malformed: {primary} file {file_index}"
+                        )
+                    try:
+                        _base_rewritten, observed_counts = rewrite_exact_references(
+                            base_raw,
+                            authoritative_replacements,
+                        )
+                    except PathMigrationPlanError as exc:
+                        raise ValueError(
+                            f"legacy scheduled dependent is unreadable: {pending_path}"
+                        ) from exc
+                    live_raw = _read_bounded_regular(
+                        repo,
+                        pending_path,
+                        label="legacy scheduled dependent",
+                        max_bytes=16 * 1024 * 1024,
+                    )
+                    if (
+                        dependent_hashes.get(pending_path.as_posix())
+                        != hashlib.sha256(live_raw).hexdigest()
+                    ):
+                        raise ValueError(
+                            "legacy scheduled dependent model manifest does not "
+                            f"bind live file: {pending_path}"
+                        )
+                    try:
+                        _live_rewritten, remaining = rewrite_exact_references(
+                            live_raw,
+                            authoritative_replacements,
+                        )
+                    except PathMigrationPlanError as exc:
+                        raise ValueError(
+                            f"legacy scheduled dependent is unreadable: {pending_path}"
+                        ) from exc
+                    if list(observed_counts) != evidence["replacements"]:
+                        raise ValueError(
+                            f"legacy scheduled dependent exact base proof differs: "
+                            f"{pending_path}"
+                        )
+                    if remaining:
+                        raise ValueError(
+                            f"legacy scheduled dependent retains an old reference: "
+                            f"{pending_path}"
+                        )
+            inventory_issues = _legacy_replacement_reference_inventory_issues(
+                repo,
+                base_commit=str(base_commit or ""),
+                authoritative_replacements=authoritative_replacements,
+                legacy=legacy,
+                replacement=receipt_replacement,
+                allow_pending_scheduled=False,
+            )
+            if inventory_issues:
+                raise ValueError(
+                    f"legacy replacement reference inventory differs: {relative}: "
+                    + "; ".join(inventory_issues)
+                )
+            authorized.update({receipt_relative, old_manifest_path, *receipt_rewrites})
+
         applied_files = payload.get("applied_files")
         if not isinstance(applied_files, list) or not applied_files:
             raise ValueError(
@@ -357,8 +817,15 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                 raise ValueError(f"{relative} applied_files[{index}] is malformed")
             label = f"{relative} applied_files[{index}].path"
             applied_path = _safe_relative_path(entry.get("path"), label=label)
-            _validate_rulespec_path(repo, applied_path, label=label)
+            if applied_path not in receipt_rewrites:
+                _validate_rulespec_path(repo, applied_path, label=label)
             authorized.add(applied_path)
+
+    if deleted_manifests - authorized:
+        raise ValueError(
+            "deleted manifests are not authenticated by a replacement receipt: "
+            + ", ".join(map(str, sorted(deleted_manifests - authorized)))
+        )
 
     unexpected = changed - authorized
     missing = authorized - changed
@@ -392,7 +859,14 @@ def stage_authorized_changes(repo: Path) -> None:
     )
     staged = {
         PurePosixPath(value.decode("utf-8"))
-        for value in _git(repo, "diff", "--cached", "--name-only", "-z").split(b"\0")
+        for value in _git(
+            repo,
+            "diff",
+            "--cached",
+            "--name-only",
+            "--no-renames",
+            "-z",
+        ).split(b"\0")
         if value
     }
     if staged != authorized:
@@ -426,6 +900,8 @@ def main() -> None:
     cascade_parser.add_argument("target_citation")
     cascade_parser.add_argument("--target-rulespec-path")
     cascade_parser.add_argument("dependent_citations", nargs="+")
+    citation_path_parser = subparsers.add_parser("citation-rulespec-path")
+    citation_path_parser.add_argument("citation")
     args = parser.parse_args()
     try:
         if args.command == "validate-country":
@@ -460,6 +936,8 @@ def main() -> None:
                     target_rulespec_path=args.target_rulespec_path,
                 )
             )
+        elif args.command == "citation-rulespec-path":
+            print(citation_rulespec_path(args.citation))
         else:
             stage_authorized_changes(args.repo)
     except (

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1410"
+__version__ = "0.2.1411"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -256,6 +256,40 @@ from .harness.validator_pipeline import (
     repair_nonnegative_amount_reductions,
     repair_source_table_band_scalar_parameters,
 )
+from .legacy_replacement import (
+    LEGACY_OWNER_CLASS as APPLIED_ENCODING_LEGACY_OWNER_CLASS,
+)
+from .legacy_replacement import (
+    RECEIPT_DIR as _LEGACY_REPLACEMENT_RECEIPT_DIR_TEXT,
+)
+from .legacy_replacement import (
+    RECEIPT_SCHEMA as APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
+)
+from .legacy_replacement import (
+    TOOL as APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL,
+)
+from .legacy_replacement import (
+    LegacyReplacementContract as _LegacyReplacementContract,
+)
+from .legacy_replacement import (
+    LegacyReplacementFile as _LegacyReplacementFile,
+)
+from .legacy_replacement import (
+    LegacyReplacementPendingFile as _LegacyReplacementPendingFile,
+)
+from .legacy_replacement import (
+    LegacyReplacementRewrite as _LegacyReplacementRewrite,
+)
+from .legacy_replacement import (
+    LegacyReplacementScheduledDependent as _LegacyReplacementScheduledDependent,
+)
+from .legacy_replacement import (
+    legacy_manual_manifest_issues as _legacy_manual_manifest_issues,
+)
+from .legacy_replacement import (
+    legacy_source_verification_citation_paths as _legacy_source_verification_citation_paths,
+)
+from .legacy_replacement import receipt_identity_payload, receipt_identity_sha256
 from .oracles.policyengine.pending import (
     PendingDeclarationError,
     apply_pending_to_report,
@@ -294,6 +328,8 @@ from .rulespec_path_migration import (
 )
 from .rulespec_path_migration import (
     PathMigrationPlanError,
+    PlannedMove,
+    canonical_destination,
     companion_path,
     exact_reference_replacements,
     load_plan_bytes,
@@ -322,6 +358,9 @@ APPLIED_ENCODING_SIGNATURE_ALGORITHM = "ed25519-domain-v1"
 APPLIED_ENCODING_DELETED_MARKER = "deleted"
 APPLIED_ENCODING_MODEL_TOOL = "axiom-encode encode --apply"
 APPLIED_ENCODING_RETIRE_TOOL = "axiom-encode retire"
+APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_DIR = Path(
+    _LEGACY_REPLACEMENT_RECEIPT_DIR_TEXT
+)
 APPLIED_ENCODING_OFFICIAL_REPOSITORY = "github.com/TheAxiomFoundation/axiom-encode"
 # Trusted-runtime attestation (encode#1147): the git-free, root-provisioned
 # cross-repo apply-identity source that EXTENDS main's checkout binding. When the
@@ -402,6 +441,44 @@ _PATH_MIGRATION_APPLY_MANIFEST_FIELDS = frozenset(
         "migration",
         "source_attestation",
         "signature",
+    }
+)
+_LEGACY_REPLACEMENT_APPLY_MANIFEST_FIELDS = frozenset(
+    {
+        "schema_version",
+        "generated_at",
+        "tool",
+        "axiom_encode_version",
+        "axiom_encode_git",
+        VALIDATION_WAIVER_SET_SHA256_FIELD,
+        "applied_files",
+        "replacement_manifest",
+        "replacement",
+        "source_attestation",
+        "signature",
+    }
+)
+_LEGACY_REPLACEMENT_RECEIPT_FIELDS = frozenset(
+    {
+        "schema_version",
+        "generated_at",
+        "tool",
+        "repository",
+        "axiom_encode_version",
+        "axiom_encode_git",
+        VALIDATION_WAIVER_SET_SHA256_FIELD,
+        "corpus_release",
+        "validation_execution",
+        "legacy",
+        "replacement",
+        "replacement_manifest",
+        "signature",
+    }
+)
+_LEGACY_REPLACEMENT_METADATA_REWRITE_PATHS = frozenset(
+    {
+        Path(".axiom/index/provisions_to_rules.json"),
+        Path("oracle-coverage-pending.yaml"),
     }
 )
 _MODEL_APPLIED_FILE_FIELDS = frozenset({"path", "sha256"})
@@ -2060,9 +2137,31 @@ def main():
         "--replace-rulespec-path",
         type=Path,
         help=(
-            "With --apply in repo-augmented mode, regenerate an existing primary "
-            "RuleSpec at this checkout-relative path when its singular corpus "
-            "citation exactly matches the requested source"
+            "With --apply in repo-augmented mode, regenerate at this explicit "
+            "checkout-relative primary RuleSpec path. The path must already exist "
+            "unless --replace-legacy-rulespec-path names its unique noncanonical "
+            "legacy predecessor."
+        ),
+    )
+    encode_parser.add_argument(
+        "--replace-legacy-rulespec-path",
+        type=Path,
+        help=(
+            "With --apply and --replace-rulespec-path, freshly model-reencode one "
+            "exact protected legacy v1/manual-owned primary, delete its primary, "
+            "companion, and legacy manifest atomically, and emit only signed v5 "
+            "replacement provenance."
+        ),
+    )
+    encode_parser.add_argument(
+        "--legacy-dependent-rulespec-path",
+        action="append",
+        default=[],
+        type=Path,
+        help=(
+            "Exact protected direct-dependent primary scheduled for a fresh "
+            "reencode in the same legacy replacement workflow. Repeat once per "
+            "dependent; no other protected old references are admitted."
         ),
     )
     _add_complete_source_unit_argument(encode_parser)
@@ -6404,6 +6503,904 @@ def cmd_guard_generated(args):
     sys.exit(0 if not issues else 1)
 
 
+def _scheduled_dependent_manifest_issue(
+    repo_path: Path,
+    *,
+    primary: str,
+    live_hashes: Mapping[str, str],
+    signing_broker: SigningBroker | Ed25519PublicKey,
+    expected_waiver_set_sha256: str,
+    expected_encoder_identity: Mapping[str, str],
+) -> str | None:
+    """Fully verify the fresh v5 manifest that resolves one scheduled group."""
+
+    manifest_path = _applied_encoding_manifest_path(Path(primary))
+    try:
+        manifest_raw = read_bounded_regular_file(
+            repo_path,
+            repo_path / manifest_path,
+            label="resolved scheduled dependent apply manifest",
+            max_bytes=1024 * 1024,
+            required_mode=0o644,
+        )
+        json.loads(manifest_raw.decode("utf-8"))
+    except (
+        OSError,
+        UnsafeCorpusPathError,
+        UnicodeError,
+        json.JSONDecodeError,
+        RecursionError,
+    ):
+        return "has no readable fresh v5 model manifest"
+    verified, _root_prefix, _digest, issues = (
+        _load_verified_applied_encoding_manifest_payload(
+            repo_path,
+            manifest_path.as_posix(),
+            signing_broker=signing_broker,
+            expected_waiver_set_sha256=expected_waiver_set_sha256,
+            expected_encoder_identity=expected_encoder_identity,
+        )
+    )
+    if verified is None or issues:
+        return "fresh v5 model manifest failed full verification"
+    if (
+        verified.get("tool") != APPLIED_ENCODING_MODEL_TOOL
+        or verified.get("backend") not in APPLIED_ENCODING_ENCODER_BACKENDS
+    ):
+        return "resolved manifest is not a fresh model encoding"
+    applied_files = verified.get("applied_files")
+    actual_hashes = (
+        {
+            str(item["path"]): str(item["sha256"])
+            for item in applied_files
+            if isinstance(item, dict)
+            and set(item) == {"path", "sha256"}
+            and isinstance(item.get("path"), str)
+            and isinstance(item.get("sha256"), str)
+        }
+        if isinstance(applied_files, list)
+        else {}
+    )
+    if any(actual_hashes.get(path) != digest for path, digest in live_hashes.items()):
+        return "fresh v5 model manifest does not bind every resolved file"
+    return None
+
+
+def _strict_legacy_replacement_map(
+    records: object,
+) -> dict[str, str] | None:
+    """Parse exact signed replacement records without Python scalar coercion."""
+
+    if not isinstance(records, list) or not records:
+        return None
+    replacements: dict[str, str] = {}
+    for item in records:
+        if (
+            not isinstance(item, dict)
+            or set(item) != {"from", "to", "count"}
+            or not isinstance(item.get("from"), str)
+            or not item["from"]
+            or not isinstance(item.get("to"), str)
+            or not item["to"]
+            or isinstance(item.get("count"), bool)
+            or not isinstance(item.get("count"), int)
+            or item["count"] <= 0
+            or item["from"] in replacements
+        ):
+            return None
+        replacements[item["from"]] = item["to"]
+    return replacements
+
+
+def _legacy_replacement_authoritative_map(
+    repo_path: Path,
+    *,
+    base_commit: str,
+    manifest_label: str,
+    legacy: object,
+    replacement: object,
+) -> tuple[dict[str, str] | None, list[str]]:
+    """Reconstruct the only replacement map authorized by signed move identity."""
+
+    issues: list[str] = []
+    if not isinstance(legacy, dict) or not isinstance(replacement, dict):
+        return None, ["legacy replacement authority blocks are malformed"]
+    source = replacement.get("source")
+    destination = replacement.get("destination")
+    source_path = Path(source) if isinstance(source, str) else Path()
+    destination_path = Path(destination) if isinstance(destination, str) else Path()
+    roots = tuple(sorted(RULESPEC_ATOMIC_MODULE_ROOTS))
+    try:
+        expected_destination = (
+            canonical_destination(source_path) if isinstance(source, str) else None
+        )
+    except PathMigrationPlanError:
+        expected_destination = None
+    for label, value, path in (
+        ("source", source, source_path),
+        ("destination", destination, destination_path),
+    ):
+        if (
+            not isinstance(value, str)
+            or path.is_absolute()
+            or path.as_posix() != value
+            or any(part in {"", ".", ".."} for part in path.parts)
+            or not _is_protected_rulespec_yaml_path(path, roots=roots)
+            or path.name.endswith(RULESPEC_TEST_FILE_SUFFIX)
+        ):
+            issues.append(f"legacy replacement {label} path is not canonical")
+    if expected_destination != destination_path:
+        issues.append("legacy replacement destination is not canonical for source")
+    if source_path == destination_path:
+        issues.append("legacy replacement source and destination must differ")
+    if (
+        legacy.get("owner_class") != APPLIED_ENCODING_LEGACY_OWNER_CLASS
+        or legacy.get("trusted_generated_provenance") is not False
+    ):
+        issues.append("legacy replacement source ownership classification is invalid")
+
+    legacy_manifest = legacy.get("manifest")
+    expected_legacy_manifest = _applied_encoding_manifest_path(source_path)
+    legacy_manifest_raw: bytes | None = None
+    if (
+        not isinstance(legacy_manifest, dict)
+        or set(legacy_manifest) != {"path", "sha256"}
+        or legacy_manifest.get("path") != expected_legacy_manifest.as_posix()
+        or not isinstance(legacy_manifest.get("sha256"), str)
+        or _SHA256_HEX_PATTERN.fullmatch(legacy_manifest["sha256"]) is None
+    ):
+        issues.append("legacy replacement manifest does not belong to source")
+    else:
+        try:
+            legacy_manifest_raw = _rulespec_migration_base_blob(
+                repo_path,
+                base_commit,
+                expected_legacy_manifest,
+            )
+        except RuntimeError as exc:
+            issues.append(f"legacy replacement source manifest is absent: {exc}")
+        else:
+            if (
+                hashlib.sha256(legacy_manifest_raw).hexdigest()
+                != legacy_manifest["sha256"]
+            ):
+                issues.append("legacy replacement source manifest hash is stale")
+
+    expected_model_manifest = _applied_encoding_manifest_path(destination_path)
+    if (
+        replacement.get("model_manifest_path") != expected_model_manifest.as_posix()
+        or manifest_label != expected_model_manifest.as_posix()
+    ):
+        issues.append(
+            "legacy replacement model manifest does not belong to destination"
+        )
+
+    expected_files: dict[str, str] = {}
+    existing_companions: set[Path] = set()
+    if isinstance(source, str):
+        for candidate in (source_path, companion_path(source_path)):
+            try:
+                raw = _rulespec_migration_base_blob(
+                    repo_path,
+                    base_commit,
+                    candidate,
+                )
+            except RuntimeError:
+                if candidate == source_path:
+                    issues.append("legacy replacement source is absent from base")
+                continue
+            expected_files[candidate.as_posix()] = hashlib.sha256(raw).hexdigest()
+            if candidate != source_path:
+                existing_companions.add(candidate)
+    legacy_files = legacy.get("files")
+    actual_files: dict[str, str] = {}
+    if not isinstance(legacy_files, list):
+        issues.append("legacy replacement source files are malformed")
+    else:
+        for item in legacy_files:
+            if (
+                not isinstance(item, dict)
+                or set(item) != {"path", "sha256"}
+                or not isinstance(item.get("path"), str)
+                or not isinstance(item.get("sha256"), str)
+                or _SHA256_HEX_PATTERN.fullmatch(item["sha256"]) is None
+                or item["path"] in actual_files
+            ):
+                issues.append("legacy replacement source file entry is malformed")
+                continue
+            actual_files[item["path"]] = item["sha256"]
+    if actual_files != expected_files:
+        issues.append(
+            "legacy replacement source files do not exactly match base source group"
+        )
+    if legacy_manifest_raw is not None:
+        try:
+            legacy_manifest_payload = json.loads(legacy_manifest_raw.decode("utf-8"))
+        except (UnicodeError, json.JSONDecodeError, RecursionError):
+            issues.append("legacy replacement source manifest is not valid JSON")
+        else:
+            legacy_manifest_issues = _legacy_manual_manifest_issues(
+                legacy_manifest_payload,
+                expected_files=expected_files,
+            )
+            issues.extend(
+                f"legacy replacement source manifest is not legacy-owned: {issue}"
+                for issue in legacy_manifest_issues
+            )
+    if issues:
+        return None, issues
+    try:
+        replacements = exact_reference_replacements(
+            [PlannedMove(source=source_path, destination=destination_path)],
+            existing_companions=existing_companions,
+        )
+    except PathMigrationPlanError as exc:
+        return None, [f"legacy replacement authority cannot be reconstructed: {exc}"]
+    return replacements, []
+
+
+def _legacy_replacement_reference_inventory_issues(
+    repo_path: Path,
+    *,
+    base_commit: str,
+    authoritative_replacements: dict[str, str],
+    legacy: object,
+    replacement: object,
+    allow_pending_scheduled: bool,
+) -> list[str]:
+    """Prove that receipt evidence covers every authoritative base reference."""
+
+    if not isinstance(legacy, dict) or not isinstance(replacement, dict):
+        return ["legacy replacement reference inventory blocks are malformed"]
+
+    issues: list[str] = []
+    classifications: dict[Path, str] = {}
+
+    def classify(raw_path: object, owner: str) -> None:
+        if not isinstance(raw_path, str):
+            issues.append(
+                f"legacy replacement reference inventory {owner} path is malformed"
+            )
+            return
+        path = Path(raw_path)
+        if (
+            path.is_absolute()
+            or path.as_posix() != raw_path
+            or any(part in {"", ".", ".."} for part in path.parts)
+        ):
+            issues.append(
+                f"legacy replacement reference inventory {owner} path is malformed"
+            )
+            return
+        previous = classifications.get(path)
+        if previous is not None:
+            issues.append(
+                "legacy replacement reference inventory classifies "
+                f"{path.as_posix()} as both {previous} and {owner}"
+            )
+            return
+        classifications[path] = owner
+
+    legacy_files = legacy.get("files")
+    if isinstance(legacy_files, list):
+        for item in legacy_files:
+            if isinstance(item, dict):
+                classify(item.get("path"), "deleted source")
+    rewrites = replacement.get("rewrites")
+    if isinstance(rewrites, list):
+        for item in rewrites:
+            if isinstance(item, dict):
+                classify(item.get("path"), "metadata rewrite")
+    scheduled = replacement.get("scheduled_dependents")
+    if isinstance(scheduled, list):
+        for dependent in scheduled:
+            files = dependent.get("files") if isinstance(dependent, dict) else None
+            if not isinstance(files, list):
+                continue
+            for item in files:
+                if isinstance(item, dict):
+                    classify(item.get("path"), "scheduled dependent")
+
+    legacy_manifest = legacy.get("manifest")
+    legacy_manifest_path = (
+        Path(legacy_manifest["path"])
+        if isinstance(legacy_manifest, dict)
+        and isinstance(legacy_manifest.get("path"), str)
+        else None
+    )
+    if legacy_manifest_path is not None and legacy_manifest_path in classifications:
+        issues.append(
+            "legacy replacement source manifest is also classified as reference input"
+        )
+
+    try:
+        listing = _rulespec_migration_git_bytes(
+            repo_path,
+            "ls-tree",
+            "-r",
+            "-l",
+            "-z",
+            "--full-tree",
+            base_commit,
+        )
+    except RuntimeError as exc:
+        return [*issues, f"cannot enumerate legacy replacement base inventory: {exc}"]
+
+    base_entries: dict[Path, tuple[str, str, int | None]] = {}
+    for record in listing.split(b"\0"):
+        if not record:
+            continue
+        try:
+            metadata, encoded_path = record.split(b"\t", 1)
+            mode, object_type, object_id, raw_size = metadata.decode("ascii").split()
+            path_text = encoded_path.decode("utf-8")
+        except (ValueError, UnicodeDecodeError):
+            issues.append("legacy replacement base inventory entry is malformed")
+            continue
+        path = Path(path_text)
+        if (
+            object_type not in {"blob", "commit"}
+            or path.is_absolute()
+            or path.as_posix() != path_text
+            or any(part in {"", ".", ".."} for part in path.parts)
+            or path in base_entries
+        ):
+            issues.append("legacy replacement base inventory entry is malformed")
+            continue
+        if object_type == "commit":
+            size = None
+        else:
+            try:
+                size = int(raw_size)
+            except ValueError:
+                issues.append("legacy replacement base inventory size is malformed")
+                continue
+            if size < 0:
+                issues.append("legacy replacement base inventory size is malformed")
+                continue
+        base_entries[path] = (mode, object_id, size)
+
+    grep_command = [
+        "git",
+        "-C",
+        str(repo_path),
+        "grep",
+        "-z",
+        "-l",
+        "-a",
+        "-F",
+    ]
+    for old_reference in authoritative_replacements:
+        grep_command.extend(("-e", old_reference))
+    grep_command.extend((base_commit, "--"))
+    grep_result = subprocess.run(
+        grep_command,
+        capture_output=True,
+        env=_rulespec_migration_git_environment(),
+        check=False,
+    )
+    if grep_result.returncode not in {0, 1}:
+        stderr = grep_result.stderr.decode("utf-8", errors="replace").strip()
+        return [
+            *issues,
+            f"cannot scan legacy replacement base inventory candidates: {stderr}",
+        ]
+    candidate_paths: set[Path] = set()
+    candidate_prefix = f"{base_commit}:".encode()
+    for encoded_candidate in grep_result.stdout.split(b"\0"):
+        if not encoded_candidate:
+            continue
+        if not encoded_candidate.startswith(candidate_prefix):
+            issues.append("legacy replacement base inventory candidate is malformed")
+            continue
+        try:
+            candidate_text = encoded_candidate[len(candidate_prefix) :].decode("utf-8")
+        except UnicodeDecodeError:
+            issues.append("legacy replacement base inventory candidate is malformed")
+            continue
+        candidate = Path(candidate_text)
+        if (
+            candidate.is_absolute()
+            or candidate.as_posix() != candidate_text
+            or any(part in {"", ".", ".."} for part in candidate.parts)
+            or candidate in candidate_paths
+            or candidate not in base_entries
+        ):
+            issues.append("legacy replacement base inventory candidate is malformed")
+            continue
+        candidate_paths.add(candidate)
+    for path, (mode, _object_id, size) in base_entries.items():
+        if size is None:
+            issues.append(
+                "legacy replacement base inventory cannot verify non-blob tracked "
+                f"path {path.as_posix()}"
+            )
+        elif mode != "100644":
+            candidate_paths.add(path)
+
+    deleted_paths = {
+        path for path, owner in classifications.items() if owner == "deleted source"
+    }
+    provenance_prefixes = (
+        APPLIED_ENCODING_MANIFEST_DIR.parts,
+        APPLIED_ENCODING_PATH_MIGRATION_RECEIPT_DIR.parts,
+        APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_DIR.parts,
+    )
+    roots = tuple(sorted(RULESPEC_ATOMIC_MODULE_ROOTS))
+    hit_paths: set[Path] = set()
+    base_hit_bytes: dict[Path, bytes] = {}
+    for path in sorted(candidate_paths, key=Path.as_posix):
+        if path in deleted_paths or path == legacy_manifest_path:
+            continue
+        mode, object_id, size = base_entries[path]
+        if size is None:
+            issues.append(
+                "legacy replacement reference candidate is not a blob: "
+                f"{path.as_posix()}"
+            )
+            continue
+        if size > 16 * 1024 * 1024:
+            issues.append(
+                "legacy replacement base inventory entry exceeds the 16 MiB "
+                f"verification limit: {path.as_posix()}"
+            )
+            continue
+        try:
+            base_raw = _rulespec_migration_git_bytes(
+                repo_path,
+                "cat-file",
+                "blob",
+                object_id,
+            )
+        except RuntimeError as exc:
+            issues.append(
+                "cannot read legacy replacement base inventory "
+                f"{path.as_posix()}: {exc}"
+            )
+            continue
+        if len(base_raw) != size:
+            issues.append(
+                f"legacy replacement base inventory size differs: {path.as_posix()}"
+            )
+            continue
+        if mode != "100644":
+            if any(
+                old_reference.encode() in base_raw
+                for old_reference in authoritative_replacements
+            ):
+                issues.append(
+                    "legacy replacement reference occurs in non-0644 tracked path "
+                    f"{path.as_posix()}"
+                )
+            continue
+        try:
+            _rewritten, counts = rewrite_exact_references(
+                base_raw,
+                authoritative_replacements,
+            )
+        except PathMigrationPlanError as exc:
+            issues.append(
+                f"legacy replacement base inventory is unreadable at {path}: {exc}"
+            )
+            continue
+        if not counts:
+            continue
+        hit_paths.add(path)
+        base_hit_bytes[path] = base_raw
+        owner = classifications.get(path)
+        if any(path.parts[: len(prefix)] == prefix for prefix in provenance_prefixes):
+            issues.append(
+                "legacy replacement reference occurs in persisted provenance "
+                f"{path.as_posix()}"
+            )
+            continue
+        if _is_protected_rulespec_yaml_path(path, roots=roots):
+            if owner != "scheduled dependent":
+                issues.append(
+                    "legacy replacement base reference inventory omits protected "
+                    f"dependent {path.as_posix()}"
+                )
+        elif (
+            owner != "metadata rewrite"
+            or path not in _LEGACY_REPLACEMENT_METADATA_REWRITE_PATHS
+        ):
+            issues.append(
+                "legacy replacement base reference inventory omits allowed rewrite "
+                f"{path.as_posix()}"
+            )
+
+    for path, owner in classifications.items():
+        if owner == "deleted source":
+            live = repo_path / path
+            if live.exists() or live.is_symlink():
+                issues.append(
+                    f"legacy replacement deleted source still exists: {path.as_posix()}"
+                )
+            continue
+        if path not in hit_paths:
+            issues.append(
+                "legacy replacement reference evidence has no authoritative base hit: "
+                f"{path.as_posix()}"
+            )
+            continue
+        base_entry = base_entries.get(path)
+        if base_entry is None or base_entry[0] != "100644":
+            continue
+        try:
+            live_raw = read_bounded_regular_file(
+                repo_path,
+                repo_path / path,
+                label="legacy replacement reference inventory live file",
+                max_bytes=16 * 1024 * 1024,
+                required_mode=0o644,
+            )
+            _unused, remaining = rewrite_exact_references(
+                live_raw,
+                authoritative_replacements,
+            )
+        except (
+            OSError,
+            UnsafeCorpusPathError,
+            PathMigrationPlanError,
+        ) as exc:
+            issues.append(
+                f"cannot read legacy replacement live inventory {path.as_posix()}: "
+                f"{exc}"
+            )
+            continue
+        if remaining and (
+            owner != "scheduled dependent"
+            or not allow_pending_scheduled
+            or live_raw != base_hit_bytes[path]
+        ):
+            issues.append(
+                "legacy replacement live inventory retains an old reference: "
+                f"{path.as_posix()}"
+            )
+    return issues
+
+
+def _legacy_replacement_pending_paths(repo_path: Path) -> list[str]:
+    """Return signed-replacement scheduled files still at their bound base bytes."""
+
+    pending: list[str] = []
+    manifest_root = repo_path / APPLIED_ENCODING_MANIFEST_DIR
+    candidates: list[tuple[str, dict[str, object]]] = []
+    if manifest_root.is_dir():
+        for manifest_path in sorted(manifest_root.rglob("*.json")):
+            manifest_label = manifest_path.relative_to(repo_path).as_posix()
+            try:
+                manifest_raw = read_bounded_regular_file(
+                    repo_path,
+                    manifest_path,
+                    label="legacy replacement pending-state manifest",
+                    max_bytes=4 * 1024 * 1024,
+                    required_mode=0o644,
+                )
+                payload = json.loads(manifest_raw.decode("utf-8"))
+            except (
+                OSError,
+                UnsafeCorpusPathError,
+                UnicodeError,
+                json.JSONDecodeError,
+                RecursionError,
+            ):
+                continue
+            if (
+                not isinstance(payload, dict)
+                or payload.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
+            ):
+                continue
+            candidates.append((manifest_label, payload))
+    receipt_root = repo_path / APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_DIR
+    receipt_candidates = (
+        sorted(receipt_root.rglob("*.json")) if receipt_root.is_dir() else []
+    )
+    if not candidates and not receipt_candidates:
+        return pending
+    try:
+        signing_broker = _applied_encoding_manifest_verifier()
+    except SigningBrokerError:
+        signing_broker = None
+    if signing_broker is None:
+        return sorted(
+            {
+                *[f"invalid:{label}" for label, _payload in candidates],
+                *[
+                    f"invalid:{path.relative_to(repo_path).as_posix()}"
+                    for path in receipt_candidates
+                ],
+            }
+        )
+    bound_receipts: set[Path] = set()
+    for manifest_label, payload in candidates:
+        if (
+            set(payload) != _LEGACY_REPLACEMENT_APPLY_MANIFEST_FIELDS
+            or _applied_encoding_manifest_signature_issue(payload, signing_broker)
+        ):
+            pending.append(f"invalid:{manifest_label}")
+            continue
+        binding = payload.get("replacement")
+        receipt_path = (
+            binding.get("receipt_path") if isinstance(binding, dict) else None
+        )
+        receipt_relative = (
+            Path(receipt_path) if isinstance(receipt_path, str) else Path()
+        )
+        if (
+            not isinstance(binding, dict)
+            or set(binding)
+            != {
+                "receipt_path",
+                "receipt_sha256",
+                "legacy_manifest_path",
+                "legacy_manifest_sha256",
+            }
+            or not isinstance(receipt_path, str)
+            or receipt_relative.is_absolute()
+            or receipt_relative.as_posix() != receipt_path
+            or receipt_relative.parent
+            != APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_DIR
+            or receipt_relative.suffix != ".json"
+            or any(part in {"", ".", ".."} for part in receipt_relative.parts)
+        ):
+            pending.append(f"invalid:{manifest_label}")
+            continue
+        try:
+            receipt_raw = read_bounded_regular_file(
+                repo_path,
+                repo_path / receipt_relative,
+                label="legacy replacement pending-state receipt",
+                max_bytes=4 * 1024 * 1024,
+                required_mode=0o644,
+            )
+            receipt = json.loads(receipt_raw.decode("utf-8"))
+        except (
+            OSError,
+            UnsafeCorpusPathError,
+            UnicodeError,
+            json.JSONDecodeError,
+            RecursionError,
+        ):
+            pending.append(f"invalid:{manifest_label}")
+            continue
+        if (
+            not isinstance(receipt, dict)
+            or set(receipt) != _LEGACY_REPLACEMENT_RECEIPT_FIELDS
+            or receipt.get("schema_version")
+            != APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+            or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
+            or hashlib.sha256(receipt_raw).hexdigest() != binding.get("receipt_sha256")
+            or _applied_encoding_manifest_signature_issue(receipt, signing_broker)
+        ):
+            pending.append(f"invalid:{manifest_label}")
+            continue
+        replacement = receipt.get("replacement") if isinstance(receipt, dict) else None
+        receipt_model_manifest = receipt.get("replacement_manifest")
+        scheduled = (
+            replacement.get("scheduled_dependents")
+            if isinstance(replacement, dict)
+            else None
+        )
+        repository = receipt.get("repository")
+        execution = receipt.get("validation_execution")
+        expected_encoder_identity = (
+            execution.get("axiom_encode") if isinstance(execution, dict) else None
+        )
+        if (
+            not isinstance(repository, dict)
+            or set(repository) != {"base_commit", "head_commit", "base_tree"}
+            or not isinstance(repository.get("base_commit"), str)
+            or re.fullmatch(r"[0-9a-f]{40}", repository["base_commit"]) is None
+            or repository.get("head_commit") != repository["base_commit"]
+            or not isinstance(repository.get("base_tree"), str)
+            or re.fullmatch(r"[0-9a-f]{40}", repository["base_tree"]) is None
+            or not isinstance(expected_encoder_identity, dict)
+            or not isinstance(receipt_model_manifest, dict)
+            or replacement.get("live_files")
+            != receipt_model_manifest.get("applied_files")
+            or not isinstance(scheduled, list)
+        ):
+            pending.append(f"invalid:{manifest_label}")
+            continue
+        base_commit = str(repository["base_commit"])
+        try:
+            actual_base_tree = _rulespec_migration_git(
+                repo_path,
+                "rev-parse",
+                f"{base_commit}^{{tree}}",
+            ).strip()
+        except RuntimeError:
+            pending.append(f"invalid:{manifest_label}")
+            continue
+        if actual_base_tree != repository["base_tree"]:
+            pending.append(f"invalid:{manifest_label}")
+            continue
+        authoritative_replacements, authority_issues = (
+            _legacy_replacement_authoritative_map(
+                repo_path,
+                base_commit=base_commit,
+                manifest_label=manifest_label,
+                legacy=receipt.get("legacy"),
+                replacement=replacement,
+            )
+        )
+        if authoritative_replacements is None or authority_issues:
+            pending.append(f"invalid:{manifest_label}")
+            continue
+        inventory_issues = _legacy_replacement_reference_inventory_issues(
+            repo_path,
+            base_commit=base_commit,
+            authoritative_replacements=authoritative_replacements,
+            legacy=receipt.get("legacy"),
+            replacement=replacement,
+            allow_pending_scheduled=True,
+        )
+        if inventory_issues:
+            pending.append(f"invalid:{manifest_label}")
+            continue
+        bound_receipts.add(receipt_relative)
+        seen_primaries: set[str] = set()
+        seen_files: set[str] = set()
+        for dependent in scheduled:
+            if (
+                not isinstance(dependent, dict)
+                or set(dependent) != {"primary", "files"}
+                or not isinstance(dependent.get("primary"), str)
+                or not isinstance(dependent.get("files"), list)
+                or not dependent["files"]
+            ):
+                pending.append(f"invalid:{manifest_label}")
+                continue
+            primary = str(dependent["primary"])
+            primary_path = Path(primary)
+            files = dependent["files"]
+            if (
+                primary in seen_primaries
+                or primary_path.is_absolute()
+                or primary_path.as_posix() != primary
+                or any(part in {"", ".", ".."} for part in primary_path.parts)
+                or not _is_protected_rulespec_yaml_path(
+                    primary_path,
+                    roots=tuple(sorted(RULESPEC_ATOMIC_MODULE_ROOTS)),
+                )
+                or primary_path.name.endswith(RULESPEC_TEST_FILE_SUFFIX)
+            ):
+                pending.append(f"invalid:{manifest_label}")
+                continue
+            seen_primaries.add(primary)
+            group_pending: list[str] = []
+            group_live_hashes: dict[str, str] = {}
+            group_invalid = False
+            for evidence in files:
+                if (
+                    not isinstance(evidence, dict)
+                    or set(evidence) != {"path", "before_sha256", "replacements"}
+                    or not isinstance(evidence.get("path"), str)
+                    or not isinstance(evidence.get("before_sha256"), str)
+                    or not isinstance(evidence.get("replacements"), list)
+                    or not evidence["replacements"]
+                ):
+                    group_invalid = True
+                    continue
+                path = str(evidence["path"])
+                before = str(evidence["before_sha256"])
+                live_relative = Path(path)
+                if (
+                    path in seen_files
+                    or live_relative.is_absolute()
+                    or live_relative.as_posix() != path
+                    or any(part in {"", ".", ".."} for part in live_relative.parts)
+                    or _SHA256_HEX_PATTERN.fullmatch(before) is None
+                    or live_relative not in {primary_path, companion_path(primary_path)}
+                ):
+                    group_invalid = True
+                    continue
+                seen_files.add(path)
+                replacements = evidence["replacements"]
+                if _strict_legacy_replacement_map(replacements) is None:
+                    group_invalid = True
+                    continue
+                try:
+                    base_raw = _rulespec_migration_base_blob(
+                        repo_path,
+                        base_commit,
+                        live_relative,
+                    )
+                    _base_rewritten, base_counts = rewrite_exact_references(
+                        base_raw,
+                        authoritative_replacements,
+                    )
+                except (RuntimeError, PathMigrationPlanError):
+                    group_invalid = True
+                    continue
+                if (
+                    hashlib.sha256(base_raw).hexdigest() != before
+                    or list(base_counts) != replacements
+                ):
+                    group_invalid = True
+                    continue
+                try:
+                    live_raw = read_bounded_regular_file(
+                        repo_path,
+                        repo_path / live_relative,
+                        label="legacy replacement scheduled dependent",
+                        max_bytes=16 * 1024 * 1024,
+                        required_mode=0o644,
+                    )
+                except (OSError, UnsafeCorpusPathError):
+                    group_invalid = True
+                    continue
+                live_sha256 = hashlib.sha256(live_raw).hexdigest()
+                if live_sha256 == before:
+                    group_pending.append(path)
+                    continue
+                try:
+                    _rewritten, remaining = rewrite_exact_references(
+                        live_raw, authoritative_replacements
+                    )
+                except PathMigrationPlanError:
+                    remaining = ({"invalid": True},)
+                if remaining:
+                    group_invalid = True
+                    continue
+                group_live_hashes[path] = live_sha256
+            if group_pending and group_live_hashes:
+                group_invalid = True
+            if group_invalid:
+                pending.append(f"invalid:{primary}")
+                continue
+            if group_pending:
+                pending.extend(group_pending)
+                continue
+            manifest_issue = _scheduled_dependent_manifest_issue(
+                repo_path,
+                primary=primary,
+                live_hashes=group_live_hashes,
+                signing_broker=signing_broker,
+                expected_waiver_set_sha256=str(
+                    payload.get(VALIDATION_WAIVER_SET_SHA256_FIELD) or ""
+                ),
+                expected_encoder_identity=expected_encoder_identity,
+            )
+            if manifest_issue:
+                pending.append(f"invalid:{primary}")
+    for receipt_path in receipt_candidates:
+        receipt_label = receipt_path.relative_to(repo_path).as_posix()
+        receipt_relative = Path(receipt_label)
+        try:
+            receipt_raw = read_bounded_regular_file(
+                repo_path,
+                receipt_path,
+                label="legacy replacement receipt census",
+                max_bytes=4 * 1024 * 1024,
+                required_mode=0o644,
+            )
+            receipt = json.loads(receipt_raw.decode("utf-8"))
+        except (
+            OSError,
+            UnsafeCorpusPathError,
+            UnicodeError,
+            json.JSONDecodeError,
+            RecursionError,
+        ):
+            pending.append(f"invalid:{receipt_label}")
+            continue
+        if (
+            receipt_relative.parent != APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_DIR
+            or _SHA256_HEX_PATTERN.fullmatch(receipt_relative.stem) is None
+            or not isinstance(receipt, dict)
+            or set(receipt) != _LEGACY_REPLACEMENT_RECEIPT_FIELDS
+            or receipt.get("schema_version")
+            != APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+            or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
+            or _applied_encoding_manifest_signature_issue(receipt, signing_broker)
+            or receipt_relative not in bound_receipts
+        ):
+            pending.append(f"invalid:{receipt_label}")
+    return sorted(set(pending))
+
+
 def _manifest_census(
     repo_path: Path,
     *,
@@ -6420,6 +7417,12 @@ def _manifest_census(
     rule file.
     """
     repo_path = _resolve_canonical_rulespec_checkout(repo_path)
+    pending_legacy = _legacy_replacement_pending_paths(repo_path)
+    if pending_legacy:
+        raise RuntimeError(
+            "manifest census is unavailable while a signed legacy replacement "
+            "has scheduled dependents pending: " + ", ".join(pending_legacy)
+        )
     _rulespec_module_paths(repo_path)
     protected = _all_protected_rulespec_yaml_paths(repo_path, roots=roots)
     manifest_paths = _all_applied_encoding_manifest_paths(repo_path, roots=roots)
@@ -18477,11 +19480,21 @@ def _manifest_coverage_by_file(
             continue
         backend = _normalized_manifest_backend(payload)
         migrated_manifest = payload.get("migrated_manifest")
-        is_generated = backend in APPLIED_ENCODING_GENERATED_BACKENDS or (
-            payload.get("tool") == APPLIED_ENCODING_PATH_MIGRATION_TOOL
-            and isinstance(migrated_manifest, dict)
-            and _normalized_manifest_backend(migrated_manifest)
-            in APPLIED_ENCODING_GENERATED_BACKENDS
+        replacement_manifest = payload.get("replacement_manifest")
+        is_generated = (
+            backend in APPLIED_ENCODING_GENERATED_BACKENDS
+            or (
+                payload.get("tool") == APPLIED_ENCODING_PATH_MIGRATION_TOOL
+                and isinstance(migrated_manifest, dict)
+                and _normalized_manifest_backend(migrated_manifest)
+                in APPLIED_ENCODING_GENERATED_BACKENDS
+            )
+            or (
+                payload.get("tool") == APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
+                and isinstance(replacement_manifest, dict)
+                and _normalized_manifest_backend(replacement_manifest)
+                in APPLIED_ENCODING_GENERATED_BACKENDS
+            )
         )
         applied_files = payload.get("applied_files")
         if not isinstance(applied_files, list):
@@ -18987,6 +20000,39 @@ def _applied_manifest_tool_execution_issues(
         return issues
     if backend is None:
         applied_files = payload.get("applied_files")
+        if tool == APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL:
+            replacement_manifest = payload.get("replacement_manifest")
+            if (
+                not isinstance(replacement_manifest, dict)
+                or replacement_manifest.get("backend")
+                not in APPLIED_ENCODING_ENCODER_BACKENDS
+                or replacement_manifest.get("tool") != APPLIED_ENCODING_MODEL_TOOL
+                or replacement_manifest.get("schema_version")
+                != APPLIED_ENCODING_MANIFEST_SCHEMA
+            ):
+                issues.append(
+                    f"{manifest_label} legacy replacement must nest a fresh "
+                    "current-v5 model apply manifest"
+                )
+            if (
+                "deterministic_execution" in payload
+                or "validation_execution" in payload
+            ):
+                issues.append(
+                    f"{manifest_label} legacy replacement must preserve nested model "
+                    "provenance instead of claiming deterministic generation"
+                )
+            provenance = payload.get("axiom_encode_git")
+            if not isinstance(provenance, dict) or (
+                provenance.get("commit") != expected_encoder_identity.get("commit")
+                or provenance.get("version") != expected_encoder_identity.get("version")
+                or provenance.get("dirty_tracked") is not False
+            ):
+                issues.append(
+                    f"{manifest_label} legacy replacement does not match the "
+                    "running pinned encoder"
+                )
+            return issues
         if tool == APPLIED_ENCODING_PATH_MIGRATION_TOOL:
             if not isinstance(applied_files, list) or any(
                 not isinstance(item, dict)
@@ -19087,6 +20133,10 @@ def _applied_manifest_exact_schema_issues(
         expected_fields = _PATH_MIGRATION_APPLY_MANIFEST_FIELDS
         expected_item_fields = None
         contract = "path migration"
+    elif backend is None and tool == APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL:
+        expected_fields = _LEGACY_REPLACEMENT_APPLY_MANIFEST_FIELDS
+        expected_item_fields = None
+        contract = "legacy replacement"
     else:
         return []
 
@@ -19190,12 +20240,12 @@ def _applied_manifest_exact_schema_issues(
         for index, item in enumerate(applied_files):
             allowed_item_fields = (
                 _PATH_MIGRATION_DELETED_FILE_FIELDS
-                if contract == "path migration"
+                if contract in {"path migration", "legacy replacement"}
                 and isinstance(item, dict)
                 and item.get("deleted") is True
                 else (
                     _PATH_MIGRATION_LIVE_FILE_FIELDS
-                    if contract == "path migration"
+                    if contract in {"path migration", "legacy replacement"}
                     else expected_item_fields
                 )
             )
@@ -20115,6 +21165,620 @@ def _migrated_model_manifest_issues(
     return issues
 
 
+def _legacy_replacement_manifest_issues(
+    payload: Mapping[str, object],
+    *,
+    repo_path: Path,
+    manifest_label: str,
+    signing_broker: SigningBroker | Ed25519PublicKey,
+    expected_waiver_set_sha256: str,
+    local_corpus_release: LocalCorpusRelease | None,
+) -> list[str]:
+    """Verify fresh model provenance and immutable-base replacement proof."""
+
+    if (
+        payload.get("backend") is not None
+        or payload.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
+    ):
+        return []
+    issues: list[str] = []
+    nested = payload.get("replacement_manifest")
+    nested_label = f"{manifest_label}.replacement_manifest"
+    if not isinstance(nested, dict):
+        return [f"{nested_label} must be a fresh signed v5 model manifest"]
+    issues.extend(
+        _applied_manifest_exact_schema_issues(nested, manifest_label=nested_label)
+    )
+    nested_signature_issue = _applied_encoding_manifest_signature_issue(
+        nested,
+        signing_broker,
+    )
+    if nested_signature_issue:
+        issues.append(f"{nested_label} {nested_signature_issue}")
+    nested_execution = nested.get("validation_execution")
+    nested_encoder = (
+        nested_execution.get("axiom_encode")
+        if isinstance(nested_execution, dict)
+        else None
+    )
+    expected_nested_encoder = nested_encoder if isinstance(nested_encoder, dict) else {}
+    issues.extend(
+        _applied_manifest_tool_execution_issues(
+            nested,
+            manifest_label=nested_label,
+            expected_encoder_identity=expected_nested_encoder,
+        )
+    )
+    issues.extend(
+        _model_apply_validation_execution_issues(
+            nested,
+            manifest_label=nested_label,
+            expected_waiver_set_sha256=expected_waiver_set_sha256,
+            expected_encoder_identity=expected_nested_encoder,
+        )
+    )
+    if nested.get(VALIDATION_WAIVER_SET_SHA256_FIELD) != expected_waiver_set_sha256:
+        issues.append(f"{nested_label} waiver-set binding is stale")
+    if payload.get("source_attestation") != nested.get("source_attestation"):
+        issues.append(f"{nested_label} source_attestation differs from replacement")
+
+    binding = payload.get("replacement")
+    expected_binding_fields = {
+        "receipt_path",
+        "receipt_sha256",
+        "legacy_manifest_path",
+        "legacy_manifest_sha256",
+    }
+    if not isinstance(binding, dict) or set(binding) != expected_binding_fields:
+        return [*issues, f"{manifest_label} replacement binding is malformed"]
+    receipt_path_raw = binding.get("receipt_path")
+    receipt_path = (
+        Path(receipt_path_raw) if isinstance(receipt_path_raw, str) else Path()
+    )
+    if (
+        not isinstance(receipt_path_raw, str)
+        or receipt_path.is_absolute()
+        or receipt_path.parent != APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_DIR
+        or receipt_path.suffix != ".json"
+        or any(part in {"", ".", ".."} for part in receipt_path.parts)
+    ):
+        return [*issues, f"{manifest_label} replacement receipt path is invalid"]
+    try:
+        receipt_raw = read_bounded_regular_file(
+            repo_path,
+            repo_path / receipt_path,
+            label="legacy replacement receipt",
+            max_bytes=4 * 1024 * 1024,
+            required_mode=0o644,
+        )
+        receipt = json.loads(receipt_raw.decode("utf-8"))
+    except (OSError, UnsafeCorpusPathError, UnicodeError, json.JSONDecodeError):
+        return [*issues, f"{manifest_label} replacement receipt is unreadable"]
+    if not isinstance(receipt, dict):
+        return [*issues, f"{manifest_label} replacement receipt is not an object"]
+    if set(receipt) != _LEGACY_REPLACEMENT_RECEIPT_FIELDS:
+        issues.append(f"{manifest_label} replacement receipt has noncanonical fields")
+    receipt_sha256 = hashlib.sha256(receipt_raw).hexdigest()
+    receipt_repository = receipt.get("repository")
+    receipt_replacement = receipt.get("replacement")
+    receipt_legacy = receipt.get("legacy")
+    identity_payload = receipt_identity_payload(
+        base_commit=(
+            str(receipt_repository.get("base_commit"))
+            if isinstance(receipt_repository, dict)
+            else ""
+        ),
+        base_tree=(
+            str(receipt_repository.get("base_tree"))
+            if isinstance(receipt_repository, dict)
+            else ""
+        ),
+        legacy_manifest_sha256=str(binding.get("legacy_manifest_sha256") or ""),
+        model_manifest_sha256=(
+            str(receipt_replacement.get("model_manifest_sha256") or "")
+            if isinstance(receipt_replacement, dict)
+            else ""
+        ),
+        live_files=(
+            receipt_replacement.get("live_files")
+            if isinstance(receipt_replacement, dict)
+            and isinstance(receipt_replacement.get("live_files"), list)
+            else []
+        ),
+        deleted_files=[
+            {"path": item.get("path"), "deleted": True}
+            for item in (
+                receipt_legacy.get("files", [])
+                if isinstance(receipt_legacy, dict)
+                and isinstance(receipt_legacy.get("files"), list)
+                else []
+            )
+            if isinstance(item, dict)
+        ],
+        rewrites=(
+            receipt_replacement.get("rewrites")
+            if isinstance(receipt_replacement, dict)
+            and isinstance(receipt_replacement.get("rewrites"), list)
+            else []
+        ),
+        scheduled_dependents=(
+            receipt_replacement.get("scheduled_dependents")
+            if isinstance(receipt_replacement, dict)
+            and isinstance(receipt_replacement.get("scheduled_dependents"), list)
+            else []
+        ),
+    )
+    if binding.get(
+        "receipt_sha256"
+    ) != receipt_sha256 or receipt_path.stem != receipt_identity_sha256(
+        identity_payload
+    ):
+        issues.append(f"{manifest_label} replacement receipt identity is stale")
+    if (
+        receipt.get("schema_version")
+        != APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+        or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
+    ):
+        issues.append(f"{manifest_label} replacement receipt schema is invalid")
+    generated_at = receipt.get("generated_at")
+    try:
+        parsed_generated_at = (
+            datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+            if isinstance(generated_at, str)
+            else None
+        )
+    except ValueError:
+        parsed_generated_at = None
+    if parsed_generated_at is None or parsed_generated_at.tzinfo is None:
+        issues.append(f"{manifest_label} replacement receipt timestamp is invalid")
+    receipt_signature_issue = _applied_encoding_manifest_signature_issue(
+        receipt,
+        signing_broker,
+    )
+    if receipt_signature_issue:
+        issues.append(f"{manifest_label} replacement receipt {receipt_signature_issue}")
+    if (
+        receipt.get("axiom_encode_version") != payload.get("axiom_encode_version")
+        or receipt.get("axiom_encode_git") != payload.get("axiom_encode_git")
+        or receipt.get(VALIDATION_WAIVER_SET_SHA256_FIELD) != expected_waiver_set_sha256
+    ):
+        issues.append(f"{manifest_label} replacement receipt provenance is stale")
+    release = receipt.get("corpus_release")
+    if local_corpus_release is not None and release != {
+        "name": local_corpus_release.name,
+        "content_sha256": local_corpus_release.content_sha256,
+        "selector_sha256": local_corpus_release.selector_sha256,
+    }:
+        issues.append(f"{manifest_label} replacement receipt corpus binding is stale")
+    if receipt.get("validation_execution") != nested_execution:
+        issues.append(f"{manifest_label} replacement validation provenance differs")
+    if receipt.get("replacement_manifest") != nested:
+        issues.append(f"{manifest_label} replacement receipt nested manifest differs")
+    nested_raw = (json.dumps(nested, indent=2, sort_keys=True) + "\n").encode()
+    nested_sha256 = hashlib.sha256(nested_raw).hexdigest()
+
+    repository = receipt.get("repository")
+    if not isinstance(repository, dict) or set(repository) != {
+        "base_commit",
+        "head_commit",
+        "base_tree",
+    }:
+        return [
+            *issues,
+            f"{manifest_label} replacement repository binding is malformed",
+        ]
+    base_commit = repository.get("base_commit")
+    base_tree = repository.get("base_tree")
+    if (
+        not isinstance(base_commit, str)
+        or re.fullmatch(r"[0-9a-f]{40}", base_commit) is None
+        or repository.get("head_commit") != base_commit
+        or not isinstance(base_tree, str)
+        or re.fullmatch(r"[0-9a-f]{40}", base_tree) is None
+    ):
+        return [*issues, f"{manifest_label} replacement repository identity is invalid"]
+    try:
+        actual_tree = _rulespec_migration_git(
+            repo_path,
+            "rev-parse",
+            f"{base_commit}^{{tree}}",
+        ).strip()
+    except RuntimeError as exc:
+        return [*issues, f"{manifest_label} cannot verify replacement base: {exc}"]
+    if actual_tree != base_tree:
+        issues.append(f"{manifest_label} replacement base tree is stale")
+
+    legacy = receipt.get("legacy")
+    replacement = receipt.get("replacement")
+    if (
+        not isinstance(legacy, dict)
+        or set(legacy)
+        != {"owner_class", "trusted_generated_provenance", "manifest", "files"}
+        or legacy.get("owner_class") != APPLIED_ENCODING_LEGACY_OWNER_CLASS
+        or legacy.get("trusted_generated_provenance") is not False
+        or not isinstance(replacement, dict)
+        or set(replacement)
+        != {
+            "source",
+            "destination",
+            "model_manifest_path",
+            "model_manifest_sha256",
+            "live_files",
+            "rewrites",
+            "scheduled_dependents",
+        }
+    ):
+        return [*issues, f"{manifest_label} legacy evidence classification is invalid"]
+    if replacement.get("live_files") != nested.get("applied_files"):
+        issues.append(
+            f"{manifest_label} replacement live files differ from nested model manifest"
+        )
+    legacy_manifest = legacy.get("manifest")
+    legacy_files = legacy.get("files")
+    if (
+        not isinstance(legacy_manifest, dict)
+        or set(legacy_manifest) != {"path", "sha256"}
+        or not isinstance(legacy_files, list)
+    ):
+        return [*issues, f"{manifest_label} legacy evidence is malformed"]
+    if legacy_manifest != {
+        "path": binding.get("legacy_manifest_path"),
+        "sha256": binding.get("legacy_manifest_sha256"),
+    }:
+        issues.append(f"{manifest_label} legacy manifest binding differs")
+    authoritative_replacements, authority_issues = (
+        _legacy_replacement_authoritative_map(
+            repo_path,
+            base_commit=base_commit,
+            manifest_label=manifest_label,
+            legacy=legacy,
+            replacement=replacement,
+        )
+    )
+    if authoritative_replacements is None or authority_issues:
+        return [
+            *issues,
+            *[
+                f"{manifest_label} replacement authority is invalid: {issue}"
+                for issue in authority_issues
+            ],
+        ]
+    issues.extend(
+        f"{manifest_label} reference inventory is invalid: {issue}"
+        for issue in _legacy_replacement_reference_inventory_issues(
+            repo_path,
+            base_commit=base_commit,
+            authoritative_replacements=authoritative_replacements,
+            legacy=legacy,
+            replacement=replacement,
+            allow_pending_scheduled=True,
+        )
+    )
+
+    for evidence in [legacy_manifest, *legacy_files]:
+        if (
+            not isinstance(evidence, dict)
+            or set(evidence) != {"path", "sha256"}
+            or not isinstance(evidence.get("path"), str)
+            or not isinstance(evidence.get("sha256"), str)
+        ):
+            issues.append(f"{manifest_label} legacy evidence entry is malformed")
+            continue
+        evidence_path = Path(evidence["path"])
+        try:
+            base_raw = _rulespec_migration_base_blob(
+                repo_path,
+                base_commit,
+                evidence_path,
+            )
+        except RuntimeError as exc:
+            issues.append(f"{manifest_label} cannot prove legacy evidence: {exc}")
+            continue
+        if hashlib.sha256(base_raw).hexdigest() != evidence["sha256"]:
+            issues.append(f"{manifest_label} legacy evidence hash is stale")
+        live = repo_path / evidence_path
+        if live.exists() or live.is_symlink():
+            issues.append(f"{manifest_label} legacy evidence path still exists")
+
+    source = replacement.get("source")
+    destination = replacement.get("destination")
+    try:
+        normalized_destination = (
+            canonical_destination(Path(source)) if isinstance(source, str) else None
+        )
+    except PathMigrationPlanError:
+        normalized_destination = None
+    if (
+        not isinstance(source, str)
+        or not isinstance(destination, str)
+        or normalized_destination != Path(destination)
+    ):
+        issues.append(f"{manifest_label} replacement path normalization is invalid")
+    if (
+        replacement.get("model_manifest_path") != manifest_label
+        or replacement.get("model_manifest_sha256") != nested_sha256
+    ):
+        issues.append(f"{manifest_label} nested model manifest binding is stale")
+
+    scheduled = replacement.get("scheduled_dependents")
+    seen_scheduled_primaries: set[str] = set()
+    seen_scheduled_files: set[str] = set()
+    if not isinstance(scheduled, list):
+        issues.append(f"{manifest_label} scheduled dependents are malformed")
+        scheduled = []
+    for dependent in scheduled:
+        if (
+            not isinstance(dependent, dict)
+            or set(dependent) != {"primary", "files"}
+            or not isinstance(dependent.get("primary"), str)
+            or not isinstance(dependent.get("files"), list)
+            or not dependent["files"]
+        ):
+            issues.append(f"{manifest_label} scheduled dependent is malformed")
+            continue
+        primary = str(dependent["primary"])
+        primary_path = Path(primary)
+        if (
+            primary in seen_scheduled_primaries
+            or primary_path.is_absolute()
+            or primary_path.as_posix() != primary
+            or any(part in {"", ".", ".."} for part in primary_path.parts)
+            or not _is_protected_rulespec_yaml_path(
+                primary_path,
+                roots=tuple(sorted(RULESPEC_ATOMIC_MODULE_ROOTS)),
+            )
+            or primary_path.name.endswith(RULESPEC_TEST_FILE_SUFFIX)
+        ):
+            issues.append(
+                f"{manifest_label} scheduled dependent primary is invalid or duplicated"
+            )
+            continue
+        seen_scheduled_primaries.add(primary)
+        dependent_manifest_path = _applied_encoding_manifest_path(primary_path)
+        try:
+            dependent_manifest_raw = read_bounded_regular_file(
+                repo_path,
+                repo_path / dependent_manifest_path,
+                label="scheduled dependent apply manifest",
+                max_bytes=1024 * 1024,
+                required_mode=0o644,
+            )
+            dependent_manifest = json.loads(dependent_manifest_raw.decode("utf-8"))
+        except (
+            OSError,
+            UnsafeCorpusPathError,
+            UnicodeError,
+            json.JSONDecodeError,
+        ):
+            dependent_manifest = None
+        dependent_applied = (
+            dependent_manifest.get("applied_files")
+            if isinstance(dependent_manifest, dict)
+            else None
+        )
+        dependent_manifest_valid = (
+            isinstance(dependent_manifest, dict)
+            and dependent_manifest.get("schema_version")
+            == APPLIED_ENCODING_MANIFEST_SCHEMA
+            and dependent_manifest.get("tool") == APPLIED_ENCODING_MODEL_TOOL
+            and dependent_manifest.get("backend") in APPLIED_ENCODING_ENCODER_BACKENDS
+            and not _applied_encoding_manifest_signature_issue(
+                dependent_manifest, signing_broker
+            )
+            and isinstance(dependent_applied, list)
+            and primary
+            in {
+                item.get("path") for item in dependent_applied if isinstance(item, dict)
+            }
+        )
+        dependent_pending = False
+        dependent_resolved = False
+        for file_evidence in dependent["files"]:
+            if (
+                not isinstance(file_evidence, dict)
+                or set(file_evidence) != {"path", "before_sha256", "replacements"}
+                or not isinstance(file_evidence.get("path"), str)
+                or not isinstance(file_evidence.get("before_sha256"), str)
+                or not isinstance(file_evidence.get("replacements"), list)
+                or not file_evidence["replacements"]
+            ):
+                issues.append(f"{manifest_label} scheduled dependent file is malformed")
+                continue
+            pending_path = str(file_evidence["path"])
+            pending_relative = Path(pending_path)
+            if (
+                pending_path in seen_scheduled_files
+                or pending_relative.is_absolute()
+                or pending_relative.as_posix() != pending_path
+                or any(part in {"", ".", ".."} for part in pending_relative.parts)
+                or pending_relative not in {primary_path, companion_path(primary_path)}
+                or _SHA256_HEX_PATTERN.fullmatch(str(file_evidence["before_sha256"]))
+                is None
+            ):
+                issues.append(
+                    f"{manifest_label} scheduled dependent file path or base hash "
+                    "is invalid"
+                )
+                continue
+            seen_scheduled_files.add(pending_path)
+            pending_replacements = _strict_legacy_replacement_map(
+                file_evidence["replacements"]
+            )
+            if pending_replacements is None:
+                issues.append(
+                    f"{manifest_label} scheduled dependent replacement records "
+                    f"are malformed: {pending_path}"
+                )
+                continue
+            try:
+                base_raw = _rulespec_migration_base_blob(
+                    repo_path, base_commit, pending_relative
+                )
+                live_raw = read_bounded_regular_file(
+                    repo_path,
+                    repo_path / pending_path,
+                    label="scheduled dependent live file",
+                    max_bytes=16 * 1024 * 1024,
+                    required_mode=0o644,
+                )
+                _base_rewritten, base_counts = rewrite_exact_references(
+                    base_raw, authoritative_replacements
+                )
+                _unused, live_counts = rewrite_exact_references(
+                    live_raw, authoritative_replacements
+                )
+            except (
+                KeyError,
+                OSError,
+                RuntimeError,
+                UnsafeCorpusPathError,
+                PathMigrationPlanError,
+            ) as exc:
+                issues.append(
+                    f"{manifest_label} cannot verify scheduled dependent "
+                    f"{pending_path}: {exc}"
+                )
+                continue
+            base_hash_matches = (
+                hashlib.sha256(base_raw).hexdigest() != file_evidence["before_sha256"]
+            )
+            if base_hash_matches or list(base_counts) != file_evidence["replacements"]:
+                issues.append(
+                    f"{manifest_label} scheduled dependent has stale base proof: "
+                    f"{pending_path}"
+                )
+            if live_raw == base_raw:
+                dependent_pending = True
+            else:
+                dependent_resolved = True
+                if live_counts:
+                    issues.append(
+                        f"{manifest_label} scheduled dependent still carries a "
+                        f"legacy reference: {pending_path}"
+                    )
+        if dependent_pending and dependent_resolved:
+            issues.append(
+                f"{manifest_label} scheduled dependent is partially resolved: {primary}"
+            )
+        if dependent_resolved and not dependent_manifest_valid:
+            issues.append(
+                f"{manifest_label} scheduled dependent lacks a fresh signed "
+                f"v5 model manifest for {primary}"
+            )
+
+    outer_entries = payload.get("applied_files")
+    outer_list = outer_entries if isinstance(outer_entries, list) else []
+    expected_entries: list[dict[str, object]] = []
+    live_files = replacement.get("live_files")
+    if isinstance(live_files, list):
+        seen_live: set[str] = set()
+        for item in live_files:
+            if (
+                not isinstance(item, dict)
+                or set(item) != {"path", "sha256"}
+                or not isinstance(item.get("path"), str)
+                or not isinstance(item.get("sha256"), str)
+                or item["path"] in seen_live
+            ):
+                issues.append(f"{manifest_label} replacement live file is malformed")
+                continue
+            seen_live.add(str(item["path"]))
+            expected_entries.append(dict(item))
+    else:
+        issues.append(f"{manifest_label} replacement live files are malformed")
+    rewrites = replacement.get("rewrites")
+    if not isinstance(rewrites, list):
+        issues.append(f"{manifest_label} replacement rewrites are malformed")
+    else:
+        seen_rewrite_paths: set[str] = set()
+        for rewrite in rewrites:
+            if not isinstance(rewrite, dict) or set(rewrite) != {
+                "path",
+                "before_sha256",
+                "after_sha256",
+                "replacements",
+            }:
+                issues.append(f"{manifest_label} replacement rewrite is malformed")
+                continue
+            path = rewrite.get("path")
+            before = rewrite.get("before_sha256")
+            after = rewrite.get("after_sha256")
+            path_relative = Path(path) if isinstance(path, str) else Path()
+            if (
+                not isinstance(path, str)
+                or path_relative.is_absolute()
+                or path_relative.as_posix() != path
+                or any(part in {"", ".", ".."} for part in path_relative.parts)
+                or path in seen_rewrite_paths
+                or not isinstance(before, str)
+                or _SHA256_HEX_PATTERN.fullmatch(before) is None
+                or not isinstance(after, str)
+                or _SHA256_HEX_PATTERN.fullmatch(after) is None
+            ):
+                issues.append(f"{manifest_label} replacement rewrite is malformed")
+                continue
+            seen_rewrite_paths.add(path)
+            if path_relative not in _LEGACY_REPLACEMENT_METADATA_REWRITE_PATHS:
+                issues.append(
+                    f"{manifest_label} replacement rewrite path is unauthorized: {path}"
+                )
+                continue
+            try:
+                base_raw = _rulespec_migration_base_blob(
+                    repo_path,
+                    base_commit,
+                    path_relative,
+                )
+                live_raw = read_bounded_regular_file(
+                    repo_path,
+                    repo_path / path,
+                    label="legacy replacement rewritten file",
+                    max_bytes=16 * 1024 * 1024,
+                )
+            except (OSError, RuntimeError, UnsafeCorpusPathError) as exc:
+                issues.append(f"{manifest_label} cannot prove rewrite {path}: {exc}")
+                continue
+            if (
+                hashlib.sha256(base_raw).hexdigest() != before
+                or hashlib.sha256(live_raw).hexdigest() != after
+                or _migration_corpus_citations(base_raw)
+                != _migration_corpus_citations(live_raw)
+            ):
+                issues.append(f"{manifest_label} rewrite proof is stale for {path}")
+            raw_replacements = rewrite["replacements"]
+            replacements = _strict_legacy_replacement_map(raw_replacements)
+            if replacements is None:
+                issues.append(
+                    f"{manifest_label} rewrite replacement records are malformed"
+                )
+            else:
+                try:
+                    recomputed, recomputed_counts = rewrite_exact_references(
+                        base_raw,
+                        authoritative_replacements,
+                    )
+                except (KeyError, PathMigrationPlanError):
+                    recomputed, recomputed_counts = b"", ()
+                if (
+                    recomputed != live_raw
+                    or list(recomputed_counts) != raw_replacements
+                ):
+                    issues.append(
+                        f"{manifest_label} rewrite transformation is not exact for {path}"
+                    )
+            expected_entries.append({"path": path, "sha256": after})
+    expected_entries.extend(
+        {"path": item["path"], "deleted": True}
+        for item in legacy_files
+        if isinstance(item, dict) and isinstance(item.get("path"), str)
+    )
+    if outer_list != expected_entries:
+        issues.append(
+            f"{manifest_label} applied files do not exactly match replacement receipt"
+        )
+    return issues
+
+
 def _load_verified_applied_encoding_manifest_payload(
     repo_path: Path,
     manifest_path: str,
@@ -20286,7 +21950,14 @@ def _load_verified_applied_encoding_manifest_payload(
                     f"{manifest_label} applied_files[{index}].path is not canonical"
                 )
                 continue
-            if relative_file.suffix != RULESPEC_FILE_SUFFIX:
+            legacy_metadata_rewrite = (
+                payload.get("tool") == APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
+                and relative_file in _LEGACY_REPLACEMENT_METADATA_REWRITE_PATHS
+            )
+            if (
+                relative_file.suffix != RULESPEC_FILE_SUFFIX
+                and not legacy_metadata_rewrite
+            ):
                 issues.append(
                     f"{manifest_label} applied_files[{index}].path must use the "
                     f"canonical {RULESPEC_FILE_SUFFIX} RuleSpec extension"
@@ -20350,6 +22021,16 @@ def _load_verified_applied_encoding_manifest_payload(
             expected_waiver_set_sha256=expected_waiver_set_sha256,
             local_corpus_release=local_corpus_release,
             path_migration_receipt_proof_cache=(path_migration_receipt_proof_cache),
+        )
+    )
+    issues.extend(
+        _legacy_replacement_manifest_issues(
+            payload,
+            repo_path=repo_path,
+            manifest_label=manifest_label,
+            signing_broker=signing_broker,
+            expected_waiver_set_sha256=expected_waiver_set_sha256,
+            local_corpus_release=local_corpus_release,
         )
     )
     issues.extend(
@@ -21140,6 +22821,345 @@ class _EncodeAttemptExecution(NamedTuple):
 class _EncodeReplacementTarget(NamedTuple):
     relative_output: Path
     context_paths: tuple[Path, ...]
+    legacy_replacement: "_LegacyReplacementContract | None" = None
+
+
+_LEGACY_REPLACEMENT_ATTR = "_axiom_legacy_replacement_contract"
+
+
+def _result_legacy_replacement_contract(result: object) -> object | None:
+    """Read only an explicitly attached contract, including on dynamic test doubles."""
+
+    try:
+        state = vars(result)
+    except TypeError:
+        return None
+    return state.get(_LEGACY_REPLACEMENT_ATTR)
+
+
+def _require_legacy_replacement_clean_checkout(checkout_root: Path) -> None:
+    if _rulespec_migration_git_bytes(
+        checkout_root,
+        "status",
+        "--porcelain=v1",
+        "-z",
+        "--untracked-files=all",
+        "--ignored=matching",
+    ):
+        raise ValueError(
+            "legacy replacement requires an exact clean HEAD with no tracked, "
+            "untracked, or ignored checkout files"
+        )
+
+
+def _require_locked_legacy_replacement_base(
+    checkout_root: Path,
+    contract: _LegacyReplacementContract,
+) -> None:
+    """Recheck the complete immutable-base admission while the apply lock is held."""
+
+    locked_head, locked_tree = _rulespec_migration_base_identity(checkout_root)
+    if locked_head != contract.base_commit or locked_tree != contract.base_tree:
+        raise RuntimeError(
+            "Legacy replacement RuleSpec HEAD/tree changed after planning"
+        )
+    _require_legacy_replacement_clean_checkout(checkout_root)
+
+
+def _resolve_legacy_replacement_contract(
+    *,
+    source_raw: Path,
+    destination_raw: Path,
+    policy_checkout_path: Path,
+    policy_repo_path: Path,
+    source_unit,
+    corpus_release: LocalCorpusRelease,
+    scheduled_dependent_paths: Sequence[Path] = (),
+) -> _LegacyReplacementContract:
+    """Bind one clean-HEAD legacy identity and its unique canonical replacement."""
+
+    source = Path(source_raw)
+    destination = Path(destination_raw)
+    roots = tuple(sorted(RULESPEC_ATOMIC_MODULE_ROOTS))
+    for label, path in (("source", source), ("destination", destination)):
+        if (
+            path.is_absolute()
+            or path.as_posix() != str(path)
+            or any(part in {"", ".", ".."} for part in path.parts)
+            or len(path.parts) < 3
+            or path.parts[0] != policy_repo_path.name
+            or not _is_protected_rulespec_yaml_path(path, roots=roots)
+            or path.name.endswith(RULESPEC_TEST_FILE_SUFFIX)
+        ):
+            raise ValueError(
+                f"legacy replacement {label} must be a canonical "
+                "checkout-relative primary RuleSpec in the requested jurisdiction"
+            )
+    if destination != canonical_destination(source):
+        raise ValueError(
+            "legacy replacement destination is not the unique canonical "
+            "normalization of its source"
+        )
+    if source == destination:
+        raise ValueError("legacy replacement source is already canonical")
+
+    base_commit, base_tree = _rulespec_migration_base_identity(policy_checkout_path)
+    _require_legacy_replacement_clean_checkout(policy_checkout_path)
+    tracked = _rulespec_migration_tracked_files(policy_checkout_path)
+    if tracked.get(source) != "100644":
+        raise ValueError("legacy replacement source is not a tracked regular 0644 file")
+    destination_group = (
+        destination,
+        companion_path(destination),
+        _applied_encoding_manifest_path(destination),
+    )
+    for candidate in destination_group:
+        candidate_absolute = policy_checkout_path / candidate
+        if (
+            candidate in tracked
+            or candidate_absolute.exists()
+            or candidate_absolute.is_symlink()
+        ):
+            raise ValueError(
+                "legacy replacement destination primary/companion/manifest group "
+                f"must be absent at clean HEAD and live: {candidate}"
+            )
+
+    old_paths = [source]
+    old_companion = companion_path(source)
+    if old_companion in tracked:
+        if tracked[old_companion] != "100644":
+            raise ValueError(
+                "legacy replacement companion is not a tracked regular 0644 file"
+            )
+        old_paths.append(old_companion)
+    deleted_files: list[_LegacyReplacementFile] = []
+    for relative in old_paths:
+        absolute = policy_checkout_path / relative
+        raw = read_bounded_regular_file(
+            policy_checkout_path,
+            absolute,
+            label=f"legacy replacement input {relative.as_posix()}",
+            max_bytes=10 * 1024 * 1024,
+            required_mode=0o644,
+        )
+        base_raw = _rulespec_migration_base_blob(
+            policy_checkout_path,
+            base_commit,
+            relative,
+        )
+        if raw != base_raw:
+            raise ValueError(
+                f"legacy replacement input differs from clean HEAD: {relative}"
+            )
+        deleted_files.append(
+            _LegacyReplacementFile(
+                relative,
+                hashlib.sha256(raw).hexdigest(),
+                raw,
+            )
+        )
+
+    try:
+        old_payload = yaml.safe_load(deleted_files[0].raw.decode("utf-8"))
+    except (UnicodeError, yaml.YAMLError, RecursionError) as exc:
+        raise ValueError("legacy replacement source is not valid UTF-8 YAML") from exc
+    module = old_payload.get("module") if isinstance(old_payload, dict) else None
+    verification = (
+        module.get("source_verification") if isinstance(module, dict) else None
+    )
+    old_citations = (
+        _legacy_source_verification_citation_paths(verification)
+        if isinstance(verification, dict)
+        else ()
+    )
+    requested_citation = normalize_corpus_identifier(source_unit.requested)
+    if old_citations != (requested_citation,):
+        raise ValueError(
+            "legacy replacement source must declare exactly the requested signed "
+            "corpus unit using only singular or legacy plural citation syntax"
+        )
+    resolved_old = resolve_corpus_source_unit(old_citations[0], corpus_release)
+    if (
+        resolved_old.citation_path != source_unit.citation_path
+        or resolved_old.requested != source_unit.requested
+        or resolved_old.body != source_unit.body
+        or resolved_old.resolved_source != source_unit.resolved_source
+    ):
+        raise ValueError(
+            "legacy replacement source does not resolve to the exact requested "
+            "signed corpus unit"
+        )
+
+    legacy_manifest_path = _applied_encoding_manifest_path(source)
+    if tracked.get(legacy_manifest_path) != "100644":
+        raise ValueError(
+            "legacy replacement requires its exact tracked v1/manual ownership manifest"
+        )
+    legacy_manifest_raw = read_bounded_regular_file(
+        policy_checkout_path,
+        policy_checkout_path / legacy_manifest_path,
+        label="legacy ownership manifest",
+        max_bytes=4 * 1024 * 1024,
+        required_mode=0o644,
+    )
+    if legacy_manifest_raw != _rulespec_migration_base_blob(
+        policy_checkout_path,
+        base_commit,
+        legacy_manifest_path,
+    ):
+        raise ValueError("legacy ownership manifest differs from clean HEAD")
+    try:
+        legacy_payload = json.loads(legacy_manifest_raw.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError, RecursionError) as exc:
+        raise ValueError("legacy ownership manifest is not valid UTF-8 JSON") from exc
+    expected_files = {item.path.as_posix(): item.sha256 for item in deleted_files}
+    legacy_issues = _legacy_manual_manifest_issues(
+        legacy_payload,
+        expected_files=expected_files,
+    )
+    if legacy_issues:
+        raise ValueError("; ".join(legacy_issues))
+    legacy_manifest = _LegacyReplacementFile(
+        legacy_manifest_path,
+        hashlib.sha256(legacy_manifest_raw).hexdigest(),
+        legacy_manifest_raw,
+    )
+
+    move = PlannedMove(source=source, destination=destination)
+    replacements = exact_reference_replacements(
+        [move],
+        existing_companions={old_companion} if old_companion in old_paths else set(),
+    )
+    scheduled_groups: dict[Path, set[Path]] = {}
+    for raw_dependent in scheduled_dependent_paths:
+        dependent = Path(raw_dependent)
+        if (
+            dependent.is_absolute()
+            or dependent.as_posix() != str(raw_dependent)
+            or any(part in {"", ".", ".."} for part in dependent.parts)
+            or len(dependent.parts) < 3
+            or dependent.parts[0] != policy_repo_path.name
+            or not _is_protected_rulespec_yaml_path(dependent, roots=roots)
+            or dependent.name.endswith(RULESPEC_TEST_FILE_SUFFIX)
+            or dependent in {source, destination}
+            or tracked.get(dependent) != "100644"
+            or dependent in scheduled_groups
+        ):
+            raise ValueError(
+                "legacy scheduled dependent must be a unique tracked 0644 "
+                "checkout-relative protected primary"
+            )
+        group = {dependent}
+        dependent_companion = companion_path(dependent)
+        if dependent_companion in tracked:
+            if tracked[dependent_companion] != "100644":
+                raise ValueError(
+                    "legacy scheduled dependent companion is not tracked 0644"
+                )
+            group.add(dependent_companion)
+        scheduled_groups[dependent] = group
+    pending_by_primary: dict[Path, list[_LegacyReplacementPendingFile]] = {
+        primary: [] for primary in scheduled_groups
+    }
+    scheduled_owner = {
+        path: primary for primary, group in scheduled_groups.items() for path in group
+    }
+    excluded = {*old_paths, legacy_manifest_path}
+    manifest_prefix = APPLIED_ENCODING_MANIFEST_DIR.parts
+    receipt_prefixes = (
+        APPLIED_ENCODING_PATH_MIGRATION_RECEIPT_DIR.parts,
+        APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_DIR.parts,
+    )
+    rewrites: list[_LegacyReplacementRewrite] = []
+    for relative, mode in sorted(tracked.items(), key=lambda item: item[0].as_posix()):
+        if relative in excluded:
+            continue
+        absolute = policy_checkout_path / relative
+        if mode != "100644":
+            base_raw = _rulespec_migration_git_bytes(
+                policy_checkout_path,
+                "show",
+                f"{base_commit}:{relative.as_posix()}",
+            )
+            if any(old.encode() in base_raw for old in replacements):
+                raise ValueError(
+                    f"legacy replacement reference occurs in non-0644 tracked "
+                    f"path {relative}"
+                )
+            continue
+        raw = read_bounded_regular_file(
+            policy_checkout_path,
+            absolute,
+            label=f"legacy replacement reference input {relative.as_posix()}",
+            max_bytes=16 * 1024 * 1024,
+            required_mode=0o644,
+        )
+        rewritten, counts = rewrite_exact_references(raw, replacements)
+        if not counts:
+            continue
+        if relative.parts[: len(manifest_prefix)] == manifest_prefix or any(
+            relative.parts[: len(prefix)] == prefix for prefix in receipt_prefixes
+        ):
+            raise ValueError(
+                f"legacy replacement cannot rewrite persisted provenance {relative}"
+            )
+        if _is_protected_rulespec_yaml_path(relative, roots=roots):
+            scheduled_primary = scheduled_owner.get(relative)
+            if scheduled_primary is not None:
+                pending_by_primary[scheduled_primary].append(
+                    _LegacyReplacementPendingFile(
+                        relative,
+                        hashlib.sha256(raw).hexdigest(),
+                        counts,
+                    )
+                )
+                continue
+            raise ValueError(
+                f"legacy replacement requires explicit protected-dependent "
+                f"reencode for {relative}"
+            )
+        if _migration_corpus_citations(raw) != _migration_corpus_citations(rewritten):
+            raise ValueError(
+                f"legacy replacement would alter legal corpus citation text in "
+                f"{relative}"
+            )
+        rewrites.append(
+            _LegacyReplacementRewrite(
+                relative,
+                hashlib.sha256(raw).hexdigest(),
+                hashlib.sha256(rewritten).hexdigest(),
+                counts,
+                rewritten,
+            )
+        )
+
+    missing_scheduled = [
+        path for path, pending in pending_by_primary.items() if not pending
+    ]
+    if missing_scheduled:
+        raise ValueError(
+            "legacy scheduled dependent has no exact protected reference to replace: "
+            + ", ".join(path.as_posix() for path in missing_scheduled)
+        )
+
+    return _LegacyReplacementContract(
+        base_commit=base_commit,
+        base_tree=base_tree,
+        source=source,
+        destination=destination,
+        legacy_manifest=legacy_manifest,
+        deleted_files=tuple(deleted_files),
+        rewrites=tuple(rewrites),
+        scheduled_dependents=tuple(
+            _LegacyReplacementScheduledDependent(
+                primary,
+                tuple(pending_by_primary[primary]),
+            )
+            for primary in scheduled_groups
+            if pending_by_primary[primary]
+        ),
+    )
 
 
 def _resolve_encode_replacement_target(
@@ -21151,13 +23171,45 @@ def _resolve_encode_replacement_target(
     corpus_release: LocalCorpusRelease,
 ) -> _EncodeReplacementTarget | None:
     raw_path = getattr(args, "replace_rulespec_path", None)
-    if raw_path is None:
+    legacy_source = getattr(args, "replace_legacy_rulespec_path", None)
+    scheduled_dependents = tuple(
+        Path(path) for path in getattr(args, "legacy_dependent_rulespec_path", ())
+    )
+    if raw_path is None and legacy_source is None:
+        if scheduled_dependents:
+            raise ValueError(
+                "--legacy-dependent-rulespec-path requires a legacy replacement"
+            )
         return None
+    if raw_path is None:
+        raise ValueError(
+            "encode --replace-legacy-rulespec-path and "
+            "--replace-rulespec-path must be supplied together"
+        )
     if getattr(args, "apply", False) is not True:
         raise ValueError("encode --replace-rulespec-path requires --apply")
     if getattr(args, "mode", None) != "repo-augmented":
         raise ValueError(
             "encode --replace-rulespec-path requires --mode repo-augmented"
+        )
+
+    if legacy_source is not None:
+        contract = _resolve_legacy_replacement_contract(
+            source_raw=Path(legacy_source),
+            destination_raw=Path(raw_path),
+            policy_checkout_path=policy_checkout_path,
+            policy_repo_path=policy_repo_path,
+            source_unit=source_unit,
+            corpus_release=corpus_release,
+            scheduled_dependent_paths=scheduled_dependents,
+        )
+        context_paths = [
+            policy_checkout_path / item.path for item in contract.deleted_files
+        ]
+        return _EncodeReplacementTarget(
+            relative_output=Path(*contract.destination.parts[1:]),
+            context_paths=tuple(context_paths),
+            legacy_replacement=contract,
         )
 
     checkout_relative = Path(raw_path)
@@ -21591,6 +23643,13 @@ def _run_encode_attempt(
     )
 
     result = results[0]
+    setattr(
+        result,
+        _LEGACY_REPLACEMENT_ATTR,
+        replacement_target.legacy_replacement
+        if replacement_target is not None
+        else None,
+    )
     protected_review_excerpts = (
         _quoted_review_finding_excerpts(
             result.context_manifest_file,
@@ -42071,7 +44130,7 @@ def _build_apply_validation_snapshot(
             supplemental_files.items(), key=lambda item: Path(item[0]).as_posix()
         )
     ]
-    return {
+    snapshot = {
         "schema": "axiom-encode/apply-validation-snapshot/v1",
         "relative_output": canonical_relative_output.as_posix(),
         "policy_content_root": str(
@@ -42100,6 +44159,48 @@ def _build_apply_validation_snapshot(
             _portable_apply_validation_execution_identity(validation_execution_identity)
         ),
     }
+    legacy_replacement = _result_legacy_replacement_contract(result)
+    if legacy_replacement is not None:
+        if not isinstance(legacy_replacement, _LegacyReplacementContract):
+            raise RuntimeError("Legacy replacement contract is malformed")
+        snapshot["legacy_replacement"] = {
+            "base_commit": legacy_replacement.base_commit,
+            "base_tree": legacy_replacement.base_tree,
+            "source": legacy_replacement.source.as_posix(),
+            "destination": legacy_replacement.destination.as_posix(),
+            "legacy_manifest": {
+                "path": legacy_replacement.legacy_manifest.path.as_posix(),
+                "sha256": legacy_replacement.legacy_manifest.sha256,
+            },
+            "deleted_files": [
+                {"path": item.path.as_posix(), "sha256": item.sha256}
+                for item in legacy_replacement.deleted_files
+            ],
+            "rewrites": [
+                {
+                    "path": item.path.as_posix(),
+                    "before_sha256": item.before_sha256,
+                    "after_sha256": item.after_sha256,
+                    "replacements": list(item.replacements),
+                }
+                for item in legacy_replacement.rewrites
+            ],
+            "scheduled_dependents": [
+                {
+                    "primary": dependent.primary.as_posix(),
+                    "files": [
+                        {
+                            "path": item.path.as_posix(),
+                            "before_sha256": item.before_sha256,
+                            "replacements": list(item.replacements),
+                        }
+                        for item in dependent.files
+                    ],
+                }
+                for dependent in legacy_replacement.scheduled_dependents
+            ],
+        }
+    return snapshot
 
 
 def _record_successful_apply_validation(
@@ -42476,6 +44577,173 @@ def _stage_signed_apply_manifest(
         )
         manifest_relative = staged_manifest.relative_to(staged_checkout)
         return manifest_relative, staged_manifest.read_bytes()
+
+
+def _stage_signed_legacy_replacement_provenance(
+    result,
+    *,
+    contract: _LegacyReplacementContract,
+    checkout_root: Path,
+    content_root: Path,
+    planned: Mapping[Path, bytes],
+    model_manifest_relative: Path,
+    model_manifest_bytes: bytes,
+    signing_broker: SigningBroker,
+    axiom_encode_git: Mapping[str, object],
+    local_corpus_release: LocalCorpusRelease,
+) -> tuple[Path, bytes, Path, bytes]:
+    """Wrap one fresh v5 model manifest in an authenticated replacement proof."""
+
+    try:
+        model_manifest = json.loads(model_manifest_bytes.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError, RecursionError) as exc:
+        raise RuntimeError("Fresh replacement model manifest is invalid JSON") from exc
+    if not isinstance(model_manifest, dict):
+        raise RuntimeError("Fresh replacement model manifest is not an object")
+    if (
+        model_manifest.get("schema_version") != APPLIED_ENCODING_MANIFEST_SCHEMA
+        or model_manifest.get("tool") != APPLIED_ENCODING_MODEL_TOOL
+        or model_manifest.get("backend") not in APPLIED_ENCODING_ENCODER_BACKENDS
+    ):
+        raise RuntimeError(
+            "Legacy replacement requires a fresh current-v5 model apply manifest"
+        )
+    if _applied_encoding_manifest_signature_issue(model_manifest, signing_broker):
+        raise RuntimeError("Fresh replacement model manifest signature is invalid")
+
+    model_manifest_sha256 = hashlib.sha256(model_manifest_bytes).hexdigest()
+    live_files = [
+        {
+            "path": (Path(content_root.name) / relative).as_posix(),
+            "sha256": hashlib.sha256(raw).hexdigest(),
+        }
+        for relative, raw in sorted(
+            planned.items(), key=lambda item: item[0].as_posix()
+        )
+    ]
+    rewrite_files = [
+        {
+            "path": rewrite.path.as_posix(),
+            "sha256": rewrite.after_sha256,
+        }
+        for rewrite in contract.rewrites
+    ]
+    deleted_files = [
+        {"path": item.path.as_posix(), "deleted": True}
+        for item in contract.deleted_files
+    ]
+    scheduled_dependents = [
+        {
+            "primary": dependent.primary.as_posix(),
+            "files": [
+                {
+                    "path": item.path.as_posix(),
+                    "before_sha256": item.before_sha256,
+                    "replacements": list(item.replacements),
+                }
+                for item in dependent.files
+            ],
+        }
+        for dependent in contract.scheduled_dependents
+    ]
+    receipt_identity = receipt_identity_payload(
+        base_commit=contract.base_commit,
+        base_tree=contract.base_tree,
+        legacy_manifest_sha256=contract.legacy_manifest.sha256,
+        model_manifest_sha256=model_manifest_sha256,
+        live_files=live_files,
+        deleted_files=deleted_files,
+        rewrites=[
+            {
+                "path": item.path.as_posix(),
+                "before_sha256": item.before_sha256,
+                "after_sha256": item.after_sha256,
+                "replacements": list(item.replacements),
+            }
+            for item in contract.rewrites
+        ],
+        scheduled_dependents=scheduled_dependents,
+    )
+    receipt_id = receipt_identity_sha256(receipt_identity)
+    receipt_relative = (
+        APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_DIR / f"{receipt_id}.json"
+    )
+    validation_execution = model_manifest.get("validation_execution")
+    if not isinstance(validation_execution, dict):
+        raise RuntimeError(
+            "Fresh replacement model manifest lacks validation execution provenance"
+        )
+    receipt = {
+        "schema_version": APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
+        "generated_at": _utc_now_iso(),
+        "tool": APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL,
+        "repository": {
+            "base_commit": contract.base_commit,
+            "head_commit": contract.base_commit,
+            "base_tree": contract.base_tree,
+        },
+        "axiom_encode_version": __version__,
+        "axiom_encode_git": dict(axiom_encode_git),
+        VALIDATION_WAIVER_SET_SHA256_FIELD: verify_rulespec_validation_waiver_set(
+            checkout_root
+        ),
+        "corpus_release": {
+            "name": local_corpus_release.name,
+            "content_sha256": local_corpus_release.content_sha256,
+            "selector_sha256": local_corpus_release.selector_sha256,
+        },
+        "validation_execution": copy.deepcopy(validation_execution),
+        "legacy": {
+            "owner_class": APPLIED_ENCODING_LEGACY_OWNER_CLASS,
+            "trusted_generated_provenance": False,
+            "manifest": {
+                "path": contract.legacy_manifest.path.as_posix(),
+                "sha256": contract.legacy_manifest.sha256,
+            },
+            "files": [
+                {"path": item.path.as_posix(), "sha256": item.sha256}
+                for item in contract.deleted_files
+            ],
+        },
+        "replacement": {
+            "source": contract.source.as_posix(),
+            "destination": contract.destination.as_posix(),
+            "model_manifest_path": model_manifest_relative.as_posix(),
+            "model_manifest_sha256": model_manifest_sha256,
+            "live_files": live_files,
+            "rewrites": receipt_identity["rewrites"],
+            "scheduled_dependents": scheduled_dependents,
+        },
+        "replacement_manifest": model_manifest,
+    }
+    _sign_applied_encoding_manifest(receipt, signing_broker)
+    receipt_bytes = (json.dumps(receipt, indent=2, sort_keys=True) + "\n").encode(
+        "utf-8"
+    )
+    receipt_sha256 = hashlib.sha256(receipt_bytes).hexdigest()
+
+    outer_manifest = {
+        "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+        "generated_at": _utc_now_iso(),
+        "tool": APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL,
+        "axiom_encode_version": __version__,
+        "axiom_encode_git": dict(axiom_encode_git),
+        VALIDATION_WAIVER_SET_SHA256_FIELD: receipt[VALIDATION_WAIVER_SET_SHA256_FIELD],
+        "applied_files": [*live_files, *rewrite_files, *deleted_files],
+        "replacement_manifest": model_manifest,
+        "replacement": {
+            "receipt_path": receipt_relative.as_posix(),
+            "receipt_sha256": receipt_sha256,
+            "legacy_manifest_path": contract.legacy_manifest.path.as_posix(),
+            "legacy_manifest_sha256": contract.legacy_manifest.sha256,
+        },
+        "source_attestation": copy.deepcopy(model_manifest["source_attestation"]),
+    }
+    _sign_applied_encoding_manifest(outer_manifest, signing_broker)
+    outer_bytes = (json.dumps(outer_manifest, indent=2, sort_keys=True) + "\n").encode(
+        "utf-8"
+    )
+    return model_manifest_relative, outer_bytes, receipt_relative, receipt_bytes
 
 
 def _require_staged_manifest_matches_validation_snapshot(
@@ -42926,14 +45194,21 @@ def _is_canonical_apply_transaction_target(
 
     if canonical_tail(relative, suffix=RULESPEC_FILE_SUFFIX):
         return True
-    receipt_prefix = APPLIED_ENCODING_PATH_MIGRATION_RECEIPT_DIR.parts
-    if relative.parts[: len(receipt_prefix)] == receipt_prefix:
-        receipt_tail = relative.parts[len(receipt_prefix) :]
-        return (
-            len(receipt_tail) == 1
-            and relative.suffix == ".json"
-            and _SHA256_HEX_PATTERN.fullmatch(Path(receipt_tail[0]).stem) is not None
-        )
+    if relative in _LEGACY_REPLACEMENT_METADATA_REWRITE_PATHS:
+        return True
+    for receipt_dir in (
+        APPLIED_ENCODING_PATH_MIGRATION_RECEIPT_DIR,
+        APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_DIR,
+    ):
+        receipt_prefix = receipt_dir.parts
+        if relative.parts[: len(receipt_prefix)] == receipt_prefix:
+            receipt_tail = relative.parts[len(receipt_prefix) :]
+            return (
+                len(receipt_tail) == 1
+                and relative.suffix == ".json"
+                and _SHA256_HEX_PATTERN.fullmatch(Path(receipt_tail[0]).stem)
+                is not None
+            )
     manifest_prefix = APPLIED_ENCODING_MANIFEST_DIR.parts
     if relative.parts[: len(manifest_prefix)] != manifest_prefix:
         return False
@@ -43550,6 +45825,9 @@ def _require_apply_post_install_closure(
     planned: Mapping[Path, bytes],
     manifest_path: Path,
     manifest_bytes: bytes,
+    legacy_replacement: _LegacyReplacementContract | None = None,
+    receipt_path: Path | None = None,
+    receipt_bytes: bytes | None = None,
 ) -> None:
     """Recheck the execution closure while rollback is still possible."""
 
@@ -43641,6 +45919,18 @@ def _require_apply_post_install_closure(
         expected_post_files[_canonical_apply_relative_path(relative).as_posix()] = (
             hashlib.sha256(raw).hexdigest()
         )
+    if legacy_replacement is not None:
+        for deleted in legacy_replacement.deleted_files:
+            if deleted.path.parts[:1] == (content_root.name,):
+                expected_post_files.pop(
+                    Path(*deleted.path.parts[1:]).as_posix(),
+                    None,
+                )
+        for rewrite in legacy_replacement.rewrites:
+            if rewrite.path.parts[:1] == (content_root.name,):
+                expected_post_files[Path(*rewrite.path.parts[1:]).as_posix()] = (
+                    rewrite.after_sha256
+                )
     if current_execution.get("policy_content_files") != expected_post_files:
         raise RuntimeError(
             "Cannot keep applied RuleSpec: live RuleSpec bytes changed during "
@@ -43656,6 +45946,31 @@ def _require_apply_post_install_closure(
         raise RuntimeError(
             "Cannot keep applied RuleSpec: installed manifest bytes changed"
         )
+    if legacy_replacement is not None:
+        checkout_root = content_root.parent
+        for deleted in legacy_replacement.deleted_files:
+            target = checkout_root / deleted.path
+            if target.exists() or target.is_symlink():
+                raise RuntimeError(
+                    f"Cannot keep legacy replacement: old path still exists: {target}"
+                )
+        old_manifest = checkout_root / legacy_replacement.legacy_manifest.path
+        if old_manifest.exists() or old_manifest.is_symlink():
+            raise RuntimeError(
+                "Cannot keep legacy replacement: old ownership manifest still exists"
+            )
+        for rewrite in legacy_replacement.rewrites:
+            target = checkout_root / rewrite.path
+            if target.read_bytes() != rewrite.raw:
+                raise RuntimeError(
+                    f"Cannot keep legacy replacement: rewrite changed for {target}"
+                )
+        if (
+            receipt_path is None
+            or receipt_bytes is None
+            or receipt_path.read_bytes() != receipt_bytes
+        ):
+            raise RuntimeError("Cannot keep legacy replacement: signed receipt changed")
 
 
 def _apply_generated_encoding_result(
@@ -43681,6 +45996,12 @@ def _apply_generated_encoding_result(
     axiom_encode_git = _require_clean_axiom_encode_git_provenance()
     backend = str(getattr(result, "backend", "") or "").strip().lower()
     supplemental_files = dict(supplemental_files or {})
+    legacy_replacement = _result_legacy_replacement_contract(result)
+    if legacy_replacement is not None and not isinstance(
+        legacy_replacement,
+        _LegacyReplacementContract,
+    ):
+        raise RuntimeError("Legacy replacement contract is malformed")
 
     supplemental_source_issues = _supplemental_source_attestation_issues(
         supplemental_files,
@@ -43739,6 +46060,7 @@ def _apply_generated_encoding_result(
         axiom_encode_git=axiom_encode_git,
         allow_shrink=allow_shrink,
     )
+    model_manifest_bytes = manifest_bytes
     # Re-open the live toolchain and every evidence artifact after manifest
     # construction so a concurrent mutation cannot be smuggled into install.
     final_corpus_release = load_rulespec_local_corpus_release(
@@ -43765,6 +46087,27 @@ def _apply_generated_encoding_result(
         local_corpus_release=final_corpus_release,
     )
 
+    receipt_relative: Path | None = None
+    receipt_bytes: bytes | None = None
+    if legacy_replacement is not None:
+        (
+            manifest_relative,
+            manifest_bytes,
+            receipt_relative,
+            receipt_bytes,
+        ) = _stage_signed_legacy_replacement_provenance(
+            result,
+            contract=legacy_replacement,
+            checkout_root=checkout_root,
+            content_root=content_root,
+            planned=planned,
+            model_manifest_relative=manifest_relative,
+            model_manifest_bytes=model_manifest_bytes,
+            signing_broker=signing_broker,
+            axiom_encode_git=axiom_encode_git,
+            local_corpus_release=final_corpus_release,
+        )
+
     applied = [content_root / relative_path for relative_path in planned]
     manifest_path = checkout_root / manifest_relative
     transaction_files = [
@@ -43774,6 +46117,23 @@ def _apply_generated_encoding_result(
         ],
         (manifest_path, manifest_bytes),
     ]
+    if legacy_replacement is not None:
+        assert receipt_relative is not None
+        assert receipt_bytes is not None
+        transaction_files.extend(
+            (checkout_root / rewrite.path, rewrite.raw)
+            for rewrite in legacy_replacement.rewrites
+        )
+        transaction_files.extend(
+            (checkout_root / item.path, None)
+            for item in legacy_replacement.deleted_files
+        )
+        transaction_files.extend(
+            [
+                (checkout_root / legacy_replacement.legacy_manifest.path, None),
+                (checkout_root / receipt_relative, receipt_bytes),
+            ]
+        )
     for target, _raw in transaction_files:
         _ensure_safe_apply_target(checkout_root, target)
 
@@ -43795,6 +46155,16 @@ def _apply_generated_encoding_result(
         for relative_path in planned
     }
     expected_originals[manifest_path] = _apply_transaction_file_digest(manifest_path)
+    if legacy_replacement is not None:
+        for rewrite in legacy_replacement.rewrites:
+            expected_originals[checkout_root / rewrite.path] = rewrite.before_sha256
+        for item in legacy_replacement.deleted_files:
+            expected_originals[checkout_root / item.path] = item.sha256
+        expected_originals[checkout_root / legacy_replacement.legacy_manifest.path] = (
+            legacy_replacement.legacy_manifest.sha256
+        )
+        assert receipt_relative is not None
+        expected_originals[checkout_root / receipt_relative] = None
     new_manifest_applied_files = {
         (Path(content_root.name) / relative_path).as_posix()
         for relative_path in planned
@@ -43803,6 +46173,11 @@ def _apply_generated_encoding_result(
     def pre_install_check() -> None:
         # The transaction lock is now held. Recheck the live destination so a
         # concurrent manifest expansion after staging cannot be overwritten.
+        if legacy_replacement is not None:
+            _require_locked_legacy_replacement_base(
+                checkout_root,
+                legacy_replacement,
+            )
         _require_applied_manifest_not_shrunk(
             manifest_path,
             new_applied_files=new_manifest_applied_files,
@@ -43814,7 +46189,7 @@ def _apply_generated_encoding_result(
         )
         _require_staged_manifest_matches_validation_snapshot(
             result,
-            manifest_bytes,
+            model_manifest_bytes,
             output_root=output_root,
             content_root=content_root,
             planned=planned,
@@ -43843,6 +46218,13 @@ def _apply_generated_encoding_result(
             planned=planned,
             manifest_path=manifest_path,
             manifest_bytes=manifest_bytes,
+            legacy_replacement=legacy_replacement,
+            receipt_path=(
+                checkout_root / receipt_relative
+                if receipt_relative is not None
+                else None
+            ),
+            receipt_bytes=receipt_bytes,
         )
 
     _install_apply_transaction(
@@ -43853,6 +46235,8 @@ def _apply_generated_encoding_result(
         post_install_check=post_install_check,
     )
     applied.append(manifest_path)
+    if receipt_relative is not None:
+        applied.append(checkout_root / receipt_relative)
     if wrote_empty_companion_test:
         print("  apply=generated_empty_deferred_companion_test")
     return applied
@@ -44390,6 +46774,12 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
 ) -> tuple[bool, list[str], dict[Path, str]]:
     """Validate generated artifacts in a temporary policy-repo overlay."""
     setattr(result, _APPLY_VALIDATION_SNAPSHOT_ATTR, None)
+    legacy_replacement = _result_legacy_replacement_contract(result)
+    if legacy_replacement is not None and not isinstance(
+        legacy_replacement,
+        _LegacyReplacementContract,
+    ):
+        return False, ["Legacy replacement contract is malformed"], {}
     output_file = Path(str(getattr(result, "output_file", "") or ""))
     if not output_file.exists():
         return False, [f"Generated output file not found: {output_file}"], {}
@@ -44480,6 +46870,118 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
         shutil.copy2(output_file, overlay_target)
         if output_test.exists():
             shutil.copy2(output_test, _rulespec_test_path(overlay_target))
+        if legacy_replacement is not None:
+            expected_relative = Path(*legacy_replacement.destination.parts[1:])
+            if relative_output != expected_relative:
+                return (
+                    False,
+                    [
+                        "Generated output does not target the authenticated legacy "
+                        "replacement destination"
+                    ],
+                    {},
+                )
+            try:
+                generated_payload = yaml.safe_load(overlay_target.read_text())
+            except (OSError, UnicodeError, yaml.YAMLError, RecursionError):
+                generated_payload = None
+            generated_module = (
+                generated_payload.get("module")
+                if isinstance(generated_payload, dict)
+                else None
+            )
+            generated_verification = (
+                generated_module.get("source_verification")
+                if isinstance(generated_module, dict)
+                else None
+            )
+            if (
+                not isinstance(generated_verification, dict)
+                or "corpus_citation_paths" in generated_verification
+                or len(_source_verification_citation_paths(generated_verification)) != 1
+            ):
+                return (
+                    False,
+                    [
+                        "Fresh legacy replacement output must use the current singular "
+                        "corpus_citation_path schema"
+                    ],
+                    {},
+                )
+            old_content = legacy_replacement.deleted_files[0].raw.decode("utf-8")
+            preservation_issues = _source_relation_preservation_issues(
+                old_content,
+                overlay_target.read_text(),
+            )
+            if preservation_issues:
+                return (
+                    False,
+                    [f"{relative_output}: {issue}" for issue in preservation_issues],
+                    {},
+                )
+            for deleted in legacy_replacement.deleted_files:
+                old_overlay = overlay_repo / deleted.path
+                if old_overlay.is_symlink() or not old_overlay.is_file():
+                    return (
+                        False,
+                        [
+                            f"Legacy replacement overlay input changed: "
+                            f"{deleted.path.as_posix()}"
+                        ],
+                        {},
+                    )
+                if (
+                    hashlib.sha256(old_overlay.read_bytes()).hexdigest()
+                    != deleted.sha256
+                ):
+                    return (
+                        False,
+                        [
+                            f"Legacy replacement overlay input changed: "
+                            f"{deleted.path.as_posix()}"
+                        ],
+                        {},
+                    )
+                old_overlay.unlink()
+            old_manifest_overlay = (
+                overlay_repo / legacy_replacement.legacy_manifest.path
+            )
+            if (
+                old_manifest_overlay.is_symlink()
+                or not old_manifest_overlay.is_file()
+                or hashlib.sha256(old_manifest_overlay.read_bytes()).hexdigest()
+                != legacy_replacement.legacy_manifest.sha256
+            ):
+                return (
+                    False,
+                    ["Legacy replacement ownership manifest changed in overlay"],
+                    {},
+                )
+            old_manifest_overlay.unlink()
+            for rewrite in legacy_replacement.rewrites:
+                rewrite_target = overlay_repo / rewrite.path
+                if rewrite_target.is_symlink() or not rewrite_target.is_file():
+                    return (
+                        False,
+                        [
+                            f"Legacy replacement rewrite input changed: "
+                            f"{rewrite.path.as_posix()}"
+                        ],
+                        {},
+                    )
+                if (
+                    hashlib.sha256(rewrite_target.read_bytes()).hexdigest()
+                    != rewrite.before_sha256
+                ):
+                    return (
+                        False,
+                        [
+                            f"Legacy replacement rewrite input changed: "
+                            f"{rewrite.path.as_posix()}"
+                        ],
+                        {},
+                    )
+                rewrite_target.write_bytes(rewrite.raw)
         if not validate_dependents:
             _suppress_rulespec_ancestor_targets_for_subsection_overlay(
                 overlay_content_root,

--- a/src/axiom_encode/legacy_replacement.py
+++ b/src/axiom_encode/legacy_replacement.py
@@ -1,0 +1,188 @@
+"""Pure contracts for authenticated legacy-to-v5 fresh re-encoding.
+
+This module deliberately cannot sign, invoke a model, read Git, or mutate a
+checkout.  It defines the exact historical evidence class and deterministic
+receipt identity used by the CLI's broker-authenticated transaction.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Final, Mapping, NamedTuple
+
+from .corpus_resolver import normalize_corpus_identifier
+
+TOOL: Final = "axiom-encode encode --apply --replace-legacy-rulespec-path"
+RECEIPT_SCHEMA: Final = "axiom-encode/legacy-fresh-reencode-receipt/v1"
+RECEIPT_DIR: Final = ".axiom/legacy-replacements"
+LEGACY_MANIFEST_SCHEMA: Final = "axiom-encode/applied-rulespec/v1"
+LEGACY_OWNER_CLASS: Final = "v1-manual-hmac-untrusted"
+
+_SHA256 = re.compile(r"[0-9a-f]{64}")
+
+
+class LegacyReplacementFile(NamedTuple):
+    path: Path
+    sha256: str
+    raw: bytes
+
+
+class LegacyReplacementRewrite(NamedTuple):
+    path: Path
+    before_sha256: str
+    after_sha256: str
+    replacements: tuple[dict[str, object], ...]
+    raw: bytes
+
+
+class LegacyReplacementPendingFile(NamedTuple):
+    path: Path
+    before_sha256: str
+    replacements: tuple[dict[str, object], ...]
+
+
+class LegacyReplacementScheduledDependent(NamedTuple):
+    primary: Path
+    files: tuple[LegacyReplacementPendingFile, ...]
+
+
+class LegacyReplacementContract(NamedTuple):
+    base_commit: str
+    base_tree: str
+    source: Path
+    destination: Path
+    legacy_manifest: LegacyReplacementFile
+    deleted_files: tuple[LegacyReplacementFile, ...]
+    rewrites: tuple[LegacyReplacementRewrite, ...]
+    scheduled_dependents: tuple[LegacyReplacementScheduledDependent, ...]
+
+
+def legacy_source_verification_citation_paths(
+    verification: Mapping[str, object],
+) -> tuple[str, ...]:
+    """Admit exactly one exclusive singular or historical plural citation."""
+
+    admitted = {"corpus_citation_path", "corpus_citation_paths"}
+    present = set(verification) & admitted
+    if present == {"corpus_citation_path"}:
+        raw_paths: object = [verification["corpus_citation_path"]]
+    elif present == {"corpus_citation_paths"}:
+        raw_paths = verification["corpus_citation_paths"]
+    else:
+        return ()
+    if (
+        not isinstance(raw_paths, list)
+        or len(raw_paths) != 1
+        or not isinstance(raw_paths[0], str)
+        or not raw_paths[0].strip()
+    ):
+        return ()
+    try:
+        return (normalize_corpus_identifier(raw_paths[0]),)
+    except (TypeError, ValueError):
+        return ()
+
+
+def legacy_manual_manifest_issues(
+    payload: object,
+    *,
+    expected_files: Mapping[str, str],
+) -> list[str]:
+    """Require the one known manual v1 class without trusting its signature."""
+
+    if not isinstance(payload, dict):
+        return ["legacy ownership manifest is not a JSON object"]
+    issues: list[str] = []
+    if payload.get("schema_version") != LEGACY_MANIFEST_SCHEMA:
+        issues.append("legacy ownership manifest is not schema v1")
+    if payload.get("tool") != "axiom-encode sign-applied-files":
+        issues.append("legacy ownership manifest tool is not sign-applied-files")
+    if payload.get("backend") != "manual":
+        issues.append("legacy ownership manifest backend is not manual")
+    if payload.get("runner") != "manual-attestation":
+        issues.append("legacy ownership manifest runner is not manual-attestation")
+    if (
+        not isinstance(payload.get("manual_exception"), str)
+        or not str(payload["manual_exception"]).strip()
+    ):
+        issues.append("legacy ownership manifest has no manual exception")
+    if any(
+        field in payload
+        for field in (
+            "deterministic_execution",
+            "validation_execution",
+            "migrated_manifest",
+            "retired_manifest",
+            "replacement_manifest",
+        )
+    ):
+        issues.append("legacy ownership manifest claims unsupported provenance")
+    signature = payload.get("signature")
+    if (
+        not isinstance(signature, dict)
+        or signature.get("algorithm") != "hmac-sha256"
+        or not isinstance(signature.get("key_id"), str)
+        or not isinstance(signature.get("value"), str)
+    ):
+        issues.append("legacy ownership manifest has unknown signature provenance")
+    entries = payload.get("applied_files")
+    actual: dict[str, str] = {}
+    if not isinstance(entries, list):
+        issues.append("legacy ownership manifest applied_files is malformed")
+    else:
+        for index, entry in enumerate(entries):
+            if (
+                not isinstance(entry, dict)
+                or set(entry) != {"path", "sha256"}
+                or not isinstance(entry.get("path"), str)
+                or not isinstance(entry.get("sha256"), str)
+                or _SHA256.fullmatch(str(entry["sha256"])) is None
+                or entry["path"] in actual
+            ):
+                issues.append(
+                    f"legacy ownership manifest applied_files[{index}] is malformed"
+                )
+                continue
+            actual[str(entry["path"])] = str(entry["sha256"])
+    if actual != dict(expected_files):
+        issues.append(
+            "legacy ownership manifest does not bind the exact old primary/test bytes"
+        )
+    return issues
+
+
+def receipt_identity_payload(
+    *,
+    base_commit: str,
+    base_tree: str,
+    legacy_manifest_sha256: str,
+    model_manifest_sha256: str,
+    live_files: list[dict[str, object]],
+    deleted_files: list[dict[str, object]],
+    rewrites: list[dict[str, object]],
+    scheduled_dependents: list[dict[str, object]],
+) -> dict[str, object]:
+    return {
+        "base_commit": base_commit,
+        "base_tree": base_tree,
+        "legacy_manifest_sha256": legacy_manifest_sha256,
+        "model_manifest_sha256": model_manifest_sha256,
+        "live_files": live_files,
+        "deleted_files": deleted_files,
+        "rewrites": rewrites,
+        "scheduled_dependents": scheduled_dependents,
+    }
+
+
+def receipt_identity_sha256(payload: Mapping[str, object]) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode("ascii")
+    ).hexdigest()

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1410"
+ENCODER_VERSION = "0.2.1411"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,6 +87,7 @@ from axiom_encode.cli import (
     _install_apply_transaction,
     _install_eval_suite_revalidation_transaction,
     _latest_axiom_encode_version_commit,
+    _legacy_replacement_pending_paths,
     _load_verified_applied_encoding_manifest_payload,
     _local_factual_input_names_from_rules_content,
     _looks_like_absolute_rulespec_output_target,
@@ -1312,6 +1313,557 @@ def test_apply_manifest_environment_public_key_cannot_replace_protected_broker(
         )
         == "uses an unsupported encoder apply manifest signature algorithm"
     )
+
+
+@pytest.mark.parametrize(
+    "records",
+    [
+        [{"from": "old", "to": "new", "count": True}],
+        [{"from": 1, "to": "new", "count": 1}],
+        [{"from": "old", "to": 2, "count": 1}],
+        [
+            {"from": "old", "to": "new", "count": 1},
+            {"from": "old", "to": "other", "count": 1},
+        ],
+    ],
+)
+def test_strict_legacy_replacement_map_rejects_noncanonical_records(records) -> None:
+    from axiom_encode.cli import _strict_legacy_replacement_map
+
+    assert _strict_legacy_replacement_map(records) is None
+
+
+def test_legacy_reference_inventory_rejects_omitted_dependent_and_companion(
+    tmp_path: Path,
+) -> None:
+    from axiom_encode import cli
+    from axiom_encode.cli import _legacy_replacement_reference_inventory_issues
+
+    repo = tmp_path / "rulespec-us"
+    source = repo / "us/statutes/47:32.yaml"
+    scheduled = repo / "us/policies/income_tax/scheduled.yaml"
+    companion = scheduled.with_name("scheduled.test.yaml")
+    omitted = repo / "us/policies/income_tax/omitted.yaml"
+    for path in (source, scheduled, companion, omitted):
+        path.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text("format: rulespec/v1\nrules: []\n")
+    scheduled.write_text("imports:\n  - us:statutes/47:32\n")
+    companion.write_text("imports:\n  - us:statutes/47:32\n")
+    omitted.write_text("imports:\n  - us:statutes/47:32\n")
+    for index in range(20):
+        unrelated = repo / f"docs/unrelated-{index}.txt"
+        unrelated.parent.mkdir(parents=True, exist_ok=True)
+        unrelated.write_text("no legacy reference\n")
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "legacy inventory base")
+    base_commit = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    source_sha256 = hashlib.sha256(source.read_bytes()).hexdigest()
+    scheduled_sha256 = hashlib.sha256(scheduled.read_bytes()).hexdigest()
+    source.unlink()
+
+    with patch(
+        "axiom_encode.cli._rulespec_migration_git_bytes",
+        wraps=cli._rulespec_migration_git_bytes,
+    ) as git_bytes:
+        issues = _legacy_replacement_reference_inventory_issues(
+            repo,
+            base_commit=base_commit,
+            authoritative_replacements={
+                "us:statutes/47:32": "us:statutes/47/32",
+            },
+            legacy={
+                "manifest": {
+                    "path": ".axiom/encoding-manifests/us/statutes/47:32.json",
+                    "sha256": "a" * 64,
+                },
+                "files": [
+                    {
+                        "path": "us/statutes/47:32.yaml",
+                        "sha256": source_sha256,
+                    }
+                ],
+            },
+            replacement={
+                "rewrites": [],
+                "scheduled_dependents": [
+                    {
+                        "primary": "us/policies/income_tax/scheduled.yaml",
+                        "files": [
+                            {
+                                "path": "us/policies/income_tax/scheduled.yaml",
+                                "before_sha256": scheduled_sha256,
+                                "replacements": [
+                                    {
+                                        "from": "us:statutes/47:32",
+                                        "to": "us:statutes/47/32",
+                                        "count": 1,
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+            allow_pending_scheduled=True,
+        )
+    cat_file_calls = [
+        call
+        for call in git_bytes.call_args_list
+        if len(call.args) > 1 and call.args[1] == "cat-file"
+    ]
+    assert len(cat_file_calls) == 3
+
+    assert any(
+        "omits protected dependent us/policies/income_tax/scheduled.test.yaml" in issue
+        for issue in issues
+    )
+    assert any(
+        "omits protected dependent us/policies/income_tax/omitted.yaml" in issue
+        for issue in issues
+    )
+
+
+def _minimal_legacy_reference_inventory_fixture(
+    tmp_path: Path,
+) -> tuple[Path, str, dict[str, object], dict[str, object]]:
+    repo = tmp_path / "rulespec-us"
+    source = repo / "us/statutes/47:32.yaml"
+    source.parent.mkdir(parents=True)
+    source.write_text("format: rulespec/v1\nrules: []\n")
+    source_sha256 = hashlib.sha256(source.read_bytes()).hexdigest()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "minimal legacy inventory base")
+    base_commit = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    source.unlink()
+    return (
+        repo,
+        base_commit,
+        {
+            "manifest": {
+                "path": ".axiom/encoding-manifests/us/statutes/47:32.json",
+                "sha256": "a" * 64,
+            },
+            "files": [
+                {
+                    "path": "us/statutes/47:32.yaml",
+                    "sha256": source_sha256,
+                }
+            ],
+        },
+        {"rewrites": [], "scheduled_dependents": []},
+    )
+
+
+def test_legacy_reference_inventory_accepts_no_external_grep_hits(
+    tmp_path: Path,
+) -> None:
+    from axiom_encode.cli import _legacy_replacement_reference_inventory_issues
+
+    repo, base_commit, legacy, replacement = (
+        _minimal_legacy_reference_inventory_fixture(tmp_path)
+    )
+
+    assert (
+        _legacy_replacement_reference_inventory_issues(
+            repo,
+            base_commit=base_commit,
+            authoritative_replacements={
+                "us:statutes/47:32": "us:statutes/47/32",
+            },
+            legacy=legacy,
+            replacement=replacement,
+            allow_pending_scheduled=True,
+        )
+        == []
+    )
+
+
+def test_legacy_reference_inventory_rejects_symlink_target_skipped_by_git_grep(
+    tmp_path: Path,
+) -> None:
+    from axiom_encode.cli import _legacy_replacement_reference_inventory_issues
+
+    repo, _base_commit, legacy, replacement = (
+        _minimal_legacy_reference_inventory_fixture(tmp_path)
+    )
+    source = repo / "us/statutes/47:32.yaml"
+    source.write_text("format: rulespec/v1\nrules: []\n")
+    legacy_link = repo / "legacy-reference-link"
+    legacy_link.symlink_to("us:statutes/47:32")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "base with legacy-reference symlink")
+    base_commit = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    source.unlink()
+    grep_result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "grep",
+            "-z",
+            "-l",
+            "-a",
+            "-F",
+            "-e",
+            "us:statutes/47:32",
+            base_commit,
+            "--",
+        ],
+        check=False,
+        capture_output=True,
+    )
+    assert grep_result.returncode == 1
+    assert grep_result.stdout == b""
+
+    issues = _legacy_replacement_reference_inventory_issues(
+        repo,
+        base_commit=base_commit,
+        authoritative_replacements={
+            "us:statutes/47:32": "us:statutes/47/32",
+        },
+        legacy=legacy,
+        replacement=replacement,
+        allow_pending_scheduled=True,
+    )
+
+    assert any(
+        "reference occurs in non-0644 tracked path legacy-reference-link" in issue
+        for issue in issues
+    ), "\n".join(issues)
+
+
+def test_legacy_reference_inventory_rejects_executable_substring(
+    tmp_path: Path,
+) -> None:
+    from axiom_encode.cli import _legacy_replacement_reference_inventory_issues
+
+    repo, _base_commit, legacy, replacement = (
+        _minimal_legacy_reference_inventory_fixture(tmp_path)
+    )
+    source = repo / "us/statutes/47:32.yaml"
+    source.write_text("format: rulespec/v1\nrules: []\n")
+    executable = repo / "legacy-reference-tool"
+    executable.write_text("#!/bin/sh\nxus:statutes/47:32y\n")
+    executable.chmod(0o755)
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "base with legacy-reference executable")
+    base_commit = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    source.unlink()
+
+    issues = _legacy_replacement_reference_inventory_issues(
+        repo,
+        base_commit=base_commit,
+        authoritative_replacements={
+            "us:statutes/47:32": "us:statutes/47/32",
+        },
+        legacy=legacy,
+        replacement=replacement,
+        allow_pending_scheduled=True,
+    )
+
+    assert any(
+        "reference occurs in non-0644 tracked path legacy-reference-tool" in issue
+        for issue in issues
+    ), "\n".join(issues)
+
+
+@pytest.mark.parametrize(
+    ("returncode", "stdout", "stderr", "expected"),
+    [
+        (2, b"", b"forced grep failure", "cannot scan"),
+        (0, b"wrong-prefix:path.yaml\0", b"", "candidate is malformed"),
+    ],
+)
+def test_legacy_reference_inventory_rejects_grep_failures_and_malformed_candidates(
+    tmp_path: Path,
+    returncode: int,
+    stdout: bytes,
+    stderr: bytes,
+    expected: str,
+) -> None:
+    from axiom_encode import cli
+
+    repo, base_commit, legacy, replacement = (
+        _minimal_legacy_reference_inventory_fixture(tmp_path)
+    )
+    real_run = subprocess.run
+
+    def run_with_grep_result(command, **kwargs):
+        if isinstance(command, list) and "grep" in command:
+            return subprocess.CompletedProcess(command, returncode, stdout, stderr)
+        return real_run(command, **kwargs)
+
+    with patch("axiom_encode.cli.subprocess.run", side_effect=run_with_grep_result):
+        issues = cli._legacy_replacement_reference_inventory_issues(
+            repo,
+            base_commit=base_commit,
+            authoritative_replacements={
+                "us:statutes/47:32": "us:statutes/47/32",
+            },
+            legacy=legacy,
+            replacement=replacement,
+            allow_pending_scheduled=True,
+        )
+
+    assert any(expected in issue for issue in issues), "\n".join(issues)
+
+
+def test_legacy_pending_detection_requires_signed_untampered_evidence(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "rulespec-us"
+    pending_file = repo / "us/policies/income_tax/dependent.yaml"
+    pending_file.parent.mkdir(parents=True)
+    unrelated_reference = "us:statutes/99:1"
+    pending_file.write_text(
+        f"imports:\n  - us:statutes/47:32\n  - {unrelated_reference}\n"
+    )
+    old_source = repo / "us/statutes/47:32.yaml"
+    old_source.parent.mkdir(parents=True)
+    old_source.write_text("format: rulespec/v1\nrules: []\n")
+    old_source_sha256 = hashlib.sha256(old_source.read_bytes()).hexdigest()
+    old_manifest = repo / ".axiom/encoding-manifests/us/statutes/47:32.json"
+    old_manifest.parent.mkdir(parents=True)
+    old_manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": "axiom-encode/applied-rulespec/v1",
+                "tool": "axiom-encode sign-applied-files",
+                "backend": "manual",
+                "runner": "manual-attestation",
+                "manual_exception": "test legacy evidence",
+                "applied_files": [
+                    {
+                        "path": "us/statutes/47:32.yaml",
+                        "sha256": old_source_sha256,
+                    }
+                ],
+                "signature": {
+                    "algorithm": "hmac-sha256",
+                    "key_id": "historical-v1",
+                    "value": "opaque-untrusted-evidence",
+                },
+            }
+        )
+        + "\n"
+    )
+    old_manifest_sha256 = hashlib.sha256(old_manifest.read_bytes()).hexdigest()
+    before = hashlib.sha256(pending_file.read_bytes()).hexdigest()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "pending legacy dependent")
+    base_commit = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    base_tree = _git(repo, "rev-parse", "HEAD^{tree}").stdout.strip()
+    old_source.unlink()
+    old_manifest.unlink()
+    encoder_execution_identity = {
+        **TEST_PINNED_ENCODER_IDENTITY,
+        "identity_source": "git",
+    }
+    encoder_git = {
+        "root": "/repo/axiom-encode",
+        "commit": TEST_PINNED_ENCODER_IDENTITY["commit"],
+        "dirty_tracked": False,
+        "version": AXIOM_ENCODE_TEST_VERSION,
+        "version_commit": "b" * 40,
+        "identity_source": "git",
+    }
+    receipt_relative = Path(".axiom/legacy-replacements") / f"{'a' * 64}.json"
+    receipt_path = repo / receipt_relative
+    receipt_path.parent.mkdir(parents=True)
+    receipt = {
+        "schema_version": "axiom-encode/legacy-fresh-reencode-receipt/v1",
+        "generated_at": "2026-07-28T00:00:00+00:00",
+        "tool": "axiom-encode encode --apply --replace-legacy-rulespec-path",
+        "repository": {
+            "base_commit": base_commit,
+            "head_commit": base_commit,
+            "base_tree": base_tree,
+        },
+        "axiom_encode_version": AXIOM_ENCODE_TEST_VERSION,
+        "axiom_encode_git": encoder_git,
+        "validation_waiver_set_sha256": TEST_VALIDATION_WAIVER_SHA256,
+        "corpus_release": {},
+        "validation_execution": {
+            "axiom_encode": encoder_execution_identity,
+        },
+        "legacy": {
+            "owner_class": "v1-manual-hmac-untrusted",
+            "trusted_generated_provenance": False,
+            "manifest": {
+                "path": ".axiom/encoding-manifests/us/statutes/47:32.json",
+                "sha256": old_manifest_sha256,
+            },
+            "files": [
+                {
+                    "path": "us/statutes/47:32.yaml",
+                    "sha256": old_source_sha256,
+                }
+            ],
+        },
+        "replacement": {
+            "source": "us/statutes/47:32.yaml",
+            "destination": "us/statutes/47/32.yaml",
+            "model_manifest_path": (".axiom/encoding-manifests/us/statutes/47/32.json"),
+            "model_manifest_sha256": hashlib.sha256(
+                (
+                    json.dumps({"applied_files": []}, indent=2, sort_keys=True) + "\n"
+                ).encode()
+            ).hexdigest(),
+            "live_files": [],
+            "rewrites": [],
+            "scheduled_dependents": [
+                {
+                    "primary": "us/policies/income_tax/dependent.yaml",
+                    "files": [
+                        {
+                            "path": "us/policies/income_tax/dependent.yaml",
+                            "before_sha256": before,
+                            "replacements": [
+                                {
+                                    "from": "us:statutes/47:32",
+                                    "to": "us:statutes/47/32",
+                                    "count": 1,
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+        },
+        "replacement_manifest": {"applied_files": []},
+    }
+    _sign_applied_encoding_manifest(receipt, TEST_APPLY_SIGNING_BROKER)
+    receipt_path.write_text(json.dumps(receipt) + "\n")
+    signed_receipt_raw = receipt_path.read_bytes()
+    manifest = {
+        "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+        "generated_at": "2026-07-28T00:00:00+00:00",
+        "tool": "axiom-encode encode --apply --replace-legacy-rulespec-path",
+        "axiom_encode_version": AXIOM_ENCODE_TEST_VERSION,
+        "axiom_encode_git": encoder_git,
+        "validation_waiver_set_sha256": TEST_VALIDATION_WAIVER_SHA256,
+        "applied_files": [],
+        "replacement_manifest": {"applied_files": []},
+        "replacement": {
+            "receipt_path": receipt_relative.as_posix(),
+            "receipt_sha256": hashlib.sha256(receipt_path.read_bytes()).hexdigest(),
+            "legacy_manifest_path": (
+                ".axiom/encoding-manifests/us/statutes/47:32.json"
+            ),
+            "legacy_manifest_sha256": old_manifest_sha256,
+        },
+        "source_attestation": {},
+    }
+    _sign_applied_encoding_manifest(manifest, TEST_APPLY_SIGNING_BROKER)
+    manifest_path = repo / ".axiom/encoding-manifests/us/statutes/47/32.json"
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(json.dumps(manifest) + "\n")
+    signed_manifest_raw = manifest_path.read_bytes()
+
+    with patch(
+        "axiom_encode.cli._applied_encoding_manifest_verifier",
+        return_value=None,
+    ):
+        assert _legacy_replacement_pending_paths(repo) == [
+            "invalid:.axiom/encoding-manifests/us/statutes/47/32.json",
+            f"invalid:{receipt_relative.as_posix()}",
+        ]
+
+    with patch(
+        "axiom_encode.cli._applied_encoding_manifest_verifier",
+        return_value=TEST_APPLY_SIGNING_BROKER,
+    ):
+        assert _legacy_replacement_pending_paths(repo) == [
+            "us/policies/income_tax/dependent.yaml"
+        ]
+        with patch(
+            "axiom_encode.cli._legacy_replacement_reference_inventory_issues",
+            return_value=[
+                "legacy replacement base reference inventory omits protected "
+                "dependent us/policies/income_tax/omitted.yaml"
+            ],
+        ):
+            assert _legacy_replacement_pending_paths(repo) == [
+                "invalid:.axiom/encoding-manifests/us/statutes/47/32.json",
+                f"invalid:{receipt_relative.as_posix()}",
+            ]
+        receipt["replacement"]["scheduled_dependents"][0]["files"][0]["replacements"][
+            0
+        ]["count"] = 2
+        _sign_applied_encoding_manifest(receipt, TEST_APPLY_SIGNING_BROKER)
+        receipt_path.write_text(json.dumps(receipt) + "\n")
+        manifest["replacement"]["receipt_sha256"] = hashlib.sha256(
+            receipt_path.read_bytes()
+        ).hexdigest()
+        _sign_applied_encoding_manifest(manifest, TEST_APPLY_SIGNING_BROKER)
+        manifest_path.write_text(json.dumps(manifest) + "\n")
+        assert _legacy_replacement_pending_paths(repo) == [
+            "invalid:us/policies/income_tax/dependent.yaml"
+        ]
+        receipt_path.write_bytes(signed_receipt_raw)
+        manifest_path.write_bytes(signed_manifest_raw)
+        receipt["replacement"]["scheduled_dependents"][0]["files"][0][
+            "replacements"
+        ] = [
+            {
+                "from": unrelated_reference,
+                "to": "us:statutes/99/1",
+                "count": 1,
+            }
+        ]
+        _sign_applied_encoding_manifest(receipt, TEST_APPLY_SIGNING_BROKER)
+        receipt_path.write_text(json.dumps(receipt) + "\n")
+        manifest["replacement"]["receipt_sha256"] = hashlib.sha256(
+            receipt_path.read_bytes()
+        ).hexdigest()
+        _sign_applied_encoding_manifest(manifest, TEST_APPLY_SIGNING_BROKER)
+        manifest_path.write_text(json.dumps(manifest) + "\n")
+        assert _legacy_replacement_pending_paths(repo) == [
+            "invalid:us/policies/income_tax/dependent.yaml"
+        ]
+        receipt_path.write_bytes(signed_receipt_raw)
+        manifest_path.write_bytes(signed_manifest_raw)
+        receipt["replacement"]["scheduled_dependents"] = []
+        receipt_path.write_text(json.dumps(receipt) + "\n")
+        assert _legacy_replacement_pending_paths(repo) == [
+            "invalid:.axiom/encoding-manifests/us/statutes/47/32.json",
+            f"invalid:{receipt_relative.as_posix()}",
+        ]
+        receipt_path.write_bytes(signed_receipt_raw)
+        manifest["signature"] = {
+            "algorithm": "ed25519-domain-v1",
+            "key_id": "sha256:" + "0" * 64,
+            "value": "AAAA",
+        }
+        manifest_path.write_text(json.dumps(manifest) + "\n")
+        assert _legacy_replacement_pending_paths(repo) == [
+            "invalid:.axiom/encoding-manifests/us/statutes/47/32.json",
+            f"invalid:{receipt_relative.as_posix()}",
+        ]
+        manifest_path.write_bytes(signed_manifest_raw)
+        manifest_path.unlink()
+        assert _legacy_replacement_pending_paths(repo) == [
+            f"invalid:{receipt_relative.as_posix()}"
+        ]
+        manifest_path.write_bytes(signed_manifest_raw)
+        resolved = b"imports:\n  - us:statutes/47/32\n"
+        _install_apply_transaction(
+            [(pending_file, resolved)],
+            checkout_root=repo,
+            expected_originals={pending_file: before},
+        )
+        assert _legacy_replacement_pending_paths(repo) == [
+            "invalid:us/policies/income_tax/dependent.yaml"
+        ]
 
 
 def _complete_source_attestation(
@@ -11673,6 +12225,10 @@ class TestCmdEncode:
         args.skip_reviewers = overrides.get("skip_reviewers", False)
         args.apply = overrides.get("apply", False)
         args.replace_rulespec_path = overrides.get("replace_rulespec_path", None)
+        args.replace_legacy_rulespec_path = overrides.get(
+            "replace_legacy_rulespec_path",
+            None,
+        )
         args.apply_target_only = overrides.get("apply_target_only", False)
         args.allow_shrink = overrides.get("allow_shrink", False)
         return args
@@ -11878,6 +12434,323 @@ class TestCmdEncode:
             mock_run.call_args.kwargs["runtime_axiom_rules_path"]
             == args.axiom_rules_path
         )
+
+    @pytest.mark.parametrize("reference_in_companion", [False, True])
+    def test_encode_apply_resolves_authenticated_legacy_pending_dependent(
+        self,
+        tmp_path,
+        reference_in_companion,
+    ):
+        dependent_relative = Path("us/policies/income_tax/dependent.yaml")
+        args = self._make_args(
+            tmp_path,
+            apply=True,
+            sync=False,
+            replace_rulespec_path=dependent_relative,
+        )
+        target = args.policy_repo_path / dependent_relative
+        target.parent.mkdir(parents=True)
+        old_reference = "us:statutes/47:32"
+        new_reference = "us:statutes/47/32"
+        target_import = (
+            "  - []\n" if reference_in_companion else f"  - {old_reference}\n"
+        )
+        target.write_text(
+            "format: rulespec/v1\n"
+            "module:\n"
+            "  source_verification:\n"
+            "    corpus_citation_path: us/statute/26/1/j/2\n"
+            "imports:\n"
+            f"{target_import}"
+            "rules: []\n"
+        )
+        companion = target.with_name("dependent.test.yaml")
+        if reference_in_companion:
+            companion.write_text(
+                f"- name: companion reference\n  source: {old_reference}\n"
+            )
+        old_source = args.policy_repo_path / "us/statutes/47:32.yaml"
+        old_source.parent.mkdir(parents=True)
+        old_source.write_text("format: rulespec/v1\nrules: []\n")
+        old_source_sha256 = hashlib.sha256(old_source.read_bytes()).hexdigest()
+        old_manifest = (
+            args.policy_repo_path / ".axiom/encoding-manifests/us/statutes/47:32.json"
+        )
+        old_manifest.parent.mkdir(parents=True)
+        old_manifest.write_text(
+            json.dumps(
+                {
+                    "schema_version": "axiom-encode/applied-rulespec/v1",
+                    "tool": "axiom-encode sign-applied-files",
+                    "backend": "manual",
+                    "runner": "manual-attestation",
+                    "manual_exception": "test legacy evidence",
+                    "applied_files": [
+                        {
+                            "path": "us/statutes/47:32.yaml",
+                            "sha256": old_source_sha256,
+                        }
+                    ],
+                    "signature": {
+                        "algorithm": "hmac-sha256",
+                        "key_id": "historical-v1",
+                        "value": "opaque-untrusted-evidence",
+                    },
+                }
+            )
+            + "\n"
+        )
+        old_manifest_sha256 = hashlib.sha256(old_manifest.read_bytes()).hexdigest()
+        evidence_path = companion if reference_in_companion else target
+        evidence_relative = evidence_path.relative_to(args.policy_repo_path)
+        before = hashlib.sha256(evidence_path.read_bytes()).hexdigest()
+        _git(args.policy_repo_path, "init", "-b", "main")
+        _git(args.policy_repo_path, "config", "user.email", "test@example.com")
+        _git(args.policy_repo_path, "config", "user.name", "Test User")
+        _git(args.policy_repo_path, "add", ".")
+        _git(args.policy_repo_path, "commit", "-m", "pending legacy dependent")
+        base_commit = _git(
+            args.policy_repo_path,
+            "rev-parse",
+            "HEAD",
+        ).stdout.strip()
+        base_tree = _git(
+            args.policy_repo_path,
+            "rev-parse",
+            "HEAD^{tree}",
+        ).stdout.strip()
+        old_source.unlink()
+        old_manifest.unlink()
+        encoder_execution_identity = {
+            **TEST_PINNED_ENCODER_IDENTITY,
+            "identity_source": "git",
+        }
+        encoder_git = {
+            "root": "/repo/axiom-encode",
+            "commit": TEST_PINNED_ENCODER_IDENTITY["commit"],
+            "dirty_tracked": False,
+            "version": AXIOM_ENCODE_TEST_VERSION,
+            "version_commit": "b" * 40,
+            "identity_source": "git",
+        }
+        replacements = [{"from": old_reference, "to": new_reference, "count": 1}]
+        receipt_relative = Path(".axiom/legacy-replacements") / f"{'a' * 64}.json"
+        receipt_path = args.policy_repo_path / receipt_relative
+        receipt_path.parent.mkdir(parents=True)
+        receipt = {
+            "schema_version": ("axiom-encode/legacy-fresh-reencode-receipt/v1"),
+            "generated_at": "2026-07-28T00:00:00+00:00",
+            "tool": ("axiom-encode encode --apply --replace-legacy-rulespec-path"),
+            "repository": {
+                "base_commit": base_commit,
+                "head_commit": base_commit,
+                "base_tree": base_tree,
+            },
+            "axiom_encode_version": AXIOM_ENCODE_TEST_VERSION,
+            "axiom_encode_git": encoder_git,
+            "validation_waiver_set_sha256": TEST_VALIDATION_WAIVER_SHA256,
+            "corpus_release": {},
+            "validation_execution": {
+                "axiom_encode": encoder_execution_identity,
+            },
+            "legacy": {
+                "owner_class": "v1-manual-hmac-untrusted",
+                "trusted_generated_provenance": False,
+                "manifest": {
+                    "path": ".axiom/encoding-manifests/us/statutes/47:32.json",
+                    "sha256": old_manifest_sha256,
+                },
+                "files": [
+                    {
+                        "path": "us/statutes/47:32.yaml",
+                        "sha256": old_source_sha256,
+                    }
+                ],
+            },
+            "replacement": {
+                "source": "us/statutes/47:32.yaml",
+                "destination": "us/statutes/47/32.yaml",
+                "model_manifest_path": (
+                    ".axiom/encoding-manifests/us/statutes/47/32.json"
+                ),
+                "model_manifest_sha256": hashlib.sha256(
+                    (
+                        json.dumps(
+                            {"applied_files": []},
+                            indent=2,
+                            sort_keys=True,
+                        )
+                        + "\n"
+                    ).encode()
+                ).hexdigest(),
+                "live_files": [],
+                "rewrites": [],
+                "scheduled_dependents": [
+                    {
+                        "primary": dependent_relative.as_posix(),
+                        "files": [
+                            {
+                                "path": evidence_relative.as_posix(),
+                                "before_sha256": before,
+                                "replacements": replacements,
+                            }
+                        ],
+                    }
+                ],
+            },
+            "replacement_manifest": {"applied_files": []},
+        }
+        _sign_applied_encoding_manifest(receipt, TEST_APPLY_SIGNING_BROKER)
+        receipt_path.write_text(json.dumps(receipt) + "\n")
+        outer = {
+            "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+            "generated_at": "2026-07-28T00:00:00+00:00",
+            "tool": ("axiom-encode encode --apply --replace-legacy-rulespec-path"),
+            "axiom_encode_version": AXIOM_ENCODE_TEST_VERSION,
+            "axiom_encode_git": encoder_git,
+            "validation_waiver_set_sha256": TEST_VALIDATION_WAIVER_SHA256,
+            "applied_files": [],
+            "replacement_manifest": {"applied_files": []},
+            "replacement": {
+                "receipt_path": receipt_relative.as_posix(),
+                "receipt_sha256": hashlib.sha256(receipt_path.read_bytes()).hexdigest(),
+                "legacy_manifest_path": (
+                    ".axiom/encoding-manifests/us/statutes/47:32.json"
+                ),
+                "legacy_manifest_sha256": old_manifest_sha256,
+            },
+            "source_attestation": {},
+        }
+        _sign_applied_encoding_manifest(outer, TEST_APPLY_SIGNING_BROKER)
+        outer_path = (
+            args.policy_repo_path / ".axiom/encoding-manifests/us/statutes/47/32.json"
+        )
+        outer_path.parent.mkdir(parents=True)
+        outer_path.write_text(json.dumps(outer) + "\n")
+
+        generated = (
+            args.output / "codex-test-model" / "policies/income_tax/dependent.yaml"
+        )
+        generated.parent.mkdir(parents=True)
+        generated.write_text(
+            "format: rulespec/v1\n"
+            "module:\n"
+            "  source_verification:\n"
+            "    corpus_citation_path: us/statute/26/1/j/2\n"
+            "imports:\n"
+            f"  - {new_reference}\n"
+            "rules: []\n"
+        )
+        if reference_in_companion:
+            generated.with_name("dependent.test.yaml").write_text(
+                f"- name: companion reference\n  source: {new_reference}\n"
+            )
+        result = self._make_eval_result(True)
+        result.output_file = str(generated)
+        result.generation_prompt_sha256 = "prompt-sha"
+        result._axiom_legacy_replacement_contract = None
+        result.trace_file = str(tmp_path / "trace.json")
+        Path(result.trace_file).write_text("{}\n")
+        source_unit = resolve_corpus_source_unit(
+            "us/statute/26/1/j/2",
+            args.corpus_release,
+        )
+        result.source_attestation = dict(source_unit.source_attestation)
+        source_text = tmp_path / "pending-dependent-source.txt"
+        source_text.write_text(source_unit.body)
+        context_manifest = tmp_path / "pending-dependent-context.json"
+        context_manifest.write_text(
+            json.dumps({"source_text_file": source_text.name}) + "\n"
+        )
+        result.context_manifest_file = str(context_manifest)
+        result.context_manifest_sha256 = hashlib.sha256(
+            context_manifest.read_bytes()
+        ).hexdigest()
+        result.source_attestation["generation_input_sha256"] = hashlib.sha256(
+            source_unit.body.encode()
+        ).hexdigest()
+        self._record_apply_validation(
+            result,
+            output_root=args.output,
+            policy_repo_path=args.policy_repo_path / "us",
+            corpus_path=args.corpus_path,
+        )
+
+        with patch(
+            "axiom_encode.cli._applied_encoding_manifest_verifier",
+            return_value=TEST_APPLY_SIGNING_BROKER,
+        ):
+            assert _legacy_replacement_pending_paths(args.policy_repo_path) == [
+                evidence_relative.as_posix()
+            ]
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                return_value=(True, [], {}),
+            ),
+            patch(
+                "axiom_encode.cli._git_repo_provenance",
+                return_value={
+                    "root": "/repo/axiom-encode",
+                    "commit": TEST_PINNED_ENCODER_IDENTITY["commit"],
+                    "dirty_tracked": False,
+                },
+            ),
+            patch(
+                "axiom_encode.cli._require_axiom_encode_version_provenance",
+                return_value={
+                    "version": AXIOM_ENCODE_TEST_VERSION,
+                    "version_commit": "f" * 40,
+                    "identity_source": "git",
+                },
+            ),
+            patch.dict(os.environ, TEST_APPLY_SIGNING_ENV, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        assert new_reference in evidence_path.read_text()
+        dependent_manifest = (
+            args.policy_repo_path
+            / ".axiom/encoding-manifests/us/policies/income_tax/dependent.json"
+        )
+        assert json.loads(dependent_manifest.read_text())["tool"] == (
+            APPLIED_ENCODING_MODEL_TOOL
+        )
+        applied_files = json.loads(dependent_manifest.read_text())["applied_files"]
+        assert evidence_relative.as_posix() in {item["path"] for item in applied_files}
+        with patch(
+            "axiom_encode.cli._applied_encoding_manifest_verifier",
+            return_value=TEST_APPLY_SIGNING_BROKER,
+        ):
+            assert _legacy_replacement_pending_paths(args.policy_repo_path) == []
+        dependent_payload = json.loads(dependent_manifest.read_text())
+        historical_commit = "c" * 40
+        historical_version = "0.1.0"
+        dependent_payload["axiom_encode_version"] = historical_version
+        dependent_payload["axiom_encode_git"]["commit"] = historical_commit
+        dependent_payload["axiom_encode_git"]["version"] = historical_version
+        dependent_payload["validation_execution"]["axiom_encode"]["commit"] = (
+            historical_commit
+        )
+        dependent_payload["validation_execution"]["axiom_encode"]["version"] = (
+            historical_version
+        )
+        _sign_applied_encoding_manifest(
+            dependent_payload,
+            TEST_APPLY_SIGNING_BROKER,
+        )
+        dependent_manifest.write_text(json.dumps(dependent_payload) + "\n")
+        with patch(
+            "axiom_encode.cli._applied_encoding_manifest_verifier",
+            return_value=TEST_APPLY_SIGNING_BROKER,
+        ):
+            assert _legacy_replacement_pending_paths(args.policy_repo_path) == [
+                f"invalid:{dependent_relative.as_posix()}"
+            ]
 
     def test_encode_escalates_after_n_validator_failures(self, tmp_path):
         args = self._make_args(
@@ -12129,6 +13002,7 @@ class TestCmdEncode:
         replacement = SimpleNamespace(
             relative_output=Path("policies/income_tax/pilot_liability_pipeline.yaml"),
             context_paths=(target, companion),
+            legacy_replacement=None,
         )
 
         with patch(
@@ -32566,6 +33440,416 @@ class TestResolverOwnedManifestWriter:
 
         assert verified is None
         assert any("canonical .yaml RuleSpec extension" in issue for issue in issues)
+
+    def test_full_loader_admits_exact_legacy_metadata_rewrite_path(self, tmp_path):
+        checkout = tmp_path / "rulespec-us"
+        metadata = checkout / ".axiom/index/provisions_to_rules.json"
+        metadata.parent.mkdir(parents=True)
+        metadata.write_text("{}\n")
+        payload = {
+            "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+            "generated_at": "2026-07-28T00:00:00+00:00",
+            "tool": ("axiom-encode encode --apply --replace-legacy-rulespec-path"),
+            "axiom_encode_version": AXIOM_ENCODE_TEST_VERSION,
+            "axiom_encode_git": {
+                "root": "/repo/axiom-encode",
+                "commit": TEST_PINNED_ENCODER_IDENTITY["commit"],
+                "dirty_tracked": False,
+                "version": AXIOM_ENCODE_TEST_VERSION,
+                "version_commit": "f" * 40,
+                "identity_source": "git",
+            },
+            "validation_waiver_set_sha256": TEST_VALIDATION_WAIVER_SHA256,
+            "applied_files": [
+                {
+                    "path": ".axiom/index/provisions_to_rules.json",
+                    "sha256": _sha256_file(metadata),
+                }
+            ],
+            "replacement_manifest": {
+                "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+                "tool": APPLIED_ENCODING_MODEL_TOOL,
+                "backend": "codex",
+            },
+            "replacement": {},
+            "source_attestation": None,
+        }
+        _sign_applied_encoding_manifest(payload, TEST_APPLY_SIGNING_BROKER)
+        manifest = checkout / ".axiom/encoding-manifests/us/statutes/47/32.json"
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text(json.dumps(payload) + "\n")
+
+        with (
+            patch(
+                "axiom_encode.cli._legacy_replacement_manifest_issues",
+                return_value=[],
+            ),
+            patch(
+                "axiom_encode.cli._applied_manifest_source_attestation_issues",
+                return_value=[],
+            ),
+        ):
+            verified, _root, _digest, issues = (
+                _load_verified_applied_encoding_manifest_payload(
+                    checkout,
+                    manifest.relative_to(checkout).as_posix(),
+                    signing_broker=TEST_APPLY_SIGNING_BROKER,
+                    expected_waiver_set_sha256=TEST_VALIDATION_WAIVER_SHA256,
+                    expected_encoder_identity=TEST_PINNED_ENCODER_IDENTITY,
+                )
+            )
+
+        assert issues == []
+        assert verified == payload
+
+    def test_legacy_verifier_rejects_protected_yaml_metadata_rewrite(
+        self,
+        tmp_path,
+    ):
+        from axiom_encode.cli import _legacy_replacement_manifest_issues
+        from axiom_encode.legacy_replacement import (
+            receipt_identity_payload,
+            receipt_identity_sha256,
+        )
+
+        checkout = tmp_path / "rulespec-us"
+        unauthorized = checkout / "us/policies/income_tax/dependent.yaml"
+        unauthorized.parent.mkdir(parents=True)
+        old_reference = "us:statutes/47:32"
+        new_reference = "us:statutes/47/32"
+        unrelated_reference = "us:statutes/99:1"
+        unauthorized.write_text(
+            f"imports:\n  - {old_reference}\n  - {unrelated_reference}\n"
+        )
+        metadata = checkout / ".axiom/index/provisions_to_rules.json"
+        metadata.parent.mkdir(parents=True)
+        metadata.write_text(json.dumps({"module": old_reference}) + "\n")
+        old_source = checkout / "us/statutes/47:32.yaml"
+        old_source.parent.mkdir(parents=True)
+        old_source.write_text("format: rulespec/v1\nrules: []\n")
+        old_source_sha256 = hashlib.sha256(old_source.read_bytes()).hexdigest()
+        manifest_label = ".axiom/encoding-manifests/us/statutes/47/32.json"
+        legacy_manifest_label = ".axiom/encoding-manifests/us/statutes/47:32.json"
+        legacy_manifest = checkout / legacy_manifest_label
+        legacy_manifest.parent.mkdir(parents=True)
+        legacy_manifest.write_text(
+            json.dumps(
+                {
+                    "schema_version": "axiom-encode/applied-rulespec/v1",
+                    "tool": "axiom-encode sign-applied-files",
+                    "backend": "manual",
+                    "runner": "manual-attestation",
+                    "manual_exception": "test legacy evidence",
+                    "applied_files": [
+                        {
+                            "path": "us/statutes/47:32.yaml",
+                            "sha256": old_source_sha256,
+                        }
+                    ],
+                    "signature": {
+                        "algorithm": "hmac-sha256",
+                        "key_id": "historical-v1",
+                        "value": "opaque-untrusted-evidence",
+                    },
+                }
+            )
+            + "\n"
+        )
+        _git(checkout, "init", "-b", "main")
+        _git(checkout, "config", "user.email", "test@example.com")
+        _git(checkout, "config", "user.name", "Test User")
+        _git(checkout, "add", ".")
+        _git(checkout, "commit", "-m", "legacy base")
+        base_commit = _git(checkout, "rev-parse", "HEAD").stdout.strip()
+        base_tree = _git(checkout, "rev-parse", "HEAD^{tree}").stdout.strip()
+        before = hashlib.sha256(unauthorized.read_bytes()).hexdigest()
+        metadata_before = hashlib.sha256(metadata.read_bytes()).hexdigest()
+        legacy_manifest_sha256 = hashlib.sha256(
+            legacy_manifest.read_bytes()
+        ).hexdigest()
+        unauthorized.write_text(f"imports:\n  - {new_reference}\n")
+        metadata.write_text(json.dumps({"module": new_reference}) + "\n")
+        after = hashlib.sha256(unauthorized.read_bytes()).hexdigest()
+        metadata_after = hashlib.sha256(metadata.read_bytes()).hexdigest()
+        legacy_manifest.unlink()
+        old_source.unlink()
+        replacements = [
+            {"from": old_reference, "to": new_reference, "count": 1},
+        ]
+        rewrite = {
+            "path": unauthorized.relative_to(checkout).as_posix(),
+            "before_sha256": before,
+            "after_sha256": after,
+            "replacements": replacements,
+        }
+        nested = {
+            "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+            "tool": APPLIED_ENCODING_MODEL_TOOL,
+            "backend": "codex",
+            "applied_files": [],
+        }
+        nested_raw = (json.dumps(nested, indent=2, sort_keys=True) + "\n").encode()
+        model_manifest_sha256 = hashlib.sha256(nested_raw).hexdigest()
+        identity = receipt_identity_payload(
+            base_commit=base_commit,
+            base_tree=base_tree,
+            legacy_manifest_sha256=legacy_manifest_sha256,
+            model_manifest_sha256=model_manifest_sha256,
+            live_files=[],
+            deleted_files=[
+                {"path": "us/statutes/47:32.yaml", "deleted": True},
+            ],
+            rewrites=[rewrite],
+            scheduled_dependents=[],
+        )
+        receipt_relative = (
+            Path(".axiom/legacy-replacements")
+            / f"{receipt_identity_sha256(identity)}.json"
+        )
+        encoder_git = {
+            "root": "/repo/axiom-encode",
+            "commit": TEST_PINNED_ENCODER_IDENTITY["commit"],
+            "dirty_tracked": False,
+            "version": AXIOM_ENCODE_TEST_VERSION,
+            "version_commit": "b" * 40,
+            "identity_source": "git",
+        }
+        receipt = {
+            "schema_version": ("axiom-encode/legacy-fresh-reencode-receipt/v1"),
+            "generated_at": "2026-07-28T00:00:00+00:00",
+            "tool": ("axiom-encode encode --apply --replace-legacy-rulespec-path"),
+            "repository": {
+                "base_commit": base_commit,
+                "head_commit": base_commit,
+                "base_tree": base_tree,
+            },
+            "axiom_encode_version": AXIOM_ENCODE_TEST_VERSION,
+            "axiom_encode_git": encoder_git,
+            "validation_waiver_set_sha256": TEST_VALIDATION_WAIVER_SHA256,
+            "corpus_release": {},
+            "validation_execution": None,
+            "legacy": {
+                "owner_class": "v1-manual-hmac-untrusted",
+                "trusted_generated_provenance": False,
+                "manifest": {
+                    "path": legacy_manifest_label,
+                    "sha256": legacy_manifest_sha256,
+                },
+                "files": [
+                    {
+                        "path": "us/statutes/47:32.yaml",
+                        "sha256": old_source_sha256,
+                    }
+                ],
+            },
+            "replacement": {
+                "source": "us/statutes/47:32.yaml",
+                "destination": "us/statutes/47/32.yaml",
+                "model_manifest_path": manifest_label,
+                "model_manifest_sha256": model_manifest_sha256,
+                "live_files": [],
+                "rewrites": [rewrite],
+                "scheduled_dependents": [],
+            },
+            "replacement_manifest": nested,
+        }
+        _sign_applied_encoding_manifest(receipt, TEST_APPLY_SIGNING_BROKER)
+        receipt_path = checkout / receipt_relative
+        receipt_path.parent.mkdir(parents=True)
+        receipt_path.write_text(json.dumps(receipt) + "\n")
+        payload = {
+            "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+            "generated_at": "2026-07-28T00:00:00+00:00",
+            "tool": ("axiom-encode encode --apply --replace-legacy-rulespec-path"),
+            "axiom_encode_version": AXIOM_ENCODE_TEST_VERSION,
+            "axiom_encode_git": encoder_git,
+            "validation_waiver_set_sha256": TEST_VALIDATION_WAIVER_SHA256,
+            "applied_files": [
+                {
+                    "path": rewrite["path"],
+                    "sha256": after,
+                },
+                {"path": "us/statutes/47:32.yaml", "deleted": True},
+            ],
+            "replacement_manifest": nested,
+            "replacement": {
+                "receipt_path": receipt_relative.as_posix(),
+                "receipt_sha256": hashlib.sha256(receipt_path.read_bytes()).hexdigest(),
+                "legacy_manifest_path": legacy_manifest_label,
+                "legacy_manifest_sha256": legacy_manifest_sha256,
+            },
+            "source_attestation": None,
+        }
+
+        issues = _legacy_replacement_manifest_issues(
+            payload,
+            repo_path=checkout,
+            manifest_label=manifest_label,
+            signing_broker=TEST_APPLY_SIGNING_BROKER,
+            expected_waiver_set_sha256=TEST_VALIDATION_WAIVER_SHA256,
+            local_corpus_release=None,
+        )
+
+        assert any(
+            "replacement rewrite path is unauthorized" in issue for issue in issues
+        ), "\n".join(issues)
+        with patch(
+            "axiom_encode.cli._legacy_replacement_reference_inventory_issues",
+            return_value=[
+                "legacy replacement base reference inventory omits protected "
+                "dependent us/policies/income_tax/omitted.yaml"
+            ],
+        ):
+            omitted_issues = _legacy_replacement_manifest_issues(
+                payload,
+                repo_path=checkout,
+                manifest_label=manifest_label,
+                signing_broker=TEST_APPLY_SIGNING_BROKER,
+                expected_waiver_set_sha256=TEST_VALIDATION_WAIVER_SHA256,
+                local_corpus_release=None,
+            )
+        assert any(
+            "reference inventory is invalid" in issue and "omitted.yaml" in issue
+            for issue in omitted_issues
+        ), "\n".join(omitted_issues)
+
+        malformed_rewrite = {
+            "path": metadata.relative_to(checkout).as_posix(),
+            "before_sha256": metadata_before,
+            "after_sha256": metadata_after,
+            "replacements": [
+                {"from": old_reference, "to": new_reference, "count": True},
+            ],
+        }
+        malformed_identity = receipt_identity_payload(
+            base_commit=base_commit,
+            base_tree=base_tree,
+            legacy_manifest_sha256=legacy_manifest_sha256,
+            model_manifest_sha256=model_manifest_sha256,
+            live_files=[],
+            deleted_files=[
+                {"path": "us/statutes/47:32.yaml", "deleted": True},
+            ],
+            rewrites=[malformed_rewrite],
+            scheduled_dependents=[],
+        )
+        malformed_receipt_relative = (
+            Path(".axiom/legacy-replacements")
+            / f"{receipt_identity_sha256(malformed_identity)}.json"
+        )
+        receipt["replacement"]["rewrites"] = [malformed_rewrite]
+        _sign_applied_encoding_manifest(receipt, TEST_APPLY_SIGNING_BROKER)
+        malformed_receipt_path = checkout / malformed_receipt_relative
+        malformed_receipt_path.write_text(json.dumps(receipt) + "\n")
+        payload["applied_files"] = [
+            {"path": malformed_rewrite["path"], "sha256": metadata_after},
+            {"path": "us/statutes/47:32.yaml", "deleted": True},
+        ]
+        payload["replacement"]["receipt_path"] = malformed_receipt_relative.as_posix()
+        payload["replacement"]["receipt_sha256"] = hashlib.sha256(
+            malformed_receipt_path.read_bytes()
+        ).hexdigest()
+
+        malformed_issues = _legacy_replacement_manifest_issues(
+            payload,
+            repo_path=checkout,
+            manifest_label=manifest_label,
+            signing_broker=TEST_APPLY_SIGNING_BROKER,
+            expected_waiver_set_sha256=TEST_VALIDATION_WAIVER_SHA256,
+            local_corpus_release=None,
+        )
+
+        assert any(
+            "rewrite replacement records are malformed" in issue
+            for issue in malformed_issues
+        ), "\n".join(malformed_issues)
+
+        unauthorized.write_text(
+            f"imports:\n  - {old_reference}\n  - us:statutes/99/1\n"
+        )
+        scheduled = [
+            {
+                "primary": unauthorized.relative_to(checkout).as_posix(),
+                "files": [
+                    {
+                        "path": unauthorized.relative_to(checkout).as_posix(),
+                        "before_sha256": before,
+                        "replacements": [
+                            {
+                                "from": unrelated_reference,
+                                "to": "us:statutes/99/1",
+                                "count": 1,
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+        unrelated_identity = receipt_identity_payload(
+            base_commit=base_commit,
+            base_tree=base_tree,
+            legacy_manifest_sha256=legacy_manifest_sha256,
+            model_manifest_sha256=model_manifest_sha256,
+            live_files=[],
+            deleted_files=[
+                {"path": "us/statutes/47:32.yaml", "deleted": True},
+            ],
+            rewrites=[],
+            scheduled_dependents=scheduled,
+        )
+        unrelated_receipt_relative = (
+            Path(".axiom/legacy-replacements")
+            / f"{receipt_identity_sha256(unrelated_identity)}.json"
+        )
+        receipt["replacement"]["rewrites"] = []
+        receipt["replacement"]["scheduled_dependents"] = scheduled
+        _sign_applied_encoding_manifest(receipt, TEST_APPLY_SIGNING_BROKER)
+        unrelated_receipt_path = checkout / unrelated_receipt_relative
+        unrelated_receipt_path.write_text(json.dumps(receipt) + "\n")
+        payload["applied_files"] = [
+            {"path": "us/statutes/47:32.yaml", "deleted": True},
+        ]
+        payload["replacement"]["receipt_path"] = unrelated_receipt_relative.as_posix()
+        payload["replacement"]["receipt_sha256"] = hashlib.sha256(
+            unrelated_receipt_path.read_bytes()
+        ).hexdigest()
+
+        unrelated_issues = _legacy_replacement_manifest_issues(
+            payload,
+            repo_path=checkout,
+            manifest_label=manifest_label,
+            signing_broker=TEST_APPLY_SIGNING_BROKER,
+            expected_waiver_set_sha256=TEST_VALIDATION_WAIVER_SHA256,
+            local_corpus_release=None,
+        )
+
+        assert any(
+            "scheduled dependent has stale base proof" in issue
+            for issue in unrelated_issues
+        ), "\n".join(unrelated_issues)
+        assert any(
+            "scheduled dependent still carries a legacy reference" in issue
+            for issue in unrelated_issues
+        ), "\n".join(unrelated_issues)
+
+        receipt["replacement"]["source"] = receipt["replacement"]["destination"]
+        _sign_applied_encoding_manifest(receipt, TEST_APPLY_SIGNING_BROKER)
+        unrelated_receipt_path.write_text(json.dumps(receipt) + "\n")
+        payload["replacement"]["receipt_sha256"] = hashlib.sha256(
+            unrelated_receipt_path.read_bytes()
+        ).hexdigest()
+        no_op_issues = _legacy_replacement_manifest_issues(
+            payload,
+            repo_path=checkout,
+            manifest_label=manifest_label,
+            signing_broker=TEST_APPLY_SIGNING_BROKER,
+            expected_waiver_set_sha256=TEST_VALIDATION_WAIVER_SHA256,
+            local_corpus_release=None,
+        )
+
+        assert any(
+            "source and destination must differ" in issue for issue in no_op_issues
+        ), "\n".join(no_op_issues)
 
     def test_model_writer_rejects_forged_resolver_row(self, tmp_path):
         _checkout, content_root, corpus_path, release = self._setup(tmp_path)

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1410"
+ENCODER_VERSION = "0.2.1411"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1410"
+ENCODER_VERSION = "0.2.1411"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_legacy_replacement.py
+++ b/tests/test_legacy_replacement.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from axiom_encode.cli import (
+    _require_locked_legacy_replacement_base,
+    _resolve_legacy_replacement_contract,
+)
+from axiom_encode.legacy_replacement import (
+    LEGACY_MANIFEST_SCHEMA,
+    legacy_manual_manifest_issues,
+    legacy_source_verification_citation_paths,
+    receipt_identity_payload,
+    receipt_identity_sha256,
+)
+
+
+@pytest.mark.parametrize(
+    "verification",
+    [
+        {},
+        {"corpus_citation_path": ""},
+        {"corpus_citation_path": 1},
+        {"corpus_citation_paths": []},
+        {"corpus_citation_paths": ["us-la/statute/47/32", "us-la/statute/47/33"]},
+        {"corpus_citation_paths": [1]},
+        {
+            "corpus_citation_path": "us-la/statute/47/32",
+            "corpus_citation_paths": ["us-la/statute/47/32"],
+        },
+    ],
+)
+def test_legacy_citation_admission_rejects_ambiguous_shapes(verification) -> None:
+    assert legacy_source_verification_citation_paths(verification) == ()
+
+
+@pytest.mark.parametrize(
+    "verification",
+    [
+        {"corpus_citation_path": "us-la/statute/47/32"},
+        {"corpus_citation_paths": ["us-la/statute/47/32"]},
+    ],
+)
+def test_legacy_citation_admission_accepts_one_exclusive_source(verification) -> None:
+    assert legacy_source_verification_citation_paths(verification) == (
+        "us-la/statute/47/32",
+    )
+
+
+def _manual_manifest() -> dict[str, object]:
+    return {
+        "schema_version": LEGACY_MANIFEST_SCHEMA,
+        "tool": "axiom-encode sign-applied-files",
+        "backend": "manual",
+        "runner": "manual-attestation",
+        "manual_exception": "composition",
+        "applied_files": [
+            {"path": "us-la/statutes/47:32.yaml", "sha256": "a" * 64},
+            {"path": "us-la/statutes/47:32.test.yaml", "sha256": "b" * 64},
+        ],
+        "signature": {
+            "algorithm": "hmac-sha256",
+            "key_id": "historical-v1",
+            "value": "opaque-untrusted-evidence",
+        },
+    }
+
+
+def test_manual_manifest_is_admitted_only_as_exact_deletion_evidence() -> None:
+    expected = {
+        "us-la/statutes/47:32.yaml": "a" * 64,
+        "us-la/statutes/47:32.test.yaml": "b" * 64,
+    }
+    assert (
+        legacy_manual_manifest_issues(
+            _manual_manifest(),
+            expected_files=expected,
+        )
+        == []
+    )
+
+
+@pytest.mark.parametrize(
+    ("mutation", "match"),
+    [
+        ({"backend": "codex"}, "backend is not manual"),
+        ({"backend": "deterministic"}, "backend is not manual"),
+        ({"runner": "unknown"}, "runner is not manual-attestation"),
+        ({"validation_execution": {}}, "unsupported provenance"),
+        (
+            {"signature": {"algorithm": "ed25519-domain-v1"}},
+            "unknown signature provenance",
+        ),
+    ],
+)
+def test_manual_manifest_cannot_be_elevated_to_generated_provenance(
+    mutation,
+    match,
+) -> None:
+    payload = _manual_manifest()
+    payload.update(mutation)
+    issues = legacy_manual_manifest_issues(
+        payload,
+        expected_files={
+            "us-la/statutes/47:32.yaml": "a" * 64,
+            "us-la/statutes/47:32.test.yaml": "b" * 64,
+        },
+    )
+    assert any(match in issue for issue in issues)
+
+
+def test_receipt_identity_binds_every_transaction_dimension() -> None:
+    payload = receipt_identity_payload(
+        base_commit="a" * 40,
+        base_tree="b" * 40,
+        legacy_manifest_sha256="c" * 64,
+        model_manifest_sha256="d" * 64,
+        live_files=[{"path": "us-la/statutes/47/32.yaml", "sha256": "e" * 64}],
+        deleted_files=[{"path": "us-la/statutes/47:32.yaml", "deleted": True}],
+        rewrites=[],
+        scheduled_dependents=[],
+    )
+    baseline = receipt_identity_sha256(payload)
+    for field in (
+        "base_commit",
+        "base_tree",
+        "legacy_manifest_sha256",
+        "model_manifest_sha256",
+        "live_files",
+        "deleted_files",
+        "rewrites",
+        "scheduled_dependents",
+    ):
+        changed = copy.deepcopy(payload)
+        changed[field] = f"changed-{field}"
+        assert receipt_identity_sha256(changed) != baseline
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+
+
+def _legacy_checkout(tmp_path: Path) -> tuple[Path, Path, SimpleNamespace]:
+    checkout = tmp_path / "rulespec-us"
+    content_root = checkout / "us-la"
+    primary = content_root / "statutes/47:32.yaml"
+    companion = content_root / "statutes/47:32.test.yaml"
+    primary.parent.mkdir(parents=True)
+    primary.write_text(
+        "format: rulespec/v1\n"
+        "module:\n"
+        "  source_verification:\n"
+        "    corpus_citation_paths:\n"
+        "      - us-la/statute/47:32\n"
+        "rules: []\n"
+    )
+    companion.write_text("[]\n")
+    expected_files = {
+        "us-la/statutes/47:32.yaml": hashlib.sha256(primary.read_bytes()).hexdigest(),
+        "us-la/statutes/47:32.test.yaml": hashlib.sha256(
+            companion.read_bytes()
+        ).hexdigest(),
+    }
+    manifest = checkout / ".axiom/encoding-manifests/us-la/statutes/47:32.json"
+    manifest.parent.mkdir(parents=True)
+    payload = _manual_manifest()
+    payload["applied_files"] = [
+        {"path": path, "sha256": digest} for path, digest in expected_files.items()
+    ]
+    manifest.write_text(json.dumps(payload) + "\n")
+    index = checkout / ".axiom/index/provisions_to_rules.json"
+    index.parent.mkdir(parents=True)
+    index.write_text('{"module":"us-la:statutes/47:32"}\n')
+    _git(checkout, "init", "-q")
+    _git(checkout, "config", "user.email", "test@example.com")
+    _git(checkout, "config", "user.name", "Test")
+    _git(checkout, "add", ".")
+    _git(checkout, "commit", "-qm", "base")
+    source = SimpleNamespace(
+        requested="us-la/statute/47:32",
+        citation_path="us-la/statute/47:32",
+        body="official body",
+        resolved_source=object(),
+    )
+    return checkout, content_root, source
+
+
+def test_contract_binds_clean_head_and_exact_metadata_rewrite(tmp_path: Path) -> None:
+    checkout, content_root, source = _legacy_checkout(tmp_path)
+    with patch(
+        "axiom_encode.cli.resolve_corpus_source_unit",
+        return_value=source,
+    ):
+        contract = _resolve_legacy_replacement_contract(
+            source_raw=Path("us-la/statutes/47:32.yaml"),
+            destination_raw=Path("us-la/statutes/47/32.yaml"),
+            policy_checkout_path=checkout,
+            policy_repo_path=content_root,
+            source_unit=source,
+            corpus_release=SimpleNamespace(),
+        )
+
+    assert contract.source == Path("us-la/statutes/47:32.yaml")
+    assert contract.destination == Path("us-la/statutes/47/32.yaml")
+    assert [item.path for item in contract.deleted_files] == [
+        Path("us-la/statutes/47:32.yaml"),
+        Path("us-la/statutes/47:32.test.yaml"),
+    ]
+    assert [item.path for item in contract.rewrites] == [
+        Path(".axiom/index/provisions_to_rules.json")
+    ]
+    assert b"us-la:statutes/47/32" in contract.rewrites[0].raw
+
+
+def test_contract_rejects_protected_dependent_rewrite(tmp_path: Path) -> None:
+    checkout, content_root, source = _legacy_checkout(tmp_path)
+    dependent = content_root / "policies/income_tax/dependent.yaml"
+    dependent.parent.mkdir(parents=True)
+    dependent.write_text(
+        "format: rulespec/v1\nimports:\n  - us-la:statutes/47:32#amount\nrules: []\n"
+    )
+    _git(checkout, "add", ".")
+    _git(checkout, "commit", "-qm", "dependent")
+
+    with (
+        patch("axiom_encode.cli.resolve_corpus_source_unit", return_value=source),
+        pytest.raises(ValueError, match="protected-dependent reencode"),
+    ):
+        _resolve_legacy_replacement_contract(
+            source_raw=Path("us-la/statutes/47:32.yaml"),
+            destination_raw=Path("us-la/statutes/47/32.yaml"),
+            policy_checkout_path=checkout,
+            policy_repo_path=content_root,
+            source_unit=source,
+            corpus_release=SimpleNamespace(),
+        )
+
+
+def test_contract_binds_only_explicit_scheduled_dependent(tmp_path: Path) -> None:
+    checkout, content_root, source = _legacy_checkout(tmp_path)
+    dependent = content_root / "policies/income_tax/dependent.yaml"
+    dependent.parent.mkdir(parents=True)
+    dependent.write_text(
+        "format: rulespec/v1\nimports:\n  - us-la:statutes/47:32#amount\nrules: []\n"
+    )
+    _git(checkout, "add", ".")
+    _git(checkout, "commit", "-qm", "dependent")
+
+    with patch("axiom_encode.cli.resolve_corpus_source_unit", return_value=source):
+        contract = _resolve_legacy_replacement_contract(
+            source_raw=Path("us-la/statutes/47:32.yaml"),
+            destination_raw=Path("us-la/statutes/47/32.yaml"),
+            policy_checkout_path=checkout,
+            policy_repo_path=content_root,
+            source_unit=source,
+            corpus_release=SimpleNamespace(),
+            scheduled_dependent_paths=(
+                Path("us-la/policies/income_tax/dependent.yaml"),
+            ),
+        )
+
+    assert [item.primary for item in contract.scheduled_dependents] == [
+        Path("us-la/policies/income_tax/dependent.yaml")
+    ]
+    assert [item.path for item in contract.scheduled_dependents[0].files] == [
+        Path("us-la/policies/income_tax/dependent.yaml")
+    ]
+    assert contract.scheduled_dependents[0].files[0].replacements == (
+        {
+            "from": "us-la:statutes/47:32",
+            "to": "us-la:statutes/47/32",
+            "count": 1,
+        },
+    )
+
+
+def test_contract_rejects_dirty_or_existing_destination(tmp_path: Path) -> None:
+    checkout, content_root, source = _legacy_checkout(tmp_path)
+    destination = content_root / "statutes/47/32.yaml"
+    destination.parent.mkdir(parents=True)
+    destination.write_text("collision\n")
+    _git(checkout, "add", ".")
+    _git(checkout, "commit", "-qm", "destination collision")
+
+    with (
+        patch("axiom_encode.cli.resolve_corpus_source_unit", return_value=source),
+        pytest.raises(ValueError, match="absent at clean HEAD and live"),
+    ):
+        _resolve_legacy_replacement_contract(
+            source_raw=Path("us-la/statutes/47:32.yaml"),
+            destination_raw=Path("us-la/statutes/47/32.yaml"),
+            policy_checkout_path=checkout,
+            policy_repo_path=content_root,
+            source_unit=source,
+            corpus_release=SimpleNamespace(),
+        )
+
+
+@pytest.mark.parametrize(
+    "relative",
+    [
+        "us-la/policies/income_tax/untracked.yaml",
+        ".axiom/index/untracked.json",
+    ],
+)
+def test_contract_rejects_untracked_checkout_influence(
+    tmp_path: Path,
+    relative: str,
+) -> None:
+    checkout, content_root, source = _legacy_checkout(tmp_path)
+    untracked = checkout / relative
+    untracked.parent.mkdir(parents=True, exist_ok=True)
+    untracked.write_text("untrusted\n")
+
+    with (
+        patch("axiom_encode.cli.resolve_corpus_source_unit", return_value=source),
+        pytest.raises(ValueError, match="exact clean HEAD"),
+    ):
+        _resolve_legacy_replacement_contract(
+            source_raw=Path("us-la/statutes/47:32.yaml"),
+            destination_raw=Path("us-la/statutes/47/32.yaml"),
+            policy_checkout_path=checkout,
+            policy_repo_path=content_root,
+            source_unit=source,
+            corpus_release=SimpleNamespace(),
+        )
+
+
+def test_locked_recheck_rejects_untracked_file_introduced_after_planning(
+    tmp_path: Path,
+) -> None:
+    checkout, content_root, source = _legacy_checkout(tmp_path)
+    with patch("axiom_encode.cli.resolve_corpus_source_unit", return_value=source):
+        contract = _resolve_legacy_replacement_contract(
+            source_raw=Path("us-la/statutes/47:32.yaml"),
+            destination_raw=Path("us-la/statutes/47/32.yaml"),
+            policy_checkout_path=checkout,
+            policy_repo_path=content_root,
+            source_unit=source,
+            corpus_release=SimpleNamespace(),
+        )
+
+    injected = checkout / ".axiom/index/lock-race.json"
+    injected.parent.mkdir(parents=True, exist_ok=True)
+    injected.write_text("{}\n")
+
+    with pytest.raises(ValueError, match="exact clean HEAD"):
+        _require_locked_legacy_replacement_base(checkout, contract)

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1410"
+ENCODER_VERSION = "0.2.1411"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1410"
+ENCODER_VERSION = "0.2.1411"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1410"
+ENCODER_VERSION = "0.2.1411"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1410"
+ENCODER_VERSION = "0.2.1411"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import subprocess
 from pathlib import Path
@@ -9,6 +10,7 @@ import pytest
 from scripts.prepare_signed_backfill import (
     REVIEWED_RULESPEC_PR_BASE_BRANCHES,
     REVIEWED_RULESPEC_REFS,
+    authorized_changed_paths,
     branch_name,
     stage_authorized_changes,
     validate_country,
@@ -63,6 +65,268 @@ def _write_signed_change(repo: Path) -> tuple[Path, Path]:
         encoding="utf-8",
     )
     return rule, manifest
+
+
+def _write_legacy_replacement_change(
+    repo: Path,
+    *,
+    scheduled_pending: bool = False,
+    omitted_dependent: bool = False,
+    omitted_scheduled_companion: bool = False,
+) -> tuple[Path, Path, Path, Path]:
+    old_rule = repo / "us/statutes/47:32.yaml"
+    old_test = repo / "us/statutes/47:32.test.yaml"
+    old_rule.parent.mkdir(parents=True)
+    old_rule.write_text("rules: []\n", encoding="utf-8")
+    old_test.write_text("[]\n", encoding="utf-8")
+    old_rule_sha256 = hashlib.sha256(old_rule.read_bytes()).hexdigest()
+    old_test_sha256 = hashlib.sha256(old_test.read_bytes()).hexdigest()
+    old_manifest = repo / ".axiom/encoding-manifests/us/statutes/47:32.json"
+    old_manifest.parent.mkdir(parents=True, exist_ok=True)
+    old_manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": "axiom-encode/applied-rulespec/v1",
+                "tool": "axiom-encode sign-applied-files",
+                "backend": "manual",
+                "runner": "manual-attestation",
+                "manual_exception": "test legacy evidence",
+                "applied_files": [
+                    {
+                        "path": old_rule.relative_to(repo).as_posix(),
+                        "sha256": old_rule_sha256,
+                    },
+                    {
+                        "path": old_test.relative_to(repo).as_posix(),
+                        "sha256": old_test_sha256,
+                    },
+                ],
+                "signature": {
+                    "algorithm": "hmac-sha256",
+                    "key_id": "historical-v1",
+                    "value": "opaque-untrusted-evidence",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    metadata = repo / ".axiom/index/provisions_to_rules.json"
+    metadata.parent.mkdir(parents=True)
+    metadata.write_text('{"module":"us:statutes/47:32"}\n', encoding="utf-8")
+    dependent = repo / "us/policies/income_tax/dependent.yaml"
+    if scheduled_pending:
+        dependent.parent.mkdir(parents=True)
+        dependent.write_text(
+            "format: rulespec/v1\n"
+            "imports:\n"
+            "  - us:statutes/47:32\n"
+            "  - us:statutes/99:1\n"
+            "rules: []\n",
+            encoding="utf-8",
+        )
+        if omitted_scheduled_companion:
+            dependent.with_name("dependent.test.yaml").write_text(
+                "imports:\n  - us:statutes/47:32\n",
+                encoding="utf-8",
+            )
+    if omitted_dependent:
+        omitted = repo / "us/policies/income_tax/omitted.yaml"
+        omitted.parent.mkdir(parents=True, exist_ok=True)
+        omitted.write_text(
+            "format: rulespec/v1\nimports:\n  - us:statutes/47:32\nrules: []\n",
+            encoding="utf-8",
+        )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "legacy baseline")
+    base_commit = _git(repo, "rev-parse", "HEAD")
+    base_tree = _git(repo, "rev-parse", "HEAD^{tree}")
+
+    old_manifest_sha256 = hashlib.sha256(old_manifest.read_bytes()).hexdigest()
+    metadata_before_sha256 = hashlib.sha256(metadata.read_bytes()).hexdigest()
+    dependent_before_sha256 = (
+        hashlib.sha256(dependent.read_bytes()).hexdigest()
+        if scheduled_pending
+        else None
+    )
+    old_rule.unlink()
+    old_test.unlink()
+    old_manifest.unlink()
+    metadata.write_text('{"module":"us:statutes/47/32"}\n', encoding="utf-8")
+
+    new_rule = repo / "us/statutes/47/32.yaml"
+    new_test = repo / "us/statutes/47/32.test.yaml"
+    new_rule.parent.mkdir(parents=True)
+    new_rule.write_text("rules: []\n", encoding="utf-8")
+    new_test.write_text("[]\n", encoding="utf-8")
+    live_files = [
+        {
+            "path": new_rule.relative_to(repo).as_posix(),
+            "sha256": hashlib.sha256(new_rule.read_bytes()).hexdigest(),
+        },
+        {
+            "path": new_test.relative_to(repo).as_posix(),
+            "sha256": hashlib.sha256(new_test.read_bytes()).hexdigest(),
+        },
+    ]
+    legacy_files = [
+        {
+            "path": old_rule.relative_to(repo).as_posix(),
+            "sha256": old_rule_sha256,
+        },
+        {
+            "path": old_test.relative_to(repo).as_posix(),
+            "sha256": old_test_sha256,
+        },
+    ]
+    metadata_after_sha256 = hashlib.sha256(metadata.read_bytes()).hexdigest()
+    nested_manifest = {
+        "schema_version": "axiom-encode/applied-rulespec/v5",
+        "tool": "axiom-encode encode --apply",
+        "backend": "codex",
+        "applied_files": live_files,
+    }
+    nested_raw = (json.dumps(nested_manifest, indent=2, sort_keys=True) + "\n").encode()
+    receipt_relative = Path(".axiom/legacy-replacements") / f"{'c' * 64}.json"
+    receipt = repo / receipt_relative
+    receipt.parent.mkdir(parents=True)
+    receipt_payload = {
+        "schema_version": "axiom-encode/legacy-fresh-reencode-receipt/v1",
+        "tool": "axiom-encode encode --apply --replace-legacy-rulespec-path",
+        "repository": {
+            "base_commit": base_commit,
+            "head_commit": base_commit,
+            "base_tree": base_tree,
+        },
+        "legacy": {
+            "owner_class": "v1-manual-hmac-untrusted",
+            "trusted_generated_provenance": False,
+            "manifest": {
+                "path": old_manifest.relative_to(repo).as_posix(),
+                "sha256": old_manifest_sha256,
+            },
+            "files": legacy_files,
+        },
+        "replacement": {
+            "source": old_rule.relative_to(repo).as_posix(),
+            "destination": new_rule.relative_to(repo).as_posix(),
+            "model_manifest_path": (".axiom/encoding-manifests/us/statutes/47/32.json"),
+            "model_manifest_sha256": hashlib.sha256(nested_raw).hexdigest(),
+            "rewrites": [
+                {
+                    "path": metadata.relative_to(repo).as_posix(),
+                    "before_sha256": metadata_before_sha256,
+                    "after_sha256": metadata_after_sha256,
+                    "replacements": [
+                        {
+                            "from": "us:statutes/47:32",
+                            "to": "us:statutes/47/32",
+                            "count": 1,
+                        }
+                    ],
+                }
+            ],
+            "live_files": live_files,
+            "scheduled_dependents": (
+                [
+                    {
+                        "primary": dependent.relative_to(repo).as_posix(),
+                        "files": [
+                            {
+                                "path": dependent.relative_to(repo).as_posix(),
+                                "before_sha256": dependent_before_sha256,
+                                "replacements": [
+                                    {
+                                        "from": "us:statutes/47:32",
+                                        "to": "us:statutes/47/32",
+                                        "count": 1,
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ]
+                if scheduled_pending
+                else []
+            ),
+        },
+        "replacement_manifest": nested_manifest,
+    }
+    receipt.write_text(
+        json.dumps(receipt_payload, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    manifest = repo / ".axiom/encoding-manifests/us/statutes/47/32.json"
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": "axiom-encode/applied-rulespec/v5",
+                "tool": ("axiom-encode encode --apply --replace-legacy-rulespec-path"),
+                "replacement_manifest": nested_manifest,
+                "replacement": {
+                    "receipt_path": receipt_relative.as_posix(),
+                    "receipt_sha256": hashlib.sha256(receipt.read_bytes()).hexdigest(),
+                    "legacy_manifest_path": old_manifest.relative_to(repo).as_posix(),
+                    "legacy_manifest_sha256": old_manifest_sha256,
+                },
+                "applied_files": [
+                    *live_files,
+                    {
+                        "path": metadata.relative_to(repo).as_posix(),
+                        "sha256": metadata_after_sha256,
+                    },
+                    *[{"path": item["path"], "deleted": True} for item in legacy_files],
+                ],
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return manifest, receipt, old_manifest, metadata
+
+
+def _complete_scheduled_legacy_dependent(
+    repo: Path,
+    *,
+    omitted_scheduled_companion: bool = False,
+) -> tuple[Path, Path, Path]:
+    manifest, receipt, _old_manifest, _metadata = _write_legacy_replacement_change(
+        repo,
+        scheduled_pending=True,
+        omitted_scheduled_companion=omitted_scheduled_companion,
+    )
+    dependent = repo / "us/policies/income_tax/dependent.yaml"
+    dependent.write_text(
+        dependent.read_text(encoding="utf-8").replace(
+            "us:statutes/47:32",
+            "us:statutes/47/32",
+        ),
+        encoding="utf-8",
+    )
+    dependent_manifest = (
+        repo / ".axiom/encoding-manifests/us/policies/income_tax/dependent.json"
+    )
+    dependent_manifest.parent.mkdir(parents=True, exist_ok=True)
+    dependent_manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": "axiom-encode/applied-rulespec/v5",
+                "tool": "axiom-encode encode --apply",
+                "backend": "codex",
+                "applied_files": [
+                    {
+                        "path": dependent.relative_to(repo).as_posix(),
+                        "sha256": hashlib.sha256(dependent.read_bytes()).hexdigest(),
+                    },
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return manifest, receipt, dependent
 
 
 def _write_module(
@@ -164,6 +428,221 @@ def test_stage_rejects_manifest_authorizing_non_rulespec_path(tmp_path: Path) ->
         stage_authorized_changes(repo)
 
     assert _git(repo, "diff", "--cached", "--name-only") == ""
+
+
+def test_stage_accepts_receipt_linked_legacy_deletion_with_dependent_manifest(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    _write_legacy_replacement_change(repo)
+    _write_signed_change(repo)
+
+    expected = authorized_changed_paths(repo)
+    stage_authorized_changes(repo)
+
+    assert set(
+        _git(repo, "diff", "--cached", "--name-only", "--no-renames").splitlines()
+    ) == {path.as_posix() for path in expected}
+
+
+def test_stage_rejects_tampered_legacy_replacement_receipt(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    _manifest, receipt, _old_manifest, _metadata = _write_legacy_replacement_change(
+        repo
+    )
+    receipt.write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="receipt digest differs"):
+        stage_authorized_changes(repo)
+
+
+def test_stage_rejects_signed_transition_while_dependent_is_pending(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    _write_legacy_replacement_change(repo, scheduled_pending=True)
+
+    with pytest.raises(
+        ValueError,
+        match="scheduled dependent lacks changed manifest",
+    ):
+        stage_authorized_changes(repo)
+
+
+def test_stage_accepts_exact_completed_legacy_dependent(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    _complete_scheduled_legacy_dependent(repo)
+
+    authorized_changed_paths(repo)
+
+
+def test_stage_rejects_inexact_legacy_dependent_replacement_count(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    manifest, receipt, _dependent = _complete_scheduled_legacy_dependent(repo)
+    receipt_payload = json.loads(receipt.read_text(encoding="utf-8"))
+    receipt_payload["replacement"]["scheduled_dependents"][0]["files"][0][
+        "replacements"
+    ][0]["count"] = 2
+    receipt.write_text(
+        json.dumps(receipt_payload, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    manifest_payload = json.loads(manifest.read_text(encoding="utf-8"))
+    manifest_payload["replacement"]["receipt_sha256"] = hashlib.sha256(
+        receipt.read_bytes()
+    ).hexdigest()
+    manifest.write_text(
+        json.dumps(manifest_payload, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="exact base proof differs"):
+        stage_authorized_changes(repo)
+
+
+def test_stage_rejects_unrelated_legacy_dependent_replacement_pair(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    manifest, receipt, dependent = _complete_scheduled_legacy_dependent(repo)
+    dependent.write_text(
+        "format: rulespec/v1\n"
+        "imports:\n"
+        "  - us:statutes/47:32\n"
+        "  - us:statutes/99/1\n"
+        "rules: []\n",
+        encoding="utf-8",
+    )
+    receipt_payload = json.loads(receipt.read_text(encoding="utf-8"))
+    receipt_payload["replacement"]["scheduled_dependents"][0]["files"][0][
+        "replacements"
+    ] = [
+        {
+            "from": "us:statutes/99:1",
+            "to": "us:statutes/99/1",
+            "count": 1,
+        }
+    ]
+    receipt.write_text(
+        json.dumps(receipt_payload, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    manifest_payload = json.loads(manifest.read_text(encoding="utf-8"))
+    manifest_payload["replacement"]["receipt_sha256"] = hashlib.sha256(
+        receipt.read_bytes()
+    ).hexdigest()
+    manifest.write_text(
+        json.dumps(manifest_payload, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    dependent_manifest = (
+        repo / ".axiom/encoding-manifests/us/policies/income_tax/dependent.json"
+    )
+    dependent_payload = json.loads(dependent_manifest.read_text(encoding="utf-8"))
+    dependent_payload["applied_files"][0]["sha256"] = hashlib.sha256(
+        dependent.read_bytes()
+    ).hexdigest()
+    dependent_manifest.write_text(
+        json.dumps(dependent_payload) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="exact base proof differs"):
+        stage_authorized_changes(repo)
+
+
+def test_stage_rejects_omitted_legacy_dependent(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    _write_legacy_replacement_change(repo, omitted_dependent=True)
+
+    with pytest.raises(
+        ValueError,
+        match=r"base reference inventory omits protected dependent .*omitted\.yaml",
+    ):
+        stage_authorized_changes(repo)
+
+
+def test_stage_rejects_omitted_scheduled_dependent_companion(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    _complete_scheduled_legacy_dependent(
+        repo,
+        omitted_scheduled_companion=True,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"base reference inventory omits protected dependent "
+            r".*dependent\.test\.yaml"
+        ),
+    ):
+        stage_authorized_changes(repo)
+
+
+def test_stage_accepts_fresh_model_edits_beyond_legacy_reference_rewrite(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    _manifest, _receipt, dependent = _complete_scheduled_legacy_dependent(repo)
+    dependent.write_text(
+        dependent.read_text(encoding="utf-8") + "# unrelated manual edit\n",
+        encoding="utf-8",
+    )
+    dependent_manifest = (
+        repo / ".axiom/encoding-manifests/us/policies/income_tax/dependent.json"
+    )
+    dependent_payload = json.loads(dependent_manifest.read_text(encoding="utf-8"))
+    dependent_payload["applied_files"][0]["sha256"] = hashlib.sha256(
+        dependent.read_bytes()
+    ).hexdigest()
+    dependent_manifest.write_text(
+        json.dumps(dependent_payload) + "\n",
+        encoding="utf-8",
+    )
+
+    authorized_changed_paths(repo)
+
+
+def test_stage_rejects_unauthorized_legacy_metadata_rewrite(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    manifest, receipt, _old_manifest, metadata = _write_legacy_replacement_change(repo)
+    receipt_payload = json.loads(receipt.read_text(encoding="utf-8"))
+    receipt_payload["replacement"]["rewrites"][0]["path"] = "README.md"
+    receipt.write_text(
+        json.dumps(receipt_payload, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    manifest_payload = json.loads(manifest.read_text(encoding="utf-8"))
+    manifest_payload["replacement"]["receipt_sha256"] = hashlib.sha256(
+        receipt.read_bytes()
+    ).hexdigest()
+    manifest.write_text(
+        json.dumps(manifest_payload, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    metadata.write_text('{"module":"us:statutes/47/32"}\n', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="rewrite\\[0\\] path is unauthorized"):
+        stage_authorized_changes(repo)
+
+
+def test_stage_rejects_unlinked_extra_deleted_manifest(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    extra = repo / ".axiom/encoding-manifests/us/statutes/extra.json"
+    extra.parent.mkdir(parents=True, exist_ok=True)
+    extra.write_text("{}\n", encoding="utf-8")
+    _write_legacy_replacement_change(repo)
+    extra.unlink()
+
+    with pytest.raises(
+        ValueError,
+        match="deleted manifests are not authenticated",
+    ):
+        stage_authorized_changes(repo)
 
 
 def test_rerun_attempt_uses_recoverable_distinct_branch() -> None:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1410"')
+        .startswith('__version__ = "0.2.1411"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1410"
+    assert encoder_package["version"] == "0.2.1411"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1410"
+    assert project["project"]["version"] == "0.2.1411"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1410"')
+        .startswith('__version__ = "0.2.1411"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1410"
+    assert encoder_package["version"] == "0.2.1411"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1410"
+    assert project["project"]["version"] == "0.2.1411"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1410"')
+        .startswith('__version__ = "0.2.1411"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1410"
+ENCODER_VERSION = "0.2.1411"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1863,6 +1863,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert inputs["pr_base_branch"]["type"] == "string"
     assert inputs["pr_base_branch"]["default"] == "main"
     assert inputs["replace_rulespec_path"]["required"] is False
+    assert inputs["replace_legacy_rulespec_path"]["required"] is False
     assert inputs["dependent_citation"]["required"] is False
     assert inputs["dependent_review_finding"]["required"] is False
     assert inputs["second_dependent_citation"]["required"] is False
@@ -2019,9 +2020,11 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert cascade_step["env"]["REPLACE_RULESPEC_PATH"] == (
         "${{ inputs.replace_rulespec_path }}"
     )
+    assert 'cascade_target="$REPLACE_RULESPEC_PATH"' in cascade_step["run"]
+    assert 'cascade_target="$REPLACE_LEGACY_RULESPEC_PATH"' in cascade_step["run"]
     assert (
-        'cascade_args+=(--target-rulespec-path "$REPLACE_RULESPEC_PATH")'
-        in (cascade_step["run"])
+        'cascade_args+=(--target-rulespec-path "$cascade_target")'
+        in cascade_step["run"]
     )
     assert 'cascade_args+=("${dependent_citations[@]}")' in cascade_step["run"]
     assert '"${cascade_args[@]}"' in cascade_step["run"]
@@ -2053,6 +2056,8 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert 'args+=(--review-findings "$review_finding_path")' in command
     assert "args+=(--apply-target-only)" in command
     assert 'args+=(--replace-rulespec-path "$replacement_path")' in command
+    assert "--legacy-dependent-rulespec-path" in command
+    assert 'citation-rulespec-path "$DEPENDENT_CITATION"' in command
     assert '[ "$target_only" = "true" ]' in command
     assert (
         "queue-authorized re-encodes cannot override the RuleSpec target path"
@@ -2061,16 +2066,10 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert '--output "$RUNNER_TEMP/generated/$output_lane"' in command
     assert '"$SECOND_DEPENDENT_CITATION"' in command
     assert '"$SECOND_DEPENDENT_REVIEW_FINDING" false dependent-2 ""' in command
-    assert (
-        '"$CITATION" "$REVIEW_FINDING" true target "$REPLACE_RULESPEC_PATH"' in command
-    )
-    assert (
-        '"$DEPENDENT_CITATION" "$DEPENDENT_REVIEW_FINDING" false dependent ""'
-        in command
-    )
-    assert (
-        '"$CITATION" "$REVIEW_FINDING" false target "$REPLACE_RULESPEC_PATH"' in command
-    )
+    assert '"$CITATION" "$REVIEW_FINDING" true target \\\n' in command
+    assert '"$DEPENDENT_CITATION" "$DEPENDENT_REVIEW_FINDING" \\\n' in command
+    assert '"$REPLACE_RULESPEC_PATH" "$REPLACE_LEGACY_RULESPEC_PATH"' in command
+    assert '"$CITATION" "$REVIEW_FINDING" false target \\\n' in command
     assert "dependent review finding is required with dependent citation" in command
     assert steps.index(cascade_step) < steps.index(apply_step)
 
@@ -2087,9 +2086,10 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert package_step["env"]["PR_BASE_BRANCH"] == ("${{ inputs.pr_base_branch }}")
     assert '"$artifact/context-manifest.json"' in package_command
     assert '".axiom/encoding-manifests"' in package_command
-    assert 'citation = payload.get("citation")' in package_command
-    assert 'applied_manifest["context_manifest_file"]' in package_command
-    assert 'applied_manifest.get("context_manifest_sha256")' in package_command
+    assert 'citation = effective.get("citation")' in package_command
+    assert 'evidence_manifest["context_manifest_file"]' in package_command
+    assert "evidence_manifest.get(" in package_command
+    assert "is still pending" in package_command
     assert "primary_paths != [normalized_replacement_path]" in package_command
     assert "replacement apply manifest primary path does not " in package_command
     assert "match the requested RuleSpec target" in package_command
@@ -2105,6 +2105,21 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert '"queue_manifest_sha256": (' in package_command
     assert '"workflow_run_attempt": int(os.environ["GITHUB_RUN_ATTEMPT"])' in (
         package_command
+    )
+    trusted_python = "/opt/axiom-verification/python/bin/python"
+    assert f"workflow_python=({trusted_python} -I)" in package_command
+    assert '"${workflow_python[@]}" - \\\n' in package_command
+
+    commit_step = next(
+        step
+        for step in steps
+        if step.get("name") == "Commit reviewed lane changes locally"
+    )
+    assert f"workflow_python=({trusted_python} -I)" in commit_step["run"]
+    assert '"${workflow_python[@]}" \\\n' in commit_step["run"]
+    assert (
+        "axiom-encode/scripts/prepare_signed_backfill.py stage \\\n"
+        in (commit_step["run"])
     )
 
     guard_step = next(
@@ -2130,6 +2145,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert publish_step["env"]["PR_BASE_BRANCH"] == ("${{ inputs.pr_base_branch }}")
     assert "AXIOM_ENCODE_APPLY_SIGNING_KEY" not in publish_step["env"]
     publish_command = publish_step["run"]
+    assert f"workflow_python=({trusted_python} -I)" in publish_command
     assert 'repo="TheAxiomFoundation/rulespec-${COUNTRY}"' in publish_command
     assert '"$COUNTRY" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT"' in publish_command
     assert "core.hooksPath=/dev/null" in publish_command
@@ -2497,6 +2513,7 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
     environment = {
         **os.environ,
         "AXIOM_ENCODE_APPLY_SIGNING_KEY": "test-key",
+        "AXIOM_TEST_PYTHON": sys.executable,
         "CALLS_PATH": str(calls_path),
         "CITATION": "us/regulation/42/435/555",
         "DEPENDENT_CITATION": "",
@@ -2547,7 +2564,7 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
     )
     if dependent_count >= 1:
         assert encode_args[1][-1] == "us/regulation/42/435/559"
-        assert "--apply-target-only" not in encode_args[1]
+        assert ("--apply-target-only" in encode_args[1]) is (dependent_count == 2)
         assert (
             Path(encode_args[1][encode_args[1].index("--review-findings") + 1])
             .read_text(encoding="utf-8")
@@ -2606,11 +2623,17 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
     environment = {
         **os.environ,
         "AXIOM_ENCODE_APPLY_SIGNING_KEY": "test-key",
+        "AXIOM_TEST_PYTHON": sys.executable,
         "CALLS_PATH": str(calls_path),
         "CITATION": "us-nc/statute/105/105-153.7",
         "DEPENDENT_CITATION": dependent_citation,
         "DEPENDENT_REVIEW_FINDING": dependent_finding,
         "GITHUB_WORKSPACE": str(tmp_path),
+        "REPLACE_LEGACY_RULESPEC_PATH": (
+            "us-nc/policies/income_tax/PILOT_LIABILITY_PIPELINE.yaml"
+            if with_dependent
+            else ""
+        ),
         "REPLACE_RULESPEC_PATH": replacement_path,
         "REVIEW_FINDING": "Preserve all supported existing semantics.",
         "RULESPEC_CHECKOUT": str(tmp_path / "rulespec-us"),
@@ -2636,6 +2659,8 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
     )
     assert encode_args[0][-1] == "us-nc/statute/105/105-153.7"
     if with_dependent:
+        assert "--replace-legacy-rulespec-path" in encode_args[0]
+        assert "--legacy-dependent-rulespec-path" in encode_args[0]
         assert "--replace-rulespec-path" not in encode_args[1]
         assert "--apply-target-only" not in encode_args[1]
         assert encode_args[1][-1] == dependent_citation
@@ -2761,12 +2786,12 @@ def test_targeted_artifact_packages_signed_review_context(tmp_path: Path) -> Non
         if step.get("name") == "Package exact generated changes"
     )["run"]
     marker = (
-        "python - \\\n"
+        '"${workflow_python[@]}" - \\\n'
         '  "$artifact/context-manifest.json" \\\n'
         "  \"$artifact/apply-manifests.json\" <<'PY'\n"
     )
     script = package_command.split(marker, 1)[1].split(
-        '\nPY\npython - "$artifact/metadata.json"', 1
+        '\nPY\n"${workflow_python[@]}" - "$artifact/metadata.json"', 1
     )[0]
 
     rulespec = tmp_path / "rulespec-nz"
@@ -2823,6 +2848,7 @@ def test_targeted_artifact_packages_signed_review_context(tmp_path: Path) -> Non
         env={
             **os.environ,
             "CITATION": citation,
+            "PYTHONPATH": str(ROOT / "src"),
             "REVIEW_FINDING_PRESENT": "true",
             "RUNNER_TEMP": str(tmp_path),
             "RULESPEC_CHECKOUT": "rulespec-nz",
@@ -2882,12 +2908,12 @@ def test_targeted_artifact_enforces_target_and_dependent_context_lanes(
         if step.get("name") == "Package exact generated changes"
     )["run"]
     marker = (
-        "python - \\\n"
+        '"${workflow_python[@]}" - \\\n'
         '  "$artifact/context-manifest.json" \\\n'
         "  \"$artifact/apply-manifests.json\" <<'PY'\n"
     )
     script = package_command.split(marker, 1)[1].split(
-        '\nPY\npython - "$artifact/metadata.json"', 1
+        '\nPY\n"${workflow_python[@]}" - "$artifact/metadata.json"', 1
     )[0]
 
     rulespec = tmp_path / "rulespec-us"
@@ -2987,6 +3013,7 @@ def test_targeted_artifact_enforces_target_and_dependent_context_lanes(
             "CITATION": target_citation,
             "DEPENDENT_CITATION": dependent_citation,
             "DEPENDENT_REVIEW_FINDING_PRESENT": "true",
+            "PYTHONPATH": str(ROOT / "src"),
             "SECOND_DEPENDENT_CITATION": second_dependent_citation,
             "SECOND_DEPENDENT_REVIEW_FINDING_PRESENT": "true",
             "REVIEW_FINDING_PRESENT": "true",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1410"
+version = "0.2.1411"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- add a paired `encode --apply --replace-legacy-rulespec-path OLD --replace-rulespec-path NEW` transaction for replacing manual/v1 RuleSpecs with genuinely fresh signed v5 model encodings
- treat the old RuleSpec and manual/HMAC manifest only as untrusted historical context and deletion evidence; they never elevate provenance
- bind source, unique canonical destination, old primary/companion bytes, destination model manifest, corpus release, waiver set, encoder identity, Git base tree, and atomic file changes in a broker-signed replacement receipt
- support explicitly scheduled dependent primary/companion re-encodes through a signed transient pending state; block publication/census until every dependent has a fully verified fresh v5 model manifest
- reproduce the producer complete base-reference inventory during census, deep verification, and staging so omitted, cross-classified, stale, provenance, non-0644, symlink, and unrelated-pair references fail closed
- preserve atomic rollback and route production staging/package verification through the isolated trusted Python runtime
- bump the encoder version contract to 0.2.1411

## Review cycle

This PR completed repeated independent review/fix cycles. Findings addressed included metadata admission, trusted runtime selection, bounded/symlink-safe reads, companion-only dependents, fresh-model versus mechanical-rewrite semantics, historical-base count proofs, encoder identity binding, exact rewrite allowlists, strict replacement schemas, source/destination authority, complete base-tree reference inventory, omitted dependents/companions, scan scalability, and non-regular/symlink blobs.

Final independent whole-commit review of `67dd56a3ff48e1421eaaa697469179c0baac7105`: **CLEAN**, with 18 independent adversarial tests passing and no secret, RuleSpec, or corpus mutations found.

## Checks

- `ruff check pyproject.toml src/axiom_encode scripts tests`: pass
- `python -m compileall -q src/axiom_encode scripts`: pass
- full CLI + staging regression: 1,138 passed, 10 skipped
- focused signing/replacement/publication tests: pass
- final repository suite: 6,017 passed, 119 skipped, 30 failed
  - the same 30 failures reproduce on clean base `405cda8644786398b1742f5bb436ca73a4d09da6`
  - all are local external `axiom_oracles` registry/runtime-pin mismatches; there are no new branch failures
- actual 13,732-file `rulespec-us` no-hit inventory benchmark: 0.40–0.41 seconds

The PR remains draft until hosted exact-head CI is green.