### PR TITLE
Wire the concept naming contract into agent instructions and README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 ## Workflow Scope
 
 - Use this repository's docs, CLI commands, RuleSpec specs, oracle registry, eval suites, and validation pipeline as the operating procedure for Axiom work.
+- Name generated concepts per the applicable section of the naming contract, `axiom-rules-engine/docs/concept-naming.md` (executable rules, relations, tables/selectors, acronyms). Nothing in `encode --apply` updates the display acronym registries: when a change introduces a new acronym token, the PR author or reviewer flags it per the contract's Acronyms section and closes the flag by updating both registries or linking an owned follow-up.
 - Do not use PolicyEngine workflow skills or PolicyEngine implementation skills for Axiom encoding, RuleSpec, corpus, or oracle-parity tasks. PolicyEngine is an oracle/comparison dependency here, not the workflow owner.
 - If a reusable workflow is missing, add or propose an Axiom-specific Codex skill or project instruction instead of borrowing a PolicyEngine skill.
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,15 @@ policy-repo overlay, and no repair manifest is written.
 
 ## Applying generated RuleSpec
 
+Generated concept names are reviewed against the naming contract in
+[`axiom-rules-engine/docs/concept-naming.md`](https://github.com/TheAxiomFoundation/axiom-rules-engine/blob/main/docs/concept-naming.md):
+fragment patterns, the upstream-concept rule, and lowercase acronym tokens
+with uppercase reserved for source-stated legal designators (the name lint
+rejects accidental mixed case; all-uppercase tokens pass it, so casing is a
+review item). `encode --apply` does not update the display acronym
+registries described in the contract's Acronyms section; new acronym tokens
+are flagged in review and closed by registry updates or an owned follow-up.
+
 Live jurisdiction RuleSpec must be installed with `axiom-encode encode --apply`,
 not by editing YAML in place. `--apply` validates the generated main file,
 companion test, and direct dependent RuleSpec modules inside a temporary


### PR DESCRIPTION
axiom-encode had no reference to the naming contract (`axiom-rules-engine/docs/concept-naming.md`) — encoder lanes generated names without it in the loop. This adds:

- an AGENTS.md workflow-scope bullet: name generated concepts per the applicable section of the contract; a new acronym token is flagged by the PR author or reviewer and closed by updating the display registries or linking an owned follow-up (nothing in `encode --apply` touches them)
- a README paragraph in "Applying generated RuleSpec" stating names are *reviewed against* the contract, with the name lint's actual scope stated precisely (rejects accidental mixed case; all-uppercase passes; casing is a review item)

Companion: TheAxiomFoundation/axiom-rules-engine#138 adds the contract's Acronyms section this points to.

**Cycle record (per AGENTS.md PR discipline, docs-only lightweight cycle):** 3 rounds of independent GPT-5.6-Sol review. R1: 4 actionable (enforcement overstated / flag had no actor; "lowercase throughout" contradicted the legal-marker exception; fragment pattern overgeneralized; registry-admission rule overbroad) — all fixed. R2: 3/4 confirmed resolved + lint-enforcement claim downgraded to match `find_mixed_case_rule_name_token_issues` behavior, plain-word claim scoped to lowercase tokens, admission universe broadened to document slugs, flag completion assigned. R3: one scoping correction (registry list vs the app's additional humanizer sets) — adopted reviewer's prescribed wording; reviewer ran the focused lint tests and `git diff --check`, no remaining actionable findings. Checks: docs-only, no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)