### PR TITLE
Fix federal code citation numeric recall

### DIFF
--- a/changelog.d/us-code-section-marker-numeric-recall.fixed.md
+++ b/changelog.d/us-code-section-marker-numeric-recall.fixed.md
@@ -1,0 +1,1 @@
+Treat post-code section markers such as ``26 U.S.C. s.32`` as structural citation evidence during numeric recall.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1441"
+version = "0.2.1442"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1441"
+__version__ = "0.2.1442"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -1172,9 +1172,10 @@ _STRUCTURAL_SOURCE_FORM_LINE_PATTERN = re.compile(
 _STRUCTURAL_SOURCE_CODE_CITATION_PATTERN = re.compile(
     r"\b\d+\s+"
     r"(?:U\.?\s*S\.?\s*C\.?|USC|C\.?\s*F\.?\s*R\.?|CFR|C\.?\s*C\.?\s*R\.?|CCR)\s+"
+    r"(?:(?:s(?:ec(?:tion)?)?\.?|§{1,2})\s*)?"
     r"\d+[A-Za-z]*(?:[.-]\d+[A-Za-z]*)*(?:\([A-Za-z0-9]+\))*"
     r"(?:\s*(?:,|and|or)\s*\d+[A-Za-z]*(?:[.-]\d+[A-Za-z]*)*(?:\([A-Za-z0-9]+\))*)*"
-    r"(?=$|[\s,.;:])",
+    r"""(?=$|[\s,.;:)\]}\'"”’–—])""",
     re.IGNORECASE,
 )
 _STRUCTURAL_SOURCE_STATE_CODE_CITATION_TARGET = (

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1441"
+ENCODER_VERSION = "0.2.1442"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1441"
+ENCODER_VERSION = "0.2.1442"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1441"
+ENCODER_VERSION = "0.2.1442"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1441"
+ENCODER_VERSION = "0.2.1442"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1441"
+ENCODER_VERSION = "0.2.1442"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1441"
+ENCODER_VERSION = "0.2.1442"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1441"
+ENCODER_VERSION = "0.2.1442"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1441"')
+        .startswith('__version__ = "0.2.1442"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1441"
+    assert encoder_package["version"] == "0.2.1442"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1441"
+    assert project["project"]["version"] == "0.2.1442"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1441"')
+        .startswith('__version__ = "0.2.1442"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1441"
+    assert encoder_package["version"] == "0.2.1442"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1441"
+    assert project["project"]["version"] == "0.2.1442"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1441"')
+        .startswith('__version__ = "0.2.1442"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1441"
+ENCODER_VERSION = "0.2.1442"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -2081,6 +2081,22 @@ def test_en_us_state_code_citation_filter_preserves_real_unit_and_ratio_values()
     ]
 
 
+def test_en_us_post_code_section_marker_citations_are_structural():
+    source = (
+        "Eligible under section 32 of the federal code (26 U.S.C. s.32) and "
+        "section 152 of that code (26 U.S.C. sec. 152), with "
+        "26 U.S.C. s.32—applying and 26 U.S.C. s.32–as amended, while "
+        "26 dollars is due."
+    )
+
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        source,
+        profile="en-US",
+    )
+
+    assert [(item.value, item.raw) for item in inventory] == [(26.0, "26")]
+
+
 def test_en_us_inline_legal_ordinal_is_structural_after_collapsed_heading():
     source = (
         "54A:4-7 New Jersey Earned Income Tax Credit program. "

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1441"
+version = "0.2.1442"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- classify bounded post-code s., sec., section, and section-symbol markers as structural federal citation syntax
- recognize normal closing punctuation and en/em-dash citation boundaries
- preserve ordinary numeric evidence such as 26 dollars and 26:1
- bump encoder to 0.2.1442

## Why
Protected NJ run 30865804737 passed every trust, routing, source, signing, replacement, and compile gate but failed closed after three model attempts with zero signatures. Complete-source numeric recall incorrectly treated the federal code title in (26 U.S.C. s.32) and (26 U.S.C. s.152) as a tax scalar. This fixes the citation classifier without relaxing numeric recall.

## Review cycle
The first independent review found one P2 boundary gap: en/em dashes after a federal section citation were not accepted and leaked title 26. That gap was fixed with a regression. The repeated independent review is CLEAN on exact commit c7cab473a9ee30fa656086622a18c703bab19f33 with no actionable findings; it verified the regression fails under the parent parser and passes under this candidate.

## Checks
- full Python 3.13 suite: 6,222 passed, 119 skipped
- affected validation suite: 1,752 passed, 31 skipped
- independent-review focused suite: 8 passed, 409 deselected
- exact pinned NJ corpus has zero leaked value-26 occurrences
- real 26 dollars and 26:1 probes remain numeric evidence
- prescribed Ruff, compileall, uv lock consistency, version consistency, and diff checks pass

No signatures were emitted by the failed protected run, and no RuleSpec PR was opened.