### PR TITLE
Add verified reuse of signed RuleSpec imports

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -39,6 +39,11 @@ on:
         required: false
         default: "[]"
         type: string
+      existing_signed_imports_json:
+        description: JSON array of tracked same-jurisdiction signed-v5 modules to reuse as direct imports
+        required: false
+        default: "[]"
+        type: string
       replace_rulespec_path:
         description: Existing target, or unique canonical destination for a legacy replacement
         required: false
@@ -366,11 +371,17 @@ jobs:
           uv pip install --python .venv/bin/python \
             --target "$RUNNER_TEMP/axiom-verification-site-packages" ".[api]"
 
-      - name: Validate atomic source bundle
+      - name: Validate atomic source inputs
         env:
           CITATION: ${{ inputs.citation }}
           DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
+          EXISTING_SIGNED_IMPORTS_JSON: ${{ inputs.existing_signed_imports_json }}
+          LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.legacy_exact_dependent_rulespec_path }}
           QUEUE_ID: ${{ inputs.queue_id }}
+          REPLACE_LEGACY_RULESPEC_PATH: ${{ inputs.replace_legacy_rulespec_path }}
+          REPLACE_RULESPEC_PATH: ${{ inputs.replace_rulespec_path }}
+          RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
+          SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.second_legacy_exact_dependent_rulespec_path }}
           SECOND_DEPENDENT_CITATION: ${{ inputs.second_dependent_citation }}
           SOURCE_BUNDLE_JSON: ${{ inputs.source_bundle_json }}
         run: |
@@ -388,8 +399,36 @@ jobs:
             source_bundle_args+=(--exclude-citation "$SECOND_DEPENDENT_CITATION")
           fi
           normalized_source_bundle="$("${source_bundle_args[@]}")"
-          if [ -n "$QUEUE_ID" ] && [ "$normalized_source_bundle" != "[]" ]; then
-            echo "queue-authorized re-encodes cannot add a source bundle until queue generation identity binds it" >&2
+          existing_import_args=(
+            axiom-encode/.venv/bin/python
+            axiom-encode/scripts/prepare_signed_backfill.py
+            parse-existing-signed-imports "$RULESPEC_CHECKOUT"
+            "${EXISTING_SIGNED_IMPORTS_JSON:-[]}"
+            --primary-citation "$CITATION"
+          )
+          while IFS= read -r source_citation; do
+            existing_import_args+=(--source-citation "$source_citation")
+          done < <(printf '%s\n' "$normalized_source_bundle" | jq -r '.[]')
+          if [ -n "$DEPENDENT_CITATION" ]; then
+            existing_import_args+=(--exclude-citation "$DEPENDENT_CITATION")
+          fi
+          if [ -n "$SECOND_DEPENDENT_CITATION" ]; then
+            existing_import_args+=(--exclude-citation "$SECOND_DEPENDENT_CITATION")
+          fi
+          for reserved_path in \
+            "$REPLACE_RULESPEC_PATH" \
+            "$REPLACE_LEGACY_RULESPEC_PATH" \
+            "$LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" \
+            "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH"; do
+            if [ -n "$reserved_path" ]; then
+              existing_import_args+=(--exclude-rulespec-path "$reserved_path")
+            fi
+          done
+          normalized_existing_imports="$("${existing_import_args[@]}")"
+          if [ -n "$QUEUE_ID" ] && \
+            { [ "$normalized_source_bundle" != "[]" ] || \
+              [ "$normalized_existing_imports" != "[]" ]; }; then
+            echo "queue-authorized re-encodes cannot add source inputs until queue generation identity binds them" >&2
             exit 1
           fi
 
@@ -585,6 +624,110 @@ jobs:
           cascade_args+=("${dependent_citations[@]}")
           "${cascade_args[@]}"
 
+      - name: Verify existing signed imports
+        env:
+          CITATION: ${{ inputs.citation }}
+          DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
+          EXISTING_SIGNED_IMPORTS_JSON: ${{ inputs.existing_signed_imports_json }}
+          LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.legacy_exact_dependent_rulespec_path }}
+          REPLACE_LEGACY_RULESPEC_PATH: ${{ inputs.replace_legacy_rulespec_path }}
+          REPLACE_RULESPEC_PATH: ${{ inputs.replace_rulespec_path }}
+          RULESPEC_CHECKOUT: ${{ github.workspace }}/rulespec-${{ inputs.country }}
+          RULESPEC_REF: ${{ inputs.rulespec_ref }}
+          SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.second_legacy_exact_dependent_rulespec_path }}
+          SECOND_DEPENDENT_CITATION: ${{ inputs.second_dependent_citation }}
+          SOURCE_BUNDLE_JSON: ${{ inputs.source_bundle_json }}
+        run: |
+          set -euo pipefail
+          workflow_python=/opt/axiom-verification/python/bin/python
+          backfill_helper=axiom-encode/scripts/prepare_signed_backfill.py
+          source_bundle_args=(
+            "$workflow_python" -I "$backfill_helper" parse-source-bundle
+            "${SOURCE_BUNDLE_JSON:-[]}" --primary-citation "$CITATION"
+          )
+          if [ -n "$DEPENDENT_CITATION" ]; then
+            source_bundle_args+=(--exclude-citation "$DEPENDENT_CITATION")
+          fi
+          if [ -n "$SECOND_DEPENDENT_CITATION" ]; then
+            source_bundle_args+=(--exclude-citation "$SECOND_DEPENDENT_CITATION")
+          fi
+          normalized_source_bundle="$("${source_bundle_args[@]}")"
+          printf '%s\n' "$normalized_source_bundle" \
+            > "$RUNNER_TEMP/source-bundle.json"
+
+          existing_import_args=(
+            "$workflow_python" -I "$backfill_helper"
+            parse-existing-signed-imports "$RULESPEC_CHECKOUT"
+            "${EXISTING_SIGNED_IMPORTS_JSON:-[]}"
+            --primary-citation "$CITATION"
+          )
+          while IFS= read -r source_citation; do
+            existing_import_args+=(--source-citation "$source_citation")
+          done < <(printf '%s\n' "$normalized_source_bundle" | jq -r '.[]')
+          if [ -n "$DEPENDENT_CITATION" ]; then
+            existing_import_args+=(--exclude-citation "$DEPENDENT_CITATION")
+          fi
+          if [ -n "$SECOND_DEPENDENT_CITATION" ]; then
+            existing_import_args+=(--exclude-citation "$SECOND_DEPENDENT_CITATION")
+          fi
+          for reserved_path in \
+            "$REPLACE_RULESPEC_PATH" \
+            "$REPLACE_LEGACY_RULESPEC_PATH" \
+            "$LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" \
+            "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH"; do
+            if [ -n "$reserved_path" ]; then
+              existing_import_args+=(--exclude-rulespec-path "$reserved_path")
+            fi
+          done
+          normalized_existing_imports="$("${existing_import_args[@]}")"
+          printf '%s\n' "$normalized_existing_imports" \
+            > "$RUNNER_TEMP/existing-signed-imports.json"
+          jq -r '.[]' "$RUNNER_TEMP/existing-signed-imports.json" \
+            > "$RUNNER_TEMP/existing-signed-import-paths.txt"
+
+          if [ -s "$RUNNER_TEMP/existing-signed-import-paths.txt" ]; then
+            signed_import_args=(
+              /opt/axiom-verification/axiom-encode-signing-supervisor
+              --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json
+              --trusted-python-runtime-root /opt/axiom-verification/python
+              --trusted-python-import-root /opt/axiom-verification/python/lib/python3.13/site-packages
+              --trusted-python-package-root /opt/axiom-verification/python/lib/python3.13/site-packages/axiom_encode
+              -- /opt/axiom-verification/axiom-encode signed-import-inventory
+              --repo "$RULESPEC_CHECKOUT"
+              --corpus-path "$GITHUB_WORKSPACE/axiom-corpus"
+              --base-ref "$RULESPEC_REF"
+              --expected-encoder-checkout "$GITHUB_WORKSPACE/axiom-encode"
+              --json
+            )
+            while IFS= read -r existing_import_path; do
+              signed_import_args+=(--rulespec-path "$existing_import_path")
+            done < "$RUNNER_TEMP/existing-signed-import-paths.txt"
+            "${signed_import_args[@]}" \
+              > "$RUNNER_TEMP/existing-signed-import-inventory.json"
+          else
+            "$workflow_python" -I - \
+              "$RULESPEC_REF" \
+              "$RUNNER_TEMP/existing-signed-import-inventory.json" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          Path(sys.argv[2]).write_text(
+              json.dumps(
+                  {
+                      "schema": "axiom-encode/signed-import-inventory/v1",
+                      "rulespec_base": sys.argv[1],
+                      "verifier_encoder_identity": None,
+                      "items": [],
+                  },
+                  indent=2,
+                  sort_keys=True,
+              )
+              + "\n",
+              encoding="utf-8",
+          )
+          PY
+
       - name: Encode, review, validate, and apply
         env:
           AXIOM_ENCODE_APPLY_SIGNING_KEY: ${{ secrets.AXIOM_ENCODE_APPLY_SIGNING_KEY }}
@@ -600,6 +743,7 @@ jobs:
           DEPENDENT_REVIEW_FINDING: ${{ inputs.dependent_review_finding }}
           SECOND_DEPENDENT_CITATION: ${{ inputs.second_dependent_citation }}
           SECOND_DEPENDENT_REVIEW_FINDING: ${{ inputs.second_dependent_review_finding }}
+          EXISTING_SIGNED_IMPORTS_JSON: ${{ inputs.existing_signed_imports_json }}
           SOURCE_BUNDLE_JSON: ${{ inputs.source_bundle_json }}
           RULESPEC_CHECKOUT: ${{ github.workspace }}/rulespec-${{ inputs.country }}
           RULESPEC_REF: ${{ inputs.rulespec_ref }}
@@ -622,7 +766,7 @@ jobs:
             local output_lane="$4"
             local replacement_path="$5"
             local legacy_source_path="$6"
-            local require_source_bundle_imports="$7"
+            local require_direct_imports="$7"
             local review_finding_path=""
             local -a args=(
               /opt/axiom-verification/axiom-encode encode
@@ -668,10 +812,10 @@ jobs:
                 )
               fi
             fi
-            if [ "$require_source_bundle_imports" = "true" ]; then
+            if [ "$require_direct_imports" = "true" ]; then
               while IFS= read -r required_import_path; do
                 args+=(--required-import-rulespec-path "$required_import_path")
-              done < "$RUNNER_TEMP/source-bundle-rulespec-paths.txt"
+              done < "$RUNNER_TEMP/required-import-rulespec-paths.txt"
             fi
             if [ -n "$review_finding" ]; then
               review_finding_dir="$(mktemp -d "$RUNNER_TEMP/axiom-targeted-review-finding.XXXXXX")"
@@ -800,8 +944,41 @@ jobs:
             source_bundle_args+=(--exclude-citation "$SECOND_DEPENDENT_CITATION")
           fi
           normalized_source_bundle="$("${source_bundle_args[@]}")"
-          if [ -n "$QUEUE_ID" ] && [ "$normalized_source_bundle" != "[]" ]; then
-            echo "queue-authorized re-encodes cannot add a source bundle until queue generation identity binds it" >&2
+          existing_import_args=(
+            "$workflow_python" "$backfill_helper"
+            parse-existing-signed-imports "$RULESPEC_CHECKOUT"
+            "${EXISTING_SIGNED_IMPORTS_JSON:-[]}"
+            --primary-citation "$CITATION"
+          )
+          while IFS= read -r source_citation; do
+            existing_import_args+=(--source-citation "$source_citation")
+          done < <(printf '%s\n' "$normalized_source_bundle" | jq -r '.[]')
+          if [ -n "$DEPENDENT_CITATION" ]; then
+            existing_import_args+=(--exclude-citation "$DEPENDENT_CITATION")
+          fi
+          if [ -n "$SECOND_DEPENDENT_CITATION" ]; then
+            existing_import_args+=(--exclude-citation "$SECOND_DEPENDENT_CITATION")
+          fi
+          for reserved_path in \
+            "$REPLACE_RULESPEC_PATH" \
+            "$REPLACE_LEGACY_RULESPEC_PATH" \
+            "$LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" \
+            "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH"; do
+            if [ -n "$reserved_path" ]; then
+              existing_import_args+=(--exclude-rulespec-path "$reserved_path")
+            fi
+          done
+          normalized_existing_imports="$("${existing_import_args[@]}")"
+          verified_existing_imports="$(tr -d '\n' \
+            < "$RUNNER_TEMP/existing-signed-imports.json")"
+          if [ "$normalized_existing_imports" != "$verified_existing_imports" ]; then
+            echo "verified existing signed imports changed before apply" >&2
+            exit 1
+          fi
+          if [ -n "$QUEUE_ID" ] && \
+            { [ "$normalized_source_bundle" != "[]" ] || \
+              [ "$normalized_existing_imports" != "[]" ]; }; then
+            echo "queue-authorized re-encodes cannot add source inputs until queue generation identity binds them" >&2
             exit 1
           fi
           printf '%s\n' "$normalized_source_bundle" \
@@ -814,11 +991,21 @@ jobs:
               citation-rulespec-path "$source_citation" \
               >> "$RUNNER_TEMP/source-bundle-rulespec-paths.txt"
           done < "$RUNNER_TEMP/source-bundle-citations.txt"
+          cat \
+            "$RUNNER_TEMP/source-bundle-rulespec-paths.txt" \
+            "$RUNNER_TEMP/existing-signed-import-paths.txt" \
+            > "$RUNNER_TEMP/required-import-rulespec-paths.txt"
           source_bundle_count="$(jq -er 'length' \
             "$RUNNER_TEMP/source-bundle.json")"
+          existing_import_count="$(jq -er 'length' \
+            "$RUNNER_TEMP/existing-signed-imports.json")"
           source_bundle_enabled=false
           if [ "$source_bundle_count" -gt 0 ]; then
             source_bundle_enabled=true
+          fi
+          required_imports_enabled=false
+          if [ $((source_bundle_count + existing_import_count)) -gt 0 ]; then
+            required_imports_enabled=true
           fi
 
           checkpoint_signed_changes() {
@@ -858,7 +1045,7 @@ jobs:
             run_signed_encode \
               "$CITATION" "$REVIEW_FINDING" true target \
               "$REPLACE_RULESPEC_PATH" "$REPLACE_LEGACY_RULESPEC_PATH" \
-              "$source_bundle_enabled"
+              "$required_imports_enabled"
             dependent_target_only=false
             if [ -n "$SECOND_DEPENDENT_CITATION" ]; then
               dependent_target_only=true
@@ -876,7 +1063,7 @@ jobs:
               "$CITATION" "$REVIEW_FINDING" false \
               target "$REPLACE_RULESPEC_PATH" \
               "$REPLACE_LEGACY_RULESPEC_PATH" \
-              "$source_bundle_enabled"
+              "$required_imports_enabled"
           fi
 
           if [ "$source_bundle_enabled" = "true" ]; then
@@ -905,6 +1092,40 @@ jobs:
             "${guard_ref_args[@]}" \
             --json > "$RUNNER_TEMP/guard-generated.json"
           git -C "$RULESPEC_CHECKOUT" diff --check
+
+      - name: Verify existing signed import integrity
+        env:
+          RULESPEC_CHECKOUT: ${{ github.workspace }}/rulespec-${{ inputs.country }}
+          RULESPEC_REF: ${{ inputs.rulespec_ref }}
+        run: |
+          set -euo pipefail
+          if [ -s "$RUNNER_TEMP/existing-signed-import-paths.txt" ]; then
+            signed_import_args=(
+              /opt/axiom-verification/axiom-encode-signing-supervisor
+              --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json
+              --trusted-python-runtime-root /opt/axiom-verification/python
+              --trusted-python-import-root /opt/axiom-verification/python/lib/python3.13/site-packages
+              --trusted-python-package-root /opt/axiom-verification/python/lib/python3.13/site-packages/axiom_encode
+              -- /opt/axiom-verification/axiom-encode signed-import-inventory
+              --repo "$RULESPEC_CHECKOUT"
+              --corpus-path "$GITHUB_WORKSPACE/axiom-corpus"
+              --base-ref "$RULESPEC_REF"
+              --expected-encoder-checkout "$GITHUB_WORKSPACE/axiom-encode"
+              --json
+            )
+            while IFS= read -r existing_import_path; do
+              signed_import_args+=(--rulespec-path "$existing_import_path")
+            done < "$RUNNER_TEMP/existing-signed-import-paths.txt"
+            "${signed_import_args[@]}" \
+              > "$RUNNER_TEMP/existing-signed-import-inventory-final.json"
+          else
+            cp \
+              "$RUNNER_TEMP/existing-signed-import-inventory.json" \
+              "$RUNNER_TEMP/existing-signed-import-inventory-final.json"
+          fi
+          cmp --silent \
+            "$RUNNER_TEMP/existing-signed-import-inventory.json" \
+            "$RUNNER_TEMP/existing-signed-import-inventory-final.json"
 
       - name: Package exact generated changes
         env:
@@ -942,6 +1163,10 @@ jobs:
             "$RULESPEC_REF" HEAD >> "$artifact/status.txt"
           cp "$RUNNER_TEMP/guard-generated.json" "$artifact/guard-generated.json"
           cp "$RUNNER_TEMP/source-bundle.json" "$artifact/source-bundle.json"
+          cp "$RUNNER_TEMP/existing-signed-imports.json" \
+            "$artifact/existing-signed-imports.json"
+          cp "$RUNNER_TEMP/existing-signed-import-inventory.json" \
+            "$artifact/signed-import-inventory.json"
           for source_guard in "$RUNNER_TEMP"/source-*-guard-generated.json; do
             if [ -f "$source_guard" ]; then
               cp "$source_guard" "$artifact/"
@@ -1467,6 +1692,7 @@ jobs:
           )
           PY
           "${workflow_python[@]}" - "$artifact/metadata.json" <<'PY'
+          import hashlib
           import json
           import os
           import subprocess
@@ -1486,6 +1712,18 @@ jobs:
                       Path(os.environ["RUNNER_TEMP"]) / "source-bundle.json"
                   ).read_text(encoding="utf-8")
               ),
+              "existing_signed_imports": json.loads(
+                  (
+                      Path(os.environ["RUNNER_TEMP"])
+                      / "existing-signed-imports.json"
+                  ).read_text(encoding="utf-8")
+              ),
+              "signed_import_inventory_sha256": hashlib.sha256(
+                  (
+                      Path(os.environ["RUNNER_TEMP"])
+                      / "existing-signed-import-inventory.json"
+                  ).read_bytes()
+              ).hexdigest(),
               "dependent_citation": os.environ.get("DEPENDENT_CITATION") or None,
               "second_dependent_citation": (
                   os.environ.get("SECOND_DEPENDENT_CITATION") or None
@@ -1590,11 +1828,14 @@ jobs:
             axiom-encode/scripts/prepare_signed_backfill.py branch-name \
             "$COUNTRY" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT")"
           source_bundle="$(tr -d '\n' < "$RUNNER_TEMP/source-bundle.json")"
+          existing_signed_imports="$(tr -d '\n' \
+            < "$RUNNER_TEMP/existing-signed-imports.json")"
           body="$(printf '%s\n' \
             '## Signed apply manifest' \
             '' \
             "Citation: \`${CITATION}\`" \
             "Atomic source bundle: \`${source_bundle}\`" \
+            "Existing signed imports: \`${existing_signed_imports}\`" \
             "Direct dependent: \`${DEPENDENT_CITATION:-n/a}\`" \
             "Second direct dependent: \`${SECOND_DEPENDENT_CITATION:-n/a}\`" \
             "Exact legacy dependent: \`${LEGACY_EXACT_DEPENDENT_RULESPEC_PATH:-n/a}\`" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1421"
+version = "0.2.1422"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1422"
+version = "0.2.1423"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -309,6 +309,146 @@ def parse_source_bundle(
     return tuple(citations)
 
 
+def _existing_import_manifest_path(path: PurePosixPath) -> PurePosixPath:
+    return MANIFEST_ROOT / path.with_suffix(".json")
+
+
+def parse_existing_signed_imports(
+    repo: Path,
+    existing_signed_imports_json: str,
+    *,
+    primary_citation: str,
+    source_bundle_citations: tuple[str, ...] = (),
+    excluded_citations: tuple[str, ...] = (),
+    excluded_rulespec_paths: tuple[str, ...] = (),
+) -> tuple[PurePosixPath, ...]:
+    """Validate bounded, tracked signed-v5 modules reused as direct imports."""
+
+    if not isinstance(existing_signed_imports_json, str):
+        raise ValueError("existing signed imports JSON must be a string")
+    if len(existing_signed_imports_json.encode("utf-8")) > MAX_SOURCE_BUNDLE_JSON_BYTES:
+        raise ValueError("existing signed imports JSON exceeds the maximum input size")
+    payload = json.loads(existing_signed_imports_json)
+    if not isinstance(payload, list):
+        raise ValueError("existing signed imports JSON must be an array")
+    if len(payload) + len(source_bundle_citations) > MAX_SOURCE_BUNDLE_CITATIONS:
+        raise ValueError(
+            "fresh source bundle and existing signed imports contain more than "
+            f"{MAX_SOURCE_BUNDLE_CITATIONS} modules"
+        )
+
+    primary_jurisdiction, primary_relative = _citation_rulespec_path(primary_citation)
+    primary_path = PurePosixPath(primary_jurisdiction) / primary_relative
+    validate_country(primary_jurisdiction.partition("-")[0])
+    reserved_paths = {primary_path}
+    for citation in (*source_bundle_citations, *excluded_citations):
+        jurisdiction, relative = _citation_rulespec_path(citation)
+        if jurisdiction != primary_jurisdiction:
+            raise ValueError(
+                "fresh source and excluded citations must use the primary "
+                "citation jurisdiction and country"
+            )
+        reserved_paths.add(PurePosixPath(jurisdiction) / relative)
+    for index, value in enumerate(excluded_rulespec_paths):
+        path = _safe_relative_path(
+            value,
+            label=f"excluded RuleSpec path #{index + 1}",
+        )
+        if (
+            len(path.parts) < 3
+            or path.parts[0] != primary_jurisdiction
+            or path.parts[1] not in RULESPEC_ATOMIC_ROOTS
+            or path.suffix != ".yaml"
+            or path.name.endswith(".test.yaml")
+        ):
+            raise ValueError(
+                "excluded RuleSpec paths must be canonical primary modules in "
+                "the primary citation jurisdiction"
+            )
+        reserved_paths.add(path)
+
+    if not payload:
+        return ()
+
+    repo = repo.resolve(strict=True)
+    expected_repo_name = f"rulespec-{primary_jurisdiction.partition('-')[0]}"
+    if repo.name != expected_repo_name:
+        raise ValueError(
+            "repository directory must match the primary citation country: "
+            f"{expected_repo_name}"
+        )
+
+    paths: list[PurePosixPath] = []
+    seen: set[PurePosixPath] = set()
+    for index, value in enumerate(payload):
+        label = f"existing signed import #{index + 1}"
+        path = _safe_relative_path(value, label=label)
+        if (
+            any(
+                ord(character) < 32 or ord(character) == 127 for character in str(value)
+            )
+            or len(path.parts) < 3
+            or path.parts[0] != primary_jurisdiction
+            or path.parts[1] not in RULESPEC_ATOMIC_ROOTS
+            or path.suffix != ".yaml"
+            or path.name.endswith(".test.yaml")
+        ):
+            raise ValueError(
+                f"{label} must be a canonical primary RuleSpec path in the "
+                "primary citation jurisdiction"
+            )
+        if path in reserved_paths:
+            raise ValueError(
+                "existing signed imports must exclude the primary, fresh source, "
+                "and dependent paths"
+            )
+        if path in seen:
+            raise ValueError("existing signed import paths must be unique")
+        manifest_path = _existing_import_manifest_path(path)
+        for tracked_path, tracked_label, max_bytes in (
+            (path, label, 16 * 1024 * 1024),
+            (manifest_path, f"{label} manifest", 1024 * 1024),
+        ):
+            try:
+                tracked = (
+                    _git(
+                        repo,
+                        "ls-files",
+                        "--error-unmatch",
+                        "--",
+                        tracked_path.as_posix(),
+                    )
+                    .decode("utf-8")
+                    .splitlines()
+                )
+            except (subprocess.CalledProcessError, UnicodeDecodeError) as exc:
+                raise ValueError(f"{tracked_label} must be exactly tracked") from exc
+            if tracked != [tracked_path.as_posix()]:
+                raise ValueError(f"{tracked_label} must be exactly tracked")
+            _read_bounded_regular(
+                repo,
+                tracked_path,
+                label=tracked_label,
+                max_bytes=max_bytes,
+            )
+        manifest = json.loads(
+            _read_bounded_regular(
+                repo,
+                manifest_path,
+                label=f"{label} manifest",
+                max_bytes=1024 * 1024,
+            ).decode("utf-8")
+        )
+        if (
+            not isinstance(manifest, dict)
+            or manifest.get("schema_version") != "axiom-encode/applied-rulespec/v5"
+        ):
+            raise ValueError(f"{label} manifest must use signed-v5 schema")
+        paths.append(path)
+        seen.add(path)
+    return tuple(paths)
+
+
 def _is_regular_file_beneath(root: Path, relative: PurePosixPath) -> bool:
     """Reject files reached through any symlink beneath the checkout root."""
 
@@ -1380,6 +1520,37 @@ def main() -> None:
         default=[],
         help="additional forbidden canonical citation; may be repeated",
     )
+    existing_imports_parser = subparsers.add_parser(
+        "parse-existing-signed-imports",
+        help=(
+            "validate tracked signed-v5 modules reused as direct imports and "
+            "emit one normalized JSON array"
+        ),
+    )
+    existing_imports_parser.add_argument("repo", type=Path)
+    existing_imports_parser.add_argument(
+        "existing_signed_imports_json",
+        help="JSON array of canonical checkout-relative primary module paths",
+    )
+    existing_imports_parser.add_argument("--primary-citation", required=True)
+    existing_imports_parser.add_argument(
+        "--source-citation",
+        action="append",
+        default=[],
+        help="fresh source citation already counted toward the 16-import limit",
+    )
+    existing_imports_parser.add_argument(
+        "--exclude-citation",
+        action="append",
+        default=[],
+        help="additional forbidden canonical citation; may be repeated",
+    )
+    existing_imports_parser.add_argument(
+        "--exclude-rulespec-path",
+        action="append",
+        default=[],
+        help="additional forbidden checkout-relative RuleSpec path; may be repeated",
+    )
     args = parser.parse_args()
     try:
         if args.command == "validate-country":
@@ -1424,6 +1595,23 @@ def main() -> None:
                         primary_citation=args.primary_citation,
                         excluded_citations=tuple(args.exclude_citation),
                     ),
+                    separators=(",", ":"),
+                )
+            )
+        elif args.command == "parse-existing-signed-imports":
+            print(
+                json.dumps(
+                    [
+                        path.as_posix()
+                        for path in parse_existing_signed_imports(
+                            args.repo,
+                            args.existing_signed_imports_json,
+                            primary_citation=args.primary_citation,
+                            source_bundle_citations=tuple(args.source_citation),
+                            excluded_citations=tuple(args.exclude_citation),
+                            excluded_rulespec_paths=tuple(args.exclude_rulespec_path),
+                        )
+                    ],
                     separators=(",", ":"),
                 )
             )

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1421"
+__version__ = "0.2.1422"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1422"
+__version__ = "0.2.1423"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -6786,6 +6786,28 @@ def signed_import_inventory(
             raise ValueError(
                 f"signed import {rulespec_path} must have a direct model manifest"
             )
+        citation = payload.get("citation")
+        source_attestation = payload.get("source_attestation")
+        requested_citation = (
+            source_attestation.get("requested_corpus_citation_path")
+            if isinstance(source_attestation, dict)
+            else None
+        )
+        try:
+            canonical_citation = (
+                require_canonical_corpus_citation_path(citation)
+                if isinstance(citation, str)
+                else None
+            )
+        except CorpusResolutionError as exc:
+            raise ValueError(
+                f"signed import {rulespec_path} has a noncanonical citation"
+            ) from exc
+        if canonical_citation is None or canonical_citation != requested_citation:
+            raise ValueError(
+                f"signed import {rulespec_path} citation does not match its "
+                "verified source attestation"
+            )
         applied_files = payload.get("applied_files")
         assert isinstance(applied_files, list)
         applied_inventory: list[dict[str, str]] = []
@@ -6824,7 +6846,7 @@ def signed_import_inventory(
                 ),
                 "manifest_path": manifest_path.as_posix(),
                 "manifest_sha256": manifest_sha256,
-                "citation": payload.get("citation"),
+                "citation": canonical_citation,
                 "applied_files": applied_inventory,
             }
         )

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -1768,6 +1768,27 @@ def main():
         "--json", action="store_true", help="Output guard result as JSON"
     )
 
+    signed_import_parser = subparsers.add_parser(
+        "signed-import-inventory",
+        help=(
+            "Verify existing historical signed-v5 RuleSpec modules at an "
+            "immutable base and emit reusable import evidence"
+        ),
+    )
+    signed_import_parser.add_argument("--repo", type=Path, required=True)
+    signed_import_parser.add_argument("--base-ref", required=True)
+    signed_import_parser.add_argument(
+        "--rulespec-path",
+        action="append",
+        required=True,
+        help="Exact checkout-relative primary RuleSpec module; may be repeated",
+    )
+    _add_required_corpus_path_argument(signed_import_parser)
+    _add_expected_encoder_checkout_argument(signed_import_parser)
+    signed_import_parser.add_argument(
+        "--json", action="store_true", help="Output inventory as JSON"
+    )
+
     manifest_census_parser = subparsers.add_parser(
         "manifest-census",
         help=(
@@ -2791,6 +2812,8 @@ def main():
         cmd_migrate_rulespec_paths(args)
     elif args.command == "guard-generated":
         cmd_guard_generated(args)
+    elif args.command == "signed-import-inventory":
+        cmd_signed_import_inventory(args)
     elif args.command == "manifest-census":
         cmd_manifest_census(args)
     elif args.command == "encode":
@@ -6550,6 +6573,267 @@ def cmd_guard_generated(args):
         else:
             print("All changed RuleSpec files have encoder apply manifests.")
     sys.exit(0 if not issues else 1)
+
+
+def cmd_signed_import_inventory(args):
+    """Verify immutable historical signed-v5 modules for direct reuse."""
+
+    payload = signed_import_inventory(
+        args.repo,
+        corpus_path=Path(args.corpus_path),
+        base_ref=args.base_ref,
+        rulespec_paths=tuple(args.rulespec_path),
+        expected_encoder_checkout=getattr(args, "expected_encoder_checkout", None),
+    )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        for item in payload["items"]:
+            print(f"verified {item['rulespec_path']}")
+
+
+def signed_import_inventory(
+    repo_path: Path,
+    *,
+    corpus_path: Path,
+    base_ref: str,
+    rulespec_paths: Sequence[str],
+    expected_encoder_checkout: Path | None = None,
+) -> dict[str, object]:
+    """Return fail-closed evidence for historical signed-v5 direct imports."""
+
+    repo_path = _resolve_canonical_rulespec_checkout(
+        repo_path,
+        label="RuleSpec checkout",
+    )
+    if re.fullmatch(r"[0-9a-f]{40}", base_ref) is None:
+        raise ValueError("signed import base ref must be a full lowercase commit SHA")
+    try:
+        resolved_base = subprocess.check_output(
+            ["git", "-C", str(repo_path), "rev-parse", f"{base_ref}^{{commit}}"],
+            text=True,
+        ).strip()
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo_path),
+                "merge-base",
+                "--is-ancestor",
+                base_ref,
+                "HEAD",
+            ],
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise ValueError(
+            "signed import base ref is unavailable or not an ancestor"
+        ) from exc
+    if resolved_base != base_ref:
+        raise ValueError("signed import base ref did not resolve exactly")
+    if not rulespec_paths or len(rulespec_paths) > 16:
+        raise ValueError("signed import inventory requires between 1 and 16 modules")
+
+    roots = tuple(sorted(RULESPEC_ATOMIC_MODULE_ROOTS))
+    country = repo_path.name.removeprefix("rulespec-")
+    normalized_paths: list[Path] = []
+    seen: set[Path] = set()
+    jurisdiction: str | None = None
+    for value in rulespec_paths:
+        path = Path(value)
+        if (
+            path.is_absolute()
+            or path.as_posix() != value
+            or any(part in {"", ".", ".."} for part in path.parts)
+            or any(ord(character) < 32 or ord(character) == 127 for character in value)
+            or len(path.parts) < 3
+            or path.parts[1] not in roots
+            or path.suffix != RULESPEC_FILE_SUFFIX
+            or path.name.endswith(RULESPEC_TEST_FILE_SUFFIX)
+        ):
+            raise ValueError(
+                "signed import path must be a canonical checkout-relative primary "
+                "RuleSpec module"
+            )
+        current_jurisdiction = path.parts[0]
+        if current_jurisdiction != country and not current_jurisdiction.startswith(
+            f"{country}-"
+        ):
+            raise ValueError(
+                "signed import jurisdiction does not belong to the checkout"
+            )
+        if jurisdiction is None:
+            jurisdiction = current_jurisdiction
+        elif jurisdiction != current_jurisdiction:
+            raise ValueError("signed imports must use exactly one jurisdiction")
+        if path in seen:
+            raise ValueError("signed import paths must be unique")
+        normalized_paths.append(path)
+        seen.add(path)
+
+    expected_waiver_set_sha256 = verify_rulespec_validation_waiver_set(repo_path)
+    local_corpus_release = load_rulespec_local_corpus_release(
+        repo_path,
+        Path(corpus_path),
+    )
+    try:
+        signing_broker = _applied_encoding_manifest_verifier()
+    except SigningBrokerError as exc:
+        raise RuntimeError(
+            "cannot initialize the protected signing verifier for signed imports"
+        ) from exc
+    if not signing_broker:
+        raise RuntimeError(
+            "A protected signing broker initialized from the three-root trust "
+            "config is required to verify signed imports"
+        )
+    verifier_encoder_identity = _read_only_guard_encoder_execution_identity(
+        expected_encoder_checkout
+    )
+
+    def base_bound_regular(relative: Path, *, label: str, max_bytes: int) -> bytes:
+        listing = subprocess.check_output(
+            [
+                "git",
+                "-C",
+                str(repo_path),
+                "ls-tree",
+                "-z",
+                "--full-tree",
+                base_ref,
+                "--",
+                relative.as_posix(),
+            ]
+        )
+        records = [record for record in listing.split(b"\0") if record]
+        if len(records) != 1:
+            raise ValueError(
+                f"{label} is not exactly present at the signed import base"
+            )
+        try:
+            metadata, encoded_path = records[0].split(b"\t", 1)
+            mode, object_type, _object_id = metadata.decode("ascii").split(" ")
+            listed_path = encoded_path.decode("utf-8")
+        except (ValueError, UnicodeDecodeError) as exc:
+            raise ValueError(f"{label} base entry is malformed") from exc
+        if (
+            mode != "100644"
+            or object_type != "blob"
+            or listed_path != relative.as_posix()
+        ):
+            raise ValueError(f"{label} is not an exact regular 0644 base blob")
+        base_bytes = _git_show_bytes(repo_path, base_ref, relative.as_posix())
+        if base_bytes is None or len(base_bytes) > max_bytes:
+            raise ValueError(f"{label} base blob is unavailable or oversized")
+        try:
+            live_bytes = read_bounded_regular_file(
+                repo_path,
+                repo_path / relative,
+                label=label,
+                max_bytes=max_bytes,
+                required_mode=0o644,
+            )
+        except UnsafeCorpusPathError as exc:
+            raise ValueError(str(exc)) from exc
+        if live_bytes != base_bytes:
+            raise ValueError(f"{label} differs from the immutable base")
+        return live_bytes
+
+    items: list[dict[str, object]] = []
+    for rulespec_path in normalized_paths:
+        manifest_path = _applied_encoding_manifest_path(rulespec_path)
+        manifest_bytes = base_bound_regular(
+            manifest_path,
+            label=f"signed import manifest {manifest_path}",
+            max_bytes=1024 * 1024,
+        )
+        try:
+            unverified_payload = json.loads(manifest_bytes.decode("utf-8"))
+        except (UnicodeError, json.JSONDecodeError, RecursionError) as exc:
+            raise ValueError(
+                f"signed import manifest {manifest_path} is invalid"
+            ) from exc
+        execution = (
+            unverified_payload.get("validation_execution")
+            if isinstance(unverified_payload, dict)
+            else None
+        )
+        historical_encoder_identity = (
+            execution.get("axiom_encode") if isinstance(execution, dict) else None
+        )
+        if not isinstance(historical_encoder_identity, dict):
+            raise ValueError(
+                f"signed import manifest {manifest_path} lacks encoder identity"
+            )
+        payload, root_prefix, manifest_sha256, issues = (
+            _load_verified_applied_encoding_manifest_payload(
+                repo_path,
+                manifest_path.as_posix(),
+                roots=roots,
+                signing_broker=signing_broker,
+                expected_waiver_set_sha256=expected_waiver_set_sha256,
+                local_corpus_release=local_corpus_release,
+                expected_encoder_identity=historical_encoder_identity,
+            )
+        )
+        if payload is None or root_prefix is None or manifest_sha256 is None or issues:
+            detail = "; ".join(issues) or "manifest verification failed"
+            raise ValueError(f"signed import {rulespec_path} is invalid: {detail}")
+        if (
+            payload.get("tool") != APPLIED_ENCODING_MODEL_TOOL
+            or payload.get("backend") not in APPLIED_ENCODING_ENCODER_BACKENDS
+        ):
+            raise ValueError(
+                f"signed import {rulespec_path} must have a direct model manifest"
+            )
+        applied_files = payload.get("applied_files")
+        assert isinstance(applied_files, list)
+        applied_inventory: list[dict[str, str]] = []
+        primary_paths: list[str] = []
+        for applied in applied_files:
+            assert isinstance(applied, dict)
+            raw_path = str(applied["path"])
+            checkout_path = Path(_prefix_applied_manifest_path(raw_path, root_prefix))
+            content = base_bound_regular(
+                checkout_path,
+                label=f"signed import applied file {checkout_path}",
+                max_bytes=10 * 1024 * 1024,
+            )
+            digest = hashlib.sha256(content).hexdigest()
+            if digest != applied.get("sha256"):
+                raise ValueError(
+                    f"signed import manifest has stale hash for {checkout_path}"
+                )
+            if not checkout_path.name.endswith(RULESPEC_TEST_FILE_SUFFIX):
+                primary_paths.append(checkout_path.as_posix())
+            applied_inventory.append(
+                {"path": checkout_path.as_posix(), "sha256": digest}
+            )
+        if primary_paths != [rulespec_path.as_posix()]:
+            raise ValueError(
+                f"signed import {rulespec_path} is not the sole primary owned by "
+                "its direct manifest"
+            )
+        items.append(
+            {
+                "rulespec_path": rulespec_path.as_posix(),
+                "rulespec_sha256": next(
+                    item["sha256"]
+                    for item in applied_inventory
+                    if item["path"] == rulespec_path.as_posix()
+                ),
+                "manifest_path": manifest_path.as_posix(),
+                "manifest_sha256": manifest_sha256,
+                "citation": payload.get("citation"),
+                "applied_files": applied_inventory,
+            }
+        )
+    return {
+        "schema": "axiom-encode/signed-import-inventory/v1",
+        "rulespec_base": base_ref,
+        "verifier_encoder_identity": verifier_encoder_identity,
+        "items": items,
+    }
 
 
 def _scheduled_dependent_manifest_issue(

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1421"
+ENCODER_VERSION = "0.2.1422"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1422"
+ENCODER_VERSION = "0.2.1423"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35109,6 +35109,46 @@ class TestGuardGenerated:
                 rulespec_paths=("us/statutes/26/1.yaml",),
             )
 
+    @pytest.mark.parametrize(
+        "manifest_citation",
+        [None, "us-ca/statute/26/1", "us/statute/26/2"],
+    )
+    def test_signed_import_inventory_rejects_unbound_manifest_citation(
+        self,
+        tmp_path: Path,
+        manifest_citation: object,
+    ):
+        repo, _base_ref, _rule, manifest = self._historical_signed_import_repo(tmp_path)
+        payload = json.loads(manifest.read_text())
+        payload["citation"] = manifest_citation
+        _sign_applied_encoding_manifest(payload, TEST_APPLY_SIGNING_BROKER)
+        manifest.write_text(json.dumps(payload) + "\n")
+        _git(repo, "add", manifest.relative_to(repo).as_posix())
+        _git(repo, "commit", "--amend", "--no-edit")
+        base_ref = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+        with (
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_PUBLIC_KEY_ENV: TEST_APPLY_PUBLIC_KEY_B64},
+            ),
+            patch(
+                "axiom_encode.cli._read_only_guard_encoder_execution_identity",
+                return_value=TEST_PINNED_ENCODER_IDENTITY,
+            ),
+            patch(
+                "axiom_encode.cli._applied_encoding_manifest_verifier",
+                return_value=TEST_APPLY_SIGNING_BROKER,
+            ),
+            pytest.raises(ValueError, match="citation"),
+        ):
+            signed_import_inventory(
+                repo,
+                corpus_path=self.corpus_path,
+                base_ref=base_ref,
+                rulespec_paths=("us/statutes/26/1.yaml",),
+            )
+
     def _waiver_entry_text(
         self,
         path: str,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -265,6 +265,7 @@ from axiom_encode.cli import (
     cmd_validate,
     guard_generated_change_issues,
     main,
+    signed_import_inventory,
 )
 from axiom_encode.constants import (
     DEFAULT_OPENAI_ESCALATE_AFTER,
@@ -34990,6 +34991,123 @@ class TestGuardGenerated:
                 "applied_files": applied_files,
             }
         )
+
+    def _historical_signed_import_repo(
+        self,
+        tmp_path: Path,
+    ) -> tuple[Path, str, Path, Path]:
+        repo = tmp_path
+        _git(repo, "init")
+        _git(repo, "config", "user.email", "test@example.com")
+        _git(repo, "config", "user.name", "Test User")
+        self._canonical_guard_repo(repo)
+        rule = repo / "us/statutes/26/1.yaml"
+        self._source_backed_rule(rule)
+        manifest = repo / ".axiom/encoding-manifests/us/statutes/26/1.json"
+        manifest.parent.mkdir(parents=True)
+        payload = self._model_manifest(
+            [
+                {
+                    "path": "us/statutes/26/1.yaml",
+                    "sha256": _sha256_file(rule),
+                }
+            ]
+        )
+        payload["citation"] = "us/statute/26/1"
+        historical_version = "0.2.1000"
+        historical_commit = "c" * 40
+        payload["axiom_encode_version"] = historical_version
+        payload["axiom_encode_git"]["commit"] = historical_commit
+        payload["axiom_encode_git"]["version"] = historical_version
+        payload["validation_execution"]["axiom_encode"]["commit"] = historical_commit
+        payload["validation_execution"]["axiom_encode"]["version"] = historical_version
+        _sign_applied_encoding_manifest(payload, TEST_APPLY_SIGNING_BROKER)
+        manifest.write_text(json.dumps(payload) + "\n")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "historical signed import")
+        base_ref = _git(repo, "rev-parse", "HEAD").stdout.strip()
+        return repo, base_ref, rule, manifest
+
+    def test_signed_import_inventory_accepts_historical_signed_v5_model(
+        self,
+        tmp_path: Path,
+    ):
+        repo, base_ref, rule, manifest = self._historical_signed_import_repo(tmp_path)
+
+        with (
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_PUBLIC_KEY_ENV: TEST_APPLY_PUBLIC_KEY_B64},
+            ),
+            patch(
+                "axiom_encode.cli._read_only_guard_encoder_execution_identity",
+                return_value=TEST_PINNED_ENCODER_IDENTITY,
+            ),
+            patch(
+                "axiom_encode.cli._applied_encoding_manifest_verifier",
+                return_value=TEST_APPLY_SIGNING_BROKER,
+            ),
+        ):
+            inventory = signed_import_inventory(
+                repo,
+                corpus_path=self.corpus_path,
+                base_ref=base_ref,
+                rulespec_paths=("us/statutes/26/1.yaml",),
+            )
+
+        assert inventory["schema"] == "axiom-encode/signed-import-inventory/v1"
+        assert inventory["rulespec_base"] == base_ref
+        assert inventory["verifier_encoder_identity"] == TEST_PINNED_ENCODER_IDENTITY
+        assert inventory["items"] == [
+            {
+                "rulespec_path": "us/statutes/26/1.yaml",
+                "rulespec_sha256": _sha256_file(rule),
+                "manifest_path": (".axiom/encoding-manifests/us/statutes/26/1.json"),
+                "manifest_sha256": _sha256_file(manifest),
+                "citation": "us/statute/26/1",
+                "applied_files": [
+                    {
+                        "path": "us/statutes/26/1.yaml",
+                        "sha256": _sha256_file(rule),
+                    }
+                ],
+            }
+        ]
+
+    @pytest.mark.parametrize("mutation", ["rule", "manifest"])
+    def test_signed_import_inventory_rejects_live_drift_from_base(
+        self,
+        tmp_path: Path,
+        mutation: str,
+    ):
+        repo, base_ref, rule, manifest = self._historical_signed_import_repo(tmp_path)
+        target = rule if mutation == "rule" else manifest
+        target.write_text(target.read_text() + "\n")
+
+        with (
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_PUBLIC_KEY_ENV: TEST_APPLY_PUBLIC_KEY_B64},
+            ),
+            patch(
+                "axiom_encode.cli._read_only_guard_encoder_execution_identity",
+                return_value=TEST_PINNED_ENCODER_IDENTITY,
+            ),
+            patch(
+                "axiom_encode.cli._applied_encoding_manifest_verifier",
+                return_value=TEST_APPLY_SIGNING_BROKER,
+            ),
+            pytest.raises(
+                ValueError,
+                match="stale sha256|differs from the immutable base",
+            ),
+        ):
+            signed_import_inventory(
+                repo,
+                corpus_path=self.corpus_path,
+                base_ref=base_ref,
+                rulespec_paths=("us/statutes/26/1.yaml",),
+            )
 
     def _waiver_entry_text(
         self,

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1421"
+ENCODER_VERSION = "0.2.1422"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1422"
+ENCODER_VERSION = "0.2.1423"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1422"
+ENCODER_VERSION = "0.2.1423"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1421"
+ENCODER_VERSION = "0.2.1422"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1421"
+ENCODER_VERSION = "0.2.1422"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1422"
+ENCODER_VERSION = "0.2.1423"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1421"
+ENCODER_VERSION = "0.2.1422"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1422"
+ENCODER_VERSION = "0.2.1423"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1421"
+ENCODER_VERSION = "0.2.1422"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1422"
+ENCODER_VERSION = "0.2.1423"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1422"
+ENCODER_VERSION = "0.2.1423"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1421"
+ENCODER_VERSION = "0.2.1422"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -14,6 +14,7 @@ from scripts.prepare_signed_backfill import (
     REVIEWED_RULESPEC_REFS,
     authorized_changed_paths,
     branch_name,
+    parse_existing_signed_imports,
     parse_source_bundle,
     stage_authorized_changes,
     validate_country,
@@ -182,6 +183,156 @@ def test_parse_source_bundle_cli_emits_normalized_json_array(
     prepare_signed_backfill_main()
 
     assert capsys.readouterr().out == '["us-ri/statute/44-30-1"]\n'
+
+
+def _add_existing_signed_import(repo: Path, path: str) -> None:
+    module = repo / path
+    module.parent.mkdir(parents=True, exist_ok=True)
+    module.write_text("rules: []\n", encoding="utf-8")
+    manifest = repo / ".axiom/encoding-manifests" / Path(path).with_suffix(".json")
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    manifest.write_text(
+        json.dumps({"schema_version": "axiom-encode/applied-rulespec/v5"}) + "\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", path, manifest.relative_to(repo).as_posix())
+    _git(repo, "commit", "-m", f"add {path}")
+
+
+def test_parse_existing_signed_imports_accepts_ordered_tracked_v5_modules(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    paths = (
+        "us-ri/statutes/44-30-1.yaml",
+        "us-ri/policies/revenue/rate-schedule.yaml",
+    )
+    for path in paths:
+        _add_existing_signed_import(repo, path)
+
+    assert parse_existing_signed_imports(
+        repo,
+        json.dumps(paths),
+        primary_citation="us-ri/statute/44-30-2.6",
+    ) == tuple(PurePosixPath(path) for path in paths)
+
+
+def test_parse_existing_signed_imports_enforces_combined_sixteen_limit(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+
+    with pytest.raises(ValueError, match="more than 16 modules"):
+        parse_existing_signed_imports(
+            repo,
+            '["us-ri/statutes/44-30-1.yaml"]',
+            primary_citation="us-ri/statute/44-30-99",
+            source_bundle_citations=tuple(
+                f"us-ri/statute/44-30-{index}" for index in range(16)
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    ("path", "kwargs"),
+    [
+        (
+            "us-ri/statutes/44-30-2/6.yaml",
+            {},
+        ),
+        (
+            "us-ri/statutes/44-30-1.yaml",
+            {"source_bundle_citations": ("us-ri/statute/44-30-1",)},
+        ),
+        (
+            "us-ri/statutes/44-30-5.yaml",
+            {"excluded_citations": ("us-ri/statute/44-30-5",)},
+        ),
+        (
+            "us-ri/policies/income_tax/target.yaml",
+            {"excluded_rulespec_paths": ("us-ri/policies/income_tax/target.yaml",)},
+        ),
+    ],
+)
+def test_parse_existing_signed_imports_rejects_reserved_paths(
+    tmp_path: Path,
+    path: str,
+    kwargs: dict[str, tuple[str, ...]],
+) -> None:
+    repo = _repo(tmp_path)
+
+    with pytest.raises(ValueError, match="must exclude"):
+        parse_existing_signed_imports(
+            repo,
+            json.dumps([path]),
+            primary_citation="us-ri/statute/44-30-2.6",
+            **kwargs,
+        )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '["us-ma/statutes/62/4.yaml"]',
+        '["us-ri/statutes/44-30-1.test.yaml"]',
+        '["us-ri/statutes/44-30-1.yaml", "us-ri/statutes/44-30-1.yaml"]',
+    ],
+)
+def test_parse_existing_signed_imports_rejects_noncanonical_or_duplicate_paths(
+    tmp_path: Path,
+    payload: str,
+) -> None:
+    repo = _repo(tmp_path)
+
+    with pytest.raises(ValueError):
+        parse_existing_signed_imports(
+            repo,
+            payload,
+            primary_citation="us-ri/statute/44-30-2.6",
+        )
+
+
+def test_parse_existing_signed_imports_requires_tracked_v5_manifest(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    path = "us-ri/statutes/44-30-1.yaml"
+    module = repo / path
+    module.parent.mkdir(parents=True)
+    module.write_text("rules: []\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="exactly tracked"):
+        parse_existing_signed_imports(
+            repo,
+            json.dumps([path]),
+            primary_citation="us-ri/statute/44-30-2.6",
+        )
+
+
+def test_parse_existing_signed_imports_cli_emits_normalized_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _repo(tmp_path)
+    path = "us-ri/statutes/44-30-1.yaml"
+    _add_existing_signed_import(repo, path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "prepare_signed_backfill.py",
+            "parse-existing-signed-imports",
+            str(repo),
+            json.dumps([path]),
+            "--primary-citation",
+            "us-ri/statute/44-30-2.6",
+        ],
+    )
+
+    prepare_signed_backfill_main()
+
+    assert capsys.readouterr().out == f'["{path}"]\n'
 
 
 def _git(repo: Path, *args: str) -> str:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1422"')
+        .startswith('__version__ = "0.2.1423"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1422"
+    assert encoder_package["version"] == "0.2.1423"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1422"
+    assert project["project"]["version"] == "0.2.1423"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1422"')
+        .startswith('__version__ = "0.2.1423"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1422"
+    assert encoder_package["version"] == "0.2.1423"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1422"
+    assert project["project"]["version"] == "0.2.1423"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1422"')
+        .startswith('__version__ = "0.2.1423"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1421"')
+        .startswith('__version__ = "0.2.1422"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1421"
+    assert encoder_package["version"] == "0.2.1422"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1421"
+    assert project["project"]["version"] == "0.2.1422"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1421"')
+        .startswith('__version__ = "0.2.1422"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1421"
+    assert encoder_package["version"] == "0.2.1422"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1421"
+    assert project["project"]["version"] == "0.2.1422"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1421"')
+        .startswith('__version__ = "0.2.1422"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1421"
+ENCODER_VERSION = "0.2.1422"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1422"
+ENCODER_VERSION = "0.2.1423"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1874,6 +1874,15 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         "default": "[]",
         "type": "string",
     }
+    assert inputs["existing_signed_imports_json"] == {
+        "description": (
+            "JSON array of tracked same-jurisdiction signed-v5 modules to reuse "
+            "as direct imports"
+        ),
+        "required": False,
+        "default": "[]",
+        "type": "string",
+    }
     assert inputs["replace_rulespec_path"]["required"] is False
     assert inputs["replace_legacy_rulespec_path"]["required"] is False
     assert inputs["dependent_citation"]["required"] is False
@@ -1937,20 +1946,32 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert all(step["with"]["fetch-depth"] == 0 for step in checkout_steps)
 
     source_bundle_step = next(
-        step for step in steps if step.get("name") == "Validate atomic source bundle"
+        step for step in steps if step.get("name") == "Validate atomic source inputs"
     )
     source_bundle_command = source_bundle_step["run"]
     assert source_bundle_step["env"]["SOURCE_BUNDLE_JSON"] == (
         "${{ inputs.source_bundle_json }}"
     )
+    assert source_bundle_step["env"]["EXISTING_SIGNED_IMPORTS_JSON"] == (
+        "${{ inputs.existing_signed_imports_json }}"
+    )
     assert 'parse-source-bundle "${SOURCE_BUNDLE_JSON:-[]}"' in (source_bundle_command)
+    assert 'parse-existing-signed-imports "$RULESPEC_CHECKOUT"' in (
+        source_bundle_command
+    )
+    assert 'existing_import_args+=(--source-citation "$source_citation")' in (
+        source_bundle_command
+    )
+    assert 'existing_import_args+=(--exclude-rulespec-path "$reserved_path")' in (
+        source_bundle_command
+    )
     assert '--primary-citation "$CITATION"' in source_bundle_command
     assert 'source_bundle_args+=(--exclude-citation "$DEPENDENT_CITATION")' in (
         source_bundle_command
     )
     assert (
-        "queue-authorized re-encodes cannot add a source bundle until queue "
-        "generation identity binds it"
+        "queue-authorized re-encodes cannot add source inputs until queue "
+        "generation identity binds them"
     ) in source_bundle_command
     assert steps.index(source_bundle_step) > next(
         index
@@ -2063,6 +2084,21 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert 'cascade_args+=("${dependent_citations[@]}")' in cascade_step["run"]
     assert '"${cascade_args[@]}"' in cascade_step["run"]
 
+    signed_import_step = next(
+        step for step in steps if step.get("name") == "Verify existing signed imports"
+    )
+    signed_import_command = signed_import_step["run"]
+    assert steps.index(cascade_step) < steps.index(signed_import_step)
+    assert "/opt/axiom-verification/axiom-encode-signing-supervisor" in (
+        signed_import_command
+    )
+    assert "signed-import-inventory" in signed_import_command
+    assert '--base-ref "$RULESPEC_REF"' in signed_import_command
+    assert '--rulespec-path "$existing_import_path"' in signed_import_command
+    assert '> "$RUNNER_TEMP/existing-signed-import-inventory.json"' in (
+        signed_import_command
+    )
+
     apply_step = next(
         step
         for step in steps
@@ -2090,7 +2126,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert 'args+=(--review-findings "$review_finding_path")' in command
     assert "args+=(--apply-target-only)" in command
     assert 'args+=(--replace-rulespec-path "$replacement_path")' in command
-    assert 'local require_source_bundle_imports="$7"' in command
+    assert 'local require_direct_imports="$7"' in command
     assert 'args+=(--required-import-rulespec-path "$required_import_path")' in (
         command
     )
@@ -2110,6 +2146,9 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert '"$CITATION" "$REVIEW_FINDING" false \\\n' in command
     assert "dependent review finding is required with dependent citation" in command
     assert "parse-source-bundle" in command
+    assert "parse-existing-signed-imports" in command
+    assert '"$RUNNER_TEMP/existing-signed-import-paths.txt"' in command
+    assert "source_bundle_count + existing_import_count" in command
     assert '> "$RUNNER_TEMP/source-bundle.json"' in command
     assert '> "$RUNNER_TEMP/source-bundle-citations.txt"' in command
     assert 'source_lane="$(printf \'source-%02d\' "$source_index")"' in command
@@ -2123,10 +2162,22 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert command.rindex(source_loop) < command.index('"$CITATION" "$REVIEW_FINDING"')
     assert "Compose signed source bundle for ${CITATION}" in command
     assert (
-        "queue-authorized re-encodes cannot add a source bundle until queue "
-        "generation identity binds it"
+        "queue-authorized re-encodes cannot add source inputs until queue "
+        "generation identity binds them"
     ) in command
     assert steps.index(cascade_step) < steps.index(apply_step)
+    assert steps.index(signed_import_step) < steps.index(apply_step)
+
+    integrity_step = next(
+        step
+        for step in steps
+        if step.get("name") == "Verify existing signed import integrity"
+    )
+    integrity_command = integrity_step["run"]
+    assert steps.index(apply_step) < steps.index(integrity_step)
+    assert "signed-import-inventory" in integrity_command
+    assert "existing-signed-import-inventory-final.json" in integrity_command
+    assert "cmp --silent" in integrity_command
 
     package_step = next(
         step for step in steps if step.get("name") == "Package exact generated changes"
@@ -2146,6 +2197,8 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert 'cp "$RUNNER_TEMP/source-bundle.json" "$artifact/source-bundle.json"' in (
         package_command
     )
+    assert '"$artifact/existing-signed-imports.json"' in package_command
+    assert '"$artifact/signed-import-inventory.json"' in package_command
     assert '"$artifact/context-manifest.json"' in package_command
     assert '".axiom/encoding-manifests"' in package_command
     assert 'citation = effective.get("citation")' in package_command
@@ -2161,6 +2214,8 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert 'f"{source_lane}-context-manifest.json"' in package_command
     assert 'os.environ["RULESPEC_REF"], "--"' in package_command
     assert '"source_bundle": json.loads(' in package_command
+    assert '"existing_signed_imports": json.loads(' in package_command
+    assert '"signed_import_inventory_sha256": hashlib.sha256(' in package_command
     assert '"rulespec_base": os.environ["RULESPEC_REF"]' in package_command
     assert '"rulespec_generated_head": rev(os.environ["RULESPEC_CHECKOUT"])' in (
         package_command
@@ -2552,6 +2607,11 @@ def test_snap_queue_activation_checks_and_merge_revalidate_live_state() -> None:
     assert upload["with"]["retention-days"] == 90
 
 
+def _prepare_empty_signed_import_inputs(runner_temp: Path) -> None:
+    (runner_temp / "existing-signed-imports.json").write_text("[]\n")
+    (runner_temp / "existing-signed-import-paths.txt").write_text("")
+
+
 @pytest.mark.parametrize("dependent_count", [0, 1, 2])
 def test_targeted_signed_reencode_orders_target_and_dependents(
     tmp_path: Path,
@@ -2586,6 +2646,7 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
     signer_stub.chmod(0o700)
     runner_temp = tmp_path / "runner-temp"
     runner_temp.mkdir()
+    _prepare_empty_signed_import_inputs(runner_temp)
 
     environment = {
         **os.environ,
@@ -2710,6 +2771,7 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
     signer_stub.chmod(0o700)
     runner_temp = tmp_path / "runner-temp"
     runner_temp.mkdir()
+    _prepare_empty_signed_import_inputs(runner_temp)
     primary = "us-ri/statute/44-30-2.6"
     sources = [
         "us-ri/statute/44-30-1",
@@ -2769,6 +2831,94 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
     ]
 
 
+def test_targeted_signed_reencode_reuses_verified_existing_import(
+    tmp_path: Path,
+) -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
+    )
+    command = next(
+        step["run"]
+        for step in workflow["jobs"]["encode"]["steps"]
+        if step.get("name") == "Encode, review, validate, and apply"
+    ).replace(
+        "/opt/axiom-verification/axiom-encode-apply-signer run",
+        '"$SIGNER_STUB"',
+    )
+
+    calls_path = tmp_path / "calls.jsonl"
+    signer_stub = tmp_path / "signer-stub"
+    signer_stub.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
+    stream.write(json.dumps(sys.argv[1:]) + "\\n")
+""",
+        encoding="utf-8",
+    )
+    signer_stub.chmod(0o700)
+
+    rulespec_repo = tmp_path / "rulespec-us"
+    existing_path = "us-ri/statutes/44-30-1.yaml"
+    manifest_path = (
+        rulespec_repo / ".axiom/encoding-manifests/us-ri/statutes/44-30-1.json"
+    )
+    rule = rulespec_repo / existing_path
+    rule.parent.mkdir(parents=True)
+    rule.write_text("format: rulespec/v1\nrules: []\n")
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(
+        json.dumps({"schema_version": "axiom-encode/applied-rulespec/v5"}) + "\n"
+    )
+    subprocess.run(["git", "-C", str(rulespec_repo), "init", "-q"], check=True)
+    subprocess.run(["git", "-C", str(rulespec_repo), "add", "."], check=True)
+
+    runner_temp = tmp_path / "runner-temp"
+    runner_temp.mkdir()
+    normalized_existing = json.dumps([existing_path], separators=(",", ":"))
+    (runner_temp / "existing-signed-imports.json").write_text(
+        normalized_existing + "\n"
+    )
+    (runner_temp / "existing-signed-import-paths.txt").write_text(existing_path + "\n")
+
+    subprocess.run(
+        ["bash", "-c", command],
+        check=True,
+        env={
+            **os.environ,
+            "AXIOM_ENCODE_APPLY_SIGNING_KEY": "test-key",
+            "AXIOM_TEST_PYTHON": sys.executable,
+            "CALLS_PATH": str(calls_path),
+            "CITATION": "us-ri/statute/44-30-2.6",
+            "DEPENDENT_CITATION": "",
+            "DEPENDENT_REVIEW_FINDING": "",
+            "EXISTING_SIGNED_IMPORTS_JSON": normalized_existing,
+            "GITHUB_WORKSPACE": str(tmp_path),
+            "REVIEW_FINDING": "Preserve direct composition semantics.",
+            "RULESPEC_CHECKOUT": str(rulespec_repo),
+            "RULESPEC_REF": "a" * 40,
+            "RUNNER_TEMP": str(runner_temp),
+            "SECOND_DEPENDENT_CITATION": "",
+            "SECOND_DEPENDENT_REVIEW_FINDING": "",
+            "SIGNER_STUB": str(signer_stub),
+            "SOURCE_BUNDLE_JSON": "[]",
+        },
+    )
+
+    calls = [
+        json.loads(line) for line in calls_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert len(calls) == 1
+    encode_args = calls[0][calls[0].index("--") + 1 :]
+    assert encode_args[-1] == "us-ri/statute/44-30-2.6"
+    required_index = encode_args.index("--required-import-rulespec-path")
+    assert encode_args[required_index + 1] == existing_path
+
+
 @pytest.mark.parametrize("with_dependent", [False, True])
 def test_targeted_signed_reencode_runs_replacement_target(
     tmp_path: Path,
@@ -2801,6 +2951,7 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
     signer_stub.chmod(0o700)
     runner_temp = tmp_path / "runner-temp"
     runner_temp.mkdir()
+    _prepare_empty_signed_import_inputs(runner_temp)
     replacement_path = "us-nc/policies/income_tax/pilot_liability_pipeline.yaml"
     dependent_citation = "us-nc/statute/105/105-153.5" if with_dependent else ""
     dependent_finding = (
@@ -2898,6 +3049,7 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
     signer_stub.chmod(0o700)
     runner_temp = tmp_path / "runner-temp"
     runner_temp.mkdir()
+    _prepare_empty_signed_import_inputs(runner_temp)
     source = "us-la/statutes/47:32.yaml"
     destination = "us-la/statutes/47/32.yaml"
     exact_dependents = [
@@ -3011,6 +3163,7 @@ def test_targeted_signed_reencode_rejects_invalid_second_dependent_inputs(
     )
     runner_temp = tmp_path / "runner-temp"
     runner_temp.mkdir()
+    _prepare_empty_signed_import_inputs(runner_temp)
     environment = {
         **os.environ,
         "AXIOM_ENCODE_APPLY_SIGNING_KEY": "test-key",
@@ -3043,6 +3196,7 @@ def test_targeted_signed_reencode_rejects_invalid_second_dependent_inputs(
 def test_targeted_review_finding_temp_file_is_valid_context(tmp_path: Path) -> None:
     runner_temp = tmp_path / "runner-temp"
     runner_temp.mkdir()
+    _prepare_empty_signed_import_inputs(runner_temp)
     policy_root = tmp_path / "rulespec-us" / "us"
     policy_root.mkdir(parents=True)
     completed = subprocess.run(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1421"
+version = "0.2.1422"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1422"
+version = "0.2.1423"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- add a supervisor-protected `signed-import-inventory` verifier for immutable historical signed-v5 RuleSpec modules
- extend targeted signed re-encoding to compose fresh sources with verified existing signed imports, capped at 16 total
- bind every imported module, direct manifest, applied file, citation, and pre/post inventory to the immutable RuleSpec base
- bump axiom-encode to 0.2.1423

## Security properties

- existing imports are never re-encoded or checkpointed
- module, manifest, and every applied file must be exact tracked 0644 blobs at the immutable base and unchanged live
- only direct model signed-v5 manifests with one requested primary module are admitted
- signed citation is canonical and exactly bound to the verified source attestation
- verification runs through the protected signing supervisor before apply and again afterward; canonical inventories must byte-match
- queue-backed runs reject unbound fresh or existing source inputs

## Review-fix cycle

Independent review found one medium provenance issue: the manifest citation was not explicitly bound to the verified source attestation. The implementation now requires canonical exact equality and includes re-signed null, foreign, and mismatched negative cases. Re-review was CLEAN on `3f73d83f`; a final lightweight review of the metadata-only 0.2.1423 bump was CLEAN on `dae59881`.

## Checks

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest -q` — 6122 passed, 119 skipped
- workflow YAML parsed; shell-level source and existing-import composition tests pass
