### PR TITLE
Admit strict generated v1 legacy owners

### DIFF
--- a/changelog.d/generated-v1-legacy-replacement.fixed.md
+++ b/changelog.d/generated-v1-legacy-replacement.fixed.md
@@ -1,0 +1,5 @@
+Admit exact historical generated-v1 HMAC ownership manifests as untrusted
+legacy replacement evidence when the authorized Git base, citation, output
+digest, backend/runner identity, and uniformly scoped applied files all match.
+Manual and generated v1 subclasses remain fail-closed and fresh replacements
+still require current signed v5 provenance.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1430"
+version = "0.2.1431"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1431"
+version = "0.2.1432"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -717,9 +717,11 @@ def _validate_legacy_exact_dependents(
     """Verify every v2 exact dependent and return unchanged authorized files."""
 
     from axiom_encode.cli import (
+        _legacy_primary_source_citations,
         _repair_proof_import_hashes,
         _strict_legacy_replacement_map,
     )
+    from axiom_encode.legacy_replacement import legacy_receipt_v1_manifest_issues
     from axiom_encode.rulespec_path_migration import (
         PathMigrationPlanError,
         rewrite_exact_references,
@@ -827,6 +829,34 @@ def _validate_legacy_exact_dependents(
                 raise ValueError(f"{label} live file hash differs: {path}")
             base_by_path[path] = base_raw
             live_by_path[path] = live_raw
+
+        try:
+            base_manifest_payload = json.loads(base_manifest_raw.decode("utf-8"))
+        except (UnicodeError, json.JSONDecodeError, RecursionError):
+            base_manifest_payload = None
+        primary_citations = _legacy_primary_source_citations(base_by_path[primary])
+        receipt_legacy = receipt.get("legacy")
+        legacy_issues = legacy_receipt_v1_manifest_issues(
+            base_manifest_payload,
+            owner_class=(
+                receipt_legacy.get("owner_class")
+                if isinstance(receipt_legacy, dict)
+                else None
+            ),
+            expected_files={
+                path.as_posix(): str(item["sha256"])
+                for path, item in zip(expected_paths, legacy_files, strict=True)
+            },
+            expected_primary_path=primary.as_posix(),
+            expected_citation=primary_citations[0] if primary_citations else "",
+            jurisdiction_prefix=primary.parts[0],
+            allow_unmarked_manual_exception=True,
+        )
+        if legacy_issues:
+            raise ValueError(
+                f"{label} exact dependent legacy ownership is invalid: "
+                + "; ".join(legacy_issues)
+            )
 
         raw_rewrites = raw_dependent.get("rewrites")
         if not isinstance(raw_rewrites, list) or not raw_rewrites:

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1431"
+__version__ = "0.2.1432"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1430"
+__version__ = "0.2.1431"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -264,6 +264,9 @@ from .legacy_replacement import (
     LEGACY_OWNER_CLASS as APPLIED_ENCODING_LEGACY_OWNER_CLASS,
 )
 from .legacy_replacement import (
+    LEGACY_OWNER_CLASSES as APPLIED_ENCODING_LEGACY_OWNER_CLASSES,
+)
+from .legacy_replacement import (
     RECEIPT_DIR as _LEGACY_REPLACEMENT_RECEIPT_DIR_TEXT,
 )
 from .legacy_replacement import (
@@ -7017,7 +7020,7 @@ def _legacy_replacement_authoritative_map(
     elif expected_destination != destination_path:
         issues.append("legacy replacement destination is not canonical for source")
     if (
-        legacy.get("owner_class") != APPLIED_ENCODING_LEGACY_OWNER_CLASS
+        legacy.get("owner_class") not in APPLIED_ENCODING_LEGACY_OWNER_CLASSES
         or legacy.get("trusted_generated_provenance") is not False
     ):
         issues.append("legacy replacement source ownership classification is invalid")
@@ -21913,7 +21916,7 @@ def _legacy_replacement_manifest_issues(
         not isinstance(legacy, dict)
         or set(legacy)
         != {"owner_class", "trusted_generated_provenance", "manifest", "files"}
-        or legacy.get("owner_class") != APPLIED_ENCODING_LEGACY_OWNER_CLASS
+        or legacy.get("owner_class") not in APPLIED_ENCODING_LEGACY_OWNER_CLASSES
         or legacy.get("trusted_generated_provenance") is not False
         or not isinstance(replacement, dict)
         or set(replacement)

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -294,10 +294,10 @@ from .legacy_replacement import (
     LegacyReplacementScheduledDependent as _LegacyReplacementScheduledDependent,
 )
 from .legacy_replacement import (
-    legacy_manual_manifest_issues as _legacy_manual_manifest_issues,
+    legacy_source_verification_citation_paths as _legacy_source_verification_citation_paths,
 )
 from .legacy_replacement import (
-    legacy_source_verification_citation_paths as _legacy_source_verification_citation_paths,
+    legacy_v1_manifest_issues as _legacy_v1_manifest_issues,
 )
 from .legacy_replacement import receipt_identity_payload, receipt_identity_sha256
 from .legacy_replacement_overlay import (
@@ -2210,7 +2210,7 @@ def main():
         type=Path,
         help=(
             "With --apply and --replace-rulespec-path, freshly model-reencode one "
-            "exact protected legacy v1/manual-owned primary, retire its old primary, "
+            "exact protected legacy v1 HMAC-owned primary, retire its old primary, "
             "companion, and legacy manifest bytes atomically at either the same "
             "canonical path or its unique normalized path, and emit only signed v5 "
             "replacement provenance."
@@ -2233,7 +2233,7 @@ def main():
         default=[],
         type=Path,
         help=(
-            "Exact protected legacy v1/manual direct-dependent primary whose "
+            "Exact protected legacy v1 HMAC direct-dependent primary whose "
             "base bytes may change only by the scheduled canonical reference "
             "rewrite. Repeat once per composite dependent; each full primary/test "
             "group and old manifest is bound to clean HEAD and replaced atomically "
@@ -6953,6 +6953,24 @@ def _strict_legacy_replacement_map(
     return replacements
 
 
+def _legacy_primary_source_citations(raw: bytes) -> tuple[str, ...]:
+    """Read the canonical ordered source history from one historical primary."""
+
+    try:
+        payload = yaml.safe_load(raw.decode("utf-8"))
+    except (UnicodeError, yaml.YAMLError, RecursionError):
+        return ()
+    module = payload.get("module") if isinstance(payload, dict) else None
+    verification = (
+        module.get("source_verification") if isinstance(module, dict) else None
+    )
+    return (
+        _legacy_source_verification_citation_paths(verification)
+        if isinstance(verification, dict)
+        else ()
+    )
+
+
 def _legacy_replacement_authoritative_map(
     repo_path: Path,
     *,
@@ -7041,6 +7059,7 @@ def _legacy_replacement_authoritative_map(
         )
 
     expected_files: dict[str, str] = {}
+    source_base_raw: bytes | None = None
     existing_companions: set[Path] = set()
     if isinstance(source, str):
         for candidate in (source_path, companion_path(source_path)):
@@ -7055,6 +7074,8 @@ def _legacy_replacement_authoritative_map(
                     issues.append("legacy replacement source is absent from base")
                 continue
             expected_files[candidate.as_posix()] = hashlib.sha256(raw).hexdigest()
+            if candidate == source_path:
+                source_base_raw = raw
             if candidate != source_path:
                 existing_companions.add(candidate)
     legacy_files = legacy.get("files")
@@ -7084,9 +7105,17 @@ def _legacy_replacement_authoritative_map(
         except (UnicodeError, json.JSONDecodeError, RecursionError):
             issues.append("legacy replacement source manifest is not valid JSON")
         else:
-            legacy_manifest_issues = _legacy_manual_manifest_issues(
+            source_citations = (
+                _legacy_primary_source_citations(source_base_raw)
+                if source_base_raw is not None
+                else ()
+            )
+            legacy_manifest_issues = _legacy_v1_manifest_issues(
                 legacy_manifest_payload,
                 expected_files=expected_files,
+                expected_primary_path=source_path.as_posix(),
+                expected_citation=source_citations[0] if source_citations else "",
+                jurisdiction_prefix=(source_path.parts[0] if source_path.parts else ""),
                 allow_unmarked_manual_exception=in_place,
             )
             issues.extend(
@@ -22325,11 +22354,24 @@ def _legacy_replacement_manifest_issues(
             legacy_manifest_payload = json.loads(legacy_manifest_raw.decode("utf-8"))
         except (UnicodeError, json.JSONDecodeError, RecursionError):
             legacy_manifest_payload = None
-        legacy_manifest_issues = _legacy_manual_manifest_issues(
+        try:
+            base_primary_raw = _rulespec_migration_base_blob(
+                repo_path, base_commit, primary_path
+            )
+        except RuntimeError:
+            base_primary_citations = ()
+        else:
+            base_primary_citations = _legacy_primary_source_citations(base_primary_raw)
+        legacy_manifest_issues = _legacy_v1_manifest_issues(
             legacy_manifest_payload,
             expected_files={
                 path.as_posix(): digest for path, digest in legacy_hashes.items()
             },
+            expected_primary_path=primary_path.as_posix(),
+            expected_citation=(
+                base_primary_citations[0] if base_primary_citations else ""
+            ),
+            jurisdiction_prefix=primary_path.parts[0],
             allow_unmarked_manual_exception=True,
         )
         if legacy_manifest_issues:
@@ -24136,7 +24178,7 @@ def _resolve_legacy_replacement_contract(
     legacy_manifest_path = _applied_encoding_manifest_path(source)
     if tracked.get(legacy_manifest_path) != "100644":
         raise ValueError(
-            "legacy replacement requires its exact tracked v1/manual ownership manifest"
+            "legacy replacement requires its exact tracked v1 HMAC ownership manifest"
         )
     legacy_manifest_raw = read_bounded_regular_file(
         policy_checkout_path,
@@ -24156,9 +24198,12 @@ def _resolve_legacy_replacement_contract(
     except (UnicodeError, json.JSONDecodeError, RecursionError) as exc:
         raise ValueError("legacy ownership manifest is not valid UTF-8 JSON") from exc
     expected_files = {item.path.as_posix(): item.sha256 for item in deleted_files}
-    legacy_issues = _legacy_manual_manifest_issues(
+    legacy_issues = _legacy_v1_manifest_issues(
         legacy_payload,
         expected_files=expected_files,
+        expected_primary_path=source.as_posix(),
+        expected_citation=requested_citation,
+        jurisdiction_prefix=source.parts[0],
         allow_unmarked_manual_exception=in_place,
     )
     if legacy_issues:
@@ -24285,7 +24330,7 @@ def _resolve_legacy_replacement_contract(
             or tracked.get(dependent_manifest_path) != "100644"
         ):
             raise ValueError(
-                "legacy exact dependent requires its unique tracked v1/manual "
+                "legacy exact dependent requires its unique tracked v1 HMAC "
                 f"ownership manifest: {primary}"
             )
         dependent_manifest_raw = read_bounded_regular_file(
@@ -24311,9 +24356,12 @@ def _resolve_legacy_replacement_contract(
             raise ValueError(
                 f"legacy exact dependent manifest is invalid JSON: {primary}"
             ) from exc
-        dependent_issues = _legacy_manual_manifest_issues(
+        dependent_issues = _legacy_v1_manifest_issues(
             dependent_manifest_payload,
             expected_files={item.path.as_posix(): item.sha256 for item in group_files},
+            expected_primary_path=primary.as_posix(),
+            expected_citation=dependent_citations[0],
+            jurisdiction_prefix=primary.parts[0],
             allow_unmarked_manual_exception=True,
         )
         if dependent_issues:

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -297,6 +297,9 @@ from .legacy_replacement import (
     LegacyReplacementScheduledDependent as _LegacyReplacementScheduledDependent,
 )
 from .legacy_replacement import (
+    legacy_receipt_v1_manifest_issues as _legacy_receipt_v1_manifest_issues,
+)
+from .legacy_replacement import (
     legacy_source_verification_citation_paths as _legacy_source_verification_citation_paths,
 )
 from .legacy_replacement import (
@@ -7113,8 +7116,9 @@ def _legacy_replacement_authoritative_map(
                 if source_base_raw is not None
                 else ()
             )
-            legacy_manifest_issues = _legacy_v1_manifest_issues(
+            legacy_manifest_issues = _legacy_receipt_v1_manifest_issues(
                 legacy_manifest_payload,
+                owner_class=legacy.get("owner_class"),
                 expected_files=expected_files,
                 expected_primary_path=source_path.as_posix(),
                 expected_citation=source_citations[0] if source_citations else "",
@@ -22365,8 +22369,9 @@ def _legacy_replacement_manifest_issues(
             base_primary_citations = ()
         else:
             base_primary_citations = _legacy_primary_source_citations(base_primary_raw)
-        legacy_manifest_issues = _legacy_v1_manifest_issues(
+        legacy_manifest_issues = _legacy_receipt_v1_manifest_issues(
             legacy_manifest_payload,
+            owner_class=legacy.get("owner_class"),
             expected_files={
                 path.as_posix(): digest for path, digest in legacy_hashes.items()
             },

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -7022,8 +7022,10 @@ def _legacy_replacement_authoritative_map(
             )
     elif expected_destination != destination_path:
         issues.append("legacy replacement destination is not canonical for source")
+    legacy_owner_class = legacy.get("owner_class")
     if (
-        legacy.get("owner_class") not in APPLIED_ENCODING_LEGACY_OWNER_CLASSES
+        not isinstance(legacy_owner_class, str)
+        or legacy_owner_class not in APPLIED_ENCODING_LEGACY_OWNER_CLASSES
         or legacy.get("trusted_generated_provenance") is not False
     ):
         issues.append("legacy replacement source ownership classification is invalid")
@@ -21920,6 +21922,7 @@ def _legacy_replacement_manifest_issues(
         not isinstance(legacy, dict)
         or set(legacy)
         != {"owner_class", "trusted_generated_provenance", "manifest", "files"}
+        or not isinstance(legacy.get("owner_class"), str)
         or legacy.get("owner_class") not in APPLIED_ENCODING_LEGACY_OWNER_CLASSES
         or legacy.get("trusted_generated_provenance") is not False
         or not isinstance(replacement, dict)

--- a/src/axiom_encode/legacy_replacement.py
+++ b/src/axiom_encode/legacy_replacement.py
@@ -26,6 +26,9 @@ RECEIPT_DIR: Final = ".axiom/legacy-replacements"
 ENCODING_MANIFEST_DIR: Final = Path(".axiom") / "encoding-manifests"
 LEGACY_MANIFEST_SCHEMA: Final = "axiom-encode/applied-rulespec/v1"
 LEGACY_OWNER_CLASS: Final = "v1-hmac-untrusted"
+LEGACY_OWNER_CLASSES: Final = frozenset(
+    {LEGACY_OWNER_CLASS, "v1-manual-hmac-untrusted"}
+)
 LEGACY_GENERATED_TOOL: Final = "axiom-encode encode --apply"
 LEGACY_GENERATED_BACKENDS: Final = frozenset({"codex", "openai", "claude"})
 LEGACY_SIGNATURE_KEY_ID: Final = "axiom-encode-apply-v1"

--- a/src/axiom_encode/legacy_replacement.py
+++ b/src/axiom_encode/legacy_replacement.py
@@ -26,8 +26,9 @@ RECEIPT_DIR: Final = ".axiom/legacy-replacements"
 ENCODING_MANIFEST_DIR: Final = Path(".axiom") / "encoding-manifests"
 LEGACY_MANIFEST_SCHEMA: Final = "axiom-encode/applied-rulespec/v1"
 LEGACY_OWNER_CLASS: Final = "v1-hmac-untrusted"
+LEGACY_MANUAL_OWNER_CLASS: Final = "v1-manual-hmac-untrusted"
 LEGACY_OWNER_CLASSES: Final = frozenset(
-    {LEGACY_OWNER_CLASS, "v1-manual-hmac-untrusted"}
+    {LEGACY_OWNER_CLASS, LEGACY_MANUAL_OWNER_CLASS}
 )
 LEGACY_GENERATED_TOOL: Final = "axiom-encode encode --apply"
 LEGACY_GENERATED_BACKENDS: Final = frozenset({"codex", "openai", "claude"})
@@ -425,6 +426,36 @@ def legacy_v1_manifest_issues(
             jurisdiction_prefix=jurisdiction_prefix,
         )
     return ["legacy ownership manifest class is unsupported"]
+
+
+def legacy_receipt_v1_manifest_issues(
+    payload: object,
+    *,
+    owner_class: object,
+    expected_files: Mapping[str, str],
+    expected_primary_path: str,
+    expected_citation: str,
+    jurisdiction_prefix: str,
+    allow_unmarked_manual_exception: bool = False,
+) -> list[str]:
+    """Preserve old manual receipts without permitting owner-class relabeling."""
+
+    if owner_class == LEGACY_MANUAL_OWNER_CLASS:
+        return legacy_manual_manifest_issues(
+            payload,
+            expected_files=expected_files,
+            allow_unmarked_manual_exception=allow_unmarked_manual_exception,
+        )
+    if owner_class == LEGACY_OWNER_CLASS:
+        return legacy_v1_manifest_issues(
+            payload,
+            expected_files=expected_files,
+            expected_primary_path=expected_primary_path,
+            expected_citation=expected_citation,
+            jurisdiction_prefix=jurisdiction_prefix,
+            allow_unmarked_manual_exception=allow_unmarked_manual_exception,
+        )
+    return ["legacy receipt ownership class is unsupported"]
 
 
 def receipt_identity_payload(

--- a/src/axiom_encode/legacy_replacement.py
+++ b/src/axiom_encode/legacy_replacement.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+from datetime import datetime
 from pathlib import Path
 from typing import Final, Mapping, NamedTuple
 
@@ -24,7 +25,37 @@ RECEIPT_SCHEMA: Final = "axiom-encode/legacy-fresh-reencode-receipt/v2"
 RECEIPT_DIR: Final = ".axiom/legacy-replacements"
 ENCODING_MANIFEST_DIR: Final = Path(".axiom") / "encoding-manifests"
 LEGACY_MANIFEST_SCHEMA: Final = "axiom-encode/applied-rulespec/v1"
-LEGACY_OWNER_CLASS: Final = "v1-manual-hmac-untrusted"
+LEGACY_OWNER_CLASS: Final = "v1-hmac-untrusted"
+LEGACY_GENERATED_TOOL: Final = "axiom-encode encode --apply"
+LEGACY_GENERATED_BACKENDS: Final = frozenset({"codex", "openai", "claude"})
+LEGACY_SIGNATURE_KEY_ID: Final = "axiom-encode-apply-v1"
+LEGACY_GENERATED_FIELDS: Final = frozenset(
+    {
+        "applied_files",
+        "axiom_encode_git",
+        "axiom_encode_version",
+        "backend",
+        "citation",
+        "context_manifest_file",
+        "context_manifest_sha256",
+        "generated_at",
+        "generated_output_file",
+        "generated_output_root",
+        "generated_output_sha256",
+        "generation_prompt_sha256",
+        "model",
+        "run_id",
+        "runner",
+        "schema_version",
+        "signature",
+        "tool",
+        "trace_file",
+        "trace_sha256",
+    }
+)
+LEGACY_GENERATED_GIT_FIELDS: Final = frozenset(
+    {"commit", "dirty_tracked", "root", "version", "version_commit"}
+)
 
 _SHA256 = re.compile(r"[0-9a-f]{64}")
 
@@ -173,6 +204,224 @@ def legacy_manual_manifest_issues(
             "legacy ownership manifest does not bind the exact old primary/test bytes"
         )
     return issues
+
+
+def legacy_generated_manifest_issues(
+    payload: object,
+    *,
+    expected_files: Mapping[str, str],
+    expected_primary_path: str,
+    expected_citation: str,
+    jurisdiction_prefix: str,
+) -> list[str]:
+    """Require one strict historical generated-v1 shape as untrusted evidence.
+
+    The historical HMAC is deliberately not verified or treated as authority.
+    Authority comes from the caller's separately authorized Git base and exact
+    blob hashes.  This parser only establishes that those blobs have the known
+    generated-v1 ownership shape and bind the expected source identity.
+    """
+
+    if not isinstance(payload, dict):
+        return ["legacy ownership manifest is not a JSON object"]
+    issues: list[str] = []
+    if set(payload) != LEGACY_GENERATED_FIELDS:
+        issues.append("legacy generated ownership manifest fields are noncanonical")
+    if payload.get("schema_version") != LEGACY_MANIFEST_SCHEMA:
+        issues.append("legacy ownership manifest is not schema v1")
+    if payload.get("tool") != LEGACY_GENERATED_TOOL:
+        issues.append("legacy generated ownership manifest tool is unsupported")
+    backend = payload.get("backend")
+    runner = payload.get("runner")
+    model = payload.get("model")
+    if not isinstance(backend, str) or backend not in LEGACY_GENERATED_BACKENDS:
+        issues.append("legacy generated ownership manifest backend is unsupported")
+    if (
+        not isinstance(runner, str)
+        or not isinstance(backend, str)
+        or not isinstance(model, str)
+        or not model.strip()
+        or runner != f"{backend}-{model}"
+    ):
+        issues.append("legacy generated ownership manifest runner/backend mismatch")
+    if "manual_exception" in payload:
+        issues.append("legacy generated ownership manifest claims a manual exception")
+    if any(
+        field in payload
+        for field in (
+            "deterministic_execution",
+            "validation_execution",
+            "migrated_manifest",
+            "retired_manifest",
+            "replacement_manifest",
+        )
+    ):
+        issues.append("legacy ownership manifest claims unsupported provenance")
+
+    signature = payload.get("signature")
+    if (
+        not isinstance(signature, dict)
+        or set(signature) != {"algorithm", "key_id", "value"}
+        or signature.get("algorithm") != "hmac-sha256"
+        or signature.get("key_id") != LEGACY_SIGNATURE_KEY_ID
+        or not isinstance(signature.get("value"), str)
+        or _SHA256.fullmatch(str(signature.get("value"))) is None
+    ):
+        issues.append("legacy generated ownership manifest has unknown signature shape")
+
+    actual: dict[str, str] = {}
+    entries = payload.get("applied_files")
+    if not isinstance(entries, list):
+        issues.append("legacy ownership manifest applied_files is malformed")
+    else:
+        for index, entry in enumerate(entries):
+            if (
+                not isinstance(entry, dict)
+                or set(entry) != {"path", "sha256"}
+                or not isinstance(entry.get("path"), str)
+                or not isinstance(entry.get("sha256"), str)
+                or _SHA256.fullmatch(str(entry["sha256"])) is None
+                or entry["path"] in actual
+            ):
+                issues.append(
+                    f"legacy ownership manifest applied_files[{index}] is malformed"
+                )
+                continue
+            actual[str(entry["path"])] = str(entry["sha256"])
+
+    canonical_files = dict(expected_files)
+    prefix = f"{jurisdiction_prefix}/"
+    uniformly_relative = bool(canonical_files) and all(
+        path.startswith(prefix) and len(path) > len(prefix) for path in canonical_files
+    )
+    relative_files = (
+        {path[len(prefix) :]: digest for path, digest in canonical_files.items()}
+        if uniformly_relative
+        else {}
+    )
+    if actual != canonical_files and actual != relative_files:
+        issues.append(
+            "legacy generated ownership manifest does not bind the exact old "
+            "primary/test bytes in one admitted path scope"
+        )
+
+    try:
+        canonical_citation = normalize_corpus_identifier(expected_citation)
+    except (TypeError, ValueError):
+        canonical_citation = ""
+    if not canonical_citation or payload.get("citation") != canonical_citation:
+        issues.append("legacy generated ownership manifest citation is stale")
+
+    primary_digest = canonical_files.get(expected_primary_path)
+    if (
+        primary_digest is None
+        or payload.get("generated_output_sha256") != primary_digest
+    ):
+        issues.append("legacy generated ownership manifest output digest is stale")
+
+    if not isinstance(model, str) or not model.strip():
+        issues.append("legacy generated ownership manifest model is malformed")
+    run_id = payload.get("run_id")
+    if not isinstance(run_id, str) or not run_id.strip():
+        issues.append("legacy generated ownership manifest run id is malformed")
+    generated_at = payload.get("generated_at")
+    try:
+        parsed_generated_at = (
+            datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+            if isinstance(generated_at, str)
+            else None
+        )
+    except ValueError:
+        parsed_generated_at = None
+    if parsed_generated_at is None or parsed_generated_at.tzinfo is None:
+        issues.append("legacy generated ownership manifest timestamp is malformed")
+
+    version = payload.get("axiom_encode_version")
+    git_identity = payload.get("axiom_encode_git")
+    if (
+        not isinstance(version, str)
+        or not version.strip()
+        or not isinstance(git_identity, dict)
+        or set(git_identity) != LEGACY_GENERATED_GIT_FIELDS
+        or not isinstance(git_identity.get("commit"), str)
+        or re.fullmatch(r"[0-9a-f]{40}", str(git_identity.get("commit"))) is None
+        or git_identity.get("dirty_tracked") is not False
+        or not isinstance(git_identity.get("root"), str)
+        or not git_identity.get("root")
+        or git_identity.get("version") != version
+        or not isinstance(git_identity.get("version_commit"), str)
+        or re.fullmatch(r"[0-9a-f]{40}", str(git_identity.get("version_commit")))
+        is None
+    ):
+        issues.append(
+            "legacy generated ownership manifest encoder identity is malformed"
+        )
+
+    for path_field, digest_field in (
+        ("generated_output_file", "generated_output_sha256"),
+        ("trace_file", "trace_sha256"),
+        ("context_manifest_file", "context_manifest_sha256"),
+    ):
+        path_value = payload.get(path_field)
+        digest_value = payload.get(digest_field)
+        if (
+            not isinstance(path_value, str)
+            or not path_value.strip()
+            or not isinstance(digest_value, str)
+            or _SHA256.fullmatch(digest_value) is None
+        ):
+            issues.append(
+                f"legacy generated ownership manifest {path_field} binding is malformed"
+            )
+    if (
+        not isinstance(payload.get("generated_output_root"), str)
+        or not payload.get("generated_output_root")
+        or not isinstance(payload.get("generation_prompt_sha256"), str)
+        or _SHA256.fullmatch(str(payload.get("generation_prompt_sha256"))) is None
+    ):
+        issues.append(
+            "legacy generated ownership manifest generation binding is malformed"
+        )
+    return issues
+
+
+def legacy_v1_manifest_issues(
+    payload: object,
+    *,
+    expected_files: Mapping[str, str],
+    expected_primary_path: str,
+    expected_citation: str,
+    jurisdiction_prefix: str,
+    allow_unmarked_manual_exception: bool = False,
+) -> list[str]:
+    """Dispatch only the two explicitly supported historical v1 owner classes."""
+
+    if not isinstance(payload, dict):
+        return ["legacy ownership manifest is not a JSON object"]
+    tool = payload.get("tool")
+    backend = payload.get("backend")
+    runner = payload.get("runner")
+    if (
+        tool == "axiom-encode sign-applied-files"
+        or backend == "manual"
+        or runner == "manual-attestation"
+    ):
+        return legacy_manual_manifest_issues(
+            payload,
+            expected_files=expected_files,
+            allow_unmarked_manual_exception=allow_unmarked_manual_exception,
+        )
+    if tool == LEGACY_GENERATED_TOOL or (
+        isinstance(backend, str) and backend in LEGACY_GENERATED_BACKENDS
+    ):
+        return legacy_generated_manifest_issues(
+            payload,
+            expected_files=expected_files,
+            expected_primary_path=expected_primary_path,
+            expected_citation=expected_citation,
+            jurisdiction_prefix=jurisdiction_prefix,
+        )
+    return ["legacy ownership manifest class is unsupported"]
 
 
 def receipt_identity_payload(

--- a/src/axiom_encode/legacy_replacement.py
+++ b/src/axiom_encode/legacy_replacement.py
@@ -27,9 +27,7 @@ ENCODING_MANIFEST_DIR: Final = Path(".axiom") / "encoding-manifests"
 LEGACY_MANIFEST_SCHEMA: Final = "axiom-encode/applied-rulespec/v1"
 LEGACY_OWNER_CLASS: Final = "v1-hmac-untrusted"
 LEGACY_MANUAL_OWNER_CLASS: Final = "v1-manual-hmac-untrusted"
-LEGACY_OWNER_CLASSES: Final = frozenset(
-    {LEGACY_OWNER_CLASS, LEGACY_MANUAL_OWNER_CLASS}
-)
+LEGACY_OWNER_CLASSES: Final = frozenset({LEGACY_OWNER_CLASS, LEGACY_MANUAL_OWNER_CLASS})
 LEGACY_GENERATED_TOOL: Final = "axiom-encode encode --apply"
 LEGACY_GENERATED_BACKENDS: Final = frozenset({"codex", "openai", "claude"})
 LEGACY_SIGNATURE_KEY_ID: Final = "axiom-encode-apply-v1"

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1431"
+ENCODER_VERSION = "0.2.1432"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1430"
+ENCODER_VERSION = "0.2.1431"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1701,7 +1701,7 @@ def test_legacy_pending_detection_requires_signed_untampered_evidence(
             "axiom_encode": encoder_execution_identity,
         },
         "legacy": {
-            "owner_class": "v1-manual-hmac-untrusted",
+            "owner_class": "v1-hmac-untrusted",
             "trusted_generated_provenance": False,
             "manifest": {
                 "path": ".axiom/encoding-manifests/us/statutes/47:32.json",
@@ -12559,7 +12559,7 @@ class TestCmdEncode:
                 "axiom_encode": encoder_execution_identity,
             },
             "legacy": {
-                "owner_class": "v1-manual-hmac-untrusted",
+                "owner_class": "v1-hmac-untrusted",
                 "trusted_generated_provenance": False,
                 "manifest": {
                     "path": ".axiom/encoding-manifests/us/statutes/47:32.json",
@@ -34471,7 +34471,7 @@ class TestResolverOwnedManifestWriter:
             "corpus_release": {},
             "validation_execution": None,
             "legacy": {
-                "owner_class": "v1-manual-hmac-untrusted",
+                "owner_class": "v1-hmac-untrusted",
                 "trusted_generated_provenance": False,
                 "manifest": {
                     "path": legacy_manifest_label,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1701,7 +1701,7 @@ def test_legacy_pending_detection_requires_signed_untampered_evidence(
             "axiom_encode": encoder_execution_identity,
         },
         "legacy": {
-            "owner_class": "v1-hmac-untrusted",
+            "owner_class": "v1-manual-hmac-untrusted",
             "trusted_generated_provenance": False,
             "manifest": {
                 "path": ".axiom/encoding-manifests/us/statutes/47:32.json",
@@ -12559,7 +12559,7 @@ class TestCmdEncode:
                 "axiom_encode": encoder_execution_identity,
             },
             "legacy": {
-                "owner_class": "v1-hmac-untrusted",
+                "owner_class": "v1-manual-hmac-untrusted",
                 "trusted_generated_provenance": False,
                 "manifest": {
                     "path": ".axiom/encoding-manifests/us/statutes/47:32.json",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1790,6 +1790,22 @@ def test_legacy_pending_detection_requires_signed_untampered_evidence(
         assert _legacy_replacement_pending_paths(repo) == [
             "us/policies/income_tax/dependent.yaml"
         ]
+        for malformed_owner_class in ([], {}):
+            receipt["legacy"]["owner_class"] = malformed_owner_class
+            _sign_applied_encoding_manifest(receipt, TEST_APPLY_SIGNING_BROKER)
+            receipt_path.write_text(json.dumps(receipt) + "\n")
+            manifest["replacement"]["receipt_sha256"] = hashlib.sha256(
+                receipt_path.read_bytes()
+            ).hexdigest()
+            _sign_applied_encoding_manifest(manifest, TEST_APPLY_SIGNING_BROKER)
+            manifest_path.write_text(json.dumps(manifest) + "\n")
+            assert _legacy_replacement_pending_paths(repo) == [
+                "invalid:.axiom/encoding-manifests/us/statutes/47/32.json",
+                f"invalid:{receipt_relative.as_posix()}",
+            ]
+        receipt["legacy"]["owner_class"] = "v1-manual-hmac-untrusted"
+        receipt_path.write_bytes(signed_receipt_raw)
+        manifest_path.write_bytes(signed_manifest_raw)
         with patch(
             "axiom_encode.cli._legacy_replacement_reference_inventory_issues",
             return_value=[
@@ -13633,6 +13649,7 @@ class TestCmdEncode:
         receipt = json.loads(
             (checkout / outer["replacement"]["receipt_path"]).read_text()
         )
+        assert receipt["legacy"]["owner_class"] == "v1-hmac-untrusted"
         assert receipt["replacement"]["source"] == checkout_relative.as_posix()
         assert receipt["replacement"]["destination"] == checkout_relative.as_posix()
         assert receipt["legacy"]["files"] == [
@@ -13651,9 +13668,11 @@ class TestCmdEncode:
         assert issues == [], "\n".join(issues)
         assert verified == outer
 
+    @pytest.mark.parametrize("dependent_owner", ["manual", "generated"])
     def test_apply_atomically_migrates_exact_legacy_dependent(
         self,
         tmp_path,
+        dependent_owner,
     ):
         from axiom_encode.cli import _resolve_legacy_replacement_contract
         from axiom_encode.toolchain import load_rulespec_local_corpus_release
@@ -13743,6 +13762,53 @@ class TestCmdEncode:
         dependent_manifest = write_manual_manifest(
             dependent, [dependent, dependent_test]
         )
+        if dependent_owner == "generated":
+            dependent_manifest.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "axiom-encode/applied-rulespec/v1",
+                        "tool": "axiom-encode encode --apply",
+                        "backend": "codex",
+                        "runner": "codex-gpt-5.5",
+                        "model": "gpt-5.5",
+                        "citation": "us-la/statute/47/32",
+                        "generated_at": "2026-07-16T19:07:09.279448+00:00",
+                        "run_id": "generated-exact-dependent",
+                        "axiom_encode_version": "0.2.1200",
+                        "axiom_encode_git": {
+                            "commit": "c" * 40,
+                            "dirty_tracked": False,
+                            "root": "/tmp/axiom-encode",
+                            "version": "0.2.1200",
+                            "version_commit": "c" * 40,
+                        },
+                        "generation_prompt_sha256": "d" * 64,
+                        "generated_output_root": "/tmp/axiom-generated",
+                        "generated_output_file": (
+                            "/tmp/axiom-generated/us-la/policies/income_tax/"
+                            "2026_resident_core.yaml"
+                        ),
+                        "generated_output_sha256": _sha256_file(dependent),
+                        "trace_file": "/tmp/axiom-generated/trace.json",
+                        "trace_sha256": "e" * 64,
+                        "context_manifest_file": "/tmp/axiom-generated/context.json",
+                        "context_manifest_sha256": "f" * 64,
+                        "applied_files": [
+                            {
+                                "path": path.relative_to(checkout).as_posix(),
+                                "sha256": _sha256_file(path),
+                            }
+                            for path in (dependent, dependent_test)
+                        ],
+                        "signature": {
+                            "algorithm": "hmac-sha256",
+                            "key_id": "axiom-encode-apply-v1",
+                            "value": "1" * 64,
+                        },
+                    }
+                )
+                + "\n"
+            )
         dependent_before = dependent.read_bytes()
         dependent_test_before = dependent_test.read_bytes()
         dependent_manifest_before = dependent_manifest.read_bytes()
@@ -13952,6 +14018,7 @@ class TestCmdEncode:
         receipt_path = checkout / outer["replacement"]["receipt_path"]
         receipt = json.loads(receipt_path.read_text())
         assert receipt["schema_version"].endswith("/v2")
+        assert receipt["legacy"]["owner_class"] == "v1-hmac-untrusted"
         assert len(receipt["replacement"]["exact_dependents"]) == 1
         exact = receipt["replacement"]["exact_dependents"][0]
         assert exact["primary"] == dependent_relative.as_posix()
@@ -13991,6 +14058,61 @@ class TestCmdEncode:
         outer_before_tamper = destination_manifest.read_bytes()
         receipt_before_tamper = receipt_path.read_bytes()
         exact_manifest_before_tamper = dependent_manifest.read_bytes()
+        compatibility_receipt = copy.deepcopy(receipt)
+        compatibility_receipt["legacy"]["owner_class"] = "v1-manual-hmac-untrusted"
+        _sign_applied_encoding_manifest(
+            compatibility_receipt,
+            TEST_APPLY_SIGNING_BROKER,
+        )
+        receipt_path.write_text(
+            json.dumps(compatibility_receipt, indent=2, sort_keys=True) + "\n"
+        )
+        compatibility_receipt_sha256 = hashlib.sha256(
+            receipt_path.read_bytes()
+        ).hexdigest()
+        compatibility_outer = copy.deepcopy(outer)
+        compatibility_outer["replacement"]["receipt_sha256"] = (
+            compatibility_receipt_sha256
+        )
+        _sign_applied_encoding_manifest(
+            compatibility_outer,
+            TEST_APPLY_SIGNING_BROKER,
+        )
+        destination_manifest.write_text(
+            json.dumps(compatibility_outer, indent=2, sort_keys=True) + "\n"
+        )
+        compatibility_exact_manifest = copy.deepcopy(exact_manifest)
+        compatibility_exact_manifest["legacy_migration"]["receipt_sha256"] = (
+            compatibility_receipt_sha256
+        )
+        _sign_applied_encoding_manifest(
+            compatibility_exact_manifest,
+            TEST_APPLY_SIGNING_BROKER,
+        )
+        dependent_manifest.write_text(
+            json.dumps(compatibility_exact_manifest, indent=2, sort_keys=True) + "\n"
+        )
+        _verified, _root, _digest, compatibility_issues = (
+            _load_verified_applied_encoding_manifest_payload(
+                checkout,
+                destination_manifest.relative_to(checkout).as_posix(),
+                signing_broker=TEST_APPLY_SIGNING_BROKER,
+                expected_waiver_set_sha256=TEST_VALIDATION_WAIVER_SHA256,
+                expected_encoder_identity=TEST_PINNED_ENCODER_IDENTITY,
+                local_corpus_release=release,
+            )
+        )
+        if dependent_owner == "manual":
+            assert compatibility_issues == [], "\n".join(compatibility_issues)
+        else:
+            assert any(
+                "exact dependent legacy ownership is invalid" in issue
+                for issue in compatibility_issues
+            )
+        destination_manifest.write_bytes(outer_before_tamper)
+        receipt_path.write_bytes(receipt_before_tamper)
+        dependent_manifest.write_bytes(exact_manifest_before_tamper)
+
         tampered_receipt = copy.deepcopy(receipt)
         tampered_receipt["replacement"]["exact_dependents"][0]["rewrites"][0][
             "proof_import_repairs"

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1431"
+ENCODER_VERSION = "0.2.1432"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1430"
+ENCODER_VERSION = "0.2.1431"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1430"
+ENCODER_VERSION = "0.2.1431"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1431"
+ENCODER_VERSION = "0.2.1432"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_legacy_replacement.py
+++ b/tests/test_legacy_replacement.py
@@ -339,6 +339,24 @@ def test_old_manual_receipt_class_cannot_relabel_generated_evidence() -> None:
     assert any("tool is not sign-applied-files" in issue for issue in issues)
 
 
+@pytest.mark.parametrize("owner_class", [[], {}])
+def test_receipt_dispatcher_rejects_nonscalar_owner_class_without_crashing(
+    owner_class: object,
+) -> None:
+    issues = legacy_receipt_v1_manifest_issues(
+        _manual_manifest(),
+        owner_class=owner_class,
+        expected_files={
+            "us-la/statutes/47:32.yaml": "a" * 64,
+            "us-la/statutes/47:32.test.yaml": "b" * 64,
+        },
+        expected_primary_path="us-la/statutes/47:32.yaml",
+        expected_citation="us-la/statute/47:32",
+        jurisdiction_prefix="us-la",
+    )
+    assert issues == ["legacy receipt ownership class is unsupported"]
+
+
 def test_receipt_identity_binds_every_transaction_dimension() -> None:
     payload = receipt_identity_payload(
         base_commit="a" * 40,
@@ -588,15 +606,40 @@ def test_receipt_authority_rejects_generated_bytes_under_old_manual_class(
     replacements, issues = _legacy_replacement_authoritative_map(
         checkout,
         base_commit=base_commit,
-        manifest_label=(
-            ".axiom/encoding-manifests/us/statutes/42/1437c-1.json"
-        ),
+        manifest_label=(".axiom/encoding-manifests/us/statutes/42/1437c-1.json"),
         legacy=legacy,
         replacement=replacement,
     )
 
     assert replacements is None
     assert any("tool is not sign-applied-files" in issue for issue in issues)
+
+
+@pytest.mark.parametrize("owner_class", [[], {}])
+def test_receipt_authority_rejects_nonscalar_owner_class_without_crashing(
+    tmp_path: Path,
+    owner_class: object,
+) -> None:
+    checkout, _content_root, _source = _generated_unicode_checkout(tmp_path)
+    legacy, replacement = _generated_unicode_receipt_blocks(checkout)
+    legacy["owner_class"] = owner_class
+    base_commit = subprocess.run(
+        ["git", "-C", str(checkout), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    replacements, issues = _legacy_replacement_authoritative_map(
+        checkout,
+        base_commit=base_commit,
+        manifest_label=(".axiom/encoding-manifests/us/statutes/42/1437c-1.json"),
+        legacy=legacy,
+        replacement=replacement,
+    )
+
+    assert replacements is None
+    assert any("ownership classification is invalid" in issue for issue in issues)
 
 
 def test_contract_rejects_generated_v1_with_wrong_citation(tmp_path: Path) -> None:

--- a/tests/test_legacy_replacement.py
+++ b/tests/test_legacy_replacement.py
@@ -11,13 +11,16 @@ from unittest.mock import patch
 import pytest
 
 from axiom_encode.cli import (
+    _legacy_replacement_authoritative_map,
     _require_locked_legacy_replacement_base,
     _resolve_legacy_replacement_contract,
 )
 from axiom_encode.legacy_replacement import (
     LEGACY_MANIFEST_SCHEMA,
+    legacy_generated_manifest_issues,
     legacy_manual_manifest_issues,
     legacy_source_verification_citation_paths,
+    legacy_v1_manifest_issues,
     receipt_identity_payload,
     receipt_identity_sha256,
 )
@@ -164,6 +167,162 @@ def test_manual_manifest_cannot_be_elevated_to_generated_provenance(
     assert any(match in issue for issue in issues)
 
 
+def _generated_manifest() -> dict[str, object]:
+    return {
+        "schema_version": LEGACY_MANIFEST_SCHEMA,
+        "tool": "axiom-encode encode --apply",
+        "backend": "codex",
+        "runner": "codex-gpt-5.5",
+        "model": "gpt-5.5",
+        "citation": "us/statute/42/1437c–1",
+        "generated_at": "2026-07-16T19:07:09.279448+00:00",
+        "run_id": "183b7163",
+        "axiom_encode_version": "0.2.1200",
+        "axiom_encode_git": {
+            "commit": "c" * 40,
+            "dirty_tracked": False,
+            "root": "/private/tmp/axiom-encode-codex",
+            "version": "0.2.1200",
+            "version_commit": "c" * 40,
+        },
+        "generation_prompt_sha256": "d" * 64,
+        "generated_output_root": "/tmp/axiom-generated",
+        "generated_output_file": "/tmp/axiom-generated/statutes/42/1437c–1.yaml",
+        "generated_output_sha256": "a" * 64,
+        "trace_file": "/tmp/axiom-generated/trace.json",
+        "trace_sha256": "e" * 64,
+        "context_manifest_file": "/tmp/axiom-generated/context.json",
+        "context_manifest_sha256": "f" * 64,
+        "applied_files": [
+            {"path": "statutes/42/1437c–1.yaml", "sha256": "a" * 64},
+            {"path": "statutes/42/1437c–1.test.yaml", "sha256": "b" * 64},
+        ],
+        "signature": {
+            "algorithm": "hmac-sha256",
+            "key_id": "axiom-encode-apply-v1",
+            "value": "1" * 64,
+        },
+    }
+
+
+def _generated_manifest_issues(payload: object) -> list[str]:
+    return legacy_generated_manifest_issues(
+        payload,
+        expected_files={
+            "us/statutes/42/1437c–1.yaml": "a" * 64,
+            "us/statutes/42/1437c–1.test.yaml": "b" * 64,
+        },
+        expected_primary_path="us/statutes/42/1437c–1.yaml",
+        expected_citation="us/statute/42/1437c–1",
+        jurisdiction_prefix="us",
+    )
+
+
+def test_generated_manifest_admits_uniform_jurisdiction_relative_scope() -> None:
+    assert _generated_manifest_issues(_generated_manifest()) == []
+
+
+def test_generated_manifest_admits_exact_checkout_relative_scope() -> None:
+    payload = _generated_manifest()
+    payload["applied_files"] = [
+        {"path": f"us/{item['path']}", "sha256": item["sha256"]}
+        for item in payload["applied_files"]
+    ]
+    assert _generated_manifest_issues(payload) == []
+
+
+@pytest.mark.parametrize(
+    ("mutation", "match"),
+    [
+        ({"citation": "us/statute/42/1437c-1"}, "citation is stale"),
+        ({"generated_output_sha256": "9" * 64}, "output digest is stale"),
+        ({"runner": "openai-gpt-5.5"}, "runner/backend mismatch"),
+        ({"runner": "codex-attacker"}, "runner/backend mismatch"),
+        (
+            {"tool": "axiom-encode encode --apply (recovered from sandbox)"},
+            "tool is unsupported",
+        ),
+        ({"manual_exception": "relabelled"}, "claims a manual exception"),
+        (
+            {
+                "signature": {
+                    "algorithm": "hmac-sha256",
+                    "key_id": "historical-v1",
+                    "value": "1" * 64,
+                }
+            },
+            "unknown signature shape",
+        ),
+    ],
+)
+def test_generated_manifest_rejects_stale_or_relabelled_evidence(
+    mutation: dict[str, object], match: str
+) -> None:
+    payload = _generated_manifest()
+    payload.update(mutation)
+    assert any(match in issue for issue in _generated_manifest_issues(payload))
+
+
+def test_generated_manifest_rejects_mixed_applied_file_scopes() -> None:
+    payload = _generated_manifest()
+    payload["applied_files"][0]["path"] = "us/statutes/42/1437c–1.yaml"
+    assert any(
+        "one admitted path scope" in issue
+        for issue in _generated_manifest_issues(payload)
+    )
+
+
+def test_generated_manifest_rejects_unknown_provenance_fields() -> None:
+    payload = _generated_manifest()
+    payload["unknown_provenance"] = {"trusted": True}
+    assert any(
+        "fields are noncanonical" in issue
+        for issue in _generated_manifest_issues(payload)
+    )
+
+    payload = _generated_manifest()
+    payload["axiom_encode_git"]["unknown_identity"] = "trusted"
+    assert any(
+        "encoder identity is malformed" in issue
+        for issue in _generated_manifest_issues(payload)
+    )
+
+
+@pytest.mark.parametrize("backend", [[], {}])
+def test_generated_manifest_rejects_nonscalar_backend_without_crashing(
+    backend: object,
+) -> None:
+    payload = _generated_manifest()
+    payload["backend"] = backend
+    issues = legacy_v1_manifest_issues(
+        payload,
+        expected_files={
+            "us/statutes/42/1437c–1.yaml": "a" * 64,
+            "us/statutes/42/1437c–1.test.yaml": "b" * 64,
+        },
+        expected_primary_path="us/statutes/42/1437c–1.yaml",
+        expected_citation="us/statute/42/1437c–1",
+        jurisdiction_prefix="us",
+    )
+    assert any("backend is unsupported" in issue for issue in issues)
+
+
+def test_v1_dispatcher_preserves_manual_owner_admission() -> None:
+    assert (
+        legacy_v1_manifest_issues(
+            _manual_manifest(),
+            expected_files={
+                "us-la/statutes/47:32.yaml": "a" * 64,
+                "us-la/statutes/47:32.test.yaml": "b" * 64,
+            },
+            expected_primary_path="us-la/statutes/47:32.yaml",
+            expected_citation="us-la/statute/47:32",
+            jurisdiction_prefix="us-la",
+        )
+        == []
+    )
+
+
 def test_receipt_identity_binds_every_transaction_dimension() -> None:
     payload = receipt_identity_payload(
         base_commit="a" * 40,
@@ -240,6 +399,184 @@ def _legacy_checkout(tmp_path: Path) -> tuple[Path, Path, SimpleNamespace]:
         resolved_source=object(),
     )
     return checkout, content_root, source
+
+
+def _generated_unicode_checkout(
+    tmp_path: Path,
+) -> tuple[Path, Path, SimpleNamespace]:
+    checkout = tmp_path / "rulespec-us"
+    content_root = checkout / "us"
+    primary = content_root / "statutes/42/1437c–1.yaml"
+    companion = primary.with_name("1437c–1.test.yaml")
+    primary.parent.mkdir(parents=True)
+    primary.write_text(
+        "format: rulespec/v1\n"
+        "module:\n"
+        "  source_verification:\n"
+        "    corpus_citation_path: us/statute/42/1437c–1\n"
+        "rules: []\n"
+    )
+    companion.write_text("[]\n")
+    primary_sha256 = hashlib.sha256(primary.read_bytes()).hexdigest()
+    companion_sha256 = hashlib.sha256(companion.read_bytes()).hexdigest()
+    manifest = checkout / ".axiom/encoding-manifests/us/statutes/42/1437c–1.json"
+    manifest.parent.mkdir(parents=True)
+    payload = _generated_manifest()
+    payload["generated_output_sha256"] = primary_sha256
+    payload["applied_files"] = [
+        {"path": "statutes/42/1437c–1.yaml", "sha256": primary_sha256},
+        {
+            "path": "statutes/42/1437c–1.test.yaml",
+            "sha256": companion_sha256,
+        },
+    ]
+    manifest.write_text(json.dumps(payload) + "\n")
+    _git(checkout, "init", "-q")
+    _git(checkout, "config", "user.email", "test@example.com")
+    _git(checkout, "config", "user.name", "Test")
+    _git(checkout, "add", ".")
+    _git(checkout, "commit", "-qm", "generated Unicode base")
+    source = SimpleNamespace(
+        requested="us/statute/42/1437c–1",
+        citation_path="us/statute/42/1437c–1",
+        body="official body",
+        resolved_source=object(),
+    )
+    return checkout, content_root, source
+
+
+def test_contract_admits_generated_v1_unicode_path_with_relative_file_scope(
+    tmp_path: Path,
+) -> None:
+    checkout, content_root, source = _generated_unicode_checkout(tmp_path)
+    with patch("axiom_encode.cli.resolve_corpus_source_unit", return_value=source):
+        contract = _resolve_legacy_replacement_contract(
+            source_raw=Path("us/statutes/42/1437c–1.yaml"),
+            destination_raw=Path("us/statutes/42/1437c-1.yaml"),
+            policy_checkout_path=checkout,
+            policy_repo_path=content_root,
+            source_unit=source,
+            corpus_release=SimpleNamespace(),
+        )
+
+    assert contract.source == Path("us/statutes/42/1437c–1.yaml")
+    assert contract.destination == Path("us/statutes/42/1437c-1.yaml")
+    assert {item.path for item in contract.deleted_files} == {
+        Path("us/statutes/42/1437c–1.yaml"),
+        Path("us/statutes/42/1437c–1.test.yaml"),
+    }
+
+
+def _generated_unicode_receipt_blocks(
+    checkout: Path,
+) -> tuple[dict[str, object], dict[str, object]]:
+    source = Path("us/statutes/42/1437c–1.yaml")
+    companion = source.with_name("1437c–1.test.yaml")
+    manifest = Path(".axiom/encoding-manifests/us/statutes/42/1437c–1.json")
+    return (
+        {
+            "owner_class": "v1-hmac-untrusted",
+            "trusted_generated_provenance": False,
+            "manifest": {
+                "path": manifest.as_posix(),
+                "sha256": hashlib.sha256(
+                    (checkout / manifest).read_bytes()
+                ).hexdigest(),
+            },
+            "files": [
+                {
+                    "path": path.as_posix(),
+                    "sha256": hashlib.sha256(
+                        (checkout / path).read_bytes()
+                    ).hexdigest(),
+                }
+                for path in (source, companion)
+            ],
+        },
+        {
+            "source": source.as_posix(),
+            "destination": "us/statutes/42/1437c-1.yaml",
+            "model_manifest_path": (
+                ".axiom/encoding-manifests/us/statutes/42/1437c-1.json"
+            ),
+        },
+    )
+
+
+def test_receipt_authority_reconstructs_generated_v1_unicode_path(
+    tmp_path: Path,
+) -> None:
+    checkout, _content_root, _source = _generated_unicode_checkout(tmp_path)
+    legacy, replacement = _generated_unicode_receipt_blocks(checkout)
+    base_commit = subprocess.run(
+        ["git", "-C", str(checkout), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    replacements, issues = _legacy_replacement_authoritative_map(
+        checkout,
+        base_commit=base_commit,
+        manifest_label=(".axiom/encoding-manifests/us/statutes/42/1437c-1.json"),
+        legacy=legacy,
+        replacement=replacement,
+    )
+
+    assert issues == []
+    assert replacements is not None
+
+
+def test_receipt_authority_rejects_relabelled_generated_v1_bytes(
+    tmp_path: Path,
+) -> None:
+    checkout, _content_root, _source = _generated_unicode_checkout(tmp_path)
+    manifest = checkout / ".axiom/encoding-manifests/us/statutes/42/1437c–1.json"
+    payload = json.loads(manifest.read_text())
+    payload["runner"] = "codex-attacker"
+    manifest.write_text(json.dumps(payload) + "\n")
+    _git(checkout, "add", ".")
+    _git(checkout, "commit", "-qm", "relabel generated owner")
+    legacy, replacement = _generated_unicode_receipt_blocks(checkout)
+    base_commit = subprocess.run(
+        ["git", "-C", str(checkout), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    replacements, issues = _legacy_replacement_authoritative_map(
+        checkout,
+        base_commit=base_commit,
+        manifest_label=(".axiom/encoding-manifests/us/statutes/42/1437c-1.json"),
+        legacy=legacy,
+        replacement=replacement,
+    )
+
+    assert replacements is None
+    assert any("runner/backend mismatch" in issue for issue in issues)
+
+
+def test_contract_rejects_generated_v1_with_wrong_citation(tmp_path: Path) -> None:
+    checkout, content_root, source = _generated_unicode_checkout(tmp_path)
+    manifest = checkout / ".axiom/encoding-manifests/us/statutes/42/1437c–1.json"
+    payload = json.loads(manifest.read_text())
+    payload["citation"] = "us/statute/42/1437c-1"
+    manifest.write_text(json.dumps(payload) + "\n")
+    _git(checkout, "add", ".")
+    _git(checkout, "commit", "-qm", "stale generated citation")
+
+    with (
+        patch("axiom_encode.cli.resolve_corpus_source_unit", return_value=source),
+        pytest.raises(ValueError, match="citation is stale"),
+    ):
+        _resolve_legacy_replacement_contract(
+            source_raw=Path("us/statutes/42/1437c–1.yaml"),
+            destination_raw=Path("us/statutes/42/1437c-1.yaml"),
+            policy_checkout_path=checkout,
+            policy_repo_path=content_root,
+            source_unit=source,
+            corpus_release=SimpleNamespace(),
+        )
 
 
 def _in_place_legacy_checkout(

--- a/tests/test_legacy_replacement.py
+++ b/tests/test_legacy_replacement.py
@@ -19,6 +19,7 @@ from axiom_encode.legacy_replacement import (
     LEGACY_MANIFEST_SCHEMA,
     legacy_generated_manifest_issues,
     legacy_manual_manifest_issues,
+    legacy_receipt_v1_manifest_issues,
     legacy_source_verification_citation_paths,
     legacy_v1_manifest_issues,
     receipt_identity_payload,
@@ -323,6 +324,21 @@ def test_v1_dispatcher_preserves_manual_owner_admission() -> None:
     )
 
 
+def test_old_manual_receipt_class_cannot_relabel_generated_evidence() -> None:
+    issues = legacy_receipt_v1_manifest_issues(
+        _generated_manifest(),
+        owner_class="v1-manual-hmac-untrusted",
+        expected_files={
+            "us/statutes/42/1437c–1.yaml": "a" * 64,
+            "us/statutes/42/1437c–1.test.yaml": "b" * 64,
+        },
+        expected_primary_path="us/statutes/42/1437c–1.yaml",
+        expected_citation="us/statute/42/1437c–1",
+        jurisdiction_prefix="us",
+    )
+    assert any("tool is not sign-applied-files" in issue for issue in issues)
+
+
 def test_receipt_identity_binds_every_transaction_dimension() -> None:
     payload = receipt_identity_payload(
         base_commit="a" * 40,
@@ -554,6 +570,33 @@ def test_receipt_authority_rejects_relabelled_generated_v1_bytes(
 
     assert replacements is None
     assert any("runner/backend mismatch" in issue for issue in issues)
+
+
+def test_receipt_authority_rejects_generated_bytes_under_old_manual_class(
+    tmp_path: Path,
+) -> None:
+    checkout, _content_root, _source = _generated_unicode_checkout(tmp_path)
+    legacy, replacement = _generated_unicode_receipt_blocks(checkout)
+    legacy["owner_class"] = "v1-manual-hmac-untrusted"
+    base_commit = subprocess.run(
+        ["git", "-C", str(checkout), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    replacements, issues = _legacy_replacement_authoritative_map(
+        checkout,
+        base_commit=base_commit,
+        manifest_label=(
+            ".axiom/encoding-manifests/us/statutes/42/1437c-1.json"
+        ),
+        legacy=legacy,
+        replacement=replacement,
+    )
+
+    assert replacements is None
+    assert any("tool is not sign-applied-files" in issue for issue in issues)
 
 
 def test_contract_rejects_generated_v1_with_wrong_citation(tmp_path: Path) -> None:

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1430"
+ENCODER_VERSION = "0.2.1431"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1431"
+ENCODER_VERSION = "0.2.1432"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1430"
+ENCODER_VERSION = "0.2.1431"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1431"
+ENCODER_VERSION = "0.2.1432"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1430"
+ENCODER_VERSION = "0.2.1431"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1431"
+ENCODER_VERSION = "0.2.1432"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1430"
+ENCODER_VERSION = "0.2.1431"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1431"
+ENCODER_VERSION = "0.2.1432"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -389,6 +389,8 @@ def _write_legacy_replacement_change(
     omitted_dependent: bool = False,
     omitted_scheduled_companion: bool = False,
     exact_dependent: bool = False,
+    generated_exact_dependent: bool = False,
+    legacy_owner_class: str = "v1-hmac-untrusted",
 ) -> tuple[Path, Path, Path, Path]:
     old_rule = repo / "us/statutes/47:32.yaml"
     old_test = repo / "us/statutes/47:32.test.yaml"
@@ -462,7 +464,14 @@ def _write_legacy_replacement_change(
         exact_primary.parent.mkdir(parents=True, exist_ok=True)
         exact_primary.write_text(
             "format: rulespec/v1\n"
-            "imports:\n"
+            + (
+                "module:\n"
+                "  source_verification:\n"
+                "    corpus_citation_path: us/statute/26/1\n"
+                if generated_exact_dependent
+                else ""
+            )
+            + "imports:\n"
             "  - us:statutes/47:32#amount\n"
             "rules:\n"
             "  - name: liability\n"
@@ -485,37 +494,66 @@ def _write_legacy_replacement_change(
         )
         exact_companion.write_text("[]\n", encoding="utf-8")
         exact_manifest.parent.mkdir(parents=True, exist_ok=True)
-        exact_manifest.write_text(
-            json.dumps(
-                {
-                    "schema_version": "axiom-encode/applied-rulespec/v1",
-                    "tool": "axiom-encode sign-applied-files",
-                    "backend": "manual",
-                    "runner": "manual-attestation",
-                    "manual_exception": "test exact dependent evidence",
-                    "applied_files": [
-                        {
-                            "path": exact_primary.relative_to(repo).as_posix(),
-                            "sha256": hashlib.sha256(
-                                exact_primary.read_bytes()
-                            ).hexdigest(),
-                        },
-                        {
-                            "path": exact_companion.relative_to(repo).as_posix(),
-                            "sha256": hashlib.sha256(
-                                exact_companion.read_bytes()
-                            ).hexdigest(),
-                        },
-                    ],
-                    "signature": {
-                        "algorithm": "hmac-sha256",
-                        "key_id": "historical-v1",
-                        "value": "opaque-untrusted-evidence",
-                    },
+        exact_applied_files = [
+            {
+                "path": exact_primary.relative_to(repo).as_posix(),
+                "sha256": hashlib.sha256(exact_primary.read_bytes()).hexdigest(),
+            },
+            {
+                "path": exact_companion.relative_to(repo).as_posix(),
+                "sha256": hashlib.sha256(exact_companion.read_bytes()).hexdigest(),
+            },
+        ]
+        exact_legacy_payload = {
+            "schema_version": "axiom-encode/applied-rulespec/v1",
+            "tool": "axiom-encode sign-applied-files",
+            "backend": "manual",
+            "runner": "manual-attestation",
+            "manual_exception": "test exact dependent evidence",
+            "applied_files": exact_applied_files,
+            "signature": {
+                "algorithm": "hmac-sha256",
+                "key_id": "historical-v1",
+                "value": "opaque-untrusted-evidence",
+            },
+        }
+        if generated_exact_dependent:
+            exact_legacy_payload = {
+                "schema_version": "axiom-encode/applied-rulespec/v1",
+                "tool": "axiom-encode encode --apply",
+                "backend": "codex",
+                "runner": "codex-gpt-5.5",
+                "model": "gpt-5.5",
+                "citation": "us/statute/26/1",
+                "generated_at": "2026-07-16T19:07:09.279448+00:00",
+                "run_id": "generated-exact-dependent",
+                "axiom_encode_version": "0.2.1200",
+                "axiom_encode_git": {
+                    "commit": "c" * 40,
+                    "dirty_tracked": False,
+                    "root": "/tmp/axiom-encode",
+                    "version": "0.2.1200",
+                    "version_commit": "c" * 40,
                 },
-                sort_keys=True,
-            )
-            + "\n",
+                "generation_prompt_sha256": "d" * 64,
+                "generated_output_root": "/tmp/axiom-generated",
+                "generated_output_file": (
+                    "/tmp/axiom-generated/us/policies/income_tax/composite.yaml"
+                ),
+                "generated_output_sha256": exact_applied_files[0]["sha256"],
+                "trace_file": "/tmp/axiom-generated/trace.json",
+                "trace_sha256": "e" * 64,
+                "context_manifest_file": "/tmp/axiom-generated/context.json",
+                "context_manifest_sha256": "f" * 64,
+                "applied_files": exact_applied_files,
+                "signature": {
+                    "algorithm": "hmac-sha256",
+                    "key_id": "axiom-encode-apply-v1",
+                    "value": "1" * 64,
+                },
+            }
+        exact_manifest.write_text(
+            json.dumps(exact_legacy_payload, sort_keys=True) + "\n",
             encoding="utf-8",
         )
     _git(repo, "add", ".")
@@ -603,7 +641,7 @@ def _write_legacy_replacement_change(
             "base_tree": base_tree,
         },
         "legacy": {
-            "owner_class": "v1-hmac-untrusted",
+            "owner_class": legacy_owner_class,
             "trusted_generated_provenance": False,
             "manifest": {
                 "path": old_manifest.relative_to(repo).as_posix(),
@@ -979,11 +1017,26 @@ def _refresh_legacy_receipt_bindings(
         )
 
 
+@pytest.mark.parametrize(
+    ("legacy_owner_class", "generated_exact_dependent"),
+    [
+        ("v1-hmac-untrusted", False),
+        ("v1-manual-hmac-untrusted", False),
+        ("v1-hmac-untrusted", True),
+    ],
+)
 def test_stage_accepts_v2_exact_dependent_with_unchanged_companion(
     tmp_path: Path,
+    legacy_owner_class: str,
+    generated_exact_dependent: bool,
 ) -> None:
     repo = _repo(tmp_path)
-    _write_legacy_replacement_change(repo, exact_dependent=True)
+    _write_legacy_replacement_change(
+        repo,
+        exact_dependent=True,
+        generated_exact_dependent=generated_exact_dependent,
+        legacy_owner_class=legacy_owner_class,
+    )
 
     expected = authorized_changed_paths(repo)
     stage_authorized_changes(repo)
@@ -993,6 +1046,21 @@ def test_stage_accepts_v2_exact_dependent_with_unchanged_companion(
         "us/policies/income_tax/composite.test.yaml"
         not in _git(repo, "diff", "--cached", "--name-only").splitlines()
     )
+
+
+def test_stage_rejects_generated_exact_dependent_under_old_manual_owner_class(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    _write_legacy_replacement_change(
+        repo,
+        exact_dependent=True,
+        generated_exact_dependent=True,
+        legacy_owner_class="v1-manual-hmac-untrusted",
+    )
+
+    with pytest.raises(ValueError, match="exact dependent legacy ownership is invalid"):
+        authorized_changed_paths(repo)
 
 
 def test_stage_keeps_v1_legacy_replacement_compatible(tmp_path: Path) -> None:

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -603,7 +603,7 @@ def _write_legacy_replacement_change(
             "base_tree": base_tree,
         },
         "legacy": {
-            "owner_class": "v1-manual-hmac-untrusted",
+            "owner_class": "v1-hmac-untrusted",
             "trusted_generated_provenance": False,
             "manifest": {
                 "path": old_manifest.relative_to(repo).as_posix(),

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1430"')
+        .startswith('__version__ = "0.2.1431"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1430"
+    assert encoder_package["version"] == "0.2.1431"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1430"
+    assert project["project"]["version"] == "0.2.1431"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1430"')
+        .startswith('__version__ = "0.2.1431"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1430"
+    assert encoder_package["version"] == "0.2.1431"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1430"
+    assert project["project"]["version"] == "0.2.1431"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1430"')
+        .startswith('__version__ = "0.2.1431"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1431"')
+        .startswith('__version__ = "0.2.1432"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1431"
+    assert encoder_package["version"] == "0.2.1432"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1431"
+    assert project["project"]["version"] == "0.2.1432"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1431"')
+        .startswith('__version__ = "0.2.1432"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1431"
+    assert encoder_package["version"] == "0.2.1432"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1431"
+    assert project["project"]["version"] == "0.2.1432"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1431"')
+        .startswith('__version__ = "0.2.1432"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1430"
+ENCODER_VERSION = "0.2.1431"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1431"
+ENCODER_VERSION = "0.2.1432"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1430"
+version = "0.2.1431"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1431"
+version = "0.2.1432"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- admit one exact historical generated-v1 HMAC manifest shape as **untrusted evidence** for fresh signed legacy replacement
- bind authority to the reviewed full Git base, exact primary/test/manifest blobs, signed corpus identity, and unique canonical destination rather than trusting the historical HMAC
- preserve old signed manual-v1 receipts only when their underlying evidence remains strictly manual; new umbrella receipts can carry strict manual or generated subclasses without relabeling
- enforce the same owner-subclass contract in runtime receipt verification and publication staging, including v2 exact dependents
- reject stale citations, relabeled runners, mixed path scopes, malformed signatures, unexpected fields, mismatched hashes, non-scalar backends, and non-scalar receipt owner classes
- cover the exact `us/statutes/42/1437c–1.yaml` jurisdiction-relative manifest shape and bump encoder identity to `0.2.1432`

## Checks
- focused legacy, signed CLI, and publication-staging matrix: 151 passed
- prescribed full Ruff and compileall: passed
- diff and formatting checks: passed
- exact authenticated 8dd Unicode manifest against exact primary/test blobs: zero issues
- compatibility matrix at both runtime and staging: new/manual pass, old/manual pass, new/generated pass, old/generated fail closed

## Protected-run context
- run 30848668534 reached the semantic ownership guard and emitted zero signatures
- run 30848985648 proved an in-place upgrade cannot compile at a noncanonical Unicode path and emitted zero signatures
- this change enables the only valid atomic route: fresh re-encode directly to the unique normalized path with a signed v5 replacement receipt

## Cycle
Independent review found and the patch fixed: prefix-only runner binding, missing exact manifest/Git field allowlists, non-scalar backend crashes, overbroad old-label compatibility, non-scalar receipt-owner crashes, and missing exact-dependent publication validation. Regression coverage was added for every finding. Fresh final independent review of substantive commit `201e7d6ba4425847dda739e81a6ad4506e97c864` was CLEAN. After hosted CI correctly required a version bump, a fresh independent exact-head review of `f3ea84b926215051daa5191cc672b82978a6bfd9` confirmed the delta is exclusively the consistent `0.2.1432` bump, the lock is valid, the branch is clean, and there are no actionable findings. Exact-head focused checks: 30 passed; prescribed Ruff, compileall, and diff checks passed. Hosted CI is still pending; do not merge until every required check is green.