### PR TITLE
Fix NJ inline ordinal and proof sibling scope

### DIFF
--- a/changelog.d/nj-inline-ordinal-proof-scope.fixed.md
+++ b/changelog.d/nj-inline-ordinal-proof-scope.fixed.md
@@ -1,0 +1,1 @@
+Treat inline legal ordinals as structural numeric evidence and honor comma-shorthand sibling subsections in proof scope declarations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1440"
+version = "0.2.1441"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1440"
+__version__ = "0.2.1441"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/proof_validator.py
+++ b/src/axiom_encode/harness/proof_validator.py
@@ -984,14 +984,29 @@ def _proof_excerpt_subsection_scope_issues(
 def _rule_source_subsection_scope(
     rule_source: str,
 ) -> dict[str, frozenset[str] | None]:
-    """Parse top-level CFR markers and any explicit numeric child ranges."""
+    """Parse top-level subsection markers and explicit numeric child ranges."""
     scope: dict[str, set[str] | None] = {}
+    current_top: str | None = None
     for segment in str(rule_source).split(","):
         top_match = re.search(r"\((?P<top>[a-z])\)", segment)
-        if top_match is None:
+        if top_match is not None:
+            current_top = top_match.group("top")
+            suffix = segment[top_match.end() :]
+        elif current_top is not None:
+            if (
+                re.fullmatch(
+                    r"\s*\(\d+\)(?:\s*-\s*\(\d+\))?\s*",
+                    segment,
+                )
+                is None
+            ):
+                current_top = None
+                continue
+            suffix = segment
+        else:
             continue
-        top = top_match.group("top")
-        suffix = segment[top_match.end() :]
+        top = current_top
+        assert top is not None
         numeric = {
             match.group("value") for match in re.finditer(r"\((?P<value>\d+)\)", suffix)
         }

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -1192,6 +1192,25 @@ _STRUCTURAL_SOURCE_STATE_CODE_CITATION_PATTERN = re.compile(
     r"""(?=$|[\s,.;:)\]}\'"”’–—])""",
     re.IGNORECASE,
 )
+_STRUCTURAL_SOURCE_NJ_TITLE_54A_HEADING_TARGET = (
+    r"54A:\d+[A-Za-z]?\-\d+[A-Za-z]?(?:\.\d+)*"
+    r"(?:\([A-Za-z0-9]+\)[A-Za-z0-9]*)*"
+)
+_STRUCTURAL_SOURCE_NJ_TITLE_54A_HEADING_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9])"
+    + _STRUCTURAL_SOURCE_NJ_TITLE_54A_HEADING_TARGET
+    + r"(?=[ \t]+[A-Z][^.!?\n]{0,160}\s*\.)"
+)
+_STRUCTURAL_INLINE_NJ_LEGAL_ORDINAL_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9])"
+    + r"(?P<citation>"
+    + _STRUCTURAL_SOURCE_NJ_TITLE_54A_HEADING_TARGET
+    + r")"
+    + r"[ \t]+[A-Z][^.!?\n]{0,160}\s*\.[ \t]+"
+    + r"(?P=citation)"
+    + r"[ \t]+[A-Z][^.!?\n]{0,160}\s*\.[ \t]+"
+    + r"(?P<ordinal>[1-9]\d?)\.(?=[ \t]+[A-Z])"
+)
 _STRUCTURAL_SOURCE_BARE_DOTTED_REFERENCE_PATTERN = re.compile(
     r"(?<![\w$£€])\d+(?:\.\d+){2,}(?![\w%])"
 )
@@ -6402,11 +6421,16 @@ def _structural_numeric_component_spans(
             _ENGLISH_STRUCTURAL_REFERENCE_PATTERN,
             _ENGLISH_STRUCTURAL_DIGIT_LABEL_PATTERN,
             _STRUCTURAL_SOURCE_STATE_CODE_CITATION_PATTERN,
+            _STRUCTURAL_SOURCE_NJ_TITLE_54A_HEADING_PATTERN,
             _STRUCTURAL_LINE_MARKER_PATTERN,
             _STRUCTURAL_GLUED_SENTENCE_MARKER_PATTERN,
         )
         for match in pattern.finditer(text)
     }
+    spans.update(
+        match.span("ordinal")
+        for match in _STRUCTURAL_INLINE_NJ_LEGAL_ORDINAL_PATTERN.finditer(text)
+    )
     return tuple(sorted(spans))
 
 

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1440"
+ENCODER_VERSION = "0.2.1441"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1440"
+ENCODER_VERSION = "0.2.1441"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1440"
+ENCODER_VERSION = "0.2.1441"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1440"
+ENCODER_VERSION = "0.2.1441"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1440"
+ENCODER_VERSION = "0.2.1441"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1440"
+ENCODER_VERSION = "0.2.1441"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1440"
+ENCODER_VERSION = "0.2.1441"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1440"')
+        .startswith('__version__ = "0.2.1441"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1440"
+    assert encoder_package["version"] == "0.2.1441"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1440"
+    assert project["project"]["version"] == "0.2.1441"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1440"')
+        .startswith('__version__ = "0.2.1441"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1440"
+    assert encoder_package["version"] == "0.2.1441"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1440"
+    assert project["project"]["version"] == "0.2.1441"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1440"')
+        .startswith('__version__ = "0.2.1441"')
     )
 
 
@@ -13007,6 +13007,113 @@ rules:
 
     assert result.passed is True
     assert result.issues == []
+
+
+def test_rulespec_proof_validator_allows_comma_shorthand_numeric_sibling():
+    excerpt = "(4) A resident individual who is at least 18 years of age is eligible."
+    content = f"""format: rulespec/v1
+rules:
+  - name: age_modified_credit
+    kind: derived
+    dtype: Money
+    source: N.J.S. 54A:4-7(a)(1), (4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: {excerpt!r}
+    versions:
+      - effective_from: '2026-01-01'
+        formula: federal_credit * state_percentage
+"""
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": excerpt},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_rejects_undeclared_comma_shorthand_sibling():
+    excerpt = "(5) A different eligibility rule applies."
+    content = f"""format: rulespec/v1
+rules:
+  - name: age_modified_credit
+    kind: derived
+    dtype: Money
+    source: N.J.S. 54A:4-7(a)(1), (4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: {excerpt!r}
+    versions:
+      - effective_from: '2026-01-01'
+        formula: federal_credit * state_percentage
+"""
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": excerpt},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue and "(5)" in issue
+        for issue in result.issues
+    )
+
+
+@pytest.mark.parametrize(
+    "rule_source",
+    [
+        "N.J.S. 54A:4-7(a)(1), as amended",
+        "N.J.S. 54A:4-7(a)(1), N.J.S. 54A:4-8",
+        "N.J.S. 54A:4-7(a)(1), as amended, (5)",
+        "N.J.S. 54A:4-7(a)(1), N.J.S. 54A:4-8, (5)",
+    ],
+)
+def test_rulespec_proof_validator_does_not_broaden_scope_for_comma_suffixes(
+    rule_source: str,
+):
+    excerpt = "(5) A different eligibility rule applies."
+    content = f"""format: rulespec/v1
+rules:
+  - name: age_modified_credit
+    kind: derived
+    dtype: Money
+    source: {rule_source}
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: {excerpt!r}
+    versions:
+      - effective_from: '2026-01-01'
+        formula: federal_credit * state_percentage
+"""
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": excerpt},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue and "(5)" in issue
+        for issue in result.issues
+    )
 
 
 def test_rulespec_proof_validator_allows_numeric_excerpt_under_broad_subsection():

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1440"
+ENCODER_VERSION = "0.2.1441"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -2081,6 +2081,47 @@ def test_en_us_state_code_citation_filter_preserves_real_unit_and_ratio_values()
     ]
 
 
+def test_en_us_inline_legal_ordinal_is_structural_after_collapsed_heading():
+    source = (
+        "54A:4-7 New Jersey Earned Income Tax Credit program. "
+        "54A:4-7 New Jersey Earned Income Tax Credit program . "
+        "2. There is established the New Jersey Earned Income Tax Credit program. "
+        "The filing fee is 2 dollars."
+    )
+
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        source,
+        profile="en-US",
+    )
+
+    assert [(item.value, item.raw) for item in inventory] == [(2.0, "2")]
+
+
+@pytest.mark.parametrize(
+    ("heading", "scalar", "unit"),
+    [
+        ("Filing fee notice", 2, "Dollars are due"),
+        ("Applicable rate notice", 25, "Percent applies"),
+        ("Deadline notice", 30, "Days are allowed"),
+    ],
+)
+def test_en_us_inline_scalar_after_single_nj_heading_is_not_a_legal_ordinal(
+    heading: str,
+    scalar: int,
+    unit: str,
+):
+    source = f"54A:4-7 {heading}. {scalar}. {unit}."
+
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        source,
+        profile="en-US",
+    )
+
+    assert [(item.value, item.raw) for item in inventory] == [
+        (float(scalar), str(scalar))
+    ]
+
+
 def test_imported_numeric_recall_only_credits_explicit_imported_scalar():
     content = """\
 format: rulespec/v1

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1440"
+version = "0.2.1441"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- classify the collapsed NJ section ordinal only inside the exact duplicated title-54A heading envelope found in the authoritative corpus
- preserve real scalar fragments after a single NJ heading
- inherit proof citation numeric shorthand only across an immediately adjacent all-numeric comma segment and reset state across prose or another full citation
- bump encoder to 0.2.1441

## Why
Protected NJ run 30863881819 passed every trust, routing, source, signing, and replacement gate but failed closed after three model attempts with zero signatures. The run exposed two parser defects: the collapsed section ordinal 2 was treated as a tax scalar, and comma shorthand proof scope did not cover the declared sibling. This fixes those parsers without relaxing source completeness or proof validation.

## Review cycle
The first independent review found two boundary issues: inherited proof state could bleed across an intervening full citation, and a single NJ heading could suppress a real scalar. Both were fixed. The repeated independent review is CLEAN on exact commit 525da1eca511db297e04f892221463faa5f02af3 with no actionable findings.

## Checks
- full Python 3.13 suite: 6,221 passed, 119 skipped
- affected validation suite: 1,751 passed, 31 skipped
- focused independent-review suite: 127 passed
- targeted NJ/parser regression selection: 7 passed
- exact collapsed NJ corpus numeric inventory is empty
- single-heading scalar probes preserve 2 dollars, 25 percent, and 30 days
- Ruff, compileall, uv lock consistency, version consistency, and diff checks pass
- literal uv run pytest selected an incomplete worktree environment and stopped before collection because cryptography was absent; the complete repository Python 3.13 environment produced the full result above

No signatures were emitted by the failed protected run, and no RuleSpec PR was opened.