### PR TITLE
ci: bump signed-apply encoder pin to 226be976 (wave-3 residual fixes)

### DIFF
--- a/.github/workflows/signed-apply-reusable.yml
+++ b/.github/workflows/signed-apply-reusable.yml
@@ -71,7 +71,7 @@ env:
   # wave pin 185b2457). The validate workflow's encode-ref is bumped to the
   # same sha in this PR so the signed PRs' CI verifies manifests with the
   # same encoder generation that produced them.
-  AXIOM_ENCODE_REF: d8d4f1bf211b7640120e88a1055bc67c68134109
+  AXIOM_ENCODE_REF: 226be976c12e268e7b319fcfa5ae66a4de97f85b
   AXIOM_RULES_ENGINE_REF: 05eac9d2f89dabe5c6673176260762cef3a58f47
 
 jobs:


### PR DESCRIPTION
One-line pin bump: signed-apply provisions 0.2.1424 (eval-loop excerpt re-anchoring, amendment-evidence guidance, word-number recall fix, generation-budget inputs — #1338). Lockstep rulespec-de bump + sol-first wave-4 dispatch follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)