### PR TITLE
Allow reviewed RuleSpec hard-cut tip 8dddb9fc

### DIFF
--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -51,7 +51,7 @@ REVIEWED_RULESPEC_REFS = frozenset(
         ),
         (
             "us",
-            "791ad4daa27346679889831876dd231d6496beb1",
+            "8dddb9fc597fc6a335bc5207c0a9edb93fd1445a",
         ),
         (
             "ca",

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -50,6 +50,10 @@ REVIEWED_RULESPEC_REFS = frozenset(
             "68cca4a6fa806b63f95277c129575d88d2ac07f1",
         ),
         (
+            "us",
+            "791ad4daa27346679889831876dd231d6496beb1",
+        ),
+        (
             "ca",
             "f60f7a84c30e38c7d4961d70647eb0457e7d76c2",
         ),

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -1559,6 +1559,7 @@ def test_validate_rulespec_base_rejects_stale_main_pr_base(
         ("us", "b61918da93fe8a1a29b35b9330aef2085291a5d0"),
         ("us", "251d8d66dabdebcb763d9e7c9b8322a281440c36"),
         ("us", "68cca4a6fa806b63f95277c129575d88d2ac07f1"),
+        ("us", "791ad4daa27346679889831876dd231d6496beb1"),
         ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
     ],
 )
@@ -1574,6 +1575,7 @@ def test_validate_rulespec_base_accepts_exact_reviewed_head_artifact_only(
             ("us", "b61918da93fe8a1a29b35b9330aef2085291a5d0"),
             ("us", "251d8d66dabdebcb763d9e7c9b8322a281440c36"),
             ("us", "68cca4a6fa806b63f95277c129575d88d2ac07f1"),
+            ("us", "791ad4daa27346679889831876dd231d6496beb1"),
             ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
         }
     )

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -1559,7 +1559,7 @@ def test_validate_rulespec_base_rejects_stale_main_pr_base(
         ("us", "b61918da93fe8a1a29b35b9330aef2085291a5d0"),
         ("us", "251d8d66dabdebcb763d9e7c9b8322a281440c36"),
         ("us", "68cca4a6fa806b63f95277c129575d88d2ac07f1"),
-        ("us", "791ad4daa27346679889831876dd231d6496beb1"),
+        ("us", "8dddb9fc597fc6a335bc5207c0a9edb93fd1445a"),
         ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
     ],
 )
@@ -1575,7 +1575,7 @@ def test_validate_rulespec_base_accepts_exact_reviewed_head_artifact_only(
             ("us", "b61918da93fe8a1a29b35b9330aef2085291a5d0"),
             ("us", "251d8d66dabdebcb763d9e7c9b8322a281440c36"),
             ("us", "68cca4a6fa806b63f95277c129575d88d2ac07f1"),
-            ("us", "791ad4daa27346679889831876dd231d6496beb1"),
+            ("us", "8dddb9fc597fc6a335bc5207c0a9edb93fd1445a"),
             ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
         }
     )


### PR DESCRIPTION
## Summary
- allow the exact independently reviewed RuleSpec hard-cut preparation head `8dddb9fc597fc6a335bc5207c0a9edb93fd1445a` for artifact-only protected signed re-encoding
- keep branch-target validation fail-closed against the live `hard-cut/canonical-layout-us` base
- replace the superseded reviewed-head allowance rather than accumulating stale tips

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest` (`6159 passed, 119 skipped`)

## Review cycle
A fresh independent review is required for this exact SHA update before ready/merge.