### PR TITLE
Fix strict source citation identity

### DIFF
--- a/changelog.d/strict-source-citation-identity.fixed.md
+++ b/changelog.d/strict-source-citation-identity.fixed.md
@@ -1,0 +1,1 @@
+Normalize legal-citation dash variants during source-scope checks and require exact proof corpus identities plus explicit branch inventories in strict encoding prompts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1442"
+version = "0.2.1443"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1442"
+__version__ = "0.2.1443"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -88,7 +88,11 @@ from axiom_encode.repo_routing import (
     monorepo_checkout_name,
 )
 from axiom_encode.rules_engine_compat import run_rulespec_compile
-from axiom_encode.statute import citation_to_citation_path, parse_usc_citation
+from axiom_encode.statute import (
+    citation_to_citation_path,
+    normalize_rulespec_path_segment,
+    parse_usc_citation,
+)
 
 from .dependency_stubs import (
     UnsafeRulespecContextPath,
@@ -2037,7 +2041,7 @@ def _citation_to_normalized_target(citation: str) -> tuple[str, ...] | None:
     if parts is None:
         return None
     pieces = ["statutes", parts.title, parts.section, *parts.fragments]
-    return tuple(p.lower() for p in pieces if p)
+    return tuple(normalize_rulespec_path_segment(p).lower() for p in pieces if p)
 
 
 def _corpus_citation_to_normalized_target(citation: str) -> tuple[str, ...] | None:
@@ -2055,7 +2059,11 @@ def _corpus_citation_to_normalized_target(citation: str) -> tuple[str, ...] | No
     target_ref = _parse_rulespec_target(candidate)
     if target_ref is not None:
         return _rulespec_relative_path_parts(target_ref.relative_path)
-    parts = [part.strip().lower() for part in candidate.split("/") if part.strip()]
+    parts = [
+        normalize_rulespec_path_segment(part.strip()).lower()
+        for part in candidate.split("/")
+        if part.strip()
+    ]
     if len(parts) < 3 or not (parts[0] == "us" or parts[0].startswith("us-")):
         return None
     class_part = parts[1]

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -2035,7 +2035,7 @@ def _citation_to_normalized_target(citation: str) -> tuple[str, ...] | None:
     if corpus_target is not None:
         return corpus_target
     try:
-        parts = parse_usc_citation(citation)
+        parts = parse_usc_citation(normalize_rulespec_path_segment(citation))
     except Exception:
         return None
     if parts is None:

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -2405,7 +2405,7 @@ def _range_endpoint_normalized_target(
 
 
 def _clean_source_citation_fragment(fragment: str) -> str:
-    cleaned = fragment.strip()
+    cleaned = normalize_rulespec_path_segment(fragment.strip())
     cleaned = re.sub(r"^(?:and|or)\s+", "", cleaned, flags=re.IGNORECASE)
     cleaned = cleaned.rstrip(".")
     cleaned = _USC_ABBREVIATION_RE.sub("USC", cleaned)

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -1649,6 +1649,13 @@ Complete-source-unit mode is enabled for this request:
   `blocked_by` only for known exact RuleSpec targets with a `#rule_fragment`;
   otherwise omit `blocked_by` and name the exact missing legal dependency or
   citation in `reason`. Never guess a blocker target.
+- Before returning YAML, inventory every top-level structural branch in the
+  authoritative source and verify that each branch has either an executable
+  rule whose `source:` cites that branch or one `module.deferred_outputs` entry
+  whose absolute output path preserves the branch label. Do not return while
+  any branch is absent. A deferral reason must identify the exact branch and a
+  concrete missing input, dependency, or runtime capability; generic omission
+  language is not coverage.
 - Companion tests must execute every source-stated formula branch, boundary,
   exception, and rounding rule with assertions on the affected principal
   output. Each branch needs distinct runtime evidence; descriptive test
@@ -1671,6 +1678,11 @@ Corpus source path: {corpus_citation_path}
 Include `{corpus_citation_path}` in `module.source_verification`.
 Use exactly
 `module.source_verification.corpus_citation_path: {corpus_citation_path}`.
+Use that exact same `{corpus_citation_path}` value in every source-backed proof
+atom's `source.corpus_citation_path`. Do not rewrite it as a display citation
+and do not append subsection markers or other path segments. Express narrower
+support through the rule-level `source:`, the proof excerpt, and the legal
+output path while keeping the corpus machine identity unchanged.
 Never emit `corpus_citation_paths`. A provision split across storage rows must
 be composed by the corpus resolver under this one canonical path. If another
 legal source is required, import its separately attested RuleSpec or defer the

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1442"
+ENCODER_VERSION = "0.2.1443"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -168,10 +168,29 @@ def test_generic_encoder_prompt_includes_durable_rule_spec_guidance():
         "module.source_verification.corpus_citation_path: us/statute/26/63"
         in normalized_prompt
     )
+    assert (
+        "Use that exact same `us/statute/26/63` value in every source-backed proof"
+        in prompt
+    )
+    assert "do not append subsection markers or other path segments" in prompt
     assert "Never emit `corpus_citation_paths`" in normalized_prompt
     assert "corpus resolver under this one canonical path" in normalized_prompt
     assert "Target citation/source id: 26 USC 63(c)(5)" in prompt
     assert "Expected output path: statutes/26/63/c/5.yaml" in prompt
+
+
+def test_complete_source_prompt_requires_explicit_branch_inventory():
+    prompt = get_encoder_prompt(
+        citation="42 USC 1437c-1",
+        output_path="statutes/42/1437c-1.yaml",
+        corpus_citation_path="us/statute/42/1437c–1",
+        require_complete_source_unit=True,
+    )
+    normalized_prompt = " ".join(prompt.split())
+
+    assert "inventory every top-level structural branch" in normalized_prompt
+    assert "Do not return while any branch is absent" in normalized_prompt
+    assert "absolute output path preserves the branch label" in normalized_prompt
 
 
 class TestClaudeCodeBackend:

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1442"
+ENCODER_VERSION = "0.2.1443"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1442"
+ENCODER_VERSION = "0.2.1443"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1442"
+ENCODER_VERSION = "0.2.1443"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1442"
+ENCODER_VERSION = "0.2.1443"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1442"
+ENCODER_VERSION = "0.2.1443"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1442"
+ENCODER_VERSION = "0.2.1443"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -26341,6 +26341,51 @@ rules:
     )
 
 
+@pytest.mark.parametrize("source_dash", ("‐", "‑", "‒", "–", "—", "−"))
+def test_out_of_scope_rule_source_normalizes_display_citation_dash_variants(
+    source_dash,
+):
+    content = f"""format: rulespec/v1
+rules:
+  - name: five_year_plan_period_fiscal_years
+    kind: parameter
+    dtype: Number
+    source: 42 USC 1437c{source_dash}1(a)(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '5'
+"""
+
+    assert (
+        find_out_of_scope_rule_source_issues(
+            content,
+            requested_source="us/statute/42/1437c–1",
+        )
+        == []
+    )
+
+
+def test_out_of_scope_rule_source_rejects_unicode_dash_display_sibling():
+    content = """format: rulespec/v1
+rules:
+  - name: sibling_plan_rule
+    kind: parameter
+    dtype: Number
+    source: 42 USC 1437c–2(a)(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '5'
+"""
+
+    issues = find_out_of_scope_rule_source_issues(
+        content,
+        requested_source="us/statute/42/1437c–1",
+    )
+
+    assert len(issues) == 1
+    assert "`sibling_plan_rule` source `42 USC 1437c–2(a)(1)`" in issues[0]
+
+
 def test_out_of_scope_rule_source_rejects_sibling_in_multicitation_source():
     content = """format: rulespec/v1
 rules:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -26316,6 +26316,31 @@ rules:
     assert issues == []
 
 
+@pytest.mark.parametrize("corpus_dash", ("‐", "‑", "‒", "–", "—", "−"))
+def test_out_of_scope_rule_source_normalizes_section_dash_variants(corpus_dash):
+    content = f"""format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/42/1437c{corpus_dash}1
+rules:
+  - name: five_year_plan_period_fiscal_years
+    kind: parameter
+    dtype: Number
+    source: 42 USC 1437c-1(a)(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '5'
+"""
+
+    assert (
+        find_out_of_scope_rule_source_issues(
+            content,
+            requested_source=f"us/statute/42/1437c{corpus_dash}1",
+        )
+        == []
+    )
+
+
 def test_out_of_scope_rule_source_rejects_sibling_in_multicitation_source():
     content = """format: rulespec/v1
 rules:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1442"')
+        .startswith('__version__ = "0.2.1443"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1442"
+    assert encoder_package["version"] == "0.2.1443"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1442"
+    assert project["project"]["version"] == "0.2.1443"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1442"')
+        .startswith('__version__ = "0.2.1443"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1442"
+    assert encoder_package["version"] == "0.2.1443"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1442"
+    assert project["project"]["version"] == "0.2.1443"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1442"')
+        .startswith('__version__ = "0.2.1443"')
     )
 
 
@@ -26670,6 +26670,51 @@ rules:
 
     assert len(issues) == 1
     assert "`agricultural_labor_range_rule` source `26 USC 3306(k)-(m)`" in issues[0]
+
+
+@pytest.mark.parametrize("range_dash", ("‐", "‑", "‒", "–", "—", "−"))
+def test_out_of_scope_rule_source_allows_unicode_dash_range_under_requested_source(
+    range_dash,
+):
+    content = f"""format: rulespec/v1
+rules:
+  - name: plan_period_range_rule
+    kind: parameter
+    dtype: Number
+    source: 42 USC 1437c–1(a)(1){range_dash}(3)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '5'
+"""
+
+    assert (
+        find_out_of_scope_rule_source_issues(
+            content,
+            requested_source="us/statute/42/1437c–1",
+        )
+        == []
+    )
+
+
+def test_out_of_scope_rule_source_rejects_unicode_dash_range_sibling():
+    content = """format: rulespec/v1
+rules:
+  - name: sibling_plan_range_rule
+    kind: parameter
+    dtype: Number
+    source: 42 USC 1437c–2(a)(1)–(3)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '5'
+"""
+
+    issues = find_out_of_scope_rule_source_issues(
+        content,
+        requested_source="us/statute/42/1437c–1",
+    )
+
+    assert len(issues) == 1
+    assert "`sibling_plan_range_rule` source `42 USC 1437c–2(a)(1)–(3)`" in issues[0]
 
 
 def test_out_of_scope_rule_source_rejects_irc_alias_sibling():

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1442"
+ENCODER_VERSION = "0.2.1443"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1442"
+version = "0.2.1443"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- normalize legal citation dash variants before strict source-scope comparison
- canonicalize Unicode range separators before source-fragment parsing
- require generated proof atoms to preserve the exact corpus citation path
- require complete-source encodings to inventory every top-level source branch
- bump encoder package to 0.2.1443

## Why
Protected repair run 30864806929 encoded 42 USC 1437c-1 but failed closed because the corpus identity uses a Unicode dash while the legal display citation uses an ASCII hyphen. It also omitted top-level subsection (c). This fixes the false scope mismatch and makes both corpus identity and branch completeness explicit in the encoder prompt.

## Checks
- full suite before final clean rebase: 6,242 passed, 119 skipped
- post-rebase provenance/scope/#1361 integration checks: 61 passed
- `uv run --python 3.13 ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run --python 3.13 ruff format --check src/axiom_encode tests`
- `python3.13 -m compileall -q src/axiom_encode scripts`

## Cycle
Three actionable review findings were fixed: Unicode display citations and Unicode subsection ranges can no longer bypass source-scope validation, and all post-fix encoder changes are behind version 0.2.1443. Final independent review and hosted CI are running on current-main exact head `88d1f648`; the PR remains draft until both are clean.