### PR TITLE
Fix state code citation numeric recall

### DIFF
--- a/changelog.d/state-code-citation-numeric-recall.fixed.md
+++ b/changelog.d/state-code-citation-numeric-recall.fixed.md
@@ -1,0 +1,1 @@
+Treat compact US state-code citations as structural numeric evidence so complete-source validation does not require fake scalar rules for citation components.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1438"
+version = "0.2.1439"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1438"
+__version__ = "0.2.1439"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -1177,6 +1177,21 @@ _STRUCTURAL_SOURCE_CODE_CITATION_PATTERN = re.compile(
     r"(?=$|[\s,.;:])",
     re.IGNORECASE,
 )
+_STRUCTURAL_SOURCE_STATE_CODE_CITATION_TARGET = (
+    r"\d+[A-Za-z]?:\d+[A-Za-z]?-\d+[A-Za-z]?(?:\.\d+)*"
+    r"(?:\([A-Za-z0-9]+\)[A-Za-z0-9]*)*"
+)
+_STRUCTURAL_SOURCE_STATE_CODE_CITATION_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9])"
+    r"(?:(?:(?:N\.J\.S\.(?:A\.)?|N\.J\.A\.C\.|R\.S\.)\s*|C\.)"
+    r"|(?:(?:sections?|sec\.?)\s+|§{1,2}\s*))"
+    + _STRUCTURAL_SOURCE_STATE_CODE_CITATION_TARGET
+    + r"(?:\s*(?:,|and|or)\s*"
+    + _STRUCTURAL_SOURCE_STATE_CODE_CITATION_TARGET
+    + r")*"
+    r"""(?=$|[\s,.;:)\]}\'"”’–—])""",
+    re.IGNORECASE,
+)
 _STRUCTURAL_SOURCE_BARE_DOTTED_REFERENCE_PATTERN = re.compile(
     r"(?<![\w$£€])\d+(?:\.\d+){2,}(?![\w%])"
 )
@@ -4985,6 +5000,7 @@ def _clean_source_text_for_numeric_extraction(text: str) -> str:
     cleaned = _STRUCTURAL_SOURCE_FORM_NUMBER_PATTERN.sub(" ", cleaned)
     cleaned = _STRUCTURAL_SOURCE_FORM_LINE_PATTERN.sub(" ", cleaned)
     cleaned = _STRUCTURAL_SOURCE_CODE_CITATION_PATTERN.sub(" ", cleaned)
+    cleaned = _STRUCTURAL_SOURCE_STATE_CODE_CITATION_PATTERN.sub(" ", cleaned)
     cleaned = _STRUCTURAL_SOURCE_BARE_DOTTED_REFERENCE_PATTERN.sub(" ", cleaned)
     cleaned = _STRUCTURAL_SOURCE_SECTION_PATTERN.sub(" ", cleaned)
     cleaned = GROUNDING_DATE_PATTERN.sub(" ", cleaned)
@@ -6385,6 +6401,7 @@ def _structural_numeric_component_spans(
             _GERMAN_STRUCTURAL_REFERENCE_PATTERN,
             _ENGLISH_STRUCTURAL_REFERENCE_PATTERN,
             _ENGLISH_STRUCTURAL_DIGIT_LABEL_PATTERN,
+            _STRUCTURAL_SOURCE_STATE_CODE_CITATION_PATTERN,
             _STRUCTURAL_LINE_MARKER_PATTERN,
             _STRUCTURAL_GLUED_SENTENCE_MARKER_PATTERN,
         )

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1438"
+ENCODER_VERSION = "0.2.1439"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1438"
+ENCODER_VERSION = "0.2.1439"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1438"
+ENCODER_VERSION = "0.2.1439"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1438"
+ENCODER_VERSION = "0.2.1439"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1438"
+ENCODER_VERSION = "0.2.1439"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1438"
+ENCODER_VERSION = "0.2.1439"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1438"
+ENCODER_VERSION = "0.2.1439"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1438"')
+        .startswith('__version__ = "0.2.1439"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1438"
+    assert encoder_package["version"] == "0.2.1439"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1438"
+    assert project["project"]["version"] == "0.2.1439"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1438"')
+        .startswith('__version__ = "0.2.1439"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1438"
+    assert encoder_package["version"] == "0.2.1439"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1438"
+    assert project["project"]["version"] == "0.2.1439"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1438"')
+        .startswith('__version__ = "0.2.1439"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1438"
+ENCODER_VERSION = "0.2.1439"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -2030,6 +2030,57 @@ rules: []
     assert _has_issue(result, "numeric-recall", "value 1")
 
 
+def test_en_us_state_code_citations_are_structural_for_numeric_recall():
+    source = (
+        "The credit applies against tax due under (N.J.S.54A:1-1) and "
+        "N.J.S.A. 54A:9-7, subject to C.54A:4-6 and section 54A:4-7. "
+        "C.54:4-8.57 and “R.S.43:21-1” also apply. "
+        "Sections 54:4-8.57 and 43:21-1 provide the same references. "
+        "'N.J.A.C. 10:90-3.8(b)1' and N.J.A.C. 10:90-3.9(d)5i control. "
+        "N.J.S.54A:4-7—this controls; R.S.43:21-1–as amended."
+    )
+
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        source,
+        profile="en-US",
+    )
+
+    assert inventory == []
+
+
+def test_en_us_state_code_citation_filter_preserves_real_unit_and_ratio_values():
+    source = (
+        "Under N.J.S.54A:1-1, the amount is 1 dollar, the required ratio is 2:1, "
+        "outline A. uses the ratio 10:2, the adjusted ratio is 10:2-3, "
+        "outline C. uses 10:2-3, the score range is 10:20-30, "
+        "and dose schedule 10mg:2-3 applies."
+    )
+
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        source,
+        profile="en-US",
+    )
+
+    assert [(item.value, item.raw) for item in inventory] == [
+        (1.0, "1"),
+        (2.0, "2"),
+        (1.0, "1"),
+        (10.0, "10"),
+        (2.0, "2"),
+        (10.0, "10"),
+        (2.0, "2"),
+        (3.0, "3"),
+        (10.0, "10"),
+        (2.0, "2"),
+        (3.0, "3"),
+        (10.0, "10"),
+        (20.0, "20"),
+        (30.0, "30"),
+        (2.0, "2"),
+        (3.0, "3"),
+    ]
+
+
 def test_imported_numeric_recall_only_credits_explicit_imported_scalar():
     content = """\
 format: rulespec/v1

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1438"
+version = "0.2.1439"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- classify compact New Jersey state-code citations as structural numeric evidence only when an explicit authority prefix or section cue is present
- support N.J.S., N.J.S.A., N.J.A.C., R.S., tightly scoped C., nested NJAC subdivisions, citation lists, enclosing punctuation, and legal-prose dashes
- preserve substantive ratios, ranges, outline labels, unit syntax, and monetary values
- bump encoder to 0.2.1439

## Why
Protected NJ run 30860854550 passed trust, routing, source, and signing gates but failed closed because N.J.S.54A:1-1 contributed fake unnamed value-1 inventory entries. Exact-corpus reproduction confirmed these were citation components, not tax scalars. No signatures or RuleSpec PR were emitted.

## Review cycle
Independent review/fix loop completed on the pre-rebase head and repeated after rebasing onto current main. Exact head bc3b40c224cb86eb816f72275a13276565d85094 is CLEAN with no actionable findings. Range-diff and direct blob comparison confirm the validated implementation, tests, and changelog are unchanged; only the expected version transition advanced to 0.2.1439.

## Checks
- full Python 3.13 suite: 6210 passed, 119 skipped
- affected validation and registry suite: 1764 passed, 31 skipped
- source completeness: 412 passed
- overlay-scope interaction selection: 15 passed
- packaged version/hash checks: 3 passed
- encoder version provenance passed
- full Ruff, changed-file format, compileall, lock, and diff checks passed
- exact NJ corpus numeric inventory is empty after the fix
- hosted Python 3.13, lint, Ubuntu signing-supervisor, and macOS signing-supervisor jobs passed