### PR TITLE
Fail closed on invalid generated proof citations

### DIFF
--- a/changelog.d/invalid-generated-proof-citation.fixed.md
+++ b/changelog.d/invalid-generated-proof-citation.fixed.md
@@ -1,0 +1,1 @@
+Fail closed on invalid model-authored proof citation paths without aborting the encode repair loop.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1439"
+version = "0.2.1440"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1439"
+__version__ = "0.2.1440"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -24144,7 +24144,12 @@ class ValidatorPipeline:
                     continue
                 citation_path = str(source.get("corpus_citation_path") or "").strip()
                 if citation_path:
-                    resolved[citation_path] = fetch_source(citation_path)
+                    try:
+                        resolved[citation_path] = fetch_source(citation_path)
+                    except InvalidCorpusCitationError:
+                        # Model-authored citation errors are validation findings, not
+                        # harness failures that should abort the repair loop.
+                        resolved[citation_path] = None
         return resolved
 
     def _trusted_source_binding_issues(self, content: str) -> list[str]:

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1439"
+ENCODER_VERSION = "0.2.1440"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1439"
+ENCODER_VERSION = "0.2.1440"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1439"
+ENCODER_VERSION = "0.2.1440"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1439"
+ENCODER_VERSION = "0.2.1440"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1439"
+ENCODER_VERSION = "0.2.1440"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1439"
+ENCODER_VERSION = "0.2.1440"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1439"
+ENCODER_VERSION = "0.2.1440"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1439"')
+        .startswith('__version__ = "0.2.1440"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1439"
+    assert encoder_package["version"] == "0.2.1440"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1439"
+    assert project["project"]["version"] == "0.2.1440"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1439"')
+        .startswith('__version__ = "0.2.1440"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1439"
+    assert encoder_package["version"] == "0.2.1440"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1439"
+    assert project["project"]["version"] == "0.2.1440"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1439"')
+        .startswith('__version__ = "0.2.1440"')
     )
 
 
@@ -22826,6 +22826,67 @@ def test_validator_pipeline_resolves_direct_proof_sources_from_authoritative_cor
 
     assert source_texts == {citation_path: "The official amount is $298."}
     assert find_rulespec_proof_issues(content, source_texts=source_texts) == []
+
+
+def test_validator_pipeline_fails_closed_for_invalid_generated_proof_citation(
+    tmp_path,
+    monkeypatch,
+):
+    citation_path = "us/statute/42/1437c–1(a)(1)"
+    content = f"""format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/42/1437c–1
+rules:
+  - name: plan_frequency
+    kind: parameter
+    dtype: Number
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: {citation_path}
+              excerpt: every 5 fiscal years
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '5'
+"""
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path / "rulespec-us",
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+    )
+
+    def reject_invalid_citation(_citation_path):
+        raise validator_pipeline.InvalidCorpusCitationError("invalid generated path")
+
+    monkeypatch.setattr(
+        validator_pipeline,
+        "_fetch_corpus_proof_evidence_text",
+        reject_invalid_citation,
+    )
+    monkeypatch.setattr(
+        validator_pipeline,
+        "_fetch_corpus_source_text",
+        reject_invalid_citation,
+    )
+
+    proof_sources = pipeline._proof_source_texts_for_rulespec_content(
+        content,
+        source_texts=None,
+    )
+    numeric_sources = pipeline._numeric_source_texts_for_rulespec_content(
+        content,
+        source_texts=None,
+    )
+
+    assert proof_sources == {citation_path: None}
+    assert numeric_sources == {citation_path: None}
+    issues = find_rulespec_proof_issues(content, source_texts=proof_sources)
+    assert any("Noncanonical corpus citation path" in issue for issue in issues)
+    assert any("Proof source unresolved" in issue for issue in issues)
 
 
 def test_source_history_proves_excerpt_without_grounding_numeric_literal(tmp_path):

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1439"
+ENCODER_VERSION = "0.2.1440"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1439"
+version = "0.2.1440"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- treat invalid model-authored proof citation paths as unresolved evidence instead of uncaught validator exceptions
- preserve the existing noncanonical-citation and unresolved-proof findings so malformed artifacts still fail closed
- cover both proof-evidence and numeric-source resolution and bump encoder to `0.2.1440`

## Incident
Protected signed repair run https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/30863630989 generated `us/statute/42/1437c–1(a)(1)` in a proof atom. `InvalidCorpusCitationError` escaped `_cited_source_texts_for_rulespec_content`, aborting the entire repair/escalation loop with zero signatures. This change keeps that artifact invalid but allows the loop to report the issue and continue to later attempts.

## Checks
- `uv run --python 3.13 pytest tests/test_rulespec_validation.py -k 'invalid_generated_proof_citation or resolves_direct_proof_sources'` (2 passed)
- `uv run --python 3.13 pytest tests/test_rulespec_validation.py` (1329 passed, 31 skipped)
- `uv run --python 3.13 ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run --python 3.13 ruff format --check src tests`
- `python3.13 -m compileall -q src/axiom_encode scripts`

The required independent review-fix cycle is pending.
