### PR TITLE
Add atomic signed source bundle encoding

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -34,6 +34,11 @@ on:
         description: Validator or independent-review finding to address
         required: false
         type: string
+      source_bundle_json:
+        description: JSON array of additional same-jurisdiction citations to encode as signed atomic imports
+        required: false
+        default: "[]"
+        type: string
       replace_rulespec_path:
         description: Existing target, or unique canonical destination for a legacy replacement
         required: false
@@ -361,6 +366,33 @@ jobs:
           uv pip install --python .venv/bin/python \
             --target "$RUNNER_TEMP/axiom-verification-site-packages" ".[api]"
 
+      - name: Validate atomic source bundle
+        env:
+          CITATION: ${{ inputs.citation }}
+          DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
+          QUEUE_ID: ${{ inputs.queue_id }}
+          SECOND_DEPENDENT_CITATION: ${{ inputs.second_dependent_citation }}
+          SOURCE_BUNDLE_JSON: ${{ inputs.source_bundle_json }}
+        run: |
+          set -euo pipefail
+          source_bundle_args=(
+            axiom-encode/.venv/bin/python
+            axiom-encode/scripts/prepare_signed_backfill.py
+            parse-source-bundle "${SOURCE_BUNDLE_JSON:-[]}"
+            --primary-citation "$CITATION"
+          )
+          if [ -n "$DEPENDENT_CITATION" ]; then
+            source_bundle_args+=(--exclude-citation "$DEPENDENT_CITATION")
+          fi
+          if [ -n "$SECOND_DEPENDENT_CITATION" ]; then
+            source_bundle_args+=(--exclude-citation "$SECOND_DEPENDENT_CITATION")
+          fi
+          normalized_source_bundle="$("${source_bundle_args[@]}")"
+          if [ -n "$QUEUE_ID" ] && [ "$normalized_source_bundle" != "[]" ]; then
+            echo "queue-authorized re-encodes cannot add a source bundle until queue generation identity binds it" >&2
+            exit 1
+          fi
+
       - name: Fetch pinned signed corpus release object
         shell: bash
         env:
@@ -568,7 +600,9 @@ jobs:
           DEPENDENT_REVIEW_FINDING: ${{ inputs.dependent_review_finding }}
           SECOND_DEPENDENT_CITATION: ${{ inputs.second_dependent_citation }}
           SECOND_DEPENDENT_REVIEW_FINDING: ${{ inputs.second_dependent_review_finding }}
+          SOURCE_BUNDLE_JSON: ${{ inputs.source_bundle_json }}
           RULESPEC_CHECKOUT: ${{ github.workspace }}/rulespec-${{ inputs.country }}
+          RULESPEC_REF: ${{ inputs.rulespec_ref }}
         run: |
           set -euo pipefail
           : "${QUEUE_ID:=}"
@@ -588,6 +622,7 @@ jobs:
             local output_lane="$4"
             local replacement_path="$5"
             local legacy_source_path="$6"
+            local require_source_bundle_imports="$7"
             local review_finding_path=""
             local -a args=(
               /opt/axiom-verification/axiom-encode encode
@@ -632,6 +667,11 @@ jobs:
                   "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH"
                 )
               fi
+            fi
+            if [ "$require_source_bundle_imports" = "true" ]; then
+              while IFS= read -r required_import_path; do
+                args+=(--required-import-rulespec-path "$required_import_path")
+              done < "$RUNNER_TEMP/source-bundle-rulespec-paths.txt"
             fi
             if [ -n "$review_finding" ]; then
               review_finding_dir="$(mktemp -d "$RUNNER_TEMP/axiom-targeted-review-finding.XXXXXX")"
@@ -749,32 +789,110 @@ jobs:
               citation-rulespec-path "$SECOND_DEPENDENT_CITATION")"
           fi
 
+          source_bundle_args=(
+            "$workflow_python" "$backfill_helper" parse-source-bundle
+            "${SOURCE_BUNDLE_JSON:-[]}" --primary-citation "$CITATION"
+          )
+          if [ -n "$DEPENDENT_CITATION" ]; then
+            source_bundle_args+=(--exclude-citation "$DEPENDENT_CITATION")
+          fi
+          if [ -n "$SECOND_DEPENDENT_CITATION" ]; then
+            source_bundle_args+=(--exclude-citation "$SECOND_DEPENDENT_CITATION")
+          fi
+          normalized_source_bundle="$("${source_bundle_args[@]}")"
+          if [ -n "$QUEUE_ID" ] && [ "$normalized_source_bundle" != "[]" ]; then
+            echo "queue-authorized re-encodes cannot add a source bundle until queue generation identity binds it" >&2
+            exit 1
+          fi
+          printf '%s\n' "$normalized_source_bundle" \
+            > "$RUNNER_TEMP/source-bundle.json"
+          jq -r '.[]' "$RUNNER_TEMP/source-bundle.json" \
+            > "$RUNNER_TEMP/source-bundle-citations.txt"
+          : > "$RUNNER_TEMP/source-bundle-rulespec-paths.txt"
+          while IFS= read -r source_citation; do
+            "$workflow_python" "$backfill_helper" \
+              citation-rulespec-path "$source_citation" \
+              >> "$RUNNER_TEMP/source-bundle-rulespec-paths.txt"
+          done < "$RUNNER_TEMP/source-bundle-citations.txt"
+          source_bundle_count="$(jq -er 'length' \
+            "$RUNNER_TEMP/source-bundle.json")"
+          source_bundle_enabled=false
+          if [ "$source_bundle_count" -gt 0 ]; then
+            source_bundle_enabled=true
+          fi
+
+          checkpoint_signed_changes() {
+            local message="$1"
+            /opt/axiom-verification/axiom-encode-signing-supervisor \
+              --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
+              --trusted-python-runtime-root /opt/axiom-verification/python \
+              --trusted-python-import-root /opt/axiom-verification/python/lib/python3.13/site-packages \
+              --trusted-python-package-root /opt/axiom-verification/python/lib/python3.13/site-packages/axiom_encode \
+              -- /opt/axiom-verification/axiom-encode guard-generated \
+              --repo "$RULESPEC_CHECKOUT" \
+              --corpus-path "$GITHUB_WORKSPACE/axiom-corpus" \
+              --expected-encoder-checkout "$GITHUB_WORKSPACE/axiom-encode" \
+              --json > "$RUNNER_TEMP/checkpoint-guard-generated.json"
+            git -C "$RULESPEC_CHECKOUT" diff --check
+            "$workflow_python" "$backfill_helper" stage "$RULESPEC_CHECKOUT"
+            git -C "$RULESPEC_CHECKOUT" \
+              -c core.hooksPath=/dev/null \
+              -c user.name=axiom-encode-bot \
+              -c user.email=axiom-encode-bot@users.noreply.github.com \
+              commit -m "$message"
+          }
+
+          source_index=0
+          while IFS= read -r source_citation; do
+            source_index=$((source_index + 1))
+            source_lane="$(printf 'source-%02d' "$source_index")"
+            run_signed_encode \
+              "$source_citation" "" true "$source_lane" "" "" false
+            checkpoint_signed_changes \
+              "Add signed source module for ${source_citation}"
+            cp "$RUNNER_TEMP/checkpoint-guard-generated.json" \
+              "$RUNNER_TEMP/${source_lane}-guard-generated.json"
+          done < "$RUNNER_TEMP/source-bundle-citations.txt"
+
           if [ -n "$DEPENDENT_CITATION" ]; then
             run_signed_encode \
               "$CITATION" "$REVIEW_FINDING" true target \
-              "$REPLACE_RULESPEC_PATH" "$REPLACE_LEGACY_RULESPEC_PATH"
+              "$REPLACE_RULESPEC_PATH" "$REPLACE_LEGACY_RULESPEC_PATH" \
+              "$source_bundle_enabled"
             dependent_target_only=false
             if [ -n "$SECOND_DEPENDENT_CITATION" ]; then
               dependent_target_only=true
             fi
             run_signed_encode \
               "$DEPENDENT_CITATION" "$DEPENDENT_REVIEW_FINDING" \
-              "$dependent_target_only" dependent "" ""
+              "$dependent_target_only" dependent "" "" false
             if [ -n "$SECOND_DEPENDENT_CITATION" ]; then
               run_signed_encode \
                 "$SECOND_DEPENDENT_CITATION" \
-                "$SECOND_DEPENDENT_REVIEW_FINDING" false dependent-2 "" ""
+                "$SECOND_DEPENDENT_REVIEW_FINDING" false dependent-2 "" "" false
             fi
           else
             run_signed_encode \
-              "$CITATION" "$REVIEW_FINDING" false target \
-              "$REPLACE_RULESPEC_PATH" "$REPLACE_LEGACY_RULESPEC_PATH"
+              "$CITATION" "$REVIEW_FINDING" false \
+              target "$REPLACE_RULESPEC_PATH" \
+              "$REPLACE_LEGACY_RULESPEC_PATH" \
+              "$source_bundle_enabled"
+          fi
+
+          if [ "$source_bundle_enabled" = "true" ]; then
+            checkpoint_signed_changes \
+              "Compose signed source bundle for ${CITATION}"
           fi
 
       - name: Verify generated provenance
         env:
           RULESPEC_CHECKOUT: ${{ github.workspace }}/rulespec-${{ inputs.country }}
+          RULESPEC_REF: ${{ inputs.rulespec_ref }}
         run: |
+          guard_ref_args=()
+          if jq -e 'length > 0' "$RUNNER_TEMP/source-bundle.json" > /dev/null; then
+            guard_ref_args+=(--base-ref "$RULESPEC_REF")
+          fi
           /opt/axiom-verification/axiom-encode-signing-supervisor \
             --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
             --trusted-python-runtime-root /opt/axiom-verification/python \
@@ -784,6 +902,7 @@ jobs:
             --repo "$RULESPEC_CHECKOUT" \
             --corpus-path "$GITHUB_WORKSPACE/axiom-corpus" \
             --expected-encoder-checkout "$GITHUB_WORKSPACE/axiom-encode" \
+            "${guard_ref_args[@]}" \
             --json > "$RUNNER_TEMP/guard-generated.json"
           git -C "$RULESPEC_CHECKOUT" diff --check
 
@@ -805,18 +924,29 @@ jobs:
           LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.legacy_exact_dependent_rulespec_path }}
           SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.second_legacy_exact_dependent_rulespec_path }}
           RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
+          RULESPEC_REF: ${{ inputs.rulespec_ref }}
         run: |
+          set -euo pipefail
           workflow_python=(/opt/axiom-verification/python/bin/python -I)
           if [ ! -x "${workflow_python[0]}" ]; then
             workflow_python=("${AXIOM_TEST_PYTHON:-python}")
           fi
           artifact="$RUNNER_TEMP/targeted-reencode"
           mkdir -p "$artifact"
-          git -C "$RULESPEC_CHECKOUT" diff --binary --full-index HEAD > "$artifact/tracked.patch"
+          git -C "$RULESPEC_CHECKOUT" diff --binary --full-index \
+            "$RULESPEC_REF" > "$artifact/tracked.patch"
           git -C "$RULESPEC_CHECKOUT" ls-files --others --exclude-standard -z \
             | tar -C "$RULESPEC_CHECKOUT" --null -czf "$artifact/untracked.tar.gz" --files-from -
           git -C "$RULESPEC_CHECKOUT" status --short > "$artifact/status.txt"
+          git -C "$RULESPEC_CHECKOUT" diff --name-status \
+            "$RULESPEC_REF" HEAD >> "$artifact/status.txt"
           cp "$RUNNER_TEMP/guard-generated.json" "$artifact/guard-generated.json"
+          cp "$RUNNER_TEMP/source-bundle.json" "$artifact/source-bundle.json"
+          for source_guard in "$RUNNER_TEMP"/source-*-guard-generated.json; do
+            if [ -f "$source_guard" ]; then
+              cp "$source_guard" "$artifact/"
+            fi
+          done
           "${workflow_python[@]}" - \
             "$artifact/context-manifest.json" \
             "$artifact/apply-manifests.json" <<'PY'
@@ -864,11 +994,13 @@ jobs:
                   raise SystemExit(str(exc)) from exc
 
           manifest_paths = git_paths(
-              "diff", "--name-only", "--diff-filter=AM", "-z", "HEAD", "--",
+              "diff", "--name-only", "--diff-filter=AM", "-z",
+              os.environ["RULESPEC_REF"], "--",
               ".axiom/encoding-manifests",
           )
           deleted_manifest_paths = git_paths(
-              "diff", "--name-only", "--diff-filter=D", "-z", "HEAD", "--",
+              "diff", "--name-only", "--diff-filter=D", "-z",
+              os.environ["RULESPEC_REF"], "--",
               ".axiom/encoding-manifests",
           )
           manifest_paths.update(
@@ -908,6 +1040,13 @@ jobs:
                   )
               normalized_replacement_path = candidate.as_posix()
           expected_citations = {os.environ["CITATION"]}
+          source_bundle_path = Path(os.environ["RUNNER_TEMP"]) / "source-bundle.json"
+          source_bundle_citations = json.loads(source_bundle_path.read_text())
+          if not isinstance(source_bundle_citations, list) or not all(
+              isinstance(item, str) and item for item in source_bundle_citations
+          ):
+              raise SystemExit("normalized source bundle is malformed")
+          expected_citations.update(source_bundle_citations)
           if dependent_citation:
               expected_citations.add(dependent_citation)
           if second_dependent_citation:
@@ -951,6 +1090,20 @@ jobs:
                   "target",
               )
           ]
+          for source_index, source_citation in enumerate(
+              source_bundle_citations, start=1
+          ):
+              source_lane = f"source-{source_index:02d}"
+              expected.append(
+                  (
+                      source_citation,
+                      False,
+                      Path(sys.argv[1]).with_name(
+                          f"{source_lane}-context-manifest.json"
+                      ),
+                      source_lane,
+                  )
+              )
           if dependent_citation:
               expected.append(
                   (
@@ -1318,6 +1471,7 @@ jobs:
           import os
           import subprocess
           import sys
+          from pathlib import Path
 
           def rev(path):
               return subprocess.check_output(
@@ -1327,6 +1481,11 @@ jobs:
           payload = {
               "schema": "axiom-encode/targeted-reencode-artifact/v1",
               "citation": os.environ["CITATION"],
+              "source_bundle": json.loads(
+                  (
+                      Path(os.environ["RUNNER_TEMP"]) / "source-bundle.json"
+                  ).read_text(encoding="utf-8")
+              ),
               "dependent_citation": os.environ.get("DEPENDENT_CITATION") or None,
               "second_dependent_citation": (
                   os.environ.get("SECOND_DEPENDENT_CITATION") or None
@@ -1354,7 +1513,8 @@ jobs:
               "queue_manifest_sha256": (
                   os.environ.get("QUEUE_MANIFEST_SHA256") or None
               ),
-              "rulespec_base": rev(os.environ["RULESPEC_CHECKOUT"]),
+              "rulespec_base": os.environ["RULESPEC_REF"],
+              "rulespec_generated_head": rev(os.environ["RULESPEC_CHECKOUT"]),
               "encoder_commit": rev("axiom-encode"),
               "corpus_commit": rev("axiom-corpus"),
               "rules_engine_commit": rev("axiom-rules-engine"),
@@ -1383,14 +1543,19 @@ jobs:
             axiom-encode/scripts/prepare_signed_backfill.py branch-name \
             "$COUNTRY" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT")"
           git -C "$RULESPEC_CHECKOUT" switch -c "$branch"
-          "${workflow_python[@]}" \
-            axiom-encode/scripts/prepare_signed_backfill.py stage \
-            "$RULESPEC_CHECKOUT"
-          git -C "$RULESPEC_CHECKOUT" \
-            -c core.hooksPath=/dev/null \
-            -c user.name=axiom-encode-bot \
-            -c user.email=axiom-encode-bot@users.noreply.github.com \
-            commit -m "Add signed encoding manifest for ${CITATION}"
+          if jq -e 'length > 0' \
+            "$RUNNER_TEMP/source-bundle.json" > /dev/null; then
+            test -z "$(git -C "$RULESPEC_CHECKOUT" status --porcelain)"
+          else
+            "${workflow_python[@]}" \
+              axiom-encode/scripts/prepare_signed_backfill.py stage \
+              "$RULESPEC_CHECKOUT"
+            git -C "$RULESPEC_CHECKOUT" \
+              -c core.hooksPath=/dev/null \
+              -c user.name=axiom-encode-bot \
+              -c user.email=axiom-encode-bot@users.noreply.github.com \
+              commit -m "Add signed encoding manifest for ${CITATION}"
+          fi
 
       - name: Push lane branch and open draft pull request
         if: ${{ inputs.open_pr }}
@@ -1424,10 +1589,12 @@ jobs:
           branch="$("${workflow_python[@]}" \
             axiom-encode/scripts/prepare_signed_backfill.py branch-name \
             "$COUNTRY" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT")"
+          source_bundle="$(tr -d '\n' < "$RUNNER_TEMP/source-bundle.json")"
           body="$(printf '%s\n' \
             '## Signed apply manifest' \
             '' \
             "Citation: \`${CITATION}\`" \
+            "Atomic source bundle: \`${source_bundle}\`" \
             "Direct dependent: \`${DEPENDENT_CITATION:-n/a}\`" \
             "Second direct dependent: \`${SECOND_DEPENDENT_CITATION:-n/a}\`" \
             "Exact legacy dependent: \`${LEGACY_EXACT_DEPENDENT_RULESPEC_PATH:-n/a}\`" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1420"
+version = "0.2.1421"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -240,8 +240,7 @@ def parse_source_bundle(
         raise ValueError("source bundle JSON must be an array")
     if len(payload) > MAX_SOURCE_BUNDLE_CITATIONS:
         raise ValueError(
-            "source bundle contains more than "
-            f"{MAX_SOURCE_BUNDLE_CITATIONS} citations"
+            f"source bundle contains more than {MAX_SOURCE_BUNDLE_CITATIONS} citations"
         )
 
     def validate_citation(value: object, *, label: str) -> tuple[str, PurePosixPath]:

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -33,6 +33,8 @@ LEGACY_REPLACEMENT_METADATA_PATHS = frozenset(
 RULESPEC_ATOMIC_ROOTS = frozenset(
     {"legislation", "policies", "regulations", "statutes"}
 )
+MAX_SOURCE_BUNDLE_CITATIONS = 16
+MAX_SOURCE_BUNDLE_JSON_BYTES = 512 * 1024
 REVIEWED_RULESPEC_REFS = frozenset(
     {
         (
@@ -215,6 +217,97 @@ def _citation_rulespec_path(citation: str) -> tuple[str, PurePosixPath]:
 def citation_rulespec_path(citation: str) -> PurePosixPath:
     jurisdiction, relative = _citation_rulespec_path(citation)
     return PurePosixPath(jurisdiction) / relative
+
+
+def parse_source_bundle(
+    source_bundle_json: str,
+    *,
+    primary_citation: str,
+    excluded_citations: tuple[str, ...] = (),
+) -> tuple[str, ...]:
+    """Validate a bounded same-jurisdiction corpus source citation bundle."""
+
+    from axiom_encode.corpus_resolver import (
+        require_canonical_corpus_citation_path,
+    )
+
+    if not isinstance(source_bundle_json, str):
+        raise ValueError("source bundle JSON must be a string")
+    if len(source_bundle_json.encode("utf-8")) > MAX_SOURCE_BUNDLE_JSON_BYTES:
+        raise ValueError("source bundle JSON exceeds the maximum input size")
+    payload = json.loads(source_bundle_json)
+    if not isinstance(payload, list):
+        raise ValueError("source bundle JSON must be an array")
+    if len(payload) > MAX_SOURCE_BUNDLE_CITATIONS:
+        raise ValueError(
+            "source bundle contains more than "
+            f"{MAX_SOURCE_BUNDLE_CITATIONS} citations"
+        )
+
+    def validate_citation(value: object, *, label: str) -> tuple[str, PurePosixPath]:
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"{label} must be a nonempty citation string")
+        try:
+            citation = require_canonical_corpus_citation_path(value)
+            path = citation_rulespec_path(citation)
+        except ValueError as exc:
+            raise ValueError(
+                f"{label} must be an exact canonical corpus citation path"
+            ) from exc
+        return citation, path
+
+    primary, primary_path = validate_citation(
+        primary_citation,
+        label="primary citation",
+    )
+    primary_jurisdiction = primary.partition("/")[0]
+    validate_country(primary_jurisdiction.partition("-")[0])
+
+    reserved_citations = {primary}
+    reserved_paths = {primary_path}
+    for index, value in enumerate(excluded_citations):
+        citation, path = validate_citation(
+            value,
+            label=f"excluded citation #{index + 1}",
+        )
+        jurisdiction = citation.partition("/")[0]
+        if jurisdiction != primary_jurisdiction:
+            raise ValueError(
+                "excluded citations must use the primary citation jurisdiction "
+                "and country"
+            )
+        reserved_citations.add(citation)
+        reserved_paths.add(path)
+
+    citations: list[str] = []
+    seen_citations: set[str] = set()
+    seen_paths: set[PurePosixPath] = set()
+    for index, value in enumerate(payload):
+        citation, path = validate_citation(
+            value,
+            label=f"source bundle item #{index + 1}",
+        )
+        jurisdiction = citation.partition("/")[0]
+        if jurisdiction != primary_jurisdiction:
+            raise ValueError(
+                "source bundle citations must use the primary citation "
+                "jurisdiction and country"
+            )
+        if citation in reserved_citations:
+            raise ValueError(
+                "source bundle must exclude the primary and excluded citations"
+            )
+        if citation in seen_citations:
+            raise ValueError("source bundle citations must be unique")
+        if path in reserved_paths or path in seen_paths:
+            raise ValueError(
+                "source bundle citations must resolve to unique, unreserved "
+                "canonical RuleSpec paths"
+            )
+        citations.append(citation)
+        seen_citations.add(citation)
+        seen_paths.add(path)
+    return tuple(citations)
 
 
 def _is_regular_file_beneath(root: Path, relative: PurePosixPath) -> bool:
@@ -1269,6 +1362,25 @@ def main() -> None:
     cascade_parser.add_argument("dependent_citations", nargs="+")
     citation_path_parser = subparsers.add_parser("citation-rulespec-path")
     citation_path_parser.add_argument("citation")
+    source_bundle_parser = subparsers.add_parser(
+        "parse-source-bundle",
+        help="validate a bounded source bundle and emit one normalized JSON array",
+    )
+    source_bundle_parser.add_argument(
+        "source_bundle_json",
+        help="JSON array containing at most 16 canonical corpus citation strings",
+    )
+    source_bundle_parser.add_argument(
+        "--primary-citation",
+        required=True,
+        help="canonical primary citation, which is forbidden in the bundle",
+    )
+    source_bundle_parser.add_argument(
+        "--exclude-citation",
+        action="append",
+        default=[],
+        help="additional forbidden canonical citation; may be repeated",
+    )
     args = parser.parse_args()
     try:
         if args.command == "validate-country":
@@ -1305,6 +1417,17 @@ def main() -> None:
             )
         elif args.command == "citation-rulespec-path":
             print(citation_rulespec_path(args.citation))
+        elif args.command == "parse-source-bundle":
+            print(
+                json.dumps(
+                    parse_source_bundle(
+                        args.source_bundle_json,
+                        primary_citation=args.primary_citation,
+                        excluded_citations=tuple(args.exclude_citation),
+                    ),
+                    separators=(",", ":"),
+                )
+            )
         else:
             stage_authorized_changes(args.repo)
     except (

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1420"
+__version__ = "0.2.1421"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -24631,8 +24631,7 @@ def _run_encode_attempt(
         corpus_release=corpus_release,
     )
     raw_required_import_paths = tuple(
-        Path(path)
-        for path in getattr(args, "required_import_rulespec_path", ())
+        Path(path) for path in getattr(args, "required_import_rulespec_path", ())
     )
     required_import_paths: tuple[Path, ...] = ()
     required_import_targets: tuple[str, ...] = ()

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -182,6 +182,7 @@ from .harness.evals import (
     _git_checkout_execution_identity,
     _load_eval_suite_resume_state,
     _render_eval_result_verdict_evidence,
+    _resolve_eval_output_path,
     _rulespec_root_execution_identity,
     _source_metadata_citation_path,
     _source_metadata_with_attestation,
@@ -2093,6 +2094,17 @@ def main():
         action="append",
         default=[],
         help="Extra file path to copy into the repo-augmented workspace (repeatable)",
+    )
+    encode_parser.add_argument(
+        "--required-import-rulespec-path",
+        action="append",
+        default=[],
+        type=Path,
+        help=(
+            "Existing checkout-relative atomic RuleSpec that must be copied into "
+            "the generation context and directly imported by the generated target "
+            "(repeatable; intended for protected source-bundle composition)"
+        ),
     )
     encode_parser.add_argument(
         "--review-findings",
@@ -23555,6 +23567,92 @@ class _EncodeReplacementTarget(NamedTuple):
 _LEGACY_REPLACEMENT_ATTR = "_axiom_legacy_replacement_contract"
 
 
+def _resolve_required_import_rulespec_paths(
+    raw_paths: Sequence[Path],
+    *,
+    policy_checkout_path: Path,
+    policy_repo_path: Path,
+    source_citation_path: str,
+    target_relative_output: Path,
+) -> tuple[tuple[Path, ...], tuple[str, ...]]:
+    """Resolve bounded, same-jurisdiction atomic modules required by composition."""
+
+    if len(raw_paths) > 16:
+        raise ValueError("at most 16 required import RuleSpec paths are supported")
+    jurisdiction = normalize_corpus_identifier(source_citation_path).split("/", 1)[0]
+    if jurisdiction != policy_repo_path.name:
+        raise ValueError("required import jurisdiction does not match source routing")
+    tracked = _rulespec_migration_tracked_files(policy_checkout_path)
+    roots = tuple(sorted(RULESPEC_ATOMIC_MODULE_ROOTS))
+    target_checkout_relative = Path(jurisdiction) / target_relative_output
+    resolved_paths: list[Path] = []
+    import_targets: list[str] = []
+    seen_paths: set[Path] = set()
+    for raw_path in raw_paths:
+        relative = Path(raw_path)
+        if (
+            relative.is_absolute()
+            or not relative.parts
+            or any(part in {"", ".", ".."} for part in relative.parts)
+            or len(relative.parts) < 3
+            or relative.parts[0] != jurisdiction
+            or not _is_protected_rulespec_yaml_path(relative, roots=roots)
+            or relative.name.endswith(RULESPEC_TEST_FILE_SUFFIX)
+        ):
+            raise ValueError(
+                "required import must be a canonical checkout-relative atomic "
+                "RuleSpec in the requested jurisdiction"
+            )
+        if relative == target_checkout_relative:
+            raise ValueError("required import must differ from the generated target")
+        if relative in seen_paths:
+            raise ValueError("required import RuleSpec paths must be unique")
+        if tracked.get(relative) != "100644":
+            raise ValueError(
+                f"required import is not a tracked regular 0644 RuleSpec: {relative}"
+            )
+        absolute = policy_checkout_path / relative
+        read_bounded_regular_file(
+            policy_checkout_path,
+            absolute,
+            label=f"required import RuleSpec {relative.as_posix()}",
+            max_bytes=16 * 1024 * 1024,
+            required_mode=0o644,
+        )
+        seen_paths.add(relative)
+        resolved_paths.append(absolute)
+        import_targets.append(
+            f"{jurisdiction}:{relative.with_suffix('').relative_to(jurisdiction).as_posix()}"
+        )
+    return tuple(resolved_paths), tuple(import_targets)
+
+
+def _required_generated_import_issues(
+    rulespec_path: Path,
+    required_import_targets: Sequence[str],
+) -> list[str]:
+    """Require at least one direct symbol import from every required module."""
+
+    if not required_import_targets:
+        return []
+    try:
+        payload = yaml.safe_load(rulespec_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, yaml.YAMLError, RecursionError) as exc:
+        return [f"cannot inspect generated required imports: {exc}"]
+    imports = payload.get("imports") if isinstance(payload, dict) else None
+    imported_modules = {
+        raw_import.split("#", 1)[0].strip().strip("/")
+        for raw_import in imports or []
+        if isinstance(raw_import, str) and "#" in raw_import
+    }
+    return [
+        "Generated target must directly import at least one exported symbol from "
+        f"required atomic module {target}"
+        for target in required_import_targets
+        if target not in imported_modules
+    ]
+
+
 def _result_legacy_replacement_contract(result: object) -> object | None:
     """Read only an explicitly attached contract, including on dynamic test doubles."""
 
@@ -24532,6 +24630,27 @@ def _run_encode_attempt(
         source_unit=source_unit,
         corpus_release=corpus_release,
     )
+    raw_required_import_paths = tuple(
+        Path(path)
+        for path in getattr(args, "required_import_rulespec_path", ())
+    )
+    required_import_paths: tuple[Path, ...] = ()
+    required_import_targets: tuple[str, ...] = ()
+    if raw_required_import_paths:
+        target_relative_output = (
+            replacement_target.relative_output
+            if replacement_target is not None
+            else _resolve_eval_output_path(source_unit.requested)
+        )
+        required_import_paths, required_import_targets = (
+            _resolve_required_import_rulespec_paths(
+                raw_required_import_paths,
+                policy_checkout_path=policy_checkout_path,
+                policy_repo_path=policy_repo_path,
+                source_citation_path=source_unit.requested,
+                target_relative_output=target_relative_output,
+            )
+        )
 
     def _validate_generated_encoding_in_policy_overlay(
         result,
@@ -24562,6 +24681,7 @@ def _run_encode_attempt(
     extra_context_paths = [Path(path) for path in args.allow_context]
     if replacement_target is not None:
         extra_context_paths.extend(replacement_target.context_paths)
+    extra_context_paths.extend(required_import_paths)
     results = run_model_eval(
         citations=[args.citation],
         runner_specs=[runner],
@@ -24585,6 +24705,7 @@ def _run_encode_attempt(
             else None
         ),
         validation_retry_feedback=_encode_validation_retry_feedback(prior_attempts),
+        required_import_targets=required_import_targets,
     )
 
     result = results[0]
@@ -27355,6 +27476,15 @@ def _run_encode_attempt(
                                 outcome["auto_repaired_invalid_test_inputs"] = (
                                     repaired_invalid_input_refs
                                 )
+                if can_apply and required_import_targets:
+                    required_import_issues = _required_generated_import_issues(
+                        Path(str(getattr(result, "output_file", "") or "")),
+                        required_import_targets,
+                    )
+                    if required_import_issues:
+                        can_apply = False
+                        apply_issues = required_import_issues
+                        outcome["overlay_validation_success"] = False
                 if not can_apply:
                     detail = (
                         apply_issues[0]

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -1361,6 +1361,7 @@ def run_model_eval(
     require_complete_source_unit: bool = False,
     target_relative_output: Path | None = None,
     validation_retry_feedback: Sequence[str] = (),
+    required_import_targets: Sequence[str] = (),
 ) -> list[EvalResult]:
     """Run a deterministic comparison over one or more citations."""
     _validate_eval_oracle_runtime(oracle, policyengine_runtime, policy_path)
@@ -1400,6 +1401,7 @@ def run_model_eval(
                         require_complete_source_unit=require_complete_source_unit,
                         target_relative_output=target_relative_output,
                         validation_retry_feedback=validation_retry_feedback,
+                        required_import_targets=required_import_targets,
                     )
                 )
 
@@ -7883,6 +7885,7 @@ def _run_single_eval(
     require_complete_source_unit: bool = False,
     target_relative_output: Path | None = None,
     validation_retry_feedback: Sequence[str] = (),
+    required_import_targets: Sequence[str] = (),
 ) -> EvalResult:
     include_tests = include_tests or require_complete_source_unit
     if source_unit is None:
@@ -7946,6 +7949,7 @@ def _run_single_eval(
         policyengine_rule_hint=policyengine_rule_hint,
         require_complete_source_unit=require_complete_source_unit,
         validation_retry_feedback=validation_retry_feedback,
+        required_import_targets=required_import_targets,
     )
     generation_prompt_sha256 = _sha256_text(prompt)
     output_file = _contained_eval_output_file(output_root, runner.name, relative_output)
@@ -8839,6 +8843,7 @@ def _build_rulespec_eval_prompt(
     include_corpus_context_injection: bool = True,
     require_complete_source_unit: bool = False,
     validation_retry_feedback: Sequence[str] = (),
+    required_import_targets: Sequence[str] = (),
 ) -> str:
     """Build the RuleSpec authoring prompt used by current evals."""
     source_text = workspace.source_text_file.read_text()
@@ -9364,6 +9369,24 @@ Preferred principal output:
     validation_retry_feedback_section = _format_validation_retry_feedback(
         validation_retry_feedback
     )
+    required_import_section = ""
+    if required_import_targets:
+        required_lines = "\n".join(
+            f"- `{target}`" for target in required_import_targets
+        )
+        required_import_section = f"""
+Protected atomic-composition requirements:
+{required_lines}
+- Each listed module is an independently source-attested atomic RuleSpec copied
+  into context. The generated target must directly import at least one exact
+  exported `#symbol` from every listed module and use imported outputs wherever
+  their legal facts are needed.
+- Do not inline or duplicate those modules' source-owned values. Do not add
+  their corpus citations to this module's `source_verification`; this target
+  remains bound to exactly one primary source.
+- Generation is rejected unless every listed module appears in top-level
+  `imports:` through at least one exact symbol import.
+"""
     complete_source_unit_section = ""
     if require_complete_source_unit:
         complete_source_unit_section = """
@@ -9415,7 +9438,7 @@ Primary legal authority:
 {legal_authority_instruction}
 {corpus_source_section.rstrip()}
 {inline_source}
-{source_metadata_section}{provision_metadata_section}{amendment_section}{context_section}{missing_cited_source_section}{mandatory_review_findings_section}{validation_retry_feedback_section}
+{source_metadata_section}{provision_metadata_section}{amendment_section}{context_section}{missing_cited_source_section}{mandatory_review_findings_section}{validation_retry_feedback_section}{required_import_section}
 {backend_section}
 {canonical_concept_section}{complete_source_unit_section}
 RuleSpec requirements:
@@ -10236,6 +10259,7 @@ def _build_eval_prompt(
     include_corpus_context_injection: bool = True,
     require_complete_source_unit: bool = False,
     validation_retry_feedback: Sequence[str] = (),
+    required_import_targets: Sequence[str] = (),
 ) -> str:
     """Build a prompt-only eval request with explicit provenance rules."""
     return _build_rulespec_eval_prompt(
@@ -10251,6 +10275,7 @@ def _build_eval_prompt(
         include_corpus_context_injection=include_corpus_context_injection,
         require_complete_source_unit=require_complete_source_unit,
         validation_retry_feedback=validation_retry_feedback,
+        required_import_targets=required_import_targets,
     )
 
 

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1420"
+ENCODER_VERSION = "0.2.1421"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42715,10 +42715,13 @@ def test_required_generated_import_issues_require_each_module(tmp_path: Path):
         encoding="utf-8",
     )
 
-    assert _required_generated_import_issues(
-        rulespec,
-        ("us-ri:guidance/tax/page-1",),
-    ) == []
+    assert (
+        _required_generated_import_issues(
+            rulespec,
+            ("us-ri:guidance/tax/page-1",),
+        )
+        == []
+    )
     assert _required_generated_import_issues(
         rulespec,
         ("us-ri:guidance/tax/page-1", "us-ri:guidance/tax/page-2"),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -157,9 +157,11 @@ from axiom_encode.cli import (
     _repair_upstream_placement_duplicate_imports,
     _require_axiom_encode_version_provenance,
     _require_clean_axiom_encode_git_provenance,
+    _required_generated_import_issues,
     _resolve_applied_manifest_placement,
     _resolve_encode_replacement_target,
     _resolve_explicit_policy_repo_for_corpus_source,
+    _resolve_required_import_rulespec_paths,
     _rewrite_gpt_runner_backend,
     _rewrite_import_output_test_input_refs,
     _rewrite_judgment_conditional_formulas,
@@ -42701,3 +42703,115 @@ def test_ci_entrypoint_is_registered():
     assert "--corpus-release-public-key" in result.stdout
     assert "--allow-ref-mismatch" in result.stdout
     assert "--allow-encoder-mismatch" in result.stdout
+
+
+def test_required_generated_import_issues_require_each_module(tmp_path: Path):
+    rulespec = tmp_path / "target.yaml"
+    rulespec.write_text(
+        "format: rulespec/v1\n"
+        "imports:\n"
+        "  - us-ri:guidance/tax/page-1#deduction_amount\n"
+        "rules: []\n",
+        encoding="utf-8",
+    )
+
+    assert _required_generated_import_issues(
+        rulespec,
+        ("us-ri:guidance/tax/page-1",),
+    ) == []
+    assert _required_generated_import_issues(
+        rulespec,
+        ("us-ri:guidance/tax/page-1", "us-ri:guidance/tax/page-2"),
+    ) == [
+        "Generated target must directly import at least one exported symbol from "
+        "required atomic module us-ri:guidance/tax/page-2"
+    ]
+
+
+def test_resolve_required_import_rulespec_paths_is_same_jurisdiction_and_tracked(
+    tmp_path: Path,
+):
+    checkout = tmp_path / "rulespec-us"
+    _init_test_git_repo(checkout)
+    required = checkout / "us-ri/policies/tax/page-2.yaml"
+    required.parent.mkdir(parents=True)
+    required.write_text("format: rulespec/v1\nrules: []\n", encoding="utf-8")
+    _git(checkout, "add", ".")
+    _git(checkout, "commit", "-m", "required atomic module")
+
+    paths, targets = _resolve_required_import_rulespec_paths(
+        (Path("us-ri/policies/tax/page-2.yaml"),),
+        policy_checkout_path=checkout,
+        policy_repo_path=checkout / "us-ri",
+        source_citation_path="us-ri/statute/44-30-2.6",
+        target_relative_output=Path("policies/income_tax/pipeline.yaml"),
+    )
+
+    assert paths == (required,)
+    assert targets == ("us-ri:policies/tax/page-2",)
+
+
+@pytest.mark.parametrize(
+    "required_path",
+    [
+        Path("us-ma/policies/tax/page-2.yaml"),
+        Path("us-ri/policies/income_tax/pipeline.yaml"),
+        Path("us-ri/policies/tax/page-2.test.yaml"),
+        Path("../us-ri/policies/tax/page-2.yaml"),
+    ],
+)
+def test_resolve_required_import_rulespec_paths_rejects_unsafe_or_target_paths(
+    tmp_path: Path,
+    required_path: Path,
+):
+    checkout = tmp_path / "rulespec-us"
+    _init_test_git_repo(checkout)
+    placeholder = checkout / "README.md"
+    placeholder.write_text("test\n", encoding="utf-8")
+    _git(checkout, "add", ".")
+    _git(checkout, "commit", "-m", "baseline")
+
+    with pytest.raises(ValueError, match="required import"):
+        _resolve_required_import_rulespec_paths(
+            (required_path,),
+            policy_checkout_path=checkout,
+            policy_repo_path=checkout / "us-ri",
+            source_citation_path="us-ri/statute/44-30-2.6",
+            target_relative_output=Path("policies/income_tax/pipeline.yaml"),
+        )
+
+
+def test_resolve_required_import_rulespec_paths_rejects_duplicates(tmp_path: Path):
+    checkout = tmp_path / "rulespec-us"
+    _init_test_git_repo(checkout)
+    required = checkout / "us-ri/policies/tax/page-2.yaml"
+    required.parent.mkdir(parents=True)
+    required.write_text("format: rulespec/v1\nrules: []\n", encoding="utf-8")
+    _git(checkout, "add", ".")
+    _git(checkout, "commit", "-m", "required atomic module")
+
+    with pytest.raises(ValueError, match="must be unique"):
+        _resolve_required_import_rulespec_paths(
+            (
+                Path("us-ri/policies/tax/page-2.yaml"),
+                Path("us-ri/policies/tax/page-2.yaml"),
+            ),
+            policy_checkout_path=checkout,
+            policy_repo_path=checkout / "us-ri",
+            source_citation_path="us-ri/statute/44-30-2.6",
+            target_relative_output=Path("policies/income_tax/pipeline.yaml"),
+        )
+
+
+def test_resolve_required_import_rulespec_paths_is_bounded(tmp_path: Path):
+    checkout = tmp_path / "rulespec-us"
+    _init_test_git_repo(checkout)
+
+    with pytest.raises(ValueError, match="at most 16"):
+        _resolve_required_import_rulespec_paths(
+            tuple(Path(f"us-ri/statutes/section-{index}.yaml") for index in range(17)),
+            policy_checkout_path=checkout,
+            policy_repo_path=checkout / "us-ri",
+            source_citation_path="us-ri/statute/44-30-2.6",
+            target_relative_output=Path("policies/income_tax/pipeline.yaml"),
+        )

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -681,7 +681,12 @@ def test_generation_resolver_uses_active_release_and_attests_full_body(tmp_path)
     assert source_unit.source_attestation["row"]["version"] == "2026"
 
 
-def _workspace_prompt_for_source_unit(tmp_path: Path, source_unit: CorpusSourceUnit):
+def _workspace_prompt_for_source_unit(
+    tmp_path: Path,
+    source_unit: CorpusSourceUnit,
+    *,
+    required_import_targets: tuple[str, ...] = (),
+):
     workspace = prepare_eval_workspace(
         citation=source_unit.requested,
         runner=parse_runner_spec("openai:gpt-5.4"),
@@ -702,8 +707,37 @@ def _workspace_prompt_for_source_unit(tmp_path: Path, source_unit: CorpusSourceU
         target_file_name="target.yaml",
         include_tests=True,
         runner_backend="openai",
+        required_import_targets=required_import_targets,
     )
     return workspace, prompt
+
+
+def test_workspace_prompt_requires_each_atomic_composition_import(tmp_path):
+    release = _write_test_corpus_release(
+        tmp_path,
+        [
+            {
+                "citation_path": "dk/statute/benefit/section-1",
+                "body": "The benefit uses the separately determined amount.",
+            }
+        ],
+    )
+    source_unit = resolve_corpus_source_unit("dk/statute/benefit/section-1", release)
+
+    _workspace, prompt = _workspace_prompt_for_source_unit(
+        tmp_path,
+        source_unit,
+        required_import_targets=(
+            "dk:guidance/benefit/current-amount",
+            "dk:statutes/benefit/eligibility",
+        ),
+    )
+
+    assert "Protected atomic-composition requirements:" in prompt
+    assert "`dk:guidance/benefit/current-amount`" in prompt
+    assert "`dk:statutes/benefit/eligibility`" in prompt
+    assert "directly import at least one exact" in prompt
+    assert "remains bound to exactly one primary source" in prompt
 
 
 def test_workspace_prompt_includes_curated_provision_metadata(tmp_path):

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1420"
+ENCODER_VERSION = "0.2.1421"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1420"
+ENCODER_VERSION = "0.2.1421"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1420"
+ENCODER_VERSION = "0.2.1421"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1420"
+ENCODER_VERSION = "0.2.1421"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1420"
+ENCODER_VERSION = "0.2.1421"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1420"
+ENCODER_VERSION = "0.2.1421"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -3,21 +3,182 @@ from __future__ import annotations
 import hashlib
 import json
 import subprocess
+import sys
 from pathlib import Path, PurePosixPath
 
 import pytest
 
 from scripts.prepare_signed_backfill import (
+    MAX_SOURCE_BUNDLE_JSON_BYTES,
     REVIEWED_RULESPEC_PR_BASE_BRANCHES,
     REVIEWED_RULESPEC_REFS,
     authorized_changed_paths,
     branch_name,
+    parse_source_bundle,
     stage_authorized_changes,
     validate_country,
     validate_dependent_cascade,
     validate_queue_tracking,
     validate_rulespec_base,
 )
+from scripts.prepare_signed_backfill import (
+    main as prepare_signed_backfill_main,
+)
+
+
+def test_parse_source_bundle_accepts_ordered_same_jurisdiction_citations() -> None:
+    raw = json.dumps(
+        [
+            "us-ri/statute/44-30-1",
+            "us-ri/guidance/revenue/2026/rate-schedule",
+        ]
+    )
+
+    assert parse_source_bundle(
+        raw,
+        primary_citation="us-ri/statute/44-30-2.6",
+        excluded_citations=("us-ri/statute/44-30-5",),
+    ) == (
+        "us-ri/statute/44-30-1",
+        "us-ri/guidance/revenue/2026/rate-schedule",
+    )
+
+
+def test_parse_source_bundle_accepts_empty_array() -> None:
+    assert parse_source_bundle(
+        "[]",
+        primary_citation="us-ri/statute/44-30-2.6",
+    ) == ()
+
+
+@pytest.mark.parametrize("raw", ['{"citation": "x"}', '"x"', "null"])
+def test_parse_source_bundle_requires_json_array(raw: str) -> None:
+    with pytest.raises(ValueError, match="must be an array"):
+        parse_source_bundle(
+            raw,
+            primary_citation="us-ri/statute/44-30-2.6",
+        )
+
+
+def test_parse_source_bundle_rejects_more_than_sixteen_items() -> None:
+    raw = json.dumps([f"us-ri/statute/44-30-{index}" for index in range(17)])
+
+    with pytest.raises(ValueError, match="more than 16"):
+        parse_source_bundle(
+            raw,
+            primary_citation="us-ri/statute/44-30-99",
+        )
+
+
+def test_parse_source_bundle_rejects_oversized_json_before_parsing() -> None:
+    raw = " " * (MAX_SOURCE_BUNDLE_JSON_BYTES + 1)
+
+    with pytest.raises(ValueError, match="maximum input size"):
+        parse_source_bundle(
+            raw,
+            primary_citation="us-ri/statute/44-30-2.6",
+        )
+
+
+@pytest.mark.parametrize("item", ["", None, 4])
+def test_parse_source_bundle_requires_nonempty_string_items(item: object) -> None:
+    with pytest.raises(ValueError, match="nonempty citation string"):
+        parse_source_bundle(
+            json.dumps([item]),
+            primary_citation="us-ri/statute/44-30-2.6",
+        )
+
+
+def test_parse_source_bundle_requires_exact_canonical_items() -> None:
+    with pytest.raises(ValueError, match="exact canonical corpus citation path"):
+        parse_source_bundle(
+            json.dumps([" us-ri/statute/44-30-1"]),
+            primary_citation="us-ri/statute/44-30-2.6",
+        )
+
+
+def test_parse_source_bundle_rejects_duplicate_citations() -> None:
+    citation = "us-ri/statute/44-30-1"
+
+    with pytest.raises(ValueError, match="must be unique"):
+        parse_source_bundle(
+            json.dumps([citation, citation]),
+            primary_citation="us-ri/statute/44-30-2.6",
+        )
+
+
+@pytest.mark.parametrize(
+    "forbidden",
+    ["us-ri/statute/44-30-2.6", "us-ri/statute/44-30-5"],
+)
+def test_parse_source_bundle_rejects_primary_and_excluded_citations(
+    forbidden: str,
+) -> None:
+    with pytest.raises(ValueError, match="primary and excluded citations"):
+        parse_source_bundle(
+            json.dumps([forbidden]),
+            primary_citation="us-ri/statute/44-30-2.6",
+            excluded_citations=("us-ri/statute/44-30-5",),
+        )
+
+
+def test_parse_source_bundle_rejects_other_jurisdiction() -> None:
+    with pytest.raises(ValueError, match="jurisdiction and country"):
+        parse_source_bundle(
+            json.dumps(["us-ma/statute/62/4"]),
+            primary_citation="us-ri/statute/44-30-2.6",
+        )
+
+
+def test_parse_source_bundle_rejects_exclusion_from_other_jurisdiction() -> None:
+    with pytest.raises(ValueError, match="jurisdiction and country"):
+        parse_source_bundle(
+            "[]",
+            primary_citation="us-ri/statute/44-30-2.6",
+            excluded_citations=("us-ma/statute/62/4",),
+        )
+
+
+def test_parse_source_bundle_rejects_citation_rulespec_path_collision() -> None:
+    with pytest.raises(ValueError, match="unique, unreserved canonical RuleSpec"):
+        parse_source_bundle(
+            json.dumps(
+                [
+                    "us-ri/guidance/revenue/section/1.2",
+                    "us-ri/guidance/revenue/section/1/2",
+                ]
+            ),
+            primary_citation="us-ri/statute/44-30-2.6",
+        )
+
+
+def test_parse_source_bundle_rejects_primary_rulespec_path_collision() -> None:
+    with pytest.raises(ValueError, match="unique, unreserved canonical RuleSpec"):
+        parse_source_bundle(
+            json.dumps(["us-ri/guidance/revenue/section/1/2"]),
+            primary_citation="us-ri/guidance/revenue/section/1.2",
+        )
+
+
+def test_parse_source_bundle_cli_emits_normalized_json_array(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "prepare_signed_backfill.py",
+            "parse-source-bundle",
+            '["us-ri/statute/44-30-1"]',
+            "--primary-citation",
+            "us-ri/statute/44-30-2.6",
+        ],
+    )
+
+    prepare_signed_backfill_main()
+
+    assert capsys.readouterr().out == '["us-ri/statute/44-30-1"]\n'
 
 
 def _git(repo: Path, *args: str) -> str:

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -45,10 +45,13 @@ def test_parse_source_bundle_accepts_ordered_same_jurisdiction_citations() -> No
 
 
 def test_parse_source_bundle_accepts_empty_array() -> None:
-    assert parse_source_bundle(
-        "[]",
-        primary_citation="us-ri/statute/44-30-2.6",
-    ) == ()
+    assert (
+        parse_source_bundle(
+            "[]",
+            primary_citation="us-ri/statute/44-30-2.6",
+        )
+        == ()
+    )
 
 
 @pytest.mark.parametrize("raw", ['{"citation": "x"}', '"x"', "null"])

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1420"')
+        .startswith('__version__ = "0.2.1421"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1420"
+    assert encoder_package["version"] == "0.2.1421"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1420"
+    assert project["project"]["version"] == "0.2.1421"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1420"')
+        .startswith('__version__ = "0.2.1421"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1420"
+    assert encoder_package["version"] == "0.2.1421"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1420"
+    assert project["project"]["version"] == "0.2.1421"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1420"')
+        .startswith('__version__ = "0.2.1421"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1420"
+ENCODER_VERSION = "0.2.1421"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1943,9 +1943,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert source_bundle_step["env"]["SOURCE_BUNDLE_JSON"] == (
         "${{ inputs.source_bundle_json }}"
     )
-    assert 'parse-source-bundle "${SOURCE_BUNDLE_JSON:-[]}"' in (
-        source_bundle_command
-    )
+    assert 'parse-source-bundle "${SOURCE_BUNDLE_JSON:-[]}"' in (source_bundle_command)
     assert '--primary-citation "$CITATION"' in source_bundle_command
     assert 'source_bundle_args+=(--exclude-citation "$DEPENDENT_CITATION")' in (
         source_bundle_command
@@ -2105,10 +2103,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     )
     assert '--output "$RUNNER_TEMP/generated/$output_lane"' in command
     assert '"$SECOND_DEPENDENT_CITATION"' in command
-    assert (
-        '"$SECOND_DEPENDENT_REVIEW_FINDING" false dependent-2 "" "" false'
-        in command
-    )
+    assert '"$SECOND_DEPENDENT_REVIEW_FINDING" false dependent-2 "" "" false' in command
     assert '"$CITATION" "$REVIEW_FINDING" true target \\\n' in command
     assert '"$DEPENDENT_CITATION" "$DEPENDENT_REVIEW_FINDING" \\\n' in command
     assert '"$REPLACE_RULESPEC_PATH" "$REPLACE_LEGACY_RULESPEC_PATH"' in command
@@ -2124,10 +2119,8 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         command
     )
     assert 'commit -m "$message"' in command
-    source_loop = 'while IFS= read -r source_citation; do'
-    assert command.rindex(source_loop) < command.index(
-        '"$CITATION" "$REVIEW_FINDING"'
-    )
+    source_loop = "while IFS= read -r source_citation; do"
+    assert command.rindex(source_loop) < command.index('"$CITATION" "$REVIEW_FINDING"')
     assert "Compose signed source bundle for ${CITATION}" in command
     assert (
         "queue-authorized re-encodes cannot add a source bundle until queue "
@@ -2203,8 +2196,8 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     )
     assert "guard-generated" in guard_step["run"]
     assert 'guard_ref_args+=(--base-ref "$RULESPEC_REF")' in guard_step["run"]
-    assert 'jq -e \'length > 0\' "$RUNNER_TEMP/source-bundle.json"' in (
-        guard_step["run"]
+    assert (
+        "jq -e 'length > 0' \"$RUNNER_TEMP/source-bundle.json\"" in (guard_step["run"])
     )
 
     secret_steps = [
@@ -2693,8 +2686,8 @@ def test_targeted_signed_reencode_composes_nonempty_source_bundle(
     command = (
         before_checkpoint
         + "checkpoint_signed_changes() {\n"
-        + "  printf '%s\\n' \"$1\" >> \"$CHECKPOINTS_PATH\"\n"
-        + "  : > \"$RUNNER_TEMP/checkpoint-guard-generated.json\"\n"
+        + '  printf \'%s\\n\' "$1" >> "$CHECKPOINTS_PATH"\n'
+        + '  : > "$RUNNER_TEMP/checkpoint-guard-generated.json"\n'
         + "}\n\nsource_index=0"
         + after_checkpoint
     )

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1865,6 +1865,15 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert inputs["open_pr"]["default"] is False
     assert inputs["pr_base_branch"]["type"] == "string"
     assert inputs["pr_base_branch"]["default"] == "main"
+    assert inputs["source_bundle_json"] == {
+        "description": (
+            "JSON array of additional same-jurisdiction citations to encode as "
+            "signed atomic imports"
+        ),
+        "required": False,
+        "default": "[]",
+        "type": "string",
+    }
     assert inputs["replace_rulespec_path"]["required"] is False
     assert inputs["replace_legacy_rulespec_path"]["required"] is False
     assert inputs["dependent_citation"]["required"] is False
@@ -1926,6 +1935,30 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert checkout_steps
     assert all(step["with"]["persist-credentials"] is False for step in checkout_steps)
     assert all(step["with"]["fetch-depth"] == 0 for step in checkout_steps)
+
+    source_bundle_step = next(
+        step for step in steps if step.get("name") == "Validate atomic source bundle"
+    )
+    source_bundle_command = source_bundle_step["run"]
+    assert source_bundle_step["env"]["SOURCE_BUNDLE_JSON"] == (
+        "${{ inputs.source_bundle_json }}"
+    )
+    assert 'parse-source-bundle "${SOURCE_BUNDLE_JSON:-[]}"' in (
+        source_bundle_command
+    )
+    assert '--primary-citation "$CITATION"' in source_bundle_command
+    assert 'source_bundle_args+=(--exclude-citation "$DEPENDENT_CITATION")' in (
+        source_bundle_command
+    )
+    assert (
+        "queue-authorized re-encodes cannot add a source bundle until queue "
+        "generation identity binds it"
+    ) in source_bundle_command
+    assert steps.index(source_bundle_step) > next(
+        index
+        for index, step in enumerate(steps)
+        if step.get("name") == "Install encoder"
+    )
 
     identity_step = next(
         step
@@ -2059,6 +2092,10 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert 'args+=(--review-findings "$review_finding_path")' in command
     assert "args+=(--apply-target-only)" in command
     assert 'args+=(--replace-rulespec-path "$replacement_path")' in command
+    assert 'local require_source_bundle_imports="$7"' in command
+    assert 'args+=(--required-import-rulespec-path "$required_import_path")' in (
+        command
+    )
     assert "--legacy-dependent-rulespec-path" in command
     assert 'citation-rulespec-path "$DEPENDENT_CITATION"' in command
     assert '[ "$target_only" = "true" ]' in command
@@ -2068,12 +2105,34 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     )
     assert '--output "$RUNNER_TEMP/generated/$output_lane"' in command
     assert '"$SECOND_DEPENDENT_CITATION"' in command
-    assert '"$SECOND_DEPENDENT_REVIEW_FINDING" false dependent-2 ""' in command
+    assert (
+        '"$SECOND_DEPENDENT_REVIEW_FINDING" false dependent-2 "" "" false'
+        in command
+    )
     assert '"$CITATION" "$REVIEW_FINDING" true target \\\n' in command
     assert '"$DEPENDENT_CITATION" "$DEPENDENT_REVIEW_FINDING" \\\n' in command
     assert '"$REPLACE_RULESPEC_PATH" "$REPLACE_LEGACY_RULESPEC_PATH"' in command
-    assert '"$CITATION" "$REVIEW_FINDING" false target \\\n' in command
+    assert '"$CITATION" "$REVIEW_FINDING" false \\\n' in command
     assert "dependent review finding is required with dependent citation" in command
+    assert "parse-source-bundle" in command
+    assert '> "$RUNNER_TEMP/source-bundle.json"' in command
+    assert '> "$RUNNER_TEMP/source-bundle-citations.txt"' in command
+    assert 'source_lane="$(printf \'source-%02d\' "$source_index")"' in command
+    assert '"$source_citation" "" true "$source_lane" "" "" false' in command
+    assert "checkpoint_signed_changes()" in command
+    assert '"$workflow_python" "$backfill_helper" stage "$RULESPEC_CHECKOUT"' in (
+        command
+    )
+    assert 'commit -m "$message"' in command
+    source_loop = 'while IFS= read -r source_citation; do'
+    assert command.rindex(source_loop) < command.index(
+        '"$CITATION" "$REVIEW_FINDING"'
+    )
+    assert "Compose signed source bundle for ${CITATION}" in command
+    assert (
+        "queue-authorized re-encodes cannot add a source bundle until queue "
+        "generation identity binds it"
+    ) in command
     assert steps.index(cascade_step) < steps.index(apply_step)
 
     package_step = next(
@@ -2087,6 +2146,13 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         "${{ inputs.dependent_review_finding != '' }}"
     )
     assert package_step["env"]["PR_BASE_BRANCH"] == ("${{ inputs.pr_base_branch }}")
+    assert package_step["env"]["RULESPEC_REF"] == "${{ inputs.rulespec_ref }}"
+    assert '"$RULESPEC_REF" > "$artifact/tracked.patch"' in package_command
+    assert '"$RULESPEC_REF" HEAD >> "$artifact/status.txt"' in package_command
+    assert "diff --binary --full-index HEAD" not in package_command
+    assert 'cp "$RUNNER_TEMP/source-bundle.json" "$artifact/source-bundle.json"' in (
+        package_command
+    )
     assert '"$artifact/context-manifest.json"' in package_command
     assert '".axiom/encoding-manifests"' in package_command
     assert 'citation = effective.get("citation")' in package_command
@@ -2099,6 +2165,13 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert 'finding.get("content")' in package_command
     assert 'finding.get("sha256")' in package_command
     assert '"dependent-context-manifest.json"' in package_command
+    assert 'f"{source_lane}-context-manifest.json"' in package_command
+    assert 'os.environ["RULESPEC_REF"], "--"' in package_command
+    assert '"source_bundle": json.loads(' in package_command
+    assert '"rulespec_base": os.environ["RULESPEC_REF"]' in package_command
+    assert '"rulespec_generated_head": rev(os.environ["RULESPEC_CHECKOUT"])' in (
+        package_command
+    )
     assert '"pr_base_branch": os.environ["PR_BASE_BRANCH"]' in package_command
     assert '"queue_id": os.environ.get("QUEUE_ID") or None' in package_command
     assert '"queue_item_id": os.environ.get("QUEUE_ITEM_ID") or None' in (
@@ -2129,7 +2202,10 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         step for step in steps if step.get("name") == "Verify generated provenance"
     )
     assert "guard-generated" in guard_step["run"]
-    assert "--base-ref" not in guard_step["run"]
+    assert 'guard_ref_args+=(--base-ref "$RULESPEC_REF")' in guard_step["run"]
+    assert 'jq -e \'length > 0\' "$RUNNER_TEMP/source-bundle.json"' in (
+        guard_step["run"]
+    )
 
     secret_steps = [
         step
@@ -2156,6 +2232,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "refs/remotes/origin/${PR_BASE_BRANCH}" in publish_command
     assert '" = "$RULESPEC_REF"' in publish_command
     assert '"HEAD:refs/heads/${branch}"' in publish_command
+    assert publish_command.count('"HEAD:refs/heads/${branch}"') == 1
     assert "gh api --method POST" in publish_command
     assert '-f base="$PR_BASE_BRANCH"' in publish_command
     assert "-F draft=true" in publish_command
@@ -2170,6 +2247,10 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         publish_command
     )
     assert "SHA256SUMS" not in publish_command
+    assert not any(
+        " push " in f" {step.get('run', '')} "
+        for step in steps[: steps.index(publish_step)]
+    )
 
     checksum_step = next(
         step
@@ -2524,10 +2605,12 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
         "GITHUB_WORKSPACE": str(tmp_path),
         "REVIEW_FINDING": "Preserve the target source.",
         "RULESPEC_CHECKOUT": str(tmp_path / "rulespec-us"),
+        "RULESPEC_REF": "a" * 40,
         "RUNNER_TEMP": str(runner_temp),
         "SECOND_DEPENDENT_CITATION": "",
         "SECOND_DEPENDENT_REVIEW_FINDING": "",
         "SIGNER_STUB": str(signer_stub),
+        "SOURCE_BUNDLE_JSON": "[]",
     }
     if dependent_count >= 1:
         environment.update(
@@ -2585,6 +2668,114 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
         )
 
 
+def test_targeted_signed_reencode_composes_nonempty_source_bundle(
+    tmp_path: Path,
+) -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
+    )
+    command = next(
+        step["run"]
+        for step in workflow["jobs"]["encode"]["steps"]
+        if step.get("name") == "Encode, review, validate, and apply"
+    ).replace(
+        "/opt/axiom-verification/axiom-encode-apply-signer run",
+        '"$SIGNER_STUB"',
+    )
+    before_checkpoint, checkpoint_and_after = command.split(
+        "checkpoint_signed_changes() {",
+        1,
+    )
+    _checkpoint_body, after_checkpoint = checkpoint_and_after.split(
+        "\n}\n\nsource_index=0",
+        1,
+    )
+    command = (
+        before_checkpoint
+        + "checkpoint_signed_changes() {\n"
+        + "  printf '%s\\n' \"$1\" >> \"$CHECKPOINTS_PATH\"\n"
+        + "  : > \"$RUNNER_TEMP/checkpoint-guard-generated.json\"\n"
+        + "}\n\nsource_index=0"
+        + after_checkpoint
+    )
+
+    calls_path = tmp_path / "calls.jsonl"
+    checkpoints_path = tmp_path / "checkpoints.txt"
+    signer_stub = tmp_path / "signer-stub"
+    signer_stub.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
+    stream.write(json.dumps(sys.argv[1:]) + "\\n")
+""",
+        encoding="utf-8",
+    )
+    signer_stub.chmod(0o700)
+    runner_temp = tmp_path / "runner-temp"
+    runner_temp.mkdir()
+    primary = "us-ri/statute/44-30-2.6"
+    sources = [
+        "us-ri/statute/44-30-1",
+        "us-ri/guidance/revenue/2026/rate-schedule",
+    ]
+
+    subprocess.run(
+        ["bash", "-c", command],
+        check=True,
+        env={
+            **os.environ,
+            "AXIOM_ENCODE_APPLY_SIGNING_KEY": "test-key",
+            "AXIOM_TEST_PYTHON": sys.executable,
+            "CALLS_PATH": str(calls_path),
+            "CHECKPOINTS_PATH": str(checkpoints_path),
+            "CITATION": primary,
+            "DEPENDENT_CITATION": "",
+            "DEPENDENT_REVIEW_FINDING": "",
+            "GITHUB_WORKSPACE": str(tmp_path),
+            "REVIEW_FINDING": "Preserve the composed target semantics.",
+            "RULESPEC_CHECKOUT": str(tmp_path / "rulespec-us"),
+            "RULESPEC_REF": "a" * 40,
+            "RUNNER_TEMP": str(runner_temp),
+            "SECOND_DEPENDENT_CITATION": "",
+            "SECOND_DEPENDENT_REVIEW_FINDING": "",
+            "SIGNER_STUB": str(signer_stub),
+            "SOURCE_BUNDLE_JSON": json.dumps(sources),
+        },
+    )
+
+    calls = [
+        json.loads(line) for line in calls_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert len(calls) == 3
+    encode_args = [call[call.index("--") + 1 :] for call in calls]
+    for index, source in enumerate(sources):
+        assert encode_args[index][-1] == source
+        assert "--apply-target-only" in encode_args[index]
+        assert "--required-import-rulespec-path" not in encode_args[index]
+
+    primary_args = encode_args[-1]
+    assert primary_args[-1] == primary
+    assert "--apply-target-only" not in primary_args
+    required_indexes = [
+        index
+        for index, value in enumerate(primary_args)
+        if value == "--required-import-rulespec-path"
+    ]
+    assert [primary_args[index + 1] for index in required_indexes] == [
+        "us-ri/statutes/44-30-1.yaml",
+        "us-ri/policies/revenue/2026/rate-schedule.yaml",
+    ]
+    assert checkpoints_path.read_text(encoding="utf-8").splitlines() == [
+        f"Add signed source module for {sources[0]}",
+        f"Add signed source module for {sources[1]}",
+        f"Compose signed source bundle for {primary}",
+    ]
+
+
 @pytest.mark.parametrize("with_dependent", [False, True])
 def test_targeted_signed_reencode_runs_replacement_target(
     tmp_path: Path,
@@ -2640,10 +2831,12 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
         "REPLACE_RULESPEC_PATH": replacement_path,
         "REVIEW_FINDING": "Preserve all supported existing semantics.",
         "RULESPEC_CHECKOUT": str(tmp_path / "rulespec-us"),
+        "RULESPEC_REF": "a" * 40,
         "RUNNER_TEMP": str(runner_temp),
         "SECOND_DEPENDENT_CITATION": "",
         "SECOND_DEPENDENT_REVIEW_FINDING": "",
         "SIGNER_STUB": str(signer_stub),
+        "SOURCE_BUNDLE_JSON": "[]",
     }
     subprocess.run(
         ["bash", "-c", command],
@@ -2732,11 +2925,13 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
         "REPLACE_RULESPEC_PATH": destination,
         "REVIEW_FINDING": "Preserve all supported existing semantics.",
         "RULESPEC_CHECKOUT": str(tmp_path / "rulespec-us"),
+        "RULESPEC_REF": "a" * 40,
         "RUNNER_TEMP": str(runner_temp),
         "SECOND_DEPENDENT_CITATION": "",
         "SECOND_DEPENDENT_REVIEW_FINDING": "",
         "SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH": exact_dependents[1],
         "SIGNER_STUB": str(signer_stub),
+        "SOURCE_BUNDLE_JSON": "[]",
     }
 
     subprocess.run(["bash", "-c", command], check=True, env=environment)
@@ -2832,9 +3027,11 @@ def test_targeted_signed_reencode_rejects_invalid_second_dependent_inputs(
         "GITHUB_WORKSPACE": str(tmp_path),
         "REVIEW_FINDING": "Preserve the target source.",
         "RULESPEC_CHECKOUT": str(tmp_path / "rulespec-us"),
+        "RULESPEC_REF": "a" * 40,
         "RUNNER_TEMP": str(runner_temp),
         "SECOND_DEPENDENT_CITATION": "",
         "SECOND_DEPENDENT_REVIEW_FINDING": "",
+        "SOURCE_BUNDLE_JSON": "[]",
         **overrides,
     }
 
@@ -2907,6 +3104,10 @@ def test_targeted_artifact_packages_signed_review_context(tmp_path: Path) -> Non
     base.write_text("fixture\n")
     subprocess.run(["git", "add", "README.md"], cwd=rulespec, check=True)
     subprocess.run(["git", "commit", "-qm", "fixture"], cwd=rulespec, check=True)
+    rulespec_ref = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=rulespec, text=True
+    ).strip()
+    (tmp_path / "source-bundle.json").write_text("[]\n", encoding="utf-8")
 
     citation = "us-la/statute/47:294"
     review_content = "Preserve every supported provision.\n"
@@ -2952,6 +3153,7 @@ def test_targeted_artifact_packages_signed_review_context(tmp_path: Path) -> Non
             "REVIEW_FINDING_PRESENT": "true",
             "RUNNER_TEMP": str(tmp_path),
             "RULESPEC_CHECKOUT": "rulespec-nz",
+            "RULESPEC_REF": rulespec_ref,
         },
     )
 
@@ -3029,6 +3231,10 @@ def test_targeted_artifact_enforces_target_and_dependent_context_lanes(
     base.write_text("fixture\n")
     subprocess.run(["git", "add", "README.md"], cwd=rulespec, check=True)
     subprocess.run(["git", "commit", "-qm", "fixture"], cwd=rulespec, check=True)
+    rulespec_ref = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=rulespec, text=True
+    ).strip()
+    (tmp_path / "source-bundle.json").write_text("[]\n", encoding="utf-8")
 
     target_citation = "us/regulation/42/435/555"
     dependent_citation = "us/regulation/42/435/559"
@@ -3119,6 +3325,7 @@ def test_targeted_artifact_enforces_target_and_dependent_context_lanes(
             "REVIEW_FINDING_PRESENT": "true",
             "RUNNER_TEMP": str(tmp_path),
             "RULESPEC_CHECKOUT": "rulespec-us",
+            "RULESPEC_REF": rulespec_ref,
         },
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1420"
+version = "0.2.1421"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- add a bounded, same-jurisdiction `source_bundle_json` contract to targeted signed re-encoding
- generate every auxiliary citation as its own signed-v5 atomic RuleSpec and checkpoint it before composing the primary target
- require direct symbol imports from every auxiliary module while preserving the target's single-source `source_verification`
- package the complete original-base diff and all source-lane provenance artifacts, with one final push and PR
- reject bundles in queue-authorized runs until queue generation identity can bind them
- keep downstream dependent validation enabled for composed primary targets

This is the structural oracle/source ownership fix for multi-source state income-tax encodings, not a plural-source-verification workaround.

## Validation

- `uv run --frozen --python 3.13 ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run --frozen --python 3.13 pytest` — 6,104 passed, 119 skipped
- focused source-bundle parser tests — 76 passed
- focused workflow/CLI/eval tests — green
- `git diff --check`
- redacted credential-pattern scan — clean

## Review-fix cycle

- independent review found one actionable issue: composed primary generation used target-only mode when no dependent cascade existed, weakening downstream validation
- fixed the workflow so a no-dependent primary retains full validation; added a live shell regression
- reran focused and full checks
- independent re-review: CLEAN (45 focused tests passed)
