### PR TITLE
Allow reviewed hard-cut RuleSpec tip

### DIFF
--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -42,6 +42,10 @@ REVIEWED_RULESPEC_REFS = frozenset(
             "b61918da93fe8a1a29b35b9330aef2085291a5d0",
         ),
         (
+            "us",
+            "251d8d66dabdebcb763d9e7c9b8322a281440c36",
+        ),
+        (
             "ca",
             "f60f7a84c30e38c7d4961d70647eb0457e7d76c2",
         ),

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -1557,6 +1557,7 @@ def test_validate_rulespec_base_rejects_stale_main_pr_base(
     ("country", "reviewed_ref"),
     [
         ("us", "b61918da93fe8a1a29b35b9330aef2085291a5d0"),
+        ("us", "251d8d66dabdebcb763d9e7c9b8322a281440c36"),
         ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
     ],
 )
@@ -1570,6 +1571,7 @@ def test_validate_rulespec_base_accepts_exact_reviewed_head_artifact_only(
     assert REVIEWED_RULESPEC_REFS == frozenset(
         {
             ("us", "b61918da93fe8a1a29b35b9330aef2085291a5d0"),
+            ("us", "251d8d66dabdebcb763d9e7c9b8322a281440c36"),
             ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
         }
     )


### PR DESCRIPTION
## Summary
- allow the independently reviewed RuleSpec hard-cut tip `251d8d66dabdebcb763d9e7c9b8322a281440c36` for targeted signed re-encode routing
- retain the previous reviewed head for artifact-only provenance while exact-tip enforcement prevents stale PR writes
- extend the allowlist contract tests

## Security boundary
This does not relax protected-branch routing. `open_pr: true` still requires the requested SHA to equal the exact remote tip of the allowlisted `hard-cut/canonical-layout-us` base branch.

## Checks
- `.venv313/bin/python -m pytest -q tests/test_prepare_signed_backfill.py -k validate_rulespec_base` (15 passed)
- `.venv313/bin/ruff check pyproject.toml src/axiom_encode scripts tests`
- `.venv313/bin/python -m compileall -q src/axiom_encode scripts`
- `.venv313/bin/python -m pytest` (6153 passed, 119 skipped)