### PR TITLE
fix: scope canonical replacement validation overlays

### DIFF
--- a/changelog.d/canonical-replacement-overlay-scope.fixed.md
+++ b/changelog.d/canonical-replacement-overlay-scope.fixed.md
@@ -1,0 +1,1 @@
+Scope authenticated canonical replacement validation to the active jurisdiction and its country ancestors, so unrelated pre-hard-cut state paths cannot block a protected repair while fresh encodes continue to validate the complete checkout.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1437"
+version = "0.2.1438"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1437"
+__version__ = "0.2.1438"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -319,7 +319,7 @@ from .legacy_replacement_overlay import (
     LegacyReplacementOverlayError as _LegacyReplacementOverlayError,
 )
 from .legacy_replacement_overlay import (
-    scope_legacy_replacement_overlay as _scope_legacy_replacement_overlay,
+    scope_replacement_overlay as _scope_replacement_overlay,
 )
 from .legacy_replacement_overlay import (
     stage_legacy_replacement_overlay as _stage_legacy_replacement_overlay,
@@ -389,6 +389,16 @@ DEFAULT_DB = Path.home() / "TheAxiomFoundation" / "axiom-encode" / "encodings.db
 DEFAULT_GPT_RUNNER = f"codex:{DEFAULT_OPENAI_MODEL}"
 APPLIED_ENCODING_MANIFEST_DIR = Path(".axiom") / "encoding-manifests"
 APPLIED_ENCODING_MANIFEST_SCHEMA = "axiom-encode/applied-rulespec/v5"
+_APPLY_VALIDATION_EXECUTION_SCHEMA_V1 = "axiom-encode/apply-validation-execution/v1"
+_APPLY_VALIDATION_EXECUTION_SCHEMA_V2 = "axiom-encode/apply-validation-execution/v2"
+_APPLY_VALIDATION_SCOPE_FULL_CHECKOUT = "full_checkout"
+_APPLY_VALIDATION_SCOPE_REPLACEMENT = "active_jurisdiction_and_country_ancestors"
+_APPLY_VALIDATION_SCOPES = frozenset(
+    {
+        _APPLY_VALIDATION_SCOPE_FULL_CHECKOUT,
+        _APPLY_VALIDATION_SCOPE_REPLACEMENT,
+    }
+)
 APPLIED_ENCODING_SIGNATURE_ALGORITHM = "ed25519-domain-v1"
 APPLIED_ENCODING_DELETED_MARKER = "deleted"
 APPLIED_ENCODING_MODEL_TOOL = "axiom-encode encode --apply"
@@ -20476,10 +20486,19 @@ def _model_apply_validation_execution_issues(
         "rulespec_dependencies",
     }
     issues: list[str] = []
+    schema = execution.get("schema")
+    if schema == _APPLY_VALIDATION_EXECUTION_SCHEMA_V2:
+        expected_top_fields.add("rulespec_scope")
+        rulespec_scope = execution.get("rulespec_scope")
+        if (
+            not isinstance(rulespec_scope, str)
+            or rulespec_scope not in _APPLY_VALIDATION_SCOPES
+        ):
+            issues.append(f"{prefix}.rulespec_scope is invalid")
+    elif schema != _APPLY_VALIDATION_EXECUTION_SCHEMA_V1:
+        issues.append(f"{prefix}.schema is not supported")
     if set(execution) != expected_top_fields:
         issues.append(f"{prefix} has noncanonical fields")
-    if execution.get("schema") != "axiom-encode/apply-validation-execution/v1":
-        issues.append(f"{prefix}.schema is not supported")
 
     def check_git_identity(
         value: object,
@@ -24188,6 +24207,7 @@ class _EncodeReplacementTarget(NamedTuple):
 
 
 _LEGACY_REPLACEMENT_ATTR = "_axiom_legacy_replacement_contract"
+_REPLACEMENT_OVERLAY_SCOPE_ATTR = "_axiom_replacement_overlay_scope"
 
 
 def _resolve_required_import_rulespec_paths(
@@ -24284,6 +24304,16 @@ def _result_legacy_replacement_contract(result: object) -> object | None:
     except TypeError:
         return None
     return state.get(_LEGACY_REPLACEMENT_ATTR)
+
+
+def _result_replacement_overlay_scope(result: object) -> bool:
+    """Return the internal marker for an authenticated replacement target."""
+
+    try:
+        state = vars(result)
+    except TypeError:
+        return False
+    return state.get(_REPLACEMENT_OVERLAY_SCOPE_ATTR) is True
 
 
 def _require_legacy_replacement_clean_checkout(checkout_root: Path) -> None:
@@ -25430,6 +25460,7 @@ def _run_encode_attempt(
             if replacement_target is not None
             else None
         ),
+        replacement_overlay_scope=replacement_target is not None,
     )
 
     result = results[0]
@@ -25439,6 +25470,11 @@ def _run_encode_attempt(
         replacement_target.legacy_replacement
         if replacement_target is not None
         else None,
+    )
+    setattr(
+        result,
+        _REPLACEMENT_OVERLAY_SCOPE_ATTR,
+        replacement_target is not None,
     )
     protected_review_excerpts = (
         _quoted_review_finding_excerpts(
@@ -45827,6 +45863,8 @@ def _portable_clean_apply_git_identity(
 
 def _portable_apply_validation_execution_identity(
     execution: Mapping[str, object],
+    *,
+    replacement_overlay_scope: bool,
 ) -> dict[str, object]:
     """Build the signed, path-portable validator provenance for one apply."""
 
@@ -45992,7 +46030,12 @@ def _portable_apply_validation_execution_identity(
         )
 
     return {
-        "schema": "axiom-encode/apply-validation-execution/v1",
+        "schema": _APPLY_VALIDATION_EXECUTION_SCHEMA_V2,
+        "rulespec_scope": (
+            _APPLY_VALIDATION_SCOPE_REPLACEMENT
+            if replacement_overlay_scope
+            else _APPLY_VALIDATION_SCOPE_FULL_CHECKOUT
+        ),
         "axiom_encode": encoder,
         "axiom_rules_engine": engine,
         "policy_pre_apply": policy_attestation,
@@ -46044,6 +46087,15 @@ def _build_apply_validation_snapshot(
             supplemental_files.items(), key=lambda item: Path(item[0]).as_posix()
         )
     ]
+    legacy_replacement = _result_legacy_replacement_contract(result)
+    if legacy_replacement is not None and not isinstance(
+        legacy_replacement,
+        _LegacyReplacementContract,
+    ):
+        raise RuntimeError("Legacy replacement contract is malformed")
+    replacement_overlay_scope = (
+        _result_replacement_overlay_scope(result) or legacy_replacement is not None
+    )
     snapshot = {
         "schema": "axiom-encode/apply-validation-snapshot/v1",
         "relative_output": canonical_relative_output.as_posix(),
@@ -46070,13 +46122,14 @@ def _build_apply_validation_snapshot(
         "supplemental": supplemental_snapshot,
         "validation_execution": copy.deepcopy(dict(validation_execution_identity)),
         "manifest_validation_execution": (
-            _portable_apply_validation_execution_identity(validation_execution_identity)
+            _portable_apply_validation_execution_identity(
+                validation_execution_identity,
+                replacement_overlay_scope=replacement_overlay_scope,
+            )
         ),
+        "replacement_overlay_scope": replacement_overlay_scope,
     }
-    legacy_replacement = _result_legacy_replacement_contract(result)
     if legacy_replacement is not None:
-        if not isinstance(legacy_replacement, _LegacyReplacementContract):
-            raise RuntimeError("Legacy replacement contract is malformed")
         snapshot["legacy_replacement"] = {
             "base_commit": legacy_replacement.base_commit,
             "base_tree": legacy_replacement.base_tree,
@@ -48890,6 +48943,7 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
     """Validate generated artifacts in a temporary policy-repo overlay."""
     setattr(result, _APPLY_VALIDATION_SNAPSHOT_ATTR, None)
     legacy_replacement = _result_legacy_replacement_contract(result)
+    replacement_overlay_scope = _result_replacement_overlay_scope(result)
     if legacy_replacement is not None and not isinstance(
         legacy_replacement,
         _LegacyReplacementContract,
@@ -48940,6 +48994,19 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
         relative_output,
     )
     existing_output = policy_content_root / relative_output
+    if (
+        replacement_overlay_scope
+        and legacy_replacement is None
+        and (existing_output.is_symlink() or not existing_output.is_file())
+    ):
+        return (
+            False,
+            [
+                "Replacement overlay scope requires an existing regular canonical "
+                f"target: {relative_output}"
+            ],
+            {},
+        )
     if existing_output.exists():
         existing_content = existing_output.read_text()
         preservation_issues = _source_relation_preservation_issues(
@@ -48974,9 +49041,9 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
             source=policy_checkout_path,
             target=overlay_repo,
         )
-        if legacy_replacement is not None:
+        if legacy_replacement is not None or replacement_overlay_scope:
             try:
-                _scope_legacy_replacement_overlay(
+                _scope_replacement_overlay(
                     overlay_repo,
                     active_jurisdiction=policy_content_root.name,
                 )

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -47,7 +47,7 @@ from axiom_encode.constants import (
 from axiom_encode.legacy_replacement import LegacyReplacementContract
 from axiom_encode.legacy_replacement_overlay import (
     LegacyReplacementOverlayError,
-    legacy_replacement_excluded_jurisdictions,
+    replacement_excluded_jurisdictions,
     stage_legacy_replacement_overlay,
 )
 from axiom_encode.prompts.encoder import SOURCE_SCOPE_PROTOCOL
@@ -1385,12 +1385,17 @@ def run_model_eval(
     validation_retry_feedback: Sequence[str] = (),
     required_import_targets: Sequence[str] = (),
     legacy_replacement: LegacyReplacementContract | None = None,
+    replacement_overlay_scope: bool = False,
 ) -> list[EvalResult]:
     """Run a deterministic comparison over one or more citations."""
     _validate_eval_oracle_runtime(oracle, policyengine_runtime, policy_path)
     if target_relative_output is not None and len(citations) != 1:
         raise ValueError(
             "A target RuleSpec output override requires exactly one citation"
+        )
+    if replacement_overlay_scope and target_relative_output is None:
+        raise ValueError(
+            "Replacement overlay scope requires an explicit target RuleSpec output"
         )
     include_tests = include_tests or require_complete_source_unit
     results: list[EvalResult] = []
@@ -1426,6 +1431,7 @@ def run_model_eval(
                         validation_retry_feedback=validation_retry_feedback,
                         required_import_targets=required_import_targets,
                         legacy_replacement=legacy_replacement,
+                        replacement_overlay_scope=replacement_overlay_scope,
                     )
                 )
 
@@ -6707,6 +6713,7 @@ def evaluate_artifact(
     require_complete_source_unit: bool = False,
     amendment_documents: Sequence[CorpusAmendmentDocument] = (),
     legacy_replacement: LegacyReplacementContract | None = None,
+    replacement_overlay_scope: bool = False,
 ) -> EvalArtifactMetrics:
     """Evaluate an artifact inside one exact named corpus release."""
 
@@ -6739,6 +6746,7 @@ def evaluate_artifact(
             require_complete_source_unit=require_complete_source_unit,
             amendment_documents=amendment_documents,
             legacy_replacement=legacy_replacement,
+            replacement_overlay_scope=replacement_overlay_scope,
         )
 
 
@@ -6859,6 +6867,7 @@ def _evaluate_artifact_in_scope(
     require_complete_source_unit: bool = False,
     amendment_documents: Sequence[CorpusAmendmentDocument] = (),
     legacy_replacement: LegacyReplacementContract | None = None,
+    replacement_overlay_scope: bool = False,
 ) -> EvalArtifactMetrics:
     """Evaluate one RuleSpec artifact with deterministic checks plus optional oracles."""
     with _rulespec_validation_target(
@@ -6866,6 +6875,7 @@ def _evaluate_artifact_in_scope(
         policy_repo_root,
         rulespec_dependency_roots=rulespec_dependency_roots,
         legacy_replacement=legacy_replacement,
+        replacement_overlay_scope=replacement_overlay_scope,
     ) as validation_file:
         validation_policy_repo_root = _validation_policy_repo_root(
             validation_file, policy_repo_root
@@ -7237,6 +7247,7 @@ def _evaluate_generated_artifact_with_repairs(
     amendment_documents: Sequence[CorpusAmendmentDocument] = (),
     protected_review_excerpts: frozenset[str] = frozenset(),
     legacy_replacement: LegacyReplacementContract | None = None,
+    replacement_overlay_scope: bool = False,
 ) -> EvalArtifactMetrics | None:
     evaluated_states: set[tuple[bytes | None, bytes | None]] = set()
     while True:
@@ -7261,6 +7272,7 @@ def _evaluate_generated_artifact_with_repairs(
             require_complete_source_unit=require_complete_source_unit,
             amendment_documents=amendment_documents,
             legacy_replacement=legacy_replacement,
+            replacement_overlay_scope=replacement_overlay_scope,
         )
         if metrics is None:
             return None
@@ -7633,7 +7645,7 @@ def _copy_validation_overlay_tree(
     )
 
 
-def _legacy_replacement_overlay_ignore(
+def _replacement_overlay_ignore(
     source_checkout: Path,
     *,
     active_jurisdiction: str,
@@ -7641,13 +7653,13 @@ def _legacy_replacement_overlay_ignore(
     """Exclude unrelated jurisdiction trees while preserving symlink checks."""
 
     try:
-        excluded = legacy_replacement_excluded_jurisdictions(
+        excluded = replacement_excluded_jurisdictions(
             source_checkout,
             active_jurisdiction=active_jurisdiction,
         )
     except LegacyReplacementOverlayError as exc:
         raise UnsafeRulespecContextPath(
-            f"Legacy replacement validation source is invalid: {exc}"
+            f"Replacement validation source is invalid: {exc}"
         ) from exc
     checkout = source_checkout.resolve()
     manifest_root = checkout / ".axiom" / "encoding-manifests"
@@ -7661,13 +7673,15 @@ def _legacy_replacement_overlay_ignore(
             candidate = Path(directory) / name
             if candidate.is_symlink() or not candidate.is_dir():
                 raise UnsafeRulespecContextPath(
-                    "Legacy replacement validation source jurisdiction is unsafe: "
-                    f"{candidate}"
+                    f"Replacement validation source jurisdiction is unsafe: {candidate}"
                 )
             ignored.add(name)
         return ignored
 
     return ignore
+
+
+_legacy_replacement_overlay_ignore = _replacement_overlay_ignore
 
 
 @contextlib.contextmanager
@@ -7677,6 +7691,7 @@ def _rulespec_validation_target(
     *,
     rulespec_dependency_roots: Sequence[Path] = (),
     legacy_replacement: LegacyReplacementContract | None = None,
+    replacement_overlay_scope: bool = False,
 ) -> Iterator[Path]:
     """Yield a validation file under the exact authorized canonical layout."""
 
@@ -7688,9 +7703,9 @@ def _rulespec_validation_target(
         )
     policy_root = Path(policy_repo_root).resolve()
     if _is_under_root(rulespec_file, policy_root):
-        if legacy_replacement is not None:
+        if legacy_replacement is not None or replacement_overlay_scope:
             raise UnsafeRulespecContextPath(
-                "Legacy replacement validation requires a separately generated "
+                "Replacement validation requires a separately generated "
                 "artifact so the live checkout cannot bypass its overlay"
             )
         staging_token = _RULESPEC_VALIDATION_STAGING_ROOT.set(None)
@@ -7732,11 +7747,11 @@ def _rulespec_validation_target(
             )
         overlay_repo = overlay_parent / overlay_repo_name
         overlay_ignore = (
-            _legacy_replacement_overlay_ignore(
+            _replacement_overlay_ignore(
                 source_checkout,
                 active_jurisdiction=policy_root.name,
             )
-            if legacy_replacement is not None
+            if legacy_replacement is not None or replacement_overlay_scope
             else _validation_overlay_ignore
         )
         _copy_validation_overlay_tree(
@@ -8072,6 +8087,7 @@ def _run_single_eval(
     validation_retry_feedback: Sequence[str] = (),
     required_import_targets: Sequence[str] = (),
     legacy_replacement: LegacyReplacementContract | None = None,
+    replacement_overlay_scope: bool = False,
 ) -> EvalResult:
     include_tests = include_tests or require_complete_source_unit
     if source_unit is None:
@@ -8193,6 +8209,7 @@ def _run_single_eval(
                 workspace
             ),
             legacy_replacement=legacy_replacement,
+            replacement_overlay_scope=replacement_overlay_scope,
         )
     validation_error = _eval_artifact_validation_error(
         metrics,

--- a/src/axiom_encode/legacy_replacement_overlay.py
+++ b/src/axiom_encode/legacy_replacement_overlay.py
@@ -49,17 +49,17 @@ def _manifest_jurisdiction_subdir_names(
     return frozenset(jurisdictions)
 
 
-def legacy_replacement_excluded_jurisdictions(
+def replacement_excluded_jurisdictions(
     source_checkout: Path,
     *,
     active_jurisdiction: str,
 ) -> frozenset[str]:
-    """Return sibling jurisdictions excluded from a migration capability.
+    """Return sibling jurisdictions excluded from a replacement capability.
 
-    Legacy replacement validation admits the active jurisdiction and its
+    Replacement validation admits the active jurisdiction and its
     country ancestors. Unrelated siblings remain outside the isolated overlay,
-    so their authenticated pre-hard-cut paths cannot broaden or block this
-    replacement. The live checkout is never changed.
+    so their paths cannot broaden or block the authenticated replacement. The
+    live checkout is never changed.
     """
 
     parts = active_jurisdiction.split("-")
@@ -70,7 +70,7 @@ def legacy_replacement_excluded_jurisdictions(
     )
     if active_jurisdiction not in content_jurisdictions:
         raise LegacyReplacementOverlayError(
-            "Legacy replacement source is missing the active jurisdiction: "
+            "Replacement source is missing the active jurisdiction: "
             f"{active_jurisdiction}"
         )
     manifest_jurisdictions = _manifest_jurisdiction_subdir_names(
@@ -80,14 +80,27 @@ def legacy_replacement_excluded_jurisdictions(
     return frozenset((content_jurisdictions | manifest_jurisdictions) - admitted)
 
 
-def scope_legacy_replacement_overlay(
+def legacy_replacement_excluded_jurisdictions(
+    source_checkout: Path,
+    *,
+    active_jurisdiction: str,
+) -> frozenset[str]:
+    """Backward-compatible alias for replacement overlay scoping."""
+
+    return replacement_excluded_jurisdictions(
+        source_checkout,
+        active_jurisdiction=active_jurisdiction,
+    )
+
+
+def scope_replacement_overlay(
     overlay_checkout: Path,
     *,
     active_jurisdiction: str,
 ) -> None:
-    """Remove unrelated jurisdictions from one isolated migration overlay."""
+    """Remove unrelated jurisdictions from one isolated replacement overlay."""
 
-    excluded = legacy_replacement_excluded_jurisdictions(
+    excluded = replacement_excluded_jurisdictions(
         overlay_checkout,
         active_jurisdiction=active_jurisdiction,
     )
@@ -101,9 +114,22 @@ def scope_legacy_replacement_overlay(
                 continue
             if candidate.is_symlink() or not candidate.is_dir():
                 raise LegacyReplacementOverlayError(
-                    f"Legacy replacement overlay jurisdiction is unsafe: {candidate}"
+                    f"Replacement overlay jurisdiction is unsafe: {candidate}"
                 )
             shutil.rmtree(candidate)
+
+
+def scope_legacy_replacement_overlay(
+    overlay_checkout: Path,
+    *,
+    active_jurisdiction: str,
+) -> None:
+    """Backward-compatible alias for replacement overlay scoping."""
+
+    scope_replacement_overlay(
+        overlay_checkout,
+        active_jurisdiction=active_jurisdiction,
+    )
 
 
 def _overlay_path(checkout_root: Path, relative: Path) -> Path:

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1437"
+ENCODER_VERSION = "0.2.1438"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,6 +34,7 @@ from axiom_encode import __version__ as AXIOM_ENCODE_TEST_VERSION
 from axiom_encode.cli import (
     _APPLY_TRANSACTION_SCHEMA,
     _APPLY_VALIDATION_SNAPSHOT_ATTR,
+    _REPLACEMENT_OVERLAY_SCOPE_ATTR,
     APPLIED_ENCODING_MANIFEST_SCHEMA,
     APPLIED_ENCODING_MODEL_TOOL,
     APPLIED_ENCODING_OFFICIAL_REPOSITORY,
@@ -12670,6 +12671,7 @@ class TestCmdEncode:
         result.output_file = str(generated)
         result.generation_prompt_sha256 = "prompt-sha"
         result._axiom_legacy_replacement_contract = None
+        setattr(result, _REPLACEMENT_OVERLAY_SCOPE_ATTR, True)
         result.trace_file = str(tmp_path / "trace.json")
         Path(result.trace_file).write_text("{}\n")
         source_unit = resolve_corpus_source_unit(
@@ -13040,6 +13042,7 @@ class TestCmdEncode:
         assert mock_run.call_args.kwargs["target_relative_output"] == (
             Path("policies/income_tax/pilot_liability_pipeline.yaml")
         )
+        assert mock_run.call_args.kwargs["replacement_overlay_scope"] is True
         assert mock_run.call_args.kwargs["extra_context_paths"] == [
             target,
             companion,
@@ -13461,6 +13464,10 @@ class TestCmdEncode:
             "repository": ("github.com/TheAxiomFoundation/axiom-rules-engine"),
             "commit": "e" * 40,
         }
+        assert payload["validation_execution"]["schema"] == (
+            "axiom-encode/apply-validation-execution/v2"
+        )
+        assert payload["validation_execution"]["rulespec_scope"] == "full_checkout"
         assert (
             payload["validation_execution"]["policy_pre_apply"]["rulespec_root"]
             == "rulespec-us/us-ny"
@@ -13648,6 +13655,13 @@ class TestCmdEncode:
         }
         receipt = json.loads(
             (checkout / outer["replacement"]["receipt_path"]).read_text()
+        )
+        replacement_execution = receipt["replacement_manifest"]["validation_execution"]
+        assert replacement_execution["schema"] == (
+            "axiom-encode/apply-validation-execution/v2"
+        )
+        assert replacement_execution["rulespec_scope"] == (
+            "active_jurisdiction_and_country_ancestors"
         )
         assert receipt["legacy"]["owner_class"] == "v1-hmac-untrusted"
         assert receipt["replacement"]["source"] == checkout_relative.as_posix()
@@ -36366,6 +36380,9 @@ class TestGuardGenerated:
                 ],
             }
         )
+        assert manifest_payload["validation_execution"]["schema"] == (
+            "axiom-encode/apply-validation-execution/v1"
+        )
         manifest.write_text(json.dumps(manifest_payload) + "\n")
 
         with patch.dict(
@@ -36822,6 +36839,26 @@ rules: []
                 "malformed_engine_commit",
                 "validation_execution.axiom_rules_engine.commit is invalid",
             ),
+            (
+                "missing_v2_scope",
+                "validation_execution has noncanonical fields",
+            ),
+            (
+                "invalid_v2_scope",
+                "validation_execution.rulespec_scope is invalid",
+            ),
+            (
+                "object_v2_scope",
+                "validation_execution.rulespec_scope is invalid",
+            ),
+            (
+                "array_v2_scope",
+                "validation_execution.rulespec_scope is invalid",
+            ),
+            (
+                "extra_v2_scope_field",
+                "validation_execution has noncanonical fields",
+            ),
         ],
     )
     def test_rejects_model_manifest_without_canonical_validation_execution(
@@ -36863,10 +36900,34 @@ rules: []
             manifest_payload["validation_execution"]["axiom_rules_engine"][
                 "repository"
             ] = "github.com/attacker/axiom-rules-engine"
-        else:
+        elif mutation == "malformed_engine_commit":
             manifest_payload["validation_execution"]["axiom_rules_engine"]["commit"] = (
                 "ABC123"
             )
+        elif mutation == "missing_v2_scope":
+            manifest_payload["validation_execution"]["schema"] = (
+                "axiom-encode/apply-validation-execution/v2"
+            )
+        elif mutation == "invalid_v2_scope":
+            manifest_payload["validation_execution"]["schema"] = (
+                "axiom-encode/apply-validation-execution/v2"
+            )
+            manifest_payload["validation_execution"]["rulespec_scope"] = (
+                "unbounded_checkout"
+            )
+        elif mutation in {"object_v2_scope", "array_v2_scope"}:
+            manifest_payload["validation_execution"]["schema"] = (
+                "axiom-encode/apply-validation-execution/v2"
+            )
+            manifest_payload["validation_execution"]["rulespec_scope"] = (
+                {} if mutation == "object_v2_scope" else []
+            )
+        else:
+            manifest_payload["validation_execution"]["schema"] = (
+                "axiom-encode/apply-validation-execution/v2"
+            )
+            manifest_payload["validation_execution"]["rulespec_scope"] = "full_checkout"
+            manifest_payload["validation_execution"]["scope_details"] = {}
         _sign_applied_encoding_manifest(manifest_payload, TEST_APPLY_SIGNING_BROKER)
         manifest.write_text(json.dumps(manifest_payload) + "\n")
 
@@ -39374,6 +39435,96 @@ rules:
         assert len(issues) == 1
         assert issues[0].startswith("regulations/18-nycrr/387/12/f/3/v/c.yaml: ")
         assert "dropped existing source_relation" in issues[0]
+
+    def test_apply_overlay_scopes_authenticated_canonical_replacement(self, tmp_path):
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us" / "us"
+        target = policy_repo / "statutes/42/1437c-1.yaml"
+        sibling = policy_repo.parent / "us-nj/statutes/54a:4-7.yaml"
+        generated = output_root / "codex-test-model/statutes/42/1437c-1.yaml"
+        target.parent.mkdir(parents=True)
+        sibling.parent.mkdir(parents=True)
+        generated.parent.mkdir(parents=True)
+        content = "format: rulespec/v1\nrules: []\n"
+        target.write_text(content)
+        sibling.write_text(content)
+        generated.write_text(content)
+        sibling_manifest = (
+            policy_repo.parent / ".axiom/encoding-manifests/us-nj/statutes/54a:4-7.json"
+        )
+        sibling_manifest.parent.mkdir(parents=True)
+        sibling_manifest.write_text("{}\n")
+        result = SimpleNamespace(
+            output_file=str(generated),
+            runner="codex-test-model",
+            backend="codex",
+        )
+        setattr(result, _REPLACEMENT_OVERLAY_SCOPE_ATTR, True)
+        overlay_observations = []
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                self.policy_root = Path(kwargs["policy_repo_path"])
+
+            def validate(self, path, *, skip_reviewers):
+                assert skip_reviewers is True
+                if self.policy_root != policy_repo:
+                    checkout = self.policy_root.parent
+                    overlay_observations.append(
+                        (
+                            (checkout / "us-nj").exists(),
+                            (checkout / ".axiom/encoding-manifests/us-nj").exists(),
+                        )
+                    )
+                return SimpleNamespace(all_passed=True, results={})
+
+        with patch("axiom_encode.cli.ValidatorPipeline", FakePipeline):
+            ok, issues, supplemental = _validate_generated_encoding_in_policy_overlay(
+                result,
+                output_root=output_root,
+                policy_repo_path=policy_repo,
+                axiom_rules_path=tmp_path / "axiom-rules-engine",
+                local_corpus_release=_bind_test_corpus_release(
+                    policy_repo, tmp_path / "axiom-corpus"
+                ),
+            )
+
+        assert ok is True
+        assert issues == []
+        assert supplemental == {}
+        assert overlay_observations
+        assert all(
+            observation == (False, False) for observation in overlay_observations
+        )
+
+    def test_apply_overlay_rejects_scope_for_missing_canonical_target(self, tmp_path):
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us" / "us"
+        generated = output_root / "codex-test-model/statutes/42/new.yaml"
+        policy_repo.mkdir(parents=True)
+        generated.parent.mkdir(parents=True)
+        generated.write_text("format: rulespec/v1\nrules: []\n")
+        result = SimpleNamespace(
+            output_file=str(generated), runner="codex-test-model", backend="codex"
+        )
+        setattr(result, _REPLACEMENT_OVERLAY_SCOPE_ATTR, True)
+
+        ok, issues, supplemental = _validate_generated_encoding_in_policy_overlay(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+            local_corpus_release=_bind_test_corpus_release(
+                policy_repo, tmp_path / "axiom-corpus"
+            ),
+        )
+
+        assert ok is False
+        assert issues == [
+            "Replacement overlay scope requires an existing regular canonical "
+            "target: statutes/42/new.yaml"
+        ]
+        assert supplemental == {}
 
     def test_apply_overlay_reads_source_metadata_from_explicit_context_manifest(
         self, tmp_path

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -1652,11 +1652,32 @@ def test_model_eval_passes_single_target_output_override(tmp_path):
             corpus_release=corpus_release,
             target_relative_output=target,
             legacy_replacement=legacy_replacement,
+            replacement_overlay_scope=True,
         )
 
     assert actual == [result]
     assert mock_run.call_args.kwargs["target_relative_output"] == target
     assert mock_run.call_args.kwargs["legacy_replacement"] is legacy_replacement
+    assert mock_run.call_args.kwargs["replacement_overlay_scope"] is True
+
+
+def test_model_eval_rejects_replacement_scope_without_target_override(tmp_path):
+    corpus_release, _source_unit = _write_test_source_unit(
+        tmp_path,
+        "authoritative source",
+        citation_path="us/statute/26/1",
+    )
+
+    with pytest.raises(ValueError, match="requires an explicit target"):
+        run_model_eval(
+            citations=["us/statute/26/1"],
+            runner_specs=["openai:model-a"],
+            output_root=tmp_path / "out",
+            policy_path=tmp_path / "rulespec-us" / "us",
+            runtime_axiom_rules_path=tmp_path / "engine",
+            corpus_release=corpus_release,
+            replacement_overlay_scope=True,
+        )
 
 
 def test_model_eval_rejects_target_override_for_multiple_citations(tmp_path):
@@ -4427,6 +4448,47 @@ def test_legacy_replacement_overlay_keeps_active_ancestor_chain(tmp_path):
     assert (copied / ".axiom/encoding-manifests/us-or/marker.json").is_file()
     assert not (copied / ".axiom/encoding-manifests/us-nj").exists()
     assert not (copied / ".axiom/encoding-manifests/us-tx").exists()
+
+
+def test_canonical_replacement_validation_excludes_unrelated_jurisdictions(tmp_path):
+    policy_repo = _canonical_rulespec_content_root(tmp_path, "us")
+    checkout = policy_repo.parent
+    sibling = checkout / "us-nj/statutes/54a:4-7.yaml"
+    sibling.parent.mkdir(parents=True)
+    sibling.write_text("format: rulespec/v1\nrules: []\n")
+    sibling_manifest = (
+        checkout / ".axiom/encoding-manifests/us-nj/statutes/54a:4-7.json"
+    )
+    sibling_manifest.parent.mkdir(parents=True)
+    sibling_manifest.write_text("{}\n")
+    generated = tmp_path / "out/openai/statutes/42/1437c-1.yaml"
+    generated.parent.mkdir(parents=True)
+    generated.write_text("format: rulespec/v1\nrules: []\n")
+
+    with _rulespec_validation_target(
+        generated,
+        policy_repo,
+        replacement_overlay_scope=True,
+    ) as validation_file:
+        overlay_checkout = validation_file.parents[3]
+        assert validation_file.is_file()
+        assert not (overlay_checkout / "us-nj").exists()
+        assert not (overlay_checkout / ".axiom/encoding-manifests/us-nj").exists()
+
+
+def test_fresh_encode_validation_preserves_unrelated_jurisdictions(tmp_path):
+    policy_repo = _canonical_rulespec_content_root(tmp_path, "us")
+    checkout = policy_repo.parent
+    sibling = checkout / "us-nj/statutes/54a:4-7.yaml"
+    sibling.parent.mkdir(parents=True)
+    sibling.write_text("format: rulespec/v1\nrules: []\n")
+    generated = tmp_path / "out/openai/statutes/42/new.yaml"
+    generated.parent.mkdir(parents=True)
+    generated.write_text("format: rulespec/v1\nrules: []\n")
+
+    with _rulespec_validation_target(generated, policy_repo) as validation_file:
+        overlay_checkout = validation_file.parents[3]
+        assert (overlay_checkout / "us-nj/statutes/54a:4-7.yaml").is_file()
 
 
 def test_legacy_replacement_overlay_rejects_manifest_jurisdiction_symlink(tmp_path):

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1437"
+ENCODER_VERSION = "0.2.1438"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1437"
+ENCODER_VERSION = "0.2.1438"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1437"
+ENCODER_VERSION = "0.2.1438"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1437"
+ENCODER_VERSION = "0.2.1438"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1437"
+ENCODER_VERSION = "0.2.1438"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1437"
+ENCODER_VERSION = "0.2.1438"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1437"')
+        .startswith('__version__ = "0.2.1438"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1437"
+    assert encoder_package["version"] == "0.2.1438"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1437"
+    assert project["project"]["version"] == "0.2.1438"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1437"')
+        .startswith('__version__ = "0.2.1438"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1437"
+    assert encoder_package["version"] == "0.2.1438"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1437"
+    assert project["project"]["version"] == "0.2.1438"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1437"')
+        .startswith('__version__ = "0.2.1438"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1437"
+ENCODER_VERSION = "0.2.1438"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1437"
+version = "0.2.1438"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- scope authenticated canonical replacement validation to the active jurisdiction and country ancestors
- bind the scope marker into apply validation snapshots and reject it for missing canonical targets
- preserve full-checkout validation for fresh encodes and retain legacy replacement compatibility
- bump axiom-encode to 0.2.1437

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest` (6196 passed, 119 skipped)

## Cycle
Independent review requested on immutable head after opening; findings and disposition will be recorded before merge.