### PR TITLE
Authenticate in-place legacy v1 re-encodes

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -1041,14 +1041,35 @@ jobs:
                   expected_old_manifest = Path(
                       ".axiom/encoding-manifests"
                   ) / Path(legacy_source_path).with_suffix(".json")
-                  if deleted_manifest_paths != {expected_old_manifest}:
-                      raise SystemExit(
-                          "legacy replacement must delete exactly its old manifest"
+                  if legacy_source_path == normalized_replacement_path:
+                      if deleted_manifest_paths:
+                          raise SystemExit(
+                              "in-place legacy replacement must overwrite, not "
+                              "delete, its ownership manifest"
+                          )
+                      if expected_old_manifest != relative_path:
+                          raise SystemExit(
+                              "in-place legacy replacement manifest path differs"
+                          )
+                      live_primary = (
+                          Path(os.environ["RULESPEC_CHECKOUT"])
+                          / normalized_replacement_path
                       )
-                  if (
-                      Path(os.environ["RULESPEC_CHECKOUT"]) / legacy_source_path
-                  ).exists():
-                      raise SystemExit("legacy replacement old primary still exists")
+                      if not live_primary.is_file():
+                          raise SystemExit(
+                              "in-place legacy replacement primary is absent"
+                          )
+                  else:
+                      if deleted_manifest_paths != {expected_old_manifest}:
+                          raise SystemExit(
+                              "legacy replacement must delete exactly its old manifest"
+                          )
+                      if (
+                          Path(os.environ["RULESPEC_CHECKOUT"]) / legacy_source_path
+                      ).exists():
+                          raise SystemExit(
+                              "legacy replacement old primary still exists"
+                          )
                   receipt_artifact = Path(sys.argv[1]).with_name(
                       "legacy-replacement-receipt.json"
                   )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1412"
+version = "0.2.1413"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1411"
+version = "0.2.1412"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1411"
+__version__ = "0.2.1412"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1412"
+__version__ = "0.2.1413"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -6793,14 +6793,18 @@ def _legacy_replacement_reference_inventory_issues(
         classifications[path] = owner
 
     live_files = replacement.get("live_files")
-    live_paths = {
-        str(item["path"])
-        for item in live_files
-        if isinstance(item, dict)
-        and set(item) == {"path", "sha256"}
-        and isinstance(item.get("path"), str)
-        and isinstance(item.get("sha256"), str)
-    } if isinstance(live_files, list) else set()
+    live_paths = (
+        {
+            str(item["path"])
+            for item in live_files
+            if isinstance(item, dict)
+            and set(item) == {"path", "sha256"}
+            and isinstance(item.get("path"), str)
+            and isinstance(item.get("sha256"), str)
+        }
+        if isinstance(live_files, list)
+        else set()
+    )
     source = replacement.get("source")
     destination = replacement.get("destination")
     in_place = (
@@ -21534,24 +21538,25 @@ def _legacy_replacement_manifest_issues(
             issues.append(f"{manifest_label} legacy evidence hash is stale")
         live = repo_path / evidence_path
         nested_files = nested.get("applied_files")
-        replacement_hashes = {
-            str(item["path"]): str(item["sha256"])
-            for item in nested_files
-            if isinstance(item, dict)
-            and set(item) == {"path", "sha256"}
-            and isinstance(item.get("path"), str)
-            and isinstance(item.get("sha256"), str)
-        } if isinstance(nested_files, list) else {}
+        replacement_hashes = (
+            {
+                str(item["path"]): str(item["sha256"])
+                for item in nested_files
+                if isinstance(item, dict)
+                and set(item) == {"path", "sha256"}
+                and isinstance(item.get("path"), str)
+                and isinstance(item.get("sha256"), str)
+            }
+            if isinstance(nested_files, list)
+            else {}
+        )
         replacement_digest = replacement_hashes.get(evidence_path.as_posix())
         if replacement_digest is None:
             replaces_manifest_in_place = (
                 replacement.get("source") == replacement.get("destination")
                 and evidence_path.as_posix() == manifest_label
             )
-            if (
-                not replaces_manifest_in_place
-                and (live.exists() or live.is_symlink())
-            ):
+            if not replaces_manifest_in_place and (live.exists() or live.is_symlink()):
                 issues.append(f"{manifest_label} legacy evidence path still exists")
         else:
             try:
@@ -21588,8 +21593,7 @@ def _legacy_replacement_manifest_issues(
             and normalized_destination != Path(destination)
         )
         or (
-            Path(source) == Path(destination)
-            and normalized_destination != Path(source)
+            Path(source) == Path(destination) and normalized_destination != Path(source)
         )
     ):
         issues.append(f"{manifest_label} replacement path normalization is invalid")
@@ -21869,7 +21873,8 @@ def _legacy_replacement_manifest_issues(
     expected_entries.extend(
         {"path": item["path"], "deleted": True}
         for item in legacy_files
-        if isinstance(item, dict) and isinstance(item.get("path"), str)
+        if isinstance(item, dict)
+        and isinstance(item.get("path"), str)
         and item["path"]
         not in {
             live.get("path")
@@ -23153,9 +23158,9 @@ def _resolve_legacy_replacement_contract(
         if in_place
         else exact_reference_replacements(
             [PlannedMove(source=source, destination=destination)],
-            existing_companions={
-                old_companion
-            } if old_companion in old_paths else set(),
+            existing_companions={old_companion}
+            if old_companion in old_paths
+            else set(),
         )
     )
     scheduled_groups: dict[Path, set[Path]] = {}
@@ -44744,23 +44749,24 @@ def _stage_signed_legacy_replacement_provenance(
 
     model_manifest_sha256 = hashlib.sha256(model_manifest_bytes).hexdigest()
     expected_live_hashes = {
-        (Path(content_root.name) / relative).as_posix(): hashlib.sha256(
-            raw
-        ).hexdigest()
+        (Path(content_root.name) / relative).as_posix(): hashlib.sha256(raw).hexdigest()
         for relative, raw in planned.items()
     }
     model_live_files = model_manifest.get("applied_files")
-    model_live_hashes = {
-        str(item["path"]): str(item["sha256"])
-        for item in model_live_files
-        if isinstance(item, dict)
-        and set(item) == {"path", "sha256"}
-        and isinstance(item.get("path"), str)
-        and isinstance(item.get("sha256"), str)
-    } if isinstance(model_live_files, list) else {}
-    if (
-        model_live_hashes != expected_live_hashes
-        or len(model_live_hashes) != len(model_live_files or [])
+    model_live_hashes = (
+        {
+            str(item["path"]): str(item["sha256"])
+            for item in model_live_files
+            if isinstance(item, dict)
+            and set(item) == {"path", "sha256"}
+            and isinstance(item.get("path"), str)
+            and isinstance(item.get("sha256"), str)
+        }
+        if isinstance(model_live_files, list)
+        else {}
+    )
+    if model_live_hashes != expected_live_hashes or len(model_live_hashes) != len(
+        model_live_files or []
     ):
         raise RuntimeError(
             "Fresh replacement model manifest does not bind exact planned live files"
@@ -46101,9 +46107,8 @@ def _require_apply_post_install_closure(
         }
         for deleted in legacy_replacement.deleted_files:
             target = checkout_root / deleted.path
-            if (
-                target not in live_replacement_paths
-                and (target.exists() or target.is_symlink())
+            if target not in live_replacement_paths and (
+                target.exists() or target.is_symlink()
             ):
                 raise RuntimeError(
                     f"Cannot keep legacy replacement: old path still exists: {target}"
@@ -46280,7 +46285,9 @@ def _apply_generated_encoding_result(
             (checkout_root / rewrite.path, rewrite.raw)
             for rewrite in legacy_replacement.rewrites
         )
-        written_targets = {target for target, raw in transaction_files if raw is not None}
+        written_targets = {
+            target for target, raw in transaction_files if raw is not None
+        }
         transaction_files.extend(
             (checkout_root / item.path, None)
             for item in legacy_replacement.deleted_files

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -2148,8 +2148,9 @@ def main():
         type=Path,
         help=(
             "With --apply and --replace-rulespec-path, freshly model-reencode one "
-            "exact protected legacy v1/manual-owned primary, delete its primary, "
-            "companion, and legacy manifest atomically, and emit only signed v5 "
+            "exact protected legacy v1/manual-owned primary, retire its old primary, "
+            "companion, and legacy manifest bytes atomically at either the same "
+            "canonical path or its unique normalized path, and emit only signed v5 "
             "replacement provenance."
         ),
     )
@@ -6629,10 +6630,14 @@ def _legacy_replacement_authoritative_map(
             or path.name.endswith(RULESPEC_TEST_FILE_SUFFIX)
         ):
             issues.append(f"legacy replacement {label} path is not canonical")
-    if expected_destination != destination_path:
+    in_place = source_path == destination_path
+    if in_place:
+        if expected_destination != source_path:
+            issues.append(
+                "in-place legacy replacement source must already be canonical"
+            )
+    elif expected_destination != destination_path:
         issues.append("legacy replacement destination is not canonical for source")
-    if source_path == destination_path:
-        issues.append("legacy replacement source and destination must differ")
     if (
         legacy.get("owner_class") != APPLIED_ENCODING_LEGACY_OWNER_CLASS
         or legacy.get("trusted_generated_provenance") is not False
@@ -6722,6 +6727,7 @@ def _legacy_replacement_authoritative_map(
             legacy_manifest_issues = _legacy_manual_manifest_issues(
                 legacy_manifest_payload,
                 expected_files=expected_files,
+                allow_unmarked_manual_exception=in_place,
             )
             issues.extend(
                 f"legacy replacement source manifest is not legacy-owned: {issue}"
@@ -6729,13 +6735,18 @@ def _legacy_replacement_authoritative_map(
             )
     if issues:
         return None, issues
-    try:
-        replacements = exact_reference_replacements(
-            [PlannedMove(source=source_path, destination=destination_path)],
-            existing_companions=existing_companions,
-        )
-    except PathMigrationPlanError as exc:
-        return None, [f"legacy replacement authority cannot be reconstructed: {exc}"]
+    if in_place:
+        replacements = {}
+    else:
+        try:
+            replacements = exact_reference_replacements(
+                [PlannedMove(source=source_path, destination=destination_path)],
+                existing_companions=existing_companions,
+            )
+        except PathMigrationPlanError as exc:
+            return None, [
+                f"legacy replacement authority cannot be reconstructed: {exc}"
+            ]
     return replacements, []
 
 
@@ -6781,11 +6792,35 @@ def _legacy_replacement_reference_inventory_issues(
             return
         classifications[path] = owner
 
+    live_files = replacement.get("live_files")
+    live_paths = {
+        str(item["path"])
+        for item in live_files
+        if isinstance(item, dict)
+        and set(item) == {"path", "sha256"}
+        and isinstance(item.get("path"), str)
+        and isinstance(item.get("sha256"), str)
+    } if isinstance(live_files, list) else set()
+    source = replacement.get("source")
+    destination = replacement.get("destination")
+    in_place = (
+        isinstance(source, str)
+        and isinstance(destination, str)
+        and source == destination
+    )
     legacy_files = legacy.get("files")
     if isinstance(legacy_files, list):
         for item in legacy_files:
             if isinstance(item, dict):
-                classify(item.get("path"), "deleted source")
+                path = item.get("path")
+                classify(
+                    path,
+                    (
+                        "replaced source"
+                        if in_place and path in live_paths
+                        else "deleted source"
+                    ),
+                )
     rewrites = replacement.get("rewrites")
     if isinstance(rewrites, list):
         for item in rewrites:
@@ -6812,6 +6847,16 @@ def _legacy_replacement_reference_inventory_issues(
         issues.append(
             "legacy replacement source manifest is also classified as reference input"
         )
+    if in_place:
+        if authoritative_replacements:
+            issues.append(
+                "in-place legacy replacement must not carry path reference rewrites"
+            )
+        if replacement.get("rewrites") != []:
+            issues.append("in-place legacy replacement must not rewrite metadata")
+        if replacement.get("scheduled_dependents") != []:
+            issues.append("in-place legacy replacement cannot schedule path dependents")
+        return issues
 
     try:
         listing = _rulespec_migration_git_bytes(
@@ -21294,6 +21339,17 @@ def _legacy_replacement_manifest_issues(
                 else []
             )
             if isinstance(item, dict)
+            and item.get("path")
+            not in {
+                live.get("path")
+                for live in (
+                    receipt_replacement.get("live_files", [])
+                    if isinstance(receipt_replacement, dict)
+                    and isinstance(receipt_replacement.get("live_files"), list)
+                    else []
+                )
+                if isinstance(live, dict)
+            }
         ],
         rewrites=(
             receipt_replacement.get("rewrites")
@@ -21477,8 +21533,44 @@ def _legacy_replacement_manifest_issues(
         if hashlib.sha256(base_raw).hexdigest() != evidence["sha256"]:
             issues.append(f"{manifest_label} legacy evidence hash is stale")
         live = repo_path / evidence_path
-        if live.exists() or live.is_symlink():
-            issues.append(f"{manifest_label} legacy evidence path still exists")
+        nested_files = nested.get("applied_files")
+        replacement_hashes = {
+            str(item["path"]): str(item["sha256"])
+            for item in nested_files
+            if isinstance(item, dict)
+            and set(item) == {"path", "sha256"}
+            and isinstance(item.get("path"), str)
+            and isinstance(item.get("sha256"), str)
+        } if isinstance(nested_files, list) else {}
+        replacement_digest = replacement_hashes.get(evidence_path.as_posix())
+        if replacement_digest is None:
+            replaces_manifest_in_place = (
+                replacement.get("source") == replacement.get("destination")
+                and evidence_path.as_posix() == manifest_label
+            )
+            if (
+                not replaces_manifest_in_place
+                and (live.exists() or live.is_symlink())
+            ):
+                issues.append(f"{manifest_label} legacy evidence path still exists")
+        else:
+            try:
+                live_raw = read_bounded_regular_file(
+                    repo_path,
+                    live,
+                    label="in-place legacy replacement live file",
+                    max_bytes=16 * 1024 * 1024,
+                    required_mode=0o644,
+                )
+            except (OSError, UnsafeCorpusPathError):
+                issues.append(
+                    f"{manifest_label} in-place replacement live file is unreadable"
+                )
+            else:
+                if hashlib.sha256(live_raw).hexdigest() != replacement_digest:
+                    issues.append(
+                        f"{manifest_label} in-place replacement live hash is stale"
+                    )
 
     source = replacement.get("source")
     destination = replacement.get("destination")
@@ -21491,7 +21583,14 @@ def _legacy_replacement_manifest_issues(
     if (
         not isinstance(source, str)
         or not isinstance(destination, str)
-        or normalized_destination != Path(destination)
+        or (
+            Path(source) != Path(destination)
+            and normalized_destination != Path(destination)
+        )
+        or (
+            Path(source) == Path(destination)
+            and normalized_destination != Path(source)
+        )
     ):
         issues.append(f"{manifest_label} replacement path normalization is invalid")
     if (
@@ -21771,6 +21870,12 @@ def _legacy_replacement_manifest_issues(
         {"path": item["path"], "deleted": True}
         for item in legacy_files
         if isinstance(item, dict) and isinstance(item.get("path"), str)
+        and item["path"]
+        not in {
+            live.get("path")
+            for live in replacement.get("live_files", [])
+            if isinstance(live, dict)
+        }
     )
     if outer_list != expected_entries:
         issues.append(
@@ -22895,13 +23000,22 @@ def _resolve_legacy_replacement_contract(
                 f"legacy replacement {label} must be a canonical "
                 "checkout-relative primary RuleSpec in the requested jurisdiction"
             )
-    if destination != canonical_destination(source):
+    canonical_source = canonical_destination(source)
+    in_place = source == destination
+    if in_place:
+        if source != canonical_source:
+            raise ValueError(
+                "in-place legacy replacement source must already be canonical"
+            )
+        if scheduled_dependent_paths:
+            raise ValueError(
+                "in-place legacy replacement cannot schedule path dependents"
+            )
+    elif destination != canonical_source:
         raise ValueError(
             "legacy replacement destination is not the unique canonical "
             "normalization of its source"
         )
-    if source == destination:
-        raise ValueError("legacy replacement source is already canonical")
 
     base_commit, base_tree = _rulespec_migration_base_identity(policy_checkout_path)
     _require_legacy_replacement_clean_checkout(policy_checkout_path)
@@ -22913,17 +23027,18 @@ def _resolve_legacy_replacement_contract(
         companion_path(destination),
         _applied_encoding_manifest_path(destination),
     )
-    for candidate in destination_group:
-        candidate_absolute = policy_checkout_path / candidate
-        if (
-            candidate in tracked
-            or candidate_absolute.exists()
-            or candidate_absolute.is_symlink()
-        ):
-            raise ValueError(
-                "legacy replacement destination primary/companion/manifest group "
-                f"must be absent at clean HEAD and live: {candidate}"
-            )
+    if not in_place:
+        for candidate in destination_group:
+            candidate_absolute = policy_checkout_path / candidate
+            if (
+                candidate in tracked
+                or candidate_absolute.exists()
+                or candidate_absolute.is_symlink()
+            ):
+                raise ValueError(
+                    "legacy replacement destination primary/companion/manifest group "
+                    f"must be absent at clean HEAD and live: {candidate}"
+                )
 
     old_paths = [source]
     old_companion = companion_path(source)
@@ -22974,10 +23089,16 @@ def _resolve_legacy_replacement_contract(
         else ()
     )
     requested_citation = normalize_corpus_identifier(source_unit.requested)
-    if old_citations != (requested_citation,):
+    citation_identity_matches = (
+        old_citations == (requested_citation,)
+        if not in_place
+        else bool(old_citations) and old_citations[0] == requested_citation
+    )
+    if not citation_identity_matches:
         raise ValueError(
-            "legacy replacement source must declare exactly the requested signed "
-            "corpus unit using only singular or legacy plural citation syntax"
+            "legacy replacement source must declare the requested signed corpus "
+            "unit as its sole source for a path move or its first historical source "
+            "for an in-place fresh replacement"
         )
     resolved_old = resolve_corpus_source_unit(old_citations[0], corpus_release)
     if (
@@ -23017,6 +23138,7 @@ def _resolve_legacy_replacement_contract(
     legacy_issues = _legacy_manual_manifest_issues(
         legacy_payload,
         expected_files=expected_files,
+        allow_unmarked_manual_exception=in_place,
     )
     if legacy_issues:
         raise ValueError("; ".join(legacy_issues))
@@ -23026,10 +23148,15 @@ def _resolve_legacy_replacement_contract(
         legacy_manifest_raw,
     )
 
-    move = PlannedMove(source=source, destination=destination)
-    replacements = exact_reference_replacements(
-        [move],
-        existing_companions={old_companion} if old_companion in old_paths else set(),
+    replacements = (
+        {}
+        if in_place
+        else exact_reference_replacements(
+            [PlannedMove(source=source, destination=destination)],
+            existing_companions={
+                old_companion
+            } if old_companion in old_paths else set(),
+        )
     )
     scheduled_groups: dict[Path, set[Path]] = {}
     for raw_dependent in scheduled_dependent_paths:
@@ -44568,9 +44695,13 @@ def _stage_signed_apply_manifest(
             signing_broker=signing_broker,
             axiom_encode_git=axiom_encode_git,
             existing_manifest_path=(
-                checkout_root
-                / _applied_encoding_manifest_path(
-                    Path(content_root.name) / relative_output
+                None
+                if _result_legacy_replacement_contract(result) is not None
+                else (
+                    checkout_root
+                    / _applied_encoding_manifest_path(
+                        Path(content_root.name) / relative_output
+                    )
                 )
             ),
             allow_shrink=allow_shrink,
@@ -44612,15 +44743,30 @@ def _stage_signed_legacy_replacement_provenance(
         raise RuntimeError("Fresh replacement model manifest signature is invalid")
 
     model_manifest_sha256 = hashlib.sha256(model_manifest_bytes).hexdigest()
-    live_files = [
-        {
-            "path": (Path(content_root.name) / relative).as_posix(),
-            "sha256": hashlib.sha256(raw).hexdigest(),
-        }
-        for relative, raw in sorted(
-            planned.items(), key=lambda item: item[0].as_posix()
+    expected_live_hashes = {
+        (Path(content_root.name) / relative).as_posix(): hashlib.sha256(
+            raw
+        ).hexdigest()
+        for relative, raw in planned.items()
+    }
+    model_live_files = model_manifest.get("applied_files")
+    model_live_hashes = {
+        str(item["path"]): str(item["sha256"])
+        for item in model_live_files
+        if isinstance(item, dict)
+        and set(item) == {"path", "sha256"}
+        and isinstance(item.get("path"), str)
+        and isinstance(item.get("sha256"), str)
+    } if isinstance(model_live_files, list) else {}
+    if (
+        model_live_hashes != expected_live_hashes
+        or len(model_live_hashes) != len(model_live_files or [])
+    ):
+        raise RuntimeError(
+            "Fresh replacement model manifest does not bind exact planned live files"
         )
-    ]
+    live_files = copy.deepcopy(model_live_files)
+    live_paths = {str(item["path"]) for item in live_files}
     rewrite_files = [
         {
             "path": rewrite.path.as_posix(),
@@ -44631,6 +44777,7 @@ def _stage_signed_legacy_replacement_provenance(
     deleted_files = [
         {"path": item.path.as_posix(), "deleted": True}
         for item in contract.deleted_files
+        if item.path.as_posix() not in live_paths
     ]
     scheduled_dependents = [
         {
@@ -45915,10 +46062,6 @@ def _require_apply_post_install_closure(
             )
 
     expected_post_files = dict(expected_policy_files)
-    for relative, raw in planned.items():
-        expected_post_files[_canonical_apply_relative_path(relative).as_posix()] = (
-            hashlib.sha256(raw).hexdigest()
-        )
     if legacy_replacement is not None:
         for deleted in legacy_replacement.deleted_files:
             if deleted.path.parts[:1] == (content_root.name,):
@@ -45931,6 +46074,10 @@ def _require_apply_post_install_closure(
                 expected_post_files[Path(*rewrite.path.parts[1:]).as_posix()] = (
                     rewrite.after_sha256
                 )
+    for relative, raw in planned.items():
+        expected_post_files[_canonical_apply_relative_path(relative).as_posix()] = (
+            hashlib.sha256(raw).hexdigest()
+        )
     if current_execution.get("policy_content_files") != expected_post_files:
         raise RuntimeError(
             "Cannot keep applied RuleSpec: live RuleSpec bytes changed during "
@@ -45948,14 +46095,23 @@ def _require_apply_post_install_closure(
         )
     if legacy_replacement is not None:
         checkout_root = content_root.parent
+        live_replacement_paths = {
+            content_root / _canonical_apply_relative_path(relative)
+            for relative in planned
+        }
         for deleted in legacy_replacement.deleted_files:
             target = checkout_root / deleted.path
-            if target.exists() or target.is_symlink():
+            if (
+                target not in live_replacement_paths
+                and (target.exists() or target.is_symlink())
+            ):
                 raise RuntimeError(
                     f"Cannot keep legacy replacement: old path still exists: {target}"
                 )
         old_manifest = checkout_root / legacy_replacement.legacy_manifest.path
-        if old_manifest.exists() or old_manifest.is_symlink():
+        if old_manifest != manifest_path and (
+            old_manifest.exists() or old_manifest.is_symlink()
+        ):
             raise RuntimeError(
                 "Cannot keep legacy replacement: old ownership manifest still exists"
             )
@@ -46124,16 +46280,16 @@ def _apply_generated_encoding_result(
             (checkout_root / rewrite.path, rewrite.raw)
             for rewrite in legacy_replacement.rewrites
         )
+        written_targets = {target for target, raw in transaction_files if raw is not None}
         transaction_files.extend(
             (checkout_root / item.path, None)
             for item in legacy_replacement.deleted_files
+            if checkout_root / item.path not in written_targets
         )
-        transaction_files.extend(
-            [
-                (checkout_root / legacy_replacement.legacy_manifest.path, None),
-                (checkout_root / receipt_relative, receipt_bytes),
-            ]
-        )
+        old_manifest_path = checkout_root / legacy_replacement.legacy_manifest.path
+        if old_manifest_path not in written_targets:
+            transaction_files.append((old_manifest_path, None))
+        transaction_files.append((checkout_root / receipt_relative, receipt_bytes))
     for target, _raw in transaction_files:
         _ensure_safe_apply_target(checkout_root, target)
 
@@ -46178,11 +46334,12 @@ def _apply_generated_encoding_result(
                 checkout_root,
                 legacy_replacement,
             )
-        _require_applied_manifest_not_shrunk(
-            manifest_path,
-            new_applied_files=new_manifest_applied_files,
-            allow_shrink=allow_shrink,
-        )
+        if legacy_replacement is None:
+            _require_applied_manifest_not_shrunk(
+                manifest_path,
+                new_applied_files=new_manifest_applied_files,
+                allow_shrink=allow_shrink,
+            )
         locked_release = load_rulespec_local_corpus_release(
             content_root,
             corpus_path,
@@ -46867,9 +47024,10 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
             )
         overlay_target = overlay_content_root / relative_output
         overlay_target.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(output_file, overlay_target)
-        if output_test.exists():
-            shutil.copy2(output_test, _rulespec_test_path(overlay_target))
+        if legacy_replacement is None:
+            shutil.copy2(output_file, overlay_target)
+            if output_test.exists():
+                shutil.copy2(output_test, _rulespec_test_path(overlay_target))
         if legacy_replacement is not None:
             expected_relative = Path(*legacy_replacement.destination.parts[1:])
             if relative_output != expected_relative:
@@ -46882,7 +47040,7 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
                     {},
                 )
             try:
-                generated_payload = yaml.safe_load(overlay_target.read_text())
+                generated_payload = yaml.safe_load(output_file.read_text())
             except (OSError, UnicodeError, yaml.YAMLError, RecursionError):
                 generated_payload = None
             generated_module = (
@@ -46911,7 +47069,7 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
             old_content = legacy_replacement.deleted_files[0].raw.decode("utf-8")
             preservation_issues = _source_relation_preservation_issues(
                 old_content,
-                overlay_target.read_text(),
+                output_file.read_text(),
             )
             if preservation_issues:
                 return (
@@ -46982,6 +47140,9 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
                         {},
                     )
                 rewrite_target.write_bytes(rewrite.raw)
+            shutil.copy2(output_file, overlay_target)
+            if output_test.exists():
+                shutil.copy2(output_test, _rulespec_test_path(overlay_target))
         if not validate_dependents:
             _suppress_rulespec_ancestor_targets_for_subsection_overlay(
                 overlay_content_root,

--- a/src/axiom_encode/legacy_replacement.py
+++ b/src/axiom_encode/legacy_replacement.py
@@ -108,18 +108,11 @@ def legacy_manual_manifest_issues(
     if payload.get("runner") != "manual-attestation":
         issues.append("legacy ownership manifest runner is not manual-attestation")
     manual_exception = payload.get("manual_exception")
-    if (
-        "manual_exception" not in payload
-        or (
-            not (
-                allow_unmarked_manual_exception
-                and manual_exception is None
-            )
-            and (
-                not isinstance(manual_exception, str)
-                or not manual_exception.strip()
-            )
-        )
+    unmarked_exception_admitted = allow_unmarked_manual_exception and (
+        "manual_exception" not in payload or manual_exception is None
+    )
+    if not unmarked_exception_admitted and (
+        not isinstance(manual_exception, str) or not manual_exception.strip()
     ):
         issues.append("legacy ownership manifest has no manual exception")
     if any(

--- a/src/axiom_encode/legacy_replacement.py
+++ b/src/axiom_encode/legacy_replacement.py
@@ -63,7 +63,7 @@ class LegacyReplacementContract(NamedTuple):
 def legacy_source_verification_citation_paths(
     verification: Mapping[str, object],
 ) -> tuple[str, ...]:
-    """Admit exactly one exclusive singular or historical plural citation."""
+    """Parse one exclusive singular citation or a historical plural list."""
 
     admitted = {"corpus_citation_path", "corpus_citation_paths"}
     present = set(verification) & admitted
@@ -75,21 +75,24 @@ def legacy_source_verification_citation_paths(
         return ()
     if (
         not isinstance(raw_paths, list)
-        or len(raw_paths) != 1
-        or not isinstance(raw_paths[0], str)
-        or not raw_paths[0].strip()
+        or not raw_paths
+        or not all(isinstance(item, str) and item.strip() for item in raw_paths)
     ):
         return ()
     try:
-        return (normalize_corpus_identifier(raw_paths[0]),)
+        normalized = tuple(normalize_corpus_identifier(item) for item in raw_paths)
     except (TypeError, ValueError):
         return ()
+    if len(set(normalized)) != len(normalized):
+        return ()
+    return normalized
 
 
 def legacy_manual_manifest_issues(
     payload: object,
     *,
     expected_files: Mapping[str, str],
+    allow_unmarked_manual_exception: bool = False,
 ) -> list[str]:
     """Require the one known manual v1 class without trusting its signature."""
 
@@ -104,9 +107,19 @@ def legacy_manual_manifest_issues(
         issues.append("legacy ownership manifest backend is not manual")
     if payload.get("runner") != "manual-attestation":
         issues.append("legacy ownership manifest runner is not manual-attestation")
+    manual_exception = payload.get("manual_exception")
     if (
-        not isinstance(payload.get("manual_exception"), str)
-        or not str(payload["manual_exception"]).strip()
+        "manual_exception" not in payload
+        or (
+            not (
+                allow_unmarked_manual_exception
+                and manual_exception is None
+            )
+            and (
+                not isinstance(manual_exception, str)
+                or not manual_exception.strip()
+            )
+        )
     ):
         issues.append("legacy ownership manifest has no manual exception")
     if any(

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1411"
+ENCODER_VERSION = "0.2.1412"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1412"
+ENCODER_VERSION = "0.2.1413"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13487,8 +13487,7 @@ class TestCmdEncode:
             for path in (target, target_test)
         }
         manifest = (
-            checkout
-            / ".axiom/encoding-manifests/us-me/policies/income_tax/"
+            checkout / ".axiom/encoding-manifests/us-me/policies/income_tax/"
             "pilot_liability_pipeline.json"
         )
         manifest.parent.mkdir(parents=True)
@@ -13497,7 +13496,6 @@ class TestCmdEncode:
             "tool": "axiom-encode sign-applied-files",
             "backend": "manual",
             "runner": "manual-attestation",
-            "manual_exception": None,
             "applied_files": [
                 {"path": path, "sha256": digest}
                 for path, digest in legacy_files.items()
@@ -13633,8 +13631,7 @@ class TestCmdEncode:
         assert receipt["replacement"]["source"] == checkout_relative.as_posix()
         assert receipt["replacement"]["destination"] == checkout_relative.as_posix()
         assert receipt["legacy"]["files"] == [
-            {"path": path, "sha256": digest}
-            for path, digest in legacy_files.items()
+            {"path": path, "sha256": digest} for path, digest in legacy_files.items()
         ]
         verified, _root, _digest, issues = (
             _load_verified_applied_encoding_manifest_payload(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13457,6 +13457,198 @@ class TestCmdEncode:
             },
         ]
 
+    def test_apply_freshly_replaces_untrusted_v1_at_same_canonical_path(
+        self,
+        tmp_path,
+    ):
+        from axiom_encode.cli import _resolve_legacy_replacement_contract
+        from axiom_encode.toolchain import load_rulespec_local_corpus_release
+
+        output_root = tmp_path / "out"
+        checkout = tmp_path / "rulespec-us"
+        content_root = checkout / "us-me"
+        relative = Path("policies/income_tax/pilot_liability_pipeline.yaml")
+        checkout_relative = Path("us-me") / relative
+        target = content_root / relative
+        target_test = target.with_name("pilot_liability_pipeline.test.yaml")
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            "format: rulespec/v1\n"
+            "module:\n"
+            "  source_verification:\n"
+            "    corpus_citation_paths:\n"
+            "      - us-me/guidance/revenue/rate-schedule\n"
+            "      - us-me/statute/36/5111\n"
+            "rules: []\n"
+        )
+        target_test.write_text("- name: old manual fixture\n")
+        legacy_files = {
+            path.relative_to(checkout).as_posix(): _sha256_file(path)
+            for path in (target, target_test)
+        }
+        manifest = (
+            checkout
+            / ".axiom/encoding-manifests/us-me/policies/income_tax/"
+            "pilot_liability_pipeline.json"
+        )
+        manifest.parent.mkdir(parents=True)
+        legacy_manifest = {
+            "schema_version": "axiom-encode/applied-rulespec/v1",
+            "tool": "axiom-encode sign-applied-files",
+            "backend": "manual",
+            "runner": "manual-attestation",
+            "manual_exception": None,
+            "applied_files": [
+                {"path": path, "sha256": digest}
+                for path, digest in legacy_files.items()
+            ],
+            "signature": {
+                "algorithm": "hmac-sha256",
+                "key_id": "axiom-encode-apply-v1",
+                "value": "untrusted-historical-evidence",
+            },
+        }
+        manifest.write_text(json.dumps(legacy_manifest) + "\n")
+        old_target = target.read_bytes()
+        old_manifest = manifest.read_bytes()
+
+        source_text = "authoritative Maine schedule\n"
+        corpus_path, source_attestation = self._bind_apply_source_release(
+            checkout,
+            tmp_path,
+            citation_path="us-me/guidance/revenue/rate-schedule",
+            source_text=source_text,
+        )
+        _git(checkout, "init", "-b", "main")
+        _git(checkout, "config", "user.email", "test@example.com")
+        _git(checkout, "config", "user.name", "Test User")
+        _git(checkout, "add", ".")
+        _git(checkout, "commit", "-m", "legacy v1 base")
+        with patch.dict(
+            os.environ,
+            {"AXIOM_CORPUS_RELEASE_PUBLIC_KEY": TEST_RELEASE_PUBLIC_KEY},
+        ):
+            release = load_rulespec_local_corpus_release(content_root, corpus_path)
+        source_unit = resolve_corpus_source_unit(
+            "us-me/guidance/revenue/rate-schedule",
+            release,
+        )
+        contract = _resolve_legacy_replacement_contract(
+            source_raw=checkout_relative,
+            destination_raw=checkout_relative,
+            policy_checkout_path=checkout,
+            policy_repo_path=content_root,
+            source_unit=source_unit,
+            corpus_release=release,
+        )
+
+        generated = output_root / "codex-test-model" / relative
+        generated.parent.mkdir(parents=True)
+        generated.write_text(
+            "format: rulespec/v1\n"
+            "module:\n"
+            "  source_verification:\n"
+            "    corpus_citation_path: us-me/guidance/revenue/rate-schedule\n"
+            "rules:\n"
+            "  - name: me_2026_schedule_tax\n"
+            "    kind: derived\n"
+            "    dtype: Money\n"
+            "    period: Year\n"
+            "    versions:\n"
+            "      - effective_from: '2026-01-01'\n"
+            "        formula: '0'\n"
+        )
+        generated_test = generated.with_name("pilot_liability_pipeline.test.yaml")
+        generated_test.write_text("[]\n")
+        result = self._make_eval_result(True)
+        result.output_file = str(generated)
+        result.trace_file = str(tmp_path / "trace.json")
+        Path(result.trace_file).write_text("{}\n")
+        source_file = tmp_path / "source.txt"
+        source_file.write_text(source_text)
+        context = tmp_path / "context.json"
+        context.write_text(json.dumps({"source_text_file": source_file.name}) + "\n")
+        result.context_manifest_file = str(context)
+        result.context_manifest_sha256 = hashlib.sha256(
+            context.read_bytes()
+        ).hexdigest()
+        result.generation_prompt_sha256 = "prompt-sha"
+        result.source_attestation = source_attestation
+        result._axiom_legacy_replacement_contract = contract
+        self._record_apply_validation(
+            result,
+            output_root=output_root,
+            policy_repo_path=content_root,
+            corpus_path=corpus_path,
+        )
+
+        with (
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_PUBLIC_KEY_ENV: TEST_APPLY_PUBLIC_KEY_B64},
+            ),
+            patch(
+                "axiom_encode.cli._git_repo_provenance",
+                return_value={
+                    "root": "/repo/axiom-encode",
+                    "commit": TEST_PINNED_ENCODER_IDENTITY["commit"],
+                    "dirty_tracked": False,
+                },
+            ),
+            patch(
+                "axiom_encode.cli._require_axiom_encode_version_provenance",
+                return_value={
+                    "version": AXIOM_ENCODE_TEST_VERSION,
+                    "version_commit": "f" * 40,
+                    "identity_source": "git",
+                },
+            ),
+        ):
+            applied = _apply_generated_encoding_result(
+                result,
+                output_root=output_root,
+                policy_repo_path=content_root,
+                corpus_path=corpus_path,
+                run_id="in-place-v1-replacement",
+            )
+
+        assert target.read_bytes() != old_target
+        assert target_test.read_bytes() == generated_test.read_bytes()
+        assert manifest.read_bytes() != old_manifest
+        assert applied[:3] == [target, target_test, manifest]
+        assert len(applied) == 4
+        assert applied[3].parent == checkout / ".axiom/legacy-replacements"
+        outer = json.loads(manifest.read_text())
+        assert outer["tool"] == (
+            "axiom-encode encode --apply --replace-legacy-rulespec-path"
+        )
+        assert all("deleted" not in item for item in outer["applied_files"])
+        assert {item["path"] for item in outer["applied_files"]} == {
+            target.relative_to(checkout).as_posix(),
+            target_test.relative_to(checkout).as_posix(),
+        }
+        receipt = json.loads(
+            (checkout / outer["replacement"]["receipt_path"]).read_text()
+        )
+        assert receipt["replacement"]["source"] == checkout_relative.as_posix()
+        assert receipt["replacement"]["destination"] == checkout_relative.as_posix()
+        assert receipt["legacy"]["files"] == [
+            {"path": path, "sha256": digest}
+            for path, digest in legacy_files.items()
+        ]
+        verified, _root, _digest, issues = (
+            _load_verified_applied_encoding_manifest_payload(
+                checkout,
+                manifest.relative_to(checkout).as_posix(),
+                signing_broker=TEST_APPLY_SIGNING_BROKER,
+                expected_waiver_set_sha256=TEST_VALIDATION_WAIVER_SHA256,
+                expected_encoder_identity=TEST_PINNED_ENCODER_IDENTITY,
+                local_corpus_release=release,
+            )
+        )
+        assert issues == [], "\n".join(issues)
+        assert verified == outer
+
     def test_apply_manifest_build_failure_leaves_live_files_byte_identical(
         self, tmp_path
     ):
@@ -33848,7 +34040,8 @@ class TestResolverOwnedManifestWriter:
         )
 
         assert any(
-            "source and destination must differ" in issue for issue in no_op_issues
+            "legacy replacement manifest does not belong to source" in issue
+            for issue in no_op_issues
         ), "\n".join(no_op_issues)
 
     def test_model_writer_rejects_forged_resolver_row(self, tmp_path):

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1411"
+ENCODER_VERSION = "0.2.1412"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1412"
+ENCODER_VERSION = "0.2.1413"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1411"
+ENCODER_VERSION = "0.2.1412"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1412"
+ENCODER_VERSION = "0.2.1413"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_legacy_replacement.py
+++ b/tests/test_legacy_replacement.py
@@ -104,7 +104,7 @@ def test_manual_manifest_is_admitted_only_as_exact_deletion_evidence() -> None:
 
 def test_unmarked_manual_manifest_is_only_admitted_for_explicit_in_place_use() -> None:
     payload = _manual_manifest()
-    payload["manual_exception"] = None
+    payload.pop("manual_exception")
     expected = {
         "us-la/statutes/47:32.yaml": "a" * 64,
         "us-la/statutes/47:32.test.yaml": "b" * 64,
@@ -116,6 +116,15 @@ def test_unmarked_manual_manifest_is_only_admitted_for_explicit_in_place_use() -
             expected_files=expected,
         )
     )
+    assert (
+        legacy_manual_manifest_issues(
+            payload,
+            expected_files=expected,
+            allow_unmarked_manual_exception=True,
+        )
+        == []
+    )
+    payload["manual_exception"] = None
     assert (
         legacy_manual_manifest_issues(
             payload,
@@ -258,13 +267,12 @@ def _in_place_legacy_checkout(
         ).hexdigest(),
     }
     manifest = (
-        checkout
-        / ".axiom/encoding-manifests/us-me/policies/income_tax/"
+        checkout / ".axiom/encoding-manifests/us-me/policies/income_tax/"
         "pilot_liability_pipeline.json"
     )
     manifest.parent.mkdir(parents=True)
     payload = _manual_manifest()
-    payload["manual_exception"] = None
+    payload.pop("manual_exception")
     payload["applied_files"] = [
         {"path": path, "sha256": digest} for path, digest in expected_files.items()
     ]

--- a/tests/test_legacy_replacement.py
+++ b/tests/test_legacy_replacement.py
@@ -30,7 +30,7 @@ from axiom_encode.legacy_replacement import (
         {"corpus_citation_path": ""},
         {"corpus_citation_path": 1},
         {"corpus_citation_paths": []},
-        {"corpus_citation_paths": ["us-la/statute/47/32", "us-la/statute/47/33"]},
+        {"corpus_citation_paths": ["us-la/statute/47/32", "us-la/statute/47/32"]},
         {"corpus_citation_paths": [1]},
         {
             "corpus_citation_path": "us-la/statute/47/32",
@@ -52,6 +52,20 @@ def test_legacy_citation_admission_rejects_ambiguous_shapes(verification) -> Non
 def test_legacy_citation_admission_accepts_one_exclusive_source(verification) -> None:
     assert legacy_source_verification_citation_paths(verification) == (
         "us-la/statute/47/32",
+    )
+
+
+def test_legacy_citation_admission_preserves_historical_source_order() -> None:
+    assert legacy_source_verification_citation_paths(
+        {
+            "corpus_citation_paths": [
+                "us-me/guidance/revenue/rate-schedule",
+                "us-me/statute/36/5111",
+            ]
+        }
+    ) == (
+        "us-me/guidance/revenue/rate-schedule",
+        "us-me/statute/36/5111",
     )
 
 
@@ -83,6 +97,30 @@ def test_manual_manifest_is_admitted_only_as_exact_deletion_evidence() -> None:
         legacy_manual_manifest_issues(
             _manual_manifest(),
             expected_files=expected,
+        )
+        == []
+    )
+
+
+def test_unmarked_manual_manifest_is_only_admitted_for_explicit_in_place_use() -> None:
+    payload = _manual_manifest()
+    payload["manual_exception"] = None
+    expected = {
+        "us-la/statutes/47:32.yaml": "a" * 64,
+        "us-la/statutes/47:32.test.yaml": "b" * 64,
+    }
+    assert any(
+        "no manual exception" in issue
+        for issue in legacy_manual_manifest_issues(
+            payload,
+            expected_files=expected,
+        )
+    )
+    assert (
+        legacy_manual_manifest_issues(
+            payload,
+            expected_files=expected,
+            allow_unmarked_manual_exception=True,
         )
         == []
     )
@@ -191,6 +229,122 @@ def _legacy_checkout(tmp_path: Path) -> tuple[Path, Path, SimpleNamespace]:
         resolved_source=object(),
     )
     return checkout, content_root, source
+
+
+def _in_place_legacy_checkout(
+    tmp_path: Path,
+) -> tuple[Path, Path, SimpleNamespace]:
+    checkout = tmp_path / "rulespec-us"
+    content_root = checkout / "us-me"
+    primary = content_root / "policies/income_tax/pilot_liability_pipeline.yaml"
+    companion = primary.with_name("pilot_liability_pipeline.test.yaml")
+    primary.parent.mkdir(parents=True)
+    primary.write_text(
+        "format: rulespec/v1\n"
+        "module:\n"
+        "  source_verification:\n"
+        "    corpus_citation_paths:\n"
+        "      - us-me/guidance/revenue/rate-schedule\n"
+        "      - us-me/statute/36/5111\n"
+        "rules: []\n"
+    )
+    companion.write_text("[]\n")
+    expected_files = {
+        primary.relative_to(checkout).as_posix(): hashlib.sha256(
+            primary.read_bytes()
+        ).hexdigest(),
+        companion.relative_to(checkout).as_posix(): hashlib.sha256(
+            companion.read_bytes()
+        ).hexdigest(),
+    }
+    manifest = (
+        checkout
+        / ".axiom/encoding-manifests/us-me/policies/income_tax/"
+        "pilot_liability_pipeline.json"
+    )
+    manifest.parent.mkdir(parents=True)
+    payload = _manual_manifest()
+    payload["manual_exception"] = None
+    payload["applied_files"] = [
+        {"path": path, "sha256": digest} for path, digest in expected_files.items()
+    ]
+    manifest.write_text(json.dumps(payload) + "\n")
+    _git(checkout, "init", "-q")
+    _git(checkout, "config", "user.email", "test@example.com")
+    _git(checkout, "config", "user.name", "Test")
+    _git(checkout, "add", ".")
+    _git(checkout, "commit", "-qm", "base")
+    source = SimpleNamespace(
+        requested="us-me/guidance/revenue/rate-schedule",
+        citation_path="us-me/guidance/revenue/rate-schedule",
+        body="official schedule",
+        resolved_source=object(),
+    )
+    return checkout, content_root, source
+
+
+def test_contract_binds_in_place_plural_source_and_unmarked_v1(
+    tmp_path: Path,
+) -> None:
+    checkout, content_root, source = _in_place_legacy_checkout(tmp_path)
+    relative = Path("us-me/policies/income_tax/pilot_liability_pipeline.yaml")
+    with patch("axiom_encode.cli.resolve_corpus_source_unit", return_value=source):
+        contract = _resolve_legacy_replacement_contract(
+            source_raw=relative,
+            destination_raw=relative,
+            policy_checkout_path=checkout,
+            policy_repo_path=content_root,
+            source_unit=source,
+            corpus_release=SimpleNamespace(),
+        )
+
+    assert contract.source == relative
+    assert contract.destination == relative
+    assert contract.rewrites == ()
+    assert contract.scheduled_dependents == ()
+    assert [item.path for item in contract.deleted_files] == [
+        relative,
+        relative.with_name("pilot_liability_pipeline.test.yaml"),
+    ]
+
+
+def test_contract_rejects_in_place_source_choice_outside_first_legacy_slot(
+    tmp_path: Path,
+) -> None:
+    checkout, content_root, source = _in_place_legacy_checkout(tmp_path)
+    source.requested = "us-me/statute/36/5111"
+    source.citation_path = source.requested
+    relative = Path("us-me/policies/income_tax/pilot_liability_pipeline.yaml")
+    with (
+        patch("axiom_encode.cli.resolve_corpus_source_unit", return_value=source),
+        pytest.raises(ValueError, match="first historical source"),
+    ):
+        _resolve_legacy_replacement_contract(
+            source_raw=relative,
+            destination_raw=relative,
+            policy_checkout_path=checkout,
+            policy_repo_path=content_root,
+            source_unit=source,
+            corpus_release=SimpleNamespace(),
+        )
+
+
+def test_contract_rejects_in_place_path_dependents(tmp_path: Path) -> None:
+    checkout, content_root, source = _in_place_legacy_checkout(tmp_path)
+    relative = Path("us-me/policies/income_tax/pilot_liability_pipeline.yaml")
+    with (
+        patch("axiom_encode.cli.resolve_corpus_source_unit", return_value=source),
+        pytest.raises(ValueError, match="cannot schedule path dependents"),
+    ):
+        _resolve_legacy_replacement_contract(
+            source_raw=relative,
+            destination_raw=relative,
+            policy_checkout_path=checkout,
+            policy_repo_path=content_root,
+            source_unit=source,
+            corpus_release=SimpleNamespace(),
+            scheduled_dependent_paths=(relative.with_name("dependent.yaml"),),
+        )
 
 
 def test_contract_binds_clean_head_and_exact_metadata_rewrite(tmp_path: Path) -> None:

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1411"
+ENCODER_VERSION = "0.2.1412"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1412"
+ENCODER_VERSION = "0.2.1413"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1411"
+ENCODER_VERSION = "0.2.1412"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1412"
+ENCODER_VERSION = "0.2.1413"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1411"
+ENCODER_VERSION = "0.2.1412"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1412"
+ENCODER_VERSION = "0.2.1413"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1411"
+ENCODER_VERSION = "0.2.1412"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1412"
+ENCODER_VERSION = "0.2.1413"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1412"')
+        .startswith('__version__ = "0.2.1413"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1412"
+    assert encoder_package["version"] == "0.2.1413"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1412"
+    assert project["project"]["version"] == "0.2.1413"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1412"')
+        .startswith('__version__ = "0.2.1413"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1412"
+    assert encoder_package["version"] == "0.2.1413"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1412"
+    assert project["project"]["version"] == "0.2.1413"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1412"')
+        .startswith('__version__ = "0.2.1413"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1411"')
+        .startswith('__version__ = "0.2.1412"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1411"
+    assert encoder_package["version"] == "0.2.1412"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1411"
+    assert project["project"]["version"] == "0.2.1412"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1411"')
+        .startswith('__version__ = "0.2.1412"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1411"
+    assert encoder_package["version"] == "0.2.1412"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1411"
+    assert project["project"]["version"] == "0.2.1412"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1411"')
+        .startswith('__version__ = "0.2.1412"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1412"
+ENCODER_VERSION = "0.2.1413"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "678dd840b4c64e54c63805b0183f05c0f769b399"
-ENCODER_VERSION = "0.2.1411"
+ENCODER_VERSION = "0.2.1412"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1412"
+version = "0.2.1413"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1411"
+version = "0.2.1412"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- extend protected legacy v1/manual replacement to fresh signed v5 output at the same canonical RuleSpec path
- bind the immutable legacy primary, companion, and manifest bytes to clean HEAD while treating the old signature only as untrusted retirement evidence
- preserve the exact nested model manifest live-file order, atomically overwrite same-path outputs, and emit a signed outer manifest plus receipt without contradictory delete entries
- keep path-move replacement strict; same-path mode permits no reference rewrites or scheduled dependents
- admit historical plural citations only for same-path replacement, requiring the selected signed corpus unit to be the first historical source
- package the in-place artifact safely in the targeted signed re-encode workflow
- advance the encoder contract to 0.2.1413

## Why

Maine's canonical 2026 pilot pipeline is owned by a historical v1/manual manifest and must be freshly model re-encoded without moving its already-canonical path. Mutating or re-signing the legacy bytes would preserve untrusted provenance. This transaction retires those exact base bytes and installs newly generated, validated, signed v5 bytes end to end.

## Review cycle

- Independent security/transaction review found one P1: the real Maine manifest omits `manual_exception`, while the initial fixture used explicit `null`.
- Fixed the explicit same-path admission to accept missing or null only in same-path mode; normal/path-move admission remains strict.
- Directly probed the held Maine manifest: strict mode rejects it and same-path mode reports zero issues.
- Repeated independent review after the fix: CLEAN.
- Final audit of the mechanical 0.2.1413 provenance bump: CLEAN.

## Checks

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest` — 6,053 passed, 119 skipped
- post-fix focused suite — 1,190 passed, 61 skipped
- workflow YAML parse check
- `git diff --check`
