### PR TITLE
Allow trusted stage inventory query

### DIFF
--- a/changelog.d/trusted-git-ls-files-stage.fixed.md
+++ b/changelog.d/trusted-git-ls-files-stage.fixed.md
@@ -1,0 +1,1 @@
+Allow legacy RuleSpec replacement to enumerate exact staged file modes through the protected signing runtime.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1428"
+version = "0.2.1429"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/provision_verification_supervisor.py
+++ b/scripts/provision_verification_supervisor.py
@@ -547,7 +547,7 @@ def _install_trusted_git_wrapper(
         "            'src/axiom_encode/__init__.py', 'uv.lock',\n"
         "        ]\n"
         "    if command == 'ls-files':\n"
-        "        if options == ['-z']:\n"
+        "        if options in (['-z'], ['--stage', '-z']):\n"
         "            return True\n"
         "        prefix = ['--others', '--exclude-standard', '-z']\n"
         "        if options == prefix:\n"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1428"
+__version__ = "0.2.1429"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -18417,25 +18417,12 @@ def _rulespec_migration_base_identity(repo_path: Path) -> tuple[str, str]:
 def _rulespec_migration_tracked_files(repo_path: Path) -> dict[Path, str]:
     """Return exact tracked regular-file modes, rejecting ambiguous Git stages."""
 
-    raw = subprocess.run(
-        [
-            "git",
-            "-C",
-            str(repo_path),
-            "-c",
-            "core.quotepath=false",
-            "ls-files",
-            "--stage",
-            "-z",
-        ],
-        capture_output=True,
-        env=_rulespec_migration_git_environment(),
-        check=False,
-    )
-    if raw.returncode != 0:
-        raise RuntimeError("Cannot enumerate tracked RuleSpec files")
+    # NUL-delimited ls-files output carries path bytes verbatim, so it does not
+    # need a caller-controlled core.quotepath override. Keep this query on the
+    # same sanitized, read-only Git path as the other migration inspections.
+    raw = _rulespec_migration_git_bytes(repo_path, "ls-files", "--stage", "-z")
     result: dict[Path, str] = {}
-    for record in raw.stdout.split(b"\0"):
+    for record in raw.split(b"\0"):
         if not record:
             continue
         try:

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1428"
+ENCODER_VERSION = "0.2.1429"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1428"
+ENCODER_VERSION = "0.2.1429"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1428"
+ENCODER_VERSION = "0.2.1429"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1428"
+ENCODER_VERSION = "0.2.1429"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1428"
+ENCODER_VERSION = "0.2.1429"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1428"
+ENCODER_VERSION = "0.2.1429"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1428"
+ENCODER_VERSION = "0.2.1429"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_provision_supervisor.py
+++ b/tests/test_provision_supervisor.py
@@ -504,6 +504,7 @@ class TestTrustedGit:
                 None,
             ),
             (["ls-files", "-z"], None),
+            (["ls-files", "--stage", "-z"], None),
             (["ls-files", "--others", "--exclude-standard", "-z"], None),
             (
                 [
@@ -628,6 +629,8 @@ class TestTrustedGit:
             ["diff", "--stat", "HEAD"],
             ["log", "--oneline"],
             ["ls-files", "--stage"],
+            ["ls-files", "-z", "--stage"],
+            ["ls-files", "--stage", "-z", "--debug"],
             ["ls-tree", "--name-only", "HEAD"],
             ["merge-base", "--octopus", "HEAD", "HEAD"],
             ["remote", "add", "blocked", "https://example.invalid/repo.git"],
@@ -757,6 +760,39 @@ class TestTrustedGit:
             assert refused_gitlink.returncode != 0
             assert "refused gitlink at sub" in refused_gitlink.stderr
         assert not marker.exists()
+
+    def test_installed_wrapper_supports_migration_stage_inventory(
+        self, tmp_path, monkeypatch
+    ):
+        from axiom_encode.cli import _rulespec_migration_tracked_files
+
+        git = shutil.which("git")
+        if git is None:
+            pytest.skip("Git is required")
+        destination = tmp_path / "destination"
+        destination.mkdir()
+        provisioner._install_trusted_git_wrapper(
+            destination,
+            Path(sys.executable).resolve(),
+            provisioner._resolve_trusted_git(Path(git).resolve()),
+        )
+        repository = tmp_path / "rulespec-us"
+        subprocess.run([git, "init", "--quiet", str(repository)], check=True)
+        unicode_path = repository / "us/statutes/42/1437c–1.yaml"
+        unicode_path.parent.mkdir(parents=True)
+        unicode_path.write_text("format: rulespec/v1\n")
+        executable = repository / "tools/check"
+        executable.parent.mkdir()
+        executable.write_text("#!/bin/sh\n")
+        executable.chmod(0o755)
+        subprocess.run([git, "-C", str(repository), "add", "."], check=True)
+
+        monkeypatch.setenv("PATH", str(destination))
+
+        assert _rulespec_migration_tracked_files(repository) == {
+            Path("tools/check"): "100755",
+            Path("us/statutes/42/1437c–1.yaml"): "100644",
+        }
 
     def test_installed_wrapper_disables_partial_clone_lazy_fetch(self, tmp_path):
         git = shutil.which("git")

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1428"')
+        .startswith('__version__ = "0.2.1429"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1428"
+    assert encoder_package["version"] == "0.2.1429"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1428"
+    assert project["project"]["version"] == "0.2.1429"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1428"')
+        .startswith('__version__ = "0.2.1429"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1428"
+    assert encoder_package["version"] == "0.2.1429"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1428"
+    assert project["project"]["version"] == "0.2.1429"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1428"')
+        .startswith('__version__ = "0.2.1429"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1428"
+ENCODER_VERSION = "0.2.1429"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1428"
+version = "0.2.1429"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- route legacy replacement tracked-file enumeration through the sanitized read-only Git helper
- remove redundant `core.quotepath=false` because NUL-delimited output carries raw path bytes
- permit only `ls-files --stage -z` and reject reordered or extended variants
- add an end-to-end wrapper inventory test covering Unicode paths and executable modes

## Production finding
Protected signed run [30845621872](https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/30845621872) passed corpus acquisition, signing setup, and strict checkout status, then failed closed with `Cannot enumerate tracked RuleSpec files`; zero signatures were emitted.

## Checks
- `tests/test_provision_supervisor.py`: `71 passed` under the existing Python 3.13 environment
- focused ruff, compileall, and `git diff --check`: passed
- full required checks: running

## Review cycle
Independent exact-head review pending.