### PR TITLE
Bump the axiom-oracles pin for the taxable-income mappings

### DIFF
--- a/changelog.d/bump-oracles-taxable-mappings.changed.md
+++ b/changelog.d/bump-oracles-taxable-mappings.changed.md
@@ -1,0 +1,1 @@
+Bump the pinned axiom-oracles commit so the changed-file oracle-coverage classifier reads the taxable-income pipeline mappings (axiom-oracles#431), unblocking rulespec-us#1181.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1417"
+version = "0.2.1418"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,7 +24,7 @@ dependencies = [
     # src/axiom_encode/oracles/policyengine/ are thin re-export shims over
     # axiom_oracles.bridges (axiom-oracles#124). Pinned to a commit because
     # axiom-oracles is not on PyPI; bump the SHA to pull bridge changes.
-    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@f8ea6027984b9da73c6f4b58d15a20b450181ac4",
+    "axiom-oracles @ git+https://github.com/TheAxiomFoundation/axiom-oracles@e1374eb30c582639f8f71f9bf9c22ba93b6e36f4",
     "cryptography>=46.0",
     "pydantic>=2.0",
     "pypdf>=6.4.0",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1417"
+__version__ = "0.2.1418"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -10,8 +10,8 @@ from axiom_oracles.bridges.registry import load_policyengine_registry
 MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
-ORACLE_MERGE = "f8ea6027984b9da73c6f4b58d15a20b450181ac4"
-ENCODER_VERSION = "0.2.1417"
+ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
+ENCODER_VERSION = "0.2.1418"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -14,8 +14,8 @@ DIRECT_VARIABLES = {
         "il_income_tax_before_non_refundable_credits"
     ),
 }
-ORACLE_MERGE = "f8ea6027984b9da73c6f4b58d15a20b450181ac4"
-ENCODER_VERSION = "0.2.1417"
+ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
+ENCODER_VERSION = "0.2.1418"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -10,8 +10,8 @@ from axiom_oracles.bridges.registry import load_policyengine_registry
 MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
-ORACLE_MERGE = "f8ea6027984b9da73c6f4b58d15a20b450181ac4"
-ENCODER_VERSION = "0.2.1417"
+ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
+ENCODER_VERSION = "0.2.1418"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -10,8 +10,8 @@ from axiom_oracles.bridges.registry import load_policyengine_registry
 MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
-ORACLE_MERGE = "f8ea6027984b9da73c6f4b58d15a20b450181ac4"
-ENCODER_VERSION = "0.2.1417"
+ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
+ENCODER_VERSION = "0.2.1418"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -10,8 +10,8 @@ from axiom_oracles.bridges.registry import load_policyengine_registry
 MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
-ORACLE_MERGE = "f8ea6027984b9da73c6f4b58d15a20b450181ac4"
-ENCODER_VERSION = "0.2.1417"
+ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
+ENCODER_VERSION = "0.2.1418"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -10,8 +10,8 @@ from axiom_oracles.bridges.registry import load_policyengine_registry
 MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
-ORACLE_MERGE = "f8ea6027984b9da73c6f4b58d15a20b450181ac4"
-ENCODER_VERSION = "0.2.1417"
+ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
+ENCODER_VERSION = "0.2.1418"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -13,8 +13,8 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_taxable_income": "pa_adjusted_taxable_income",
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
-ORACLE_MERGE = "f8ea6027984b9da73c6f4b58d15a20b450181ac4"
-ENCODER_VERSION = "0.2.1417"
+ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
+ENCODER_VERSION = "0.2.1418"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5120,7 +5120,7 @@ def test_packaged_alabama_2026_schedule_registry_and_fallback_are_synchronized()
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "f8ea6027984b9da73c6f4b58d15a20b450181ac4"
+    assert pin == "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5231,7 +5231,7 @@ def test_packaged_connecticut_2026_ordinary_tax_registry_is_exactly_synchronized
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "f8ea6027984b9da73c6f4b58d15a20b450181ac4"
+    assert pin == "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5315,7 +5315,7 @@ def test_packaged_georgia_2026_annual_tax_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "f8ea6027984b9da73c6f4b58d15a20b450181ac4"
+    assert pin == "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5410,7 +5410,7 @@ def test_packaged_mississippi_2026_schedule_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "f8ea6027984b9da73c6f4b58d15a20b450181ac4"
+    assert pin == "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5571,7 +5571,7 @@ def test_packaged_kansas_2026_k40es_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "f8ea6027984b9da73c6f4b58d15a20b450181ac4"
+    assert pin == "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 
@@ -5676,7 +5676,7 @@ def test_packaged_dc_2026_section_47_1806_03_has_exact_bounded_slice():
 def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "f8ea6027984b9da73c6f4b58d15a20b450181ac4"
+    durable_oracle_merge = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1417"')
+        .startswith('__version__ = "0.2.1418"')
     )
 
 
@@ -5879,7 +5879,7 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
 
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "f8ea6027984b9da73c6f4b58d15a20b450181ac4"
+    durable_oracle_merge = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1417"
+    assert encoder_package["version"] == "0.2.1418"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1417"
+    assert project["project"]["version"] == "0.2.1418"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1417"')
+        .startswith('__version__ = "0.2.1418"')
     )
 
 
@@ -6155,7 +6155,7 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
 
     import axiom_oracles.bridges.registry as runtime_registry_module
 
-    durable_oracle_merge = "f8ea6027984b9da73c6f4b58d15a20b450181ac4"
+    durable_oracle_merge = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
     root = Path(__file__).parents[1]
     bundled_path = root / "src/axiom_encode/oracles/policyengine/mappings/us.yaml"
     runtime_path = (
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1417"
+    assert encoder_package["version"] == "0.2.1418"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1417"
+    assert project["project"]["version"] == "0.2.1418"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1417"')
+        .startswith('__version__ = "0.2.1418"')
     )
 
 
@@ -6506,7 +6506,7 @@ def test_packaged_utah_2026_before_credit_registry_is_exactly_synchronized():
     )
     assert dependency_pin is not None
     pin = dependency_pin.group(0).removeprefix("axiom-oracles@")
-    assert pin == "f8ea6027984b9da73c6f4b58d15a20b450181ac4"
+    assert pin == "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
     assert f"?rev={pin}#{pin}" in (root / "uv.lock").read_text()
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -11,8 +11,8 @@ MODULE = "us-sc:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
-ORACLE_MERGE = "f8ea6027984b9da73c6f4b58d15a20b450181ac4"
-ENCODER_VERSION = "0.2.1417"
+ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
+ENCODER_VERSION = "0.2.1418"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1417"
+version = "0.2.1418"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },
@@ -101,7 +101,7 @@ observability = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.40.0" },
     { name = "axiom-encode", extras = ["api", "dev", "observability"], marker = "extra == 'all'" },
-    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=f8ea6027984b9da73c6f4b58d15a20b450181ac4" },
+    { name = "axiom-oracles", git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=e1374eb30c582639f8f71f9bf9c22ba93b6e36f4" },
     { name = "claude-agent-sdk", marker = "extra == 'api'", specifier = ">=0.1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.28.0" },
@@ -125,7 +125,7 @@ provides-extras = ["api", "observability", "dev", "all"]
 [[package]]
 name = "axiom-oracles"
 version = "0.2.1"
-source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=f8ea6027984b9da73c6f4b58d15a20b450181ac4#f8ea6027984b9da73c6f4b58d15a20b450181ac4" }
+source = { git = "https://github.com/TheAxiomFoundation/axiom-oracles?rev=e1374eb30c582639f8f71f9bf9c22ba93b6e36f4#e1374eb30c582639f8f71f9bf9c22ba93b6e36f4" }
 dependencies = [
     { name = "click" },
     { name = "pyyaml" },


### PR DESCRIPTION
Pin bump: `axiom-oracles` `f8ea6027` → `e1374eb3` (includes **#431**'s taxable-income pipeline rows plus the merged #424/#425/#426/#430-era main). rulespec-us#1181's changed-file gate reads bridge mappings from the commit pinned here. Version 0.2.1418 atomically with the lock and the registry exact-version/exact-pin constants (checked main's pin first: f8ea6027 predates #431).

🤖 Generated with [Claude Code](https://claude.com/claude-code)