### PR TITLE
Fix empty signed import workflow branch

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -727,6 +727,7 @@ jobs:
               encoding="utf-8",
           )
           PY
+          fi
 
       - name: Encode, review, validate, and apply
         env:

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1817,6 +1817,21 @@ def test_production_apply_signer_binary_rejects_wrong_ci_context(
     assert "does not match the expected repository" in completed.stderr
 
 
+def test_targeted_signed_reencode_shell_steps_have_valid_syntax(tmp_path: Path) -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
+    )
+
+    for job_name, job in workflow["jobs"].items():
+        for index, step in enumerate(job.get("steps", [])):
+            command = step.get("run")
+            if command is None:
+                continue
+            script = tmp_path / f"{job_name}-{index}.bash"
+            script.write_text(command, encoding="utf-8")
+            subprocess.run(["bash", "-n", str(script)], check=True)
+
+
 def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     workflow = yaml.safe_load(
         (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()


### PR DESCRIPTION
## Summary
- close the empty existing-import shell branch in the targeted signed re-encode workflow
- syntax-check every multiline shell step in that workflow with `bash -n`

## Failure reproduced
Run 30822959470 failed before encoding with `syntax error: unexpected end of file` in `Verify existing signed imports`.

## Checks
- `uv run --python 3.13 pytest -q tests/test_signing_supervisor.py -k "targeted_signed_reencode_shell_steps_have_valid_syntax or targeted_signed_reencode_workflow_is_main_dispatch_only"` (2 passed)
- full mandated checks pending
- independent review pending