### PR TITLE
Authenticate occupied canonical legacy replacements

### DIFF
--- a/changelog.d/legacy-canonical-predecessor.fixed.md
+++ b/changelog.d/legacy-canonical-predecessor.fixed.md
@@ -1,0 +1,1 @@
+Allow targeted legacy replacement to absorb an occupied canonical destination only when its unowned files are the exact base-bound canonical projection of the authenticated legacy group, with predecessor evidence recorded in a signed v3 receipt and rechecked atomically.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1436"
+version = "0.2.1437"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -19,6 +19,7 @@ LEGACY_REPLACEMENT_RECEIPT_ROOT = PurePosixPath(".axiom/legacy-replacements")
 LEGACY_REPLACEMENT_TOOL = "axiom-encode encode --apply --replace-legacy-rulespec-path"
 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V1 = "axiom-encode/legacy-fresh-reencode-receipt/v1"
 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2 = "axiom-encode/legacy-fresh-reencode-receipt/v2"
+LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3 = "axiom-encode/legacy-fresh-reencode-receipt/v3"
 LEGACY_EXACT_DEPENDENT_TOOL = (
     "axiom-encode encode --apply --legacy-exact-dependent-rulespec-path"
 )
@@ -1068,6 +1069,7 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                 not in {
                     LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V1,
                     LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
+                    LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                 }
                 or receipt.get("tool") != LEGACY_REPLACEMENT_TOOL
             ):
@@ -1125,6 +1127,18 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                 raise ValueError(
                     f"legacy replacement exact_dependents are malformed: {relative}"
                 )
+            if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3 and (
+                not isinstance(
+                    receipt_replacement.get("destination_predecessor_class"), str
+                )
+                or not isinstance(
+                    receipt_replacement.get("destination_predecessor_files"), list
+                )
+            ):
+                raise ValueError(
+                    "legacy replacement destination predecessor files are malformed: "
+                    f"{relative}"
+                )
             nested_manifest = payload.get("replacement_manifest")
             if (
                 not isinstance(nested_manifest, dict)
@@ -1140,6 +1154,7 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                 repository.get("base_commit") if isinstance(repository, dict) else None
             )
             from axiom_encode.cli import (
+                _legacy_destination_predecessor_issues,
                 _legacy_replacement_authoritative_map,
                 _legacy_replacement_reference_inventory_issues,
                 _strict_legacy_replacement_map,
@@ -1158,6 +1173,26 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                 raise ValueError(
                     f"legacy replacement authority differs: {relative}: "
                     + "; ".join(authority_issues)
+                )
+            if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3:
+                predecessor_issues = _legacy_destination_predecessor_issues(
+                    repo,
+                    base_commit=str(base_commit or ""),
+                    authoritative_replacements=authoritative_replacements,
+                    legacy=legacy,
+                    replacement=receipt_replacement,
+                )
+                if predecessor_issues:
+                    raise ValueError(
+                        f"legacy replacement destination predecessor differs: {relative}: "
+                        + "; ".join(predecessor_issues)
+                    )
+                authorized_unchanged.update(
+                    PurePosixPath(item["path"])
+                    for item in receipt_replacement["destination_predecessor_files"]
+                    if isinstance(item, dict)
+                    and isinstance(item.get("path"), str)
+                    and PurePosixPath(item["path"]) not in changed
                 )
             from axiom_encode.rulespec_path_migration import (
                 PathMigrationPlanError,
@@ -1429,7 +1464,10 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                     f"legacy replacement reference inventory differs: {relative}: "
                     + "; ".join(inventory_issues)
                 )
-            if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2:
+            if receipt_schema in {
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
+            }:
                 authorized_unchanged.update(
                     _validate_legacy_exact_dependents(
                         repo,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1436"
+__version__ = "0.2.1437"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -258,6 +258,12 @@ from .harness.validator_pipeline import (
     repair_source_table_band_scalar_parameters,
 )
 from .legacy_replacement import (
+    DESTINATION_PREDECESSOR_ABSENT as APPLIED_ENCODING_DESTINATION_PREDECESSOR_ABSENT,
+)
+from .legacy_replacement import (
+    DESTINATION_PREDECESSOR_CANONICALIZED_UNOWNED_DUPLICATE as APPLIED_ENCODING_DESTINATION_PREDECESSOR_CANONICALIZED_UNOWNED_DUPLICATE,
+)
+from .legacy_replacement import (
     EXACT_DEPENDENT_TOOL as APPLIED_ENCODING_LEGACY_EXACT_DEPENDENT_TOOL,
 )
 from .legacy_replacement import (
@@ -274,6 +280,9 @@ from .legacy_replacement import (
 )
 from .legacy_replacement import (
     RECEIPT_SCHEMA_V1 as APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V1,
+)
+from .legacy_replacement import (
+    RECEIPT_SCHEMA_V2 as APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
 )
 from .legacy_replacement import (
     TOOL as APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL,
@@ -7151,6 +7160,201 @@ def _legacy_replacement_authoritative_map(
     return replacements, []
 
 
+def _legacy_destination_manifest_claimants_at_base(
+    repo_path: Path,
+    *,
+    base_commit: str,
+    destination_paths: set[Path],
+) -> list[Path]:
+    """Return base manifests that claim any unowned destination predecessor.
+
+    Historical v1 manifests may record either checkout-relative or
+    jurisdiction-relative paths. Inspect the authorized Git base rather than
+    the live post-transaction tree so a freshly installed owner cannot be
+    confused with preexisting authority.
+    """
+
+    if not destination_paths:
+        return []
+    patterns = sorted(
+        {
+            candidate
+            for path in destination_paths
+            for candidate in (
+                path.as_posix(),
+                path.relative_to(path.parts[0]).as_posix(),
+            )
+        }
+    )
+    if len(patterns) > 4:
+        raise RuntimeError("Legacy destination predecessor group is oversized")
+    command = ["git", "-C", str(repo_path), "grep", "-z", "-l", "-a", "-F"]
+    for pattern in patterns:
+        command.extend(("-e", pattern))
+    command.extend((base_commit, "--"))
+    completed = subprocess.run(
+        command,
+        capture_output=True,
+        env=_rulespec_migration_git_environment(),
+        check=False,
+    )
+    if completed.returncode not in {0, 1}:
+        stderr = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(
+            f"Cannot scan legacy destination manifest ownership: {stderr}"
+        )
+
+    prefix = f"{base_commit}:".encode()
+    claimants: set[Path] = set()
+    for encoded_candidate in completed.stdout.split(b"\0"):
+        if not encoded_candidate:
+            continue
+        if not encoded_candidate.startswith(prefix):
+            raise RuntimeError("Legacy destination manifest candidate is malformed")
+        try:
+            candidate_text = encoded_candidate[len(prefix) :].decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise RuntimeError(
+                "Legacy destination manifest candidate is not UTF-8"
+            ) from exc
+        candidate = Path(candidate_text)
+        try:
+            relative = candidate.relative_to(APPLIED_ENCODING_MANIFEST_DIR)
+        except ValueError:
+            continue
+        if (
+            candidate.is_absolute()
+            or candidate.as_posix() != candidate_text
+            or any(part in {"", ".", ".."} for part in candidate.parts)
+            or candidate.suffix != ".json"
+            or len(relative.parts) < 2
+        ):
+            raise RuntimeError("Legacy destination manifest candidate is malformed")
+        claimants.add(candidate)
+    return sorted(claimants, key=Path.as_posix)
+
+
+def _legacy_destination_predecessor_issues(
+    repo_path: Path,
+    *,
+    base_commit: str,
+    authoritative_replacements: Mapping[str, str],
+    legacy: object,
+    replacement: object,
+) -> list[str]:
+    """Verify an exact, unowned canonical destination already present at base."""
+
+    if not isinstance(legacy, dict) or not isinstance(replacement, dict):
+        return ["legacy destination predecessor blocks are malformed"]
+    predecessor_class = replacement.get("destination_predecessor_class")
+    raw_predecessors = replacement.get("destination_predecessor_files")
+    if not isinstance(raw_predecessors, list):
+        return ["legacy destination predecessor files are malformed"]
+    if predecessor_class not in {
+        APPLIED_ENCODING_DESTINATION_PREDECESSOR_ABSENT,
+        APPLIED_ENCODING_DESTINATION_PREDECESSOR_CANONICALIZED_UNOWNED_DUPLICATE,
+    }:
+        return ["legacy destination predecessor classification is malformed"]
+    if (
+        predecessor_class == APPLIED_ENCODING_DESTINATION_PREDECESSOR_ABSENT
+        and raw_predecessors
+    ) or (
+        predecessor_class
+        == APPLIED_ENCODING_DESTINATION_PREDECESSOR_CANONICALIZED_UNOWNED_DUPLICATE
+        and not raw_predecessors
+    ):
+        return ["legacy destination predecessor classification differs from evidence"]
+    predecessors: dict[Path, str] = {}
+    issues: list[str] = []
+    for item in raw_predecessors:
+        if (
+            not isinstance(item, dict)
+            or set(item) != {"path", "sha256"}
+            or not isinstance(item.get("path"), str)
+            or not isinstance(item.get("sha256"), str)
+            or _SHA256_HEX_PATTERN.fullmatch(item["sha256"]) is None
+        ):
+            issues.append("legacy destination predecessor entry is malformed")
+            continue
+        path = Path(item["path"])
+        if (
+            path.is_absolute()
+            or path.as_posix() != item["path"]
+            or any(part in {"", ".", ".."} for part in path.parts)
+            or path in predecessors
+        ):
+            issues.append("legacy destination predecessor path is malformed")
+            continue
+        predecessors[path] = item["sha256"]
+    if issues or not predecessors:
+        return issues
+
+    legacy_files = legacy.get("files")
+    if not isinstance(legacy_files, list):
+        return ["legacy destination predecessor lacks source file evidence"]
+    expected_sources: dict[Path, Path] = {}
+    for item in legacy_files:
+        source_raw = item.get("path") if isinstance(item, dict) else None
+        if not isinstance(source_raw, str):
+            return ["legacy destination predecessor source evidence is malformed"]
+        destination_raw = authoritative_replacements.get(source_raw)
+        if not isinstance(destination_raw, str):
+            return ["legacy destination predecessor does not cover the source group"]
+        expected_sources[Path(destination_raw)] = Path(source_raw)
+    if set(predecessors) != set(expected_sources):
+        return ["legacy destination predecessor does not exactly match source group"]
+
+    for destination, source in sorted(
+        expected_sources.items(), key=lambda item: item[0].as_posix()
+    ):
+        try:
+            source_raw = _rulespec_migration_base_blob(
+                repo_path,
+                base_commit,
+                source,
+            )
+            destination_raw = _rulespec_migration_base_blob(
+                repo_path,
+                base_commit,
+                destination,
+            )
+            expected_raw, _counts = rewrite_exact_references(
+                source_raw,
+                authoritative_replacements,
+            )
+        except (RuntimeError, PathMigrationPlanError) as exc:
+            issues.append(
+                "legacy destination predecessor base evidence is unreadable: "
+                f"{destination.as_posix()}: {exc}"
+            )
+            continue
+        if hashlib.sha256(destination_raw).hexdigest() != predecessors[destination]:
+            issues.append(
+                "legacy destination predecessor hash is stale: "
+                f"{destination.as_posix()}"
+            )
+        if destination_raw != expected_raw:
+            issues.append(
+                "legacy destination predecessor is not an exact canonicalized source "
+                f"duplicate: {destination.as_posix()}"
+            )
+    try:
+        claimants = _legacy_destination_manifest_claimants_at_base(
+            repo_path,
+            base_commit=base_commit,
+            destination_paths=set(predecessors),
+        )
+    except RuntimeError as exc:
+        issues.append(f"legacy destination predecessor ownership is unreadable: {exc}")
+    else:
+        if claimants:
+            issues.append(
+                "legacy destination predecessor is already manifest-owned: "
+                + ", ".join(path.as_posix() for path in claimants)
+            )
+    return issues
+
+
 def _legacy_replacement_reference_inventory_issues(
     repo_path: Path,
     *,
@@ -7646,6 +7850,7 @@ def _legacy_replacement_pending_paths(repo_path: Path) -> list[str]:
             or receipt.get("schema_version")
             not in {
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V1,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
             }
             or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
@@ -7705,6 +7910,19 @@ def _legacy_replacement_pending_paths(repo_path: Path) -> list[str]:
             )
         )
         if authoritative_replacements is None or authority_issues:
+            pending.append(f"invalid:{manifest_label}")
+            continue
+        if (
+            receipt.get("schema_version")
+            == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+            and _legacy_destination_predecessor_issues(
+                repo_path,
+                base_commit=base_commit,
+                authoritative_replacements=authoritative_replacements,
+                legacy=receipt.get("legacy"),
+                replacement=replacement,
+            )
+        ):
             pending.append(f"invalid:{manifest_label}")
             continue
         inventory_issues = _legacy_replacement_reference_inventory_issues(
@@ -7873,6 +8091,7 @@ def _legacy_replacement_pending_paths(repo_path: Path) -> list[str]:
             or receipt.get("schema_version")
             not in {
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V1,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
             }
             or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
@@ -21832,7 +22051,29 @@ def _legacy_replacement_manifest_issues(
         ),
         exact_dependents=(
             receipt_exact_dependents
+            if receipt_schema
+            in {
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
+            }
+            else None
+        ),
+        destination_predecessor_files=(
+            receipt_replacement.get("destination_predecessor_files")
             if receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+            and isinstance(receipt_replacement, dict)
+            and isinstance(
+                receipt_replacement.get("destination_predecessor_files"), list
+            )
+            else None
+        ),
+        destination_predecessor_class=(
+            receipt_replacement.get("destination_predecessor_class")
+            if receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+            and isinstance(receipt_replacement, dict)
+            and isinstance(
+                receipt_replacement.get("destination_predecessor_class"), str
+            )
             else None
         ),
     )
@@ -21846,6 +22087,7 @@ def _legacy_replacement_manifest_issues(
         receipt_schema
         not in {
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V1,
+            APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
         }
         or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
@@ -21942,6 +22184,18 @@ def _legacy_replacement_manifest_issues(
             }
             | (
                 {"exact_dependents"}
+                if receipt_schema
+                in {
+                    APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
+                    APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
+                }
+                else set()
+            )
+            | (
+                {
+                    "destination_predecessor_class",
+                    "destination_predecessor_files",
+                }
                 if receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
                 else set()
             )
@@ -21982,6 +22236,17 @@ def _legacy_replacement_manifest_issues(
                 for issue in authority_issues
             ],
         ]
+    if receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA:
+        issues.extend(
+            f"{manifest_label} destination predecessor is invalid: {issue}"
+            for issue in _legacy_destination_predecessor_issues(
+                repo_path,
+                base_commit=base_commit,
+                authoritative_replacements=authoritative_replacements,
+                legacy=legacy,
+                replacement=replacement,
+            )
+        )
     issues.extend(
         f"{manifest_label} reference inventory is invalid: {issue}"
         for issue in _legacy_replacement_reference_inventory_issues(
@@ -22763,7 +23028,10 @@ def _legacy_exact_dependent_manifest_issues(
         not isinstance(receipt, dict)
         or set(receipt) != _LEGACY_REPLACEMENT_RECEIPT_FIELDS
         or receipt.get("schema_version")
-        != APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+        not in {
+            APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
+            APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
+        }
         or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
         or receipt_sha256 != binding.get("receipt_sha256")
         or _applied_encoding_manifest_signature_issue(receipt, signing_broker)
@@ -24099,23 +24367,34 @@ def _resolve_legacy_replacement_contract(
     tracked = _rulespec_migration_tracked_files(policy_checkout_path)
     if tracked.get(source) != "100644":
         raise ValueError("legacy replacement source is not a tracked regular 0644 file")
-    destination_group = (
-        destination,
-        companion_path(destination),
-        _applied_encoding_manifest_path(destination),
-    )
+    destination_companion = companion_path(destination)
+    destination_manifest_path = _applied_encoding_manifest_path(destination)
+    destination_predecessor_present = False
     if not in_place:
-        for candidate in destination_group:
-            candidate_absolute = policy_checkout_path / candidate
-            if (
-                candidate in tracked
-                or candidate_absolute.exists()
-                or candidate_absolute.is_symlink()
-            ):
-                raise ValueError(
-                    "legacy replacement destination primary/companion/manifest group "
-                    f"must be absent at clean HEAD and live: {candidate}"
-                )
+        destination_absolute = policy_checkout_path / destination
+        companion_absolute = policy_checkout_path / destination_companion
+        manifest_absolute = policy_checkout_path / destination_manifest_path
+        if (
+            destination_manifest_path in tracked
+            or manifest_absolute.exists()
+            or manifest_absolute.is_symlink()
+        ):
+            raise ValueError(
+                "legacy replacement canonical destination predecessor must be "
+                "unowned at clean HEAD and live"
+            )
+        if destination_absolute.exists() or destination_absolute.is_symlink():
+            destination_predecessor_present = True
+        elif (
+            destination in tracked
+            or destination_companion in tracked
+            or companion_absolute.exists()
+            or companion_absolute.is_symlink()
+        ):
+            raise ValueError(
+                "legacy replacement destination primary/companion group must be "
+                "either absent or an exact tracked canonical predecessor"
+            )
 
     old_paths = [source]
     old_companion = companion_path(source)
@@ -24238,6 +24517,80 @@ def _resolve_legacy_replacement_contract(
             else set(),
         )
     )
+    destination_predecessor_files: list[_LegacyReplacementFile] = []
+    if destination_predecessor_present:
+        source_by_destination = {
+            destination: deleted_files[0],
+            **(
+                {destination_companion: deleted_files[1]}
+                if len(deleted_files) == 2
+                else {}
+            ),
+        }
+        if len(deleted_files) == 1 and (
+            destination_companion in tracked
+            or (policy_checkout_path / destination_companion).exists()
+            or (policy_checkout_path / destination_companion).is_symlink()
+        ):
+            raise ValueError(
+                "legacy replacement canonical destination predecessor has an "
+                "unmatched companion"
+            )
+        for predecessor_path, source_file in source_by_destination.items():
+            if tracked.get(predecessor_path) != "100644":
+                raise ValueError(
+                    "legacy replacement canonical destination predecessor is not a "
+                    f"tracked regular 0644 file: {predecessor_path}"
+                )
+            predecessor_raw = read_bounded_regular_file(
+                policy_checkout_path,
+                policy_checkout_path / predecessor_path,
+                label="legacy replacement canonical destination predecessor",
+                max_bytes=10 * 1024 * 1024,
+                required_mode=0o644,
+            )
+            predecessor_base_raw = _rulespec_migration_base_blob(
+                policy_checkout_path,
+                base_commit,
+                predecessor_path,
+            )
+            try:
+                expected_predecessor_raw, _counts = rewrite_exact_references(
+                    source_file.raw,
+                    replacements,
+                )
+            except PathMigrationPlanError as exc:
+                raise ValueError(
+                    "legacy replacement canonical destination predecessor cannot be "
+                    "derived exactly"
+                ) from exc
+            if predecessor_raw != predecessor_base_raw:
+                raise ValueError(
+                    "legacy replacement canonical destination predecessor differs "
+                    f"from clean HEAD: {predecessor_path}"
+                )
+            if predecessor_raw != expected_predecessor_raw:
+                raise ValueError(
+                    "legacy replacement canonical destination predecessor is not an "
+                    f"exact canonicalized source duplicate: {predecessor_path}"
+                )
+            destination_predecessor_files.append(
+                _LegacyReplacementFile(
+                    predecessor_path,
+                    hashlib.sha256(predecessor_raw).hexdigest(),
+                    predecessor_raw,
+                )
+            )
+        claimants = _legacy_destination_manifest_claimants_at_base(
+            policy_checkout_path,
+            base_commit=base_commit,
+            destination_paths={item.path for item in destination_predecessor_files},
+        )
+        if claimants:
+            raise ValueError(
+                "legacy replacement canonical destination predecessor is already "
+                "manifest-owned: " + ", ".join(path.as_posix() for path in claimants)
+            )
     scheduled_groups: dict[Path, set[Path]] = {}
     exact_groups: dict[Path, set[Path]] = {}
 
@@ -24559,6 +24912,12 @@ def _resolve_legacy_replacement_contract(
             if pending_by_primary[primary]
         ),
         exact_dependents=tuple(exact_dependents),
+        destination_predecessor_files=tuple(destination_predecessor_files),
+        destination_predecessor_class=(
+            APPLIED_ENCODING_DESTINATION_PREDECESSOR_CANONICALIZED_UNOWNED_DUPLICATE
+            if destination_predecessor_files
+            else APPLIED_ENCODING_DESTINATION_PREDECESSOR_ABSENT
+        ),
     )
 
 
@@ -45727,6 +46086,13 @@ def _build_apply_validation_snapshot(
                 "path": legacy_replacement.legacy_manifest.path.as_posix(),
                 "sha256": legacy_replacement.legacy_manifest.sha256,
             },
+            "destination_predecessor_files": [
+                {"path": item.path.as_posix(), "sha256": item.sha256}
+                for item in legacy_replacement.destination_predecessor_files
+            ],
+            "destination_predecessor_class": (
+                legacy_replacement.destination_predecessor_class
+            ),
             "deleted_files": [
                 {"path": item.path.as_posix(), "sha256": item.sha256}
                 for item in legacy_replacement.deleted_files
@@ -46278,6 +46644,10 @@ def _stage_signed_legacy_replacement_provenance(
         }
         for dependent in contract.exact_dependents
     ]
+    destination_predecessor_files = [
+        {"path": item.path.as_posix(), "sha256": item.sha256}
+        for item in contract.destination_predecessor_files
+    ]
     receipt_identity = receipt_identity_payload(
         base_commit=contract.base_commit,
         base_tree=contract.base_tree,
@@ -46296,6 +46666,8 @@ def _stage_signed_legacy_replacement_provenance(
         ],
         scheduled_dependents=scheduled_dependents,
         exact_dependents=exact_dependents,
+        destination_predecessor_class=contract.destination_predecessor_class,
+        destination_predecessor_files=destination_predecessor_files,
     )
     receipt_id = receipt_identity_sha256(receipt_identity)
     receipt_relative = (
@@ -46347,6 +46719,8 @@ def _stage_signed_legacy_replacement_provenance(
             "rewrites": receipt_identity["rewrites"],
             "scheduled_dependents": scheduled_dependents,
             "exact_dependents": exact_dependents,
+            "destination_predecessor_class": (contract.destination_predecessor_class),
+            "destination_predecessor_files": destination_predecessor_files,
         },
         "replacement_manifest": model_manifest,
     }
@@ -47873,6 +48247,8 @@ def _apply_generated_encoding_result(
     }
     expected_originals[manifest_path] = _apply_transaction_file_digest(manifest_path)
     if legacy_replacement is not None:
+        for item in legacy_replacement.destination_predecessor_files:
+            expected_originals[checkout_root / item.path] = item.sha256
         for rewrite in legacy_replacement.rewrites:
             expected_originals[checkout_root / rewrite.path] = rewrite.before_sha256
         for item in legacy_replacement.deleted_files:

--- a/src/axiom_encode/legacy_replacement.py
+++ b/src/axiom_encode/legacy_replacement.py
@@ -21,8 +21,13 @@ EXACT_DEPENDENT_TOOL: Final = (
     "axiom-encode encode --apply --legacy-exact-dependent-rulespec-path"
 )
 RECEIPT_SCHEMA_V1: Final = "axiom-encode/legacy-fresh-reencode-receipt/v1"
-RECEIPT_SCHEMA: Final = "axiom-encode/legacy-fresh-reencode-receipt/v2"
+RECEIPT_SCHEMA_V2: Final = "axiom-encode/legacy-fresh-reencode-receipt/v2"
+RECEIPT_SCHEMA: Final = "axiom-encode/legacy-fresh-reencode-receipt/v3"
 RECEIPT_DIR: Final = ".axiom/legacy-replacements"
+DESTINATION_PREDECESSOR_ABSENT: Final = "absent"
+DESTINATION_PREDECESSOR_CANONICALIZED_UNOWNED_DUPLICATE: Final = (
+    "canonicalized-unowned-duplicate"
+)
 ENCODING_MANIFEST_DIR: Final = Path(".axiom") / "encoding-manifests"
 LEGACY_MANIFEST_SCHEMA: Final = "axiom-encode/applied-rulespec/v1"
 LEGACY_OWNER_CLASS: Final = "v1-hmac-untrusted"
@@ -106,6 +111,8 @@ class LegacyReplacementContract(NamedTuple):
     rewrites: tuple[LegacyReplacementRewrite, ...]
     scheduled_dependents: tuple[LegacyReplacementScheduledDependent, ...]
     exact_dependents: tuple[LegacyReplacementExactDependent, ...]
+    destination_predecessor_class: str = DESTINATION_PREDECESSOR_ABSENT
+    destination_predecessor_files: tuple[LegacyReplacementFile, ...] = ()
 
 
 def legacy_source_verification_citation_paths(
@@ -467,6 +474,8 @@ def receipt_identity_payload(
     rewrites: list[dict[str, object]],
     scheduled_dependents: list[dict[str, object]],
     exact_dependents: list[dict[str, object]] | None = None,
+    destination_predecessor_class: str | None = None,
+    destination_predecessor_files: list[dict[str, object]] | None = None,
 ) -> dict[str, object]:
     payload = {
         "base_commit": base_commit,
@@ -480,6 +489,10 @@ def receipt_identity_payload(
     }
     if exact_dependents is not None:
         payload["exact_dependents"] = exact_dependents
+    if destination_predecessor_class is not None:
+        payload["destination_predecessor_class"] = destination_predecessor_class
+    if destination_predecessor_files is not None:
+        payload["destination_predecessor_files"] = destination_predecessor_files
     return payload
 
 

--- a/src/axiom_encode/legacy_replacement_overlay.py
+++ b/src/axiom_encode/legacy_replacement_overlay.py
@@ -8,6 +8,8 @@ import shutil
 from pathlib import Path
 
 from .legacy_replacement import (
+    DESTINATION_PREDECESSOR_ABSENT,
+    DESTINATION_PREDECESSOR_CANONICALIZED_UNOWNED_DUPLICATE,
     ENCODING_MANIFEST_DIR,
     LegacyReplacementContract,
     LegacyReplacementFile,
@@ -227,6 +229,27 @@ def stage_legacy_replacement_overlay(
                 )
             exact_targets.append((target, live_file))
 
+    predecessor_present = bool(contract.destination_predecessor_files)
+    if (
+        predecessor_present
+        and contract.destination_predecessor_class
+        != DESTINATION_PREDECESSOR_CANONICALIZED_UNOWNED_DUPLICATE
+    ) or (
+        not predecessor_present
+        and contract.destination_predecessor_class != DESTINATION_PREDECESSOR_ABSENT
+    ):
+        raise LegacyReplacementOverlayError(
+            "Legacy replacement canonical destination predecessor classification "
+            "differs from its evidence"
+        )
+    predecessor_targets = [
+        _require_overlay_file(
+            root,
+            item,
+            label="Legacy replacement canonical destination predecessor",
+        )
+        for item in contract.destination_predecessor_files
+    ]
     if contract.source != contract.destination:
         destination = _overlay_path(root, contract.destination)
         destination_manifest = _overlay_path(
@@ -238,14 +261,26 @@ def stage_legacy_replacement_overlay(
             destination.with_name(f"{destination.stem}.test.yaml"),
             destination_manifest,
         )
+        admitted_predecessors = set(predecessor_targets)
+        if admitted_predecessors and (
+            destination not in admitted_predecessors
+            or not admitted_predecessors.issubset(set(destination_group[:2]))
+        ):
+            raise LegacyReplacementOverlayError(
+                "Legacy replacement canonical destination predecessor group is malformed"
+            )
         for target in destination_group:
-            if target.exists() or target.is_symlink():
+            if target not in admitted_predecessors and (
+                target.exists() or target.is_symlink()
+            ):
                 raise LegacyReplacementOverlayError(
                     "Legacy replacement destination primary/companion/manifest "
                     f"collision: {target.relative_to(root).as_posix()}"
                 )
 
     for target in deleted_targets:
+        target.unlink()
+    for target in predecessor_targets:
         target.unlink()
     manifest_target.unlink()
     for target, rewrite in rewrite_targets:

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1436"
+ENCODER_VERSION = "0.2.1437"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13716,6 +13716,15 @@ class TestCmdEncode:
             "rules: []\n"
         )
         source_test.write_text("[]\n")
+        canonical_predecessor = checkout / destination_relative
+        canonical_predecessor_test = canonical_predecessor.with_name("32.test.yaml")
+        canonical_predecessor.parent.mkdir(parents=True, exist_ok=True)
+        canonical_predecessor.write_bytes(source.read_bytes())
+        canonical_predecessor_test.write_bytes(source_test.read_bytes())
+        predecessor_hashes = {
+            path.relative_to(checkout).as_posix(): _sha256_file(path)
+            for path in (canonical_predecessor, canonical_predecessor_test)
+        }
         source_before_sha256 = _sha256_file(source)
         dependent.write_text(
             "format: rulespec/v1\n"
@@ -14054,8 +14063,15 @@ class TestCmdEncode:
         outer = json.loads(destination_manifest.read_text())
         receipt_path = checkout / outer["replacement"]["receipt_path"]
         receipt = json.loads(receipt_path.read_text())
-        assert receipt["schema_version"].endswith("/v2")
+        assert receipt["schema_version"].endswith("/v3")
         assert receipt["legacy"]["owner_class"] == "v1-hmac-untrusted"
+        assert receipt["replacement"]["destination_predecessor_class"] == (
+            "canonicalized-unowned-duplicate"
+        )
+        assert {
+            item["path"]: item["sha256"]
+            for item in receipt["replacement"]["destination_predecessor_files"]
+        } == predecessor_hashes
         assert len(receipt["replacement"]["exact_dependents"]) == 1
         exact = receipt["replacement"]["exact_dependents"][0]
         assert exact["primary"] == dependent_relative.as_posix()

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1436"
+ENCODER_VERSION = "0.2.1437"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1436"
+ENCODER_VERSION = "0.2.1437"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_legacy_replacement.py
+++ b/tests/test_legacy_replacement.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 import pytest
 
 from axiom_encode.cli import (
+    _legacy_destination_manifest_claimants_at_base,
     _legacy_replacement_authoritative_map,
     _require_locked_legacy_replacement_base,
     _resolve_legacy_replacement_contract,
@@ -24,6 +25,10 @@ from axiom_encode.legacy_replacement import (
     legacy_v1_manifest_issues,
     receipt_identity_payload,
     receipt_identity_sha256,
+)
+from axiom_encode.legacy_replacement_overlay import (
+    LegacyReplacementOverlayError,
+    stage_legacy_replacement_overlay,
 )
 
 
@@ -368,6 +373,10 @@ def test_receipt_identity_binds_every_transaction_dimension() -> None:
         rewrites=[],
         scheduled_dependents=[],
         exact_dependents=[],
+        destination_predecessor_class="canonicalized-unowned-duplicate",
+        destination_predecessor_files=[
+            {"path": "us-la/statutes/47/32.yaml", "sha256": "f" * 64}
+        ],
     )
     baseline = receipt_identity_sha256(payload)
     for field in (
@@ -380,6 +389,8 @@ def test_receipt_identity_binds_every_transaction_dimension() -> None:
         "rewrites",
         "scheduled_dependents",
         "exact_dependents",
+        "destination_predecessor_class",
+        "destination_predecessor_files",
     ):
         changed = copy.deepcopy(payload)
         changed[field] = f"changed-{field}"
@@ -499,6 +510,183 @@ def test_contract_admits_generated_v1_unicode_path_with_relative_file_scope(
         Path("us/statutes/42/1437c–1.yaml"),
         Path("us/statutes/42/1437c–1.test.yaml"),
     }
+
+
+def test_contract_absorbs_exact_unowned_canonical_destination_predecessor(
+    tmp_path: Path,
+) -> None:
+    checkout, content_root, source = _generated_unicode_checkout(tmp_path)
+    legacy = checkout / "us/statutes/42/1437c–1.yaml"
+    legacy_test = legacy.with_name("1437c–1.test.yaml")
+    destination = checkout / "us/statutes/42/1437c-1.yaml"
+    destination_test = destination.with_name("1437c-1.test.yaml")
+    destination.write_bytes(legacy.read_bytes())
+    destination_test.write_bytes(legacy_test.read_bytes())
+    _git(checkout, "add", ".")
+    _git(checkout, "commit", "-qm", "unowned canonical predecessor")
+
+    with patch("axiom_encode.cli.resolve_corpus_source_unit", return_value=source):
+        contract = _resolve_legacy_replacement_contract(
+            source_raw=Path("us/statutes/42/1437c–1.yaml"),
+            destination_raw=Path("us/statutes/42/1437c-1.yaml"),
+            policy_checkout_path=checkout,
+            policy_repo_path=content_root,
+            source_unit=source,
+            corpus_release=SimpleNamespace(),
+        )
+
+    assert {item.path for item in contract.destination_predecessor_files} == {
+        Path("us/statutes/42/1437c-1.yaml"),
+        Path("us/statutes/42/1437c-1.test.yaml"),
+    }
+    assert contract.destination_predecessor_class == "canonicalized-unowned-duplicate"
+    with pytest.raises(
+        LegacyReplacementOverlayError,
+        match="classification differs",
+    ):
+        stage_legacy_replacement_overlay(
+            contract._replace(destination_predecessor_class="absent"),
+            checkout,
+        )
+    stage_legacy_replacement_overlay(contract, checkout)
+    assert not legacy.exists()
+    assert not legacy_test.exists()
+    assert not destination.exists()
+    assert not destination_test.exists()
+    assert not (
+        checkout / ".axiom/encoding-manifests/us/statutes/42/1437c–1.json"
+    ).exists()
+
+
+def test_destination_manifest_claimant_scan_is_one_conservative_base_query(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_commit = "a" * 40
+    claimant = Path(".axiom/encoding-manifests/us/statutes/claimant.json")
+    commands: list[list[str]] = []
+
+    def run(command, **_kwargs):
+        commands.append(command)
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=f"{base_commit}:{claimant.as_posix()}\0".encode(),
+            stderr=b"",
+        )
+
+    monkeypatch.setattr("axiom_encode.cli.subprocess.run", run)
+
+    assert _legacy_destination_manifest_claimants_at_base(
+        tmp_path,
+        base_commit=base_commit,
+        destination_paths={
+            Path("us/statutes/42/1437c-1.yaml"),
+            Path("us/statutes/42/1437c-1.test.yaml"),
+        },
+    ) == [claimant]
+    assert len(commands) == 1
+    assert commands[0][3:9] == ["grep", "-z", "-l", "-a", "-F", "-e"]
+
+
+@pytest.mark.parametrize(
+    "claimant_schema",
+    ["axiom-encode/applied-rulespec/v1", "axiom-encode/applied-rulespec/v5"],
+)
+def test_canonical_destination_predecessor_rejects_owner_and_overlay_race(
+    tmp_path: Path,
+    claimant_schema: str,
+) -> None:
+    checkout, content_root, source = _generated_unicode_checkout(tmp_path)
+    legacy = checkout / "us/statutes/42/1437c–1.yaml"
+    legacy_test = legacy.with_name("1437c–1.test.yaml")
+    destination = checkout / "us/statutes/42/1437c-1.yaml"
+    destination_test = destination.with_name("1437c-1.test.yaml")
+    destination.write_bytes(legacy.read_bytes())
+    destination_test.write_bytes(legacy_test.read_bytes())
+    _git(checkout, "add", ".")
+    _git(checkout, "commit", "-qm", "unowned canonical predecessor")
+
+    with patch("axiom_encode.cli.resolve_corpus_source_unit", return_value=source):
+        contract = _resolve_legacy_replacement_contract(
+            source_raw=Path("us/statutes/42/1437c–1.yaml"),
+            destination_raw=Path("us/statutes/42/1437c-1.yaml"),
+            policy_checkout_path=checkout,
+            policy_repo_path=content_root,
+            source_unit=source,
+            corpus_release=SimpleNamespace(),
+        )
+    destination.write_text("changed after planning\n")
+    with pytest.raises(LegacyReplacementOverlayError, match="predecessor changed"):
+        stage_legacy_replacement_overlay(contract, checkout)
+
+    destination.write_bytes(
+        next(
+            item.raw
+            for item in contract.destination_predecessor_files
+            if item.path.name == "1437c-1.yaml"
+        )
+    )
+    claimant = checkout / ".axiom/encoding-manifests/us/policies/claimant.json"
+    claimant.parent.mkdir(parents=True, exist_ok=True)
+    claimant.write_text(
+        json.dumps(
+            {
+                "schema_version": claimant_schema,
+                "applied_files": [
+                    {
+                        "path": "statutes/42/1437c-1.yaml",
+                        "sha256": hashlib.sha256(destination.read_bytes()).hexdigest(),
+                    }
+                ],
+            }
+        )
+        + "\n"
+    )
+    _git(checkout, "add", ".")
+    _git(checkout, "commit", "-qm", "claim canonical predecessor")
+    with (
+        patch("axiom_encode.cli.resolve_corpus_source_unit", return_value=source),
+        pytest.raises(ValueError, match="already manifest-owned"),
+    ):
+        _resolve_legacy_replacement_contract(
+            source_raw=Path("us/statutes/42/1437c–1.yaml"),
+            destination_raw=Path("us/statutes/42/1437c-1.yaml"),
+            policy_checkout_path=checkout,
+            policy_repo_path=content_root,
+            source_unit=source,
+            corpus_release=SimpleNamespace(),
+        )
+
+
+def test_canonical_destination_predecessor_rejects_malformed_manifest_candidate(
+    tmp_path: Path,
+) -> None:
+    checkout, content_root, source = _generated_unicode_checkout(tmp_path)
+    legacy = checkout / "us/statutes/42/1437c–1.yaml"
+    destination = checkout / "us/statutes/42/1437c-1.yaml"
+    destination.write_bytes(legacy.read_bytes())
+    destination.with_name("1437c-1.test.yaml").write_bytes(
+        legacy.with_name("1437c–1.test.yaml").read_bytes()
+    )
+    claimant = checkout / ".axiom/encoding-manifests/us/statutes/malformed.json"
+    claimant.parent.mkdir(parents=True, exist_ok=True)
+    claimant.write_text('{"applied_files":["us/statutes/42/1437c-1.yaml"\n')
+    _git(checkout, "add", ".")
+    _git(checkout, "commit", "-qm", "malformed destination claimant")
+
+    with (
+        patch("axiom_encode.cli.resolve_corpus_source_unit", return_value=source),
+        pytest.raises(ValueError, match="already manifest-owned"),
+    ):
+        _resolve_legacy_replacement_contract(
+            source_raw=Path("us/statutes/42/1437c–1.yaml"),
+            destination_raw=Path("us/statutes/42/1437c-1.yaml"),
+            policy_checkout_path=checkout,
+            policy_repo_path=content_root,
+            source_unit=source,
+            corpus_release=SimpleNamespace(),
+        )
 
 
 def _generated_unicode_receipt_blocks(
@@ -980,17 +1168,18 @@ def test_contract_rejects_exact_dependent_without_v1_ownership(
         )
 
 
-def test_contract_rejects_dirty_or_existing_destination(tmp_path: Path) -> None:
+def test_contract_rejects_dirty_or_inexact_existing_destination(tmp_path: Path) -> None:
     checkout, content_root, source = _legacy_checkout(tmp_path)
     destination = content_root / "statutes/47/32.yaml"
     destination.parent.mkdir(parents=True)
     destination.write_text("collision\n")
+    destination.with_name("32.test.yaml").write_text("collision\n")
     _git(checkout, "add", ".")
     _git(checkout, "commit", "-qm", "destination collision")
 
     with (
         patch("axiom_encode.cli.resolve_corpus_source_unit", return_value=source),
-        pytest.raises(ValueError, match="absent at clean HEAD and live"),
+        pytest.raises(ValueError, match="not an exact canonicalized source duplicate"),
     ):
         _resolve_legacy_replacement_contract(
             source_raw=Path("us-la/statutes/47:32.yaml"),

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1436"
+ENCODER_VERSION = "0.2.1437"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1436"
+ENCODER_VERSION = "0.2.1437"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1436"
+ENCODER_VERSION = "0.2.1437"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1436"
+ENCODER_VERSION = "0.2.1437"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -390,6 +390,7 @@ def _write_legacy_replacement_change(
     omitted_scheduled_companion: bool = False,
     exact_dependent: bool = False,
     generated_exact_dependent: bool = False,
+    destination_predecessor: bool = False,
     legacy_owner_class: str = "v1-hmac-untrusted",
 ) -> tuple[Path, Path, Path, Path]:
     old_rule = repo / "us/statutes/47:32.yaml"
@@ -460,6 +461,23 @@ def _write_legacy_replacement_change(
     exact_manifest = (
         repo / ".axiom/encoding-manifests/us/policies/income_tax/composite.json"
     )
+    new_rule = repo / "us/statutes/47/32.yaml"
+    new_test = repo / "us/statutes/47/32.test.yaml"
+    destination_predecessor_files: list[dict[str, str]] = []
+    if destination_predecessor:
+        new_rule.parent.mkdir(parents=True, exist_ok=True)
+        new_rule.write_bytes(old_rule.read_bytes())
+        new_test.write_bytes(old_test.read_bytes())
+        destination_predecessor_files = [
+            {
+                "path": new_rule.relative_to(repo).as_posix(),
+                "sha256": hashlib.sha256(new_rule.read_bytes()).hexdigest(),
+            },
+            {
+                "path": new_test.relative_to(repo).as_posix(),
+                "sha256": hashlib.sha256(new_test.read_bytes()).hexdigest(),
+            },
+        ]
     if exact_dependent:
         exact_primary.parent.mkdir(parents=True, exist_ok=True)
         exact_primary.write_text(
@@ -584,9 +602,7 @@ def _write_legacy_replacement_change(
             encoding="utf-8",
         )
 
-    new_rule = repo / "us/statutes/47/32.yaml"
-    new_test = repo / "us/statutes/47/32.test.yaml"
-    new_rule.parent.mkdir(parents=True)
+    new_rule.parent.mkdir(parents=True, exist_ok=True)
     new_rule.write_text("format: rulespec/v1\nrules: []\n", encoding="utf-8")
     new_test.write_text("[]\n", encoding="utf-8")
     if exact_dependent:
@@ -630,9 +646,13 @@ def _write_legacy_replacement_change(
     receipt.parent.mkdir(parents=True)
     receipt_payload = {
         "schema_version": (
-            "axiom-encode/legacy-fresh-reencode-receipt/v2"
-            if exact_dependent
-            else "axiom-encode/legacy-fresh-reencode-receipt/v1"
+            "axiom-encode/legacy-fresh-reencode-receipt/v3"
+            if destination_predecessor
+            else (
+                "axiom-encode/legacy-fresh-reencode-receipt/v2"
+                if exact_dependent
+                else "axiom-encode/legacy-fresh-reencode-receipt/v1"
+            )
         ),
         "tool": "axiom-encode encode --apply --replace-legacy-rulespec-path",
         "repository": {
@@ -694,6 +714,14 @@ def _write_legacy_replacement_change(
         },
         "replacement_manifest": nested_manifest,
     }
+    if destination_predecessor:
+        receipt_payload["replacement"]["destination_predecessor_class"] = (
+            "canonicalized-unowned-duplicate"
+        )
+        receipt_payload["replacement"]["destination_predecessor_files"] = (
+            destination_predecessor_files
+        )
+        receipt_payload["replacement"]["exact_dependents"] = []
     if exact_dependent:
         assert exact_primary_before is not None
         assert exact_companion_before is not None
@@ -1074,6 +1102,42 @@ def test_stage_keeps_v1_legacy_replacement_compatible(tmp_path: Path) -> None:
         == "axiom-encode/legacy-fresh-reencode-receipt/v1"
     )
     authorized_changed_paths(repo)
+
+
+def test_stage_accepts_v3_unowned_canonical_destination_predecessor(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    _manifest, receipt, _old_manifest, _metadata = _write_legacy_replacement_change(
+        repo,
+        destination_predecessor=True,
+    )
+
+    assert (
+        json.loads(receipt.read_text(encoding="utf-8"))["schema_version"]
+        == "axiom-encode/legacy-fresh-reencode-receipt/v3"
+    )
+    expected = authorized_changed_paths(repo)
+    stage_authorized_changes(repo)
+
+    assert PurePosixPath("us/statutes/47/32.yaml") in expected
+
+
+def test_stage_rejects_v3_destination_predecessor_hash_tamper(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    manifest, receipt, _old_manifest, _metadata = _write_legacy_replacement_change(
+        repo,
+        destination_predecessor=True,
+    )
+    payload = json.loads(receipt.read_text(encoding="utf-8"))
+    payload["replacement"]["destination_predecessor_files"][0]["sha256"] = "0" * 64
+    receipt.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+    _refresh_legacy_receipt_bindings(repo, manifest, receipt)
+
+    with pytest.raises(ValueError, match="destination predecessor differs"):
+        authorized_changed_paths(repo)
 
 
 def test_stage_rejects_v2_exact_dependent_live_file_tamper(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1436"')
+        .startswith('__version__ = "0.2.1437"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1436"
+    assert encoder_package["version"] == "0.2.1437"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1436"
+    assert project["project"]["version"] == "0.2.1437"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1436"')
+        .startswith('__version__ = "0.2.1437"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1436"
+    assert encoder_package["version"] == "0.2.1437"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1436"
+    assert project["project"]["version"] == "0.2.1437"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1436"')
+        .startswith('__version__ = "0.2.1437"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1436"
+ENCODER_VERSION = "0.2.1437"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1436"
+version = "0.2.1437"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- extend fresh authenticated legacy replacement to absorb a pre-existing canonical destination only when it is an exact base-bound canonical projection of the authenticated legacy group
- record an explicit `canonicalized-unowned-duplicate`/`absent` classification and every predecessor path/hash in a signed v3 receipt identity
- reject destination manifests or any other base manifest that claims the canonical predecessor, using one bounded supervisor-admitted fixed-string Git query
- revalidate predecessor bytes in the isolated overlay and the atomic install transaction while retaining v1/v2 receipt verification compatibility
- teach signed-backfill validation to reconstruct v3 predecessor evidence
- authorize independently reviewed RuleSpec hard-cut head `1e04e456ab404860050586c34eef51321eea95e9`
- bump Axiom Encode to `0.2.1437`

This is a provenance transition, not a canonical-path exception: the v1 HMAC remains untrusted shape evidence; authority comes from the reviewed Git base, exact source/destination bytes, signed corpus resolution, complete overlay validation, and the new Ed25519 v5 manifest/receipt.

## Security invariants

- destination is mechanically derived and must be tracked mode `100644`
- destination primary/test must equal the exact durable-reference projection of the legacy primary/test
- destination manifest must be absent and no base manifest may mention the destination group
- source, legacy manifest, predecessor, dependent, and rewrite bytes are locked to the exact base and rechecked before mutation
- the live checkout is unchanged during overlay validation
- apply includes predecessor hashes in the journaled expected-original set and rolls back on failure
- no signing authority is derived from the legacy v1 HMAC

## Checks

- focused predecessor/E2E selection: 6 passed
- legacy replacement, signed backfill, and supervisor suites: 224 passed
- focused CLI transaction/rollback suite: 8 passed
- RuleSpec validation and oracle registry suites: 1,352 passed, 31 skipped
- agent focused legacy/backfill/E2E suite: 157 passed
- version/registry checks: 27 passed
- prescribed Ruff, repository format check, compileall, changelog draft, and `git diff --check`: passed
- real reviewed New Jersey base claimant query: no claimant, under one second
- full Python 3.13 `pytest`: 6,199 passed, 119 skipped
- post-rebase legacy replacement/backfill/CLI suite: 1,271 passed, 10 skipped
- post-rebase RuleSpec validation/oracle registry suite: 1,352 passed, 31 skipped

## Review cycle

The first hosted cycle found formatting-only drift in three changed Python files. The repository formatter was applied and all static checks now pass. A missing project-convention changelog fragment was then added.

Independent review of exact amended head `4b1767eec20403efba576a577b387f0b0237fcdb` is **CLEAN**, with no actionable findings. The reviewer reverified predecessor authentication, v1/v2/v3 compatibility, bounded base ownership scanning, overlay/live atomicity, signed-backfill reconstruction, RuleSpec authorization, version consistency, and the changelog-only final amendment. Reviewer checks: 80 focused tests, Ruff, hosted format scope, compileall, Towncrier draft, and clean diff/worktree.

After `main` advanced through #1354, the branch was rebased onto exact base `a354c5fecdc4d2d7fc0f37cf866fd69cb86bf095`. Conflict resolution retained only current reviewed RuleSpec authorization `1e04e456ab404860050586c34eef51321eea95e9`, removed the superseded authorization, and advanced the package version to `0.2.1437`. A semantic range-diff then caught and removed a duplicate current-authorization tuple that was runtime-idempotent under `frozenset` but noncanonical. Exact rebased head: `c68c9bcb72ed190971cdbc845d2ec900135a14da`.

Independent post-rebase review of exact `c68c9bcb72ed190971cdbc845d2ec900135a14da` is **CLEAN**, with no actionable findings. It confirmed byte-identical core security implementation, exactly one current authorization and no stale authorization, consistent `0.2.1437` versioning, and all predecessor/receipt/overlay/transaction invariants. Reviewer checks passed: Ruff, hosted formatter scope, compileall, Towncrier, diff check, and 1,484 affected tests with 31 expected skips.

Exact-head hosted CI is green: lint, Python 3.13 full tests, and signing-supervisor suites on Ubuntu and macOS all passed. The review-fix cycle is complete with no actionable findings.
