### PR TITLE
Validate legacy replacements in post-transaction overlays

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1424"
+version = "0.2.1425"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1424"
+__version__ = "0.2.1425"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -300,6 +300,12 @@ from .legacy_replacement import (
     legacy_source_verification_citation_paths as _legacy_source_verification_citation_paths,
 )
 from .legacy_replacement import receipt_identity_payload, receipt_identity_sha256
+from .legacy_replacement_overlay import (
+    LegacyReplacementOverlayError as _LegacyReplacementOverlayError,
+)
+from .legacy_replacement_overlay import (
+    stage_legacy_replacement_overlay as _stage_legacy_replacement_overlay,
+)
 from .oracles.policyengine.pending import (
     PendingDeclarationError,
     apply_pending_to_report,
@@ -25011,6 +25017,11 @@ def _run_encode_attempt(
         ),
         validation_retry_feedback=_encode_validation_retry_feedback(prior_attempts),
         required_import_targets=required_import_targets,
+        legacy_replacement=(
+            replacement_target.legacy_replacement
+            if replacement_target is not None
+            else None
+        ),
     )
 
     result = results[0]
@@ -48575,90 +48586,13 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
                     [f"{relative_output}: {issue}" for issue in preservation_issues],
                     {},
                 )
-            for deleted in legacy_replacement.deleted_files:
-                old_overlay = overlay_repo / deleted.path
-                if old_overlay.is_symlink() or not old_overlay.is_file():
-                    return (
-                        False,
-                        [
-                            f"Legacy replacement overlay input changed: "
-                            f"{deleted.path.as_posix()}"
-                        ],
-                        {},
-                    )
-                if (
-                    hashlib.sha256(old_overlay.read_bytes()).hexdigest()
-                    != deleted.sha256
-                ):
-                    return (
-                        False,
-                        [
-                            f"Legacy replacement overlay input changed: "
-                            f"{deleted.path.as_posix()}"
-                        ],
-                        {},
-                    )
-                old_overlay.unlink()
-            old_manifest_overlay = (
-                overlay_repo / legacy_replacement.legacy_manifest.path
-            )
-            if (
-                old_manifest_overlay.is_symlink()
-                or not old_manifest_overlay.is_file()
-                or hashlib.sha256(old_manifest_overlay.read_bytes()).hexdigest()
-                != legacy_replacement.legacy_manifest.sha256
-            ):
-                return (
-                    False,
-                    ["Legacy replacement ownership manifest changed in overlay"],
-                    {},
+            try:
+                _stage_legacy_replacement_overlay(
+                    legacy_replacement,
+                    overlay_repo,
                 )
-            old_manifest_overlay.unlink()
-            for rewrite in legacy_replacement.rewrites:
-                rewrite_target = overlay_repo / rewrite.path
-                if rewrite_target.is_symlink() or not rewrite_target.is_file():
-                    return (
-                        False,
-                        [
-                            f"Legacy replacement rewrite input changed: "
-                            f"{rewrite.path.as_posix()}"
-                        ],
-                        {},
-                    )
-                if (
-                    hashlib.sha256(rewrite_target.read_bytes()).hexdigest()
-                    != rewrite.before_sha256
-                ):
-                    return (
-                        False,
-                        [
-                            f"Legacy replacement rewrite input changed: "
-                            f"{rewrite.path.as_posix()}"
-                        ],
-                        {},
-                    )
-                rewrite_target.write_bytes(rewrite.raw)
-            for dependent in legacy_replacement.exact_dependents:
-                legacy_by_path = {item.path: item for item in dependent.legacy_files}
-                for live_file in dependent.live_files:
-                    legacy_file = legacy_by_path.get(live_file.path)
-                    exact_target = overlay_repo / live_file.path
-                    if (
-                        legacy_file is None
-                        or exact_target.is_symlink()
-                        or not exact_target.is_file()
-                        or hashlib.sha256(exact_target.read_bytes()).hexdigest()
-                        != legacy_file.sha256
-                    ):
-                        return (
-                            False,
-                            [
-                                "Legacy exact dependent overlay input changed: "
-                                f"{live_file.path.as_posix()}"
-                            ],
-                            {},
-                        )
-                    exact_target.write_bytes(live_file.raw)
+            except _LegacyReplacementOverlayError as exc:
+                return False, [str(exc)], {}
             shutil.copy2(output_file, overlay_target)
             if output_test.exists():
                 shutil.copy2(output_test, _rulespec_test_path(overlay_target))

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -44,6 +44,8 @@ from axiom_encode.constants import (
     RULESPEC_FILE_SUFFIX,
     RULESPEC_TEST_FILE_SUFFIX,
 )
+from axiom_encode.legacy_replacement import LegacyReplacementContract
+from axiom_encode.legacy_replacement_overlay import stage_legacy_replacement_overlay
 from axiom_encode.prompts.encoder import SOURCE_SCOPE_PROTOCOL
 from axiom_encode.repo_routing import (
     canonical_rulespec_repo_name,
@@ -1378,6 +1380,7 @@ def run_model_eval(
     target_relative_output: Path | None = None,
     validation_retry_feedback: Sequence[str] = (),
     required_import_targets: Sequence[str] = (),
+    legacy_replacement: LegacyReplacementContract | None = None,
 ) -> list[EvalResult]:
     """Run a deterministic comparison over one or more citations."""
     _validate_eval_oracle_runtime(oracle, policyengine_runtime, policy_path)
@@ -1418,6 +1421,7 @@ def run_model_eval(
                         target_relative_output=target_relative_output,
                         validation_retry_feedback=validation_retry_feedback,
                         required_import_targets=required_import_targets,
+                        legacy_replacement=legacy_replacement,
                     )
                 )
 
@@ -6698,6 +6702,7 @@ def evaluate_artifact(
     rulespec_dependency_roots: Sequence[Path] = (),
     require_complete_source_unit: bool = False,
     amendment_documents: Sequence[CorpusAmendmentDocument] = (),
+    legacy_replacement: LegacyReplacementContract | None = None,
 ) -> EvalArtifactMetrics:
     """Evaluate an artifact inside one exact named corpus release."""
 
@@ -6729,6 +6734,7 @@ def evaluate_artifact(
             rulespec_dependency_roots=rulespec_dependency_roots,
             require_complete_source_unit=require_complete_source_unit,
             amendment_documents=amendment_documents,
+            legacy_replacement=legacy_replacement,
         )
 
 
@@ -6848,12 +6854,14 @@ def _evaluate_artifact_in_scope(
     rulespec_dependency_roots: Sequence[Path] = (),
     require_complete_source_unit: bool = False,
     amendment_documents: Sequence[CorpusAmendmentDocument] = (),
+    legacy_replacement: LegacyReplacementContract | None = None,
 ) -> EvalArtifactMetrics:
     """Evaluate one RuleSpec artifact with deterministic checks plus optional oracles."""
     with _rulespec_validation_target(
         rulespec_file,
         policy_repo_root,
         rulespec_dependency_roots=rulespec_dependency_roots,
+        legacy_replacement=legacy_replacement,
     ) as validation_file:
         validation_policy_repo_root = _validation_policy_repo_root(
             validation_file, policy_repo_root
@@ -7224,6 +7232,7 @@ def _evaluate_generated_artifact_with_repairs(
     require_complete_source_unit: bool = False,
     amendment_documents: Sequence[CorpusAmendmentDocument] = (),
     protected_review_excerpts: frozenset[str] = frozenset(),
+    legacy_replacement: LegacyReplacementContract | None = None,
 ) -> EvalArtifactMetrics | None:
     evaluated_states: set[tuple[bytes | None, bytes | None]] = set()
     while True:
@@ -7247,6 +7256,7 @@ def _evaluate_generated_artifact_with_repairs(
             rulespec_dependency_roots=rulespec_dependency_roots,
             require_complete_source_unit=require_complete_source_unit,
             amendment_documents=amendment_documents,
+            legacy_replacement=legacy_replacement,
         )
         if metrics is None:
             return None
@@ -7624,6 +7634,7 @@ def _rulespec_validation_target(
     policy_repo_root: Path,
     *,
     rulespec_dependency_roots: Sequence[Path] = (),
+    legacy_replacement: LegacyReplacementContract | None = None,
 ) -> Iterator[Path]:
     """Yield a validation file under the exact authorized canonical layout."""
 
@@ -7635,6 +7646,11 @@ def _rulespec_validation_target(
         )
     policy_root = Path(policy_repo_root).resolve()
     if _is_under_root(rulespec_file, policy_root):
+        if legacy_replacement is not None:
+            raise UnsafeRulespecContextPath(
+                "Legacy replacement validation requires a separately generated "
+                "artifact so the live checkout cannot bypass its overlay"
+            )
         staging_token = _RULESPEC_VALIDATION_STAGING_ROOT.set(None)
         try:
             yield validate_rulespec_context_file(rulespec_file, policy_root)
@@ -7685,6 +7701,14 @@ def _rulespec_validation_target(
             )
         validation_file = validation_content_root / relative
         validation_file.parent.mkdir(parents=True, exist_ok=True)
+        if legacy_replacement is not None:
+            expected_relative = Path(*legacy_replacement.destination.parts[1:])
+            if relative != expected_relative:
+                raise UnsafeRulespecContextPath(
+                    "Generated RuleSpec does not target the authenticated legacy "
+                    "replacement destination"
+                )
+            stage_legacy_replacement_overlay(legacy_replacement, overlay_repo)
         safe_rulespec_file = validate_explicit_context_file(
             rulespec_file,
             generated_root,
@@ -7996,6 +8020,7 @@ def _run_single_eval(
     target_relative_output: Path | None = None,
     validation_retry_feedback: Sequence[str] = (),
     required_import_targets: Sequence[str] = (),
+    legacy_replacement: LegacyReplacementContract | None = None,
 ) -> EvalResult:
     include_tests = include_tests or require_complete_source_unit
     if source_unit is None:
@@ -8116,6 +8141,7 @@ def _run_single_eval(
             protected_review_excerpts=_workspace_quoted_review_finding_excerpts(
                 workspace
             ),
+            legacy_replacement=legacy_replacement,
         )
     validation_error = _eval_artifact_validation_error(
         metrics,

--- a/src/axiom_encode/legacy_replacement.py
+++ b/src/axiom_encode/legacy_replacement.py
@@ -22,6 +22,7 @@ EXACT_DEPENDENT_TOOL: Final = (
 RECEIPT_SCHEMA_V1: Final = "axiom-encode/legacy-fresh-reencode-receipt/v1"
 RECEIPT_SCHEMA: Final = "axiom-encode/legacy-fresh-reencode-receipt/v2"
 RECEIPT_DIR: Final = ".axiom/legacy-replacements"
+ENCODING_MANIFEST_DIR: Final = Path(".axiom") / "encoding-manifests"
 LEGACY_MANIFEST_SCHEMA: Final = "axiom-encode/applied-rulespec/v1"
 LEGACY_OWNER_CLASS: Final = "v1-manual-hmac-untrusted"
 

--- a/src/axiom_encode/legacy_replacement_overlay.py
+++ b/src/axiom_encode/legacy_replacement_overlay.py
@@ -1,0 +1,167 @@
+"""Authenticated legacy-replacement transformations for isolated checkouts."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from .legacy_replacement import (
+    ENCODING_MANIFEST_DIR,
+    LegacyReplacementContract,
+    LegacyReplacementFile,
+    LegacyReplacementRewrite,
+)
+
+
+class LegacyReplacementOverlayError(ValueError):
+    """Raised when an authenticated replacement cannot be staged exactly."""
+
+
+def _overlay_path(checkout_root: Path, relative: Path) -> Path:
+    """Resolve one contract path beneath an already isolated checkout copy."""
+
+    relative = Path(relative)
+    if (
+        relative.is_absolute()
+        or not relative.parts
+        or relative.as_posix() != str(relative)
+        or any(part in {"", ".", ".."} for part in relative.parts)
+    ):
+        raise LegacyReplacementOverlayError(
+            f"Legacy replacement overlay path is unsafe: {relative}"
+        )
+    root = Path(checkout_root).resolve(strict=True)
+    target = root / relative
+    try:
+        target.resolve(strict=False).relative_to(root)
+    except (OSError, ValueError) as exc:
+        raise LegacyReplacementOverlayError(
+            f"Legacy replacement overlay path escapes checkout: {relative}"
+        ) from exc
+    return target
+
+
+def _require_overlay_file(
+    checkout_root: Path,
+    item: LegacyReplacementFile,
+    *,
+    label: str,
+) -> Path:
+    target = _overlay_path(checkout_root, item.path)
+    if target.is_symlink() or not target.is_file():
+        raise LegacyReplacementOverlayError(
+            f"{label} is not a regular file: {item.path.as_posix()}"
+        )
+    try:
+        observed = hashlib.sha256(target.read_bytes()).hexdigest()
+    except OSError as exc:
+        raise LegacyReplacementOverlayError(
+            f"Cannot read {label}: {item.path.as_posix()}"
+        ) from exc
+    if observed != item.sha256:
+        raise LegacyReplacementOverlayError(f"{label} changed: {item.path.as_posix()}")
+    return target
+
+
+def stage_legacy_replacement_overlay(
+    contract: LegacyReplacementContract,
+    checkout_root: Path,
+) -> None:
+    """Apply an authenticated replacement plan to an isolated checkout copy.
+
+    Every original byte identity and destination collision is checked before the
+    copy is mutated. The caller may then overlay the freshly generated primary
+    and companion at ``contract.destination`` and validate the post-replacement
+    repository shape.
+    """
+
+    if type(contract) is not LegacyReplacementContract:
+        raise LegacyReplacementOverlayError(
+            "Legacy replacement overlay contract is malformed"
+        )
+    root = Path(checkout_root)
+    if root.is_symlink() or not root.is_dir():
+        raise LegacyReplacementOverlayError(
+            "Legacy replacement overlay checkout is not a regular directory"
+        )
+
+    deleted_targets = [
+        _require_overlay_file(
+            root,
+            item,
+            label="Legacy replacement overlay input",
+        )
+        for item in contract.deleted_files
+    ]
+    manifest_target = _require_overlay_file(
+        root,
+        contract.legacy_manifest,
+        label="Legacy replacement ownership manifest",
+    )
+
+    rewrite_targets: list[tuple[Path, LegacyReplacementRewrite]] = []
+    for rewrite in contract.rewrites:
+        target = _require_overlay_file(
+            root,
+            LegacyReplacementFile(rewrite.path, rewrite.before_sha256, b""),
+            label="Legacy replacement rewrite input",
+        )
+        if hashlib.sha256(rewrite.raw).hexdigest() != rewrite.after_sha256:
+            raise LegacyReplacementOverlayError(
+                "Legacy replacement rewrite output does not match its authenticated "
+                f"digest: {rewrite.path.as_posix()}"
+            )
+        rewrite_targets.append((target, rewrite))
+
+    exact_targets: list[tuple[Path, LegacyReplacementFile]] = []
+    for dependent in contract.exact_dependents:
+        _require_overlay_file(
+            root,
+            dependent.legacy_manifest,
+            label="Legacy exact dependent ownership manifest",
+        )
+        legacy_by_path = {item.path: item for item in dependent.legacy_files}
+        for live_file in dependent.live_files:
+            legacy_file = legacy_by_path.get(live_file.path)
+            if legacy_file is None:
+                raise LegacyReplacementOverlayError(
+                    "Legacy exact dependent live file lacks an authenticated input: "
+                    f"{live_file.path.as_posix()}"
+                )
+            target = _require_overlay_file(
+                root,
+                legacy_file,
+                label="Legacy exact dependent overlay input",
+            )
+            if hashlib.sha256(live_file.raw).hexdigest() != live_file.sha256:
+                raise LegacyReplacementOverlayError(
+                    "Legacy exact dependent output does not match its authenticated "
+                    f"digest: {live_file.path.as_posix()}"
+                )
+            exact_targets.append((target, live_file))
+
+    if contract.source != contract.destination:
+        destination = _overlay_path(root, contract.destination)
+        destination_manifest = _overlay_path(
+            root,
+            (ENCODING_MANIFEST_DIR / contract.destination).with_suffix(".json"),
+        )
+        destination_group = (
+            destination,
+            destination.with_name(f"{destination.stem}.test.yaml"),
+            destination_manifest,
+        )
+        for target in destination_group:
+            if target.exists() or target.is_symlink():
+                raise LegacyReplacementOverlayError(
+                    "Legacy replacement destination primary/companion/manifest "
+                    f"collision: {target.relative_to(root).as_posix()}"
+                )
+
+    for target in deleted_targets:
+        target.unlink()
+    manifest_target.unlink()
+    for target, rewrite in rewrite_targets:
+        target.write_bytes(rewrite.raw)
+    for target, live_file in exact_targets:
+        target.write_bytes(live_file.raw)

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1424"
+ENCODER_VERSION = "0.2.1425"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -119,6 +119,10 @@ from axiom_encode.harness.validator_pipeline import (
     ValidatorPipeline,
     find_test_input_assignment_issues,
 )
+from axiom_encode.legacy_replacement import (
+    LegacyReplacementContract,
+    LegacyReplacementFile,
+)
 from axiom_encode.repo_routing import find_policy_repo_root, monorepo_checkout_name
 from axiom_encode.signing_broker import get_signing_broker
 from axiom_encode.statute import CitationParts, citation_to_relative_rulespec_path
@@ -1625,6 +1629,7 @@ def test_model_eval_passes_single_target_output_override(tmp_path):
         citation_path="us-nc/statute/105/105-153.7",
     )
     target = Path("policies/income_tax/pilot_liability_pipeline.yaml")
+    legacy_replacement = Mock(spec=LegacyReplacementContract)
     result = Mock(name="result")
 
     with (
@@ -1645,10 +1650,12 @@ def test_model_eval_passes_single_target_output_override(tmp_path):
             runtime_axiom_rules_path=tmp_path / "engine",
             corpus_release=corpus_release,
             target_relative_output=target,
+            legacy_replacement=legacy_replacement,
         )
 
     assert actual == [result]
     assert mock_run.call_args.kwargs["target_relative_output"] == target
+    assert mock_run.call_args.kwargs["legacy_replacement"] is legacy_replacement
 
 
 def test_model_eval_rejects_target_override_for_multiple_citations(tmp_path):
@@ -4316,6 +4323,158 @@ def test_rulespec_validation_overlay_does_not_copy_ambient_source_metadata(tmp_p
         validation_root = find_policy_repo_root(validation_file)
         assert validation_root is not None
         assert not (validation_root.parent.parent / "_eval_workspaces").exists()
+
+
+def _unicode_path_replacement_fixture(
+    tmp_path: Path,
+) -> tuple[Path, Path, LegacyReplacementContract]:
+    policy_repo = _canonical_rulespec_content_root(tmp_path, "us")
+    checkout = policy_repo.parent
+    source = Path("us/statutes/42/1437c–1.yaml")
+    destination = Path("us/statutes/42/1437c-1.yaml")
+    source_file = checkout / source
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    source_raw = b"format: rulespec/v1\nrules: []\n"
+    source_file.write_bytes(source_raw)
+    companion = source.with_name(f"{source.stem}.test.yaml")
+    companion_file = checkout / companion
+    companion_raw = b"cases: []\n"
+    companion_file.write_bytes(companion_raw)
+    manifest = Path(".axiom/encoding-manifests") / source.with_suffix(".json")
+    manifest_file = checkout / manifest
+    manifest_file.parent.mkdir(parents=True, exist_ok=True)
+    manifest_raw = b'{"schema_version":"axiom-encode/applied-rulespec/v1"}\n'
+    manifest_file.write_bytes(manifest_raw)
+
+    def bound_file(path: Path, raw: bytes) -> LegacyReplacementFile:
+        return LegacyReplacementFile(path, hashlib.sha256(raw).hexdigest(), raw)
+
+    contract = LegacyReplacementContract(
+        base_commit="1" * 40,
+        base_tree="2" * 40,
+        source=source,
+        destination=destination,
+        legacy_manifest=bound_file(manifest, manifest_raw),
+        deleted_files=(
+            bound_file(source, source_raw),
+            bound_file(companion, companion_raw),
+        ),
+        rewrites=(),
+        scheduled_dependents=(),
+        exact_dependents=(),
+    )
+    generated = tmp_path / "out" / "openai" / "statutes" / "42" / destination.name
+    generated.parent.mkdir(parents=True)
+    generated.write_text("format: rulespec/v1\nrules: []\n")
+    return policy_repo, generated, contract
+
+
+def test_rulespec_prevalidation_stages_authenticated_unicode_path_replacement(
+    tmp_path,
+):
+    policy_repo, generated, contract = _unicode_path_replacement_fixture(tmp_path)
+
+    with _rulespec_validation_target(
+        generated,
+        policy_repo,
+        legacy_replacement=contract,
+    ) as validation_file:
+        checkout = validation_file.parents[3]
+        assert validation_file.read_text() == "format: rulespec/v1\nrules: []\n"
+        assert not (checkout / contract.source).exists()
+        assert not (checkout / contract.legacy_manifest.path).exists()
+        assert all(
+            part.isascii() for path in checkout.rglob("*") for part in path.parts
+        )
+
+
+def test_rulespec_prevalidation_rejects_changed_legacy_replacement_input(tmp_path):
+    policy_repo, generated, contract = _unicode_path_replacement_fixture(tmp_path)
+    (policy_repo.parent / contract.source).write_text("changed\n")
+
+    with pytest.raises(ValueError, match="overlay input changed"):
+        with _rulespec_validation_target(
+            generated,
+            policy_repo,
+            legacy_replacement=contract,
+        ):
+            pass
+
+
+@pytest.mark.parametrize("collision", ["primary", "companion", "manifest"])
+def test_rulespec_prevalidation_rejects_replacement_destination_collision(
+    tmp_path,
+    collision,
+):
+    policy_repo, generated, contract = _unicode_path_replacement_fixture(tmp_path)
+    checkout = policy_repo.parent
+    targets = {
+        "primary": checkout / contract.destination,
+        "companion": checkout
+        / contract.destination.with_name(f"{contract.destination.stem}.test.yaml"),
+        "manifest": checkout
+        / (Path(".axiom/encoding-manifests") / contract.destination).with_suffix(
+            ".json"
+        ),
+    }
+    targets[collision].parent.mkdir(parents=True, exist_ok=True)
+    targets[collision].write_text("collision\n")
+
+    with pytest.raises(ValueError, match="destination.*collision"):
+        with _rulespec_validation_target(
+            generated,
+            policy_repo,
+            legacy_replacement=contract,
+        ):
+            pass
+
+
+def test_rulespec_prevalidation_rejects_live_checkout_artifact(tmp_path):
+    policy_repo, _generated, contract = _unicode_path_replacement_fixture(tmp_path)
+
+    with pytest.raises(ValueError, match="separately generated artifact"):
+        with _rulespec_validation_target(
+            policy_repo / Path(*contract.source.parts[1:]),
+            policy_repo,
+            legacy_replacement=contract,
+        ):
+            pass
+
+
+def test_evaluate_artifact_uses_post_replacement_tree_for_first_compile(tmp_path):
+    policy_repo, generated, contract = _unicode_path_replacement_fixture(tmp_path)
+    observed = []
+
+    def reject_non_ascii_checkout(_pipeline, validation_file):
+        checkout = validation_file.parents[3]
+        unsafe = [
+            path
+            for path in checkout.rglob("*")
+            if any(not part.isascii() for part in path.relative_to(checkout).parts)
+        ]
+        observed.append((validation_file, unsafe))
+        return ValidationResult("hard-cut", passed=not unsafe)
+
+    with (
+        patch.object(
+            ValidatorPipeline, "_run_compile_check", reject_non_ascii_checkout
+        ),
+        patch.object(ValidatorPipeline, "_run_ci", reject_non_ascii_checkout),
+    ):
+        metrics = evaluate_artifact(
+            local_corpus_release=_write_test_corpus_provision(tmp_path / "release"),
+            rulespec_file=generated,
+            policy_repo_root=policy_repo,
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+            source_text="No numeric values.",
+            skip_reviewers=True,
+            legacy_replacement=contract,
+        )
+
+    assert metrics.compile_pass is True
+    assert metrics.ci_pass is True
+    assert len(observed) == 2
+    assert all(not unsafe for _path, unsafe in observed)
 
 
 @pytest.mark.parametrize("indirection", ["file", "directory"])

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1424"
+ENCODER_VERSION = "0.2.1425"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1424"
+ENCODER_VERSION = "0.2.1425"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1424"
+ENCODER_VERSION = "0.2.1425"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1424"
+ENCODER_VERSION = "0.2.1425"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1424"
+ENCODER_VERSION = "0.2.1425"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1424"
+ENCODER_VERSION = "0.2.1425"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1424"')
+        .startswith('__version__ = "0.2.1425"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1424"
+    assert encoder_package["version"] == "0.2.1425"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1424"
+    assert project["project"]["version"] == "0.2.1425"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1424"')
+        .startswith('__version__ = "0.2.1425"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1424"
+    assert encoder_package["version"] == "0.2.1425"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1424"
+    assert project["project"]["version"] == "0.2.1425"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1424"')
+        .startswith('__version__ = "0.2.1425"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1424"
+ENCODER_VERSION = "0.2.1425"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1424"
+version = "0.2.1425"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- stage authenticated legacy replacement deletions, rewrites, exact dependents, and destination collision checks before first generated-artifact validation
- share the same fail-closed overlay transaction between prevalidation and final signed-apply validation
- reject live-checkout bypasses and mismatched generated destinations
- cover the real Unicode-to-ASCII legacy path migration shape and tamper/collision cases

## Why

The legacy replacement contract was previously applied only in the later signed-apply overlay. The first compile/CI validation copied the live checkout and overlaid the ASCII destination while leaving the authenticated Unicode legacy path present, so a hard engine ASCII-path cut failed before the replacement transaction could be exercised. This change validates the actual post-transaction repository structure end to end.

## Review cycle

Independent review: CLEAN. Reviewed fail-closed path/hash/collision handling, consistency between first validation and final apply, API propagation, and regression coverage. No actionable findings.

## Checks

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest` — 6152 passed, 119 skipped
- `uv run pytest tests/test_evals.py` — 724 passed
- focused legacy replacement and prevalidation tests — green
- `git diff --check`