### PR TITLE
fix: scope legacy replacement validation overlays

### DIFF
--- a/changelog.d/targeted-legacy-overlay-scope.fixed.md
+++ b/changelog.d/targeted-legacy-overlay-scope.fixed.md
@@ -1,0 +1,1 @@
+Scope targeted legacy-replacement compile overlays to the active jurisdiction and its ancestors so unrelated legacy state paths cannot block an atomic canonical migration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1433"
+version = "0.2.1434"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1432"
+version = "0.2.1433"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1432"
+__version__ = "0.2.1433"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1433"
+__version__ = "0.2.1434"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -310,6 +310,9 @@ from .legacy_replacement_overlay import (
     LegacyReplacementOverlayError as _LegacyReplacementOverlayError,
 )
 from .legacy_replacement_overlay import (
+    scope_legacy_replacement_overlay as _scope_legacy_replacement_overlay,
+)
+from .legacy_replacement_overlay import (
     stage_legacy_replacement_overlay as _stage_legacy_replacement_overlay,
 )
 from .oracles.policyengine.pending import (
@@ -48595,6 +48598,14 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
             source=policy_checkout_path,
             target=overlay_repo,
         )
+        if legacy_replacement is not None:
+            try:
+                _scope_legacy_replacement_overlay(
+                    overlay_repo,
+                    active_jurisdiction=policy_content_root.name,
+                )
+            except _LegacyReplacementOverlayError as exc:
+                return False, [str(exc)], {}
         overlay_content_root = overlay_repo / policy_content_root.name
         if canonical_rulespec_root_identity(overlay_content_root) is None:
             raise ValueError(

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -45,7 +45,11 @@ from axiom_encode.constants import (
     RULESPEC_TEST_FILE_SUFFIX,
 )
 from axiom_encode.legacy_replacement import LegacyReplacementContract
-from axiom_encode.legacy_replacement_overlay import stage_legacy_replacement_overlay
+from axiom_encode.legacy_replacement_overlay import (
+    LegacyReplacementOverlayError,
+    legacy_replacement_excluded_jurisdictions,
+    stage_legacy_replacement_overlay,
+)
 from axiom_encode.prompts.encoder import SOURCE_SCOPE_PROTOCOL
 from axiom_encode.repo_routing import (
     canonical_rulespec_repo_name,
@@ -7612,6 +7616,7 @@ def _copy_validation_overlay_tree(
     destination: Path,
     *,
     dirs_exist_ok: bool = False,
+    ignore: Callable[[str, list[str]], set[str]] = _validation_overlay_ignore,
 ) -> None:
     """Copy a validation tree without ever dereferencing source symlinks."""
     safe_source = validate_rulespec_context_directory(source, source)
@@ -7623,9 +7628,46 @@ def _copy_validation_overlay_tree(
         safe_source,
         destination,
         symlinks=True,
-        ignore=_validation_overlay_ignore,
+        ignore=ignore,
         dirs_exist_ok=dirs_exist_ok,
     )
+
+
+def _legacy_replacement_overlay_ignore(
+    source_checkout: Path,
+    *,
+    active_jurisdiction: str,
+) -> Callable[[str, list[str]], set[str]]:
+    """Exclude unrelated jurisdiction trees while preserving symlink checks."""
+
+    try:
+        excluded = legacy_replacement_excluded_jurisdictions(
+            source_checkout,
+            active_jurisdiction=active_jurisdiction,
+        )
+    except LegacyReplacementOverlayError as exc:
+        raise UnsafeRulespecContextPath(
+            f"Legacy replacement validation source is invalid: {exc}"
+        ) from exc
+    checkout = source_checkout.resolve()
+    manifest_root = checkout / ".axiom" / "encoding-manifests"
+
+    def ignore(directory: str, names: list[str]) -> set[str]:
+        ignored = _validation_overlay_ignore(directory, names)
+        current = Path(directory).resolve()
+        if current not in {checkout, manifest_root}:
+            return ignored
+        for name in set(names) & excluded:
+            candidate = Path(directory) / name
+            if candidate.is_symlink() or not candidate.is_dir():
+                raise UnsafeRulespecContextPath(
+                    "Legacy replacement validation source jurisdiction is unsafe: "
+                    f"{candidate}"
+                )
+            ignored.add(name)
+        return ignored
+
+    return ignore
 
 
 @contextlib.contextmanager
@@ -7689,9 +7731,18 @@ def _rulespec_validation_target(
                 overlay_parent / dependency_root.name,
             )
         overlay_repo = overlay_parent / overlay_repo_name
+        overlay_ignore = (
+            _legacy_replacement_overlay_ignore(
+                source_checkout,
+                active_jurisdiction=policy_root.name,
+            )
+            if legacy_replacement is not None
+            else _validation_overlay_ignore
+        )
         _copy_validation_overlay_tree(
             source_checkout,
             overlay_repo,
+            ignore=overlay_ignore,
         )
         validation_content_root = overlay_repo / policy_root.name
         if canonical_rulespec_root_identity(validation_content_root) != identity:

--- a/src/axiom_encode/legacy_replacement_overlay.py
+++ b/src/axiom_encode/legacy_replacement_overlay.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import re
 import shutil
 from pathlib import Path
 
@@ -17,6 +18,33 @@ from .repo_routing import jurisdiction_subdir_names
 
 class LegacyReplacementOverlayError(ValueError):
     """Raised when an authenticated replacement cannot be staged exactly."""
+
+
+def _manifest_jurisdiction_subdir_names(
+    source_checkout: Path,
+    *,
+    country: str,
+) -> frozenset[str]:
+    """Return validated jurisdiction directories in the manifest tree."""
+
+    manifest_root = source_checkout / ENCODING_MANIFEST_DIR
+    if not manifest_root.exists() and not manifest_root.is_symlink():
+        return frozenset()
+    if manifest_root.is_symlink() or not manifest_root.is_dir():
+        raise LegacyReplacementOverlayError(
+            f"Legacy replacement manifest root is unsafe: {manifest_root}"
+        )
+    jurisdiction_pattern = re.compile(rf"{re.escape(country)}(?:-[a-z0-9]+)*")
+    jurisdictions: set[str] = set()
+    for child in manifest_root.iterdir():
+        if jurisdiction_pattern.fullmatch(child.name) is None:
+            continue
+        if child.is_symlink() or not child.is_dir():
+            raise LegacyReplacementOverlayError(
+                f"Legacy replacement manifest jurisdiction is unsafe: {child}"
+            )
+        jurisdictions.add(child.name)
+    return frozenset(jurisdictions)
 
 
 def legacy_replacement_excluded_jurisdictions(
@@ -34,16 +62,20 @@ def legacy_replacement_excluded_jurisdictions(
 
     parts = active_jurisdiction.split("-")
     admitted = {"-".join(parts[:length]) for length in range(1, len(parts) + 1)}
-    available = jurisdiction_subdir_names(
+    content_jurisdictions = jurisdiction_subdir_names(
         source_checkout,
         allow_composition_specs=True,
     )
-    if active_jurisdiction not in available:
+    if active_jurisdiction not in content_jurisdictions:
         raise LegacyReplacementOverlayError(
             "Legacy replacement source is missing the active jurisdiction: "
             f"{active_jurisdiction}"
         )
-    return frozenset(available - admitted)
+    manifest_jurisdictions = _manifest_jurisdiction_subdir_names(
+        source_checkout,
+        country=active_jurisdiction.split("-", 1)[0],
+    )
+    return frozenset((content_jurisdictions | manifest_jurisdictions) - admitted)
 
 
 def scope_legacy_replacement_overlay(

--- a/src/axiom_encode/legacy_replacement_overlay.py
+++ b/src/axiom_encode/legacy_replacement_overlay.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import shutil
 from pathlib import Path
 
 from .legacy_replacement import (
@@ -11,10 +12,64 @@ from .legacy_replacement import (
     LegacyReplacementFile,
     LegacyReplacementRewrite,
 )
+from .repo_routing import jurisdiction_subdir_names
 
 
 class LegacyReplacementOverlayError(ValueError):
     """Raised when an authenticated replacement cannot be staged exactly."""
+
+
+def legacy_replacement_excluded_jurisdictions(
+    source_checkout: Path,
+    *,
+    active_jurisdiction: str,
+) -> frozenset[str]:
+    """Return sibling jurisdictions excluded from a migration capability.
+
+    Legacy replacement validation admits the active jurisdiction and its
+    country ancestors. Unrelated siblings remain outside the isolated overlay,
+    so their authenticated pre-hard-cut paths cannot broaden or block this
+    replacement. The live checkout is never changed.
+    """
+
+    parts = active_jurisdiction.split("-")
+    admitted = {"-".join(parts[:length]) for length in range(1, len(parts) + 1)}
+    available = jurisdiction_subdir_names(
+        source_checkout,
+        allow_composition_specs=True,
+    )
+    if active_jurisdiction not in available:
+        raise LegacyReplacementOverlayError(
+            "Legacy replacement source is missing the active jurisdiction: "
+            f"{active_jurisdiction}"
+        )
+    return frozenset(available - admitted)
+
+
+def scope_legacy_replacement_overlay(
+    overlay_checkout: Path,
+    *,
+    active_jurisdiction: str,
+) -> None:
+    """Remove unrelated jurisdictions from one isolated migration overlay."""
+
+    excluded = legacy_replacement_excluded_jurisdictions(
+        overlay_checkout,
+        active_jurisdiction=active_jurisdiction,
+    )
+    manifest_root = overlay_checkout / ENCODING_MANIFEST_DIR
+    for jurisdiction in sorted(excluded):
+        for candidate in (
+            overlay_checkout / jurisdiction,
+            manifest_root / jurisdiction,
+        ):
+            if not candidate.exists() and not candidate.is_symlink():
+                continue
+            if candidate.is_symlink() or not candidate.is_dir():
+                raise LegacyReplacementOverlayError(
+                    f"Legacy replacement overlay jurisdiction is unsafe: {candidate}"
+                )
+            shutil.rmtree(candidate)
 
 
 def _overlay_path(checkout_root: Path, relative: Path) -> Path:

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1433"
+ENCODER_VERSION = "0.2.1434"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1432"
+ENCODER_VERSION = "0.2.1433"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13685,14 +13685,20 @@ class TestCmdEncode:
         unrelated_sibling_manifest = (
             checkout / ".axiom/encoding-manifests/us-nj/statutes/54a:4-7.json"
         )
+        orphan_sibling_manifest = (
+            checkout / ".axiom/encoding-manifests/us-tx/statutes/11/orphan.json"
+        )
         federal_ancestor.parent.mkdir(parents=True)
         unrelated_sibling.parent.mkdir(parents=True)
         unrelated_sibling_manifest.parent.mkdir(parents=True)
+        orphan_sibling_manifest.parent.mkdir(parents=True)
         federal_ancestor.write_text("format: rulespec/v1\nrules: []\n")
         unrelated_sibling.write_text("format: rulespec/v1\nrules: []\n")
         unrelated_sibling_manifest.write_text("{}\n")
+        orphan_sibling_manifest.write_text("{}\n")
         unrelated_sibling_before = unrelated_sibling.read_bytes()
         unrelated_sibling_manifest_before = unrelated_sibling_manifest.read_bytes()
+        orphan_sibling_manifest_before = orphan_sibling_manifest.read_bytes()
         source_relative = Path("us-la/statutes/47:32.yaml")
         destination_relative = Path("us-la/statutes/47/32.yaml")
         source = checkout / source_relative
@@ -13912,6 +13918,7 @@ class TestCmdEncode:
             assert (overlay_checkout / "us/statutes/26/1.yaml").is_file()
             assert not (overlay_checkout / "us-nj").exists()
             assert not (overlay_checkout / ".axiom/encoding-manifests/us-nj").exists()
+            assert not (overlay_checkout / ".axiom/encoding-manifests/us-tx").exists()
             assert not (overlay_checkout / source_relative).exists()
             assert not (
                 overlay_checkout / _applied_encoding_manifest_path(source_relative)
@@ -13955,6 +13962,7 @@ class TestCmdEncode:
         assert (
             unrelated_sibling_manifest.read_bytes() == unrelated_sibling_manifest_before
         )
+        assert orphan_sibling_manifest.read_bytes() == orphan_sibling_manifest_before
         assert b"us-la:statutes/47/32#amount" in observed_overlay["bytes"]
         assert b"us-la:statutes/47:32#amount" not in observed_overlay["bytes"]
         assert (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13680,6 +13680,19 @@ class TestCmdEncode:
         output_root = tmp_path / "out"
         checkout = tmp_path / "rulespec-us"
         content_root = checkout / "us-la"
+        federal_ancestor = checkout / "us/statutes/26/1.yaml"
+        unrelated_sibling = checkout / "us-nj/statutes/54a:4-7.yaml"
+        unrelated_sibling_manifest = (
+            checkout / ".axiom/encoding-manifests/us-nj/statutes/54a:4-7.json"
+        )
+        federal_ancestor.parent.mkdir(parents=True)
+        unrelated_sibling.parent.mkdir(parents=True)
+        unrelated_sibling_manifest.parent.mkdir(parents=True)
+        federal_ancestor.write_text("format: rulespec/v1\nrules: []\n")
+        unrelated_sibling.write_text("format: rulespec/v1\nrules: []\n")
+        unrelated_sibling_manifest.write_text("{}\n")
+        unrelated_sibling_before = unrelated_sibling.read_bytes()
+        unrelated_sibling_manifest_before = unrelated_sibling_manifest.read_bytes()
         source_relative = Path("us-la/statutes/47:32.yaml")
         destination_relative = Path("us-la/statutes/47/32.yaml")
         source = checkout / source_relative
@@ -13895,6 +13908,16 @@ class TestCmdEncode:
             dependents,
         ):
             del dependent_pipeline
+            overlay_checkout = overlay_target.parents[3]
+            assert (overlay_checkout / "us/statutes/26/1.yaml").is_file()
+            assert not (overlay_checkout / "us-nj").exists()
+            assert not (overlay_checkout / ".axiom/encoding-manifests/us-nj").exists()
+            assert not (overlay_checkout / source_relative).exists()
+            assert not (
+                overlay_checkout / _applied_encoding_manifest_path(source_relative)
+            ).exists()
+            assert overlay_target.is_file()
+            assert overlay_target.read_bytes() == generated.read_bytes()
             exact_path = next(
                 path
                 for path in dependents
@@ -13926,6 +13949,12 @@ class TestCmdEncode:
         assert can_apply is True, issues
         assert issues == []
         assert supplemental == {}
+        assert source.is_file()
+        assert source_manifest.is_file()
+        assert unrelated_sibling.read_bytes() == unrelated_sibling_before
+        assert (
+            unrelated_sibling_manifest.read_bytes() == unrelated_sibling_manifest_before
+        )
         assert b"us-la:statutes/47/32#amount" in observed_overlay["bytes"]
         assert b"us-la:statutes/47:32#amount" not in observed_overlay["bytes"]
         assert (

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -4345,6 +4345,9 @@ def _unicode_path_replacement_fixture(
     manifest_file.parent.mkdir(parents=True, exist_ok=True)
     manifest_raw = b'{"schema_version":"axiom-encode/applied-rulespec/v1"}\n'
     manifest_file.write_bytes(manifest_raw)
+    unrelated_legacy = checkout / "us-nj/statutes/54a:4-7.yaml"
+    unrelated_legacy.parent.mkdir(parents=True, exist_ok=True)
+    unrelated_legacy.write_text("format: rulespec/v1\nrules: []\n")
 
     def bound_file(path: Path, raw: bytes) -> LegacyReplacementFile:
         return LegacyReplacementFile(path, hashlib.sha256(raw).hexdigest(), raw)
@@ -4383,9 +4386,39 @@ def test_rulespec_prevalidation_stages_authenticated_unicode_path_replacement(
         assert validation_file.read_text() == "format: rulespec/v1\nrules: []\n"
         assert not (checkout / contract.source).exists()
         assert not (checkout / contract.legacy_manifest.path).exists()
+        assert not (checkout / "us-nj").exists()
         assert all(
             part.isascii() for path in checkout.rglob("*") for part in path.parts
         )
+
+
+def test_legacy_replacement_overlay_keeps_active_ancestor_chain(tmp_path):
+    state_root = _canonical_rulespec_content_root(tmp_path, "us-or")
+    checkout = state_root.parent
+    (checkout / "us").mkdir()
+    (checkout / "us-nj").mkdir()
+    manifest_root = checkout / ".axiom/encoding-manifests"
+    for jurisdiction in ("us", "us-or", "us-nj"):
+        manifest_dir = manifest_root / jurisdiction
+        manifest_dir.mkdir(parents=True, exist_ok=True)
+        (manifest_dir / "marker.json").write_text("{}\n")
+
+    copied = tmp_path / "copy" / "rulespec-us"
+    evals_module._copy_validation_overlay_tree(
+        checkout,
+        copied,
+        ignore=evals_module._legacy_replacement_overlay_ignore(
+            checkout,
+            active_jurisdiction="us-or",
+        ),
+    )
+
+    assert (copied / "us").is_dir()
+    assert (copied / state_root.name).is_dir()
+    assert not (copied / "us-nj").exists()
+    assert (copied / ".axiom/encoding-manifests/us/marker.json").is_file()
+    assert (copied / ".axiom/encoding-manifests/us-or/marker.json").is_file()
+    assert not (copied / ".axiom/encoding-manifests/us-nj").exists()
 
 
 def test_rulespec_prevalidation_rejects_changed_legacy_replacement_input(tmp_path):

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -122,6 +122,7 @@ from axiom_encode.harness.validator_pipeline import (
 from axiom_encode.legacy_replacement import (
     LegacyReplacementContract,
     LegacyReplacementFile,
+    LegacyReplacementRewrite,
 )
 from axiom_encode.repo_routing import find_policy_repo_root, monorepo_checkout_name
 from axiom_encode.signing_broker import get_signing_broker
@@ -4419,6 +4420,34 @@ def test_legacy_replacement_overlay_keeps_active_ancestor_chain(tmp_path):
     assert (copied / ".axiom/encoding-manifests/us/marker.json").is_file()
     assert (copied / ".axiom/encoding-manifests/us-or/marker.json").is_file()
     assert not (copied / ".axiom/encoding-manifests/us-nj").exists()
+
+
+def test_rulespec_prevalidation_rejects_excluded_sibling_rewrite(tmp_path):
+    policy_repo, generated, contract = _unicode_path_replacement_fixture(tmp_path)
+    sibling = Path("us-nj/statutes/54a:4-7.yaml")
+    sibling_raw = (policy_repo.parent / sibling).read_bytes()
+    replacement_raw = b"format: rulespec/v1\nrules:\n  - name: changed\n"
+    contract = contract._replace(
+        rewrites=(
+            LegacyReplacementRewrite(
+                path=sibling,
+                before_sha256=hashlib.sha256(sibling_raw).hexdigest(),
+                after_sha256=hashlib.sha256(replacement_raw).hexdigest(),
+                replacements=(),
+                raw=replacement_raw,
+            ),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="rewrite input is not a regular file"):
+        with _rulespec_validation_target(
+            generated,
+            policy_repo,
+            legacy_replacement=contract,
+        ):
+            pass
+
+    assert (policy_repo.parent / sibling).read_bytes() == sibling_raw
 
 
 def test_rulespec_prevalidation_rejects_changed_legacy_replacement_input(tmp_path):

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -4346,6 +4346,11 @@ def _unicode_path_replacement_fixture(
     manifest_file.parent.mkdir(parents=True, exist_ok=True)
     manifest_raw = b'{"schema_version":"axiom-encode/applied-rulespec/v1"}\n'
     manifest_file.write_bytes(manifest_raw)
+    orphan_manifest = checkout / (
+        ".axiom/encoding-manifests/us-tx/statutes/11/orphan.json"
+    )
+    orphan_manifest.parent.mkdir(parents=True, exist_ok=True)
+    orphan_manifest.write_text("{}\n")
     unrelated_legacy = checkout / "us-nj/statutes/54a:4-7.yaml"
     unrelated_legacy.parent.mkdir(parents=True, exist_ok=True)
     unrelated_legacy.write_text("format: rulespec/v1\nrules: []\n")
@@ -4388,6 +4393,7 @@ def test_rulespec_prevalidation_stages_authenticated_unicode_path_replacement(
         assert not (checkout / contract.source).exists()
         assert not (checkout / contract.legacy_manifest.path).exists()
         assert not (checkout / "us-nj").exists()
+        assert not (checkout / ".axiom/encoding-manifests/us-tx").exists()
         assert all(
             part.isascii() for path in checkout.rglob("*") for part in path.parts
         )
@@ -4399,7 +4405,7 @@ def test_legacy_replacement_overlay_keeps_active_ancestor_chain(tmp_path):
     (checkout / "us").mkdir()
     (checkout / "us-nj").mkdir()
     manifest_root = checkout / ".axiom/encoding-manifests"
-    for jurisdiction in ("us", "us-or", "us-nj"):
+    for jurisdiction in ("us", "us-or", "us-nj", "us-tx"):
         manifest_dir = manifest_root / jurisdiction
         manifest_dir.mkdir(parents=True, exist_ok=True)
         (manifest_dir / "marker.json").write_text("{}\n")
@@ -4420,6 +4426,25 @@ def test_legacy_replacement_overlay_keeps_active_ancestor_chain(tmp_path):
     assert (copied / ".axiom/encoding-manifests/us/marker.json").is_file()
     assert (copied / ".axiom/encoding-manifests/us-or/marker.json").is_file()
     assert not (copied / ".axiom/encoding-manifests/us-nj").exists()
+    assert not (copied / ".axiom/encoding-manifests/us-tx").exists()
+
+
+def test_legacy_replacement_overlay_rejects_manifest_jurisdiction_symlink(tmp_path):
+    state_root = _canonical_rulespec_content_root(tmp_path, "us-or")
+    manifest_root = state_root.parent / ".axiom/encoding-manifests"
+    manifest_root.mkdir(parents=True)
+    outside = tmp_path / "outside-manifests"
+    outside.mkdir()
+    (manifest_root / "us-tx").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(
+        UnsafeRulespecContextPath,
+        match="manifest jurisdiction is unsafe",
+    ):
+        evals_module._legacy_replacement_overlay_ignore(
+            state_root.parent,
+            active_jurisdiction="us-or",
+        )
 
 
 def test_rulespec_prevalidation_rejects_excluded_sibling_rewrite(tmp_path):

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1433"
+ENCODER_VERSION = "0.2.1434"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1432"
+ENCODER_VERSION = "0.2.1433"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1432"
+ENCODER_VERSION = "0.2.1433"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1433"
+ENCODER_VERSION = "0.2.1434"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1432"
+ENCODER_VERSION = "0.2.1433"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1433"
+ENCODER_VERSION = "0.2.1434"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1432"
+ENCODER_VERSION = "0.2.1433"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1433"
+ENCODER_VERSION = "0.2.1434"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1433"
+ENCODER_VERSION = "0.2.1434"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1432"
+ENCODER_VERSION = "0.2.1433"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1433"
+ENCODER_VERSION = "0.2.1434"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1432"
+ENCODER_VERSION = "0.2.1433"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1433"')
+        .startswith('__version__ = "0.2.1434"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1433"
+    assert encoder_package["version"] == "0.2.1434"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1433"
+    assert project["project"]["version"] == "0.2.1434"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1433"')
+        .startswith('__version__ = "0.2.1434"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1433"
+    assert encoder_package["version"] == "0.2.1434"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1433"
+    assert project["project"]["version"] == "0.2.1434"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1433"')
+        .startswith('__version__ = "0.2.1434"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1432"')
+        .startswith('__version__ = "0.2.1433"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1432"
+    assert encoder_package["version"] == "0.2.1433"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1432"
+    assert project["project"]["version"] == "0.2.1433"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1432"')
+        .startswith('__version__ = "0.2.1433"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1432"
+    assert encoder_package["version"] == "0.2.1433"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1432"
+    assert project["project"]["version"] == "0.2.1433"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1432"')
+        .startswith('__version__ = "0.2.1433"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1432"
+ENCODER_VERSION = "0.2.1433"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1433"
+ENCODER_VERSION = "0.2.1434"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1433"
+version = "0.2.1434"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1432"
+version = "0.2.1433"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- scope legacy-replacement validation overlays to the active jurisdiction and its country ancestors
- exclude unrelated jurisdiction RuleSpec and manifest trees from harness prevalidation and release-bound apply validation
- include manifest-only sibling jurisdictions in the exclusion inventory and reject unsafe manifest jurisdiction paths
- preserve fail-closed symlink checks and leave the source checkout unchanged
- bump the encoder to `0.2.1434`

## Why
The protected federal hard-cut repair generated the canonical target, but compilation scanned unrelated legacy state paths such as `us-nj/statutes/54a:4-7.yaml` and failed before signing. A replacement capability should validate the active jurisdiction and required ancestors, not unrelated sibling jurisdictions.

## Checks
- exact pinned hard-cut reproduction: `us/statutes/42/1437c-1.yaml` compiled successfully with rules engine `05eac9d2f89dabe5c6673176260762cef3a58f47`; unrelated `us-nj`, `us-la`, and manifest trees absent from overlay
- full local suite: 6,191 passed, 119 skipped
- focused harness overlay/replacement tests: 19 passed
- parameterized CLI legacy migration tests: 2 passed
- `ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv lock --check --offline`
- `git diff --check`
- hosted CI, signing supervisor macOS, and signing supervisor Ubuntu: green

## Review Cycle
- independent review at `47952211`: P2 found for manifest-only sibling jurisdictions
- fixed by validated union of content and manifest jurisdiction inventories, with harness/CLI and symlink regressions
- independent re-review: **CLEAN** at exact head `b8a270adde3ed9131ebc35a4fd0ea86da1bad16d`