### PR TITLE
Support atomic legacy composite re-encoding

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -42,6 +42,14 @@ on:
         description: Exact noncanonical legacy primary replaced by a fresh model encode
         required: false
         type: string
+      legacy_exact_dependent_rulespec_path:
+        description: Exact v1/manual direct dependent migrated by canonical reference rewrite
+        required: false
+        type: string
+      second_legacy_exact_dependent_rulespec_path:
+        description: Second exact v1/manual direct dependent in the same atomic migration
+        required: false
+        type: string
       dependent_citation:
         description: Direct dependent to re-encode atomically after a breaking target
         required: false
@@ -553,6 +561,8 @@ jobs:
           REVIEW_FINDING: ${{ inputs.review_finding }}
           REPLACE_RULESPEC_PATH: ${{ inputs.replace_rulespec_path }}
           REPLACE_LEGACY_RULESPEC_PATH: ${{ inputs.replace_legacy_rulespec_path }}
+          LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.legacy_exact_dependent_rulespec_path }}
+          SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.second_legacy_exact_dependent_rulespec_path }}
           QUEUE_ID: ${{ inputs.queue_id }}
           DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
           DEPENDENT_REVIEW_FINDING: ${{ inputs.dependent_review_finding }}
@@ -564,6 +574,8 @@ jobs:
           : "${QUEUE_ID:=}"
           : "${REPLACE_RULESPEC_PATH:=}"
           : "${REPLACE_LEGACY_RULESPEC_PATH:=}"
+          : "${LEGACY_EXACT_DEPENDENT_RULESPEC_PATH:=}"
+          : "${SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH:=}"
           : "${SECOND_DEPENDENT_CITATION:=}"
           : "${SECOND_DEPENDENT_REVIEW_FINDING:=}"
           dependent_rulespec_path=""
@@ -608,6 +620,18 @@ jobs:
                   "$second_dependent_rulespec_path"
                 )
               fi
+              if [ -n "$LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" ]; then
+                args+=(
+                  --legacy-exact-dependent-rulespec-path \
+                  "$LEGACY_EXACT_DEPENDENT_RULESPEC_PATH"
+                )
+              fi
+              if [ -n "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" ]; then
+                args+=(
+                  --legacy-exact-dependent-rulespec-path \
+                  "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH"
+                )
+              fi
             fi
             if [ -n "$review_finding" ]; then
               review_finding_dir="$(mktemp -d "$RUNNER_TEMP/axiom-targeted-review-finding.XXXXXX")"
@@ -637,13 +661,46 @@ jobs:
           fi
           if [ -n "$QUEUE_ID" ] && \
             { [ -n "$REPLACE_RULESPEC_PATH" ] || \
-              [ -n "$REPLACE_LEGACY_RULESPEC_PATH" ]; }; then
+              [ -n "$REPLACE_LEGACY_RULESPEC_PATH" ] || \
+              [ -n "$LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" ] || \
+              [ -n "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" ]; }; then
             echo "queue-authorized re-encodes cannot override the RuleSpec target path" >&2
             exit 1
           fi
           if [ -n "$REPLACE_LEGACY_RULESPEC_PATH" ] && \
             [ -z "$REPLACE_RULESPEC_PATH" ]; then
             echo "legacy source and canonical destination must be paired" >&2
+            exit 1
+          fi
+          if { [ -n "$LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" ] || \
+               [ -n "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" ]; } && \
+             [ -z "$REPLACE_LEGACY_RULESPEC_PATH" ]; then
+            echo "exact legacy dependents require a legacy source replacement" >&2
+            exit 1
+          fi
+          if [ -n "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" ] && \
+             [ -z "$LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" ]; then
+            echo "first exact legacy dependent is required before a second" >&2
+            exit 1
+          fi
+          if { [ -n "$LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" ] || \
+               [ -n "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" ]; } && \
+             { [ -n "$DEPENDENT_CITATION" ] || \
+               [ -n "$SECOND_DEPENDENT_CITATION" ]; }; then
+            echo "exact and model-regenerated dependent modes cannot be combined" >&2
+            exit 1
+          fi
+          if [ -n "$LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" ] && \
+             { [ "$LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" = "$REPLACE_RULESPEC_PATH" ] || \
+               [ "$LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" = "$REPLACE_LEGACY_RULESPEC_PATH" ]; }; then
+            echo "exact legacy dependent must differ from source and destination" >&2
+            exit 1
+          fi
+          if [ -n "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" ] && \
+             { [ "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" = "$REPLACE_RULESPEC_PATH" ] || \
+               [ "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" = "$REPLACE_LEGACY_RULESPEC_PATH" ] || \
+               [ "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" = "$LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" ]; }; then
+            echo "second exact legacy dependent must be unique" >&2
             exit 1
           fi
           if [ -n "$DEPENDENT_CITATION" ] && [ -z "$DEPENDENT_REVIEW_FINDING" ]; then
@@ -745,6 +802,8 @@ jobs:
           REVIEW_FINDING_PRESENT: ${{ inputs.review_finding != '' }}
           REPLACE_RULESPEC_PATH: ${{ inputs.replace_rulespec_path }}
           REPLACE_LEGACY_RULESPEC_PATH: ${{ inputs.replace_legacy_rulespec_path }}
+          LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.legacy_exact_dependent_rulespec_path }}
+          SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.second_legacy_exact_dependent_rulespec_path }}
           RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
         run: |
           workflow_python=(/opt/axiom-verification/python/bin/python -I)
@@ -826,6 +885,16 @@ jobs:
           legacy_source_path = (
               os.environ.get("REPLACE_LEGACY_RULESPEC_PATH") or ""
           )
+          exact_dependent_paths = [
+              value
+              for value in (
+                  os.environ.get("LEGACY_EXACT_DEPENDENT_RULESPEC_PATH") or "",
+                  os.environ.get(
+                      "SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH"
+                  ) or "",
+              )
+              if value
+          ]
           normalized_replacement_path = ""
           if replacement_path:
               candidate = Path(replacement_path)
@@ -962,9 +1031,12 @@ jobs:
                       )
                   receipt = json.loads(receipt_bytes)
                   receipt_replacement = receipt.get("replacement")
+                  receipt_schema = receipt.get("schema_version")
                   if (
-                      receipt.get("schema_version")
-                      != "axiom-encode/legacy-fresh-reencode-receipt/v1"
+                      receipt_schema not in {
+                          "axiom-encode/legacy-fresh-reencode-receipt/v1",
+                          "axiom-encode/legacy-fresh-reencode-receipt/v2",
+                      }
                       or not isinstance(receipt_replacement, dict)
                       or receipt_replacement.get("source")
                       != legacy_source_path
@@ -972,6 +1044,75 @@ jobs:
                       != normalized_replacement_path
                   ):
                       raise SystemExit("legacy replacement receipt paths differ")
+                  exact_dependents = receipt_replacement.get(
+                      "exact_dependents",
+                      [],
+                  )
+                  if (
+                      not isinstance(exact_dependents, list)
+                      or [
+                          item.get("primary")
+                          for item in exact_dependents
+                          if isinstance(item, dict)
+                      ]
+                      != exact_dependent_paths
+                      or (
+                          exact_dependent_paths
+                          and receipt_schema
+                          != "axiom-encode/legacy-fresh-reencode-receipt/v2"
+                      )
+                  ):
+                      raise SystemExit(
+                          "legacy replacement exact dependents differ from inputs"
+                      )
+                  receipt_sha256 = hashlib.sha256(receipt_bytes).hexdigest()
+                  for exact_dependent in exact_dependents:
+                      primary = exact_dependent.get("primary")
+                      if not isinstance(primary, str):
+                          raise SystemExit(
+                              "legacy replacement exact dependent is malformed"
+                          )
+                      exact_manifest_path = (
+                          Path(".axiom/encoding-manifests")
+                          / Path(primary).with_suffix(".json")
+                      )
+                      if exact_manifest_path not in manifest_paths:
+                          raise SystemExit(
+                              "legacy replacement exact dependent lacks "
+                              "a changed signed manifest"
+                          )
+                      exact_manifest_bytes = read_bounded_regular(
+                          os.environ["RULESPEC_CHECKOUT"],
+                          exact_manifest_path,
+                          label="legacy exact dependent manifest",
+                          max_bytes=1024 * 1024,
+                      )
+                      exact_manifest = json.loads(exact_manifest_bytes)
+                      migration = exact_manifest.get("legacy_migration")
+                      if (
+                          exact_manifest.get("tool")
+                          != "axiom-encode encode --apply "
+                          "--legacy-exact-dependent-rulespec-path"
+                          or not isinstance(migration, dict)
+                          or migration.get("receipt_path")
+                          != receipt_path.as_posix()
+                          or migration.get("receipt_sha256") != receipt_sha256
+                          or migration.get("primary") != primary
+                          or exact_manifest.get("applied_files")
+                          != exact_dependent.get("live_files")
+                      ):
+                          raise SystemExit(
+                              "legacy exact dependent manifest binding differs"
+                          )
+                      applied_inventory.append(
+                          {
+                              "citation": None,
+                              "path": exact_manifest_path.as_posix(),
+                              "sha256": hashlib.sha256(
+                                  exact_manifest_bytes
+                              ).hexdigest(),
+                          }
+                      )
                   scheduled = receipt_replacement.get("scheduled_dependents")
                   if not isinstance(scheduled, list):
                       raise SystemExit(
@@ -1196,6 +1337,14 @@ jobs:
               "replace_legacy_rulespec_path": (
                   os.environ.get("REPLACE_LEGACY_RULESPEC_PATH") or None
               ),
+              "legacy_exact_dependent_rulespec_path": (
+                  os.environ.get("LEGACY_EXACT_DEPENDENT_RULESPEC_PATH") or None
+              ),
+              "second_legacy_exact_dependent_rulespec_path": (
+                  os.environ.get(
+                      "SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH"
+                  ) or None
+              ),
               "pr_base_branch": os.environ["PR_BASE_BRANCH"],
               "queue_id": os.environ.get("QUEUE_ID") or None,
               "queue_item_id": os.environ.get("QUEUE_ITEM_ID") or None,
@@ -1251,6 +1400,8 @@ jobs:
           CITATION: ${{ inputs.citation }}
           DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
           SECOND_DEPENDENT_CITATION: ${{ inputs.second_dependent_citation }}
+          LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.legacy_exact_dependent_rulespec_path }}
+          SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.second_legacy_exact_dependent_rulespec_path }}
           RULESPEC_REF: ${{ inputs.rulespec_ref }}
           PR_BASE_BRANCH: ${{ inputs.pr_base_branch }}
           QUEUE_ID: ${{ inputs.queue_id }}
@@ -1279,6 +1430,8 @@ jobs:
             "Citation: \`${CITATION}\`" \
             "Direct dependent: \`${DEPENDENT_CITATION:-n/a}\`" \
             "Second direct dependent: \`${SECOND_DEPENDENT_CITATION:-n/a}\`" \
+            "Exact legacy dependent: \`${LEGACY_EXACT_DEPENDENT_RULESPEC_PATH:-n/a}\`" \
+            "Second exact legacy dependent: \`${SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH:-n/a}\`" \
             "Base commit: \`${RULESPEC_REF}\`" \
             "Base branch: \`${PR_BASE_BRANCH}\`" \
             "Queue item: \`${QUEUE_ID:-ad-hoc}/${QUEUE_ITEM_ID:-ad-hoc}\`" \

--- a/changelog.d/legacy-composite-cascade.changed.md
+++ b/changelog.d/legacy-composite-cascade.changed.md
@@ -1,0 +1,1 @@
+Migrate v1/manual RuleSpec dependents atomically with a fresh canonical v5 source replacement, binding every exact reference and proof-import hash rewrite, unchanged companion, legacy ownership manifest, and live file to one signed base-bound receipt.

--- a/cmd/axiom-encode-signing-supervisor/execution_trust_test.go
+++ b/cmd/axiom-encode-signing-supervisor/execution_trust_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -94,6 +95,19 @@ func TestDefaultTrustPolicyAcceptsProtectedSystemNativeExecutable(t *testing.T) 
 	info, err := os.Lstat(path)
 	if err != nil || info.Mode()&os.ModeSymlink != 0 {
 		t.Skip("platform does not expose /usr/bin/env as a regular native executable")
+	}
+	for current := path; ; current = filepath.Dir(current) {
+		if syscall.Access(current, accessWriteMode) == nil {
+			t.Skipf(
+				"host does not protect %s from writes by the invoking user; "+
+					"the production-fixture test covers the protected success path",
+				current,
+			)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
 	}
 	trusted, err := validateTrustedNativeExecutable(path)
 	if err != nil {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1419"
+version = "0.2.1420"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1418"
+version = "0.2.1419"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -17,6 +17,11 @@ QUEUE_TRACKING_PATTERN = re.compile(r"[a-z0-9][a-z0-9-]{0,63}")
 MANIFEST_ROOT = PurePosixPath(".axiom/encoding-manifests")
 LEGACY_REPLACEMENT_RECEIPT_ROOT = PurePosixPath(".axiom/legacy-replacements")
 LEGACY_REPLACEMENT_TOOL = "axiom-encode encode --apply --replace-legacy-rulespec-path"
+LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V1 = "axiom-encode/legacy-fresh-reencode-receipt/v1"
+LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2 = "axiom-encode/legacy-fresh-reencode-receipt/v2"
+LEGACY_EXACT_DEPENDENT_TOOL = (
+    "axiom-encode encode --apply --legacy-exact-dependent-rulespec-path"
+)
 MODEL_APPLY_TOOL = "axiom-encode encode --apply"
 MODEL_APPLY_BACKENDS = frozenset({"claude", "codex", "openai"})
 LEGACY_REPLACEMENT_METADATA_PATHS = frozenset(
@@ -381,6 +386,338 @@ def _validate_rulespec_path(repo: Path, path: PurePosixPath, *, label: str) -> N
         raise ValueError(f"{label} is not a canonical RuleSpec YAML path")
 
 
+def _rulespec_companion_path(primary: PurePosixPath) -> PurePosixPath:
+    return primary.with_name(f"{primary.stem}.test.yaml")
+
+
+def _base_regular_blob(
+    repo: Path,
+    base_commit: str,
+    path: PurePosixPath,
+    *,
+    required: bool,
+) -> bytes | None:
+    listing = _git(
+        repo,
+        "ls-tree",
+        "-z",
+        "--full-tree",
+        base_commit,
+        "--",
+        path.as_posix(),
+    )
+    records = [record for record in listing.split(b"\0") if record]
+    if not records and not required:
+        return None
+    if len(records) != 1:
+        raise ValueError(
+            f"legacy exact dependent base does not contain exactly one {path}"
+        )
+    try:
+        metadata, encoded_path = records[0].split(b"\t", 1)
+        mode, object_type, _object_id = metadata.decode("ascii").split(" ")
+        listed_path = encoded_path.decode("utf-8")
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise ValueError("legacy exact dependent base entry is malformed") from exc
+    if mode != "100644" or object_type != "blob" or listed_path != path.as_posix():
+        raise ValueError(
+            f"legacy exact dependent base path is not regular 0644: {path}"
+        )
+    return _git(repo, "show", f"{base_commit}:{path.as_posix()}")
+
+
+def _exact_file_entries(
+    repo: Path,
+    value: object,
+    *,
+    label: str,
+) -> tuple[list[dict[str, object]], list[PurePosixPath]]:
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"{label} is malformed")
+    entries: list[dict[str, object]] = []
+    paths: list[PurePosixPath] = []
+    for index, item in enumerate(value):
+        if (
+            not isinstance(item, dict)
+            or set(item) != {"path", "sha256"}
+            or not isinstance(item.get("sha256"), str)
+            or DIGEST_PATTERN.fullmatch(item["sha256"]) is None
+        ):
+            raise ValueError(f"{label}[{index}] is malformed")
+        path = _safe_relative_path(
+            item.get("path"),
+            label=f"{label}[{index}].path",
+        )
+        _validate_rulespec_path(repo, path, label=f"{label}[{index}].path")
+        if path in paths:
+            raise ValueError(f"{label} contains duplicate paths")
+        entries.append(item)
+        paths.append(path)
+    return entries, paths
+
+
+def _validate_legacy_exact_dependents(
+    repo: Path,
+    *,
+    root_manifest: PurePosixPath,
+    receipt_relative: PurePosixPath,
+    receipt_sha256: str,
+    receipt: dict[str, object],
+    receipt_replacement: dict[str, object],
+    base_commit: str,
+    authoritative_replacements: dict[str, str],
+    live_manifests: set[PurePosixPath],
+    manifest_payloads: dict[PurePosixPath, dict[str, object]],
+    changed: set[PurePosixPath],
+) -> set[PurePosixPath]:
+    """Verify every v2 exact dependent and return unchanged authorized files."""
+
+    from axiom_encode.cli import (
+        _repair_proof_import_hashes,
+        _strict_legacy_replacement_map,
+    )
+    from axiom_encode.rulespec_path_migration import (
+        PathMigrationPlanError,
+        rewrite_exact_references,
+    )
+
+    raw_dependents = receipt_replacement.get("exact_dependents")
+    if not isinstance(raw_dependents, list):
+        raise ValueError(
+            f"legacy replacement exact_dependents are malformed: {root_manifest}"
+        )
+    unchanged_authorized: set[PurePosixPath] = set()
+    seen_primaries: set[PurePosixPath] = set()
+    seen_group_paths: set[PurePosixPath] = set()
+    seen_manifests: set[PurePosixPath] = set()
+    for index, raw_dependent in enumerate(raw_dependents):
+        label = f"{root_manifest} exact_dependents[{index}]"
+        if not isinstance(raw_dependent, dict) or set(raw_dependent) != {
+            "primary",
+            "legacy_manifest",
+            "legacy_files",
+            "live_files",
+            "rewrites",
+        }:
+            raise ValueError(f"{label} is malformed")
+        primary = _safe_relative_path(
+            raw_dependent.get("primary"),
+            label=f"{label}.primary",
+        )
+        _validate_rulespec_path(repo, primary, label=f"{label}.primary")
+        if primary.name.endswith(".test.yaml") or primary in seen_primaries:
+            raise ValueError(f"{label}.primary is invalid or duplicated")
+        seen_primaries.add(primary)
+
+        manifest_evidence = raw_dependent.get("legacy_manifest")
+        expected_manifest = MANIFEST_ROOT / primary.with_suffix(".json")
+        if (
+            not isinstance(manifest_evidence, dict)
+            or set(manifest_evidence) != {"path", "sha256"}
+            or manifest_evidence.get("path") != expected_manifest.as_posix()
+            or not isinstance(manifest_evidence.get("sha256"), str)
+            or DIGEST_PATTERN.fullmatch(manifest_evidence["sha256"]) is None
+            or expected_manifest in seen_manifests
+        ):
+            raise ValueError(f"{label}.legacy_manifest is malformed")
+        seen_manifests.add(expected_manifest)
+        base_manifest_raw = _base_regular_blob(
+            repo,
+            base_commit,
+            expected_manifest,
+            required=True,
+        )
+        assert base_manifest_raw is not None
+        if hashlib.sha256(base_manifest_raw).hexdigest() != manifest_evidence["sha256"]:
+            raise ValueError(f"{label} legacy manifest base hash differs")
+
+        legacy_files, legacy_paths = _exact_file_entries(
+            repo,
+            raw_dependent.get("legacy_files"),
+            label=f"{label}.legacy_files",
+        )
+        live_files, live_paths = _exact_file_entries(
+            repo,
+            raw_dependent.get("live_files"),
+            label=f"{label}.live_files",
+        )
+        companion = _rulespec_companion_path(primary)
+        companion_raw = _base_regular_blob(
+            repo,
+            base_commit,
+            companion,
+            required=False,
+        )
+        expected_paths = sorted(
+            [primary, *([companion] if companion_raw is not None else [])],
+            key=PurePosixPath.as_posix,
+        )
+        if legacy_paths != expected_paths or live_paths != expected_paths:
+            raise ValueError(f"{label} does not bind the exact full file group")
+        overlap = set(expected_paths) & seen_group_paths
+        if overlap:
+            raise ValueError(f"{label} overlaps another exact dependent group")
+        seen_group_paths.update(expected_paths)
+
+        base_by_path: dict[PurePosixPath, bytes] = {}
+        live_by_path: dict[PurePosixPath, bytes] = {}
+        for file_index, (path, legacy_item, live_item) in enumerate(
+            zip(expected_paths, legacy_files, live_files, strict=True)
+        ):
+            base_raw = _base_regular_blob(
+                repo,
+                base_commit,
+                path,
+                required=True,
+            )
+            assert base_raw is not None
+            live_raw = _read_bounded_regular(
+                repo,
+                path,
+                label=f"{label}.live_files[{file_index}]",
+                max_bytes=16 * 1024 * 1024,
+            )
+            if hashlib.sha256(base_raw).hexdigest() != legacy_item["sha256"]:
+                raise ValueError(f"{label} legacy file base hash differs: {path}")
+            if hashlib.sha256(live_raw).hexdigest() != live_item["sha256"]:
+                raise ValueError(f"{label} live file hash differs: {path}")
+            base_by_path[path] = base_raw
+            live_by_path[path] = live_raw
+
+        raw_rewrites = raw_dependent.get("rewrites")
+        if not isinstance(raw_rewrites, list) or not raw_rewrites:
+            raise ValueError(f"{label}.rewrites is malformed")
+        rewrite_paths: set[PurePosixPath] = set()
+        for rewrite_index, rewrite in enumerate(raw_rewrites):
+            rewrite_label = f"{label}.rewrites[{rewrite_index}]"
+            if not isinstance(rewrite, dict) or set(rewrite) != {
+                "path",
+                "before_sha256",
+                "after_sha256",
+                "replacements",
+                "proof_import_repairs",
+            }:
+                raise ValueError(f"{rewrite_label} is malformed")
+            rewrite_path = _safe_relative_path(
+                rewrite.get("path"),
+                label=f"{rewrite_label}.path",
+            )
+            if rewrite_path not in base_by_path or rewrite_path in rewrite_paths:
+                raise ValueError(f"{rewrite_label}.path is invalid or duplicated")
+            before = rewrite.get("before_sha256")
+            after = rewrite.get("after_sha256")
+            replacement_records = rewrite.get("replacements")
+            if (
+                not isinstance(before, str)
+                or DIGEST_PATTERN.fullmatch(before) is None
+                or not isinstance(after, str)
+                or DIGEST_PATTERN.fullmatch(after) is None
+                or before == after
+                or _strict_legacy_replacement_map(replacement_records) is None
+                or not isinstance(rewrite.get("proof_import_repairs"), int)
+                or isinstance(rewrite.get("proof_import_repairs"), bool)
+                or rewrite["proof_import_repairs"] < 0
+            ):
+                raise ValueError(f"{rewrite_label} proof is malformed")
+            try:
+                expected_live, observed_counts = rewrite_exact_references(
+                    base_by_path[rewrite_path],
+                    authoritative_replacements,
+                )
+                observed_proof_repairs = 0
+                if rewrite_path == primary:
+                    content_root = repo / primary.parts[0]
+                    expected_text, observed_proof_repairs = (
+                        _repair_proof_import_hashes(
+                            expected_live.decode("utf-8"),
+                            target_base=(
+                                f"{content_root.name}:"
+                                f"{PurePosixPath(*primary.parts[1:]).with_suffix('').as_posix()}"
+                            ),
+                            rules_file=repo.joinpath(*primary.parts),
+                            repo_path=content_root,
+                        )
+                    )
+                    expected_live = expected_text.encode("utf-8")
+            except (PathMigrationPlanError, UnicodeError) as exc:
+                raise ValueError(f"{rewrite_label} is unreadable") from exc
+            if (
+                hashlib.sha256(base_by_path[rewrite_path]).hexdigest() != before
+                or hashlib.sha256(live_by_path[rewrite_path]).hexdigest() != after
+                or expected_live != live_by_path[rewrite_path]
+                or list(observed_counts) != replacement_records
+                or rewrite["proof_import_repairs"] != observed_proof_repairs
+                or rewrite_path not in changed
+            ):
+                raise ValueError(f"{rewrite_label} transformation differs")
+            rewrite_paths.add(rewrite_path)
+
+        for path in expected_paths:
+            if path in rewrite_paths:
+                continue
+            if base_by_path[path] != live_by_path[path] or path in changed:
+                raise ValueError(f"{label} unrewritten file differs: {path}")
+            unchanged_authorized.add(path)
+
+        if expected_manifest not in live_manifests or expected_manifest not in changed:
+            raise ValueError(f"{label} lacks a changed exact dependent manifest")
+        dependent_manifest = manifest_payloads[expected_manifest]
+        exact_manifest_fields = {
+            "schema_version",
+            "generated_at",
+            "tool",
+            "axiom_encode_version",
+            "axiom_encode_git",
+            "validation_waiver_set_sha256",
+            "applied_files",
+            "legacy_migration",
+            "signature",
+        }
+        signature = dependent_manifest.get("signature")
+        if (
+            set(dependent_manifest) != exact_manifest_fields
+            or dependent_manifest.get("schema_version")
+            != "axiom-encode/applied-rulespec/v5"
+            or dependent_manifest.get("tool") != LEGACY_EXACT_DEPENDENT_TOOL
+            or dependent_manifest.get("applied_files") != live_files
+            or dependent_manifest.get("axiom_encode_version")
+            != receipt.get("axiom_encode_version")
+            or dependent_manifest.get("axiom_encode_git")
+            != receipt.get("axiom_encode_git")
+            or dependent_manifest.get("validation_waiver_set_sha256")
+            != receipt.get("validation_waiver_set_sha256")
+            or not isinstance(dependent_manifest.get("axiom_encode_version"), str)
+            or not dependent_manifest["axiom_encode_version"]
+            or not isinstance(dependent_manifest.get("axiom_encode_git"), dict)
+            or not isinstance(
+                dependent_manifest.get("validation_waiver_set_sha256"), str
+            )
+            or DIGEST_PATTERN.fullmatch(
+                dependent_manifest["validation_waiver_set_sha256"]
+            )
+            is None
+            or not isinstance(dependent_manifest.get("generated_at"), str)
+            or not dependent_manifest["generated_at"]
+            or not isinstance(signature, dict)
+            or set(signature) != {"algorithm", "key_id", "value"}
+            or not all(
+                isinstance(signature.get(field), str) and signature[field]
+                for field in ("algorithm", "key_id", "value")
+            )
+        ):
+            raise ValueError(f"{label} exact dependent manifest is malformed")
+        migration = dependent_manifest.get("legacy_migration")
+        if not isinstance(migration, dict) or migration != {
+            "receipt_path": receipt_relative.as_posix(),
+            "receipt_sha256": receipt_sha256,
+            "primary": primary.as_posix(),
+            "legacy_manifest_path": expected_manifest.as_posix(),
+            "legacy_manifest_sha256": manifest_evidence["sha256"],
+        }:
+            raise ValueError(f"{label} exact dependent manifest binding differs")
+    return unchanged_authorized
+
+
 def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
     changed = _changed_paths(repo)
     manifests = {
@@ -421,6 +758,7 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
         )
 
     authorized = set(live_manifests)
+    authorized_unchanged: set[PurePosixPath] = set()
     for relative, payload in manifest_payloads.items():
         replacement = payload.get("replacement")
         receipt_rewrites: set[PurePosixPath] = set()
@@ -452,9 +790,13 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                     f"legacy replacement receipt digest differs: {relative}"
                 )
             receipt = json.loads(receipt_raw.decode("utf-8"))
+            receipt_schema = receipt.get("schema_version")
             if (
-                receipt.get("schema_version")
-                != "axiom-encode/legacy-fresh-reencode-receipt/v1"
+                receipt_schema
+                not in {
+                    LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V1,
+                    LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
+                }
                 or receipt.get("tool") != LEGACY_REPLACEMENT_TOOL
             ):
                 raise ValueError(
@@ -489,6 +831,7 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
             live_files = receipt_replacement.get("live_files")
             legacy_files = legacy.get("files")
             scheduled_dependents = receipt_replacement.get("scheduled_dependents")
+            exact_dependents = receipt_replacement.get("exact_dependents")
             if not isinstance(raw_rewrites, list):
                 raise ValueError(
                     f"legacy replacement receipt rewrites are malformed: {relative}"
@@ -500,6 +843,15 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
             ):
                 raise ValueError(
                     f"legacy replacement receipt file sets are malformed: {relative}"
+                )
+            if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V1:
+                if "exact_dependents" in receipt_replacement:
+                    raise ValueError(
+                        f"legacy replacement v1 receipt has v2 fields: {relative}"
+                    )
+            elif not isinstance(exact_dependents, list):
+                raise ValueError(
+                    f"legacy replacement exact_dependents are malformed: {relative}"
                 )
             nested_manifest = payload.get("replacement_manifest")
             if (
@@ -805,6 +1157,22 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                     f"legacy replacement reference inventory differs: {relative}: "
                     + "; ".join(inventory_issues)
                 )
+            if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2:
+                authorized_unchanged.update(
+                    _validate_legacy_exact_dependents(
+                        repo,
+                        root_manifest=relative,
+                        receipt_relative=receipt_relative,
+                        receipt_sha256=hashlib.sha256(receipt_raw).hexdigest(),
+                        receipt=receipt,
+                        receipt_replacement=receipt_replacement,
+                        base_commit=str(base_commit or ""),
+                        authoritative_replacements=authoritative_replacements,
+                        live_manifests=live_manifests,
+                        manifest_payloads=manifest_payloads,
+                        changed=changed,
+                    )
+                )
             authorized.update({receipt_relative, old_manifest_path, *receipt_rewrites})
 
         applied_files = payload.get("applied_files")
@@ -827,6 +1195,7 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
             + ", ".join(map(str, sorted(deleted_manifests - authorized)))
         )
 
+    authorized.difference_update(authorized_unchanged)
     unexpected = changed - authorized
     missing = authorized - changed
     if unexpected:

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -627,16 +627,14 @@ def _validate_legacy_exact_dependents(
                 observed_proof_repairs = 0
                 if rewrite_path == primary:
                     content_root = repo / primary.parts[0]
-                    expected_text, observed_proof_repairs = (
-                        _repair_proof_import_hashes(
-                            expected_live.decode("utf-8"),
-                            target_base=(
-                                f"{content_root.name}:"
-                                f"{PurePosixPath(*primary.parts[1:]).with_suffix('').as_posix()}"
-                            ),
-                            rules_file=repo.joinpath(*primary.parts),
-                            repo_path=content_root,
-                        )
+                    expected_text, observed_proof_repairs = _repair_proof_import_hashes(
+                        expected_live.decode("utf-8"),
+                        target_base=(
+                            f"{content_root.name}:"
+                            f"{PurePosixPath(*primary.parts[1:]).with_suffix('').as_posix()}"
+                        ),
+                        rules_file=repo.joinpath(*primary.parts),
+                        repo_path=content_root,
                     )
                     expected_live = expected_text.encode("utf-8")
             except (PathMigrationPlanError, UnicodeError) as exc:

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1418"
+__version__ = "0.2.1419"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1419"
+__version__ = "0.2.1420"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -19612,8 +19612,7 @@ def _manifest_coverage_by_file(
                 and _normalized_manifest_backend(replacement_manifest)
                 in APPLIED_ENCODING_GENERATED_BACKENDS
             )
-            or payload.get("tool")
-            == APPLIED_ENCODING_LEGACY_EXACT_DEPENDENT_TOOL
+            or payload.get("tool") == APPLIED_ENCODING_LEGACY_EXACT_DEPENDENT_TOOL
         )
         applied_files = payload.get("applied_files")
         if not isinstance(applied_files, list):
@@ -20123,8 +20122,7 @@ def _applied_manifest_tool_execution_issues(
         applied_files = payload.get("applied_files")
         if tool == APPLIED_ENCODING_LEGACY_EXACT_DEPENDENT_TOOL:
             if not isinstance(applied_files, list) or any(
-                not isinstance(item, dict)
-                or set(item) != {"path", "sha256"}
+                not isinstance(item, dict) or set(item) != {"path", "sha256"}
                 for item in applied_files
             ):
                 issues.append(
@@ -21482,8 +21480,7 @@ def _legacy_replacement_manifest_issues(
         ),
         exact_dependents=(
             receipt_exact_dependents
-            if receipt_schema
-            == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+            if receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
             else None
         ),
     )
@@ -21580,21 +21577,22 @@ def _legacy_replacement_manifest_issues(
         or legacy.get("trusted_generated_provenance") is not False
         or not isinstance(replacement, dict)
         or set(replacement)
-        != ({
-            "source",
-            "destination",
-            "model_manifest_path",
-            "model_manifest_sha256",
-            "live_files",
-            "rewrites",
-            "scheduled_dependents",
-        }
-        | (
-            {"exact_dependents"}
-            if receipt_schema
-            == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
-            else set()
-        ))
+        != (
+            {
+                "source",
+                "destination",
+                "model_manifest_path",
+                "model_manifest_sha256",
+                "live_files",
+                "rewrites",
+                "scheduled_dependents",
+            }
+            | (
+                {"exact_dependents"}
+                if receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+                else set()
+            )
+        )
     ):
         return [*issues, f"{manifest_label} legacy evidence classification is invalid"]
     if replacement.get("live_files") != nested.get("applied_files"):
@@ -21971,10 +21969,7 @@ def _legacy_replacement_manifest_issues(
                 f"{manifest_label} cannot prove exact dependent manifest: {exc}"
             )
             continue
-        if (
-            hashlib.sha256(legacy_manifest_raw).hexdigest()
-            != legacy_manifest["sha256"]
-        ):
+        if hashlib.sha256(legacy_manifest_raw).hexdigest() != legacy_manifest["sha256"]:
             issues.append(
                 f"{manifest_label} exact dependent legacy manifest hash is stale"
             )
@@ -22011,16 +22006,12 @@ def _legacy_replacement_manifest_issues(
                 return None
             return parsed
 
-        legacy_hashes = exact_file_map(
-            dependent["legacy_files"], label="legacy file"
-        )
+        legacy_hashes = exact_file_map(dependent["legacy_files"], label="legacy file")
         live_hashes = exact_file_map(dependent["live_files"], label="live file")
         if legacy_hashes is None or live_hashes is None:
             continue
         try:
-            legacy_manifest_payload = json.loads(
-                legacy_manifest_raw.decode("utf-8")
-            )
+            legacy_manifest_payload = json.loads(legacy_manifest_raw.decode("utf-8"))
         except (UnicodeError, json.JSONDecodeError, RecursionError):
             legacy_manifest_payload = None
         legacy_manifest_issues = _legacy_manual_manifest_issues(
@@ -22052,9 +22043,7 @@ def _legacy_replacement_manifest_issues(
         expected_rewrite_paths: set[Path] = set()
         for path in sorted(expected_group, key=Path.as_posix):
             try:
-                base_raw = _rulespec_migration_base_blob(
-                    repo_path, base_commit, path
-                )
+                base_raw = _rulespec_migration_base_blob(repo_path, base_commit, path)
                 live_raw = read_bounded_regular_file(
                     repo_path,
                     repo_path / path,
@@ -22068,16 +22057,14 @@ def _legacy_replacement_manifest_issues(
                 proof_import_repairs = 0
                 if path == primary_path:
                     content_root = repo_path / primary_path.parts[0]
-                    rewritten_text, proof_import_repairs = (
-                        _repair_proof_import_hashes(
-                            rewritten.decode("utf-8"),
-                            target_base=(
-                                f"{content_root.name}:"
-                                f"{_relative_rulespec_import_target(Path(*path.parts[1:]))}"
-                            ),
-                            rules_file=repo_path / path,
-                            repo_path=content_root,
-                        )
+                    rewritten_text, proof_import_repairs = _repair_proof_import_hashes(
+                        rewritten.decode("utf-8"),
+                        target_base=(
+                            f"{content_root.name}:"
+                            f"{_relative_rulespec_import_target(Path(*path.parts[1:]))}"
+                        ),
+                        rules_file=repo_path / path,
+                        repo_path=content_root,
                     )
                     rewritten = rewritten_text.encode("utf-8")
             except (
@@ -22153,8 +22140,7 @@ def _legacy_replacement_manifest_issues(
                     or rewrite.get("before_sha256") != before_sha256
                     or rewrite.get("after_sha256") != after_sha256
                     or rewrite.get("replacements") != list(counts)
-                    or rewrite.get("proof_import_repairs")
-                    != proof_import_repairs
+                    or rewrite.get("proof_import_repairs") != proof_import_repairs
                     or not isinstance(
                         rewrite.get("proof_import_repairs"),
                         int,
@@ -22199,8 +22185,7 @@ def _legacy_replacement_manifest_issues(
         }
         if (
             not isinstance(dependent_manifest, dict)
-            or set(dependent_manifest)
-            != _LEGACY_EXACT_DEPENDENT_APPLY_MANIFEST_FIELDS
+            or set(dependent_manifest) != _LEGACY_EXACT_DEPENDENT_APPLY_MANIFEST_FIELDS
             or dependent_manifest.get("schema_version")
             != APPLIED_ENCODING_MANIFEST_SCHEMA
             or dependent_manifest.get("tool")
@@ -22211,8 +22196,7 @@ def _legacy_replacement_manifest_issues(
             != payload.get("axiom_encode_git")
             or dependent_manifest.get(VALIDATION_WAIVER_SET_SHA256_FIELD)
             != expected_waiver_set_sha256
-            or dependent_manifest.get("applied_files")
-            != dependent["live_files"]
+            or dependent_manifest.get("applied_files") != dependent["live_files"]
             or dependent_manifest.get("legacy_migration") != expected_migration
             or _applied_encoding_manifest_signature_issue(
                 dependent_manifest, signing_broker
@@ -22421,21 +22405,22 @@ def _legacy_exact_dependent_manifest_issues(
     if (
         receipt.get("axiom_encode_version") != payload.get("axiom_encode_version")
         or receipt.get("axiom_encode_git") != payload.get("axiom_encode_git")
-        or receipt.get(VALIDATION_WAIVER_SET_SHA256_FIELD)
-        != expected_waiver_set_sha256
+        or receipt.get(VALIDATION_WAIVER_SET_SHA256_FIELD) != expected_waiver_set_sha256
     ):
         issues.append(f"{manifest_label} exact dependent provenance is stale")
     replacement = receipt.get("replacement")
     exact_dependents = (
-        replacement.get("exact_dependents")
-        if isinstance(replacement, dict)
-        else None
+        replacement.get("exact_dependents") if isinstance(replacement, dict) else None
     )
-    matches = [
-        item
-        for item in exact_dependents
-        if isinstance(item, dict) and item.get("primary") == primary_raw
-    ] if isinstance(exact_dependents, list) else []
+    matches = (
+        [
+            item
+            for item in exact_dependents
+            if isinstance(item, dict) and item.get("primary") == primary_raw
+        ]
+        if isinstance(exact_dependents, list)
+        else []
+    )
     if len(matches) != 1:
         return [
             *issues,
@@ -23931,9 +23916,7 @@ def _resolve_legacy_replacement_contract(
             ) from exc
         dependent_issues = _legacy_manual_manifest_issues(
             dependent_manifest_payload,
-            expected_files={
-                item.path.as_posix(): item.sha256 for item in group_files
-            },
+            expected_files={item.path.as_posix(): item.sha256 for item in group_files},
             allow_unmarked_manual_exception=True,
         )
         if dependent_issues:
@@ -24134,14 +24117,11 @@ def _resolve_encode_replacement_target(
         Path(path) for path in getattr(args, "legacy_dependent_rulespec_path", ())
     )
     exact_dependents = tuple(
-        Path(path)
-        for path in getattr(args, "legacy_exact_dependent_rulespec_path", ())
+        Path(path) for path in getattr(args, "legacy_exact_dependent_rulespec_path", ())
     )
     if raw_path is None and legacy_source is None:
         if scheduled_dependents or exact_dependents:
-            raise ValueError(
-                "legacy dependent paths require a legacy replacement"
-            )
+            raise ValueError("legacy dependent paths require a legacy replacement")
         return None
     if raw_path is None:
         raise ValueError(
@@ -45824,9 +45804,7 @@ def _stage_signed_legacy_replacement_provenance(
 
     exact_dependent_manifests: dict[Path, bytes] = {}
     for dependent in contract.exact_dependents:
-        dependent_manifest_relative = _applied_encoding_manifest_path(
-            dependent.primary
-        )
+        dependent_manifest_relative = _applied_encoding_manifest_path(dependent.primary)
         exact_manifest = {
             "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
             "generated_at": _utc_now_iso(),
@@ -47068,9 +47046,9 @@ def _require_apply_post_install_closure(
         for dependent in legacy_replacement.exact_dependents:
             for live_file in dependent.live_files:
                 if live_file.path.parts[:1] == (content_root.name,):
-                    expected_post_files[
-                        Path(*live_file.path.parts[1:]).as_posix()
-                    ] = live_file.sha256
+                    expected_post_files[Path(*live_file.path.parts[1:]).as_posix()] = (
+                        live_file.sha256
+                    )
     for relative, raw in planned.items():
         expected_post_files[_canonical_apply_relative_path(relative).as_posix()] = (
             hashlib.sha256(raw).hexdigest()
@@ -47126,9 +47104,7 @@ def _require_apply_post_install_closure(
                         "Cannot keep legacy replacement: exact dependent changed "
                         f"for {target}"
                     )
-            dependent_manifest_path = _applied_encoding_manifest_path(
-                dependent.primary
-            )
+            dependent_manifest_path = _applied_encoding_manifest_path(dependent.primary)
             expected_manifest = exact_manifest_bytes.get(dependent_manifest_path)
             if (
                 expected_manifest is None
@@ -47353,9 +47329,9 @@ def _apply_generated_encoding_result(
         for dependent in legacy_replacement.exact_dependents:
             for item in dependent.legacy_files:
                 expected_originals[checkout_root / item.path] = item.sha256
-            expected_originals[
-                checkout_root / dependent.legacy_manifest.path
-            ] = dependent.legacy_manifest.sha256
+            expected_originals[checkout_root / dependent.legacy_manifest.path] = (
+                dependent.legacy_manifest.sha256
+            )
         assert receipt_relative is not None
         expected_originals[checkout_root / receipt_relative] = None
     new_manifest_applied_files = {
@@ -47438,9 +47414,7 @@ def _apply_generated_encoding_result(
             for dependent in legacy_replacement.exact_dependents
             for item in dependent.live_files
         )
-        applied.extend(
-            checkout_root / path for path in exact_dependent_manifest_bytes
-        )
+        applied.extend(checkout_root / path for path in exact_dependent_manifest_bytes)
     if wrote_empty_companion_test:
         print("  apply=generated_empty_deferred_companion_test")
     return applied
@@ -48195,9 +48169,7 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
                     )
                 rewrite_target.write_bytes(rewrite.raw)
             for dependent in legacy_replacement.exact_dependents:
-                legacy_by_path = {
-                    item.path: item for item in dependent.legacy_files
-                }
+                legacy_by_path = {item.path: item for item in dependent.legacy_files}
                 for live_file in dependent.live_files:
                     legacy_file = legacy_by_path.get(live_file.path)
                     exact_target = overlay_repo / live_file.path
@@ -50658,9 +50630,7 @@ def _finalize_legacy_exact_dependents_from_overlay(
                 )
                 continue
 
-            replacements = _strict_legacy_replacement_map(
-                list(rewrite.replacements)
-            )
+            replacements = _strict_legacy_replacement_map(list(rewrite.replacements))
             if replacements is None:
                 issues.append(
                     "Legacy exact dependent reference proof is malformed for "
@@ -50687,13 +50657,11 @@ def _finalize_legacy_exact_dependents_from_overlay(
             proof_import_repairs = 0
             if legacy_file.path == dependent.primary:
                 try:
-                    expected_text, proof_import_repairs = (
-                        _repair_proof_import_hashes(
-                            expected_raw.decode("utf-8"),
-                            target_base=target_base,
-                            rules_file=live_path,
-                            repo_path=overlay_content_root,
-                        )
+                    expected_text, proof_import_repairs = _repair_proof_import_hashes(
+                        expected_raw.decode("utf-8"),
+                        target_base=target_base,
+                        rules_file=live_path,
+                        repo_path=overlay_content_root,
                     )
                     expected_raw = expected_text.encode("utf-8")
                 except UnicodeError:
@@ -50702,11 +50670,9 @@ def _finalize_legacy_exact_dependents_from_overlay(
                         f"{legacy_file.path.as_posix()}"
                     )
                     continue
-            if (
-                live_raw != expected_raw
-                or _migration_corpus_citations(legacy_file.raw)
-                != _migration_corpus_citations(live_raw)
-            ):
+            if live_raw != expected_raw or _migration_corpus_citations(
+                legacy_file.raw
+            ) != _migration_corpus_citations(live_raw):
                 issues.append(
                     "Legacy exact dependent final transformation is not limited "
                     "to authenticated reference and proof-import hash rewrites for "

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -257,6 +257,9 @@ from .harness.validator_pipeline import (
     repair_source_table_band_scalar_parameters,
 )
 from .legacy_replacement import (
+    EXACT_DEPENDENT_TOOL as APPLIED_ENCODING_LEGACY_EXACT_DEPENDENT_TOOL,
+)
+from .legacy_replacement import (
     LEGACY_OWNER_CLASS as APPLIED_ENCODING_LEGACY_OWNER_CLASS,
 )
 from .legacy_replacement import (
@@ -266,10 +269,16 @@ from .legacy_replacement import (
     RECEIPT_SCHEMA as APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
 )
 from .legacy_replacement import (
+    RECEIPT_SCHEMA_V1 as APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V1,
+)
+from .legacy_replacement import (
     TOOL as APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL,
 )
 from .legacy_replacement import (
     LegacyReplacementContract as _LegacyReplacementContract,
+)
+from .legacy_replacement import (
+    LegacyReplacementExactDependent as _LegacyReplacementExactDependent,
 )
 from .legacy_replacement import (
     LegacyReplacementFile as _LegacyReplacementFile,
@@ -456,6 +465,19 @@ _LEGACY_REPLACEMENT_APPLY_MANIFEST_FIELDS = frozenset(
         "replacement_manifest",
         "replacement",
         "source_attestation",
+        "signature",
+    }
+)
+_LEGACY_EXACT_DEPENDENT_APPLY_MANIFEST_FIELDS = frozenset(
+    {
+        "schema_version",
+        "generated_at",
+        "tool",
+        "axiom_encode_version",
+        "axiom_encode_git",
+        VALIDATION_WAIVER_SET_SHA256_FIELD,
+        "applied_files",
+        "legacy_migration",
         "signature",
     }
 )
@@ -2164,6 +2186,19 @@ def main():
             "Exact protected direct-dependent primary scheduled for a fresh "
             "reencode in the same legacy replacement workflow. Repeat once per "
             "dependent; no other protected old references are admitted."
+        ),
+    )
+    encode_parser.add_argument(
+        "--legacy-exact-dependent-rulespec-path",
+        action="append",
+        default=[],
+        type=Path,
+        help=(
+            "Exact protected legacy v1/manual direct-dependent primary whose "
+            "base bytes may change only by the scheduled canonical reference "
+            "rewrite. Repeat once per composite dependent; each full primary/test "
+            "group and old manifest is bound to clean HEAD and replaced atomically "
+            "with signed v5 migration provenance."
         ),
     )
     _add_complete_source_unit_argument(encode_parser)
@@ -6840,6 +6875,23 @@ def _legacy_replacement_reference_inventory_issues(
             for item in files:
                 if isinstance(item, dict):
                     classify(item.get("path"), "scheduled dependent")
+    exact = replacement.get("exact_dependents")
+    exact_manifest_paths: set[Path] = set()
+    if isinstance(exact, list):
+        for dependent in exact:
+            if not isinstance(dependent, dict):
+                continue
+            exact_manifest = dependent.get("legacy_manifest")
+            if isinstance(exact_manifest, dict) and isinstance(
+                exact_manifest.get("path"), str
+            ):
+                exact_manifest_paths.add(Path(exact_manifest["path"]))
+            exact_rewrites = dependent.get("rewrites")
+            if not isinstance(exact_rewrites, list):
+                continue
+            for item in exact_rewrites:
+                if isinstance(item, dict):
+                    classify(item.get("path"), "exact dependent")
 
     legacy_manifest = legacy.get("manifest")
     legacy_manifest_path = (
@@ -6861,6 +6913,11 @@ def _legacy_replacement_reference_inventory_issues(
             issues.append("in-place legacy replacement must not rewrite metadata")
         if replacement.get("scheduled_dependents") != []:
             issues.append("in-place legacy replacement cannot schedule path dependents")
+        if (
+            "exact_dependents" in replacement
+            and replacement.get("exact_dependents") != []
+        ):
+            issues.append("in-place legacy replacement cannot migrate exact dependents")
         return issues
 
     try:
@@ -6980,7 +7037,11 @@ def _legacy_replacement_reference_inventory_issues(
     hit_paths: set[Path] = set()
     base_hit_bytes: dict[Path, bytes] = {}
     for path in sorted(candidate_paths, key=Path.as_posix):
-        if path in deleted_paths or path == legacy_manifest_path:
+        if (
+            path in deleted_paths
+            or path == legacy_manifest_path
+            or path in exact_manifest_paths
+        ):
             continue
         mode, object_id, size = base_entries[path]
         if size is None:
@@ -7045,7 +7106,7 @@ def _legacy_replacement_reference_inventory_issues(
             )
             continue
         if _is_protected_rulespec_yaml_path(path, roots=roots):
-            if owner != "scheduled dependent":
+            if owner not in {"scheduled dependent", "exact dependent"}:
                 issues.append(
                     "legacy replacement base reference inventory omits protected "
                     f"dependent {path.as_posix()}"
@@ -7218,7 +7279,10 @@ def _legacy_replacement_pending_paths(repo_path: Path) -> list[str]:
             not isinstance(receipt, dict)
             or set(receipt) != _LEGACY_REPLACEMENT_RECEIPT_FIELDS
             or receipt.get("schema_version")
-            != APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+            not in {
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V1,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
+            }
             or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
             or hashlib.sha256(receipt_raw).hexdigest() != binding.get("receipt_sha256")
             or _applied_encoding_manifest_signature_issue(receipt, signing_broker)
@@ -7442,7 +7506,10 @@ def _legacy_replacement_pending_paths(repo_path: Path) -> list[str]:
             or not isinstance(receipt, dict)
             or set(receipt) != _LEGACY_REPLACEMENT_RECEIPT_FIELDS
             or receipt.get("schema_version")
-            != APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+            not in {
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V1,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
+            }
             or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
             or _applied_encoding_manifest_signature_issue(receipt, signing_broker)
             or receipt_relative not in bound_receipts
@@ -19502,9 +19569,9 @@ def _manifest_coverage_by_file(
     """Map each non-deleted covered file to a list of covering-manifest records.
 
     Each record is ``{"manifest": label, "backend": normalized_backend,
-    "is_generated": bool}`` where ``is_generated`` means the backend is a
-    recognized model encoder. Payloads come only from the canonical v3
-    verifier.
+    "is_generated": bool}`` where ``is_generated`` means the file is owned by
+    either a recognized encoder or an authenticated exact legacy migration.
+    Payloads come only from the canonical v5 verifier.
     """
     if expected_encoder_identity is None:
         try:
@@ -19545,6 +19612,8 @@ def _manifest_coverage_by_file(
                 and _normalized_manifest_backend(replacement_manifest)
                 in APPLIED_ENCODING_GENERATED_BACKENDS
             )
+            or payload.get("tool")
+            == APPLIED_ENCODING_LEGACY_EXACT_DEPENDENT_TOOL
         )
         applied_files = payload.get("applied_files")
         if not isinstance(applied_files, list):
@@ -19594,6 +19663,8 @@ def _applied_manifest_source_attestation_issues(
 ) -> list[str]:
     """Validate source provenance claimed by an applied encoding manifest."""
 
+    if payload.get("tool") == APPLIED_ENCODING_LEGACY_EXACT_DEPENDENT_TOOL:
+        return []
     backend = _normalized_manifest_backend(payload)
     attestation_claimed = "source_attestation" in payload
     attestation = payload.get("source_attestation")
@@ -20050,6 +20121,36 @@ def _applied_manifest_tool_execution_issues(
         return issues
     if backend is None:
         applied_files = payload.get("applied_files")
+        if tool == APPLIED_ENCODING_LEGACY_EXACT_DEPENDENT_TOOL:
+            if not isinstance(applied_files, list) or any(
+                not isinstance(item, dict)
+                or set(item) != {"path", "sha256"}
+                for item in applied_files
+            ):
+                issues.append(
+                    f"{manifest_label} exact dependent migration has malformed "
+                    "file entries"
+                )
+            if (
+                "deterministic_execution" in payload
+                or "validation_execution" in payload
+                or "source_attestation" in payload
+            ):
+                issues.append(
+                    f"{manifest_label} exact dependent migration must preserve "
+                    "receipt-bound provenance"
+                )
+            provenance = payload.get("axiom_encode_git")
+            if not isinstance(provenance, dict) or (
+                provenance.get("commit") != expected_encoder_identity.get("commit")
+                or provenance.get("version") != expected_encoder_identity.get("version")
+                or provenance.get("dirty_tracked") is not False
+            ):
+                issues.append(
+                    f"{manifest_label} exact dependent migration does not match "
+                    "the running pinned encoder"
+                )
+            return issues
         if tool == APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL:
             replacement_manifest = payload.get("replacement_manifest")
             if (
@@ -20187,6 +20288,10 @@ def _applied_manifest_exact_schema_issues(
         expected_fields = _LEGACY_REPLACEMENT_APPLY_MANIFEST_FIELDS
         expected_item_fields = None
         contract = "legacy replacement"
+    elif backend is None and tool == APPLIED_ENCODING_LEGACY_EXACT_DEPENDENT_TOOL:
+        expected_fields = _LEGACY_EXACT_DEPENDENT_APPLY_MANIFEST_FIELDS
+        expected_item_fields = _MODEL_APPLIED_FILE_FIELDS
+        contract = "legacy exact dependent"
     else:
         return []
 
@@ -21312,6 +21417,13 @@ def _legacy_replacement_manifest_issues(
     receipt_repository = receipt.get("repository")
     receipt_replacement = receipt.get("replacement")
     receipt_legacy = receipt.get("legacy")
+    receipt_schema = receipt.get("schema_version")
+    receipt_exact_dependents = (
+        receipt_replacement.get("exact_dependents")
+        if isinstance(receipt_replacement, dict)
+        and isinstance(receipt_replacement.get("exact_dependents"), list)
+        else []
+    )
     identity_payload = receipt_identity_payload(
         base_commit=(
             str(receipt_repository.get("base_commit"))
@@ -21368,6 +21480,12 @@ def _legacy_replacement_manifest_issues(
             and isinstance(receipt_replacement.get("scheduled_dependents"), list)
             else []
         ),
+        exact_dependents=(
+            receipt_exact_dependents
+            if receipt_schema
+            == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+            else None
+        ),
     )
     if binding.get(
         "receipt_sha256"
@@ -21376,8 +21494,11 @@ def _legacy_replacement_manifest_issues(
     ):
         issues.append(f"{manifest_label} replacement receipt identity is stale")
     if (
-        receipt.get("schema_version")
-        != APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+        receipt_schema
+        not in {
+            APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V1,
+            APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
+        }
         or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
     ):
         issues.append(f"{manifest_label} replacement receipt schema is invalid")
@@ -21459,7 +21580,7 @@ def _legacy_replacement_manifest_issues(
         or legacy.get("trusted_generated_provenance") is not False
         or not isinstance(replacement, dict)
         or set(replacement)
-        != {
+        != ({
             "source",
             "destination",
             "model_manifest_path",
@@ -21468,6 +21589,12 @@ def _legacy_replacement_manifest_issues(
             "rewrites",
             "scheduled_dependents",
         }
+        | (
+            {"exact_dependents"}
+            if receipt_schema
+            == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+            else set()
+        ))
     ):
         return [*issues, f"{manifest_label} legacy evidence classification is invalid"]
     if replacement.get("live_files") != nested.get("applied_files"):
@@ -21770,6 +21897,332 @@ def _legacy_replacement_manifest_issues(
                 f"v5 model manifest for {primary}"
             )
 
+    exact_dependents = replacement.get("exact_dependents", [])
+    if not isinstance(exact_dependents, list):
+        issues.append(f"{manifest_label} exact dependents are malformed")
+        exact_dependents = []
+    seen_exact_primaries: set[str] = set()
+    seen_exact_files: set[str] = set()
+    for dependent in exact_dependents:
+        if (
+            not isinstance(dependent, dict)
+            or set(dependent)
+            != {
+                "primary",
+                "legacy_manifest",
+                "legacy_files",
+                "live_files",
+                "rewrites",
+            }
+            or not isinstance(dependent.get("primary"), str)
+            or not isinstance(dependent.get("legacy_manifest"), dict)
+            or not isinstance(dependent.get("legacy_files"), list)
+            or not isinstance(dependent.get("live_files"), list)
+            or not isinstance(dependent.get("rewrites"), list)
+        ):
+            issues.append(f"{manifest_label} exact dependent is malformed")
+            continue
+        primary = str(dependent["primary"])
+        primary_path = Path(primary)
+        if (
+            primary in seen_exact_primaries
+            or primary_path.is_absolute()
+            or primary_path.as_posix() != primary
+            or any(part in {"", ".", ".."} for part in primary_path.parts)
+            or not _is_protected_rulespec_yaml_path(
+                primary_path,
+                roots=tuple(sorted(RULESPEC_ATOMIC_MODULE_ROOTS)),
+            )
+            or primary_path.name.endswith(RULESPEC_TEST_FILE_SUFFIX)
+        ):
+            issues.append(
+                f"{manifest_label} exact dependent primary is invalid or duplicated"
+            )
+            continue
+        seen_exact_primaries.add(primary)
+        expected_group = {primary_path}
+        try:
+            _rulespec_migration_base_blob(
+                repo_path, base_commit, companion_path(primary_path)
+            )
+        except RuntimeError:
+            pass
+        else:
+            expected_group.add(companion_path(primary_path))
+
+        legacy_manifest = dependent["legacy_manifest"]
+        dependent_manifest_path = _applied_encoding_manifest_path(primary_path)
+        if (
+            set(legacy_manifest) != {"path", "sha256"}
+            or legacy_manifest.get("path") != dependent_manifest_path.as_posix()
+            or not isinstance(legacy_manifest.get("sha256"), str)
+            or _SHA256_HEX_PATTERN.fullmatch(str(legacy_manifest["sha256"])) is None
+        ):
+            issues.append(
+                f"{manifest_label} exact dependent legacy manifest is malformed"
+            )
+            continue
+        try:
+            legacy_manifest_raw = _rulespec_migration_base_blob(
+                repo_path, base_commit, dependent_manifest_path
+            )
+        except RuntimeError as exc:
+            issues.append(
+                f"{manifest_label} cannot prove exact dependent manifest: {exc}"
+            )
+            continue
+        if (
+            hashlib.sha256(legacy_manifest_raw).hexdigest()
+            != legacy_manifest["sha256"]
+        ):
+            issues.append(
+                f"{manifest_label} exact dependent legacy manifest hash is stale"
+            )
+
+        def exact_file_map(
+            raw_entries: object, *, label: str
+        ) -> dict[Path, str] | None:
+            if not isinstance(raw_entries, list):
+                return None
+            parsed: dict[Path, str] = {}
+            for entry in raw_entries:
+                if (
+                    not isinstance(entry, dict)
+                    or set(entry) != {"path", "sha256"}
+                    or not isinstance(entry.get("path"), str)
+                    or not isinstance(entry.get("sha256"), str)
+                    or _SHA256_HEX_PATTERN.fullmatch(str(entry["sha256"])) is None
+                ):
+                    issues.append(
+                        f"{manifest_label} exact dependent {label} entry is malformed"
+                    )
+                    return None
+                path = Path(str(entry["path"]))
+                if path in parsed or path not in expected_group:
+                    issues.append(
+                        f"{manifest_label} exact dependent {label} path is invalid"
+                    )
+                    return None
+                parsed[path] = str(entry["sha256"])
+            if set(parsed) != expected_group:
+                issues.append(
+                    f"{manifest_label} exact dependent {label} group is incomplete"
+                )
+                return None
+            return parsed
+
+        legacy_hashes = exact_file_map(
+            dependent["legacy_files"], label="legacy file"
+        )
+        live_hashes = exact_file_map(dependent["live_files"], label="live file")
+        if legacy_hashes is None or live_hashes is None:
+            continue
+        try:
+            legacy_manifest_payload = json.loads(
+                legacy_manifest_raw.decode("utf-8")
+            )
+        except (UnicodeError, json.JSONDecodeError, RecursionError):
+            legacy_manifest_payload = None
+        legacy_manifest_issues = _legacy_manual_manifest_issues(
+            legacy_manifest_payload,
+            expected_files={
+                path.as_posix(): digest for path, digest in legacy_hashes.items()
+            },
+            allow_unmarked_manual_exception=True,
+        )
+        if legacy_manifest_issues:
+            issues.append(
+                f"{manifest_label} exact dependent legacy ownership is invalid: "
+                + "; ".join(legacy_manifest_issues)
+            )
+        if seen_exact_files & {path.as_posix() for path in expected_group}:
+            issues.append(f"{manifest_label} exact dependent files overlap")
+            continue
+        seen_exact_files.update(path.as_posix() for path in expected_group)
+
+        rewrite_entries = dependent["rewrites"]
+        rewrite_by_path = {
+            Path(str(item.get("path"))): item
+            for item in rewrite_entries
+            if isinstance(item, dict) and isinstance(item.get("path"), str)
+        }
+        if len(rewrite_by_path) != len(rewrite_entries):
+            issues.append(f"{manifest_label} exact dependent rewrites are malformed")
+            continue
+        expected_rewrite_paths: set[Path] = set()
+        for path in sorted(expected_group, key=Path.as_posix):
+            try:
+                base_raw = _rulespec_migration_base_blob(
+                    repo_path, base_commit, path
+                )
+                live_raw = read_bounded_regular_file(
+                    repo_path,
+                    repo_path / path,
+                    label="legacy exact dependent live file",
+                    max_bytes=16 * 1024 * 1024,
+                    required_mode=0o644,
+                )
+                rewritten, counts = rewrite_exact_references(
+                    base_raw, authoritative_replacements
+                )
+                proof_import_repairs = 0
+                if path == primary_path:
+                    content_root = repo_path / primary_path.parts[0]
+                    rewritten_text, proof_import_repairs = (
+                        _repair_proof_import_hashes(
+                            rewritten.decode("utf-8"),
+                            target_base=(
+                                f"{content_root.name}:"
+                                f"{_relative_rulespec_import_target(Path(*path.parts[1:]))}"
+                            ),
+                            rules_file=repo_path / path,
+                            repo_path=content_root,
+                        )
+                    )
+                    rewritten = rewritten_text.encode("utf-8")
+            except (
+                OSError,
+                RuntimeError,
+                UnsafeCorpusPathError,
+                UnicodeError,
+                PathMigrationPlanError,
+            ) as exc:
+                issues.append(
+                    f"{manifest_label} cannot prove exact dependent {path}: {exc}"
+                )
+                continue
+            before_sha256 = hashlib.sha256(base_raw).hexdigest()
+            after_sha256 = hashlib.sha256(live_raw).hexdigest()
+            if (
+                legacy_hashes[path] != before_sha256
+                or live_hashes[path] != after_sha256
+                or rewritten != live_raw
+                or _migration_corpus_citations(base_raw)
+                != _migration_corpus_citations(live_raw)
+            ):
+                issues.append(
+                    f"{manifest_label} exact dependent transformation is stale "
+                    f"for {path}"
+                )
+            if path == primary_path and local_corpus_release is not None:
+                try:
+                    live_payload = yaml.safe_load(live_raw.decode("utf-8"))
+                    live_module = (
+                        live_payload.get("module")
+                        if isinstance(live_payload, dict)
+                        else None
+                    )
+                    live_verification = (
+                        live_module.get("source_verification")
+                        if isinstance(live_module, dict)
+                        else None
+                    )
+                    live_citations = (
+                        _legacy_source_verification_citation_paths(live_verification)
+                        if isinstance(live_verification, dict)
+                        else ()
+                    )
+                    if not live_citations:
+                        raise ValueError("source history is empty")
+                    for citation in live_citations:
+                        resolve_corpus_source_unit(citation, local_corpus_release)
+                except (
+                    CorpusResolutionError,
+                    UnicodeError,
+                    ValueError,
+                    yaml.YAMLError,
+                    RecursionError,
+                ) as exc:
+                    issues.append(
+                        f"{manifest_label} exact dependent source history is "
+                        f"unverifiable for {path}: {exc}"
+                    )
+            if counts:
+                expected_rewrite_paths.add(path)
+                rewrite = rewrite_by_path.get(path)
+                if (
+                    not isinstance(rewrite, dict)
+                    or set(rewrite)
+                    != {
+                        "path",
+                        "before_sha256",
+                        "after_sha256",
+                        "replacements",
+                        "proof_import_repairs",
+                    }
+                    or rewrite.get("before_sha256") != before_sha256
+                    or rewrite.get("after_sha256") != after_sha256
+                    or rewrite.get("replacements") != list(counts)
+                    or rewrite.get("proof_import_repairs")
+                    != proof_import_repairs
+                    or not isinstance(
+                        rewrite.get("proof_import_repairs"),
+                        int,
+                    )
+                    or isinstance(
+                        rewrite.get("proof_import_repairs"),
+                        bool,
+                    )
+                ):
+                    issues.append(
+                        f"{manifest_label} exact dependent rewrite proof is stale "
+                        f"for {path}"
+                    )
+        if set(rewrite_by_path) != expected_rewrite_paths:
+            issues.append(
+                f"{manifest_label} exact dependent rewrite inventory is not exact"
+            )
+
+        try:
+            dependent_manifest_raw = read_bounded_regular_file(
+                repo_path,
+                repo_path / dependent_manifest_path,
+                label="legacy exact dependent apply manifest",
+                max_bytes=1024 * 1024,
+                required_mode=0o644,
+            )
+            dependent_manifest = json.loads(dependent_manifest_raw.decode("utf-8"))
+        except (
+            OSError,
+            UnsafeCorpusPathError,
+            UnicodeError,
+            json.JSONDecodeError,
+            RecursionError,
+        ):
+            dependent_manifest = None
+        expected_migration = {
+            "receipt_path": receipt_path.as_posix(),
+            "receipt_sha256": receipt_sha256,
+            "primary": primary,
+            "legacy_manifest_path": dependent_manifest_path.as_posix(),
+            "legacy_manifest_sha256": legacy_manifest["sha256"],
+        }
+        if (
+            not isinstance(dependent_manifest, dict)
+            or set(dependent_manifest)
+            != _LEGACY_EXACT_DEPENDENT_APPLY_MANIFEST_FIELDS
+            or dependent_manifest.get("schema_version")
+            != APPLIED_ENCODING_MANIFEST_SCHEMA
+            or dependent_manifest.get("tool")
+            != APPLIED_ENCODING_LEGACY_EXACT_DEPENDENT_TOOL
+            or dependent_manifest.get("axiom_encode_version")
+            != payload.get("axiom_encode_version")
+            or dependent_manifest.get("axiom_encode_git")
+            != payload.get("axiom_encode_git")
+            or dependent_manifest.get(VALIDATION_WAIVER_SET_SHA256_FIELD)
+            != expected_waiver_set_sha256
+            or dependent_manifest.get("applied_files")
+            != dependent["live_files"]
+            or dependent_manifest.get("legacy_migration") != expected_migration
+            or _applied_encoding_manifest_signature_issue(
+                dependent_manifest, signing_broker
+            )
+        ):
+            issues.append(
+                f"{manifest_label} exact dependent lacks its authenticated v5 "
+                f"migration manifest for {primary}"
+            )
+
     outer_entries = payload.get("applied_files")
     outer_list = outer_entries if isinstance(outer_entries, list) else []
     expected_entries: list[dict[str, object]] = []
@@ -21887,6 +22340,175 @@ def _legacy_replacement_manifest_issues(
         issues.append(
             f"{manifest_label} applied files do not exactly match replacement receipt"
         )
+    return issues
+
+
+def _legacy_exact_dependent_manifest_issues(
+    payload: Mapping[str, object],
+    *,
+    repo_path: Path,
+    manifest_label: str,
+    signing_broker: SigningBroker | Ed25519PublicKey,
+    expected_waiver_set_sha256: str,
+    local_corpus_release: LocalCorpusRelease | None,
+) -> list[str]:
+    """Verify one exact dependent through its shared signed cascade receipt."""
+
+    if (
+        payload.get("backend") is not None
+        or payload.get("tool") != APPLIED_ENCODING_LEGACY_EXACT_DEPENDENT_TOOL
+    ):
+        return []
+    binding = payload.get("legacy_migration")
+    expected_binding_fields = {
+        "receipt_path",
+        "receipt_sha256",
+        "primary",
+        "legacy_manifest_path",
+        "legacy_manifest_sha256",
+    }
+    if not isinstance(binding, dict) or set(binding) != expected_binding_fields:
+        return [f"{manifest_label} exact dependent binding is malformed"]
+    receipt_path_raw = binding.get("receipt_path")
+    receipt_path = (
+        Path(receipt_path_raw) if isinstance(receipt_path_raw, str) else Path()
+    )
+    primary_raw = binding.get("primary")
+    primary = Path(primary_raw) if isinstance(primary_raw, str) else Path()
+    if (
+        not isinstance(receipt_path_raw, str)
+        or receipt_path.is_absolute()
+        or receipt_path.as_posix() != receipt_path_raw
+        or receipt_path.parent != APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_DIR
+        or receipt_path.suffix != ".json"
+        or any(part in {"", ".", ".."} for part in receipt_path.parts)
+        or not isinstance(primary_raw, str)
+        or primary.is_absolute()
+        or primary.as_posix() != primary_raw
+        or any(part in {"", ".", ".."} for part in primary.parts)
+        or _applied_encoding_manifest_path(primary).as_posix() != manifest_label
+    ):
+        return [f"{manifest_label} exact dependent identity is invalid"]
+    issues: list[str] = []
+    try:
+        receipt_raw = read_bounded_regular_file(
+            repo_path,
+            repo_path / receipt_path,
+            label="legacy exact dependent receipt",
+            max_bytes=4 * 1024 * 1024,
+            required_mode=0o644,
+        )
+        receipt = json.loads(receipt_raw.decode("utf-8"))
+    except (
+        OSError,
+        UnsafeCorpusPathError,
+        UnicodeError,
+        json.JSONDecodeError,
+        RecursionError,
+    ):
+        return [f"{manifest_label} exact dependent receipt is unreadable"]
+    receipt_sha256 = hashlib.sha256(receipt_raw).hexdigest()
+    if (
+        not isinstance(receipt, dict)
+        or set(receipt) != _LEGACY_REPLACEMENT_RECEIPT_FIELDS
+        or receipt.get("schema_version")
+        != APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+        or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
+        or receipt_sha256 != binding.get("receipt_sha256")
+        or _applied_encoding_manifest_signature_issue(receipt, signing_broker)
+    ):
+        return [f"{manifest_label} exact dependent receipt is invalid"]
+    if (
+        receipt.get("axiom_encode_version") != payload.get("axiom_encode_version")
+        or receipt.get("axiom_encode_git") != payload.get("axiom_encode_git")
+        or receipt.get(VALIDATION_WAIVER_SET_SHA256_FIELD)
+        != expected_waiver_set_sha256
+    ):
+        issues.append(f"{manifest_label} exact dependent provenance is stale")
+    replacement = receipt.get("replacement")
+    exact_dependents = (
+        replacement.get("exact_dependents")
+        if isinstance(replacement, dict)
+        else None
+    )
+    matches = [
+        item
+        for item in exact_dependents
+        if isinstance(item, dict) and item.get("primary") == primary_raw
+    ] if isinstance(exact_dependents, list) else []
+    if len(matches) != 1:
+        return [
+            *issues,
+            f"{manifest_label} is not uniquely authorized by its cascade receipt",
+        ]
+    exact = matches[0]
+    legacy_manifest = exact.get("legacy_manifest")
+    if (
+        exact.get("live_files") != payload.get("applied_files")
+        or not isinstance(legacy_manifest, dict)
+        or legacy_manifest.get("path") != binding.get("legacy_manifest_path")
+        or legacy_manifest.get("sha256") != binding.get("legacy_manifest_sha256")
+    ):
+        issues.append(f"{manifest_label} exact dependent receipt binding is stale")
+
+    outer_path_raw = (
+        replacement.get("model_manifest_path")
+        if isinstance(replacement, dict)
+        else None
+    )
+    outer_path = Path(outer_path_raw) if isinstance(outer_path_raw, str) else Path()
+    if (
+        not isinstance(outer_path_raw, str)
+        or outer_path.is_absolute()
+        or outer_path.as_posix() != outer_path_raw
+        or _applied_encoding_manifest_root_prefix(
+            outer_path,
+            roots=tuple(sorted(RULESPEC_ATOMIC_MODULE_ROOTS)),
+        )
+        is None
+    ):
+        return [*issues, f"{manifest_label} cascade owner path is invalid"]
+    try:
+        outer_raw = read_bounded_regular_file(
+            repo_path,
+            repo_path / outer_path,
+            label="legacy exact dependent cascade owner",
+            max_bytes=4 * 1024 * 1024,
+            required_mode=0o644,
+        )
+        outer = json.loads(outer_raw.decode("utf-8"))
+    except (
+        OSError,
+        UnsafeCorpusPathError,
+        UnicodeError,
+        json.JSONDecodeError,
+        RecursionError,
+    ):
+        return [*issues, f"{manifest_label} cascade owner is unreadable"]
+    if (
+        not isinstance(outer, dict)
+        or set(outer) != _LEGACY_REPLACEMENT_APPLY_MANIFEST_FIELDS
+        or outer.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
+        or _applied_encoding_manifest_signature_issue(outer, signing_broker)
+    ):
+        return [*issues, f"{manifest_label} cascade owner is invalid"]
+    owner_binding = outer.get("replacement")
+    if (
+        not isinstance(owner_binding, dict)
+        or owner_binding.get("receipt_path") != receipt_path_raw
+        or owner_binding.get("receipt_sha256") != receipt_sha256
+    ):
+        issues.append(f"{manifest_label} cascade owner receipt binding is stale")
+    issues.extend(
+        _legacy_replacement_manifest_issues(
+            outer,
+            repo_path=repo_path,
+            manifest_label=outer_path.as_posix(),
+            signing_broker=signing_broker,
+            expected_waiver_set_sha256=expected_waiver_set_sha256,
+            local_corpus_release=local_corpus_release,
+        )
+    )
     return issues
 
 
@@ -22136,6 +22758,16 @@ def _load_verified_applied_encoding_manifest_payload(
     )
     issues.extend(
         _legacy_replacement_manifest_issues(
+            payload,
+            repo_path=repo_path,
+            manifest_label=manifest_label,
+            signing_broker=signing_broker,
+            expected_waiver_set_sha256=expected_waiver_set_sha256,
+            local_corpus_release=local_corpus_release,
+        )
+    )
+    issues.extend(
+        _legacy_exact_dependent_manifest_issues(
             payload,
             repo_path=repo_path,
             manifest_label=manifest_label,
@@ -22986,6 +23618,7 @@ def _resolve_legacy_replacement_contract(
     source_unit,
     corpus_release: LocalCorpusRelease,
     scheduled_dependent_paths: Sequence[Path] = (),
+    exact_dependent_paths: Sequence[Path] = (),
 ) -> _LegacyReplacementContract:
     """Bind one clean-HEAD legacy identity and its unique canonical replacement."""
 
@@ -23013,7 +23646,7 @@ def _resolve_legacy_replacement_contract(
             raise ValueError(
                 "in-place legacy replacement source must already be canonical"
             )
-        if scheduled_dependent_paths:
+        if scheduled_dependent_paths or exact_dependent_paths:
             raise ValueError(
                 "in-place legacy replacement cannot schedule path dependents"
             )
@@ -23165,8 +23798,11 @@ def _resolve_legacy_replacement_contract(
         )
     )
     scheduled_groups: dict[Path, set[Path]] = {}
-    for raw_dependent in scheduled_dependent_paths:
+    exact_groups: dict[Path, set[Path]] = {}
+
+    def admit_dependent(raw_dependent: Path, *, exact: bool) -> None:
         dependent = Path(raw_dependent)
+        destination_groups = exact_groups if exact else scheduled_groups
         if (
             dependent.is_absolute()
             or dependent.as_posix() != str(raw_dependent)
@@ -23178,9 +23814,10 @@ def _resolve_legacy_replacement_contract(
             or dependent in {source, destination}
             or tracked.get(dependent) != "100644"
             or dependent in scheduled_groups
+            or dependent in exact_groups
         ):
             raise ValueError(
-                "legacy scheduled dependent must be a unique tracked 0644 "
+                "legacy dependent must be a unique tracked 0644 "
                 "checkout-relative protected primary"
             )
         group = {dependent}
@@ -23191,14 +23828,143 @@ def _resolve_legacy_replacement_contract(
                     "legacy scheduled dependent companion is not tracked 0644"
                 )
             group.add(dependent_companion)
-        scheduled_groups[dependent] = group
+        destination_groups[dependent] = group
+
+    for raw_dependent in scheduled_dependent_paths:
+        admit_dependent(raw_dependent, exact=False)
+    for raw_dependent in exact_dependent_paths:
+        admit_dependent(raw_dependent, exact=True)
+
+    exact_legacy_files: dict[Path, tuple[_LegacyReplacementFile, ...]] = {}
+    exact_legacy_manifests: dict[Path, _LegacyReplacementFile] = {}
+    for primary, group in exact_groups.items():
+        group_files: list[_LegacyReplacementFile] = []
+        for relative in sorted(group, key=Path.as_posix):
+            raw = read_bounded_regular_file(
+                policy_checkout_path,
+                policy_checkout_path / relative,
+                label=f"legacy exact dependent input {relative.as_posix()}",
+                max_bytes=10 * 1024 * 1024,
+                required_mode=0o644,
+            )
+            if raw != _rulespec_migration_base_blob(
+                policy_checkout_path,
+                base_commit,
+                relative,
+            ):
+                raise ValueError(
+                    f"legacy exact dependent differs from clean HEAD: {relative}"
+                )
+            group_files.append(
+                _LegacyReplacementFile(
+                    relative,
+                    hashlib.sha256(raw).hexdigest(),
+                    raw,
+                )
+            )
+        try:
+            primary_file = next(item for item in group_files if item.path == primary)
+            dependent_payload = yaml.safe_load(primary_file.raw.decode("utf-8"))
+        except (UnicodeError, yaml.YAMLError, RecursionError) as exc:
+            raise ValueError(
+                f"legacy exact dependent is not valid UTF-8 YAML: {primary}"
+            ) from exc
+        dependent_module = (
+            dependent_payload.get("module")
+            if isinstance(dependent_payload, dict)
+            else None
+        )
+        dependent_verification = (
+            dependent_module.get("source_verification")
+            if isinstance(dependent_module, dict)
+            else None
+        )
+        dependent_citations = (
+            _legacy_source_verification_citation_paths(dependent_verification)
+            if isinstance(dependent_verification, dict)
+            else ()
+        )
+        if not dependent_citations:
+            raise ValueError(
+                f"legacy exact dependent has no canonical source history: {primary}"
+            )
+        for citation in dependent_citations:
+            try:
+                resolve_corpus_source_unit(citation, corpus_release)
+            except (CorpusResolutionError, ValueError) as exc:
+                raise ValueError(
+                    "legacy exact dependent source history is absent from the "
+                    f"signed corpus release: {primary}: {citation}"
+                ) from exc
+
+        dependent_manifest_path = _applied_encoding_manifest_path(primary)
+        if (
+            dependent_manifest_path == legacy_manifest_path
+            or tracked.get(dependent_manifest_path) != "100644"
+        ):
+            raise ValueError(
+                "legacy exact dependent requires its unique tracked v1/manual "
+                f"ownership manifest: {primary}"
+            )
+        dependent_manifest_raw = read_bounded_regular_file(
+            policy_checkout_path,
+            policy_checkout_path / dependent_manifest_path,
+            label="legacy exact dependent ownership manifest",
+            max_bytes=4 * 1024 * 1024,
+            required_mode=0o644,
+        )
+        if dependent_manifest_raw != _rulespec_migration_base_blob(
+            policy_checkout_path,
+            base_commit,
+            dependent_manifest_path,
+        ):
+            raise ValueError(
+                f"legacy exact dependent manifest differs from clean HEAD: {primary}"
+            )
+        try:
+            dependent_manifest_payload = json.loads(
+                dependent_manifest_raw.decode("utf-8")
+            )
+        except (UnicodeError, json.JSONDecodeError, RecursionError) as exc:
+            raise ValueError(
+                f"legacy exact dependent manifest is invalid JSON: {primary}"
+            ) from exc
+        dependent_issues = _legacy_manual_manifest_issues(
+            dependent_manifest_payload,
+            expected_files={
+                item.path.as_posix(): item.sha256 for item in group_files
+            },
+            allow_unmarked_manual_exception=True,
+        )
+        if dependent_issues:
+            raise ValueError(
+                f"legacy exact dependent manifest is not admissible: {primary}: "
+                + "; ".join(dependent_issues)
+            )
+        exact_legacy_files[primary] = tuple(group_files)
+        exact_legacy_manifests[primary] = _LegacyReplacementFile(
+            dependent_manifest_path,
+            hashlib.sha256(dependent_manifest_raw).hexdigest(),
+            dependent_manifest_raw,
+        )
+
     pending_by_primary: dict[Path, list[_LegacyReplacementPendingFile]] = {
         primary: [] for primary in scheduled_groups
     }
-    scheduled_owner = {
+    exact_rewrites_by_primary: dict[Path, list[_LegacyReplacementRewrite]] = {
+        primary: [] for primary in exact_groups
+    }
+    dependent_owner = {
         path: primary for primary, group in scheduled_groups.items() for path in group
     }
-    excluded = {*old_paths, legacy_manifest_path}
+    dependent_owner.update(
+        {path: primary for primary, group in exact_groups.items() for path in group}
+    )
+    excluded = {
+        *old_paths,
+        legacy_manifest_path,
+        *[item.path for item in exact_legacy_manifests.values()],
+    }
     manifest_prefix = APPLIED_ENCODING_MANIFEST_DIR.parts
     receipt_prefixes = (
         APPLIED_ENCODING_PATH_MIGRATION_RECEIPT_DIR.parts,
@@ -23238,15 +24004,33 @@ def _resolve_legacy_replacement_contract(
                 f"legacy replacement cannot rewrite persisted provenance {relative}"
             )
         if _is_protected_rulespec_yaml_path(relative, roots=roots):
-            scheduled_primary = scheduled_owner.get(relative)
-            if scheduled_primary is not None:
-                pending_by_primary[scheduled_primary].append(
-                    _LegacyReplacementPendingFile(
-                        relative,
-                        hashlib.sha256(raw).hexdigest(),
-                        counts,
+            dependent_primary = dependent_owner.get(relative)
+            if dependent_primary is not None:
+                if dependent_primary in exact_groups:
+                    if _migration_corpus_citations(raw) != _migration_corpus_citations(
+                        rewritten
+                    ):
+                        raise ValueError(
+                            "legacy exact dependent rewrite would alter legal corpus "
+                            f"citation text in {relative}"
+                        )
+                    exact_rewrites_by_primary[dependent_primary].append(
+                        _LegacyReplacementRewrite(
+                            relative,
+                            hashlib.sha256(raw).hexdigest(),
+                            hashlib.sha256(rewritten).hexdigest(),
+                            counts,
+                            rewritten,
+                        )
                     )
-                )
+                else:
+                    pending_by_primary[dependent_primary].append(
+                        _LegacyReplacementPendingFile(
+                            relative,
+                            hashlib.sha256(raw).hexdigest(),
+                            counts,
+                        )
+                    )
                 continue
             raise ValueError(
                 f"legacy replacement requires explicit protected-dependent "
@@ -23276,6 +24060,46 @@ def _resolve_legacy_replacement_contract(
             + ", ".join(path.as_posix() for path in missing_scheduled)
         )
 
+    missing_exact = [
+        path for path, rewrites in exact_rewrites_by_primary.items() if not rewrites
+    ]
+    if missing_exact:
+        raise ValueError(
+            "legacy exact dependent has no exact protected reference to replace: "
+            + ", ".join(path.as_posix() for path in missing_exact)
+        )
+
+    exact_dependents: list[_LegacyReplacementExactDependent] = []
+    for primary in exact_groups:
+        rewritten_by_path = {
+            item.path: item for item in exact_rewrites_by_primary[primary]
+        }
+        live_files = tuple(
+            _LegacyReplacementFile(
+                item.path,
+                (
+                    rewritten_by_path[item.path].after_sha256
+                    if item.path in rewritten_by_path
+                    else item.sha256
+                ),
+                (
+                    rewritten_by_path[item.path].raw
+                    if item.path in rewritten_by_path
+                    else item.raw
+                ),
+            )
+            for item in exact_legacy_files[primary]
+        )
+        exact_dependents.append(
+            _LegacyReplacementExactDependent(
+                primary=primary,
+                legacy_manifest=exact_legacy_manifests[primary],
+                legacy_files=exact_legacy_files[primary],
+                live_files=live_files,
+                rewrites=tuple(exact_rewrites_by_primary[primary]),
+            )
+        )
+
     return _LegacyReplacementContract(
         base_commit=base_commit,
         base_tree=base_tree,
@@ -23292,6 +24116,7 @@ def _resolve_legacy_replacement_contract(
             for primary in scheduled_groups
             if pending_by_primary[primary]
         ),
+        exact_dependents=tuple(exact_dependents),
     )
 
 
@@ -23308,10 +24133,14 @@ def _resolve_encode_replacement_target(
     scheduled_dependents = tuple(
         Path(path) for path in getattr(args, "legacy_dependent_rulespec_path", ())
     )
+    exact_dependents = tuple(
+        Path(path)
+        for path in getattr(args, "legacy_exact_dependent_rulespec_path", ())
+    )
     if raw_path is None and legacy_source is None:
-        if scheduled_dependents:
+        if scheduled_dependents or exact_dependents:
             raise ValueError(
-                "--legacy-dependent-rulespec-path requires a legacy replacement"
+                "legacy dependent paths require a legacy replacement"
             )
         return None
     if raw_path is None:
@@ -23325,6 +24154,8 @@ def _resolve_encode_replacement_target(
         raise ValueError(
             "encode --replace-rulespec-path requires --mode repo-augmented"
         )
+    if legacy_source is None and (scheduled_dependents or exact_dependents):
+        raise ValueError("legacy dependent paths require a legacy replacement")
 
     if legacy_source is not None:
         contract = _resolve_legacy_replacement_contract(
@@ -23335,6 +24166,7 @@ def _resolve_encode_replacement_target(
             source_unit=source_unit,
             corpus_release=corpus_release,
             scheduled_dependent_paths=scheduled_dependents,
+            exact_dependent_paths=exact_dependents,
         )
         context_paths = [
             policy_checkout_path / item.path for item in contract.deleted_files
@@ -44388,6 +45220,34 @@ def _build_apply_validation_snapshot(
                 }
                 for dependent in legacy_replacement.scheduled_dependents
             ],
+            "exact_dependents": [
+                {
+                    "primary": dependent.primary.as_posix(),
+                    "legacy_manifest": {
+                        "path": dependent.legacy_manifest.path.as_posix(),
+                        "sha256": dependent.legacy_manifest.sha256,
+                    },
+                    "legacy_files": [
+                        {"path": item.path.as_posix(), "sha256": item.sha256}
+                        for item in dependent.legacy_files
+                    ],
+                    "live_files": [
+                        {"path": item.path.as_posix(), "sha256": item.sha256}
+                        for item in dependent.live_files
+                    ],
+                    "rewrites": [
+                        {
+                            "path": item.path.as_posix(),
+                            "before_sha256": item.before_sha256,
+                            "after_sha256": item.after_sha256,
+                            "replacements": list(item.replacements),
+                            "proof_import_repairs": item.proof_import_repairs,
+                        }
+                        for item in dependent.rewrites
+                    ],
+                }
+                for dependent in legacy_replacement.exact_dependents
+            ],
         }
     return snapshot
 
@@ -44784,7 +45644,7 @@ def _stage_signed_legacy_replacement_provenance(
     signing_broker: SigningBroker,
     axiom_encode_git: Mapping[str, object],
     local_corpus_release: LocalCorpusRelease,
-) -> tuple[Path, bytes, Path, bytes]:
+) -> tuple[Path, bytes, Path, bytes, dict[Path, bytes]]:
     """Wrap one fresh v5 model manifest in an authenticated replacement proof."""
 
     try:
@@ -44856,6 +45716,34 @@ def _stage_signed_legacy_replacement_provenance(
         }
         for dependent in contract.scheduled_dependents
     ]
+    exact_dependents = [
+        {
+            "primary": dependent.primary.as_posix(),
+            "legacy_manifest": {
+                "path": dependent.legacy_manifest.path.as_posix(),
+                "sha256": dependent.legacy_manifest.sha256,
+            },
+            "legacy_files": [
+                {"path": item.path.as_posix(), "sha256": item.sha256}
+                for item in dependent.legacy_files
+            ],
+            "live_files": [
+                {"path": item.path.as_posix(), "sha256": item.sha256}
+                for item in dependent.live_files
+            ],
+            "rewrites": [
+                {
+                    "path": item.path.as_posix(),
+                    "before_sha256": item.before_sha256,
+                    "after_sha256": item.after_sha256,
+                    "replacements": list(item.replacements),
+                    "proof_import_repairs": item.proof_import_repairs,
+                }
+                for item in dependent.rewrites
+            ],
+        }
+        for dependent in contract.exact_dependents
+    ]
     receipt_identity = receipt_identity_payload(
         base_commit=contract.base_commit,
         base_tree=contract.base_tree,
@@ -44873,6 +45761,7 @@ def _stage_signed_legacy_replacement_provenance(
             for item in contract.rewrites
         ],
         scheduled_dependents=scheduled_dependents,
+        exact_dependents=exact_dependents,
     )
     receipt_id = receipt_identity_sha256(receipt_identity)
     receipt_relative = (
@@ -44923,6 +45812,7 @@ def _stage_signed_legacy_replacement_provenance(
             "live_files": live_files,
             "rewrites": receipt_identity["rewrites"],
             "scheduled_dependents": scheduled_dependents,
+            "exact_dependents": exact_dependents,
         },
         "replacement_manifest": model_manifest,
     }
@@ -44931,6 +45821,37 @@ def _stage_signed_legacy_replacement_provenance(
         "utf-8"
     )
     receipt_sha256 = hashlib.sha256(receipt_bytes).hexdigest()
+
+    exact_dependent_manifests: dict[Path, bytes] = {}
+    for dependent in contract.exact_dependents:
+        dependent_manifest_relative = _applied_encoding_manifest_path(
+            dependent.primary
+        )
+        exact_manifest = {
+            "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+            "generated_at": _utc_now_iso(),
+            "tool": APPLIED_ENCODING_LEGACY_EXACT_DEPENDENT_TOOL,
+            "axiom_encode_version": __version__,
+            "axiom_encode_git": dict(axiom_encode_git),
+            VALIDATION_WAIVER_SET_SHA256_FIELD: receipt[
+                VALIDATION_WAIVER_SET_SHA256_FIELD
+            ],
+            "applied_files": [
+                {"path": item.path.as_posix(), "sha256": item.sha256}
+                for item in dependent.live_files
+            ],
+            "legacy_migration": {
+                "receipt_path": receipt_relative.as_posix(),
+                "receipt_sha256": receipt_sha256,
+                "primary": dependent.primary.as_posix(),
+                "legacy_manifest_path": dependent.legacy_manifest.path.as_posix(),
+                "legacy_manifest_sha256": dependent.legacy_manifest.sha256,
+            },
+        }
+        _sign_applied_encoding_manifest(exact_manifest, signing_broker)
+        exact_dependent_manifests[dependent_manifest_relative] = (
+            json.dumps(exact_manifest, indent=2, sort_keys=True) + "\n"
+        ).encode("utf-8")
 
     outer_manifest = {
         "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
@@ -44953,7 +45874,13 @@ def _stage_signed_legacy_replacement_provenance(
     outer_bytes = (json.dumps(outer_manifest, indent=2, sort_keys=True) + "\n").encode(
         "utf-8"
     )
-    return model_manifest_relative, outer_bytes, receipt_relative, receipt_bytes
+    return (
+        model_manifest_relative,
+        outer_bytes,
+        receipt_relative,
+        receipt_bytes,
+        exact_dependent_manifests,
+    )
 
 
 def _require_staged_manifest_matches_validation_snapshot(
@@ -46038,6 +46965,7 @@ def _require_apply_post_install_closure(
     legacy_replacement: _LegacyReplacementContract | None = None,
     receipt_path: Path | None = None,
     receipt_bytes: bytes | None = None,
+    exact_dependent_manifest_bytes: Mapping[Path, bytes] | None = None,
 ) -> None:
     """Recheck the execution closure while rollback is still possible."""
 
@@ -46137,6 +47065,12 @@ def _require_apply_post_install_closure(
                 expected_post_files[Path(*rewrite.path.parts[1:]).as_posix()] = (
                     rewrite.after_sha256
                 )
+        for dependent in legacy_replacement.exact_dependents:
+            for live_file in dependent.live_files:
+                if live_file.path.parts[:1] == (content_root.name,):
+                    expected_post_files[
+                        Path(*live_file.path.parts[1:]).as_posix()
+                    ] = live_file.sha256
     for relative, raw in planned.items():
         expected_post_files[_canonical_apply_relative_path(relative).as_posix()] = (
             hashlib.sha256(raw).hexdigest()
@@ -46182,6 +47116,28 @@ def _require_apply_post_install_closure(
             if target.read_bytes() != rewrite.raw:
                 raise RuntimeError(
                     f"Cannot keep legacy replacement: rewrite changed for {target}"
+                )
+        exact_manifest_bytes = dict(exact_dependent_manifest_bytes or {})
+        for dependent in legacy_replacement.exact_dependents:
+            for item in dependent.live_files:
+                target = checkout_root / item.path
+                if target.read_bytes() != item.raw:
+                    raise RuntimeError(
+                        "Cannot keep legacy replacement: exact dependent changed "
+                        f"for {target}"
+                    )
+            dependent_manifest_path = _applied_encoding_manifest_path(
+                dependent.primary
+            )
+            expected_manifest = exact_manifest_bytes.get(dependent_manifest_path)
+            if (
+                expected_manifest is None
+                or (checkout_root / dependent_manifest_path).read_bytes()
+                != expected_manifest
+            ):
+                raise RuntimeError(
+                    "Cannot keep legacy replacement: exact dependent manifest changed "
+                    f"for {dependent.primary}"
                 )
         if (
             receipt_path is None
@@ -46307,12 +47263,14 @@ def _apply_generated_encoding_result(
 
     receipt_relative: Path | None = None
     receipt_bytes: bytes | None = None
+    exact_dependent_manifest_bytes: dict[Path, bytes] = {}
     if legacy_replacement is not None:
         (
             manifest_relative,
             manifest_bytes,
             receipt_relative,
             receipt_bytes,
+            exact_dependent_manifest_bytes,
         ) = _stage_signed_legacy_replacement_provenance(
             result,
             contract=legacy_replacement,
@@ -46341,6 +47299,15 @@ def _apply_generated_encoding_result(
         transaction_files.extend(
             (checkout_root / rewrite.path, rewrite.raw)
             for rewrite in legacy_replacement.rewrites
+        )
+        transaction_files.extend(
+            (checkout_root / item.path, item.raw)
+            for dependent in legacy_replacement.exact_dependents
+            for item in dependent.live_files
+        )
+        transaction_files.extend(
+            (checkout_root / path, raw)
+            for path, raw in exact_dependent_manifest_bytes.items()
         )
         written_targets = {
             target for target, raw in transaction_files if raw is not None
@@ -46383,6 +47350,12 @@ def _apply_generated_encoding_result(
         expected_originals[checkout_root / legacy_replacement.legacy_manifest.path] = (
             legacy_replacement.legacy_manifest.sha256
         )
+        for dependent in legacy_replacement.exact_dependents:
+            for item in dependent.legacy_files:
+                expected_originals[checkout_root / item.path] = item.sha256
+            expected_originals[
+                checkout_root / dependent.legacy_manifest.path
+            ] = dependent.legacy_manifest.sha256
         assert receipt_relative is not None
         expected_originals[checkout_root / receipt_relative] = None
     new_manifest_applied_files = {
@@ -46446,6 +47419,7 @@ def _apply_generated_encoding_result(
                 else None
             ),
             receipt_bytes=receipt_bytes,
+            exact_dependent_manifest_bytes=exact_dependent_manifest_bytes,
         )
 
     _install_apply_transaction(
@@ -46458,6 +47432,15 @@ def _apply_generated_encoding_result(
     applied.append(manifest_path)
     if receipt_relative is not None:
         applied.append(checkout_root / receipt_relative)
+    if legacy_replacement is not None:
+        applied.extend(
+            checkout_root / item.path
+            for dependent in legacy_replacement.exact_dependents
+            for item in dependent.live_files
+        )
+        applied.extend(
+            checkout_root / path for path in exact_dependent_manifest_bytes
+        )
     if wrote_empty_companion_test:
         print("  apply=generated_empty_deferred_companion_test")
     return applied
@@ -47211,6 +48194,29 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
                         {},
                     )
                 rewrite_target.write_bytes(rewrite.raw)
+            for dependent in legacy_replacement.exact_dependents:
+                legacy_by_path = {
+                    item.path: item for item in dependent.legacy_files
+                }
+                for live_file in dependent.live_files:
+                    legacy_file = legacy_by_path.get(live_file.path)
+                    exact_target = overlay_repo / live_file.path
+                    if (
+                        legacy_file is None
+                        or exact_target.is_symlink()
+                        or not exact_target.is_file()
+                        or hashlib.sha256(exact_target.read_bytes()).hexdigest()
+                        != legacy_file.sha256
+                    ):
+                        return (
+                            False,
+                            [
+                                "Legacy exact dependent overlay input changed: "
+                                f"{live_file.path.as_posix()}"
+                            ],
+                            {},
+                        )
+                    exact_target.write_bytes(live_file.raw)
             shutil.copy2(output_file, overlay_target)
             if output_test.exists():
                 shutil.copy2(output_test, _rulespec_test_path(overlay_target))
@@ -47282,12 +48288,31 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
         )
         for _ in range(_APPLY_OVERLAY_VALIDATION_REPAIR_LIMIT):
             if all(validation.all_passed for _, validation in validations):
-                stamped_supplemental_files = (
-                    _stamp_matching_supplemental_source_attestations(
-                        supplemental_files,
-                        attestation=_generated_result_source_attestation(result),
+                exact_relative_paths = {
+                    Path(*item.path.parts[1:])
+                    for dependent in (
+                        legacy_replacement.exact_dependents
+                        if legacy_replacement is not None
+                        else ()
                     )
-                )
+                    for item in dependent.live_files
+                }
+                exact_supplemental_files = {
+                    path: content
+                    for path, content in supplemental_files.items()
+                    if path in exact_relative_paths
+                }
+                stamped_supplemental_files = {
+                    **exact_supplemental_files,
+                    **_stamp_matching_supplemental_source_attestations(
+                        {
+                            path: content
+                            for path, content in supplemental_files.items()
+                            if path not in exact_relative_paths
+                        },
+                        attestation=_generated_result_source_attestation(result),
+                    ),
+                }
                 if stamped_supplemental_files != supplemental_files:
                     stamped_paths = {
                         relative_path
@@ -47327,6 +48352,27 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
                         dependents=dependents,
                     )
                 if all(validation.all_passed for _, validation in validations):
+                    repaired_exact_paths = exact_relative_paths.intersection(
+                        supplemental_files
+                    )
+                    if legacy_replacement is not None:
+                        finalized_replacement, finalization_issues = (
+                            _finalize_legacy_exact_dependents_from_overlay(
+                                legacy_replacement,
+                                overlay_checkout_root=overlay_repo,
+                                overlay_content_root=overlay_content_root,
+                            )
+                        )
+                        if finalized_replacement is None:
+                            return False, finalization_issues, {}
+                        legacy_replacement = finalized_replacement
+                        setattr(
+                            result,
+                            _LEGACY_REPLACEMENT_ATTR,
+                            legacy_replacement,
+                        )
+                    for path in repaired_exact_paths:
+                        supplemental_files.pop(path, None)
                     _record_successful_apply_validation(
                         result,
                         output_root=output_root,
@@ -49559,6 +50605,141 @@ def _repair_dependent_proof_import_hashes(
         dependent.write_bytes(repaired.encode("utf-8"))
         changed.append(dependent)
     return changed
+
+
+def _finalize_legacy_exact_dependents_from_overlay(
+    contract: _LegacyReplacementContract,
+    *,
+    overlay_checkout_root: Path,
+    overlay_content_root: Path,
+) -> tuple[_LegacyReplacementContract | None, list[str]]:
+    """Bind exact dependents after deterministic proof-import hash refreshes."""
+
+    finalized_dependents: list[_LegacyReplacementExactDependent] = []
+    issues: list[str] = []
+    for dependent in contract.exact_dependents:
+        rewrite_by_path = {item.path: item for item in dependent.rewrites}
+        finalized_rewrites: list[_LegacyReplacementRewrite] = []
+        finalized_files: list[_LegacyReplacementFile] = []
+        primary_relative = Path(*dependent.primary.parts[1:])
+        target_base = (
+            f"{overlay_content_root.name}:"
+            f"{_relative_rulespec_import_target(primary_relative)}"
+        )
+        for legacy_file in dependent.legacy_files:
+            live_path = overlay_checkout_root / legacy_file.path
+            try:
+                live_raw = read_bounded_regular_file(
+                    overlay_checkout_root,
+                    live_path,
+                    label="legacy exact dependent finalized overlay file",
+                    max_bytes=16 * 1024 * 1024,
+                    required_mode=0o644,
+                )
+            except (OSError, UnsafeCorpusPathError) as exc:
+                issues.append(
+                    "Legacy exact dependent final overlay is unreadable for "
+                    f"{legacy_file.path.as_posix()}: {exc}"
+                )
+                continue
+            rewrite = rewrite_by_path.get(legacy_file.path)
+            if rewrite is None:
+                if live_raw != legacy_file.raw:
+                    issues.append(
+                        "Legacy exact dependent unrewritten file changed for "
+                        f"{legacy_file.path.as_posix()}"
+                    )
+                finalized_files.append(
+                    _LegacyReplacementFile(
+                        legacy_file.path,
+                        hashlib.sha256(live_raw).hexdigest(),
+                        live_raw,
+                    )
+                )
+                continue
+
+            replacements = _strict_legacy_replacement_map(
+                list(rewrite.replacements)
+            )
+            if replacements is None:
+                issues.append(
+                    "Legacy exact dependent reference proof is malformed for "
+                    f"{legacy_file.path.as_posix()}"
+                )
+                continue
+            try:
+                expected_raw, observed_replacements = rewrite_exact_references(
+                    legacy_file.raw,
+                    replacements,
+                )
+            except PathMigrationPlanError as exc:
+                issues.append(
+                    "Legacy exact dependent reference proof is unreadable for "
+                    f"{legacy_file.path.as_posix()}: {exc}"
+                )
+                continue
+            if list(observed_replacements) != list(rewrite.replacements):
+                issues.append(
+                    "Legacy exact dependent reference proof is stale for "
+                    f"{legacy_file.path.as_posix()}"
+                )
+                continue
+            proof_import_repairs = 0
+            if legacy_file.path == dependent.primary:
+                try:
+                    expected_text, proof_import_repairs = (
+                        _repair_proof_import_hashes(
+                            expected_raw.decode("utf-8"),
+                            target_base=target_base,
+                            rules_file=live_path,
+                            repo_path=overlay_content_root,
+                        )
+                    )
+                    expected_raw = expected_text.encode("utf-8")
+                except UnicodeError:
+                    issues.append(
+                        "Legacy exact dependent primary is not UTF-8 for "
+                        f"{legacy_file.path.as_posix()}"
+                    )
+                    continue
+            if (
+                live_raw != expected_raw
+                or _migration_corpus_citations(legacy_file.raw)
+                != _migration_corpus_citations(live_raw)
+            ):
+                issues.append(
+                    "Legacy exact dependent final transformation is not limited "
+                    "to authenticated reference and proof-import hash rewrites for "
+                    f"{legacy_file.path.as_posix()} "
+                    f"(expected {hashlib.sha256(expected_raw).hexdigest()}, "
+                    f"found {hashlib.sha256(live_raw).hexdigest()})"
+                )
+                continue
+            finalized_rewrites.append(
+                rewrite._replace(
+                    after_sha256=hashlib.sha256(live_raw).hexdigest(),
+                    raw=live_raw,
+                    proof_import_repairs=proof_import_repairs,
+                )
+            )
+            finalized_files.append(
+                _LegacyReplacementFile(
+                    legacy_file.path,
+                    hashlib.sha256(live_raw).hexdigest(),
+                    live_raw,
+                )
+            )
+        if len(finalized_files) != len(dependent.legacy_files):
+            continue
+        finalized_dependents.append(
+            dependent._replace(
+                live_files=tuple(finalized_files),
+                rewrites=tuple(finalized_rewrites),
+            )
+        )
+    if issues or len(finalized_dependents) != len(contract.exact_dependents):
+        return None, issues or ["Legacy exact dependent finalization is incomplete"]
+    return contract._replace(exact_dependents=tuple(finalized_dependents)), []
 
 
 _MISSING_INPUT_RE = re.compile(

--- a/src/axiom_encode/legacy_replacement.py
+++ b/src/axiom_encode/legacy_replacement.py
@@ -16,7 +16,11 @@ from typing import Final, Mapping, NamedTuple
 from .corpus_resolver import normalize_corpus_identifier
 
 TOOL: Final = "axiom-encode encode --apply --replace-legacy-rulespec-path"
-RECEIPT_SCHEMA: Final = "axiom-encode/legacy-fresh-reencode-receipt/v1"
+EXACT_DEPENDENT_TOOL: Final = (
+    "axiom-encode encode --apply --legacy-exact-dependent-rulespec-path"
+)
+RECEIPT_SCHEMA_V1: Final = "axiom-encode/legacy-fresh-reencode-receipt/v1"
+RECEIPT_SCHEMA: Final = "axiom-encode/legacy-fresh-reencode-receipt/v2"
 RECEIPT_DIR: Final = ".axiom/legacy-replacements"
 LEGACY_MANIFEST_SCHEMA: Final = "axiom-encode/applied-rulespec/v1"
 LEGACY_OWNER_CLASS: Final = "v1-manual-hmac-untrusted"
@@ -36,6 +40,7 @@ class LegacyReplacementRewrite(NamedTuple):
     after_sha256: str
     replacements: tuple[dict[str, object], ...]
     raw: bytes
+    proof_import_repairs: int = 0
 
 
 class LegacyReplacementPendingFile(NamedTuple):
@@ -49,6 +54,14 @@ class LegacyReplacementScheduledDependent(NamedTuple):
     files: tuple[LegacyReplacementPendingFile, ...]
 
 
+class LegacyReplacementExactDependent(NamedTuple):
+    primary: Path
+    legacy_manifest: LegacyReplacementFile
+    legacy_files: tuple[LegacyReplacementFile, ...]
+    live_files: tuple[LegacyReplacementFile, ...]
+    rewrites: tuple[LegacyReplacementRewrite, ...]
+
+
 class LegacyReplacementContract(NamedTuple):
     base_commit: str
     base_tree: str
@@ -58,6 +71,7 @@ class LegacyReplacementContract(NamedTuple):
     deleted_files: tuple[LegacyReplacementFile, ...]
     rewrites: tuple[LegacyReplacementRewrite, ...]
     scheduled_dependents: tuple[LegacyReplacementScheduledDependent, ...]
+    exact_dependents: tuple[LegacyReplacementExactDependent, ...]
 
 
 def legacy_source_verification_citation_paths(
@@ -170,8 +184,9 @@ def receipt_identity_payload(
     deleted_files: list[dict[str, object]],
     rewrites: list[dict[str, object]],
     scheduled_dependents: list[dict[str, object]],
+    exact_dependents: list[dict[str, object]] | None = None,
 ) -> dict[str, object]:
-    return {
+    payload = {
         "base_commit": base_commit,
         "base_tree": base_tree,
         "legacy_manifest_sha256": legacy_manifest_sha256,
@@ -181,6 +196,9 @@ def receipt_identity_payload(
         "rewrites": rewrites,
         "scheduled_dependents": scheduled_dependents,
     }
+    if exact_dependents is not None:
+        payload["exact_dependents"] = exact_dependents
+    return payload
 
 
 def receipt_identity_sha256(payload: Mapping[str, object]) -> str:

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1419"
+ENCODER_VERSION = "0.2.1420"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1418"
+ENCODER_VERSION = "0.2.1419"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13661,9 +13661,7 @@ class TestCmdEncode:
         destination_relative = Path("us-la/statutes/47/32.yaml")
         source = checkout / source_relative
         source_test = source.with_name("47:32.test.yaml")
-        dependent_relative = Path(
-            "us-la/policies/income_tax/2026_resident_core.yaml"
-        )
+        dependent_relative = Path("us-la/policies/income_tax/2026_resident_core.yaml")
         dependent = checkout / dependent_relative
         dependent_test = dependent.with_name("2026_resident_core.test.yaml")
         source.parent.mkdir(parents=True)
@@ -13960,13 +13958,13 @@ class TestCmdEncode:
         exact_live_hashes = {
             item["path"]: item["sha256"] for item in exact["live_files"]
         }
-        assert exact_legacy_hashes[dependent_test.relative_to(checkout).as_posix()] == (
-            exact_live_hashes[dependent_test.relative_to(checkout).as_posix()]
+        assert (
+            exact_legacy_hashes[dependent_test.relative_to(checkout).as_posix()]
+            == (exact_live_hashes[dependent_test.relative_to(checkout).as_posix()])
         )
         exact_manifest = json.loads(dependent_manifest.read_text())
         assert exact_manifest["tool"] == (
-            "axiom-encode encode --apply "
-            "--legacy-exact-dependent-rulespec-path"
+            "axiom-encode encode --apply --legacy-exact-dependent-rulespec-path"
         )
         assert exact_manifest["legacy_migration"]["receipt_sha256"] == (
             hashlib.sha256(receipt_path.read_bytes()).hexdigest()
@@ -14000,13 +13998,9 @@ class TestCmdEncode:
         receipt_path.write_text(
             json.dumps(tampered_receipt, indent=2, sort_keys=True) + "\n"
         )
-        tampered_receipt_sha256 = hashlib.sha256(
-            receipt_path.read_bytes()
-        ).hexdigest()
+        tampered_receipt_sha256 = hashlib.sha256(receipt_path.read_bytes()).hexdigest()
         tampered_outer = copy.deepcopy(outer)
-        tampered_outer["replacement"]["receipt_sha256"] = (
-            tampered_receipt_sha256
-        )
+        tampered_outer["replacement"]["receipt_sha256"] = tampered_receipt_sha256
         _sign_applied_encoding_manifest(
             tampered_outer,
             TEST_APPLY_SIGNING_BROKER,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13647,6 +13647,421 @@ class TestCmdEncode:
         assert issues == [], "\n".join(issues)
         assert verified == outer
 
+    def test_apply_atomically_migrates_exact_legacy_dependent(
+        self,
+        tmp_path,
+    ):
+        from axiom_encode.cli import _resolve_legacy_replacement_contract
+        from axiom_encode.toolchain import load_rulespec_local_corpus_release
+
+        output_root = tmp_path / "out"
+        checkout = tmp_path / "rulespec-us"
+        content_root = checkout / "us-la"
+        source_relative = Path("us-la/statutes/47:32.yaml")
+        destination_relative = Path("us-la/statutes/47/32.yaml")
+        source = checkout / source_relative
+        source_test = source.with_name("47:32.test.yaml")
+        dependent_relative = Path(
+            "us-la/policies/income_tax/2026_resident_core.yaml"
+        )
+        dependent = checkout / dependent_relative
+        dependent_test = dependent.with_name("2026_resident_core.test.yaml")
+        source.parent.mkdir(parents=True)
+        dependent.parent.mkdir(parents=True)
+        source.write_text(
+            "format: rulespec/v1\n"
+            "module:\n"
+            "  source_verification:\n"
+            "    corpus_citation_path: us-la/statute/47/32\n"
+            "rules: []\n"
+        )
+        source_test.write_text("[]\n")
+        source_before_sha256 = _sha256_file(source)
+        dependent.write_text(
+            "format: rulespec/v1\n"
+            "module:\n"
+            "  source_verification:\n"
+            "    corpus_citation_path: us-la/statute/47/32\n"
+            "  proof_validation:\n"
+            "    required: true\n"
+            "imports:\n"
+            "  - us-la:statutes/47:32#amount\n"
+            "rules:\n"
+            "  - name: liability\n"
+            "    kind: derived\n"
+            "    dtype: Money\n"
+            "    period: Year\n"
+            "    metadata:\n"
+            "      proof:\n"
+            "        atoms:\n"
+            "          - path: versions[0].formula\n"
+            "            kind: import\n"
+            "            import:\n"
+            "              target: us-la:statutes/47:32#amount\n"
+            "              output: amount\n"
+            f"              hash: sha256:{source_before_sha256}\n"
+            "    versions:\n"
+            "      - effective_from: '2026-01-01'\n"
+            "        formula: amount\n"
+        )
+        dependent_test.write_text("[]\n")
+
+        def write_manual_manifest(primary: Path, files: list[Path]) -> Path:
+            manifest = checkout / _applied_encoding_manifest_path(
+                primary.relative_to(checkout)
+            )
+            manifest.parent.mkdir(parents=True, exist_ok=True)
+            manifest.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "axiom-encode/applied-rulespec/v1",
+                        "tool": "axiom-encode sign-applied-files",
+                        "backend": "manual",
+                        "runner": "manual-attestation",
+                        "manual_exception": "test legacy composition",
+                        "applied_files": [
+                            {
+                                "path": path.relative_to(checkout).as_posix(),
+                                "sha256": _sha256_file(path),
+                            }
+                            for path in files
+                        ],
+                        "signature": {
+                            "algorithm": "hmac-sha256",
+                            "key_id": "historical-v1",
+                            "value": "opaque-untrusted-evidence",
+                        },
+                    }
+                )
+                + "\n"
+            )
+            return manifest
+
+        source_manifest = write_manual_manifest(source, [source, source_test])
+        dependent_manifest = write_manual_manifest(
+            dependent, [dependent, dependent_test]
+        )
+        dependent_before = dependent.read_bytes()
+        dependent_test_before = dependent_test.read_bytes()
+        dependent_manifest_before = dependent_manifest.read_bytes()
+
+        source_text = "authoritative Louisiana section 47:32\n"
+        corpus_path, source_attestation = self._bind_apply_source_release(
+            checkout,
+            tmp_path,
+            citation_path="us-la/statute/47/32",
+            source_text=source_text,
+        )
+        _git(checkout, "init", "-b", "main")
+        _git(checkout, "config", "user.email", "test@example.com")
+        _git(checkout, "config", "user.name", "Test User")
+        _git(checkout, "add", ".")
+        _git(checkout, "commit", "-m", "legacy cascade base")
+        with patch.dict(
+            os.environ,
+            {"AXIOM_CORPUS_RELEASE_PUBLIC_KEY": TEST_RELEASE_PUBLIC_KEY},
+        ):
+            release = load_rulespec_local_corpus_release(content_root, corpus_path)
+        source_unit = resolve_corpus_source_unit("us-la/statute/47/32", release)
+        contract = _resolve_legacy_replacement_contract(
+            source_raw=source_relative,
+            destination_raw=destination_relative,
+            policy_checkout_path=checkout,
+            policy_repo_path=content_root,
+            source_unit=source_unit,
+            corpus_release=release,
+            exact_dependent_paths=(dependent_relative,),
+        )
+
+        generated = output_root / "codex-test-model/statutes/47/32.yaml"
+        generated.parent.mkdir(parents=True)
+        generated.write_text(
+            "format: rulespec/v1\n"
+            "module:\n"
+            "  source_verification:\n"
+            "    corpus_citation_path: us-la/statute/47/32\n"
+            "rules:\n"
+            "  - name: amount\n"
+            "    kind: derived\n"
+            "    dtype: Money\n"
+            "    period: Year\n"
+            "    versions:\n"
+            "      - effective_from: '2026-01-01'\n"
+            "        formula: '0'\n"
+        )
+        generated_test = generated.with_name("32.test.yaml")
+        generated_test.write_text("[]\n")
+        result = self._make_eval_result(True)
+        result.output_file = str(generated)
+        result.trace_file = str(tmp_path / "trace.json")
+        Path(result.trace_file).write_text("{}\n")
+        source_file = tmp_path / "source.txt"
+        source_file.write_text(source_text)
+        context = tmp_path / "context.json"
+        context.write_text(
+            json.dumps(
+                {
+                    "source_text_file": source_file.name,
+                    "source_metadata": {
+                        "source_attestation": source_attestation,
+                    },
+                }
+            )
+            + "\n"
+        )
+        result.context_manifest_file = str(context)
+        result.context_manifest_sha256 = hashlib.sha256(
+            context.read_bytes()
+        ).hexdigest()
+        result.generation_prompt_sha256 = "prompt-sha"
+        result.source_attestation = source_attestation
+        result._axiom_legacy_replacement_contract = contract
+
+        observed_overlay: dict[str, object] = {}
+
+        def validate_exact_overlay(
+            _pipeline,
+            *,
+            dependent_pipeline,
+            overlay_target,
+            dependents,
+        ):
+            del dependent_pipeline
+            exact_path = next(
+                path
+                for path in dependents
+                if path.as_posix().endswith(dependent_relative.as_posix())
+            )
+            exact_bytes = exact_path.read_bytes()
+            observed_overlay["dependent"] = exact_path
+            observed_overlay["bytes"] = exact_bytes
+            passed = SimpleNamespace(all_passed=True, results={})
+            return [(overlay_target, passed), (exact_path, passed)]
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline"),
+            patch(
+                "axiom_encode.cli._validate_overlay_files",
+                side_effect=validate_exact_overlay,
+            ),
+            patch("axiom_encode.cli._record_successful_apply_validation"),
+        ):
+            can_apply, issues, supplemental = (
+                _validate_generated_encoding_in_policy_overlay(
+                    result,
+                    output_root=output_root,
+                    policy_repo_path=content_root,
+                    axiom_rules_path=tmp_path / "axiom-rules-engine",
+                    local_corpus_release=release,
+                )
+            )
+        assert can_apply is True, issues
+        assert issues == []
+        assert supplemental == {}
+        assert b"us-la:statutes/47/32#amount" in observed_overlay["bytes"]
+        assert b"us-la:statutes/47:32#amount" not in observed_overlay["bytes"]
+        assert (
+            f"hash: sha256:{_sha256_file(generated)}".encode()
+            in observed_overlay["bytes"]
+        )
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline"),
+            patch(
+                "axiom_encode.cli._validate_overlay_files",
+                side_effect=validate_exact_overlay,
+            ),
+            patch("axiom_encode.cli._record_successful_apply_validation"),
+        ):
+            second_can_apply, second_issues, second_supplemental = (
+                _validate_generated_encoding_in_policy_overlay(
+                    result,
+                    output_root=output_root,
+                    policy_repo_path=content_root,
+                    axiom_rules_path=tmp_path / "axiom-rules-engine",
+                    local_corpus_release=release,
+                )
+            )
+        assert second_can_apply is True, second_issues
+        assert second_issues == []
+        assert second_supplemental == {}
+
+        self._record_apply_validation(
+            result,
+            output_root=output_root,
+            policy_repo_path=content_root,
+            corpus_path=corpus_path,
+        )
+
+        with (
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_PUBLIC_KEY_ENV: TEST_APPLY_PUBLIC_KEY_B64},
+            ),
+            patch(
+                "axiom_encode.cli._git_repo_provenance",
+                return_value={
+                    "root": "/repo/axiom-encode",
+                    "commit": TEST_PINNED_ENCODER_IDENTITY["commit"],
+                    "dirty_tracked": False,
+                },
+            ),
+            patch(
+                "axiom_encode.cli._require_axiom_encode_version_provenance",
+                return_value={
+                    "version": AXIOM_ENCODE_TEST_VERSION,
+                    "version_commit": "f" * 40,
+                    "identity_source": "git",
+                },
+            ),
+        ):
+            applied = _apply_generated_encoding_result(
+                result,
+                output_root=output_root,
+                policy_repo_path=content_root,
+                corpus_path=corpus_path,
+                run_id="legacy-exact-cascade",
+            )
+
+        destination = checkout / destination_relative
+        destination_test = destination.with_name("32.test.yaml")
+        destination_manifest = checkout / _applied_encoding_manifest_path(
+            destination_relative
+        )
+        assert not source.exists()
+        assert not source_test.exists()
+        assert not source_manifest.exists()
+        assert destination.exists()
+        assert destination_test.exists()
+        assert b"us-la:statutes/47/32#amount" in dependent.read_bytes()
+        assert (
+            f"hash: sha256:{_sha256_file(destination)}".encode()
+            in dependent.read_bytes()
+        )
+        assert dependent.read_bytes() != dependent_before
+        assert dependent_test.read_bytes() == dependent_test_before
+        assert dependent_manifest.read_bytes() != dependent_manifest_before
+        assert destination_manifest in applied
+        assert dependent in applied
+        assert dependent_test in applied
+        assert dependent_manifest in applied
+
+        outer = json.loads(destination_manifest.read_text())
+        receipt_path = checkout / outer["replacement"]["receipt_path"]
+        receipt = json.loads(receipt_path.read_text())
+        assert receipt["schema_version"].endswith("/v2")
+        assert len(receipt["replacement"]["exact_dependents"]) == 1
+        exact = receipt["replacement"]["exact_dependents"][0]
+        assert exact["primary"] == dependent_relative.as_posix()
+        assert exact["rewrites"][0]["proof_import_repairs"] == 1
+        exact_legacy_hashes = {
+            item["path"]: item["sha256"] for item in exact["legacy_files"]
+        }
+        exact_live_hashes = {
+            item["path"]: item["sha256"] for item in exact["live_files"]
+        }
+        assert exact_legacy_hashes[dependent_test.relative_to(checkout).as_posix()] == (
+            exact_live_hashes[dependent_test.relative_to(checkout).as_posix()]
+        )
+        exact_manifest = json.loads(dependent_manifest.read_text())
+        assert exact_manifest["tool"] == (
+            "axiom-encode encode --apply "
+            "--legacy-exact-dependent-rulespec-path"
+        )
+        assert exact_manifest["legacy_migration"]["receipt_sha256"] == (
+            hashlib.sha256(receipt_path.read_bytes()).hexdigest()
+        )
+
+        for manifest_path in (destination_manifest, dependent_manifest):
+            verified, _root, _digest, issues = (
+                _load_verified_applied_encoding_manifest_payload(
+                    checkout,
+                    manifest_path.relative_to(checkout).as_posix(),
+                    signing_broker=TEST_APPLY_SIGNING_BROKER,
+                    expected_waiver_set_sha256=TEST_VALIDATION_WAIVER_SHA256,
+                    expected_encoder_identity=TEST_PINNED_ENCODER_IDENTITY,
+                    local_corpus_release=release,
+                )
+            )
+            assert issues == [], "\n".join(issues)
+            assert verified is not None
+
+        outer_before_tamper = destination_manifest.read_bytes()
+        receipt_before_tamper = receipt_path.read_bytes()
+        exact_manifest_before_tamper = dependent_manifest.read_bytes()
+        tampered_receipt = copy.deepcopy(receipt)
+        tampered_receipt["replacement"]["exact_dependents"][0]["rewrites"][0][
+            "proof_import_repairs"
+        ] = 0
+        _sign_applied_encoding_manifest(
+            tampered_receipt,
+            TEST_APPLY_SIGNING_BROKER,
+        )
+        receipt_path.write_text(
+            json.dumps(tampered_receipt, indent=2, sort_keys=True) + "\n"
+        )
+        tampered_receipt_sha256 = hashlib.sha256(
+            receipt_path.read_bytes()
+        ).hexdigest()
+        tampered_outer = copy.deepcopy(outer)
+        tampered_outer["replacement"]["receipt_sha256"] = (
+            tampered_receipt_sha256
+        )
+        _sign_applied_encoding_manifest(
+            tampered_outer,
+            TEST_APPLY_SIGNING_BROKER,
+        )
+        destination_manifest.write_text(
+            json.dumps(tampered_outer, indent=2, sort_keys=True) + "\n"
+        )
+        tampered_exact_manifest = copy.deepcopy(exact_manifest)
+        tampered_exact_manifest["legacy_migration"]["receipt_sha256"] = (
+            tampered_receipt_sha256
+        )
+        _sign_applied_encoding_manifest(
+            tampered_exact_manifest,
+            TEST_APPLY_SIGNING_BROKER,
+        )
+        dependent_manifest.write_text(
+            json.dumps(tampered_exact_manifest, indent=2, sort_keys=True) + "\n"
+        )
+        verified, _root, _digest, issues = (
+            _load_verified_applied_encoding_manifest_payload(
+                checkout,
+                destination_manifest.relative_to(checkout).as_posix(),
+                signing_broker=TEST_APPLY_SIGNING_BROKER,
+                expected_waiver_set_sha256=TEST_VALIDATION_WAIVER_SHA256,
+                expected_encoder_identity=TEST_PINNED_ENCODER_IDENTITY,
+                local_corpus_release=release,
+            )
+        )
+        assert any("rewrite proof is stale" in issue for issue in issues)
+
+        destination_manifest.write_bytes(outer_before_tamper)
+        receipt_path.write_bytes(receipt_before_tamper)
+        dependent_manifest.write_bytes(exact_manifest_before_tamper)
+        exact_manifest = json.loads(dependent_manifest.read_text())
+        exact_manifest["legacy_migration"]["receipt_sha256"] = "0" * 64
+        _sign_applied_encoding_manifest(
+            exact_manifest,
+            TEST_APPLY_SIGNING_BROKER,
+        )
+        dependent_manifest.write_text(
+            json.dumps(exact_manifest, indent=2, sort_keys=True) + "\n"
+        )
+        verified, _root, _digest, issues = (
+            _load_verified_applied_encoding_manifest_payload(
+                checkout,
+                dependent_manifest.relative_to(checkout).as_posix(),
+                signing_broker=TEST_APPLY_SIGNING_BROKER,
+                expected_waiver_set_sha256=TEST_VALIDATION_WAIVER_SHA256,
+                expected_encoder_identity=TEST_PINNED_ENCODER_IDENTITY,
+                local_corpus_release=release,
+            )
+        )
+        assert verified is None
+        assert any("exact dependent receipt is invalid" in issue for issue in issues)
+
     def test_apply_manifest_build_failure_leaves_live_files_byte_identical(
         self, tmp_path
     ):

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1419"
+ENCODER_VERSION = "0.2.1420"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1418"
+ENCODER_VERSION = "0.2.1419"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1418"
+ENCODER_VERSION = "0.2.1419"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1419"
+ENCODER_VERSION = "0.2.1420"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_legacy_replacement.py
+++ b/tests/test_legacy_replacement.py
@@ -469,8 +469,7 @@ def _add_exact_dependent(checkout: Path, content_root: Path) -> Path:
         for path in (dependent, companion)
     }
     manifest = (
-        checkout
-        / ".axiom/encoding-manifests/us-la/policies/income_tax/"
+        checkout / ".axiom/encoding-manifests/us-la/policies/income_tax/"
         "2026_resident_core.json"
     )
     manifest.parent.mkdir(parents=True, exist_ok=True)
@@ -534,8 +533,7 @@ def test_contract_rejects_exact_dependent_without_v1_ownership(
     checkout, content_root, source = _legacy_checkout(tmp_path)
     dependent = _add_exact_dependent(checkout, content_root)
     manifest = (
-        checkout
-        / ".axiom/encoding-manifests/us-la/policies/income_tax/"
+        checkout / ".axiom/encoding-manifests/us-la/policies/income_tax/"
         "2026_resident_core.json"
     )
     payload = json.loads(manifest.read_text())

--- a/tests/test_legacy_replacement.py
+++ b/tests/test_legacy_replacement.py
@@ -174,6 +174,7 @@ def test_receipt_identity_binds_every_transaction_dimension() -> None:
         deleted_files=[{"path": "us-la/statutes/47:32.yaml", "deleted": True}],
         rewrites=[],
         scheduled_dependents=[],
+        exact_dependents=[],
     )
     baseline = receipt_identity_sha256(payload)
     for field in (
@@ -185,6 +186,7 @@ def test_receipt_identity_binds_every_transaction_dimension() -> None:
         "deleted_files",
         "rewrites",
         "scheduled_dependents",
+        "exact_dependents",
     ):
         changed = copy.deepcopy(payload)
         changed[field] = f"changed-{field}"
@@ -442,6 +444,119 @@ def test_contract_binds_only_explicit_scheduled_dependent(tmp_path: Path) -> Non
             "count": 1,
         },
     )
+
+
+def _add_exact_dependent(checkout: Path, content_root: Path) -> Path:
+    dependent = content_root / "policies/income_tax/2026_resident_core.yaml"
+    companion = dependent.with_name("2026_resident_core.test.yaml")
+    dependent.parent.mkdir(parents=True)
+    dependent.write_text(
+        "format: rulespec/v1\n"
+        "module:\n"
+        "  source_verification:\n"
+        "    corpus_citation_paths:\n"
+        "      - us-la/statute/47:32\n"
+        "      - us-la/statute/47:294\n"
+        "imports:\n"
+        "  - us-la:statutes/47:32#amount\n"
+        "rules: []\n"
+    )
+    companion.write_text("[]\n")
+    expected_files = {
+        path.relative_to(checkout).as_posix(): hashlib.sha256(
+            path.read_bytes()
+        ).hexdigest()
+        for path in (dependent, companion)
+    }
+    manifest = (
+        checkout
+        / ".axiom/encoding-manifests/us-la/policies/income_tax/"
+        "2026_resident_core.json"
+    )
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    payload = _manual_manifest()
+    payload["applied_files"] = [
+        {"path": path, "sha256": digest} for path, digest in expected_files.items()
+    ]
+    manifest.write_text(json.dumps(payload) + "\n")
+    _git(checkout, "add", ".")
+    _git(checkout, "commit", "-qm", "exact dependent")
+    return dependent.relative_to(checkout)
+
+
+def test_contract_binds_exact_composite_dependent_to_clean_base(
+    tmp_path: Path,
+) -> None:
+    checkout, content_root, source = _legacy_checkout(tmp_path)
+    dependent = _add_exact_dependent(checkout, content_root)
+
+    with patch("axiom_encode.cli.resolve_corpus_source_unit", return_value=source):
+        contract = _resolve_legacy_replacement_contract(
+            source_raw=Path("us-la/statutes/47:32.yaml"),
+            destination_raw=Path("us-la/statutes/47/32.yaml"),
+            policy_checkout_path=checkout,
+            policy_repo_path=content_root,
+            source_unit=source,
+            corpus_release=SimpleNamespace(),
+            exact_dependent_paths=(dependent,),
+        )
+
+    assert contract.scheduled_dependents == ()
+    assert len(contract.exact_dependents) == 1
+    exact = contract.exact_dependents[0]
+    assert exact.primary == dependent
+    assert {item.path for item in exact.legacy_files} == {
+        dependent,
+        dependent.with_name("2026_resident_core.test.yaml"),
+    }
+    assert {item.path for item in exact.live_files} == {
+        dependent,
+        dependent.with_name("2026_resident_core.test.yaml"),
+    }
+    assert [item.path for item in exact.rewrites] == [dependent]
+    assert b"us-la:statutes/47/32#amount" in next(
+        item.raw for item in exact.live_files if item.path == dependent
+    )
+    assert next(
+        item.sha256
+        for item in exact.legacy_files
+        if item.path.name.endswith(".test.yaml")
+    ) == next(
+        item.sha256
+        for item in exact.live_files
+        if item.path.name.endswith(".test.yaml")
+    )
+
+
+def test_contract_rejects_exact_dependent_without_v1_ownership(
+    tmp_path: Path,
+) -> None:
+    checkout, content_root, source = _legacy_checkout(tmp_path)
+    dependent = _add_exact_dependent(checkout, content_root)
+    manifest = (
+        checkout
+        / ".axiom/encoding-manifests/us-la/policies/income_tax/"
+        "2026_resident_core.json"
+    )
+    payload = json.loads(manifest.read_text())
+    payload["backend"] = "codex"
+    manifest.write_text(json.dumps(payload) + "\n")
+    _git(checkout, "add", ".")
+    _git(checkout, "commit", "-qm", "forged ownership")
+
+    with (
+        patch("axiom_encode.cli.resolve_corpus_source_unit", return_value=source),
+        pytest.raises(ValueError, match="not admissible"),
+    ):
+        _resolve_legacy_replacement_contract(
+            source_raw=Path("us-la/statutes/47:32.yaml"),
+            destination_raw=Path("us-la/statutes/47/32.yaml"),
+            policy_checkout_path=checkout,
+            policy_repo_path=content_root,
+            source_unit=source,
+            corpus_release=SimpleNamespace(),
+            exact_dependent_paths=(dependent,),
+        )
 
 
 def test_contract_rejects_dirty_or_existing_destination(tmp_path: Path) -> None:

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1419"
+ENCODER_VERSION = "0.2.1420"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1418"
+ENCODER_VERSION = "0.2.1419"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1419"
+ENCODER_VERSION = "0.2.1420"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1418"
+ENCODER_VERSION = "0.2.1419"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1418"
+ENCODER_VERSION = "0.2.1419"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1419"
+ENCODER_VERSION = "0.2.1420"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1419"
+ENCODER_VERSION = "0.2.1420"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1418"
+ENCODER_VERSION = "0.2.1419"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import subprocess
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import pytest
 
@@ -73,6 +73,7 @@ def _write_legacy_replacement_change(
     scheduled_pending: bool = False,
     omitted_dependent: bool = False,
     omitted_scheduled_companion: bool = False,
+    exact_dependent: bool = False,
 ) -> tuple[Path, Path, Path, Path]:
     old_rule = repo / "us/statutes/47:32.yaml"
     old_test = repo / "us/statutes/47:32.test.yaml"
@@ -137,6 +138,71 @@ def _write_legacy_replacement_change(
             "format: rulespec/v1\nimports:\n  - us:statutes/47:32\nrules: []\n",
             encoding="utf-8",
         )
+    exact_primary = repo / "us/policies/income_tax/composite.yaml"
+    exact_companion = repo / "us/policies/income_tax/composite.test.yaml"
+    exact_manifest = (
+        repo / ".axiom/encoding-manifests/us/policies/income_tax/composite.json"
+    )
+    if exact_dependent:
+        exact_primary.parent.mkdir(parents=True, exist_ok=True)
+        exact_primary.write_text(
+            "format: rulespec/v1\n"
+            "imports:\n"
+            "  - us:statutes/47:32#amount\n"
+            "rules:\n"
+            "  - name: liability\n"
+            "    kind: derived\n"
+            "    dtype: Money\n"
+            "    period: Year\n"
+            "    metadata:\n"
+            "      proof:\n"
+            "        atoms:\n"
+            "          - path: versions[0].formula\n"
+            "            kind: import\n"
+            "            import:\n"
+            "              target: us:statutes/47:32#amount\n"
+            "              output: amount\n"
+            f"              hash: sha256:{old_rule_sha256}\n"
+            "    versions:\n"
+            "      - effective_from: '2026-01-01'\n"
+            "        formula: amount\n",
+            encoding="utf-8",
+        )
+        exact_companion.write_text("[]\n", encoding="utf-8")
+        exact_manifest.parent.mkdir(parents=True, exist_ok=True)
+        exact_manifest.write_text(
+            json.dumps(
+                {
+                    "schema_version": "axiom-encode/applied-rulespec/v1",
+                    "tool": "axiom-encode sign-applied-files",
+                    "backend": "manual",
+                    "runner": "manual-attestation",
+                    "manual_exception": "test exact dependent evidence",
+                    "applied_files": [
+                        {
+                            "path": exact_primary.relative_to(repo).as_posix(),
+                            "sha256": hashlib.sha256(
+                                exact_primary.read_bytes()
+                            ).hexdigest(),
+                        },
+                        {
+                            "path": exact_companion.relative_to(repo).as_posix(),
+                            "sha256": hashlib.sha256(
+                                exact_companion.read_bytes()
+                            ).hexdigest(),
+                        },
+                    ],
+                    "signature": {
+                        "algorithm": "hmac-sha256",
+                        "key_id": "historical-v1",
+                        "value": "opaque-untrusted-evidence",
+                    },
+                },
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
     _git(repo, "add", ".")
     _git(repo, "commit", "-m", "legacy baseline")
     base_commit = _git(repo, "rev-parse", "HEAD")
@@ -149,16 +215,35 @@ def _write_legacy_replacement_change(
         if scheduled_pending
         else None
     )
+    exact_primary_before = exact_primary.read_bytes() if exact_dependent else None
+    exact_companion_before = exact_companion.read_bytes() if exact_dependent else None
+    exact_manifest_before = exact_manifest.read_bytes() if exact_dependent else None
     old_rule.unlink()
     old_test.unlink()
     old_manifest.unlink()
     metadata.write_text('{"module":"us:statutes/47/32"}\n', encoding="utf-8")
+    if exact_dependent:
+        exact_primary.write_text(
+            exact_primary.read_text(encoding="utf-8").replace(
+                "us:statutes/47:32",
+                "us:statutes/47/32",
+            ),
+            encoding="utf-8",
+        )
 
     new_rule = repo / "us/statutes/47/32.yaml"
     new_test = repo / "us/statutes/47/32.test.yaml"
     new_rule.parent.mkdir(parents=True)
-    new_rule.write_text("rules: []\n", encoding="utf-8")
+    new_rule.write_text("format: rulespec/v1\nrules: []\n", encoding="utf-8")
     new_test.write_text("[]\n", encoding="utf-8")
+    if exact_dependent:
+        exact_primary.write_text(
+            exact_primary.read_text(encoding="utf-8").replace(
+                old_rule_sha256,
+                hashlib.sha256(new_rule.read_bytes()).hexdigest(),
+            ),
+            encoding="utf-8",
+        )
     live_files = [
         {
             "path": new_rule.relative_to(repo).as_posix(),
@@ -191,7 +276,11 @@ def _write_legacy_replacement_change(
     receipt = repo / receipt_relative
     receipt.parent.mkdir(parents=True)
     receipt_payload = {
-        "schema_version": "axiom-encode/legacy-fresh-reencode-receipt/v1",
+        "schema_version": (
+            "axiom-encode/legacy-fresh-reencode-receipt/v2"
+            if exact_dependent
+            else "axiom-encode/legacy-fresh-reencode-receipt/v1"
+        ),
         "tool": "axiom-encode encode --apply --replace-legacy-rulespec-path",
         "repository": {
             "base_commit": base_commit,
@@ -252,10 +341,116 @@ def _write_legacy_replacement_change(
         },
         "replacement_manifest": nested_manifest,
     }
+    if exact_dependent:
+        assert exact_primary_before is not None
+        assert exact_companion_before is not None
+        assert exact_manifest_before is not None
+        exact_live_files = [
+            {
+                "path": exact_companion.relative_to(repo).as_posix(),
+                "sha256": hashlib.sha256(exact_companion.read_bytes()).hexdigest(),
+            },
+            {
+                "path": exact_primary.relative_to(repo).as_posix(),
+                "sha256": hashlib.sha256(exact_primary.read_bytes()).hexdigest(),
+            },
+        ]
+        receipt_payload.update(
+            {
+                "generated_at": "2026-07-30T00:00:00+00:00",
+                "axiom_encode_version": "0.2.1414",
+                "axiom_encode_git": {
+                    "commit": "a" * 40,
+                    "dirty_tracked": False,
+                },
+                "validation_waiver_set_sha256": "b" * 64,
+            }
+        )
+        receipt_payload["replacement"]["exact_dependents"] = [
+            {
+                "primary": exact_primary.relative_to(repo).as_posix(),
+                "legacy_manifest": {
+                    "path": exact_manifest.relative_to(repo).as_posix(),
+                    "sha256": hashlib.sha256(exact_manifest_before).hexdigest(),
+                },
+                "legacy_files": [
+                    {
+                        "path": exact_companion.relative_to(repo).as_posix(),
+                        "sha256": hashlib.sha256(exact_companion_before).hexdigest(),
+                    },
+                    {
+                        "path": exact_primary.relative_to(repo).as_posix(),
+                        "sha256": hashlib.sha256(exact_primary_before).hexdigest(),
+                    },
+                ],
+                "live_files": exact_live_files,
+                "rewrites": [
+                    {
+                        "path": exact_primary.relative_to(repo).as_posix(),
+                        "before_sha256": hashlib.sha256(
+                            exact_primary_before
+                        ).hexdigest(),
+                        "after_sha256": hashlib.sha256(
+                            exact_primary.read_bytes()
+                        ).hexdigest(),
+                        "replacements": [
+                            {
+                                "from": "us:statutes/47:32",
+                                "to": "us:statutes/47/32",
+                                "count": 2,
+                            }
+                        ],
+                        "proof_import_repairs": 1,
+                    }
+                ],
+            }
+        ]
     receipt.write_text(
         json.dumps(receipt_payload, sort_keys=True) + "\n",
         encoding="utf-8",
     )
+    if exact_dependent:
+        exact_manifest.write_text(
+            json.dumps(
+                {
+                    "schema_version": "axiom-encode/applied-rulespec/v5",
+                    "generated_at": "2026-07-30T00:00:00+00:00",
+                    "tool": (
+                        "axiom-encode encode --apply "
+                        "--legacy-exact-dependent-rulespec-path"
+                    ),
+                    "axiom_encode_version": receipt_payload["axiom_encode_version"],
+                    "axiom_encode_git": receipt_payload["axiom_encode_git"],
+                    "validation_waiver_set_sha256": receipt_payload[
+                        "validation_waiver_set_sha256"
+                    ],
+                    "applied_files": receipt_payload["replacement"]["exact_dependents"][
+                        0
+                    ]["live_files"],
+                    "legacy_migration": {
+                        "receipt_path": receipt_relative.as_posix(),
+                        "receipt_sha256": hashlib.sha256(
+                            receipt.read_bytes()
+                        ).hexdigest(),
+                        "primary": exact_primary.relative_to(repo).as_posix(),
+                        "legacy_manifest_path": exact_manifest.relative_to(
+                            repo
+                        ).as_posix(),
+                        "legacy_manifest_sha256": hashlib.sha256(
+                            exact_manifest_before
+                        ).hexdigest(),
+                    },
+                    "signature": {
+                        "algorithm": "ed25519-domain-v1",
+                        "key_id": f"sha256:{'d' * 64}",
+                        "value": "signed-test-value",
+                    },
+                },
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
     manifest = repo / ".axiom/encoding-manifests/us/statutes/47/32.json"
     manifest.parent.mkdir(parents=True, exist_ok=True)
     manifest.write_text(
@@ -443,6 +638,157 @@ def test_stage_accepts_receipt_linked_legacy_deletion_with_dependent_manifest(
     assert set(
         _git(repo, "diff", "--cached", "--name-only", "--no-renames").splitlines()
     ) == {path.as_posix() for path in expected}
+
+
+def _refresh_legacy_receipt_bindings(
+    repo: Path,
+    manifest: Path,
+    receipt: Path,
+) -> None:
+    receipt_sha256 = hashlib.sha256(receipt.read_bytes()).hexdigest()
+    manifest_payload = json.loads(manifest.read_text(encoding="utf-8"))
+    manifest_payload["replacement"]["receipt_sha256"] = receipt_sha256
+    manifest.write_text(
+        json.dumps(manifest_payload, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    exact_manifest = (
+        repo / ".axiom/encoding-manifests/us/policies/income_tax/composite.json"
+    )
+    if exact_manifest.is_file():
+        exact_payload = json.loads(exact_manifest.read_text(encoding="utf-8"))
+        exact_payload["legacy_migration"]["receipt_sha256"] = receipt_sha256
+        exact_manifest.write_text(
+            json.dumps(exact_payload, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+
+def test_stage_accepts_v2_exact_dependent_with_unchanged_companion(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    _write_legacy_replacement_change(repo, exact_dependent=True)
+
+    expected = authorized_changed_paths(repo)
+    stage_authorized_changes(repo)
+
+    assert PurePosixPath("us/policies/income_tax/composite.test.yaml") not in expected
+    assert (
+        "us/policies/income_tax/composite.test.yaml"
+        not in _git(repo, "diff", "--cached", "--name-only").splitlines()
+    )
+
+
+def test_stage_keeps_v1_legacy_replacement_compatible(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    _manifest, receipt, _old_manifest, _metadata = _write_legacy_replacement_change(
+        repo
+    )
+
+    assert (
+        json.loads(receipt.read_text(encoding="utf-8"))["schema_version"]
+        == "axiom-encode/legacy-fresh-reencode-receipt/v1"
+    )
+    authorized_changed_paths(repo)
+
+
+def test_stage_rejects_v2_exact_dependent_live_file_tamper(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    _write_legacy_replacement_change(repo, exact_dependent=True)
+    primary = repo / "us/policies/income_tax/composite.yaml"
+    primary.write_text(primary.read_text(encoding="utf-8") + "# tampered\n")
+
+    with pytest.raises(ValueError, match="live file hash differs"):
+        authorized_changed_paths(repo)
+
+
+def test_stage_rejects_v2_exact_dependent_manifest_binding_tamper(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    _write_legacy_replacement_change(repo, exact_dependent=True)
+    exact_manifest = (
+        repo / ".axiom/encoding-manifests/us/policies/income_tax/composite.json"
+    )
+    payload = json.loads(exact_manifest.read_text(encoding="utf-8"))
+    payload["legacy_migration"]["primary"] = "us/policies/income_tax/unrelated.yaml"
+    exact_manifest.write_text(json.dumps(payload, sort_keys=True) + "\n")
+
+    with pytest.raises(ValueError, match="manifest binding differs"):
+        authorized_changed_paths(repo)
+
+
+def test_stage_rejects_v2_exact_dependent_signature_tamper(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    _write_legacy_replacement_change(repo, exact_dependent=True)
+    exact_manifest = (
+        repo / ".axiom/encoding-manifests/us/policies/income_tax/composite.json"
+    )
+    payload = json.loads(exact_manifest.read_text(encoding="utf-8"))
+    payload["signature"] = {}
+    exact_manifest.write_text(json.dumps(payload, sort_keys=True) + "\n")
+
+    with pytest.raises(ValueError, match="manifest is malformed"):
+        authorized_changed_paths(repo)
+
+
+def test_stage_rejects_v2_exact_dependent_rewrite_tamper(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    manifest, receipt, _old_manifest, _metadata = _write_legacy_replacement_change(
+        repo, exact_dependent=True
+    )
+    payload = json.loads(receipt.read_text(encoding="utf-8"))
+    payload["replacement"]["exact_dependents"][0]["rewrites"][0]["replacements"][0][
+        "count"
+    ] = 3
+    receipt.write_text(json.dumps(payload, sort_keys=True) + "\n")
+    _refresh_legacy_receipt_bindings(repo, manifest, receipt)
+
+    with pytest.raises(ValueError, match="transformation differs"):
+        authorized_changed_paths(repo)
+
+
+def test_stage_rejects_v2_exact_dependent_proof_hash_repair_tamper(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    manifest, receipt, _old_manifest, _metadata = _write_legacy_replacement_change(
+        repo, exact_dependent=True
+    )
+    payload = json.loads(receipt.read_text(encoding="utf-8"))
+    payload["replacement"]["exact_dependents"][0]["rewrites"][0][
+        "proof_import_repairs"
+    ] = 0
+    receipt.write_text(json.dumps(payload, sort_keys=True) + "\n")
+    _refresh_legacy_receipt_bindings(repo, manifest, receipt)
+
+    with pytest.raises(ValueError, match="transformation differs"):
+        authorized_changed_paths(repo)
+
+
+def test_stage_rejects_v2_exact_dependent_incomplete_legacy_group(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    manifest, receipt, _old_manifest, _metadata = _write_legacy_replacement_change(
+        repo, exact_dependent=True
+    )
+    payload = json.loads(receipt.read_text(encoding="utf-8"))
+    payload["replacement"]["exact_dependents"][0]["legacy_files"] = payload[
+        "replacement"
+    ]["exact_dependents"][0]["legacy_files"][1:]
+    receipt.write_text(json.dumps(payload, sort_keys=True) + "\n")
+    _refresh_legacy_receipt_bindings(repo, manifest, receipt)
+
+    with pytest.raises(ValueError, match="exact full file group"):
+        authorized_changed_paths(repo)
 
 
 def test_stage_rejects_tampered_legacy_replacement_receipt(tmp_path: Path) -> None:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1419"')
+        .startswith('__version__ = "0.2.1420"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1419"
+    assert encoder_package["version"] == "0.2.1420"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1419"
+    assert project["project"]["version"] == "0.2.1420"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1419"')
+        .startswith('__version__ = "0.2.1420"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1419"
+    assert encoder_package["version"] == "0.2.1420"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1419"
+    assert project["project"]["version"] == "0.2.1420"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1419"')
+        .startswith('__version__ = "0.2.1420"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1418"')
+        .startswith('__version__ = "0.2.1419"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1418"
+    assert encoder_package["version"] == "0.2.1419"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1418"
+    assert project["project"]["version"] == "0.2.1419"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1418"')
+        .startswith('__version__ = "0.2.1419"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1418"
+    assert encoder_package["version"] == "0.2.1419"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1418"
+    assert project["project"]["version"] == "0.2.1419"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1418"')
+        .startswith('__version__ = "0.2.1419"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1418"
+ENCODER_VERSION = "0.2.1419"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1419"
+ENCODER_VERSION = "0.2.1420"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -976,7 +976,7 @@ def test_subscription_tampered_binary_hard_fails_before_child(
 
 @pytest.mark.parametrize(
     "outbox_kind",
-    ["symlink", "fifo", "socket", "device", "protected-directory"],
+    ["symlink", "fifo", "socket", "device", "writable-directory"],
 )
 def test_subscription_refuses_unsafe_auth_outbox(
     signing_supervisor: Path,
@@ -1027,7 +1027,10 @@ def test_subscription_refuses_unsafe_auth_outbox(
     elif outbox_kind == "device":
         outbox = Path("/dev/null")
     else:
-        outbox = Path("/etc") / f"axiom-encode-test-{os.getpid()}.json"
+        unsafe_directory = tmp_path / "unsafe-outbox"
+        unsafe_directory.mkdir(mode=0o777)
+        unsafe_directory.chmod(0o777)
+        outbox = unsafe_directory / "out.json"
     try:
         completed = _invoke(
             signing_supervisor,

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2679,6 +2679,83 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
     )
 
 
+def test_targeted_signed_reencode_passes_exact_legacy_dependents_atomically(
+    tmp_path: Path,
+) -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
+    )
+    command = next(
+        step["run"]
+        for step in workflow["jobs"]["encode"]["steps"]
+        if step.get("name") == "Encode, review, validate, and apply"
+    ).replace(
+        "/opt/axiom-verification/axiom-encode-apply-signer run",
+        '"$SIGNER_STUB"',
+    )
+    calls_path = tmp_path / "calls.jsonl"
+    signer_stub = tmp_path / "signer-stub"
+    signer_stub.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
+    stream.write(json.dumps(sys.argv[1:]) + "\\n")
+"""
+    )
+    signer_stub.chmod(0o700)
+    runner_temp = tmp_path / "runner-temp"
+    runner_temp.mkdir()
+    source = "us-la/statutes/47:32.yaml"
+    destination = "us-la/statutes/47/32.yaml"
+    exact_dependents = [
+        "us-la/policies/income_tax/2026_resident_core.yaml",
+        "us-la/policies/income_tax/pilot_liability_pipeline.yaml",
+    ]
+    environment = {
+        **os.environ,
+        "AXIOM_ENCODE_APPLY_SIGNING_KEY": "test-key",
+        "AXIOM_TEST_PYTHON": sys.executable,
+        "CALLS_PATH": str(calls_path),
+        "CITATION": "us-la/statute/47:32",
+        "DEPENDENT_CITATION": "",
+        "DEPENDENT_REVIEW_FINDING": "",
+        "GITHUB_WORKSPACE": str(tmp_path),
+        "LEGACY_EXACT_DEPENDENT_RULESPEC_PATH": exact_dependents[0],
+        "REPLACE_LEGACY_RULESPEC_PATH": source,
+        "REPLACE_RULESPEC_PATH": destination,
+        "REVIEW_FINDING": "Preserve all supported existing semantics.",
+        "RULESPEC_CHECKOUT": str(tmp_path / "rulespec-us"),
+        "RUNNER_TEMP": str(runner_temp),
+        "SECOND_DEPENDENT_CITATION": "",
+        "SECOND_DEPENDENT_REVIEW_FINDING": "",
+        "SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH": exact_dependents[1],
+        "SIGNER_STUB": str(signer_stub),
+    }
+
+    subprocess.run(["bash", "-c", command], check=True, env=environment)
+
+    calls = [
+        json.loads(line) for line in calls_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert len(calls) == 1
+    encode_args = calls[0][calls[0].index("--") + 1 :]
+    assert encode_args[encode_args.index("--replace-rulespec-path") + 1] == destination
+    assert (
+        encode_args[encode_args.index("--replace-legacy-rulespec-path") + 1] == source
+    )
+    exact_indexes = [
+        index
+        for index, value in enumerate(encode_args)
+        if value == "--legacy-exact-dependent-rulespec-path"
+    ]
+    assert [encode_args[index + 1] for index in exact_indexes] == exact_dependents
+    assert "--apply-target-only" not in encode_args
+
+
 @pytest.mark.parametrize(
     ("overrides", "error"),
     [
@@ -2705,6 +2782,26 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
                 "SECOND_DEPENDENT_REVIEW_FINDING": "Preserve the second source.",
             },
             "second dependent citation is required with its review finding",
+        ),
+        (
+            {
+                "SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH": (
+                    "us-la/policies/income_tax/pilot_liability_pipeline.yaml"
+                ),
+            },
+            "exact legacy dependents require a legacy source replacement",
+        ),
+        (
+            {
+                "LEGACY_EXACT_DEPENDENT_RULESPEC_PATH": (
+                    "us-la/policies/income_tax/2026_resident_core.yaml"
+                ),
+                "REPLACE_LEGACY_RULESPEC_PATH": "us-la/statutes/47:32.yaml",
+                "REPLACE_RULESPEC_PATH": "us-la/statutes/47/32.yaml",
+                "DEPENDENT_CITATION": "us-la/statute/47:294",
+                "DEPENDENT_REVIEW_FINDING": "Preserve dependent semantics.",
+            },
+            "exact and model-regenerated dependent modes cannot be combined",
         ),
     ],
 )

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1419"
+version = "0.2.1420"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1418"
+version = "0.2.1419"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- add a v2 signed legacy-replacement receipt for exact v1/manual dependent groups
- validate the fresh canonical source and migrated composites as one final graph
- bind canonical reference rewrites, deterministic proof-import hash refreshes, unchanged companions, old manifests, and final live hashes
- install the source, exact dependents, v5 manifests, and shared receipt in one recoverable transaction
- pass both Louisiana income-tax composites through the protected targeted re-encode workflow
- preserve v1 receipt compatibility and fail closed in runtime and publication verification

## Review-fix cycle

- First independent review found a P1: proof-import hash repairs could enter the ordinary supplemental path and duplicate an exact transaction target.
- Fixed by finalizing exact dependent bytes from immutable base evidence, authenticating proof-hash repair counts/final hashes, and excluding exact groups from model supplemental ownership.
- Added changed-target-hash, idempotency, resigned-tamper, and publication-tamper coverage.
- Second independent review: CLEAN, no actionable correctness or security findings.

## Checks

- uv run ruff check pyproject.toml src/axiom_encode scripts tests
- python -m compileall -q src/axiom_encode scripts
- uv run pytest: 6075 passed, 119 skipped
- uv lock --check
- towncrier draft
- git diff --check

## Post-review CI stabilization cycle

- Exact reviewed head: 372e568e535c9b1949f6beacf85bf1abda9aff49
- Independent review first found the host-dependent /etc outbox fixture as a P1 merge blocker.
- Replaced it with a deterministic mode-0777 temporary outbox directory; production trust behavior is unchanged.
- Repeat independent review: CLEAN, no remaining actionable findings.
- Ubuntu and macOS signing-supervisor jobs passed, including race tests and the root-owned untagged production end-to-end fixture.
- Local: Ruff, compileall, diff check, and encoder provenance guard passed; the local Go-backed target skipped because this host has no Go toolchain.
