### PR TITLE
Recognize us/rulemaking corpus citation paths in the encode CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1423"
+version = "0.2.1424"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1423"
+__version__ = "0.2.1424"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -5995,6 +5995,13 @@ def _looks_like_corpus_citation_path(identifier: str) -> bool:
         "policy",
         "regulation",
         "regulations",
+        # Federal Register instruments (proclamations, executive orders,
+        # notices) live under us/rulemaking/... in the corpus; without this
+        # token the CLI mangles such citations via citation_to_citation_path
+        # into us/statute/us/rulemaking/... and the provisions lookup fails.
+        # Validate-time source verification already resolves these paths
+        # verbatim.
+        "rulemaking",
         "statute",
         "statutes",
     }

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1423"
+ENCODER_VERSION = "0.2.1424"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -1958,6 +1958,24 @@ def test_resolve_corpus_source_unit_accepts_form_citation_path(tmp_path):
     assert source_unit.body == "CMS Medicaid, CHIP, and BHP eligibility levels table"
 
 
+def test_resolve_corpus_source_unit_accepts_rulemaking_citation_path(tmp_path):
+    # Federal Register instruments live under us/rulemaking/...; the citation
+    # must resolve verbatim instead of being mangled through
+    # citation_to_citation_path into us/statute/us/rulemaking/...
+    citation = "us/rulemaking/fr/2026-03829"
+    corpus_release = _write_test_corpus_provision(
+        tmp_path,
+        citation_path=citation,
+        body="Termination of certain IEEPA tariff actions",
+    )
+
+    source_unit = resolve_corpus_source_unit(citation, corpus_release)
+
+    assert source_unit.citation_path == citation
+    assert source_unit.source == "local"
+    assert source_unit.body == "Termination of certain IEEPA tariff actions"
+
+
 def test_resolve_corpus_source_unit_slices_before_bracketed_sibling(tmp_path):
     corpus_release = _write_test_corpus_provision(
         tmp_path,

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1423"
+ENCODER_VERSION = "0.2.1424"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1423"
+ENCODER_VERSION = "0.2.1424"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1423"
+ENCODER_VERSION = "0.2.1424"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1423"
+ENCODER_VERSION = "0.2.1424"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1423"
+ENCODER_VERSION = "0.2.1424"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1423"
+ENCODER_VERSION = "0.2.1424"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1423"')
+        .startswith('__version__ = "0.2.1424"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1423"
+    assert encoder_package["version"] == "0.2.1424"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1423"
+    assert project["project"]["version"] == "0.2.1424"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1423"')
+        .startswith('__version__ = "0.2.1424"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1423"
+    assert encoder_package["version"] == "0.2.1424"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1423"
+    assert project["project"]["version"] == "0.2.1424"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1423"')
+        .startswith('__version__ = "0.2.1424"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1423"
+ENCODER_VERSION = "0.2.1424"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1423"
+version = "0.2.1424"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

Upstreams the US tariff T0 lane-local fix (TheAxiomFoundation/rulespec-us#1190; lane commit 07f2285e on the pinned 3869d66d toolchain): the corpus stores Federal Register instruments (proclamations, executive orders, notices) under `us/rulemaking/...`, but `_looks_like_corpus_citation_path` lacked the token, so the encode CLI mangled such citations via `citation_to_citation_path` into `us/statute/us/rulemaking/...` and the provisions lookup failed. Validate-time source verification already resolves these paths verbatim.

- Adds `"rulemaking"` to the second-segment token set in `_looks_like_corpus_citation_path` (harness/evals.py).
- Adds `test_resolve_corpus_source_unit_accepts_rulemaking_citation_path`.
- Version 0.2.1424, with the pinned-version tests (`test_rulespec_validation.py` + the eight `test_*_2026_oracle_registry.py` pins) updated in lockstep.

## Checks

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests` clean on the touched files
- `python -m compileall -q src/axiom_encode` clean
- `uv run pytest -q tests/test_cli.py tests/test_rulespec_validation.py tests/test_evals.py -k "rulespec or EncoderPrompt"` — 1461 passed
- The eight pinned oracle-registry test modules — 24 passed
- `pytest -k corpus_source_unit` — 13 passed (includes the new test)

## Cycle

Review-fix cycle per repo discipline: independent review dispatched; will record the outcome here before marking ready.
