### PR TITLE
Fix generated SNAP repair serialization

### DIFF
--- a/changelog.d/generated-snap-repair-serialization.fixed.md
+++ b/changelog.d/generated-snap-repair-serialization.fixed.md
@@ -1,0 +1,1 @@
+Preserve valid generated RuleSpec YAML when SNAP delegated-policy repair appends imports, and keep numeric household-size test inputs from being misclassified as booleans.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1425"
+version = "0.2.1426"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1427"
+version = "0.2.1428"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1426"
+version = "0.2.1427"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1427"
+__version__ = "0.2.1428"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1425"
+__version__ = "0.2.1426"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1426"
+__version__ = "0.2.1427"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -29670,14 +29670,18 @@ def _add_rulespec_imports_preserving_content(
         (
             index
             for index, line in enumerate(lines)
-            if line.strip() == "imports:" and not line.startswith((" ", "\t"))
+            if line.startswith("imports:")
         ),
         None,
     )
-    rendered = [f"  - {target}" for target in missing]
+    rendered_indent = "  "
     if import_line is None:
+        rendered = [f"{rendered_indent}- {target}" for target in missing]
         suffix = "\n" if content.endswith("\n") else "\n"
         return f"{content}{suffix}imports:\n" + "\n".join(rendered) + "\n"
+    if lines[import_line].strip() != "imports:":
+        payload["imports"] = [*imports, *missing] if isinstance(imports, list) else missing
+        return yaml.safe_dump(payload, sort_keys=False, allow_unicode=False)
 
     insert_at = import_line + 1
     while insert_at < len(lines):
@@ -29685,7 +29689,12 @@ def _add_rulespec_imports_preserving_content(
         if line.startswith((" ", "\t")) or not line.strip():
             insert_at += 1
             continue
+        if line.startswith("- "):
+            rendered_indent = ""
+            insert_at += 1
+            continue
         break
+    rendered = [f"{rendered_indent}- {target}" for target in missing]
     next_lines = [*lines[:insert_at], *rendered, *lines[insert_at:]]
     return "\n".join(next_lines) + ("\n" if content.endswith("\n") else "")
 
@@ -43898,6 +43907,8 @@ def _factual_input_appears_numeric(
         if any(boolean_context.search(formula) for formula in formula_hits):
             return False
 
+    if _factual_input_name_looks_positive_count(input_name):
+        return True
     input_tokens = set(input_name.split("_"))
     numeric_name_fragments = (
         "amount",

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -29667,11 +29667,7 @@ def _add_rulespec_imports_preserving_content(
 
     lines = content.splitlines()
     import_line = next(
-        (
-            index
-            for index, line in enumerate(lines)
-            if line.startswith("imports:")
-        ),
+        (index for index, line in enumerate(lines) if line.startswith("imports:")),
         None,
     )
     rendered_indent = "  "
@@ -29680,7 +29676,9 @@ def _add_rulespec_imports_preserving_content(
         suffix = "\n" if content.endswith("\n") else "\n"
         return f"{content}{suffix}imports:\n" + "\n".join(rendered) + "\n"
     if lines[import_line].strip() != "imports:":
-        payload["imports"] = [*imports, *missing] if isinstance(imports, list) else missing
+        payload["imports"] = (
+            [*imports, *missing] if isinstance(imports, list) else missing
+        )
         return yaml.safe_dump(payload, sort_keys=False, allow_unicode=False)
 
     insert_at = import_line + 1

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -43817,12 +43817,13 @@ def _factual_input_appears_string_selector(
     if not isinstance(rules, list):
         return False
 
+    string_literal = rf"(?:{_RULESPEC_STRING_LITERAL_RE})"
     string_comparison = re.compile(
         rf"""
         (?:
-            \b{re.escape(input_name)}\b\s*(?:==|!=)\s*(['"])[^'"]*\1
+            \b{re.escape(input_name)}\b\s*(?:==|!=)\s*{string_literal}
             |
-            (['"])[^'"]*\2\s*(?:==|!=)\s*\b{re.escape(input_name)}\b
+            {string_literal}\s*(?:==|!=)\s*\b{re.escape(input_name)}\b
         )
         """,
         re.VERBOSE,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -43827,6 +43827,13 @@ def _factual_input_appears_string_selector(
         """,
         re.VERBOSE,
     )
+    string_membership = re.compile(
+        rf"""
+        \b{re.escape(input_name)}\b\s+(?:not\s+)?in\s*
+        [\[\(\{{][^\]\)\}}]*{_RULESPEC_STRING_LITERAL_RE}
+        """,
+        re.VERBOSE,
+    )
     for rule in rules:
         if not isinstance(rule, dict):
             continue
@@ -43837,7 +43844,9 @@ def _factual_input_appears_string_selector(
             if not isinstance(version, dict):
                 continue
             formula = version.get("formula")
-            if isinstance(formula, str) and string_comparison.search(formula):
+            if isinstance(formula, str) and (
+                string_comparison.search(formula) or string_membership.search(formula)
+            ):
                 return True
     return False
 
@@ -43859,6 +43868,11 @@ def _factual_input_name_looks_positive_count(input_name: str) -> bool:
 def _factual_input_appears_numeric(
     input_name: str, *, rules_payload: dict[str, object]
 ) -> bool:
+    if _factual_input_appears_string_selector(
+        input_name,
+        rules_payload=rules_payload,
+    ):
+        return False
     if input_name == "filing_status":
         return True
     if _factual_input_name_looks_boolean(input_name):

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1426"
+ENCODER_VERSION = "0.2.1427"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1427"
+ENCODER_VERSION = "0.2.1428"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1425"
+ENCODER_VERSION = "0.2.1426"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,6 +74,7 @@ from axiom_encode.cli import (
     _exclusive_apply_transaction_lock,
     _execute_rulespec_test_file,
     _expected_proof_import_hash,
+    _factual_input_appears_numeric,
     _find_rulespec_dependents,
     _generated_result_source_metadata,
     _git_changed_files,
@@ -18201,7 +18202,17 @@ rules:
         cases = yaml.safe_load(test_file.read_text())
         assert [case["name"] for case in cases] == ["cash_assistance_case"]
 
-    def test_delegated_policy_setting_repair_skips_existing_sets_edge(self, tmp_path):
+    @pytest.mark.parametrize(
+        "imports_block",
+        [
+            "imports:\n- us:policies/usda/snap/fy-2026-cola/deductions",
+            "imports: [us:policies/usda/snap/fy-2026-cola/deductions]",
+        ],
+        ids=("indentless-sequence", "inline-sequence"),
+    )
+    def test_delegated_policy_setting_repair_skips_existing_sets_edge(
+        self, tmp_path, imports_block
+    ):
         output_root = tmp_path / "out"
         policy_repo = tmp_path / "rulespec-us" / "us-ca"
         policy_repo.mkdir(parents=True)
@@ -18225,7 +18236,8 @@ rules:
         rules_file = output_root / "runner" / "state_rule.yaml"
         rules_file.parent.mkdir(parents=True)
         rules_file.write_text(
-            """format: rulespec/v1
+            f"""format: rulespec/v1
+{imports_block}
 module:
   summary: State SNAP standard utility allowance.
 rules:
@@ -18259,7 +18271,10 @@ rules:
 
         assert repaired == ["import:us:regulations/7-cfr/273/9"]
         payload = yaml.safe_load(rules_file.read_text())
-        assert payload["imports"] == ["us:regulations/7-cfr/273/9"]
+        assert payload["imports"] == [
+            "us:policies/usda/snap/fy-2026-cola/deductions",
+            "us:regulations/7-cfr/273/9",
+        ]
 
     def test_delegated_policy_setting_repair_drops_unresolved_sets_edge(self, tmp_path):
         output_root = tmp_path / "out"
@@ -24941,6 +24956,7 @@ rules:
   period: 2026-01
   input:
     us:statutes/26/151#input.adjusted_needs: false
+    us:statutes/26/151#input.household_size: 6
   output:
     us:statutes/26/151#benefit_amount: 0
 """
@@ -24986,6 +25002,7 @@ rules:
         mock_apply.assert_called_once()
         test_payload = yaml.safe_load(test_file.read_text())
         assert test_payload[0]["input"]["us:statutes/26/151#input.adjusted_needs"] == 0
+        assert test_payload[0]["input"]["us:statutes/26/151#input.household_size"] == 6
         run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
         assert run.outcome["auto_repaired_wrong_typed_test_inputs"] == [
             "zero_adjusted_needs_produces_zero_benefit:"
@@ -24993,6 +25010,26 @@ rules:
         ]
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
+
+    def test_size_named_string_selector_is_not_numeric(self):
+        rules_payload = {
+            "rules": [
+                {
+                    "versions": [
+                        {
+                            "formula": (
+                                'if household_size_category == "large": 1 else: 0'
+                            )
+                        }
+                    ]
+                }
+            ]
+        }
+
+        assert not _factual_input_appears_numeric(
+            "household_size_category",
+            rules_payload=rules_payload,
+        )
 
     def test_encode_apply_auto_repairs_string_selector_test_input_values(
         self, capsys, tmp_path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24956,7 +24956,7 @@ rules:
   period: 2026-01
   input:
     us:statutes/26/151#input.adjusted_needs: false
-    us:statutes/26/151#input.household_size: 6
+    us:statutes/26/151#input.household_size: false
   output:
     us:statutes/26/151#benefit_amount: 0
 """
@@ -25002,11 +25002,13 @@ rules:
         mock_apply.assert_called_once()
         test_payload = yaml.safe_load(test_file.read_text())
         assert test_payload[0]["input"]["us:statutes/26/151#input.adjusted_needs"] == 0
-        assert test_payload[0]["input"]["us:statutes/26/151#input.household_size"] == 6
+        assert test_payload[0]["input"]["us:statutes/26/151#input.household_size"] == 0
         run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
         assert run.outcome["auto_repaired_wrong_typed_test_inputs"] == [
             "zero_adjusted_needs_produces_zero_benefit:"
-            "us:statutes/26/151#input.adjusted_needs"
+            "us:statutes/26/151#input.adjusted_needs",
+            "zero_adjusted_needs_produces_zero_benefit:"
+            "us:statutes/26/151#input.household_size",
         ]
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
@@ -25019,6 +25021,27 @@ rules:
                         {
                             "formula": (
                                 'if household_size_category == "large": 1 else: 0'
+                            )
+                        }
+                    ]
+                }
+            ]
+        }
+
+        assert not _factual_input_appears_numeric(
+            "household_size_category",
+            rules_payload=rules_payload,
+        )
+
+    def test_size_named_string_membership_selector_is_not_numeric(self):
+        rules_payload = {
+            "rules": [
+                {
+                    "versions": [
+                        {
+                            "formula": (
+                                'if household_size_category in ["small", "large"]: '
+                                "1 else: 0"
                             )
                         }
                     ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25086,7 +25086,7 @@ rules:
     versions:
       - effective_from: '2026-01-01'
         formula: |-
-          if federal_code == "A" and state_os_code == "A":
+          if federal_code == "children's" and state_os_code == "A":
               1675
           else:
               0

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1427"
+ENCODER_VERSION = "0.2.1428"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1426"
+ENCODER_VERSION = "0.2.1427"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1425"
+ENCODER_VERSION = "0.2.1426"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1426"
+ENCODER_VERSION = "0.2.1427"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1425"
+ENCODER_VERSION = "0.2.1426"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1427"
+ENCODER_VERSION = "0.2.1428"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1427"
+ENCODER_VERSION = "0.2.1428"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1426"
+ENCODER_VERSION = "0.2.1427"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1425"
+ENCODER_VERSION = "0.2.1426"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1425"
+ENCODER_VERSION = "0.2.1426"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1426"
+ENCODER_VERSION = "0.2.1427"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1427"
+ENCODER_VERSION = "0.2.1428"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1426"
+ENCODER_VERSION = "0.2.1427"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1425"
+ENCODER_VERSION = "0.2.1426"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1427"
+ENCODER_VERSION = "0.2.1428"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1425"
+ENCODER_VERSION = "0.2.1426"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1426"
+ENCODER_VERSION = "0.2.1427"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1427"
+ENCODER_VERSION = "0.2.1428"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1427"')
+        .startswith('__version__ = "0.2.1428"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1427"
+    assert encoder_package["version"] == "0.2.1428"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1427"
+    assert project["project"]["version"] == "0.2.1428"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1427"')
+        .startswith('__version__ = "0.2.1428"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1427"
+    assert encoder_package["version"] == "0.2.1428"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1427"
+    assert project["project"]["version"] == "0.2.1428"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1427"')
+        .startswith('__version__ = "0.2.1428"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1426"')
+        .startswith('__version__ = "0.2.1427"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1426"
+    assert encoder_package["version"] == "0.2.1427"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1426"
+    assert project["project"]["version"] == "0.2.1427"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1426"')
+        .startswith('__version__ = "0.2.1427"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1426"
+    assert encoder_package["version"] == "0.2.1427"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1426"
+    assert project["project"]["version"] == "0.2.1427"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1426"')
+        .startswith('__version__ = "0.2.1427"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1425"')
+        .startswith('__version__ = "0.2.1426"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1425"
+    assert encoder_package["version"] == "0.2.1426"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1425"
+    assert project["project"]["version"] == "0.2.1426"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1425"')
+        .startswith('__version__ = "0.2.1426"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1425"
+    assert encoder_package["version"] == "0.2.1426"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1425"
+    assert project["project"]["version"] == "0.2.1426"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1425"')
+        .startswith('__version__ = "0.2.1426"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1426"
+ENCODER_VERSION = "0.2.1427"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1427"
+ENCODER_VERSION = "0.2.1428"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1425"
+ENCODER_VERSION = "0.2.1426"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1426"
+version = "0.2.1427"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1427"
+version = "0.2.1428"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1425"
+version = "0.2.1426"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- preserve valid YAML when delegated-policy repair appends imports to PyYAML-stamped indentless or inline import sequences
- classify count/size inputs as numeric only after formula-based string/boolean detection
- keep valid numeric household-size test assignments unchanged during wrong-type auto-repair

## Context
Unblocks the South Carolina SNAP page 159 signed re-encode after run 30824208194 exposed both repair-path defects.

## Validation
- `pytest -q tests/test_cli.py -k "delegated_policy_setting_repair or wrong_typed_test_input or size_named_string_selector"` (10 passed)
- `ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- full `pytest` in progress locally; required CI will also run

## Review cycle
- independent review found a size-named string-selector regression risk
- fixed by applying count/size fallback only after formula classification and added a regression test
- second independent review: CLEAN
