### PR TITLE
Add authenticated retained-successor reconciliation

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -60,6 +60,11 @@ on:
         description: Second exact v1/manual direct dependent in the same atomic migration
         required: false
         type: string
+      legacy_retained_successor_rulespec_paths_json:
+        description: JSON array of legacy primaries removed for existing signed-v5 canonical successors
+        required: false
+        default: "[]"
+        type: string
       dependent_citation:
         description: Direct dependent to re-encode atomically after a breaking target
         required: false
@@ -377,6 +382,7 @@ jobs:
           DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
           EXISTING_SIGNED_IMPORTS_JSON: ${{ inputs.existing_signed_imports_json }}
           LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.legacy_exact_dependent_rulespec_path }}
+          LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON: ${{ inputs.legacy_retained_successor_rulespec_paths_json }}
           QUEUE_ID: ${{ inputs.queue_id }}
           REPLACE_LEGACY_RULESPEC_PATH: ${{ inputs.replace_legacy_rulespec_path }}
           REPLACE_RULESPEC_PATH: ${{ inputs.replace_rulespec_path }}
@@ -415,11 +421,25 @@ jobs:
           if [ -n "$SECOND_DEPENDENT_CITATION" ]; then
             existing_import_args+=(--exclude-citation "$SECOND_DEPENDENT_CITATION")
           fi
+          if ! printf '%s\n' "${LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON:-[]}" \
+            | jq -e 'type == "array" and all(.[]; type == "string" and length > 0)' \
+              > /dev/null; then
+            echo "retained successor paths must be a JSON array of non-empty strings" >&2
+            exit 1
+          fi
+          retained_successor_paths=()
+          while IFS= read -r retained_successor_path; do
+            retained_successor_paths+=("$retained_successor_path")
+          done < <(
+            printf '%s\n' "${LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON:-[]}" \
+              | jq -r '.[]'
+          )
           for reserved_path in \
             "$REPLACE_RULESPEC_PATH" \
             "$REPLACE_LEGACY_RULESPEC_PATH" \
             "$LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" \
-            "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH"; do
+            "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" \
+            "${retained_successor_paths[@]-}"; do
             if [ -n "$reserved_path" ]; then
               existing_import_args+=(--exclude-rulespec-path "$reserved_path")
             fi
@@ -630,6 +650,7 @@ jobs:
           DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
           EXISTING_SIGNED_IMPORTS_JSON: ${{ inputs.existing_signed_imports_json }}
           LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.legacy_exact_dependent_rulespec_path }}
+          LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON: ${{ inputs.legacy_retained_successor_rulespec_paths_json }}
           REPLACE_LEGACY_RULESPEC_PATH: ${{ inputs.replace_legacy_rulespec_path }}
           REPLACE_RULESPEC_PATH: ${{ inputs.replace_rulespec_path }}
           RULESPEC_CHECKOUT: ${{ github.workspace }}/rulespec-${{ inputs.country }}
@@ -670,11 +691,25 @@ jobs:
           if [ -n "$SECOND_DEPENDENT_CITATION" ]; then
             existing_import_args+=(--exclude-citation "$SECOND_DEPENDENT_CITATION")
           fi
+          if ! printf '%s\n' "${LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON:-[]}" \
+            | jq -e 'type == "array" and all(.[]; type == "string" and length > 0)' \
+              > /dev/null; then
+            echo "retained successor paths must be a JSON array of non-empty strings" >&2
+            exit 1
+          fi
+          retained_successor_paths=()
+          while IFS= read -r retained_successor_path; do
+            retained_successor_paths+=("$retained_successor_path")
+          done < <(
+            printf '%s\n' "${LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON:-[]}" \
+              | jq -r '.[]'
+          )
           for reserved_path in \
             "$REPLACE_RULESPEC_PATH" \
             "$REPLACE_LEGACY_RULESPEC_PATH" \
             "$LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" \
-            "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH"; do
+            "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" \
+            "${retained_successor_paths[@]-}"; do
             if [ -n "$reserved_path" ]; then
               existing_import_args+=(--exclude-rulespec-path "$reserved_path")
             fi
@@ -739,6 +774,7 @@ jobs:
           REPLACE_LEGACY_RULESPEC_PATH: ${{ inputs.replace_legacy_rulespec_path }}
           LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.legacy_exact_dependent_rulespec_path }}
           SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.second_legacy_exact_dependent_rulespec_path }}
+          LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON: ${{ inputs.legacy_retained_successor_rulespec_paths_json }}
           QUEUE_ID: ${{ inputs.queue_id }}
           DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
           DEPENDENT_REVIEW_FINDING: ${{ inputs.dependent_review_finding }}
@@ -755,6 +791,22 @@ jobs:
           : "${REPLACE_LEGACY_RULESPEC_PATH:=}"
           : "${LEGACY_EXACT_DEPENDENT_RULESPEC_PATH:=}"
           : "${SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH:=}"
+          : "${LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON:=[]}"
+          if ! printf '%s\n' "$LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON" \
+            | jq -e 'type == "array" and all(.[]; type == "string" and length > 0)' \
+              > /dev/null; then
+            echo "retained successor paths must be a JSON array of non-empty strings" >&2
+            exit 1
+          fi
+          retained_successor_paths=()
+          retained_successor_count=0
+          while IFS= read -r retained_successor_path; do
+            retained_successor_paths+=("$retained_successor_path")
+            retained_successor_count=$((retained_successor_count + 1))
+          done < <(
+            printf '%s\n' "$LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON" \
+              | jq -r '.[]'
+          )
           : "${SECOND_DEPENDENT_CITATION:=}"
           : "${SECOND_DEPENDENT_REVIEW_FINDING:=}"
           dependent_rulespec_path=""
@@ -813,6 +865,14 @@ jobs:
                   "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH"
                 )
               fi
+            for retained_successor_path in "${retained_successor_paths[@]-}"; do
+                if [ -n "$retained_successor_path" ]; then
+                  args+=(
+                    --legacy-retained-successor-rulespec-path \
+                    "$retained_successor_path"
+                  )
+                fi
+              done
             fi
             if [ "$require_direct_imports" = "true" ]; then
               while IFS= read -r required_import_path; do
@@ -849,7 +909,8 @@ jobs:
             { [ -n "$REPLACE_RULESPEC_PATH" ] || \
               [ -n "$REPLACE_LEGACY_RULESPEC_PATH" ] || \
               [ -n "$LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" ] || \
-              [ -n "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" ]; }; then
+              [ -n "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" ] || \
+              [ "$retained_successor_count" -gt 0 ]; }; then
             echo "queue-authorized re-encodes cannot override the RuleSpec target path" >&2
             exit 1
           fi
@@ -862,6 +923,11 @@ jobs:
                [ -n "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" ]; } && \
              [ -z "$REPLACE_LEGACY_RULESPEC_PATH" ]; then
             echo "exact legacy dependents require a legacy source replacement" >&2
+            exit 1
+          fi
+          if [ "$retained_successor_count" -gt 0 ] && \
+             [ -z "$REPLACE_LEGACY_RULESPEC_PATH" ]; then
+            echo "retained successors require a legacy source replacement" >&2
             exit 1
           fi
           if [ -n "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" ] && \
@@ -965,7 +1031,8 @@ jobs:
             "$REPLACE_RULESPEC_PATH" \
             "$REPLACE_LEGACY_RULESPEC_PATH" \
             "$LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" \
-            "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH"; do
+            "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" \
+            "${retained_successor_paths[@]-}"; do
             if [ -n "$reserved_path" ]; then
               existing_import_args+=(--exclude-rulespec-path "$reserved_path")
             fi
@@ -1146,6 +1213,7 @@ jobs:
           REPLACE_LEGACY_RULESPEC_PATH: ${{ inputs.replace_legacy_rulespec_path }}
           LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.legacy_exact_dependent_rulespec_path }}
           SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.second_legacy_exact_dependent_rulespec_path }}
+          LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON: ${{ inputs.legacy_retained_successor_rulespec_paths_json }}
           RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
           RULESPEC_REF: ${{ inputs.rulespec_ref }}
         run: |
@@ -1189,6 +1257,10 @@ jobs:
               UnsafeCorpusPathError,
               read_bounded_regular_file,
           )
+          from axiom_encode.rulespec_path_migration import (
+              canonical_destination,
+              rewrite_exact_references,
+          )
 
           def git_paths(*args):
               output = subprocess.check_output(
@@ -1199,6 +1271,31 @@ jobs:
                   for value in output.split(b"\0")
                   if value
               }
+
+          def git_blob(relative, *, label, max_bytes):
+              relative = Path(relative)
+              if (
+                  relative.is_absolute()
+                  or not relative.parts
+                  or any(part in {"", ".", ".."} for part in relative.parts)
+              ):
+                  raise SystemExit(f"{label} path is not canonical")
+              completed = subprocess.run(
+                  [
+                      "git",
+                      "-C",
+                      os.environ["RULESPEC_CHECKOUT"],
+                      "show",
+                      f"{os.environ['RULESPEC_REF']}:{relative.as_posix()}",
+                  ],
+                  check=False,
+                  capture_output=True,
+              )
+              if completed.returncode != 0:
+                  raise SystemExit(f"{label} is absent from the base commit")
+              if len(completed.stdout) > max_bytes:
+                  raise SystemExit(f"{label} exceeds its size limit")
+              return completed.stdout
 
           def read_bounded_regular(root, relative, *, label, max_bytes):
               relative = Path(relative)
@@ -1254,6 +1351,40 @@ jobs:
               )
               if value
           ]
+          try:
+              retained_successor_paths = json.loads(
+                  os.environ.get(
+                      "LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON", "[]"
+                  )
+              )
+          except json.JSONDecodeError as exc:
+              raise SystemExit(
+                  "retained successor inputs are not valid JSON"
+              ) from exc
+          if not isinstance(retained_successor_paths, list):
+              raise SystemExit("retained successor inputs are not a JSON array")
+          normalized_retained_successor_paths = []
+          for raw_retained_path in retained_successor_paths:
+              if not isinstance(raw_retained_path, str):
+                  raise SystemExit("retained successor input is not a string")
+              retained_path = Path(raw_retained_path)
+              if (
+                  retained_path.is_absolute()
+                  or retained_path.as_posix() != raw_retained_path
+                  or any(
+                      part in {"", ".", ".."} for part in retained_path.parts
+                  )
+                  or retained_path.suffix != ".yaml"
+                  or retained_path.name.endswith(".test.yaml")
+                  or retained_path
+                  == canonical_destination(retained_path)
+                  or raw_retained_path in normalized_retained_successor_paths
+              ):
+                  raise SystemExit(
+                      "retained successor input is not a unique noncanonical "
+                      "primary RuleSpec path"
+                  )
+              normalized_retained_successor_paths.append(raw_retained_path)
           normalized_replacement_path = ""
           if replacement_path:
               candidate = Path(replacement_path)
@@ -1416,6 +1547,8 @@ jobs:
                       receipt_schema not in {
                           "axiom-encode/legacy-fresh-reencode-receipt/v1",
                           "axiom-encode/legacy-fresh-reencode-receipt/v2",
+                          "axiom-encode/legacy-fresh-reencode-receipt/v3",
+                          "axiom-encode/legacy-fresh-reencode-receipt/v4",
                       }
                       or not isinstance(receipt_replacement, dict)
                       or receipt_replacement.get("source")
@@ -1439,13 +1572,314 @@ jobs:
                       or (
                           exact_dependent_paths
                           and receipt_schema
-                          != "axiom-encode/legacy-fresh-reencode-receipt/v2"
+                          == "axiom-encode/legacy-fresh-reencode-receipt/v1"
                       )
                   ):
                       raise SystemExit(
                           "legacy replacement exact dependents differ from inputs"
                       )
                   receipt_sha256 = hashlib.sha256(receipt_bytes).hexdigest()
+                  retained_successors = receipt_replacement.get(
+                      "retained_successors"
+                  )
+                  if receipt_schema == (
+                      "axiom-encode/legacy-fresh-reencode-receipt/v4"
+                  ):
+                      if (
+                          not isinstance(retained_successors, list)
+                          or not isinstance(
+                              receipt_replacement.get("metadata_reconciliations"),
+                              list,
+                          )
+                          or [
+                              item.get("source")
+                              for item in retained_successors
+                              if isinstance(item, dict)
+                          ]
+                          != normalized_retained_successor_paths
+                      ):
+                          raise SystemExit(
+                              "legacy replacement retained successors differ "
+                              "from inputs"
+                          )
+                  elif (
+                      normalized_retained_successor_paths
+                      or "retained_successors" in receipt_replacement
+                      or "metadata_reconciliations" in receipt_replacement
+                  ):
+                      raise SystemExit(
+                          "legacy replacement pre-v4 receipt has retained inputs"
+                      )
+                  else:
+                      retained_successors = []
+                  expected_deleted_manifest_paths = set()
+                  for retained_successor in retained_successors:
+                      if (
+                          not isinstance(retained_successor, dict)
+                          or set(retained_successor)
+                          != {
+                              "source",
+                              "destination",
+                              "legacy_owner_class",
+                              "legacy_manifest",
+                              "legacy_files",
+                              "successor_manifest",
+                              "successor_files",
+                          }
+                      ):
+                          raise SystemExit(
+                              "legacy replacement retained successor is malformed"
+                          )
+                      retained_source = retained_successor["source"]
+                      retained_destination = retained_successor.get("destination")
+                      if (
+                          not isinstance(retained_source, str)
+                          or not isinstance(retained_destination, str)
+                          or canonical_destination(Path(retained_source)).as_posix()
+                          != retained_destination
+                          or retained_successor.get("legacy_owner_class")
+                          not in {
+                              "v1-hmac-untrusted",
+                              "v1-manual-hmac-untrusted",
+                          }
+                      ):
+                          raise SystemExit(
+                              "legacy replacement retained successor paths differ"
+                          )
+                      legacy_manifest = retained_successor["legacy_manifest"]
+                      successor_manifest = retained_successor[
+                          "successor_manifest"
+                      ]
+                      expected_legacy_manifest_path = (
+                          Path(".axiom/encoding-manifests")
+                          / Path(retained_source).with_suffix(".json")
+                      )
+                      expected_successor_manifest_path = (
+                          Path(".axiom/encoding-manifests")
+                          / Path(retained_destination).with_suffix(".json")
+                      )
+                      if (
+                          not isinstance(legacy_manifest, dict)
+                          or set(legacy_manifest) != {"path", "sha256"}
+                          or legacy_manifest.get("path")
+                          != expected_legacy_manifest_path.as_posix()
+                          or not isinstance(legacy_manifest.get("sha256"), str)
+                          or re.fullmatch(
+                              r"[0-9a-f]{64}", legacy_manifest["sha256"]
+                          )
+                          is None
+                          or not isinstance(successor_manifest, dict)
+                          or set(successor_manifest)
+                          != {"path", "sha256", "payload"}
+                          or successor_manifest.get("path")
+                          != expected_successor_manifest_path.as_posix()
+                          or not isinstance(successor_manifest.get("sha256"), str)
+                          or re.fullmatch(
+                              r"[0-9a-f]{64}", successor_manifest["sha256"]
+                          )
+                          is None
+                          or not isinstance(
+                              successor_manifest.get("payload"), dict
+                          )
+                      ):
+                          raise SystemExit(
+                              "legacy replacement retained manifest evidence "
+                              "is malformed"
+                          )
+                      legacy_manifest_bytes = git_blob(
+                          expected_legacy_manifest_path,
+                          label="legacy retained predecessor manifest",
+                          max_bytes=1024 * 1024,
+                      )
+                      original_successor_bytes = (
+                          json.dumps(
+                              successor_manifest["payload"],
+                              indent=2,
+                              sort_keys=True,
+                          )
+                          + "\n"
+                      ).encode("utf-8")
+                      if (
+                          hashlib.sha256(legacy_manifest_bytes).hexdigest()
+                          != legacy_manifest["sha256"]
+                          or hashlib.sha256(
+                              git_blob(
+                                  expected_successor_manifest_path,
+                                  label="legacy retained original manifest",
+                                  max_bytes=1024 * 1024,
+                              )
+                          ).hexdigest()
+                          != successor_manifest["sha256"]
+                          or hashlib.sha256(
+                              original_successor_bytes
+                          ).hexdigest()
+                          != successor_manifest["sha256"]
+                      ):
+                          raise SystemExit(
+                              "legacy replacement retained original manifest "
+                              "digest differs"
+                          )
+                      legacy_files = retained_successor["legacy_files"]
+                      successor_files = retained_successor["successor_files"]
+                      allowed_legacy_files = {
+                          retained_source,
+                          Path(retained_source).with_name(
+                              f"{Path(retained_source).stem}.test.yaml"
+                          ).as_posix(),
+                      }
+                      allowed_successor_files = {
+                          retained_destination,
+                          Path(retained_destination).with_name(
+                              f"{Path(retained_destination).stem}.test.yaml"
+                          ).as_posix(),
+                      }
+                      for label, files, required, allowed, must_exist in (
+                          (
+                              "legacy",
+                              legacy_files,
+                              retained_source,
+                              allowed_legacy_files,
+                              False,
+                          ),
+                          (
+                              "successor",
+                              successor_files,
+                              retained_destination,
+                              allowed_successor_files,
+                              True,
+                          ),
+                      ):
+                          if (
+                              not isinstance(files, list)
+                              or not files
+                              or [
+                                  item.get("path")
+                                  for item in files
+                                  if isinstance(item, dict)
+                              ].count(required)
+                              != 1
+                              or len(
+                                  {
+                                      item.get("path")
+                                      for item in files
+                                      if isinstance(item, dict)
+                                  }
+                              )
+                              != len(files)
+                          ):
+                              raise SystemExit(
+                                  f"legacy replacement retained {label} files "
+                                  "are malformed"
+                              )
+                          for item in files:
+                              if (
+                                  not isinstance(item, dict)
+                                  or set(item) != {"path", "sha256"}
+                                  or item.get("path") not in allowed
+                                  or not isinstance(item.get("sha256"), str)
+                                  or re.fullmatch(r"[0-9a-f]{64}", item["sha256"])
+                                  is None
+                              ):
+                                  raise SystemExit(
+                                      "legacy replacement retained file evidence "
+                                      "is malformed"
+                                  )
+                              live_path = (
+                                  Path(os.environ["RULESPEC_CHECKOUT"])
+                                  / item["path"]
+                              )
+                              if must_exist:
+                                  live_bytes = read_bounded_regular(
+                                      os.environ["RULESPEC_CHECKOUT"],
+                                      Path(item["path"]),
+                                      label="legacy retained successor live file",
+                                      max_bytes=16 * 1024 * 1024,
+                                  )
+                                  if (
+                                      hashlib.sha256(live_bytes).hexdigest()
+                                      != item["sha256"]
+                                      or hashlib.sha256(
+                                          git_blob(
+                                              Path(item["path"]),
+                                              label=(
+                                                  "legacy retained original "
+                                                  "successor file"
+                                              ),
+                                              max_bytes=16 * 1024 * 1024,
+                                          )
+                                      ).hexdigest()
+                                      != item["sha256"]
+                                  ):
+                                      raise SystemExit(
+                                          "legacy replacement retained successor "
+                                          "live file digest differs"
+                                      )
+                              elif live_path.exists() or live_path.is_symlink():
+                                  raise SystemExit(
+                                      "legacy replacement retained legacy file "
+                                      "still exists"
+                                  )
+                              elif hashlib.sha256(
+                                  git_blob(
+                                      Path(item["path"]),
+                                      label="legacy retained predecessor file",
+                                      max_bytes=16 * 1024 * 1024,
+                                  )
+                              ).hexdigest() != item["sha256"]:
+                                  raise SystemExit(
+                                      "legacy replacement retained predecessor "
+                                      "file digest differs"
+                                  )
+                      if expected_successor_manifest_path not in manifest_paths:
+                          raise SystemExit(
+                              "legacy replacement retained successor lacks a "
+                              "changed signed manifest"
+                          )
+                      retained_manifest_bytes = read_bounded_regular(
+                          os.environ["RULESPEC_CHECKOUT"],
+                          expected_successor_manifest_path,
+                          label="legacy retained successor manifest",
+                          max_bytes=1024 * 1024,
+                      )
+                      retained_manifest = json.loads(retained_manifest_bytes)
+                      migration = retained_manifest.get("legacy_migration")
+                      if (
+                          retained_manifest.get("tool")
+                          != "axiom-encode encode --apply "
+                          "--legacy-retained-successor-rulespec-path"
+                          or retained_manifest.get("applied_files")
+                          != successor_files
+                          or retained_manifest.get("retained_successor_manifest")
+                          != successor_manifest["payload"]
+                          or not isinstance(migration, dict)
+                          or migration.get("receipt_path")
+                          != receipt_path.as_posix()
+                          or migration.get("receipt_sha256") != receipt_sha256
+                          or migration.get("source") != retained_source
+                          or migration.get("destination")
+                          != retained_destination
+                          or migration.get("legacy_manifest_path")
+                          != expected_legacy_manifest_path.as_posix()
+                          or migration.get("legacy_manifest_sha256")
+                          != legacy_manifest["sha256"]
+                          or migration.get("successor_manifest_sha256")
+                          != successor_manifest["sha256"]
+                      ):
+                          raise SystemExit(
+                              "legacy retained successor manifest binding differs"
+                          )
+                      expected_deleted_manifest_paths.add(
+                          expected_legacy_manifest_path
+                      )
+                      applied_inventory.append(
+                          {
+                              "citation": None,
+                              "path": expected_successor_manifest_path.as_posix(),
+                              "sha256": hashlib.sha256(
+                                  retained_manifest_bytes
+                              ).hexdigest(),
+                          }
+                      )
                   for exact_dependent in exact_dependents:
                       primary = exact_dependent.get("primary")
                       if not isinstance(primary, str):
@@ -1498,9 +1932,6 @@ jobs:
                       raise SystemExit(
                           "legacy replacement scheduled dependents are malformed"
                       )
-                  from axiom_encode.rulespec_path_migration import (
-                      rewrite_exact_references,
-                  )
                   for dependent in scheduled:
                       if (
                           not isinstance(dependent, dict)
@@ -1563,11 +1994,6 @@ jobs:
                       ".axiom/encoding-manifests"
                   ) / Path(legacy_source_path).with_suffix(".json")
                   if legacy_source_path == normalized_replacement_path:
-                      if deleted_manifest_paths:
-                          raise SystemExit(
-                              "in-place legacy replacement must overwrite, not "
-                              "delete, its ownership manifest"
-                          )
                       if expected_old_manifest != relative_path:
                           raise SystemExit(
                               "in-place legacy replacement manifest path differs"
@@ -1581,16 +2007,17 @@ jobs:
                               "in-place legacy replacement primary is absent"
                           )
                   else:
-                      if deleted_manifest_paths != {expected_old_manifest}:
-                          raise SystemExit(
-                              "legacy replacement must delete exactly its old manifest"
-                          )
+                      expected_deleted_manifest_paths.add(expected_old_manifest)
                       if (
                           Path(os.environ["RULESPEC_CHECKOUT"]) / legacy_source_path
                       ).exists():
                           raise SystemExit(
                               "legacy replacement old primary still exists"
                           )
+                  if deleted_manifest_paths != expected_deleted_manifest_paths:
+                      raise SystemExit(
+                          "legacy replacement deleted manifest inventory differs"
+                      )
                   receipt_artifact = Path(sys.argv[1]).with_name(
                       "legacy-replacement-receipt.json"
                   )
@@ -1744,6 +2171,11 @@ jobs:
                       "SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH"
                   ) or None
               ),
+              "legacy_retained_successor_rulespec_paths": json.loads(
+                  os.environ.get(
+                      "LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON", "[]"
+                  )
+              ),
               "pr_base_branch": os.environ["PR_BASE_BRANCH"],
               "queue_id": os.environ.get("QUEUE_ID") or None,
               "queue_item_id": os.environ.get("QUEUE_ITEM_ID") or None,
@@ -1807,6 +2239,7 @@ jobs:
           SECOND_DEPENDENT_CITATION: ${{ inputs.second_dependent_citation }}
           LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.legacy_exact_dependent_rulespec_path }}
           SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.second_legacy_exact_dependent_rulespec_path }}
+          LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON: ${{ inputs.legacy_retained_successor_rulespec_paths_json }}
           RULESPEC_REF: ${{ inputs.rulespec_ref }}
           PR_BASE_BRANCH: ${{ inputs.pr_base_branch }}
           QUEUE_ID: ${{ inputs.queue_id }}
@@ -1842,6 +2275,7 @@ jobs:
             "Second direct dependent: \`${SECOND_DEPENDENT_CITATION:-n/a}\`" \
             "Exact legacy dependent: \`${LEGACY_EXACT_DEPENDENT_RULESPEC_PATH:-n/a}\`" \
             "Second exact legacy dependent: \`${SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH:-n/a}\`" \
+            "Retained successor legacy paths: \`${LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON:-[]}\`" \
             "Base commit: \`${RULESPEC_REF}\`" \
             "Base branch: \`${PR_BASE_BRANCH}\`" \
             "Queue item: \`${QUEUE_ID:-ad-hoc}/${QUEUE_ITEM_ID:-ad-hoc}\`" \

--- a/changelog.d/legacy-retained-successor-reconciliation.fixed.md
+++ b/changelog.d/legacy-retained-successor-reconciliation.fixed.md
@@ -1,0 +1,1 @@
+Reconcile authenticated legacy RuleSpec groups with already-retained canonical successors, exact dependent rewrites, canonical predecessor evidence, structured metadata inventories, and the derived validation-waiver toolchain binding in one atomic signed replacement.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1443"
+version = "0.2.1444"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -20,15 +20,23 @@ LEGACY_REPLACEMENT_TOOL = "axiom-encode encode --apply --replace-legacy-rulespec
 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V1 = "axiom-encode/legacy-fresh-reencode-receipt/v1"
 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2 = "axiom-encode/legacy-fresh-reencode-receipt/v2"
 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3 = "axiom-encode/legacy-fresh-reencode-receipt/v3"
+LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4 = "axiom-encode/legacy-fresh-reencode-receipt/v4"
 LEGACY_EXACT_DEPENDENT_TOOL = (
     "axiom-encode encode --apply --legacy-exact-dependent-rulespec-path"
+)
+LEGACY_RETAINED_SUCCESSOR_TOOL = (
+    "axiom-encode encode --apply --legacy-retained-successor-rulespec-path"
 )
 MODEL_APPLY_TOOL = "axiom-encode encode --apply"
 MODEL_APPLY_BACKENDS = frozenset({"claude", "codex", "openai"})
 LEGACY_REPLACEMENT_METADATA_PATHS = frozenset(
     {
         PurePosixPath(".axiom/index/provisions_to_rules.json"),
+        PurePosixPath(".axiom/pending-validation-fingerprints.json"),
+        PurePosixPath(".axiom/toolchain.toml"),
+        PurePosixPath("known-validation-gaps.yaml"),
         PurePosixPath("oracle-coverage-pending.yaml"),
+        PurePosixPath("tests/test_encoding_manifests.py"),
     }
 )
 RULESPEC_ATOMIC_ROOTS = frozenset(
@@ -1070,6 +1078,7 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                     LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V1,
                     LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
                     LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
+                    LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                 }
                 or receipt.get("tool") != LEGACY_REPLACEMENT_TOOL
             ):
@@ -1127,7 +1136,122 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                 raise ValueError(
                     f"legacy replacement exact_dependents are malformed: {relative}"
                 )
-            if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3 and (
+            retained_successors = receipt_replacement.get("retained_successors")
+            metadata_reconciliations = receipt_replacement.get(
+                "metadata_reconciliations"
+            )
+            if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4:
+                if not isinstance(retained_successors, list) or not isinstance(
+                    metadata_reconciliations, list
+                ):
+                    raise ValueError(
+                        f"legacy replacement v4 reconciliation fields are malformed: "
+                        f"{relative}"
+                    )
+            elif (
+                "retained_successors" in receipt_replacement
+                or "metadata_reconciliations" in receipt_replacement
+            ):
+                raise ValueError(
+                    f"legacy replacement pre-v4 receipt has v4 fields: {relative}"
+                )
+            else:
+                retained_successors = []
+                metadata_reconciliations = []
+            repository = receipt.get("repository")
+            live_paths = {
+                item.get("path") for item in live_files if isinstance(item, dict)
+            }
+            identity_deleted_files = [
+                {"path": item.get("path"), "deleted": True}
+                for item in legacy_files
+                if isinstance(item, dict) and item.get("path") not in live_paths
+            ]
+            if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4:
+                identity_deleted_files.extend(
+                    {"path": item.get("path"), "deleted": True}
+                    for successor in retained_successors
+                    if isinstance(successor, dict)
+                    for item in (
+                        successor.get("legacy_files", [])
+                        if isinstance(successor.get("legacy_files"), list)
+                        else []
+                    )
+                    if isinstance(item, dict)
+                )
+            from axiom_encode.legacy_replacement import (
+                receipt_identity_payload,
+                receipt_identity_sha256,
+            )
+
+            identity_payload = receipt_identity_payload(
+                base_commit=(
+                    str(repository.get("base_commit"))
+                    if isinstance(repository, dict)
+                    else ""
+                ),
+                base_tree=(
+                    str(repository.get("base_tree"))
+                    if isinstance(repository, dict)
+                    else ""
+                ),
+                legacy_manifest_sha256=str(
+                    replacement.get("legacy_manifest_sha256") or ""
+                ),
+                model_manifest_sha256=str(
+                    receipt_replacement.get("model_manifest_sha256") or ""
+                ),
+                live_files=live_files,
+                deleted_files=identity_deleted_files,
+                rewrites=raw_rewrites,
+                scheduled_dependents=scheduled_dependents,
+                exact_dependents=(
+                    exact_dependents
+                    if receipt_schema
+                    in {
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+                    }
+                    else None
+                ),
+                destination_predecessor_class=(
+                    receipt_replacement.get("destination_predecessor_class")
+                    if receipt_schema
+                    in {
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+                    }
+                    else None
+                ),
+                destination_predecessor_files=(
+                    receipt_replacement.get("destination_predecessor_files")
+                    if receipt_schema
+                    in {
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+                    }
+                    else None
+                ),
+                retained_successors=(
+                    retained_successors
+                    if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4
+                    else None
+                ),
+                metadata_reconciliations=(
+                    metadata_reconciliations
+                    if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4
+                    else None
+                ),
+            )
+            if receipt_relative.stem != receipt_identity_sha256(identity_payload):
+                raise ValueError(
+                    f"legacy replacement receipt identity differs: {relative}"
+                )
+            if receipt_schema in {
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+            } and (
                 not isinstance(
                     receipt_replacement.get("destination_predecessor_class"), str
                 )
@@ -1155,6 +1279,7 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
             )
             from axiom_encode.cli import (
                 _legacy_destination_predecessor_issues,
+                _legacy_metadata_reconciliation_bytes,
                 _legacy_replacement_authoritative_map,
                 _legacy_replacement_reference_inventory_issues,
                 _strict_legacy_replacement_map,
@@ -1174,7 +1299,10 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                     f"legacy replacement authority differs: {relative}: "
                     + "; ".join(authority_issues)
                 )
-            if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3:
+            if receipt_schema in {
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+            }:
                 predecessor_issues = _legacy_destination_predecessor_issues(
                     repo,
                     base_commit=str(base_commit or ""),
@@ -1196,6 +1324,7 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                 )
             from axiom_encode.rulespec_path_migration import (
                 PathMigrationPlanError,
+                PlannedMove,
                 rewrite_exact_references,
             )
 
@@ -1261,6 +1390,230 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                         f"legacy replacement rewrite[{index}] state differs"
                     )
                 receipt_rewrites.add(rewrite_path)
+            primary_moves = [
+                PlannedMove(source=Path(old), destination=Path(new))
+                for old, new in authoritative_replacements.items()
+                if old.endswith(".yaml") and not old.endswith(".test.yaml")
+            ]
+            post_migration_waiver_sha256: str | None = None
+            try:
+                base_waiver_raw = _git(
+                    repo,
+                    "show",
+                    "HEAD:known-validation-gaps.yaml",
+                )
+                rewritten_waiver_raw, _waiver_operations = (
+                    _legacy_metadata_reconciliation_bytes(
+                        Path("known-validation-gaps.yaml"),
+                        base_waiver_raw,
+                        moves=primary_moves,
+                    )
+                )
+                post_migration_waiver_sha256 = hashlib.sha256(
+                    rewritten_waiver_raw
+                ).hexdigest()
+            except (subprocess.CalledProcessError, ValueError):
+                pass
+            metadata_paths: set[PurePosixPath] = set()
+            for index, reconciliation in enumerate(metadata_reconciliations):
+                if not isinstance(reconciliation, dict) or set(reconciliation) != {
+                    "path",
+                    "before_sha256",
+                    "after_sha256",
+                    "operations",
+                }:
+                    raise ValueError(
+                        f"legacy metadata reconciliation[{index}] is malformed"
+                    )
+                metadata_path = _safe_relative_path(
+                    reconciliation.get("path"),
+                    label=f"{relative} metadata_reconciliations[{index}].path",
+                )
+                if (
+                    metadata_path not in LEGACY_REPLACEMENT_METADATA_PATHS
+                    or metadata_path in metadata_paths
+                ):
+                    raise ValueError(
+                        f"legacy metadata reconciliation[{index}] path is unauthorized"
+                    )
+                base_raw = _git(repo, "show", f"HEAD:{metadata_path.as_posix()}")
+                live_raw = _read_bounded_regular(
+                    repo,
+                    metadata_path,
+                    label="legacy metadata reconciliation",
+                    max_bytes=16 * 1024 * 1024,
+                )
+                try:
+                    expected_live, expected_operations = (
+                        _legacy_metadata_reconciliation_bytes(
+                            Path(metadata_path),
+                            base_raw,
+                            moves=primary_moves,
+                            validation_waiver_set_sha256=(
+                                post_migration_waiver_sha256
+                            ),
+                        )
+                    )
+                except ValueError as exc:
+                    raise ValueError(
+                        f"legacy metadata reconciliation[{index}] is unverifiable"
+                    ) from exc
+                if (
+                    reconciliation.get("before_sha256")
+                    != hashlib.sha256(base_raw).hexdigest()
+                    or reconciliation.get("after_sha256")
+                    != hashlib.sha256(live_raw).hexdigest()
+                    or live_raw != expected_live
+                    or reconciliation.get("operations")
+                    != list(expected_operations)
+                ):
+                    raise ValueError(
+                        f"legacy metadata reconciliation[{index}] state differs"
+                )
+                metadata_paths.add(metadata_path)
+            expected_metadata_paths: set[PurePosixPath] = set()
+            for metadata_path in LEGACY_REPLACEMENT_METADATA_PATHS:
+                try:
+                    base_raw = _git(
+                        repo, "show", f"HEAD:{metadata_path.as_posix()}"
+                    )
+                except subprocess.CalledProcessError:
+                    continue
+                try:
+                    expected_live, _expected_operations = (
+                        _legacy_metadata_reconciliation_bytes(
+                            Path(metadata_path),
+                            base_raw,
+                            moves=primary_moves,
+                            validation_waiver_set_sha256=(
+                                post_migration_waiver_sha256
+                            ),
+                        )
+                    )
+                except ValueError:
+                    continue
+                if expected_live != base_raw:
+                    expected_metadata_paths.add(metadata_path)
+            if metadata_paths != expected_metadata_paths:
+                raise ValueError(
+                    "legacy metadata reconciliation inventory is not exact"
+                )
+            receipt_rewrites.update(metadata_paths)
+            retained_deleted_files: list[dict[str, object]] = []
+            for index, successor in enumerate(retained_successors):
+                if not isinstance(successor, dict) or set(successor) != {
+                    "source",
+                    "destination",
+                    "legacy_owner_class",
+                    "legacy_manifest",
+                    "legacy_files",
+                    "successor_manifest",
+                    "successor_files",
+                }:
+                    raise ValueError(f"legacy retained successor[{index}] is malformed")
+                old_manifest_evidence = successor.get("legacy_manifest")
+                successor_manifest_evidence = successor.get("successor_manifest")
+                successor_files = successor.get("successor_files")
+                old_files = successor.get("legacy_files")
+                if (
+                    not isinstance(old_manifest_evidence, dict)
+                    or not isinstance(successor_manifest_evidence, dict)
+                    or not isinstance(successor_files, list)
+                    or not isinstance(old_files, list)
+                ):
+                    raise ValueError(
+                        f"legacy retained successor[{index}] evidence is malformed"
+                    )
+                retained_old_manifest = _safe_relative_path(
+                    old_manifest_evidence.get("path"),
+                    label=f"{relative} retained_successors[{index}].legacy_manifest",
+                )
+                retained_manifest = _safe_relative_path(
+                    successor_manifest_evidence.get("path"),
+                    label=f"{relative} retained_successors[{index}].successor_manifest",
+                )
+                retained_payload = manifest_payloads.get(retained_manifest)
+                if (
+                    retained_old_manifest not in deleted_manifests
+                    or retained_manifest not in live_manifests
+                    or not isinstance(retained_payload, dict)
+                    or retained_payload.get("tool") != LEGACY_RETAINED_SUCCESSOR_TOOL
+                    or retained_payload.get("applied_files") != successor_files
+                    or retained_payload.get("retained_successor_manifest")
+                    != successor_manifest_evidence.get("payload")
+                ):
+                    raise ValueError(
+                        f"legacy retained successor[{index}] manifest transition differs"
+                    )
+                migration = retained_payload.get("legacy_migration")
+                if (
+                    not isinstance(migration, dict)
+                    or migration.get("receipt_path") != receipt_relative.as_posix()
+                    or migration.get("receipt_sha256")
+                    != hashlib.sha256(receipt_raw).hexdigest()
+                    or migration.get("source") != successor.get("source")
+                    or migration.get("destination") != successor.get("destination")
+                    or migration.get("legacy_manifest_path")
+                    != retained_old_manifest.as_posix()
+                    or migration.get("legacy_manifest_sha256")
+                    != old_manifest_evidence.get("sha256")
+                    or migration.get("successor_manifest_sha256")
+                    != successor_manifest_evidence.get("sha256")
+                ):
+                    raise ValueError(
+                        f"legacy retained successor[{index}] receipt binding differs"
+                    )
+                for file_index, item in enumerate(old_files):
+                    if not isinstance(item, dict) or set(item) != {"path", "sha256"}:
+                        raise ValueError(
+                            f"legacy retained successor[{index}] old file is malformed"
+                        )
+                    old_path = _safe_relative_path(
+                        item.get("path"),
+                        label=(
+                            f"{relative} retained_successors[{index}]."
+                            f"legacy_files[{file_index}]"
+                        ),
+                    )
+                    if (repo / old_path).exists() or (repo / old_path).is_symlink():
+                        raise ValueError(
+                            f"legacy retained successor source still exists: {old_path}"
+                        )
+                    if hashlib.sha256(
+                        _git(repo, "show", f"HEAD:{old_path.as_posix()}")
+                    ).hexdigest() != item.get("sha256"):
+                        raise ValueError(
+                            f"legacy retained successor base differs: {old_path}"
+                        )
+                    retained_deleted_files.append(
+                        {"path": old_path.as_posix(), "deleted": True}
+                    )
+                for file_index, item in enumerate(successor_files):
+                    if not isinstance(item, dict) or set(item) != {"path", "sha256"}:
+                        raise ValueError(
+                            f"legacy retained successor[{index}] live file is malformed"
+                        )
+                    live_path = _safe_relative_path(
+                        item.get("path"),
+                        label=(
+                            f"{relative} retained_successors[{index}]."
+                            f"successor_files[{file_index}]"
+                        ),
+                    )
+                    if hashlib.sha256(
+                        _read_bounded_regular(
+                            repo,
+                            live_path,
+                            label="legacy retained successor file",
+                            max_bytes=16 * 1024 * 1024,
+                        )
+                    ).hexdigest() != item.get("sha256"):
+                        raise ValueError(
+                            f"legacy retained successor live file differs: {live_path}"
+                        )
+                    if live_path not in changed:
+                        authorized_unchanged.add(live_path)
+                authorized.add(retained_old_manifest)
             expected_applied_files = [
                 *live_files,
                 *[
@@ -1272,10 +1625,19 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                     if isinstance(rewrite, dict)
                 ],
                 *[
+                    {
+                        "path": item.get("path"),
+                        "sha256": item.get("after_sha256"),
+                    }
+                    for item in metadata_reconciliations
+                    if isinstance(item, dict)
+                ],
+                *[
                     {"path": item.get("path"), "deleted": True}
                     for item in legacy_files
                     if isinstance(item, dict)
                 ],
+                *retained_deleted_files,
             ]
             if payload.get("applied_files") != expected_applied_files:
                 raise ValueError(
@@ -1467,6 +1829,7 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
             if receipt_schema in {
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
             }:
                 authorized_unchanged.update(
                     _validate_legacy_exact_dependents(

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1443"
+__version__ = "0.2.1444"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -267,6 +267,9 @@ from .legacy_replacement import (
     EXACT_DEPENDENT_TOOL as APPLIED_ENCODING_LEGACY_EXACT_DEPENDENT_TOOL,
 )
 from .legacy_replacement import (
+    LEGACY_MANUAL_OWNER_CLASS as APPLIED_ENCODING_LEGACY_MANUAL_OWNER_CLASS,
+)
+from .legacy_replacement import (
     LEGACY_OWNER_CLASS as APPLIED_ENCODING_LEGACY_OWNER_CLASS,
 )
 from .legacy_replacement import (
@@ -285,6 +288,12 @@ from .legacy_replacement import (
     RECEIPT_SCHEMA_V2 as APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
 )
 from .legacy_replacement import (
+    RECEIPT_SCHEMA_V3 as APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
+)
+from .legacy_replacement import (
+    RETAINED_SUCCESSOR_TOOL as APPLIED_ENCODING_LEGACY_RETAINED_SUCCESSOR_TOOL,
+)
+from .legacy_replacement import (
     TOOL as APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL,
 )
 from .legacy_replacement import (
@@ -298,6 +307,9 @@ from .legacy_replacement import (
 )
 from .legacy_replacement import (
     LegacyReplacementPendingFile as _LegacyReplacementPendingFile,
+)
+from .legacy_replacement import (
+    LegacyReplacementRetainedSuccessor as _LegacyReplacementRetainedSuccessor,
 )
 from .legacy_replacement import (
     LegacyReplacementRewrite as _LegacyReplacementRewrite,
@@ -369,6 +381,7 @@ from .rulespec_path_migration import (
     exact_reference_replacements,
     load_plan_bytes,
     rewrite_exact_references,
+    rulespec_identity,
 )
 from .signing_broker import (
     _SIGNATURE_DOMAIN_PREFIX,
@@ -516,6 +529,20 @@ _LEGACY_EXACT_DEPENDENT_APPLY_MANIFEST_FIELDS = frozenset(
         "signature",
     }
 )
+_LEGACY_RETAINED_SUCCESSOR_APPLY_MANIFEST_FIELDS = frozenset(
+    {
+        "schema_version",
+        "generated_at",
+        "tool",
+        "axiom_encode_version",
+        "axiom_encode_git",
+        VALIDATION_WAIVER_SET_SHA256_FIELD,
+        "applied_files",
+        "legacy_migration",
+        "retained_successor_manifest",
+        "signature",
+    }
+)
 _LEGACY_REPLACEMENT_RECEIPT_FIELDS = frozenset(
     {
         "schema_version",
@@ -536,7 +563,11 @@ _LEGACY_REPLACEMENT_RECEIPT_FIELDS = frozenset(
 _LEGACY_REPLACEMENT_METADATA_REWRITE_PATHS = frozenset(
     {
         Path(".axiom/index/provisions_to_rules.json"),
+        Path(".axiom/pending-validation-fingerprints.json"),
+        Path(".axiom/toolchain.toml"),
+        Path("known-validation-gaps.yaml"),
         Path("oracle-coverage-pending.yaml"),
+        Path("tests/test_encoding_manifests.py"),
     }
 )
 _MODEL_APPLIED_FILE_FIELDS = frozenset({"path", "sha256"})
@@ -2266,6 +2297,19 @@ def main():
             "rewrite. Repeat once per composite dependent; each full primary/test "
             "group and old manifest is bound to clean HEAD and replaced atomically "
             "with signed v5 migration provenance."
+        ),
+    )
+    encode_parser.add_argument(
+        "--legacy-retained-successor-rulespec-path",
+        action="append",
+        default=[],
+        type=Path,
+        help=(
+            "Exact protected legacy v1 HMAC-owned primary whose unique canonical "
+            "destination already has a verified signed-v5 manifest. Repeat once "
+            "per retained successor; the old group is retired, canonical content "
+            "bytes are preserved, and its manifest is refreshed with common "
+            "replacement-receipt provenance."
         ),
     )
     _add_complete_source_unit_argument(encode_parser)
@@ -7153,20 +7197,237 @@ def _legacy_replacement_authoritative_map(
                 f"legacy replacement source manifest is not legacy-owned: {issue}"
                 for issue in legacy_manifest_issues
             )
+    moves = (
+        []
+        if in_place
+        else [PlannedMove(source=source_path, destination=destination_path)]
+    )
+    retained = replacement.get("retained_successors", [])
+    if not isinstance(retained, list):
+        issues.append("legacy retained successor authority is malformed")
+        retained = []
+    seen_retained_sources: set[Path] = set()
+    seen_retained_destinations: set[Path] = set()
+    for index, item in enumerate(retained):
+        label = f"legacy retained successor[{index}]"
+        if not isinstance(item, dict) or set(item) != {
+            "source",
+            "destination",
+            "legacy_owner_class",
+            "legacy_manifest",
+            "legacy_files",
+            "successor_manifest",
+            "successor_files",
+        }:
+            issues.append(f"{label} evidence is malformed")
+            continue
+        retained_source_raw = item.get("source")
+        retained_destination_raw = item.get("destination")
+        retained_source = (
+            Path(retained_source_raw)
+            if isinstance(retained_source_raw, str)
+            else Path()
+        )
+        retained_destination = (
+            Path(retained_destination_raw)
+            if isinstance(retained_destination_raw, str)
+            else Path()
+        )
+        try:
+            canonical_retained = canonical_destination(retained_source)
+        except PathMigrationPlanError:
+            canonical_retained = None
+        if (
+            not isinstance(retained_source_raw, str)
+            or not isinstance(retained_destination_raw, str)
+            or retained_source.is_absolute()
+            or retained_destination.is_absolute()
+            or retained_source.as_posix() != retained_source_raw
+            or retained_destination.as_posix() != retained_destination_raw
+            or canonical_retained != retained_destination
+            or retained_source == retained_destination
+            or retained_source in seen_retained_sources
+            or retained_source in seen_retained_destinations
+            or retained_destination in seen_retained_destinations
+            or retained_destination in seen_retained_sources
+            or retained_source in {source_path, destination_path}
+            or retained_destination in {source_path, destination_path}
+            or not _is_protected_rulespec_yaml_path(retained_source, roots=roots)
+            or not _is_protected_rulespec_yaml_path(retained_destination, roots=roots)
+            or retained_source.name.endswith(RULESPEC_TEST_FILE_SUFFIX)
+            or retained_destination.name.endswith(RULESPEC_TEST_FILE_SUFFIX)
+        ):
+            issues.append(f"{label} move identity is invalid")
+            continue
+        seen_retained_sources.add(retained_source)
+        seen_retained_destinations.add(retained_destination)
+
+        expected_old_group: dict[str, str] = {}
+        expected_successor_group: dict[str, str] = {}
+        retained_companions: set[Path] = set()
+        for old_path, successor_path in (
+            (retained_source, retained_destination),
+            (companion_path(retained_source), companion_path(retained_destination)),
+        ):
+            try:
+                old_raw = _rulespec_migration_base_blob(
+                    repo_path, base_commit, old_path
+                )
+            except RuntimeError:
+                old_raw = None
+            try:
+                successor_raw = _rulespec_migration_base_blob(
+                    repo_path, base_commit, successor_path
+                )
+            except RuntimeError:
+                successor_raw = None
+            if old_raw is None or successor_raw is None:
+                if old_path == retained_source or (old_raw is None) != (
+                    successor_raw is None
+                ):
+                    issues.append(f"{label} base group is incomplete")
+                continue
+            expected_old_group[old_path.as_posix()] = hashlib.sha256(
+                old_raw
+            ).hexdigest()
+            expected_successor_group[successor_path.as_posix()] = hashlib.sha256(
+                successor_raw
+            ).hexdigest()
+            if old_path != retained_source:
+                retained_companions.add(old_path)
+
+        def evidence_map(raw: object, *, evidence_label: str) -> dict[str, str]:
+            parsed: dict[str, str] = {}
+            if not isinstance(raw, list):
+                issues.append(f"{label} {evidence_label} is malformed")
+                return parsed
+            for entry in raw:
+                if (
+                    not isinstance(entry, dict)
+                    or set(entry) != {"path", "sha256"}
+                    or not isinstance(entry.get("path"), str)
+                    or not isinstance(entry.get("sha256"), str)
+                    or _SHA256_HEX_PATTERN.fullmatch(entry["sha256"]) is None
+                    or entry["path"] in parsed
+                ):
+                    issues.append(f"{label} {evidence_label} entry is malformed")
+                    continue
+                parsed[entry["path"]] = entry["sha256"]
+            return parsed
+
+        old_evidence = evidence_map(
+            item.get("legacy_files"), evidence_label="legacy files"
+        )
+        successor_evidence = evidence_map(
+            item.get("successor_files"), evidence_label="successor files"
+        )
+        if old_evidence != expected_old_group:
+            issues.append(f"{label} legacy files do not match the base group")
+        if successor_evidence != expected_successor_group:
+            issues.append(f"{label} successor files do not match the base group")
+
+        old_manifest = item.get("legacy_manifest")
+        old_manifest_path = _applied_encoding_manifest_path(retained_source)
+        old_manifest_raw: bytes | None = None
+        if (
+            not isinstance(old_manifest, dict)
+            or set(old_manifest) != {"path", "sha256"}
+            or old_manifest.get("path") != old_manifest_path.as_posix()
+            or not isinstance(old_manifest.get("sha256"), str)
+        ):
+            issues.append(f"{label} legacy manifest evidence is malformed")
+        else:
+            try:
+                old_manifest_raw = _rulespec_migration_base_blob(
+                    repo_path, base_commit, old_manifest_path
+                )
+            except RuntimeError as exc:
+                issues.append(f"{label} legacy manifest is absent: {exc}")
+            else:
+                if (
+                    hashlib.sha256(old_manifest_raw).hexdigest()
+                    != old_manifest["sha256"]
+                ):
+                    issues.append(f"{label} legacy manifest hash is stale")
+        if old_manifest_raw is not None:
+            try:
+                old_payload = json.loads(old_manifest_raw.decode("utf-8"))
+            except (UnicodeError, json.JSONDecodeError, RecursionError):
+                issues.append(f"{label} legacy manifest is not JSON")
+            else:
+                try:
+                    retained_primary_raw = _rulespec_migration_base_blob(
+                        repo_path, base_commit, retained_source
+                    )
+                except RuntimeError:
+                    retained_citations = ()
+                else:
+                    retained_citations = _legacy_primary_source_citations(
+                        retained_primary_raw
+                    )
+                owner_issues = _legacy_receipt_v1_manifest_issues(
+                    old_payload,
+                    owner_class=item.get("legacy_owner_class"),
+                    expected_files=expected_old_group,
+                    expected_primary_path=retained_source.as_posix(),
+                    expected_citation=(
+                        retained_citations[0] if retained_citations else ""
+                    ),
+                    jurisdiction_prefix=retained_source.parts[0],
+                    allow_unmarked_manual_exception=True,
+                )
+                issues.extend(
+                    f"{label} legacy ownership is invalid: {issue}"
+                    for issue in owner_issues
+                )
+
+        successor_manifest = item.get("successor_manifest")
+        successor_manifest_path = _applied_encoding_manifest_path(retained_destination)
+        if (
+            not isinstance(successor_manifest, dict)
+            or set(successor_manifest) != {"path", "sha256", "payload"}
+            or successor_manifest.get("path") != successor_manifest_path.as_posix()
+            or not isinstance(successor_manifest.get("sha256"), str)
+            or not isinstance(successor_manifest.get("payload"), dict)
+        ):
+            issues.append(f"{label} successor manifest evidence is malformed")
+        else:
+            try:
+                base_successor_manifest = _rulespec_migration_base_blob(
+                    repo_path, base_commit, successor_manifest_path
+                )
+            except RuntimeError as exc:
+                issues.append(f"{label} successor manifest is absent: {exc}")
+            else:
+                nested_raw = (
+                    json.dumps(successor_manifest["payload"], indent=2, sort_keys=True)
+                    + "\n"
+                ).encode()
+                if (
+                    base_successor_manifest != nested_raw
+                    or hashlib.sha256(base_successor_manifest).hexdigest()
+                    != successor_manifest["sha256"]
+                    or successor_manifest["payload"].get("applied_files")
+                    != item.get("successor_files")
+                ):
+                    issues.append(f"{label} successor manifest base binding is stale")
+
+        moves.append(
+            PlannedMove(
+                source=retained_source,
+                destination=retained_destination,
+            )
+        )
+        existing_companions.update(retained_companions)
     if issues:
         return None, issues
-    if in_place:
-        replacements = {}
-    else:
-        try:
-            replacements = exact_reference_replacements(
-                [PlannedMove(source=source_path, destination=destination_path)],
-                existing_companions=existing_companions,
-            )
-        except PathMigrationPlanError as exc:
-            return None, [
-                f"legacy replacement authority cannot be reconstructed: {exc}"
-            ]
+    try:
+        replacements = exact_reference_replacements(
+            moves,
+            existing_companions=existing_companions,
+        )
+    except PathMigrationPlanError as exc:
+        return None, [f"legacy replacement authority cannot be reconstructed: {exc}"]
     return replacements, []
 
 
@@ -7471,6 +7732,27 @@ def _legacy_replacement_reference_inventory_issues(
             for item in exact_rewrites:
                 if isinstance(item, dict):
                     classify(item.get("path"), "exact dependent")
+    retained_manifest_paths: set[Path] = set()
+    retained = replacement.get("retained_successors")
+    if isinstance(retained, list):
+        for successor in retained:
+            if not isinstance(successor, dict):
+                continue
+            legacy_manifest_evidence = successor.get("legacy_manifest")
+            if isinstance(legacy_manifest_evidence, dict) and isinstance(
+                legacy_manifest_evidence.get("path"), str
+            ):
+                retained_manifest_paths.add(Path(legacy_manifest_evidence["path"]))
+            legacy_successor_files = successor.get("legacy_files")
+            if isinstance(legacy_successor_files, list):
+                for item in legacy_successor_files:
+                    if isinstance(item, dict):
+                        classify(item.get("path"), "deleted source")
+    metadata_reconciliations = replacement.get("metadata_reconciliations")
+    if isinstance(metadata_reconciliations, list):
+        for item in metadata_reconciliations:
+            if isinstance(item, dict):
+                classify(item.get("path"), "metadata rewrite")
 
     legacy_manifest = legacy.get("manifest")
     legacy_manifest_path = (
@@ -7620,6 +7902,7 @@ def _legacy_replacement_reference_inventory_issues(
             path in deleted_paths
             or path == legacy_manifest_path
             or path in exact_manifest_paths
+            or path in retained_manifest_paths
         ):
             continue
         mode, object_id, size = base_entries[path]
@@ -7708,6 +7991,13 @@ def _legacy_replacement_reference_inventory_issues(
                 )
             continue
         if path not in hit_paths:
+            if (
+                owner == "metadata rewrite"
+                and path in _LEGACY_REPLACEMENT_METADATA_REWRITE_PATHS
+            ):
+                # Structured metadata removals and the derived toolchain binding
+                # are proved by their dedicated deterministic verifier below.
+                continue
             issues.append(
                 "legacy replacement reference evidence has no authoritative base hit: "
                 f"{path.as_posix()}"
@@ -7861,6 +8151,7 @@ def _legacy_replacement_pending_paths(repo_path: Path) -> list[str]:
             not in {
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V1,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
             }
             or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
@@ -7922,16 +8213,15 @@ def _legacy_replacement_pending_paths(repo_path: Path) -> list[str]:
         if authoritative_replacements is None or authority_issues:
             pending.append(f"invalid:{manifest_label}")
             continue
-        if (
-            receipt.get("schema_version")
-            == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
-            and _legacy_destination_predecessor_issues(
-                repo_path,
-                base_commit=base_commit,
-                authoritative_replacements=authoritative_replacements,
-                legacy=receipt.get("legacy"),
-                replacement=replacement,
-            )
+        if receipt.get("schema_version") in {
+            APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
+            APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
+        } and _legacy_destination_predecessor_issues(
+            repo_path,
+            base_commit=base_commit,
+            authoritative_replacements=authoritative_replacements,
+            legacy=receipt.get("legacy"),
+            replacement=replacement,
         ):
             pending.append(f"invalid:{manifest_label}")
             continue
@@ -8102,6 +8392,7 @@ def _legacy_replacement_pending_paths(repo_path: Path) -> list[str]:
             not in {
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V1,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
             }
             or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
@@ -20194,6 +20485,7 @@ def _manifest_coverage_by_file(
                 in APPLIED_ENCODING_GENERATED_BACKENDS
             )
             or payload.get("tool") == APPLIED_ENCODING_LEGACY_EXACT_DEPENDENT_TOOL
+            or payload.get("tool") == APPLIED_ENCODING_LEGACY_RETAINED_SUCCESSOR_TOOL
         )
         applied_files = payload.get("applied_files")
         if not isinstance(applied_files, list):
@@ -20243,7 +20535,10 @@ def _applied_manifest_source_attestation_issues(
 ) -> list[str]:
     """Validate source provenance claimed by an applied encoding manifest."""
 
-    if payload.get("tool") == APPLIED_ENCODING_LEGACY_EXACT_DEPENDENT_TOOL:
+    if payload.get("tool") in {
+        APPLIED_ENCODING_LEGACY_EXACT_DEPENDENT_TOOL,
+        APPLIED_ENCODING_LEGACY_RETAINED_SUCCESSOR_TOOL,
+    }:
         return []
     backend = _normalized_manifest_backend(payload)
     attestation_claimed = "source_attestation" in payload
@@ -20739,6 +21034,48 @@ def _applied_manifest_tool_execution_issues(
                     "the running pinned encoder"
                 )
             return issues
+        if tool == APPLIED_ENCODING_LEGACY_RETAINED_SUCCESSOR_TOOL:
+            if not isinstance(applied_files, list) or any(
+                not isinstance(item, dict) or set(item) != {"path", "sha256"}
+                for item in applied_files
+            ):
+                issues.append(
+                    f"{manifest_label} retained successor migration has malformed "
+                    "file entries"
+                )
+            retained_manifest = payload.get("retained_successor_manifest")
+            if (
+                not isinstance(retained_manifest, dict)
+                or retained_manifest.get("backend")
+                not in APPLIED_ENCODING_ENCODER_BACKENDS
+                or retained_manifest.get("tool") != APPLIED_ENCODING_MODEL_TOOL
+                or retained_manifest.get("schema_version")
+                != APPLIED_ENCODING_MANIFEST_SCHEMA
+            ):
+                issues.append(
+                    f"{manifest_label} retained successor must nest its original "
+                    "current-v5 model apply manifest"
+                )
+            if (
+                "deterministic_execution" in payload
+                or "validation_execution" in payload
+                or "source_attestation" in payload
+            ):
+                issues.append(
+                    f"{manifest_label} retained successor migration must preserve "
+                    "receipt-bound provenance"
+                )
+            provenance = payload.get("axiom_encode_git")
+            if not isinstance(provenance, dict) or (
+                provenance.get("commit") != expected_encoder_identity.get("commit")
+                or provenance.get("version") != expected_encoder_identity.get("version")
+                or provenance.get("dirty_tracked") is not False
+            ):
+                issues.append(
+                    f"{manifest_label} retained successor migration does not match "
+                    "the running pinned encoder"
+                )
+            return issues
         if tool == APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL:
             replacement_manifest = payload.get("replacement_manifest")
             if (
@@ -20880,6 +21217,10 @@ def _applied_manifest_exact_schema_issues(
         expected_fields = _LEGACY_EXACT_DEPENDENT_APPLY_MANIFEST_FIELDS
         expected_item_fields = _MODEL_APPLIED_FILE_FIELDS
         contract = "legacy exact dependent"
+    elif backend is None and tool == APPLIED_ENCODING_LEGACY_RETAINED_SUCCESSOR_TOOL:
+        expected_fields = _LEGACY_RETAINED_SUCCESSOR_APPLY_MANIFEST_FIELDS
+        expected_item_fields = _MODEL_APPLIED_FILE_FIELDS
+        contract = "legacy retained successor"
     else:
         return []
 
@@ -21939,6 +22280,10 @@ def _legacy_replacement_manifest_issues(
     if nested_signature_issue:
         issues.append(f"{nested_label} {nested_signature_issue}")
     nested_execution = nested.get("validation_execution")
+    nested_waiver_set_sha256 = nested.get(VALIDATION_WAIVER_SET_SHA256_FIELD)
+    pre_migration_waiver_set_sha256s: set[str] = set()
+    if isinstance(nested_waiver_set_sha256, str):
+        pre_migration_waiver_set_sha256s.add(nested_waiver_set_sha256)
     nested_encoder = (
         nested_execution.get("axiom_encode")
         if isinstance(nested_execution, dict)
@@ -21956,12 +22301,12 @@ def _legacy_replacement_manifest_issues(
         _model_apply_validation_execution_issues(
             nested,
             manifest_label=nested_label,
-            expected_waiver_set_sha256=expected_waiver_set_sha256,
+            expected_waiver_set_sha256=str(nested_waiver_set_sha256 or ""),
             expected_encoder_identity=expected_nested_encoder,
         )
     )
-    if nested.get(VALIDATION_WAIVER_SET_SHA256_FIELD) != expected_waiver_set_sha256:
-        issues.append(f"{nested_label} waiver-set binding is stale")
+    if not isinstance(nested_waiver_set_sha256, str):
+        issues.append(f"{nested_label} waiver-set binding is malformed")
     if payload.get("source_attestation") != nested.get("source_attestation"):
         issues.append(f"{nested_label} source_attestation differs from replacement")
 
@@ -22012,6 +22357,43 @@ def _legacy_replacement_manifest_issues(
         and isinstance(receipt_replacement.get("exact_dependents"), list)
         else []
     )
+    receipt_retained_successors = (
+        receipt_replacement.get("retained_successors")
+        if isinstance(receipt_replacement, dict)
+        and isinstance(receipt_replacement.get("retained_successors"), list)
+        else []
+    )
+    receipt_live_files = (
+        receipt_replacement.get("live_files")
+        if isinstance(receipt_replacement, dict)
+        and isinstance(receipt_replacement.get("live_files"), list)
+        else []
+    )
+    receipt_live_paths = {
+        item.get("path") for item in receipt_live_files if isinstance(item, dict)
+    }
+    identity_deleted_files = [
+        {"path": item.get("path"), "deleted": True}
+        for item in (
+            receipt_legacy.get("files", [])
+            if isinstance(receipt_legacy, dict)
+            and isinstance(receipt_legacy.get("files"), list)
+            else []
+        )
+        if isinstance(item, dict) and item.get("path") not in receipt_live_paths
+    ]
+    if receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA:
+        identity_deleted_files.extend(
+            {"path": item.get("path"), "deleted": True}
+            for successor in receipt_retained_successors
+            if isinstance(successor, dict)
+            for item in (
+                successor.get("legacy_files", [])
+                if isinstance(successor.get("legacy_files"), list)
+                else []
+            )
+            if isinstance(item, dict)
+        )
     identity_payload = receipt_identity_payload(
         base_commit=(
             str(receipt_repository.get("base_commit"))
@@ -22029,33 +22411,8 @@ def _legacy_replacement_manifest_issues(
             if isinstance(receipt_replacement, dict)
             else ""
         ),
-        live_files=(
-            receipt_replacement.get("live_files")
-            if isinstance(receipt_replacement, dict)
-            and isinstance(receipt_replacement.get("live_files"), list)
-            else []
-        ),
-        deleted_files=[
-            {"path": item.get("path"), "deleted": True}
-            for item in (
-                receipt_legacy.get("files", [])
-                if isinstance(receipt_legacy, dict)
-                and isinstance(receipt_legacy.get("files"), list)
-                else []
-            )
-            if isinstance(item, dict)
-            and item.get("path")
-            not in {
-                live.get("path")
-                for live in (
-                    receipt_replacement.get("live_files", [])
-                    if isinstance(receipt_replacement, dict)
-                    and isinstance(receipt_replacement.get("live_files"), list)
-                    else []
-                )
-                if isinstance(live, dict)
-            }
-        ],
+        live_files=receipt_live_files,
+        deleted_files=identity_deleted_files,
         rewrites=(
             receipt_replacement.get("rewrites")
             if isinstance(receipt_replacement, dict)
@@ -22073,13 +22430,18 @@ def _legacy_replacement_manifest_issues(
             if receipt_schema
             in {
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
             }
             else None
         ),
         destination_predecessor_files=(
             receipt_replacement.get("destination_predecessor_files")
-            if receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+            if receipt_schema
+            in {
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
+            }
             and isinstance(receipt_replacement, dict)
             and isinstance(
                 receipt_replacement.get("destination_predecessor_files"), list
@@ -22088,11 +22450,27 @@ def _legacy_replacement_manifest_issues(
         ),
         destination_predecessor_class=(
             receipt_replacement.get("destination_predecessor_class")
-            if receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+            if receipt_schema
+            in {
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
+            }
             and isinstance(receipt_replacement, dict)
             and isinstance(
                 receipt_replacement.get("destination_predecessor_class"), str
             )
+            else None
+        ),
+        retained_successors=(
+            receipt_retained_successors
+            if receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+            else None
+        ),
+        metadata_reconciliations=(
+            receipt_replacement.get("metadata_reconciliations")
+            if receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+            and isinstance(receipt_replacement, dict)
+            and isinstance(receipt_replacement.get("metadata_reconciliations"), list)
             else None
         ),
     )
@@ -22107,6 +22485,7 @@ def _legacy_replacement_manifest_issues(
         not in {
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V1,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
+            APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
         }
         or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
@@ -22206,6 +22585,7 @@ def _legacy_replacement_manifest_issues(
                 if receipt_schema
                 in {
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
+                    APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
                 }
                 else set()
@@ -22215,6 +22595,15 @@ def _legacy_replacement_manifest_issues(
                     "destination_predecessor_class",
                     "destination_predecessor_files",
                 }
+                if receipt_schema
+                in {
+                    APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
+                    APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
+                }
+                else set()
+            )
+            | (
+                {"retained_successors", "metadata_reconciliations"}
                 if receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
                 else set()
             )
@@ -22255,7 +22644,10 @@ def _legacy_replacement_manifest_issues(
                 for issue in authority_issues
             ],
         ]
-    if receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA:
+    if receipt_schema in {
+        APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
+        APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
+    }:
         issues.extend(
             f"{manifest_label} destination predecessor is invalid: {issue}"
             for issue in _legacy_destination_predecessor_issues(
@@ -22858,6 +23250,314 @@ def _legacy_replacement_manifest_issues(
                 f"migration manifest for {primary}"
             )
 
+    retained_successors = replacement.get("retained_successors", [])
+    retained_deleted_entries: list[dict[str, object]] = []
+    if not isinstance(retained_successors, list):
+        issues.append(f"{manifest_label} retained successors are malformed")
+        retained_successors = []
+    for successor in retained_successors:
+        if not isinstance(successor, dict):
+            continue
+        source_raw = successor.get("source")
+        destination_raw = successor.get("destination")
+        if not isinstance(source_raw, str) or not isinstance(destination_raw, str):
+            continue
+        source_path = Path(source_raw)
+        destination_path = Path(destination_raw)
+        legacy_successor_files = successor.get("legacy_files")
+        successor_files = successor.get("successor_files")
+        successor_manifest_evidence = successor.get("successor_manifest")
+        if not isinstance(legacy_successor_files, list) or not isinstance(
+            successor_files, list
+        ):
+            continue
+        retained_deleted_entries.extend(
+            {"path": item["path"], "deleted": True}
+            for item in legacy_successor_files
+            if isinstance(item, dict) and isinstance(item.get("path"), str)
+        )
+        old_manifest_path = _applied_encoding_manifest_path(source_path)
+        if (repo_path / old_manifest_path).exists() or (
+            repo_path / old_manifest_path
+        ).is_symlink():
+            issues.append(
+                f"{manifest_label} retained successor legacy manifest still exists: "
+                f"{old_manifest_path}"
+            )
+        for item in legacy_successor_files:
+            old_path = Path(str(item.get("path"))) if isinstance(item, dict) else Path()
+            if (repo_path / old_path).exists() or (repo_path / old_path).is_symlink():
+                issues.append(
+                    f"{manifest_label} retained successor source still exists: {old_path}"
+                )
+
+        nested_successor = (
+            successor_manifest_evidence.get("payload")
+            if isinstance(successor_manifest_evidence, dict)
+            else None
+        )
+        nested_label = f"{manifest_label}.retained_successor[{destination_raw}]"
+        if not isinstance(nested_successor, dict):
+            issues.append(f"{nested_label} original manifest is malformed")
+            continue
+        issues.extend(
+            _applied_manifest_exact_schema_issues(
+                nested_successor, manifest_label=nested_label
+            )
+        )
+        nested_successor_signature_issue = _applied_encoding_manifest_signature_issue(
+            nested_successor, signing_broker
+        )
+        if nested_successor_signature_issue:
+            issues.append(f"{nested_label} {nested_successor_signature_issue}")
+        successor_execution = nested_successor.get("validation_execution")
+        successor_encoder = (
+            successor_execution.get("axiom_encode")
+            if isinstance(successor_execution, dict)
+            else None
+        )
+        expected_successor_encoder = (
+            successor_encoder if isinstance(successor_encoder, dict) else {}
+        )
+        issues.extend(
+            _applied_manifest_tool_execution_issues(
+                nested_successor,
+                manifest_label=nested_label,
+                expected_encoder_identity=expected_successor_encoder,
+            )
+        )
+        issues.extend(
+            _model_apply_validation_execution_issues(
+                nested_successor,
+                manifest_label=nested_label,
+                expected_waiver_set_sha256=str(
+                    nested_successor.get(VALIDATION_WAIVER_SET_SHA256_FIELD) or ""
+                ),
+                expected_encoder_identity=expected_successor_encoder,
+            )
+        )
+        successor_waiver_set_sha256 = nested_successor.get(
+            VALIDATION_WAIVER_SET_SHA256_FIELD
+        )
+        if isinstance(successor_waiver_set_sha256, str):
+            pre_migration_waiver_set_sha256s.add(successor_waiver_set_sha256)
+        else:
+            issues.append(f"{nested_label} waiver-set binding is malformed")
+        live_successor_snapshots: dict[str, bytes] = {}
+        for item in successor_files:
+            if not isinstance(item, dict) or not isinstance(item.get("path"), str):
+                continue
+            current_path = Path(item["path"])
+            try:
+                current_raw = read_bounded_regular_file(
+                    repo_path,
+                    repo_path / current_path,
+                    label="retained successor live file",
+                    max_bytes=16 * 1024 * 1024,
+                    required_mode=0o644,
+                )
+            except (OSError, UnsafeCorpusPathError) as exc:
+                issues.append(f"{nested_label} live file is unreadable: {exc}")
+                continue
+            live_successor_snapshots[current_path.as_posix()] = current_raw
+            if hashlib.sha256(current_raw).hexdigest() != item.get("sha256"):
+                issues.append(f"{nested_label} live file hash is stale: {current_path}")
+        issues.extend(
+            _applied_manifest_source_attestation_issues(
+                nested_successor,
+                repo_path=repo_path,
+                root_prefix="",
+                manifest_label=nested_label,
+                rulespec_snapshots=live_successor_snapshots,
+            )
+        )
+        current_manifest_path = _applied_encoding_manifest_path(destination_path)
+        try:
+            current_manifest_raw = read_bounded_regular_file(
+                repo_path,
+                repo_path / current_manifest_path,
+                label="retained successor refreshed manifest",
+                max_bytes=4 * 1024 * 1024,
+                required_mode=0o644,
+            )
+            current_manifest = json.loads(current_manifest_raw.decode("utf-8"))
+        except (
+            OSError,
+            UnsafeCorpusPathError,
+            UnicodeError,
+            json.JSONDecodeError,
+            RecursionError,
+        ):
+            current_manifest = None
+        legacy_manifest_evidence = successor.get("legacy_manifest")
+        expected_successor_migration = {
+            "receipt_path": receipt_path.as_posix(),
+            "receipt_sha256": receipt_sha256,
+            "source": source_raw,
+            "destination": destination_raw,
+            "legacy_manifest_path": (
+                legacy_manifest_evidence.get("path")
+                if isinstance(legacy_manifest_evidence, dict)
+                else None
+            ),
+            "legacy_manifest_sha256": (
+                legacy_manifest_evidence.get("sha256")
+                if isinstance(legacy_manifest_evidence, dict)
+                else None
+            ),
+            "successor_manifest_sha256": (
+                successor_manifest_evidence.get("sha256")
+                if isinstance(successor_manifest_evidence, dict)
+                else None
+            ),
+        }
+        if (
+            not isinstance(current_manifest, dict)
+            or set(current_manifest) != _LEGACY_RETAINED_SUCCESSOR_APPLY_MANIFEST_FIELDS
+            or current_manifest.get("schema_version")
+            != APPLIED_ENCODING_MANIFEST_SCHEMA
+            or current_manifest.get("tool")
+            != APPLIED_ENCODING_LEGACY_RETAINED_SUCCESSOR_TOOL
+            or current_manifest.get("axiom_encode_version")
+            != payload.get("axiom_encode_version")
+            or current_manifest.get("axiom_encode_git")
+            != payload.get("axiom_encode_git")
+            or current_manifest.get(VALIDATION_WAIVER_SET_SHA256_FIELD)
+            != expected_waiver_set_sha256
+            or current_manifest.get("applied_files") != successor_files
+            or current_manifest.get("legacy_migration") != expected_successor_migration
+            or current_manifest.get("retained_successor_manifest") != nested_successor
+            or _applied_encoding_manifest_signature_issue(
+                current_manifest, signing_broker
+            )
+        ):
+            issues.append(
+                f"{manifest_label} retained successor lacks its authenticated v5 "
+                f"migration manifest for {destination_raw}"
+            )
+
+    metadata_reconciliations = replacement.get("metadata_reconciliations", [])
+    metadata_entries: list[dict[str, object]] = []
+    if not isinstance(metadata_reconciliations, list):
+        issues.append(f"{manifest_label} metadata reconciliations are malformed")
+        metadata_reconciliations = []
+    primary_moves = [
+        PlannedMove(source=Path(old), destination=Path(new))
+        for old, new in authoritative_replacements.items()
+        if old.endswith(RULESPEC_FILE_SUFFIX)
+        and not old.endswith(RULESPEC_TEST_FILE_SUFFIX)
+    ]
+    post_migration_waiver_sha256: str | None = None
+    try:
+        base_waiver_raw = _rulespec_migration_base_blob(
+            repo_path,
+            base_commit,
+            Path("known-validation-gaps.yaml"),
+        )
+        rewritten_waiver_raw, _waiver_operations = (
+            _legacy_metadata_reconciliation_bytes(
+                Path("known-validation-gaps.yaml"),
+                base_waiver_raw,
+                moves=primary_moves,
+            )
+        )
+        post_migration_waiver_sha256 = hashlib.sha256(rewritten_waiver_raw).hexdigest()
+    except (RuntimeError, ValueError):
+        pass
+    listed_metadata_paths: set[Path] = set()
+    for reconciliation in metadata_reconciliations:
+        if not isinstance(reconciliation, dict) or set(reconciliation) != {
+            "path",
+            "before_sha256",
+            "after_sha256",
+            "operations",
+        }:
+            issues.append(f"{manifest_label} metadata reconciliation is malformed")
+            continue
+        path_raw = reconciliation.get("path")
+        path = Path(path_raw) if isinstance(path_raw, str) else Path()
+        if (
+            path not in _LEGACY_REPLACEMENT_METADATA_REWRITE_PATHS
+            or path in listed_metadata_paths
+        ):
+            issues.append(
+                f"{manifest_label} metadata reconciliation path is unauthorized"
+            )
+            continue
+        listed_metadata_paths.add(path)
+        try:
+            base_raw = _rulespec_migration_base_blob(repo_path, base_commit, path)
+            live_raw = read_bounded_regular_file(
+                repo_path,
+                repo_path / path,
+                label="legacy metadata reconciliation live file",
+                max_bytes=16 * 1024 * 1024,
+                required_mode=0o644,
+            )
+            expected_raw, expected_operations = _legacy_metadata_reconciliation_bytes(
+                path,
+                base_raw,
+                moves=primary_moves,
+                validation_waiver_set_sha256=post_migration_waiver_sha256,
+            )
+        except (OSError, RuntimeError, UnsafeCorpusPathError, ValueError) as exc:
+            issues.append(
+                f"{manifest_label} metadata reconciliation is unverifiable: {exc}"
+            )
+            continue
+        if (
+            reconciliation.get("before_sha256") != hashlib.sha256(base_raw).hexdigest()
+            or reconciliation.get("after_sha256")
+            != hashlib.sha256(live_raw).hexdigest()
+            or live_raw != expected_raw
+            or reconciliation.get("operations") != list(expected_operations)
+            or expected_raw == base_raw
+        ):
+            issues.append(
+                f"{manifest_label} metadata reconciliation proof is stale for {path}"
+            )
+        metadata_entries.append(
+            {"path": path.as_posix(), "sha256": hashlib.sha256(live_raw).hexdigest()}
+        )
+    expected_metadata_paths: set[Path] = set()
+    for path in _LEGACY_REPLACEMENT_METADATA_REWRITE_PATHS:
+        try:
+            base_raw = _rulespec_migration_base_blob(repo_path, base_commit, path)
+            expected_raw, _operations = _legacy_metadata_reconciliation_bytes(
+                path,
+                base_raw,
+                moves=primary_moves,
+                validation_waiver_set_sha256=post_migration_waiver_sha256,
+            )
+        except (RuntimeError, ValueError):
+            continue
+        if expected_raw != base_raw:
+            expected_metadata_paths.add(path)
+    if listed_metadata_paths != expected_metadata_paths:
+        issues.append(
+            f"{manifest_label} metadata reconciliation inventory is not exact"
+        )
+    waiver_transition = next(
+        (
+            item
+            for item in metadata_reconciliations
+            if isinstance(item, dict)
+            and item.get("path") == "known-validation-gaps.yaml"
+            and item.get("after_sha256") == expected_waiver_set_sha256
+        ),
+        None,
+    )
+    for pre_migration_waiver in pre_migration_waiver_set_sha256s:
+        if pre_migration_waiver == expected_waiver_set_sha256:
+            continue
+        if (
+            not isinstance(waiver_transition, dict)
+            or waiver_transition.get("before_sha256") != pre_migration_waiver
+        ):
+            issues.append(
+                f"{manifest_label} nested waiver-set transition is not authenticated"
+            )
+
     outer_entries = payload.get("applied_files")
     outer_list = outer_entries if isinstance(outer_entries, list) else []
     expected_entries: list[dict[str, object]] = []
@@ -22959,7 +23659,7 @@ def _legacy_replacement_manifest_issues(
                         f"{manifest_label} rewrite transformation is not exact for {path}"
                     )
             expected_entries.append({"path": path, "sha256": after})
-    expected_entries.extend(
+    primary_deleted_entries = [
         {"path": item["path"], "deleted": True}
         for item in legacy_files
         if isinstance(item, dict)
@@ -22970,7 +23670,10 @@ def _legacy_replacement_manifest_issues(
             for live in replacement.get("live_files", [])
             if isinstance(live, dict)
         }
-    )
+    ]
+    expected_entries.extend(metadata_entries)
+    expected_entries.extend(primary_deleted_entries)
+    expected_entries.extend(retained_deleted_entries)
     if outer_list != expected_entries:
         issues.append(
             f"{manifest_label} applied files do not exactly match replacement receipt"
@@ -23049,6 +23752,7 @@ def _legacy_exact_dependent_manifest_issues(
         or receipt.get("schema_version")
         not in {
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
+            APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
         }
         or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
@@ -23149,6 +23853,152 @@ def _legacy_exact_dependent_manifest_issues(
         )
     )
     return issues
+
+
+def _legacy_retained_successor_manifest_issues(
+    payload: Mapping[str, object],
+    *,
+    repo_path: Path,
+    manifest_label: str,
+    signing_broker: SigningBroker | Ed25519PublicKey,
+    expected_waiver_set_sha256: str,
+    local_corpus_release: LocalCorpusRelease | None,
+) -> list[str]:
+    """Verify a preserved canonical successor through its shared v4 receipt."""
+
+    if (
+        payload.get("backend") is not None
+        or payload.get("tool") != APPLIED_ENCODING_LEGACY_RETAINED_SUCCESSOR_TOOL
+    ):
+        return []
+    binding = payload.get("legacy_migration")
+    if not isinstance(binding, dict) or set(binding) != {
+        "receipt_path",
+        "receipt_sha256",
+        "source",
+        "destination",
+        "legacy_manifest_path",
+        "legacy_manifest_sha256",
+        "successor_manifest_sha256",
+    }:
+        return [f"{manifest_label} retained successor binding is malformed"]
+    receipt_path_raw = binding.get("receipt_path")
+    receipt_path = (
+        Path(receipt_path_raw) if isinstance(receipt_path_raw, str) else Path()
+    )
+    destination_raw = binding.get("destination")
+    destination = Path(destination_raw) if isinstance(destination_raw, str) else Path()
+    if (
+        not isinstance(receipt_path_raw, str)
+        or receipt_path.is_absolute()
+        or receipt_path.parent != APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_DIR
+        or receipt_path.suffix != ".json"
+        or not isinstance(destination_raw, str)
+        or destination.is_absolute()
+        or destination.as_posix() != destination_raw
+        or _applied_encoding_manifest_path(destination).as_posix() != manifest_label
+    ):
+        return [f"{manifest_label} retained successor identity is invalid"]
+    try:
+        receipt_raw = read_bounded_regular_file(
+            repo_path,
+            repo_path / receipt_path,
+            label="legacy retained successor receipt",
+            max_bytes=4 * 1024 * 1024,
+            required_mode=0o644,
+        )
+        receipt = json.loads(receipt_raw.decode("utf-8"))
+    except (
+        OSError,
+        UnsafeCorpusPathError,
+        UnicodeError,
+        json.JSONDecodeError,
+        RecursionError,
+    ):
+        return [f"{manifest_label} retained successor receipt is unreadable"]
+    receipt_sha256 = hashlib.sha256(receipt_raw).hexdigest()
+    if (
+        not isinstance(receipt, dict)
+        or set(receipt) != _LEGACY_REPLACEMENT_RECEIPT_FIELDS
+        or receipt.get("schema_version")
+        != APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+        or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
+        or receipt_sha256 != binding.get("receipt_sha256")
+        or _applied_encoding_manifest_signature_issue(receipt, signing_broker)
+    ):
+        return [f"{manifest_label} retained successor receipt is invalid"]
+    replacement = receipt.get("replacement")
+    retained = (
+        replacement.get("retained_successors")
+        if isinstance(replacement, dict)
+        else None
+    )
+    matches = (
+        [
+            item
+            for item in retained
+            if isinstance(item, dict)
+            and item.get("source") == binding.get("source")
+            and item.get("destination") == destination_raw
+        ]
+        if isinstance(retained, list)
+        else []
+    )
+    if len(matches) != 1:
+        return [f"{manifest_label} is not uniquely authorized by its cascade receipt"]
+    evidence = matches[0]
+    legacy_manifest = evidence.get("legacy_manifest")
+    successor_manifest = evidence.get("successor_manifest")
+    if (
+        evidence.get("successor_files") != payload.get("applied_files")
+        or not isinstance(legacy_manifest, dict)
+        or legacy_manifest.get("path") != binding.get("legacy_manifest_path")
+        or legacy_manifest.get("sha256") != binding.get("legacy_manifest_sha256")
+        or not isinstance(successor_manifest, dict)
+        or successor_manifest.get("sha256") != binding.get("successor_manifest_sha256")
+        or successor_manifest.get("payload")
+        != payload.get("retained_successor_manifest")
+    ):
+        return [f"{manifest_label} retained successor receipt binding is stale"]
+    outer_path_raw = (
+        replacement.get("model_manifest_path")
+        if isinstance(replacement, dict)
+        else None
+    )
+    outer_path = Path(outer_path_raw) if isinstance(outer_path_raw, str) else Path()
+    try:
+        outer_raw = read_bounded_regular_file(
+            repo_path,
+            repo_path / outer_path,
+            label="legacy retained successor cascade owner",
+            max_bytes=4 * 1024 * 1024,
+            required_mode=0o644,
+        )
+        outer = json.loads(outer_raw.decode("utf-8"))
+    except (
+        OSError,
+        UnsafeCorpusPathError,
+        UnicodeError,
+        json.JSONDecodeError,
+        RecursionError,
+    ):
+        return [f"{manifest_label} retained successor cascade owner is unreadable"]
+    if (
+        not isinstance(outer_path_raw, str)
+        or not isinstance(outer, dict)
+        or set(outer) != _LEGACY_REPLACEMENT_APPLY_MANIFEST_FIELDS
+        or outer.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
+        or _applied_encoding_manifest_signature_issue(outer, signing_broker)
+    ):
+        return [f"{manifest_label} retained successor cascade owner is invalid"]
+    return _legacy_replacement_manifest_issues(
+        outer,
+        repo_path=repo_path,
+        manifest_label=outer_path.as_posix(),
+        signing_broker=signing_broker,
+        expected_waiver_set_sha256=expected_waiver_set_sha256,
+        local_corpus_release=local_corpus_release,
+    )
 
 
 def _load_verified_applied_encoding_manifest_payload(
@@ -23407,6 +24257,16 @@ def _load_verified_applied_encoding_manifest_payload(
     )
     issues.extend(
         _legacy_exact_dependent_manifest_issues(
+            payload,
+            repo_path=repo_path,
+            manifest_label=manifest_label,
+            signing_broker=signing_broker,
+            expected_waiver_set_sha256=expected_waiver_set_sha256,
+            local_corpus_release=local_corpus_release,
+        )
+    )
+    issues.extend(
+        _legacy_retained_successor_manifest_issues(
             payload,
             repo_path=repo_path,
             manifest_label=manifest_label,
@@ -24345,6 +25205,391 @@ def _require_locked_legacy_replacement_base(
     _require_legacy_replacement_clean_checkout(checkout_root)
 
 
+def _remove_nested_mapping_keys(value: object, keys: set[str]) -> tuple[object, int]:
+    """Return a copy with exact mapping keys removed at any nesting level."""
+
+    if isinstance(value, dict):
+        removed = 0
+        result: dict[object, object] = {}
+        for key, item in value.items():
+            if isinstance(key, str) and key in keys:
+                removed += 1
+                continue
+            rewritten, child_removed = _remove_nested_mapping_keys(item, keys)
+            result[key] = rewritten
+            removed += child_removed
+        return result, removed
+    if isinstance(value, list):
+        result_list: list[object] = []
+        removed = 0
+        for item in value:
+            rewritten, child_removed = _remove_nested_mapping_keys(item, keys)
+            result_list.append(rewritten)
+            removed += child_removed
+        return result_list, removed
+    return value, 0
+
+
+def _remove_index_module_records(
+    value: object,
+    *,
+    old_modules: set[str],
+) -> tuple[object, int]:
+    """Remove exact legacy module records without rewriting canonical records."""
+
+    if isinstance(value, list):
+        result: list[object] = []
+        removed = 0
+        for item in value:
+            if isinstance(item, dict) and item.get("module") in old_modules:
+                removed += 1
+                continue
+            rewritten, child_removed = _remove_index_module_records(
+                item,
+                old_modules=old_modules,
+            )
+            result.append(rewritten)
+            removed += child_removed
+        return result, removed
+    if isinstance(value, dict):
+        result_dict: dict[object, object] = {}
+        removed = 0
+        for key, item in value.items():
+            rewritten, child_removed = _remove_index_module_records(
+                item,
+                old_modules=old_modules,
+            )
+            result_dict[key] = rewritten
+            removed += child_removed
+        return result_dict, removed
+    return value, 0
+
+
+def _index_module_record_counts(value: object) -> Counter[str]:
+    """Count exact ``module`` fields only on removable list-item records."""
+
+    counts: Counter[str] = Counter()
+    if isinstance(value, list):
+        for item in value:
+            if isinstance(item, dict):
+                module = item.get("module")
+                if isinstance(module, str):
+                    counts[module] += 1
+                for child in item.values():
+                    counts.update(_index_module_record_counts(child))
+            else:
+                counts.update(_index_module_record_counts(item))
+    elif isinstance(value, dict):
+        for item in value.values():
+            counts.update(_index_module_record_counts(item))
+    return counts
+
+
+def _line_preserving_yaml_mapping_removal(
+    raw: bytes,
+    *,
+    keys: set[str],
+) -> tuple[bytes, int]:
+    """Remove exact YAML mapping blocks and prove the semantic result."""
+
+    try:
+        text = raw.decode("utf-8")
+        before = yaml.safe_load(text)
+    except (UnicodeError, yaml.YAMLError, RecursionError) as exc:
+        raise ValueError("legacy metadata YAML is not valid UTF-8 YAML") from exc
+    expected, expected_count = _remove_nested_mapping_keys(before, keys)
+    lines = text.splitlines(keepends=True)
+    remove_indexes: set[int] = set()
+    observed = 0
+    for index, line in enumerate(lines):
+        stripped = line.lstrip(" ")
+        indent = len(line) - len(stripped)
+        matched = next(
+            (
+                key
+                for key in keys
+                if stripped.startswith((f'"{key}":', f"'{key}':", f"{key}:"))
+            ),
+            None,
+        )
+        if matched is None:
+            continue
+        observed += 1
+        remove_indexes.add(index)
+        cursor = index + 1
+        while cursor < len(lines):
+            candidate = lines[cursor]
+            candidate_stripped = candidate.lstrip(" ")
+            if (
+                candidate_stripped.strip()
+                and (len(candidate) - len(candidate_stripped)) <= indent
+            ):
+                break
+            remove_indexes.add(cursor)
+            cursor += 1
+    rewritten = "".join(
+        line for index, line in enumerate(lines) if index not in remove_indexes
+    ).encode("utf-8")
+    try:
+        actual = yaml.safe_load(rewritten.decode("utf-8"))
+    except (UnicodeError, yaml.YAMLError, RecursionError) as exc:
+        raise ValueError("legacy metadata YAML removal produced invalid YAML") from exc
+    if actual != expected or observed != expected_count:
+        raise ValueError("legacy metadata YAML removal is not exact")
+    return rewritten, observed
+
+
+def _line_preserving_oracle_pending_removal(
+    raw: bytes,
+    *,
+    old_identities: set[str],
+    canonical_identities: set[str],
+) -> tuple[bytes, int]:
+    """Remove legacy pending records only when a canonical successor is present."""
+
+    try:
+        text = raw.decode("utf-8")
+        before = yaml.safe_load(text)
+    except (UnicodeError, yaml.YAMLError, RecursionError) as exc:
+        raise ValueError("legacy oracle metadata is not valid UTF-8 YAML") from exc
+    if not isinstance(before, list):
+        raise ValueError("legacy oracle metadata is not a YAML list")
+    canonical_present = {
+        identity
+        for identity in canonical_identities
+        if any(
+            isinstance(item, dict)
+            and isinstance(item.get("legal_id"), str)
+            and str(item["legal_id"]).startswith(f"{identity}#")
+            for item in before
+        )
+    }
+    expected = [
+        item
+        for item in before
+        if not (
+            isinstance(item, dict)
+            and isinstance(item.get("legal_id"), str)
+            and any(
+                str(item["legal_id"]).startswith(f"{identity}#")
+                for identity in old_identities
+            )
+        )
+    ]
+    removed = len(before) - len(expected)
+    if removed and canonical_present != canonical_identities:
+        raise ValueError(
+            "legacy oracle metadata lacks an exact canonical successor record"
+        )
+    lines = text.splitlines(keepends=True)
+    starts = [
+        index for index, line in enumerate(lines) if line.startswith("- legal_id:")
+    ]
+    remove_indexes: set[int] = set()
+    observed = 0
+    for position, start in enumerate(starts):
+        end = starts[position + 1] if position + 1 < len(starts) else len(lines)
+        first = lines[start]
+        if any(f"{identity}#" in first for identity in old_identities):
+            observed += 1
+            remove_indexes.update(range(start, end))
+    rewritten = "".join(
+        line for index, line in enumerate(lines) if index not in remove_indexes
+    ).encode("utf-8")
+    try:
+        actual = yaml.safe_load(rewritten.decode("utf-8"))
+    except (UnicodeError, yaml.YAMLError, RecursionError) as exc:
+        raise ValueError(
+            "legacy oracle metadata removal produced invalid YAML"
+        ) from exc
+    if actual != expected or observed != removed:
+        raise ValueError("legacy oracle metadata removal is not exact")
+    return rewritten, observed
+
+
+def _legacy_metadata_reconciliation_bytes(
+    path: Path,
+    raw: bytes,
+    *,
+    moves: Sequence[PlannedMove],
+    validation_waiver_set_sha256: str | None = None,
+) -> tuple[bytes, tuple[dict[str, object], ...]]:
+    """Apply one audited metadata cleanup from an explicit move set."""
+
+    old_modules = {move.source.as_posix() for move in moves}
+    old_identities = {rulespec_identity(move.source) for move in moves}
+    canonical_identities = {rulespec_identity(move.destination) for move in moves}
+    old_manifests = {
+        _applied_encoding_manifest_path(move.source).as_posix() for move in moves
+    }
+    if path == Path(".axiom/toolchain.toml"):
+        if (
+            validation_waiver_set_sha256 is None
+            or _SHA256_HEX_PATTERN.fullmatch(validation_waiver_set_sha256) is None
+        ):
+            raise ValueError(
+                "legacy toolchain reconciliation lacks the post-migration waiver digest"
+            )
+        try:
+            text = raw.decode("utf-8")
+        except UnicodeError as exc:
+            raise ValueError("legacy toolchain metadata is not UTF-8") from exc
+        pattern = re.compile(r'(?m)^validation_waiver_set_sha256 = "[0-9a-f]{64}"$')
+        rewritten_text, count = pattern.subn(
+            f'validation_waiver_set_sha256 = "{validation_waiver_set_sha256}"',
+            text,
+        )
+        if count != 1:
+            raise ValueError(
+                "legacy toolchain waiver binding is not one canonical entry"
+            )
+        rewritten = rewritten_text.encode("utf-8")
+        operations = ({"operation": "update_validation_waiver_set_sha256", "count": 1},)
+    elif path == Path(".axiom/index/provisions_to_rules.json"):
+        try:
+            before = json.loads(raw.decode("utf-8"))
+        except (UnicodeError, json.JSONDecodeError, RecursionError) as exc:
+            raise ValueError("legacy provision index is invalid JSON") from exc
+        module_counts = _index_module_record_counts(before)
+        missing_successors = [
+            move.destination.as_posix()
+            for move in moves
+            if module_counts[move.source.as_posix()] > 0
+            and module_counts[move.destination.as_posix()] == 0
+        ]
+        if missing_successors:
+            raise ValueError(
+                "legacy provision index lacks exact canonical module records: "
+                + ", ".join(missing_successors)
+            )
+        after, count = _remove_index_module_records(before, old_modules=old_modules)
+        if count != sum(module_counts[module] for module in old_modules):
+            raise ValueError("legacy provision index removal count is inconsistent")
+        rewritten = (json.dumps(after, indent=2, ensure_ascii=True) + "\n").encode()
+        operations = ({"operation": "remove_legacy_module_records", "count": count},)
+    elif path == Path(".axiom/pending-validation-fingerprints.json"):
+        try:
+            before = json.loads(raw.decode("utf-8"))
+        except (UnicodeError, json.JSONDecodeError, RecursionError) as exc:
+            raise ValueError("legacy pending fingerprints are invalid JSON") from exc
+        after, count = _remove_nested_mapping_keys(before, old_modules)
+        rewritten = (json.dumps(after, indent=2, ensure_ascii=True) + "\n").encode()
+        operations = ({"operation": "remove_legacy_fingerprints", "count": count},)
+    elif path == Path("known-validation-gaps.yaml"):
+        rewritten, count = _line_preserving_yaml_mapping_removal(raw, keys=old_modules)
+        operations = ({"operation": "remove_legacy_validation_gaps", "count": count},)
+    elif path == Path("oracle-coverage-pending.yaml"):
+        rewritten, count = _line_preserving_oracle_pending_removal(
+            raw,
+            old_identities=old_identities,
+            canonical_identities=canonical_identities,
+        )
+        operations = ({"operation": "remove_legacy_oracle_pending", "count": count},)
+    elif path == Path("tests/test_encoding_manifests.py"):
+        try:
+            lines = raw.decode("utf-8").splitlines(keepends=True)
+        except UnicodeError as exc:
+            raise ValueError("legacy manifest inventory is not UTF-8") from exc
+        removed_lines = [
+            line
+            for line in lines
+            if any(manifest in line for manifest in old_manifests)
+        ]
+        if any(
+            line.strip()
+            not in {
+                *(f"'{manifest}'," for manifest in old_manifests),
+                *(f'"{manifest}",' for manifest in old_manifests),
+            }
+            for line in removed_lines
+        ):
+            raise ValueError("legacy manifest inventory match is not an exact entry")
+        rewritten = "".join(
+            line for line in lines if line not in removed_lines
+        ).encode()
+        count = len(removed_lines)
+        operations = (
+            {"operation": "remove_retired_manifest_allowances", "count": count},
+        )
+    else:
+        raise ValueError(f"legacy metadata reconciliation path is unauthorized: {path}")
+    for old in [*old_modules, *old_identities, *old_manifests]:
+        if old.encode() in rewritten:
+            raise ValueError(
+                f"legacy metadata reconciliation retains old identity {old} in {path}"
+            )
+    return rewritten, operations
+
+
+def _legacy_retained_metadata_reconciliations(
+    *,
+    checkout_root: Path,
+    base_commit: str,
+    tracked: Mapping[Path, str],
+    moves: Sequence[PlannedMove],
+) -> tuple[_LegacyReplacementRewrite, ...]:
+    """Build audited inventory removals and their derived toolchain binding."""
+
+    if not moves:
+        return ()
+    post_migration_waiver_sha256: str | None = None
+    waiver_path = Path("known-validation-gaps.yaml")
+    if waiver_path in tracked:
+        waiver_raw = read_bounded_regular_file(
+            checkout_root,
+            checkout_root / waiver_path,
+            label="legacy validation waiver reconciliation",
+            max_bytes=16 * 1024 * 1024,
+            required_mode=0o644,
+        )
+        waiver_rewritten, _operations = _legacy_metadata_reconciliation_bytes(
+            waiver_path,
+            waiver_raw,
+            moves=moves,
+        )
+        post_migration_waiver_sha256 = hashlib.sha256(waiver_rewritten).hexdigest()
+    reconciliations: list[_LegacyReplacementRewrite] = []
+    for path in sorted(
+        _LEGACY_REPLACEMENT_METADATA_REWRITE_PATHS,
+        key=Path.as_posix,
+    ):
+        if path not in tracked:
+            continue
+        if tracked[path] != "100644":
+            raise ValueError(
+                f"legacy metadata reconciliation is not tracked 0644: {path}"
+            )
+        raw = read_bounded_regular_file(
+            checkout_root,
+            checkout_root / path,
+            label=f"legacy metadata reconciliation {path.as_posix()}",
+            max_bytes=16 * 1024 * 1024,
+            required_mode=0o644,
+        )
+        if raw != _rulespec_migration_base_blob(checkout_root, base_commit, path):
+            raise ValueError(
+                f"legacy metadata reconciliation differs from clean HEAD: {path}"
+            )
+        rewritten, operations = _legacy_metadata_reconciliation_bytes(
+            path,
+            raw,
+            moves=moves,
+            validation_waiver_set_sha256=post_migration_waiver_sha256,
+        )
+        if rewritten == raw:
+            continue
+        reconciliations.append(
+            _LegacyReplacementRewrite(
+                path=path,
+                before_sha256=hashlib.sha256(raw).hexdigest(),
+                after_sha256=hashlib.sha256(rewritten).hexdigest(),
+                replacements=tuple(operations),
+                raw=rewritten,
+            )
+        )
+    return tuple(reconciliations)
+
+
 def _resolve_legacy_replacement_contract(
     *,
     source_raw: Path,
@@ -24355,6 +25600,7 @@ def _resolve_legacy_replacement_contract(
     corpus_release: LocalCorpusRelease,
     scheduled_dependent_paths: Sequence[Path] = (),
     exact_dependent_paths: Sequence[Path] = (),
+    retained_successor_paths: Sequence[Path] = (),
 ) -> _LegacyReplacementContract:
     """Bind one clean-HEAD legacy identity and its unique canonical replacement."""
 
@@ -24382,7 +25628,11 @@ def _resolve_legacy_replacement_contract(
             raise ValueError(
                 "in-place legacy replacement source must already be canonical"
             )
-        if scheduled_dependent_paths or exact_dependent_paths:
+        if (
+            scheduled_dependent_paths
+            or exact_dependent_paths
+            or retained_successor_paths
+        ):
             raise ValueError(
                 "in-place legacy replacement cannot schedule path dependents"
             )
@@ -24537,15 +25787,317 @@ def _resolve_legacy_replacement_contract(
         legacy_manifest_raw,
     )
 
-    replacements = (
-        {}
-        if in_place
-        else exact_reference_replacements(
-            [PlannedMove(source=source, destination=destination)],
-            existing_companions={old_companion}
-            if old_companion in old_paths
-            else set(),
+    retained_successors: list[_LegacyReplacementRetainedSuccessor] = []
+    retained_moves: list[PlannedMove] = []
+    retained_companions: set[Path] = set()
+    occupied_move_paths = {source, destination}
+    expected_waiver_set_sha256: str | None = None
+    verifier: Ed25519PublicKey | None = None
+    for raw_retained in retained_successor_paths:
+        retained_source = Path(raw_retained)
+        retained_destination = canonical_destination(retained_source)
+        if (
+            retained_source.is_absolute()
+            or retained_source.as_posix() != str(raw_retained)
+            or any(part in {"", ".", ".."} for part in retained_source.parts)
+            or len(retained_source.parts) < 3
+            or retained_source.parts[0] != policy_repo_path.name
+            or not _is_protected_rulespec_yaml_path(retained_source, roots=roots)
+            or retained_source.name.endswith(RULESPEC_TEST_FILE_SUFFIX)
+            or retained_source == retained_destination
+            or retained_source in occupied_move_paths
+            or retained_destination in occupied_move_paths
+        ):
+            raise ValueError(
+                "legacy retained successor must name a unique noncanonical "
+                "checkout-relative protected primary in the requested jurisdiction"
+            )
+        retained_old_paths = [retained_source]
+        retained_old_companion = companion_path(retained_source)
+        if tracked.get(retained_source) != "100644":
+            raise ValueError(
+                f"legacy retained successor source is not tracked 0644: {retained_source}"
+            )
+        if retained_old_companion in tracked:
+            if tracked[retained_old_companion] != "100644":
+                raise ValueError(
+                    "legacy retained successor companion is not tracked 0644: "
+                    f"{retained_old_companion}"
+                )
+            retained_old_paths.append(retained_old_companion)
+            retained_companions.add(retained_old_companion)
+        retained_legacy_files: list[_LegacyReplacementFile] = []
+        for relative in retained_old_paths:
+            raw = read_bounded_regular_file(
+                policy_checkout_path,
+                policy_checkout_path / relative,
+                label=f"legacy retained successor input {relative.as_posix()}",
+                max_bytes=10 * 1024 * 1024,
+                required_mode=0o644,
+            )
+            if raw != _rulespec_migration_base_blob(
+                policy_checkout_path,
+                base_commit,
+                relative,
+            ):
+                raise ValueError(
+                    f"legacy retained successor input differs from clean HEAD: {relative}"
+                )
+            retained_legacy_files.append(
+                _LegacyReplacementFile(
+                    relative,
+                    hashlib.sha256(raw).hexdigest(),
+                    raw,
+                )
+            )
+        try:
+            retained_payload = yaml.safe_load(
+                retained_legacy_files[0].raw.decode("utf-8")
+            )
+        except (UnicodeError, yaml.YAMLError, RecursionError) as exc:
+            raise ValueError(
+                f"legacy retained successor source is invalid YAML: {retained_source}"
+            ) from exc
+        retained_module = (
+            retained_payload.get("module")
+            if isinstance(retained_payload, dict)
+            else None
         )
+        retained_verification = (
+            retained_module.get("source_verification")
+            if isinstance(retained_module, dict)
+            else None
+        )
+        retained_citations = (
+            _legacy_source_verification_citation_paths(retained_verification)
+            if isinstance(retained_verification, dict)
+            else ()
+        )
+        if len(retained_citations) != 1:
+            raise ValueError(
+                "legacy retained successor source must declare exactly one signed "
+                f"corpus unit: {retained_source}"
+            )
+        try:
+            resolve_corpus_source_unit(retained_citations[0], corpus_release)
+        except (CorpusResolutionError, ValueError) as exc:
+            raise ValueError(
+                "legacy retained successor source is absent from the signed corpus "
+                f"release: {retained_source}"
+            ) from exc
+        retained_legacy_manifest_path = _applied_encoding_manifest_path(retained_source)
+        if tracked.get(retained_legacy_manifest_path) != "100644":
+            raise ValueError(
+                "legacy retained successor requires its exact tracked v1 HMAC "
+                f"manifest: {retained_source}"
+            )
+        retained_legacy_manifest_raw = read_bounded_regular_file(
+            policy_checkout_path,
+            policy_checkout_path / retained_legacy_manifest_path,
+            label="legacy retained successor ownership manifest",
+            max_bytes=4 * 1024 * 1024,
+            required_mode=0o644,
+        )
+        if retained_legacy_manifest_raw != _rulespec_migration_base_blob(
+            policy_checkout_path,
+            base_commit,
+            retained_legacy_manifest_path,
+        ):
+            raise ValueError(
+                f"legacy retained successor manifest differs from clean HEAD: {retained_source}"
+            )
+        try:
+            retained_legacy_manifest_payload = json.loads(
+                retained_legacy_manifest_raw.decode("utf-8")
+            )
+        except (UnicodeError, json.JSONDecodeError, RecursionError) as exc:
+            raise ValueError(
+                f"legacy retained successor manifest is invalid JSON: {retained_source}"
+            ) from exc
+        retained_legacy_issues = _legacy_v1_manifest_issues(
+            retained_legacy_manifest_payload,
+            expected_files={
+                item.path.as_posix(): item.sha256 for item in retained_legacy_files
+            },
+            expected_primary_path=retained_source.as_posix(),
+            expected_citation=retained_citations[0],
+            jurisdiction_prefix=retained_source.parts[0],
+        )
+        if retained_legacy_issues:
+            raise ValueError(
+                f"legacy retained successor ownership is invalid: {retained_source}: "
+                + "; ".join(retained_legacy_issues)
+            )
+
+        successor_paths = [retained_destination]
+        retained_destination_companion = companion_path(retained_destination)
+        if tracked.get(retained_destination) != "100644":
+            raise ValueError(
+                "legacy retained successor canonical primary is not tracked 0644: "
+                f"{retained_destination}"
+            )
+        if retained_destination_companion in tracked:
+            if tracked[retained_destination_companion] != "100644":
+                raise ValueError(
+                    "legacy retained successor canonical companion is not tracked 0644: "
+                    f"{retained_destination_companion}"
+                )
+            successor_paths.append(retained_destination_companion)
+        successor_files: list[_LegacyReplacementFile] = []
+        for relative in successor_paths:
+            raw = read_bounded_regular_file(
+                policy_checkout_path,
+                policy_checkout_path / relative,
+                label=f"legacy retained successor live file {relative.as_posix()}",
+                max_bytes=10 * 1024 * 1024,
+                required_mode=0o644,
+            )
+            if raw != _rulespec_migration_base_blob(
+                policy_checkout_path,
+                base_commit,
+                relative,
+            ):
+                raise ValueError(
+                    "legacy retained successor live file differs from clean HEAD: "
+                    f"{relative}"
+                )
+            successor_files.append(
+                _LegacyReplacementFile(
+                    relative,
+                    hashlib.sha256(raw).hexdigest(),
+                    raw,
+                )
+            )
+        successor_manifest_path = _applied_encoding_manifest_path(retained_destination)
+        if tracked.get(successor_manifest_path) != "100644":
+            raise ValueError(
+                "legacy retained successor requires its exact signed-v5 manifest: "
+                f"{retained_destination}"
+            )
+        successor_manifest_raw = read_bounded_regular_file(
+            policy_checkout_path,
+            policy_checkout_path / successor_manifest_path,
+            label="legacy retained successor signed manifest",
+            max_bytes=4 * 1024 * 1024,
+            required_mode=0o644,
+        )
+        if successor_manifest_raw != _rulespec_migration_base_blob(
+            policy_checkout_path,
+            base_commit,
+            successor_manifest_path,
+        ):
+            raise ValueError(
+                "legacy retained successor signed manifest differs from clean HEAD: "
+                f"{retained_destination}"
+            )
+        try:
+            successor_manifest_payload = json.loads(
+                successor_manifest_raw.decode("utf-8")
+            )
+        except (UnicodeError, json.JSONDecodeError, RecursionError) as exc:
+            raise ValueError(
+                f"legacy retained successor signed manifest is invalid JSON: {retained_destination}"
+            ) from exc
+        execution = (
+            successor_manifest_payload.get("validation_execution")
+            if isinstance(successor_manifest_payload, dict)
+            else None
+        )
+        historical_encoder = (
+            execution.get("axiom_encode") if isinstance(execution, dict) else None
+        )
+        if not isinstance(historical_encoder, dict):
+            raise ValueError(
+                "legacy retained successor lacks signed encoder execution identity: "
+                f"{retained_destination}"
+            )
+        if verifier is None:
+            verifier = _applied_encoding_manifest_verifier()
+        if verifier is None:
+            raise ValueError(
+                "legacy retained successor requires the protected apply-manifest "
+                "verification key"
+            )
+        if expected_waiver_set_sha256 is None:
+            expected_waiver_set_sha256 = verify_rulespec_validation_waiver_set(
+                policy_checkout_path
+            )
+        verified_successor, _root, manifest_sha256, successor_issues = (
+            _load_verified_applied_encoding_manifest_payload(
+                policy_checkout_path,
+                successor_manifest_path.as_posix(),
+                signing_broker=verifier,
+                expected_waiver_set_sha256=expected_waiver_set_sha256,
+                local_corpus_release=corpus_release,
+                expected_encoder_identity=historical_encoder,
+            )
+        )
+        if successor_issues or verified_successor is None or manifest_sha256 is None:
+            raise ValueError(
+                f"legacy retained successor signed-v5 ownership is invalid: {retained_destination}: "
+                + "; ".join(successor_issues or ["manifest was not verified"])
+            )
+        expected_successor_files = {
+            item.path.as_posix(): item.sha256 for item in successor_files
+        }
+        actual_successor_files = {
+            str(item.get("path")): str(item.get("sha256"))
+            for item in verified_successor.get("applied_files", [])
+            if isinstance(item, dict) and set(item) == {"path", "sha256"}
+        }
+        if actual_successor_files != expected_successor_files:
+            raise ValueError(
+                "legacy retained successor signed manifest does not bind the exact "
+                f"canonical group: {retained_destination}"
+            )
+        try:
+            successor_citation = normalize_corpus_identifier(
+                str(verified_successor.get("citation") or "")
+            )
+        except (TypeError, ValueError):
+            successor_citation = ""
+        if successor_citation != retained_citations[0]:
+            raise ValueError(
+                "legacy retained successor corpus identity differs from its legacy "
+                f"source: {retained_destination}"
+            )
+        retained_successors.append(
+            _LegacyReplacementRetainedSuccessor(
+                source=retained_source,
+                destination=retained_destination,
+                legacy_manifest=_LegacyReplacementFile(
+                    retained_legacy_manifest_path,
+                    hashlib.sha256(retained_legacy_manifest_raw).hexdigest(),
+                    retained_legacy_manifest_raw,
+                ),
+                legacy_files=tuple(retained_legacy_files),
+                successor_manifest=_LegacyReplacementFile(
+                    successor_manifest_path,
+                    manifest_sha256,
+                    successor_manifest_raw,
+                ),
+                successor_files=tuple(successor_files),
+            )
+        )
+        retained_moves.append(
+            PlannedMove(
+                source=retained_source,
+                destination=retained_destination,
+            )
+        )
+        occupied_move_paths.update({retained_source, retained_destination})
+
+    all_moves = (
+        []
+        if in_place
+        else [PlannedMove(source=source, destination=destination), *retained_moves]
+    )
+    replacements = exact_reference_replacements(
+        all_moves,
+        existing_companions={
+            *({old_companion} if old_companion in old_paths else set()),
+            *retained_companions,
+        },
     )
     destination_predecessor_files: list[_LegacyReplacementFile] = []
     if destination_predecessor_present:
@@ -24635,7 +26187,7 @@ def _resolve_legacy_replacement_contract(
             or dependent.parts[0] != policy_repo_path.name
             or not _is_protected_rulespec_yaml_path(dependent, roots=roots)
             or dependent.name.endswith(RULESPEC_TEST_FILE_SUFFIX)
-            or dependent in {source, destination}
+            or dependent in occupied_move_paths
             or tracked.get(dependent) != "100644"
             or dependent in scheduled_groups
             or dependent in exact_groups
@@ -24724,6 +26276,10 @@ def _resolve_legacy_replacement_contract(
         dependent_manifest_path = _applied_encoding_manifest_path(primary)
         if (
             dependent_manifest_path == legacy_manifest_path
+            or dependent_manifest_path
+            in {item.legacy_manifest.path for item in retained_successors}
+            or dependent_manifest_path
+            in {item.successor_manifest.path for item in retained_successors}
             or tracked.get(dependent_manifest_path) != "100644"
         ):
             raise ValueError(
@@ -24789,7 +26345,38 @@ def _resolve_legacy_replacement_contract(
         *old_paths,
         legacy_manifest_path,
         *[item.path for item in exact_legacy_manifests.values()],
+        *[
+            item.path
+            for successor in retained_successors
+            for item in successor.legacy_files
+        ],
+        *[item.legacy_manifest.path for item in retained_successors],
+        *[
+            item.path
+            for successor in retained_successors
+            for item in successor.successor_files
+        ],
+        *[item.successor_manifest.path for item in retained_successors],
     }
+    metadata_reconciliations = _legacy_retained_metadata_reconciliations(
+        checkout_root=policy_checkout_path,
+        base_commit=base_commit,
+        tracked=tracked,
+        moves=all_moves if retained_successors else (),
+    )
+    metadata_reconciliation_paths = {item.path for item in metadata_reconciliations}
+    excluded.update(metadata_reconciliation_paths)
+    for successor in retained_successors:
+        for item in successor.successor_files:
+            _unused, successor_counts = rewrite_exact_references(
+                item.raw,
+                replacements,
+            )
+            if successor_counts:
+                raise ValueError(
+                    "legacy retained successor contains an old durable reference: "
+                    f"{item.path}"
+                )
     manifest_prefix = APPLIED_ENCODING_MANIFEST_DIR.parts
     receipt_prefixes = (
         APPLIED_ENCODING_PATH_MIGRATION_RECEIPT_DIR.parts,
@@ -24948,6 +26535,8 @@ def _resolve_legacy_replacement_contract(
             if destination_predecessor_files
             else APPLIED_ENCODING_DESTINATION_PREDECESSOR_ABSENT
         ),
+        retained_successors=tuple(retained_successors),
+        metadata_reconciliations=metadata_reconciliations,
     )
 
 
@@ -24967,8 +26556,12 @@ def _resolve_encode_replacement_target(
     exact_dependents = tuple(
         Path(path) for path in getattr(args, "legacy_exact_dependent_rulespec_path", ())
     )
+    retained_successors = tuple(
+        Path(path)
+        for path in getattr(args, "legacy_retained_successor_rulespec_path", ())
+    )
     if raw_path is None and legacy_source is None:
-        if scheduled_dependents or exact_dependents:
+        if scheduled_dependents or exact_dependents or retained_successors:
             raise ValueError("legacy dependent paths require a legacy replacement")
         return None
     if raw_path is None:
@@ -24982,7 +26575,9 @@ def _resolve_encode_replacement_target(
         raise ValueError(
             "encode --replace-rulespec-path requires --mode repo-augmented"
         )
-    if legacy_source is None and (scheduled_dependents or exact_dependents):
+    if legacy_source is None and (
+        scheduled_dependents or exact_dependents or retained_successors
+    ):
         raise ValueError("legacy dependent paths require a legacy replacement")
 
     if legacy_source is not None:
@@ -24995,10 +26590,16 @@ def _resolve_encode_replacement_target(
             corpus_release=corpus_release,
             scheduled_dependent_paths=scheduled_dependents,
             exact_dependent_paths=exact_dependents,
+            retained_successor_paths=retained_successors,
         )
         context_paths = [
             policy_checkout_path / item.path for item in contract.deleted_files
         ]
+        context_paths.extend(
+            policy_checkout_path / item.path
+            for successor in contract.retained_successors
+            for item in successor.legacy_files
+        )
         return _EncodeReplacementTarget(
             relative_output=Path(*contract.destination.parts[1:]),
             context_paths=tuple(context_paths),
@@ -46201,6 +47802,38 @@ def _build_apply_validation_snapshot(
                 }
                 for dependent in legacy_replacement.exact_dependents
             ],
+            "retained_successors": [
+                {
+                    "source": successor.source.as_posix(),
+                    "destination": successor.destination.as_posix(),
+                    "legacy_manifest": {
+                        "path": successor.legacy_manifest.path.as_posix(),
+                        "sha256": successor.legacy_manifest.sha256,
+                    },
+                    "legacy_files": [
+                        {"path": item.path.as_posix(), "sha256": item.sha256}
+                        for item in successor.legacy_files
+                    ],
+                    "successor_manifest": {
+                        "path": successor.successor_manifest.path.as_posix(),
+                        "sha256": successor.successor_manifest.sha256,
+                    },
+                    "successor_files": [
+                        {"path": item.path.as_posix(), "sha256": item.sha256}
+                        for item in successor.successor_files
+                    ],
+                }
+                for successor in legacy_replacement.retained_successors
+            ],
+            "metadata_reconciliations": [
+                {
+                    "path": item.path.as_posix(),
+                    "before_sha256": item.before_sha256,
+                    "after_sha256": item.after_sha256,
+                    "operations": list(item.replacements),
+                }
+                for item in legacy_replacement.metadata_reconciliations
+            ],
         }
     return snapshot
 
@@ -46650,11 +48283,23 @@ def _stage_signed_legacy_replacement_provenance(
         }
         for rewrite in contract.rewrites
     ]
+    metadata_files = [
+        {
+            "path": rewrite.path.as_posix(),
+            "sha256": rewrite.after_sha256,
+        }
+        for rewrite in contract.metadata_reconciliations
+    ]
     deleted_files = [
         {"path": item.path.as_posix(), "deleted": True}
         for item in contract.deleted_files
         if item.path.as_posix() not in live_paths
     ]
+    deleted_files.extend(
+        {"path": item.path.as_posix(), "deleted": True}
+        for successor in contract.retained_successors
+        for item in successor.legacy_files
+    )
     scheduled_dependents = [
         {
             "primary": dependent.primary.as_posix(),
@@ -46701,6 +48346,67 @@ def _stage_signed_legacy_replacement_provenance(
         {"path": item.path.as_posix(), "sha256": item.sha256}
         for item in contract.destination_predecessor_files
     ]
+    retained_successors: list[dict[str, object]] = []
+    for successor in contract.retained_successors:
+        try:
+            legacy_payload = json.loads(successor.legacy_manifest.raw.decode("utf-8"))
+            successor_payload = json.loads(
+                successor.successor_manifest.raw.decode("utf-8")
+            )
+        except (UnicodeError, json.JSONDecodeError, RecursionError) as exc:
+            raise RuntimeError(
+                "Retained-successor evidence changed after contract admission"
+            ) from exc
+        owner_class = (
+            APPLIED_ENCODING_LEGACY_MANUAL_OWNER_CLASS
+            if isinstance(legacy_payload, dict)
+            and (
+                legacy_payload.get("tool") == "axiom-encode sign-applied-files"
+                or legacy_payload.get("backend") == "manual"
+            )
+            else APPLIED_ENCODING_LEGACY_OWNER_CLASS
+        )
+        retained_successors.append(
+            {
+                "source": successor.source.as_posix(),
+                "destination": successor.destination.as_posix(),
+                "legacy_owner_class": owner_class,
+                "legacy_manifest": {
+                    "path": successor.legacy_manifest.path.as_posix(),
+                    "sha256": successor.legacy_manifest.sha256,
+                },
+                "legacy_files": [
+                    {"path": item.path.as_posix(), "sha256": item.sha256}
+                    for item in successor.legacy_files
+                ],
+                "successor_manifest": {
+                    "path": successor.successor_manifest.path.as_posix(),
+                    "sha256": successor.successor_manifest.sha256,
+                    "payload": successor_payload,
+                },
+                "successor_files": [
+                    {"path": item.path.as_posix(), "sha256": item.sha256}
+                    for item in successor.successor_files
+                ],
+            }
+        )
+    metadata_reconciliations = [
+        {
+            "path": item.path.as_posix(),
+            "before_sha256": item.before_sha256,
+            "after_sha256": item.after_sha256,
+            "operations": list(item.replacements),
+        }
+        for item in contract.metadata_reconciliations
+    ]
+    post_migration_waiver_sha256 = next(
+        (
+            item.after_sha256
+            for item in contract.metadata_reconciliations
+            if item.path == Path("known-validation-gaps.yaml")
+        ),
+        verify_rulespec_validation_waiver_set(checkout_root),
+    )
     receipt_identity = receipt_identity_payload(
         base_commit=contract.base_commit,
         base_tree=contract.base_tree,
@@ -46721,6 +48427,8 @@ def _stage_signed_legacy_replacement_provenance(
         exact_dependents=exact_dependents,
         destination_predecessor_class=contract.destination_predecessor_class,
         destination_predecessor_files=destination_predecessor_files,
+        retained_successors=retained_successors,
+        metadata_reconciliations=metadata_reconciliations,
     )
     receipt_id = receipt_identity_sha256(receipt_identity)
     receipt_relative = (
@@ -46742,9 +48450,7 @@ def _stage_signed_legacy_replacement_provenance(
         },
         "axiom_encode_version": __version__,
         "axiom_encode_git": dict(axiom_encode_git),
-        VALIDATION_WAIVER_SET_SHA256_FIELD: verify_rulespec_validation_waiver_set(
-            checkout_root
-        ),
+        VALIDATION_WAIVER_SET_SHA256_FIELD: post_migration_waiver_sha256,
         "corpus_release": {
             "name": local_corpus_release.name,
             "content_sha256": local_corpus_release.content_sha256,
@@ -46774,6 +48480,8 @@ def _stage_signed_legacy_replacement_provenance(
             "exact_dependents": exact_dependents,
             "destination_predecessor_class": (contract.destination_predecessor_class),
             "destination_predecessor_files": destination_predecessor_files,
+            "retained_successors": retained_successors,
+            "metadata_reconciliations": metadata_reconciliations,
         },
         "replacement_manifest": model_manifest,
     }
@@ -46812,6 +48520,43 @@ def _stage_signed_legacy_replacement_provenance(
             json.dumps(exact_manifest, indent=2, sort_keys=True) + "\n"
         ).encode("utf-8")
 
+    for successor, evidence in zip(
+        contract.retained_successors,
+        retained_successors,
+        strict=True,
+    ):
+        successor_manifest_relative = successor.successor_manifest.path
+        retained_manifest = {
+            "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+            "generated_at": _utc_now_iso(),
+            "tool": APPLIED_ENCODING_LEGACY_RETAINED_SUCCESSOR_TOOL,
+            "axiom_encode_version": __version__,
+            "axiom_encode_git": dict(axiom_encode_git),
+            VALIDATION_WAIVER_SET_SHA256_FIELD: receipt[
+                VALIDATION_WAIVER_SET_SHA256_FIELD
+            ],
+            "applied_files": [
+                {"path": item.path.as_posix(), "sha256": item.sha256}
+                for item in successor.successor_files
+            ],
+            "legacy_migration": {
+                "receipt_path": receipt_relative.as_posix(),
+                "receipt_sha256": receipt_sha256,
+                "source": successor.source.as_posix(),
+                "destination": successor.destination.as_posix(),
+                "legacy_manifest_path": successor.legacy_manifest.path.as_posix(),
+                "legacy_manifest_sha256": successor.legacy_manifest.sha256,
+                "successor_manifest_sha256": successor.successor_manifest.sha256,
+            },
+            "retained_successor_manifest": copy.deepcopy(
+                evidence["successor_manifest"]["payload"]
+            ),
+        }
+        _sign_applied_encoding_manifest(retained_manifest, signing_broker)
+        exact_dependent_manifests[successor_manifest_relative] = (
+            json.dumps(retained_manifest, indent=2, sort_keys=True) + "\n"
+        ).encode("utf-8")
+
     outer_manifest = {
         "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
         "generated_at": _utc_now_iso(),
@@ -46819,7 +48564,12 @@ def _stage_signed_legacy_replacement_provenance(
         "axiom_encode_version": __version__,
         "axiom_encode_git": dict(axiom_encode_git),
         VALIDATION_WAIVER_SET_SHA256_FIELD: receipt[VALIDATION_WAIVER_SET_SHA256_FIELD],
-        "applied_files": [*live_files, *rewrite_files, *deleted_files],
+        "applied_files": [
+            *live_files,
+            *rewrite_files,
+            *metadata_files,
+            *deleted_files,
+        ],
         "replacement_manifest": model_manifest,
         "replacement": {
             "receipt_path": receipt_relative.as_posix(),
@@ -47925,6 +49675,7 @@ def _require_apply_post_install_closure(
     receipt_path: Path | None = None,
     receipt_bytes: bytes | None = None,
     exact_dependent_manifest_bytes: Mapping[Path, bytes] | None = None,
+    signing_broker: SigningBroker | None = None,
 ) -> None:
     """Recheck the execution closure while rollback is still possible."""
 
@@ -47987,16 +49738,48 @@ def _require_apply_post_install_closure(
         current_policy_identity, dict
     ):
         raise RuntimeError("Apply execution identity lacks RuleSpec provenance")
-    for field in (
-        "path",
-        "toolchain_root",
-        "toolchain_contract_sha256",
-        "validation_waiver_set_sha256",
-    ):
+    waiver_reconciliation = next(
+        (
+            item
+            for item in (
+                legacy_replacement.metadata_reconciliations
+                if legacy_replacement is not None
+                else ()
+            )
+            if item.path == Path("known-validation-gaps.yaml")
+        ),
+        None,
+    )
+    toolchain_reconciliation = next(
+        (
+            item
+            for item in (
+                legacy_replacement.metadata_reconciliations
+                if legacy_replacement is not None
+                else ()
+            )
+            if item.path == Path(".axiom/toolchain.toml")
+        ),
+        None,
+    )
+    stable_policy_identity_fields = ["path", "toolchain_root"]
+    if waiver_reconciliation is None or toolchain_reconciliation is None:
+        stable_policy_identity_fields.extend(
+            ["toolchain_contract_sha256", "validation_waiver_set_sha256"]
+        )
+    for field in stable_policy_identity_fields:
         if current_policy_identity.get(field) != expected_policy_identity.get(field):
             raise RuntimeError(
                 "Cannot keep applied RuleSpec: RuleSpec contract changed during "
                 f"installation ({field})"
+            )
+    if waiver_reconciliation is not None and toolchain_reconciliation is not None:
+        if (
+            current_policy_identity.get("validation_waiver_set_sha256")
+            != waiver_reconciliation.after_sha256
+        ):
+            raise RuntimeError(
+                "Cannot keep applied RuleSpec: migrated waiver identity is stale"
             )
     expected_checkout = expected_policy_identity.get("checkout_identity")
     current_checkout = current_policy_identity.get("checkout_identity")
@@ -48026,6 +49809,18 @@ def _require_apply_post_install_closure(
                 )
         for dependent in legacy_replacement.exact_dependents:
             for live_file in dependent.live_files:
+                if live_file.path.parts[:1] == (content_root.name,):
+                    expected_post_files[Path(*live_file.path.parts[1:]).as_posix()] = (
+                        live_file.sha256
+                    )
+        for successor in legacy_replacement.retained_successors:
+            for legacy_file in successor.legacy_files:
+                if legacy_file.path.parts[:1] == (content_root.name,):
+                    expected_post_files.pop(
+                        Path(*legacy_file.path.parts[1:]).as_posix(),
+                        None,
+                    )
+            for live_file in successor.successor_files:
                 if live_file.path.parts[:1] == (content_root.name,):
                     expected_post_files[Path(*live_file.path.parts[1:]).as_posix()] = (
                         live_file.sha256
@@ -48076,6 +49871,13 @@ def _require_apply_post_install_closure(
                 raise RuntimeError(
                     f"Cannot keep legacy replacement: rewrite changed for {target}"
                 )
+        for rewrite in legacy_replacement.metadata_reconciliations:
+            target = checkout_root / rewrite.path
+            if target.read_bytes() != rewrite.raw:
+                raise RuntimeError(
+                    "Cannot keep legacy replacement: metadata reconciliation changed "
+                    f"for {target}"
+                )
         exact_manifest_bytes = dict(exact_dependent_manifest_bytes or {})
         for dependent in legacy_replacement.exact_dependents:
             for item in dependent.live_files:
@@ -48096,12 +49898,70 @@ def _require_apply_post_install_closure(
                     "Cannot keep legacy replacement: exact dependent manifest changed "
                     f"for {dependent.primary}"
                 )
+        for successor in legacy_replacement.retained_successors:
+            for item in successor.legacy_files:
+                target = checkout_root / item.path
+                if target.exists() or target.is_symlink():
+                    raise RuntimeError(
+                        "Cannot keep legacy replacement: retained-successor legacy "
+                        f"path still exists: {target}"
+                    )
+            old_successor_manifest = checkout_root / successor.legacy_manifest.path
+            if old_successor_manifest.exists() or old_successor_manifest.is_symlink():
+                raise RuntimeError(
+                    "Cannot keep legacy replacement: retained-successor legacy "
+                    f"manifest still exists: {old_successor_manifest}"
+                )
+            for item in successor.successor_files:
+                target = checkout_root / item.path
+                if target.read_bytes() != item.raw:
+                    raise RuntimeError(
+                        "Cannot keep legacy replacement: retained successor changed "
+                        f"for {target}"
+                    )
+            expected_manifest = exact_manifest_bytes.get(
+                successor.successor_manifest.path
+            )
+            if (
+                expected_manifest is None
+                or (checkout_root / successor.successor_manifest.path).read_bytes()
+                != expected_manifest
+            ):
+                raise RuntimeError(
+                    "Cannot keep legacy replacement: retained-successor manifest "
+                    f"changed for {successor.destination}"
+                )
         if (
             receipt_path is None
             or receipt_bytes is None
             or receipt_path.read_bytes() != receipt_bytes
         ):
             raise RuntimeError("Cannot keep legacy replacement: signed receipt changed")
+        if signing_broker is None:
+            raise RuntimeError(
+                "Cannot keep legacy replacement without its signing verifier"
+            )
+        try:
+            installed_manifest = json.loads(manifest_bytes.decode("utf-8"))
+        except (UnicodeError, json.JSONDecodeError, RecursionError) as exc:
+            raise RuntimeError(
+                "Cannot keep legacy replacement: installed manifest is invalid"
+            ) from exc
+        semantic_issues = _legacy_replacement_manifest_issues(
+            installed_manifest,
+            repo_path=checkout_root,
+            manifest_label=manifest_path.relative_to(checkout_root).as_posix(),
+            signing_broker=signing_broker,
+            expected_waiver_set_sha256=verify_rulespec_validation_waiver_set(
+                checkout_root
+            ),
+            local_corpus_release=final_release,
+        )
+        if semantic_issues:
+            raise RuntimeError(
+                "Cannot keep legacy replacement: persisted provenance is invalid: "
+                + "; ".join(semantic_issues)
+            )
 
 
 def _apply_generated_encoding_result(
@@ -48258,6 +50118,10 @@ def _apply_generated_encoding_result(
             for rewrite in legacy_replacement.rewrites
         )
         transaction_files.extend(
+            (checkout_root / rewrite.path, rewrite.raw)
+            for rewrite in legacy_replacement.metadata_reconciliations
+        )
+        transaction_files.extend(
             (checkout_root / item.path, item.raw)
             for dependent in legacy_replacement.exact_dependents
             for item in dependent.live_files
@@ -48274,9 +50138,20 @@ def _apply_generated_encoding_result(
             for item in legacy_replacement.deleted_files
             if checkout_root / item.path not in written_targets
         )
+        transaction_files.extend(
+            (checkout_root / item.path, None)
+            for successor in legacy_replacement.retained_successors
+            for item in successor.legacy_files
+            if checkout_root / item.path not in written_targets
+        )
         old_manifest_path = checkout_root / legacy_replacement.legacy_manifest.path
         if old_manifest_path not in written_targets:
             transaction_files.append((old_manifest_path, None))
+        transaction_files.extend(
+            (checkout_root / successor.legacy_manifest.path, None)
+            for successor in legacy_replacement.retained_successors
+            if checkout_root / successor.legacy_manifest.path not in written_targets
+        )
         transaction_files.append((checkout_root / receipt_relative, receipt_bytes))
     for target, _raw in transaction_files:
         _ensure_safe_apply_target(checkout_root, target)
@@ -48304,6 +50179,8 @@ def _apply_generated_encoding_result(
             expected_originals[checkout_root / item.path] = item.sha256
         for rewrite in legacy_replacement.rewrites:
             expected_originals[checkout_root / rewrite.path] = rewrite.before_sha256
+        for rewrite in legacy_replacement.metadata_reconciliations:
+            expected_originals[checkout_root / rewrite.path] = rewrite.before_sha256
         for item in legacy_replacement.deleted_files:
             expected_originals[checkout_root / item.path] = item.sha256
         expected_originals[checkout_root / legacy_replacement.legacy_manifest.path] = (
@@ -48314,6 +50191,17 @@ def _apply_generated_encoding_result(
                 expected_originals[checkout_root / item.path] = item.sha256
             expected_originals[checkout_root / dependent.legacy_manifest.path] = (
                 dependent.legacy_manifest.sha256
+            )
+        for successor in legacy_replacement.retained_successors:
+            for item in successor.legacy_files:
+                expected_originals[checkout_root / item.path] = item.sha256
+            for item in successor.successor_files:
+                expected_originals[checkout_root / item.path] = item.sha256
+            expected_originals[checkout_root / successor.legacy_manifest.path] = (
+                successor.legacy_manifest.sha256
+            )
+            expected_originals[checkout_root / successor.successor_manifest.path] = (
+                successor.successor_manifest.sha256
             )
         assert receipt_relative is not None
         expected_originals[checkout_root / receipt_relative] = None
@@ -48379,6 +50267,7 @@ def _apply_generated_encoding_result(
             ),
             receipt_bytes=receipt_bytes,
             exact_dependent_manifest_bytes=exact_dependent_manifest_bytes,
+            signing_broker=signing_broker,
         )
 
     _install_apply_transaction(

--- a/src/axiom_encode/legacy_replacement.py
+++ b/src/axiom_encode/legacy_replacement.py
@@ -20,9 +20,13 @@ TOOL: Final = "axiom-encode encode --apply --replace-legacy-rulespec-path"
 EXACT_DEPENDENT_TOOL: Final = (
     "axiom-encode encode --apply --legacy-exact-dependent-rulespec-path"
 )
+RETAINED_SUCCESSOR_TOOL: Final = (
+    "axiom-encode encode --apply --legacy-retained-successor-rulespec-path"
+)
 RECEIPT_SCHEMA_V1: Final = "axiom-encode/legacy-fresh-reencode-receipt/v1"
 RECEIPT_SCHEMA_V2: Final = "axiom-encode/legacy-fresh-reencode-receipt/v2"
-RECEIPT_SCHEMA: Final = "axiom-encode/legacy-fresh-reencode-receipt/v3"
+RECEIPT_SCHEMA_V3: Final = "axiom-encode/legacy-fresh-reencode-receipt/v3"
+RECEIPT_SCHEMA: Final = "axiom-encode/legacy-fresh-reencode-receipt/v4"
 RECEIPT_DIR: Final = ".axiom/legacy-replacements"
 DESTINATION_PREDECESSOR_ABSENT: Final = "absent"
 DESTINATION_PREDECESSOR_CANONICALIZED_UNOWNED_DUPLICATE: Final = (
@@ -101,6 +105,15 @@ class LegacyReplacementExactDependent(NamedTuple):
     rewrites: tuple[LegacyReplacementRewrite, ...]
 
 
+class LegacyReplacementRetainedSuccessor(NamedTuple):
+    source: Path
+    destination: Path
+    legacy_manifest: LegacyReplacementFile
+    legacy_files: tuple[LegacyReplacementFile, ...]
+    successor_manifest: LegacyReplacementFile
+    successor_files: tuple[LegacyReplacementFile, ...]
+
+
 class LegacyReplacementContract(NamedTuple):
     base_commit: str
     base_tree: str
@@ -113,6 +126,8 @@ class LegacyReplacementContract(NamedTuple):
     exact_dependents: tuple[LegacyReplacementExactDependent, ...]
     destination_predecessor_class: str = DESTINATION_PREDECESSOR_ABSENT
     destination_predecessor_files: tuple[LegacyReplacementFile, ...] = ()
+    retained_successors: tuple[LegacyReplacementRetainedSuccessor, ...] = ()
+    metadata_reconciliations: tuple[LegacyReplacementRewrite, ...] = ()
 
 
 def legacy_source_verification_citation_paths(
@@ -476,6 +491,8 @@ def receipt_identity_payload(
     exact_dependents: list[dict[str, object]] | None = None,
     destination_predecessor_class: str | None = None,
     destination_predecessor_files: list[dict[str, object]] | None = None,
+    retained_successors: list[dict[str, object]] | None = None,
+    metadata_reconciliations: list[dict[str, object]] | None = None,
 ) -> dict[str, object]:
     payload = {
         "base_commit": base_commit,
@@ -493,6 +510,10 @@ def receipt_identity_payload(
         payload["destination_predecessor_class"] = destination_predecessor_class
     if destination_predecessor_files is not None:
         payload["destination_predecessor_files"] = destination_predecessor_files
+    if retained_successors is not None:
+        payload["retained_successors"] = retained_successors
+    if metadata_reconciliations is not None:
+        payload["metadata_reconciliations"] = metadata_reconciliations
     return payload
 
 

--- a/src/axiom_encode/legacy_replacement_overlay.py
+++ b/src/axiom_encode/legacy_replacement_overlay.py
@@ -255,6 +255,57 @@ def stage_legacy_replacement_overlay(
                 )
             exact_targets.append((target, live_file))
 
+    retained_deleted_targets: list[Path] = []
+    retained_manifest_targets: list[Path] = []
+    for successor in contract.retained_successors:
+        retained_deleted_targets.extend(
+            _require_overlay_file(
+                root,
+                item,
+                label="Legacy retained-successor input",
+            )
+            for item in successor.legacy_files
+        )
+        retained_manifest_targets.append(
+            _require_overlay_file(
+                root,
+                successor.legacy_manifest,
+                label="Legacy retained-successor ownership manifest",
+            )
+        )
+        _require_overlay_file(
+            root,
+            successor.successor_manifest,
+            label="Legacy retained-successor signed manifest",
+        )
+        for item in successor.successor_files:
+            _require_overlay_file(
+                root,
+                item,
+                label="Legacy retained-successor live file",
+            )
+
+    metadata_targets: list[tuple[Path, LegacyReplacementRewrite]] = []
+    for reconciliation in contract.metadata_reconciliations:
+        target = _require_overlay_file(
+            root,
+            LegacyReplacementFile(
+                reconciliation.path,
+                reconciliation.before_sha256,
+                b"",
+            ),
+            label="Legacy metadata reconciliation input",
+        )
+        if (
+            hashlib.sha256(reconciliation.raw).hexdigest()
+            != reconciliation.after_sha256
+        ):
+            raise LegacyReplacementOverlayError(
+                "Legacy metadata reconciliation output does not match its digest: "
+                f"{reconciliation.path.as_posix()}"
+            )
+        metadata_targets.append((target, reconciliation))
+
     predecessor_present = bool(contract.destination_predecessor_files)
     if (
         predecessor_present
@@ -306,10 +357,16 @@ def stage_legacy_replacement_overlay(
 
     for target in deleted_targets:
         target.unlink()
+    for target in retained_deleted_targets:
+        target.unlink()
     for target in predecessor_targets:
         target.unlink()
     manifest_target.unlink()
+    for target in retained_manifest_targets:
+        target.unlink()
     for target, rewrite in rewrite_targets:
         target.write_bytes(rewrite.raw)
     for target, live_file in exact_targets:
         target.write_bytes(live_file.raw)
+    for target, reconciliation in metadata_targets:
+        target.write_bytes(reconciliation.raw)

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1443"
+ENCODER_VERSION = "0.2.1444"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13720,6 +13720,13 @@ class TestCmdEncode:
         dependent_relative = Path("us-la/policies/income_tax/2026_resident_core.yaml")
         dependent = checkout / dependent_relative
         dependent_test = dependent.with_name("2026_resident_core.test.yaml")
+        second_dependent_relative = Path(
+            "us-la/policies/income_tax/2026_nonresident_core.yaml"
+        )
+        second_dependent = checkout / second_dependent_relative
+        second_dependent_test = second_dependent.with_name(
+            "2026_nonresident_core.test.yaml"
+        )
         source.parent.mkdir(parents=True)
         dependent.parent.mkdir(parents=True)
         source.write_text(
@@ -13730,6 +13737,33 @@ class TestCmdEncode:
             "rules: []\n"
         )
         source_test.write_text("[]\n")
+        source_text = "authoritative Louisiana section 47:32\n"
+        corpus_path, source_attestation = self._bind_apply_source_release(
+            checkout,
+            tmp_path,
+            citation_path="us-la/statute/47/32",
+            source_text=source_text,
+        )
+        retained_pairs: list[tuple[Path, Path]] = []
+        for section in range(294, 298):
+            legacy = checkout / f"us-la/statutes/47:{section}.yaml"
+            successor = checkout / f"us-la/statutes/47/{section}.yaml"
+            legacy.parent.mkdir(parents=True, exist_ok=True)
+            successor.parent.mkdir(parents=True, exist_ok=True)
+            legacy.write_text(
+                "format: rulespec/v1\n"
+                "module:\n"
+                "  source_verification:\n"
+                "    corpus_citation_path: us-la/statute/47/32\n"
+                f"    source_sha256: {source_attestation['source_sha256']}\n"
+                "rules: []\n"
+            )
+            legacy.with_name(f"47:{section}.test.yaml").write_text("[]\n")
+            successor.write_bytes(legacy.read_bytes())
+            successor.with_name(f"{section}.test.yaml").write_text("[]\n")
+            retained_pairs.append(
+                (legacy.relative_to(checkout), successor.relative_to(checkout))
+            )
         canonical_predecessor = checkout / destination_relative
         canonical_predecessor_test = canonical_predecessor.with_name("32.test.yaml")
         canonical_predecessor.parent.mkdir(parents=True, exist_ok=True)
@@ -13768,6 +13802,9 @@ class TestCmdEncode:
             "        formula: amount\n"
         )
         dependent_test.write_text("[]\n")
+        second_dependent.parent.mkdir(parents=True, exist_ok=True)
+        second_dependent.write_bytes(dependent.read_bytes())
+        second_dependent_test.write_text("[]\n")
 
         def write_manual_manifest(primary: Path, files: list[Path]) -> Path:
             manifest = checkout / _applied_encoding_manifest_path(
@@ -13803,6 +13840,10 @@ class TestCmdEncode:
         source_manifest = write_manual_manifest(source, [source, source_test])
         dependent_manifest = write_manual_manifest(
             dependent, [dependent, dependent_test]
+        )
+        second_dependent_manifest = write_manual_manifest(
+            second_dependent,
+            [second_dependent, second_dependent_test],
         )
         if dependent_owner == "generated":
             dependent_manifest.write_text(
@@ -13851,16 +13892,140 @@ class TestCmdEncode:
                 )
                 + "\n"
             )
+        retained_manifests: list[tuple[Path, Path]] = []
+        retained_successor_originals: dict[Path, bytes] = {}
+        for legacy_relative, successor_relative in retained_pairs:
+            legacy = checkout / legacy_relative
+            successor = checkout / successor_relative
+            legacy_test = legacy.with_name(f"{legacy.stem}.test.yaml")
+            successor_test = successor.with_name(f"{successor.stem}.test.yaml")
+            legacy_manifest = write_manual_manifest(legacy, [legacy, legacy_test])
+            successor_manifest = checkout / _applied_encoding_manifest_path(
+                successor_relative
+            )
+            successor_manifest.parent.mkdir(parents=True, exist_ok=True)
+            successor_payload = _signed_manifest_payload(
+                {
+                    "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+                    "backend": "codex",
+                    "citation": "us-la/statute/47/32",
+                    "source_attestation": {
+                        **source_attestation,
+                        "rulespec_root": "rulespec-us/us-la",
+                    },
+                    "applied_files": [
+                        {
+                            "path": path.relative_to(checkout).as_posix(),
+                            "sha256": _sha256_file(path),
+                        }
+                        for path in (successor, successor_test)
+                    ],
+                }
+            )
+            successor_manifest.write_text(
+                json.dumps(successor_payload, indent=2, sort_keys=True) + "\n"
+            )
+            retained_manifests.append((legacy_manifest, successor_manifest))
+            retained_successor_originals[successor_manifest] = (
+                successor_manifest.read_bytes()
+            )
         dependent_before = dependent.read_bytes()
         dependent_test_before = dependent_test.read_bytes()
         dependent_manifest_before = dependent_manifest.read_bytes()
-
-        source_text = "authoritative Louisiana section 47:32\n"
-        corpus_path, source_attestation = self._bind_apply_source_release(
-            checkout,
-            tmp_path,
-            citation_path="us-la/statute/47/32",
-            source_text=source_text,
+        second_dependent_before = second_dependent.read_bytes()
+        second_dependent_test_before = second_dependent_test.read_bytes()
+        second_dependent_manifest_before = second_dependent_manifest.read_bytes()
+        old_modules = [
+            source_relative.as_posix(),
+            *[old.as_posix() for old, _new in retained_pairs],
+        ]
+        canonical_modules = [
+            destination_relative.as_posix(),
+            *[new.as_posix() for _old, new in retained_pairs],
+        ]
+        provision_index = checkout / ".axiom/index/provisions_to_rules.json"
+        provision_index.parent.mkdir(parents=True, exist_ok=True)
+        provision_index.write_text(
+            json.dumps(
+                {
+                    "records": [
+                        *[{"module": module} for module in old_modules],
+                        *[{"module": module} for module in canonical_modules],
+                    ]
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        pending_fingerprints = checkout / ".axiom/pending-validation-fingerprints.json"
+        pending_fingerprints.write_text(
+            json.dumps(
+                {
+                    **{module: "legacy" for module in old_modules},
+                    **{module: "canonical" for module in canonical_modules},
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        known_gaps = checkout / "known-validation-gaps.yaml"
+        known_gaps.write_text(
+            "".join(
+                f"'{module}':\n  reason: "
+                f"{'legacy' if module in old_modules else 'canonical'}\n"
+                for module in [*old_modules, *canonical_modules]
+            )
+        )
+        toolchain = checkout / ".axiom/toolchain.toml"
+        toolchain.write_text(
+            re.sub(
+                r'validation_waiver_set_sha256 = "[0-9a-f]{64}"',
+                "validation_waiver_set_sha256 = "
+                f'"{hashlib.sha256(known_gaps.read_bytes()).hexdigest()}"',
+                toolchain.read_text(),
+            )
+        )
+        waiver_sha256 = hashlib.sha256(known_gaps.read_bytes()).hexdigest()
+        for _legacy_manifest, successor_manifest in retained_manifests:
+            successor_payload = json.loads(successor_manifest.read_text())
+            successor_payload["validation_waiver_set_sha256"] = waiver_sha256
+            successor_payload["validation_execution"]["policy_pre_apply"][
+                "validation_waiver_set_sha256"
+            ] = waiver_sha256
+            _sign_applied_encoding_manifest(
+                successor_payload,
+                TEST_APPLY_SIGNING_BROKER,
+            )
+            successor_manifest.write_text(
+                json.dumps(successor_payload, indent=2, sort_keys=True) + "\n"
+            )
+            retained_successor_originals[successor_manifest] = (
+                successor_manifest.read_bytes()
+            )
+        oracle_pending = checkout / "oracle-coverage-pending.yaml"
+        oracle_pending.write_text(
+            "".join(
+                f"- legal_id: us-la:"
+                f"{path.relative_to('us-la').with_suffix('').as_posix()}#output.tax\n"
+                f"  reason: "
+                f"{'legacy' if path.as_posix() in old_modules else 'canonical'}\n"
+                for pair in [
+                    (source_relative, destination_relative),
+                    *retained_pairs,
+                ]
+                for path in pair
+            )
+        )
+        manifest_inventory = checkout / "tests/test_encoding_manifests.py"
+        manifest_inventory.parent.mkdir(parents=True, exist_ok=True)
+        manifest_inventory.write_text(
+            "ALLOW = {\n"
+            f"    '{source_manifest.relative_to(checkout).as_posix()}',\n"
+            + "".join(
+                f"    '{legacy.relative_to(checkout).as_posix()}',\n"
+                for legacy, _successor in retained_manifests
+            )
+            + "    'keep.json',\n}\n"
         )
         _git(checkout, "init", "-b", "main")
         _git(checkout, "config", "user.email", "test@example.com")
@@ -13880,7 +14045,8 @@ class TestCmdEncode:
             policy_repo_path=content_root,
             source_unit=source_unit,
             corpus_release=release,
-            exact_dependent_paths=(dependent_relative,),
+            exact_dependent_paths=(dependent_relative, second_dependent_relative),
+            retained_successor_paths=tuple(old for old, _new in retained_pairs),
         )
 
         generated = output_root / "codex-test-model/statutes/47/32.yaml"
@@ -13948,16 +14114,37 @@ class TestCmdEncode:
             ).exists()
             assert overlay_target.is_file()
             assert overlay_target.read_bytes() == generated.read_bytes()
-            exact_path = next(
+            exact_paths = [
                 path
                 for path in dependents
-                if path.as_posix().endswith(dependent_relative.as_posix())
-            )
-            exact_bytes = exact_path.read_bytes()
-            observed_overlay["dependent"] = exact_path
-            observed_overlay["bytes"] = exact_bytes
+                if any(
+                    path.as_posix().endswith(relative.as_posix())
+                    for relative in (dependent_relative, second_dependent_relative)
+                )
+            ]
+            assert len(exact_paths) == 2
+            observed_overlay["dependents"] = exact_paths
+            observed_overlay["bytes"] = [path.read_bytes() for path in exact_paths]
+            for legacy_relative, successor_relative in retained_pairs:
+                assert not (overlay_checkout / legacy_relative).exists()
+                assert not (
+                    overlay_checkout / _applied_encoding_manifest_path(legacy_relative)
+                ).exists()
+                assert (overlay_checkout / successor_relative).is_file()
+            for metadata_path in (
+                provision_index,
+                pending_fingerprints,
+                known_gaps,
+                oracle_pending,
+                manifest_inventory,
+            ):
+                overlay_metadata = overlay_checkout / metadata_path.relative_to(
+                    checkout
+                )
+                metadata_bytes = overlay_metadata.read_bytes()
+                assert all(old.encode() not in metadata_bytes for old in old_modules)
             passed = SimpleNamespace(all_passed=True, results={})
-            return [(overlay_target, passed), (exact_path, passed)]
+            return [(overlay_target, passed), *[(path, passed) for path in exact_paths]]
 
         with (
             patch("axiom_encode.cli.ValidatorPipeline"),
@@ -13986,12 +14173,10 @@ class TestCmdEncode:
             unrelated_sibling_manifest.read_bytes() == unrelated_sibling_manifest_before
         )
         assert orphan_sibling_manifest.read_bytes() == orphan_sibling_manifest_before
-        assert b"us-la:statutes/47/32#amount" in observed_overlay["bytes"]
-        assert b"us-la:statutes/47:32#amount" not in observed_overlay["bytes"]
-        assert (
-            f"hash: sha256:{_sha256_file(generated)}".encode()
-            in observed_overlay["bytes"]
-        )
+        for overlay_bytes in observed_overlay["bytes"]:
+            assert b"us-la:statutes/47/32#amount" in overlay_bytes
+            assert b"us-la:statutes/47:32#amount" not in overlay_bytes
+            assert f"hash: sha256:{_sha256_file(generated)}".encode() in overlay_bytes
 
         with (
             patch("axiom_encode.cli.ValidatorPipeline"),
@@ -14013,6 +14198,65 @@ class TestCmdEncode:
         assert second_can_apply is True, second_issues
         assert second_issues == []
         assert second_supplemental == {}
+
+        self._record_apply_validation(
+            result,
+            output_root=output_root,
+            policy_repo_path=content_root,
+            corpus_path=corpus_path,
+        )
+
+        retained_probe_legacy = checkout / retained_pairs[0][0]
+        retained_probe_successor = checkout / retained_pairs[0][1]
+        retained_probe_manifest = retained_manifests[0][1]
+        with (
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_PUBLIC_KEY_ENV: TEST_APPLY_PUBLIC_KEY_B64},
+            ),
+            patch(
+                "axiom_encode.cli._git_repo_provenance",
+                return_value={
+                    "root": "/repo/axiom-encode",
+                    "commit": TEST_PINNED_ENCODER_IDENTITY["commit"],
+                    "dirty_tracked": False,
+                },
+            ),
+            patch(
+                "axiom_encode.cli._require_axiom_encode_version_provenance",
+                return_value={
+                    "version": AXIOM_ENCODE_TEST_VERSION,
+                    "version_commit": "f" * 40,
+                    "identity_source": "git",
+                },
+            ),
+            patch(
+                "axiom_encode.cli._require_apply_post_install_closure",
+                side_effect=RuntimeError(
+                    "injected retained-successor post-install failure"
+                ),
+            ),
+            pytest.raises(
+                RuntimeError,
+                match="injected retained-successor post-install failure",
+            ),
+        ):
+            _apply_generated_encoding_result(
+                result,
+                output_root=output_root,
+                policy_repo_path=content_root,
+                corpus_path=corpus_path,
+                run_id="legacy-retained-rollback-probe",
+            )
+        assert _git(checkout, "status", "--porcelain").stdout == ""
+        assert retained_probe_legacy.is_file()
+        assert retained_probe_successor.is_file()
+        assert (
+            retained_probe_manifest.read_bytes()
+            == retained_successor_originals[retained_probe_manifest]
+        )
+        assert source.is_file()
+        assert source_manifest.is_file()
 
         self._record_apply_validation(
             result,
@@ -14069,15 +14313,78 @@ class TestCmdEncode:
         assert dependent.read_bytes() != dependent_before
         assert dependent_test.read_bytes() == dependent_test_before
         assert dependent_manifest.read_bytes() != dependent_manifest_before
+        assert b"us-la:statutes/47/32#amount" in second_dependent.read_bytes()
+        assert (
+            f"hash: sha256:{_sha256_file(destination)}".encode()
+            in second_dependent.read_bytes()
+        )
+        assert second_dependent.read_bytes() != second_dependent_before
+        assert second_dependent_test.read_bytes() == second_dependent_test_before
+        assert (
+            second_dependent_manifest.read_bytes() != second_dependent_manifest_before
+        )
         assert destination_manifest in applied
         assert dependent in applied
         assert dependent_test in applied
         assert dependent_manifest in applied
+        assert second_dependent in applied
+        assert second_dependent_test in applied
+        assert second_dependent_manifest in applied
+
+        for (legacy_relative, successor_relative), (
+            legacy_manifest,
+            successor_manifest,
+        ) in zip(retained_pairs, retained_manifests, strict=True):
+            legacy = checkout / legacy_relative
+            legacy_test = legacy.with_name(f"{legacy.stem}.test.yaml")
+            successor = checkout / successor_relative
+            successor_test = successor.with_name(f"{successor.stem}.test.yaml")
+            assert not legacy.exists()
+            assert not legacy_test.exists()
+            assert not legacy_manifest.exists()
+            assert successor.is_file()
+            assert successor_test.is_file()
+            assert (
+                successor_manifest.read_bytes()
+                != retained_successor_originals[successor_manifest]
+            )
+            assert successor_manifest in applied
 
         outer = json.loads(destination_manifest.read_text())
         receipt_path = checkout / outer["replacement"]["receipt_path"]
         receipt = json.loads(receipt_path.read_text())
-        assert receipt["schema_version"].endswith("/v3")
+        assert receipt["schema_version"].endswith("/v4")
+        assert len(receipt["replacement"]["retained_successors"]) == 4
+        assert {
+            item["destination"]
+            for item in receipt["replacement"]["retained_successors"]
+        } == {new.as_posix() for _old, new in retained_pairs}
+        metadata_reconciliations = receipt["replacement"]["metadata_reconciliations"]
+        assert {item["path"] for item in metadata_reconciliations} == {
+            ".axiom/index/provisions_to_rules.json",
+            ".axiom/pending-validation-fingerprints.json",
+            ".axiom/toolchain.toml",
+            "known-validation-gaps.yaml",
+            "oracle-coverage-pending.yaml",
+            "tests/test_encoding_manifests.py",
+        }
+        for reconciliation in metadata_reconciliations:
+            metadata_path = checkout / reconciliation["path"]
+            assert reconciliation["before_sha256"] != reconciliation["after_sha256"]
+            assert _sha256_file(metadata_path) == reconciliation["after_sha256"]
+        for old_module in old_modules:
+            assert old_module.encode() not in provision_index.read_bytes()
+            assert old_module.encode() not in pending_fingerprints.read_bytes()
+            assert old_module.encode() not in known_gaps.read_bytes()
+        assert b"us-la:statutes/47:" not in oracle_pending.read_bytes()
+        for legacy_manifest, _successor_manifest in retained_manifests:
+            assert (
+                legacy_manifest.relative_to(checkout).as_posix().encode()
+                not in manifest_inventory.read_bytes()
+            )
+        assert source_manifest.relative_to(checkout).as_posix().encode() not in (
+            manifest_inventory.read_bytes()
+        )
         assert receipt["legacy"]["owner_class"] == "v1-hmac-untrusted"
         assert receipt["replacement"]["destination_predecessor_class"] == (
             "canonicalized-unowned-duplicate"
@@ -14086,8 +14393,15 @@ class TestCmdEncode:
             item["path"]: item["sha256"]
             for item in receipt["replacement"]["destination_predecessor_files"]
         } == predecessor_hashes
-        assert len(receipt["replacement"]["exact_dependents"]) == 1
-        exact = receipt["replacement"]["exact_dependents"][0]
+        assert len(receipt["replacement"]["exact_dependents"]) == 2
+        exact_by_primary = {
+            item["primary"]: item for item in receipt["replacement"]["exact_dependents"]
+        }
+        assert set(exact_by_primary) == {
+            dependent_relative.as_posix(),
+            second_dependent_relative.as_posix(),
+        }
+        exact = exact_by_primary[dependent_relative.as_posix()]
         assert exact["primary"] == dependent_relative.as_posix()
         assert exact["rewrites"][0]["proof_import_repairs"] == 1
         exact_legacy_hashes = {
@@ -14108,13 +14422,22 @@ class TestCmdEncode:
             hashlib.sha256(receipt_path.read_bytes()).hexdigest()
         )
 
-        for manifest_path in (destination_manifest, dependent_manifest):
+        post_migration_waiver_sha256 = hashlib.sha256(
+            known_gaps.read_bytes()
+        ).hexdigest()
+        persisted_manifests = (
+            destination_manifest,
+            dependent_manifest,
+            second_dependent_manifest,
+            *(successor for _legacy, successor in retained_manifests),
+        )
+        for manifest_path in persisted_manifests:
             verified, _root, _digest, issues = (
                 _load_verified_applied_encoding_manifest_payload(
                     checkout,
                     manifest_path.relative_to(checkout).as_posix(),
                     signing_broker=TEST_APPLY_SIGNING_BROKER,
-                    expected_waiver_set_sha256=TEST_VALIDATION_WAIVER_SHA256,
+                    expected_waiver_set_sha256=post_migration_waiver_sha256,
                     expected_encoder_identity=TEST_PINNED_ENCODER_IDENTITY,
                     local_corpus_release=release,
                 )
@@ -14122,9 +14445,48 @@ class TestCmdEncode:
             assert issues == [], "\n".join(issues)
             assert verified is not None
 
+        from scripts.prepare_signed_backfill import authorized_changed_paths
+
+        with patch.dict(
+            os.environ,
+            {APPLIED_ENCODING_SIGNING_PUBLIC_KEY_ENV: TEST_APPLY_PUBLIC_KEY_B64},
+        ):
+            authorized = authorized_changed_paths(checkout)
+        expected_authorized = {
+            source_relative,
+            _applied_encoding_manifest_path(source_relative),
+            destination_relative,
+            _applied_encoding_manifest_path(destination_relative),
+            dependent_relative,
+            second_dependent_relative,
+            *[old for old, _new in retained_pairs],
+            *[_applied_encoding_manifest_path(old) for old, _new in retained_pairs],
+            *[_applied_encoding_manifest_path(new) for _old, new in retained_pairs],
+            *(Path(item["path"]) for item in metadata_reconciliations),
+            receipt_path.relative_to(checkout),
+        }
+        assert expected_authorized <= {Path(path) for path in authorized}
+
         outer_before_tamper = destination_manifest.read_bytes()
         receipt_before_tamper = receipt_path.read_bytes()
-        exact_manifest_before_tamper = dependent_manifest.read_bytes()
+        linked_manifest_bytes = {
+            path: path.read_bytes() for path in persisted_manifests[1:]
+        }
+
+        def rebind_linked_manifests(receipt_sha256: str) -> None:
+            for path, original in linked_manifest_bytes.items():
+                payload = json.loads(original)
+                payload["legacy_migration"]["receipt_sha256"] = receipt_sha256
+                _sign_applied_encoding_manifest(
+                    payload,
+                    TEST_APPLY_SIGNING_BROKER,
+                )
+                path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+        def restore_linked_manifests() -> None:
+            for path, original in linked_manifest_bytes.items():
+                path.write_bytes(original)
+
         compatibility_receipt = copy.deepcopy(receipt)
         compatibility_receipt["legacy"]["owner_class"] = "v1-manual-hmac-untrusted"
         _sign_applied_encoding_manifest(
@@ -14148,23 +14510,13 @@ class TestCmdEncode:
         destination_manifest.write_text(
             json.dumps(compatibility_outer, indent=2, sort_keys=True) + "\n"
         )
-        compatibility_exact_manifest = copy.deepcopy(exact_manifest)
-        compatibility_exact_manifest["legacy_migration"]["receipt_sha256"] = (
-            compatibility_receipt_sha256
-        )
-        _sign_applied_encoding_manifest(
-            compatibility_exact_manifest,
-            TEST_APPLY_SIGNING_BROKER,
-        )
-        dependent_manifest.write_text(
-            json.dumps(compatibility_exact_manifest, indent=2, sort_keys=True) + "\n"
-        )
+        rebind_linked_manifests(compatibility_receipt_sha256)
         _verified, _root, _digest, compatibility_issues = (
             _load_verified_applied_encoding_manifest_payload(
                 checkout,
                 destination_manifest.relative_to(checkout).as_posix(),
                 signing_broker=TEST_APPLY_SIGNING_BROKER,
-                expected_waiver_set_sha256=TEST_VALIDATION_WAIVER_SHA256,
+                expected_waiver_set_sha256=post_migration_waiver_sha256,
                 expected_encoder_identity=TEST_PINNED_ENCODER_IDENTITY,
                 local_corpus_release=release,
             )
@@ -14178,7 +14530,7 @@ class TestCmdEncode:
             )
         destination_manifest.write_bytes(outer_before_tamper)
         receipt_path.write_bytes(receipt_before_tamper)
-        dependent_manifest.write_bytes(exact_manifest_before_tamper)
+        restore_linked_manifests()
 
         tampered_receipt = copy.deepcopy(receipt)
         tampered_receipt["replacement"]["exact_dependents"][0]["rewrites"][0][
@@ -14201,23 +14553,13 @@ class TestCmdEncode:
         destination_manifest.write_text(
             json.dumps(tampered_outer, indent=2, sort_keys=True) + "\n"
         )
-        tampered_exact_manifest = copy.deepcopy(exact_manifest)
-        tampered_exact_manifest["legacy_migration"]["receipt_sha256"] = (
-            tampered_receipt_sha256
-        )
-        _sign_applied_encoding_manifest(
-            tampered_exact_manifest,
-            TEST_APPLY_SIGNING_BROKER,
-        )
-        dependent_manifest.write_text(
-            json.dumps(tampered_exact_manifest, indent=2, sort_keys=True) + "\n"
-        )
+        rebind_linked_manifests(tampered_receipt_sha256)
         verified, _root, _digest, issues = (
             _load_verified_applied_encoding_manifest_payload(
                 checkout,
                 destination_manifest.relative_to(checkout).as_posix(),
                 signing_broker=TEST_APPLY_SIGNING_BROKER,
-                expected_waiver_set_sha256=TEST_VALIDATION_WAIVER_SHA256,
+                expected_waiver_set_sha256=post_migration_waiver_sha256,
                 expected_encoder_identity=TEST_PINNED_ENCODER_IDENTITY,
                 local_corpus_release=release,
             )
@@ -14226,7 +14568,7 @@ class TestCmdEncode:
 
         destination_manifest.write_bytes(outer_before_tamper)
         receipt_path.write_bytes(receipt_before_tamper)
-        dependent_manifest.write_bytes(exact_manifest_before_tamper)
+        restore_linked_manifests()
         exact_manifest = json.loads(dependent_manifest.read_text())
         exact_manifest["legacy_migration"]["receipt_sha256"] = "0" * 64
         _sign_applied_encoding_manifest(
@@ -14241,7 +14583,7 @@ class TestCmdEncode:
                 checkout,
                 dependent_manifest.relative_to(checkout).as_posix(),
                 signing_broker=TEST_APPLY_SIGNING_BROKER,
-                expected_waiver_set_sha256=TEST_VALIDATION_WAIVER_SHA256,
+                expected_waiver_set_sha256=post_migration_waiver_sha256,
                 expected_encoder_identity=TEST_PINNED_ENCODER_IDENTITY,
                 local_corpus_release=release,
             )

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1443"
+ENCODER_VERSION = "0.2.1444"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1443"
+ENCODER_VERSION = "0.2.1444"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_legacy_replacement.py
+++ b/tests/test_legacy_replacement.py
@@ -12,12 +12,17 @@ import pytest
 
 from axiom_encode.cli import (
     _legacy_destination_manifest_claimants_at_base,
+    _legacy_metadata_reconciliation_bytes,
     _legacy_replacement_authoritative_map,
     _require_locked_legacy_replacement_base,
     _resolve_legacy_replacement_contract,
 )
 from axiom_encode.legacy_replacement import (
     LEGACY_MANIFEST_SCHEMA,
+    LegacyReplacementContract,
+    LegacyReplacementFile,
+    LegacyReplacementRetainedSuccessor,
+    LegacyReplacementRewrite,
     legacy_generated_manifest_issues,
     legacy_manual_manifest_issues,
     legacy_receipt_v1_manifest_issues,
@@ -30,6 +35,7 @@ from axiom_encode.legacy_replacement_overlay import (
     LegacyReplacementOverlayError,
     stage_legacy_replacement_overlay,
 )
+from axiom_encode.rulespec_path_migration import PlannedMove
 
 
 @pytest.mark.parametrize(
@@ -377,6 +383,8 @@ def test_receipt_identity_binds_every_transaction_dimension() -> None:
         destination_predecessor_files=[
             {"path": "us-la/statutes/47/32.yaml", "sha256": "f" * 64}
         ],
+        retained_successors=[{"source": "us-la/statutes/47:294.yaml"}],
+        metadata_reconciliations=[{"path": "known-validation-gaps.yaml"}],
     )
     baseline = receipt_identity_sha256(payload)
     for field in (
@@ -391,6 +399,8 @@ def test_receipt_identity_binds_every_transaction_dimension() -> None:
         "exact_dependents",
         "destination_predecessor_class",
         "destination_predecessor_files",
+        "retained_successors",
+        "metadata_reconciliations",
     ):
         changed = copy.deepcopy(payload)
         changed[field] = f"changed-{field}"
@@ -556,6 +566,123 @@ def test_contract_absorbs_exact_unowned_canonical_destination_predecessor(
     assert not (
         checkout / ".axiom/encoding-manifests/us/statutes/42/1437c–1.json"
     ).exists()
+
+
+def test_contract_admits_cryptographically_verified_retained_successor(
+    tmp_path: Path,
+) -> None:
+    checkout, content_root, source_unit = _legacy_checkout(tmp_path)
+    old = checkout / "us-la/statutes/47:294.yaml"
+    old_test = old.with_name("47:294.test.yaml")
+    successor = checkout / "us-la/statutes/47/294.yaml"
+    successor_test = successor.with_name("294.test.yaml")
+    old.parent.mkdir(parents=True, exist_ok=True)
+    successor.parent.mkdir(parents=True, exist_ok=True)
+    old.write_text(
+        "format: rulespec/v1\nmodule:\n  source_verification:\n"
+        "    corpus_citation_path: us-la/statute/47:294\nrules: []\n"
+    )
+    old_test.write_text("[]\n")
+    successor.write_bytes(old.read_bytes())
+    successor_test.write_bytes(old_test.read_bytes())
+    old_manifest = checkout / ".axiom/encoding-manifests/us-la/statutes/47:294.json"
+    old_manifest.parent.mkdir(parents=True, exist_ok=True)
+    old_payload = _manual_manifest()
+    old_payload["applied_files"] = [
+        {
+            "path": path.relative_to(checkout).as_posix(),
+            "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+        }
+        for path in (old, old_test)
+    ]
+    old_manifest.write_text(json.dumps(old_payload) + "\n")
+    successor_manifest = (
+        checkout / ".axiom/encoding-manifests/us-la/statutes/47/294.json"
+    )
+    successor_manifest.parent.mkdir(parents=True, exist_ok=True)
+    successor_payload = {
+        "schema_version": "axiom-encode/applied-rulespec/v5",
+        "tool": "axiom-encode encode --apply",
+        "backend": "openai",
+        "citation": "us-la/statute/47:294",
+        "validation_execution": {"axiom_encode": {"commit": "a" * 40}},
+        "applied_files": [
+            {
+                "path": path.relative_to(checkout).as_posix(),
+                "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+            }
+            for path in (successor, successor_test)
+        ],
+    }
+    successor_manifest.write_text(
+        json.dumps(successor_payload, indent=2, sort_keys=True) + "\n"
+    )
+    index = checkout / ".axiom/index/provisions_to_rules.json"
+    index.write_text(
+        json.dumps(
+            {
+                "records": [
+                    {"module": "us-la/statutes/47:32.yaml"},
+                    {"module": "us-la/statutes/47/32.yaml"},
+                    {"module": "us-la/statutes/47:294.yaml"},
+                    {"module": "us-la/statutes/47/294.yaml"},
+                ]
+            }
+        )
+        + "\n"
+    )
+    _git(checkout, "add", ".")
+    _git(checkout, "commit", "-qm", "retained successor base")
+
+    resolved_294 = SimpleNamespace(
+        requested="us-la/statute/47:294",
+        citation_path="us-la/statute/47:294",
+        body="official body",
+        resolved_source=object(),
+    )
+    with (
+        patch(
+            "axiom_encode.cli.resolve_corpus_source_unit",
+            side_effect=lambda citation, _release: (
+                resolved_294 if citation.endswith("47:294") else source_unit
+            ),
+        ),
+        patch(
+            "axiom_encode.cli._applied_encoding_manifest_verifier",
+            return_value=object(),
+        ),
+        patch(
+            "axiom_encode.cli.verify_rulespec_validation_waiver_set",
+            return_value="f" * 64,
+        ),
+        patch(
+            "axiom_encode.cli._load_verified_applied_encoding_manifest_payload",
+            return_value=(
+                successor_payload,
+                "",
+                hashlib.sha256(successor_manifest.read_bytes()).hexdigest(),
+                [],
+            ),
+        ) as verified,
+    ):
+        contract = _resolve_legacy_replacement_contract(
+            source_raw=Path("us-la/statutes/47:32.yaml"),
+            destination_raw=Path("us-la/statutes/47/32.yaml"),
+            policy_checkout_path=checkout,
+            policy_repo_path=content_root,
+            source_unit=source_unit,
+            corpus_release=SimpleNamespace(),
+            retained_successor_paths=(Path("us-la/statutes/47:294.yaml"),),
+        )
+
+    assert verified.call_count == 1
+    assert len(contract.retained_successors) == 1
+    assert contract.retained_successors[0].destination == Path(
+        "us-la/statutes/47/294.yaml"
+    )
+    assert [item.path for item in contract.metadata_reconciliations] == [
+        Path(".axiom/index/provisions_to_rules.json")
+    ]
 
 
 def test_destination_manifest_claimant_scan_is_one_conservative_base_query(
@@ -1241,3 +1368,236 @@ def test_locked_recheck_rejects_untracked_file_introduced_after_planning(
 
     with pytest.raises(ValueError, match="exact clean HEAD"):
         _require_locked_legacy_replacement_base(checkout, contract)
+
+
+def test_five_inventory_reconciliation_is_exact_and_deterministic() -> None:
+    moves = (
+        PlannedMove(
+            source=Path("us-la/statutes/47:294.yaml"),
+            destination=Path("us-la/statutes/47/294.yaml"),
+        ),
+    )
+    old_module = "us-la/statutes/47:294.yaml"
+    new_module = "us-la/statutes/47/294.yaml"
+    old_identity = "us-la:statutes/47:294"
+    new_identity = "us-la:statutes/47/294"
+    old_manifest = ".axiom/encoding-manifests/us-la/statutes/47:294.json"
+    cases = {
+        Path(".axiom/index/provisions_to_rules.json"): (
+            json.dumps(
+                {
+                    "records": [
+                        {"module": old_module},
+                        {"module": new_module},
+                    ]
+                }
+            ).encode(),
+            "remove_legacy_module_records",
+        ),
+        Path(".axiom/pending-validation-fingerprints.json"): (
+            json.dumps({old_module: "old", new_module: "new"}).encode(),
+            "remove_legacy_fingerprints",
+        ),
+        Path("known-validation-gaps.yaml"): (
+            f"'{old_module}':\n  reason: old\n'{new_module}':\n  reason: new\n".encode(),
+            "remove_legacy_validation_gaps",
+        ),
+        Path("oracle-coverage-pending.yaml"): (
+            (
+                f"- legal_id: {old_identity}#output.tax\n  reason: old\n"
+                f"- legal_id: {new_identity}#output.tax\n  reason: new\n"
+            ).encode(),
+            "remove_legacy_oracle_pending",
+        ),
+        Path("tests/test_encoding_manifests.py"): (
+            f"ALLOW = {{\n    '{old_manifest}',\n    'keep.json',\n}}\n".encode(),
+            "remove_retired_manifest_allowances",
+        ),
+    }
+    for path, (raw, operation) in cases.items():
+        rewritten, operations = _legacy_metadata_reconciliation_bytes(
+            path, raw, moves=moves
+        )
+        assert operations == ({"operation": operation, "count": 1},)
+        assert old_module.encode() not in rewritten
+        assert old_identity.encode() not in rewritten
+        assert old_manifest.encode() not in rewritten
+
+
+def test_toolchain_reconciliation_binds_exact_post_migration_waiver_digest() -> None:
+    moves = (
+        PlannedMove(
+            source=Path("us-la/statutes/47:294.yaml"),
+            destination=Path("us-la/statutes/47/294.yaml"),
+        ),
+    )
+    digest = "e" * 64
+    raw = (
+        f'rulespec_root = "rulespec-us"\nvalidation_waiver_set_sha256 = "{"f" * 64}"\n'
+    ).encode()
+
+    rewritten, operations = _legacy_metadata_reconciliation_bytes(
+        Path(".axiom/toolchain.toml"),
+        raw,
+        moves=moves,
+        validation_waiver_set_sha256=digest,
+    )
+
+    assert (
+        rewritten
+        == (
+            'rulespec_root = "rulespec-us"\n'
+            f'validation_waiver_set_sha256 = "{digest}"\n'
+        ).encode()
+    )
+    assert operations == (
+        {"operation": "update_validation_waiver_set_sha256", "count": 1},
+    )
+    with pytest.raises(ValueError, match="lacks the post-migration waiver digest"):
+        _legacy_metadata_reconciliation_bytes(
+            Path(".axiom/toolchain.toml"),
+            raw,
+            moves=moves,
+        )
+    with pytest.raises(ValueError, match="not one canonical entry"):
+        _legacy_metadata_reconciliation_bytes(
+            Path(".axiom/toolchain.toml"),
+            raw + raw,
+            moves=moves,
+            validation_waiver_set_sha256=digest,
+        )
+
+
+@pytest.mark.parametrize(
+    "records",
+    [
+        [
+            {"module": "us-la/statutes/47:294.yaml"},
+            {"note": "successor us-la/statutes/47/294.yaml is available"},
+        ],
+        [{"module": "us-la/statutes/47:294.yaml"}],
+        [
+            {"module": "us-la/statutes/47:294.yaml"},
+            {"module": "us-la/statutes/47/295.yaml"},
+        ],
+    ],
+)
+def test_provision_index_requires_exact_canonical_module_record(
+    records: list[dict[str, str]],
+) -> None:
+    moves = (
+        PlannedMove(
+            source=Path("us-la/statutes/47:294.yaml"),
+            destination=Path("us-la/statutes/47/294.yaml"),
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="lacks exact canonical module records: us-la/statutes/47/294.yaml",
+    ):
+        _legacy_metadata_reconciliation_bytes(
+            Path(".axiom/index/provisions_to_rules.json"),
+            json.dumps({"records": records}).encode(),
+            moves=moves,
+        )
+
+
+def test_provision_index_rejects_out_of_band_structured_successor_field() -> None:
+    moves = (
+        PlannedMove(
+            source=Path("us-la/statutes/47:294.yaml"),
+            destination=Path("us-la/statutes/47/294.yaml"),
+        ),
+    )
+    payload = {
+        "records": [{"module": "us-la/statutes/47:294.yaml"}],
+        "metadata": {"module": "us-la/statutes/47/294.yaml"},
+    }
+
+    with pytest.raises(ValueError, match="lacks exact canonical module records"):
+        _legacy_metadata_reconciliation_bytes(
+            Path(".axiom/index/provisions_to_rules.json"),
+            json.dumps(payload).encode(),
+            moves=moves,
+        )
+
+
+def test_retained_successor_overlay_preflights_then_removes_one_composite(
+    tmp_path: Path,
+) -> None:
+    checkout = tmp_path / "rulespec-us"
+    main = Path("us-la/statutes/47:32.yaml")
+    main_manifest = Path(".axiom/encoding-manifests/us-la/statutes/47:32.json")
+    old = Path("us-la/statutes/47:294.yaml")
+    old_manifest = Path(".axiom/encoding-manifests/us-la/statutes/47:294.json")
+    successor = Path("us-la/statutes/47/294.yaml")
+    successor_manifest = Path(".axiom/encoding-manifests/us-la/statutes/47/294.json")
+    metadata = Path("known-validation-gaps.yaml")
+    for path, raw in {
+        main: b"main\n",
+        main_manifest: b"main manifest\n",
+        old: b"old\n",
+        old_manifest: b"old manifest\n",
+        successor: b"successor\n",
+        successor_manifest: b"signed successor manifest\n",
+        metadata: b"old metadata\n",
+    }.items():
+        target = checkout / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(raw)
+
+    def evidence(path: Path) -> LegacyReplacementFile:
+        raw = (checkout / path).read_bytes()
+        return LegacyReplacementFile(path, hashlib.sha256(raw).hexdigest(), raw)
+
+    successor_manifest_evidence = evidence(successor_manifest)
+    contract = LegacyReplacementContract(
+        base_commit="a" * 40,
+        base_tree="b" * 40,
+        source=main,
+        destination=main,
+        legacy_manifest=evidence(main_manifest),
+        deleted_files=(evidence(main),),
+        rewrites=(),
+        scheduled_dependents=(),
+        exact_dependents=(),
+        retained_successors=(
+            LegacyReplacementRetainedSuccessor(
+                source=old,
+                destination=successor,
+                legacy_manifest=evidence(old_manifest),
+                legacy_files=(evidence(old),),
+                successor_manifest=successor_manifest_evidence,
+                successor_files=(evidence(successor),),
+            ),
+        ),
+        metadata_reconciliations=(
+            LegacyReplacementRewrite(
+                path=metadata,
+                before_sha256=hashlib.sha256(b"old metadata\n").hexdigest(),
+                after_sha256=hashlib.sha256(b"new metadata\n").hexdigest(),
+                replacements=({"operation": "test", "count": 1},),
+                raw=b"new metadata\n",
+            ),
+        ),
+    )
+
+    (checkout / successor_manifest).write_text("tampered\n")
+    with pytest.raises(LegacyReplacementOverlayError, match="signed manifest changed"):
+        stage_legacy_replacement_overlay(contract, checkout)
+    assert (checkout / main).exists()
+    assert (checkout / old).exists()
+    assert (checkout / metadata).read_bytes() == b"old metadata\n"
+
+    (checkout / successor_manifest).write_bytes(successor_manifest_evidence.raw)
+    stage_legacy_replacement_overlay(contract, checkout)
+    assert not (checkout / main).exists()
+    assert not (checkout / main_manifest).exists()
+    assert not (checkout / old).exists()
+    assert not (checkout / old_manifest).exists()
+    assert (checkout / successor).read_bytes() == b"successor\n"
+    assert (
+        checkout / successor_manifest
+    ).read_bytes() == successor_manifest_evidence.raw
+    assert (checkout / metadata).read_bytes() == b"new metadata\n"

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1443"
+ENCODER_VERSION = "0.2.1444"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1443"
+ENCODER_VERSION = "0.2.1444"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1443"
+ENCODER_VERSION = "0.2.1444"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1443"
+ENCODER_VERSION = "0.2.1444"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -7,7 +7,13 @@ import sys
 from pathlib import Path, PurePosixPath
 
 import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
+from axiom_encode.cli import _legacy_replacement_manifest_issues
+from axiom_encode.legacy_replacement import (
+    receipt_identity_payload,
+    receipt_identity_sha256,
+)
 from scripts.prepare_signed_backfill import (
     MAX_SOURCE_BUNDLE_JSON_BYTES,
     REVIEWED_RULESPEC_PR_BASE_BRANCHES,
@@ -382,6 +388,86 @@ def _write_signed_change(repo: Path) -> tuple[Path, Path]:
     return rule, manifest
 
 
+def _legacy_receipt_identity(receipt: dict[str, object]) -> dict[str, object]:
+    repository = receipt["repository"]
+    legacy = receipt["legacy"]
+    replacement = receipt["replacement"]
+    assert isinstance(repository, dict)
+    assert isinstance(legacy, dict)
+    assert isinstance(replacement, dict)
+    legacy_manifest = legacy["manifest"]
+    legacy_files = legacy["files"]
+    live_files = replacement["live_files"]
+    assert isinstance(legacy_manifest, dict)
+    assert isinstance(legacy_files, list)
+    assert isinstance(live_files, list)
+    live_paths = {item["path"] for item in live_files if isinstance(item, dict)}
+    deleted_files = [
+        {"path": item["path"], "deleted": True}
+        for item in legacy_files
+        if isinstance(item, dict) and item.get("path") not in live_paths
+    ]
+    schema = receipt["schema_version"]
+    retained_successors = replacement.get("retained_successors")
+    if schema == "axiom-encode/legacy-fresh-reencode-receipt/v4":
+        assert isinstance(retained_successors, list)
+        deleted_files.extend(
+            {"path": item["path"], "deleted": True}
+            for successor in retained_successors
+            if isinstance(successor, dict)
+            for item in successor.get("legacy_files", [])
+            if isinstance(item, dict)
+        )
+    return receipt_identity_payload(
+        base_commit=str(repository["base_commit"]),
+        base_tree=str(repository["base_tree"]),
+        legacy_manifest_sha256=str(legacy_manifest["sha256"]),
+        model_manifest_sha256=str(replacement["model_manifest_sha256"]),
+        live_files=live_files,
+        deleted_files=deleted_files,
+        rewrites=replacement["rewrites"],
+        scheduled_dependents=replacement["scheduled_dependents"],
+        exact_dependents=(
+            replacement["exact_dependents"]
+            if schema
+            in {
+                "axiom-encode/legacy-fresh-reencode-receipt/v2",
+                "axiom-encode/legacy-fresh-reencode-receipt/v3",
+                "axiom-encode/legacy-fresh-reencode-receipt/v4",
+            }
+            else None
+        ),
+        destination_predecessor_class=(
+            str(replacement["destination_predecessor_class"])
+            if schema
+            in {
+                "axiom-encode/legacy-fresh-reencode-receipt/v3",
+                "axiom-encode/legacy-fresh-reencode-receipt/v4",
+            }
+            else None
+        ),
+        destination_predecessor_files=(
+            replacement["destination_predecessor_files"]
+            if schema
+            in {
+                "axiom-encode/legacy-fresh-reencode-receipt/v3",
+                "axiom-encode/legacy-fresh-reencode-receipt/v4",
+            }
+            else None
+        ),
+        retained_successors=(
+            retained_successors
+            if schema == "axiom-encode/legacy-fresh-reencode-receipt/v4"
+            else None
+        ),
+        metadata_reconciliations=(
+            replacement["metadata_reconciliations"]
+            if schema == "axiom-encode/legacy-fresh-reencode-receipt/v4"
+            else None
+        ),
+    )
+
+
 def _write_legacy_replacement_change(
     repo: Path,
     *,
@@ -391,6 +477,7 @@ def _write_legacy_replacement_change(
     exact_dependent: bool = False,
     generated_exact_dependent: bool = False,
     destination_predecessor: bool = False,
+    retained_successor: bool = False,
     legacy_owner_class: str = "v1-hmac-untrusted",
 ) -> tuple[Path, Path, Path, Path]:
     old_rule = repo / "us/statutes/47:32.yaml"
@@ -463,6 +550,83 @@ def _write_legacy_replacement_change(
     )
     new_rule = repo / "us/statutes/47/32.yaml"
     new_test = repo / "us/statutes/47/32.test.yaml"
+    retained_old_rule = repo / "us/statutes/47:294.yaml"
+    retained_old_test = repo / "us/statutes/47:294.test.yaml"
+    retained_old_manifest = repo / ".axiom/encoding-manifests/us/statutes/47:294.json"
+    retained_rule = repo / "us/statutes/47/294.yaml"
+    retained_test = repo / "us/statutes/47/294.test.yaml"
+    retained_manifest = repo / ".axiom/encoding-manifests/us/statutes/47/294.json"
+    retained_metadata = repo / "known-validation-gaps.yaml"
+    retained_old_files: list[dict[str, str]] = []
+    retained_files: list[dict[str, str]] = []
+    retained_old_manifest_raw = b""
+    retained_manifest_raw = b""
+    retained_manifest_payload: dict[str, object] = {}
+    retained_metadata_before = b""
+    if retained_successor:
+        retained_old_rule.parent.mkdir(parents=True, exist_ok=True)
+        retained_rule.parent.mkdir(parents=True, exist_ok=True)
+        retained_old_rule.write_text("format: rulespec/v1\nrules: []\n")
+        retained_old_test.write_text("[]\n")
+        retained_rule.write_bytes(retained_old_rule.read_bytes())
+        retained_test.write_bytes(retained_old_test.read_bytes())
+        retained_old_files = [
+            {
+                "path": path.relative_to(repo).as_posix(),
+                "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+            }
+            for path in (retained_old_rule, retained_old_test)
+        ]
+        retained_files = [
+            {
+                "path": path.relative_to(repo).as_posix(),
+                "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+            }
+            for path in (retained_rule, retained_test)
+        ]
+        retained_old_manifest.parent.mkdir(parents=True, exist_ok=True)
+        retained_old_manifest.write_text(
+            json.dumps(
+                {
+                    "schema_version": "axiom-encode/applied-rulespec/v1",
+                    "tool": "axiom-encode sign-applied-files",
+                    "backend": "manual",
+                    "runner": "manual-attestation",
+                    "manual_exception": "test retained legacy evidence",
+                    "applied_files": retained_old_files,
+                    "signature": {
+                        "algorithm": "hmac-sha256",
+                        "key_id": "historical-v1",
+                        "value": "opaque-untrusted-evidence",
+                    },
+                },
+                sort_keys=True,
+            )
+            + "\n"
+        )
+        retained_old_manifest_raw = retained_old_manifest.read_bytes()
+        retained_manifest_payload = {
+            "schema_version": "axiom-encode/applied-rulespec/v5",
+            "tool": "axiom-encode encode --apply",
+            "backend": "codex",
+            "citation": "us/statute/47:294",
+            "applied_files": retained_files,
+            "signature": {
+                "algorithm": "ed25519-domain-v1",
+                "key_id": f"sha256:{'d' * 64}",
+                "value": "signed-test-value",
+            },
+        }
+        retained_manifest.parent.mkdir(parents=True, exist_ok=True)
+        retained_manifest.write_text(
+            json.dumps(retained_manifest_payload, indent=2, sort_keys=True) + "\n"
+        )
+        retained_manifest_raw = retained_manifest.read_bytes()
+        retained_metadata.write_text(
+            "'us/statutes/47:294.yaml':\n  reason: legacy\n"
+            "'us/statutes/47/294.yaml':\n  reason: canonical\n"
+        )
+        retained_metadata_before = retained_metadata.read_bytes()
     destination_predecessor_files: list[dict[str, str]] = []
     if destination_predecessor:
         new_rule.parent.mkdir(parents=True, exist_ok=True)
@@ -592,6 +756,13 @@ def _write_legacy_replacement_change(
     old_rule.unlink()
     old_test.unlink()
     old_manifest.unlink()
+    if retained_successor:
+        retained_old_rule.unlink()
+        retained_old_test.unlink()
+        retained_old_manifest.unlink()
+        retained_metadata.write_text(
+            "'us/statutes/47/294.yaml':\n  reason: canonical\n"
+        )
     metadata.write_text('{"module":"us:statutes/47/32"}\n', encoding="utf-8")
     if exact_dependent:
         exact_primary.write_text(
@@ -641,7 +812,7 @@ def _write_legacy_replacement_change(
         "applied_files": live_files,
     }
     nested_raw = (json.dumps(nested_manifest, indent=2, sort_keys=True) + "\n").encode()
-    receipt_relative = Path(".axiom/legacy-replacements") / f"{'c' * 64}.json"
+    receipt_relative = Path(".axiom/legacy-replacements") / "pending.json"
     receipt = repo / receipt_relative
     receipt.parent.mkdir(parents=True)
     receipt_payload = {
@@ -786,10 +957,102 @@ def _write_legacy_replacement_change(
                 ],
             }
         ]
+    if retained_successor:
+        retained_metadata_after = retained_metadata.read_bytes()
+        receipt_payload["schema_version"] = (
+            "axiom-encode/legacy-fresh-reencode-receipt/v4"
+        )
+        receipt_payload["replacement"].setdefault("exact_dependents", [])
+        receipt_payload["replacement"].setdefault(
+            "destination_predecessor_class", "none"
+        )
+        receipt_payload["replacement"].setdefault("destination_predecessor_files", [])
+        receipt_payload["replacement"]["retained_successors"] = [
+            {
+                "source": retained_old_rule.relative_to(repo).as_posix(),
+                "destination": retained_rule.relative_to(repo).as_posix(),
+                "legacy_owner_class": "v1-manual-hmac-untrusted",
+                "legacy_manifest": {
+                    "path": retained_old_manifest.relative_to(repo).as_posix(),
+                    "sha256": hashlib.sha256(retained_old_manifest_raw).hexdigest(),
+                },
+                "legacy_files": retained_old_files,
+                "successor_manifest": {
+                    "path": retained_manifest.relative_to(repo).as_posix(),
+                    "sha256": hashlib.sha256(retained_manifest_raw).hexdigest(),
+                    "payload": retained_manifest_payload,
+                },
+                "successor_files": retained_files,
+            }
+        ]
+        receipt_payload["replacement"]["metadata_reconciliations"] = [
+            {
+                "path": retained_metadata.relative_to(repo).as_posix(),
+                "before_sha256": hashlib.sha256(retained_metadata_before).hexdigest(),
+                "after_sha256": hashlib.sha256(retained_metadata_after).hexdigest(),
+                "operations": [
+                    {
+                        "operation": "remove_legacy_validation_gaps",
+                        "count": 1,
+                    }
+                ],
+            }
+        ]
+    receipt_relative = Path(".axiom/legacy-replacements") / (
+        receipt_identity_sha256(_legacy_receipt_identity(receipt_payload)) + ".json"
+    )
+    receipt = repo / receipt_relative
+    receipt.parent.mkdir(parents=True, exist_ok=True)
     receipt.write_text(
         json.dumps(receipt_payload, sort_keys=True) + "\n",
         encoding="utf-8",
     )
+    if retained_successor:
+        retained_manifest.write_text(
+            json.dumps(
+                {
+                    "schema_version": "axiom-encode/applied-rulespec/v5",
+                    "generated_at": "2026-07-30T00:00:00+00:00",
+                    "tool": (
+                        "axiom-encode encode --apply "
+                        "--legacy-retained-successor-rulespec-path"
+                    ),
+                    "axiom_encode_version": "0.2.1414",
+                    "axiom_encode_git": {
+                        "commit": "a" * 40,
+                        "dirty_tracked": False,
+                    },
+                    "validation_waiver_set_sha256": "b" * 64,
+                    "applied_files": retained_files,
+                    "retained_successor_manifest": retained_manifest_payload,
+                    "legacy_migration": {
+                        "receipt_path": receipt_relative.as_posix(),
+                        "receipt_sha256": hashlib.sha256(
+                            receipt.read_bytes()
+                        ).hexdigest(),
+                        "source": retained_old_rule.relative_to(repo).as_posix(),
+                        "destination": retained_rule.relative_to(repo).as_posix(),
+                        "legacy_manifest_path": retained_old_manifest.relative_to(
+                            repo
+                        ).as_posix(),
+                        "legacy_manifest_sha256": hashlib.sha256(
+                            retained_old_manifest_raw
+                        ).hexdigest(),
+                        "successor_manifest_sha256": hashlib.sha256(
+                            retained_manifest_raw
+                        ).hexdigest(),
+                    },
+                    "signature": {
+                        "algorithm": "ed25519-domain-v1",
+                        "key_id": f"sha256:{'d' * 64}",
+                        "value": "signed-test-value",
+                    },
+                },
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
     if exact_dependent:
         exact_manifest.write_text(
             json.dumps(
@@ -852,7 +1115,27 @@ def _write_legacy_replacement_change(
                         "path": metadata.relative_to(repo).as_posix(),
                         "sha256": metadata_after_sha256,
                     },
+                    *(
+                        [
+                            {
+                                "path": retained_metadata.relative_to(repo).as_posix(),
+                                "sha256": hashlib.sha256(
+                                    retained_metadata.read_bytes()
+                                ).hexdigest(),
+                            }
+                        ]
+                        if retained_successor
+                        else []
+                    ),
                     *[{"path": item["path"], "deleted": True} for item in legacy_files],
+                    *(
+                        [
+                            {"path": item["path"], "deleted": True}
+                            for item in retained_old_files
+                        ]
+                        if retained_successor
+                        else []
+                    ),
                 ],
             },
             sort_keys=True,
@@ -1026,8 +1309,16 @@ def _refresh_legacy_receipt_bindings(
     manifest: Path,
     receipt: Path,
 ) -> None:
-    receipt_sha256 = hashlib.sha256(receipt.read_bytes()).hexdigest()
+    receipt_payload = json.loads(receipt.read_text(encoding="utf-8"))
+    receipt_relative = Path(".axiom/legacy-replacements") / (
+        receipt_identity_sha256(_legacy_receipt_identity(receipt_payload)) + ".json"
+    )
+    refreshed_receipt = repo / receipt_relative
+    if refreshed_receipt != receipt:
+        receipt.replace(refreshed_receipt)
+    receipt_sha256 = hashlib.sha256(refreshed_receipt.read_bytes()).hexdigest()
     manifest_payload = json.loads(manifest.read_text(encoding="utf-8"))
+    manifest_payload["replacement"]["receipt_path"] = receipt_relative.as_posix()
     manifest_payload["replacement"]["receipt_sha256"] = receipt_sha256
     manifest.write_text(
         json.dumps(manifest_payload, sort_keys=True) + "\n",
@@ -1038,9 +1329,34 @@ def _refresh_legacy_receipt_bindings(
     )
     if exact_manifest.is_file():
         exact_payload = json.loads(exact_manifest.read_text(encoding="utf-8"))
+        exact_payload["legacy_migration"]["receipt_path"] = receipt_relative.as_posix()
         exact_payload["legacy_migration"]["receipt_sha256"] = receipt_sha256
         exact_manifest.write_text(
             json.dumps(exact_payload, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    replacement = receipt_payload.get("replacement")
+    retained = (
+        replacement.get("retained_successors", [])
+        if isinstance(replacement, dict)
+        else []
+    )
+    for successor in retained if isinstance(retained, list) else []:
+        if not isinstance(successor, dict):
+            continue
+        evidence = successor.get("successor_manifest")
+        if not isinstance(evidence, dict) or not isinstance(evidence.get("path"), str):
+            continue
+        retained_manifest = repo / evidence["path"]
+        if not retained_manifest.is_file():
+            continue
+        retained_payload = json.loads(retained_manifest.read_text(encoding="utf-8"))
+        retained_payload["legacy_migration"]["receipt_path"] = (
+            receipt_relative.as_posix()
+        )
+        retained_payload["legacy_migration"]["receipt_sha256"] = receipt_sha256
+        retained_manifest.write_text(
+            json.dumps(retained_payload, sort_keys=True) + "\n",
             encoding="utf-8",
         )
 
@@ -1121,6 +1437,128 @@ def test_stage_accepts_v3_unowned_canonical_destination_predecessor(
     stage_authorized_changes(repo)
 
     assert PurePosixPath("us/statutes/47/32.yaml") in expected
+
+
+def test_stage_accepts_v4_additive_reconciliation_contract(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    manifest, receipt, _old_manifest, _metadata = _write_legacy_replacement_change(
+        repo,
+        destination_predecessor=True,
+    )
+    payload = json.loads(receipt.read_text(encoding="utf-8"))
+    payload["schema_version"] = "axiom-encode/legacy-fresh-reencode-receipt/v4"
+    payload["replacement"]["retained_successors"] = []
+    payload["replacement"]["metadata_reconciliations"] = []
+    receipt.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+    _refresh_legacy_receipt_bindings(repo, manifest, receipt)
+
+    expected = authorized_changed_paths(repo)
+    stage_authorized_changes(repo)
+
+    assert PurePosixPath("us/statutes/47/32.yaml") in expected
+
+
+def test_stage_accepts_v4_nonempty_retained_successor_identity(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    _manifest, receipt, _old_manifest, _metadata = _write_legacy_replacement_change(
+        repo, destination_predecessor=True, retained_successor=True
+    )
+
+    expected = authorized_changed_paths(repo)
+    stage_authorized_changes(repo)
+
+    assert (
+        PurePosixPath(".axiom/encoding-manifests/us/statutes/47:294.json") in expected
+    )
+    assert PurePosixPath("us/statutes/47:294.yaml") in expected
+    assert (
+        ".axiom/encoding-manifests/us/statutes/47:294.json"
+        in _git(repo, "diff", "--cached", "--name-only", "--no-renames").splitlines()
+    )
+    assert json.loads(receipt.read_text())["replacement"]["retained_successors"]
+
+
+def test_persisted_verifier_reconstructs_nonempty_v4_retained_identity(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    manifest, receipt, _old_manifest, _metadata = _write_legacy_replacement_change(
+        repo, destination_predecessor=True, retained_successor=True
+    )
+    manifest_label = manifest.relative_to(repo).as_posix()
+    signing_key = Ed25519PrivateKey.generate().public_key()
+
+    issues = _legacy_replacement_manifest_issues(
+        json.loads(manifest.read_text()),
+        repo_path=repo,
+        manifest_label=manifest_label,
+        signing_broker=signing_key,
+        expected_waiver_set_sha256="b" * 64,
+        local_corpus_release=None,
+    )
+    assert not any("replacement receipt identity is stale" in issue for issue in issues)
+
+    receipt_payload = json.loads(receipt.read_text())
+    receipt_payload["replacement"]["retained_successors"][0]["legacy_files"][0][
+        "sha256"
+    ] = "0" * 64
+    receipt.write_text(json.dumps(receipt_payload, sort_keys=True) + "\n")
+    manifest_payload = json.loads(manifest.read_text())
+    manifest_payload["replacement"]["receipt_sha256"] = hashlib.sha256(
+        receipt.read_bytes()
+    ).hexdigest()
+    manifest.write_text(json.dumps(manifest_payload, sort_keys=True) + "\n")
+
+    tampered_issues = _legacy_replacement_manifest_issues(
+        manifest_payload,
+        repo_path=repo,
+        manifest_label=manifest_label,
+        signing_broker=signing_key,
+        expected_waiver_set_sha256="b" * 64,
+        local_corpus_release=None,
+    )
+    assert any(
+        "replacement receipt identity is stale" in issue for issue in tampered_issues
+    )
+
+
+def test_stage_rejects_v4_retained_deleted_file_evidence_tamper(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    manifest, receipt, _old_manifest, _metadata = _write_legacy_replacement_change(
+        repo, destination_predecessor=True, retained_successor=True
+    )
+    payload = json.loads(receipt.read_text(encoding="utf-8"))
+    payload["replacement"]["retained_successors"][0]["legacy_files"][0]["sha256"] = (
+        "0" * 64
+    )
+    receipt.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+    _refresh_legacy_receipt_bindings(repo, manifest, receipt)
+
+    with pytest.raises(ValueError, match="retained successor.*base group"):
+        authorized_changed_paths(repo)
+
+
+def test_stage_rejects_v4_missing_retained_deleted_file_from_outer_manifest(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    manifest, _receipt, _old_manifest, _metadata = _write_legacy_replacement_change(
+        repo, destination_predecessor=True, retained_successor=True
+    )
+    payload = json.loads(manifest.read_text(encoding="utf-8"))
+    payload["applied_files"] = [
+        item
+        for item in payload["applied_files"]
+        if item.get("path") != "us/statutes/47:294.yaml"
+    ]
+    manifest.write_text(json.dumps(payload, sort_keys=True) + "\n")
+
+    with pytest.raises(ValueError, match="outer applied_files differ"):
+        authorized_changed_paths(repo)
 
 
 def test_stage_rejects_v3_destination_predecessor_hash_tamper(
@@ -1282,14 +1720,7 @@ def test_stage_rejects_inexact_legacy_dependent_replacement_count(
         json.dumps(receipt_payload, sort_keys=True) + "\n",
         encoding="utf-8",
     )
-    manifest_payload = json.loads(manifest.read_text(encoding="utf-8"))
-    manifest_payload["replacement"]["receipt_sha256"] = hashlib.sha256(
-        receipt.read_bytes()
-    ).hexdigest()
-    manifest.write_text(
-        json.dumps(manifest_payload, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
+    _refresh_legacy_receipt_bindings(repo, manifest, receipt)
 
     with pytest.raises(ValueError, match="exact base proof differs"):
         stage_authorized_changes(repo)
@@ -1322,14 +1753,7 @@ def test_stage_rejects_unrelated_legacy_dependent_replacement_pair(
         json.dumps(receipt_payload, sort_keys=True) + "\n",
         encoding="utf-8",
     )
-    manifest_payload = json.loads(manifest.read_text(encoding="utf-8"))
-    manifest_payload["replacement"]["receipt_sha256"] = hashlib.sha256(
-        receipt.read_bytes()
-    ).hexdigest()
-    manifest.write_text(
-        json.dumps(manifest_payload, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
+    _refresh_legacy_receipt_bindings(repo, manifest, receipt)
     dependent_manifest = (
         repo / ".axiom/encoding-manifests/us/policies/income_tax/dependent.json"
     )
@@ -1409,14 +1833,7 @@ def test_stage_rejects_unauthorized_legacy_metadata_rewrite(tmp_path: Path) -> N
         json.dumps(receipt_payload, sort_keys=True) + "\n",
         encoding="utf-8",
     )
-    manifest_payload = json.loads(manifest.read_text(encoding="utf-8"))
-    manifest_payload["replacement"]["receipt_sha256"] = hashlib.sha256(
-        receipt.read_bytes()
-    ).hexdigest()
-    manifest.write_text(
-        json.dumps(manifest_payload, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
+    _refresh_legacy_receipt_bindings(repo, manifest, receipt)
     metadata.write_text('{"module":"us:statutes/47/32"}\n', encoding="utf-8")
 
     with pytest.raises(ValueError, match="rewrite\\[0\\] path is unauthorized"):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1443"')
+        .startswith('__version__ = "0.2.1444"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1443"
+    assert encoder_package["version"] == "0.2.1444"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1443"
+    assert project["project"]["version"] == "0.2.1444"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1443"')
+        .startswith('__version__ = "0.2.1444"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1443"
+    assert encoder_package["version"] == "0.2.1444"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1443"
+    assert project["project"]["version"] == "0.2.1444"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1443"')
+        .startswith('__version__ = "0.2.1444"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1443"
+ENCODER_VERSION = "0.2.1444"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -3075,6 +3075,12 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
         "us-la/policies/income_tax/2026_resident_core.yaml",
         "us-la/policies/income_tax/pilot_liability_pipeline.yaml",
     ]
+    retained_successors = [
+        "us-la/statutes/47:294.yaml",
+        "us-la/statutes/47:295.yaml",
+        "us-la/statutes/47:297/4.yaml",
+        "us-la/statutes/47:297/8.yaml",
+    ]
     environment = {
         **os.environ,
         "AXIOM_ENCODE_APPLY_SIGNING_KEY": "test-key",
@@ -3085,6 +3091,9 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
         "DEPENDENT_REVIEW_FINDING": "",
         "GITHUB_WORKSPACE": str(tmp_path),
         "LEGACY_EXACT_DEPENDENT_RULESPEC_PATH": exact_dependents[0],
+        "LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON": json.dumps(
+            retained_successors
+        ),
         "REPLACE_LEGACY_RULESPEC_PATH": source,
         "REPLACE_RULESPEC_PATH": destination,
         "REVIEW_FINDING": "Preserve all supported existing semantics.",
@@ -3115,6 +3124,14 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
         if value == "--legacy-exact-dependent-rulespec-path"
     ]
     assert [encode_args[index + 1] for index in exact_indexes] == exact_dependents
+    retained_indexes = [
+        index
+        for index, value in enumerate(encode_args)
+        if value == "--legacy-retained-successor-rulespec-path"
+    ]
+    assert [encode_args[index + 1] for index in retained_indexes] == (
+        retained_successors
+    )
     assert "--apply-target-only" not in encode_args
 
 
@@ -3334,6 +3351,370 @@ def test_targeted_artifact_packages_signed_review_context(tmp_path: Path) -> Non
             "sha256": hashlib.sha256(applied_path.read_bytes()).hexdigest(),
         }
     ]
+
+
+def _targeted_package_script() -> str:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
+    )
+    package_command = next(
+        step
+        for step in workflow["jobs"]["encode"]["steps"]
+        if step.get("name") == "Package exact generated changes"
+    )["run"]
+    marker = (
+        '"${workflow_python[@]}" - \\\n'
+        '  "$artifact/context-manifest.json" \\\n'
+        "  \"$artifact/apply-manifests.json\" <<'PY'\n"
+    )
+    return package_command.split(marker, 1)[1].split(
+        '\nPY\n"${workflow_python[@]}" - "$artifact/metadata.json"', 1
+    )[0]
+
+
+@pytest.mark.parametrize(
+    ("mutation", "error"),
+    [
+        ("success", None),
+        ("missing-input", "retained successors differ from inputs"),
+        ("extra-input", "retained successors differ from inputs"),
+        ("reordered-input", "retained successors differ from inputs"),
+        ("tampered-evidence", "retained predecessor file digest differs"),
+        ("missing-deleted-manifest", "deleted manifest inventory differs"),
+        ("extra-deleted-manifest", "deleted manifest inventory differs"),
+    ],
+)
+def test_targeted_artifact_packages_v4_retained_successor_closure(
+    tmp_path: Path,
+    mutation: str,
+    error: str | None,
+) -> None:
+    script = _targeted_package_script()
+    rulespec = tmp_path / "rulespec-us"
+    rulespec.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=rulespec, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=rulespec,
+        check=True,
+    )
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=rulespec, check=True)
+
+    def write(path: str, raw: bytes) -> Path:
+        target = rulespec / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(raw)
+        return target
+
+    def evidence(path: Path) -> dict[str, str]:
+        return {
+            "path": path.relative_to(rulespec).as_posix(),
+            "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+        }
+
+    main_old = write("us/statutes/47:32.yaml", b"old main\n")
+    main_old_manifest = write(
+        ".axiom/encoding-manifests/us/statutes/47:32.json", b"old main manifest\n"
+    )
+    unrelated_manifest = write(
+        ".axiom/encoding-manifests/us/statutes/unrelated.json", b"unrelated\n"
+    )
+    retained_rows: list[dict[str, object]] = []
+    retained_sources = [
+        "us/statutes/47:294.yaml",
+        "us/statutes/47:295.yaml",
+    ]
+    for number in (294, 295):
+        old = write(f"us/statutes/47:{number}.yaml", f"old {number}\n".encode())
+        old_test = write(f"us/statutes/47:{number}.test.yaml", b"[]\n")
+        old_manifest = write(
+            f".axiom/encoding-manifests/us/statutes/47:{number}.json",
+            f"old manifest {number}\n".encode(),
+        )
+        successor = write(f"us/statutes/47/{number}.yaml", old.read_bytes())
+        successor_test = write(
+            f"us/statutes/47/{number}.test.yaml", old_test.read_bytes()
+        )
+        successor_files = [evidence(successor), evidence(successor_test)]
+        original_payload = {
+            "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+            "tool": "axiom-encode encode --apply",
+            "backend": "codex",
+            "citation": f"us/statute/47:{number}",
+            "applied_files": successor_files,
+        }
+        original_raw = (
+            json.dumps(original_payload, indent=2, sort_keys=True) + "\n"
+        ).encode()
+        successor_manifest = write(
+            f".axiom/encoding-manifests/us/statutes/47/{number}.json",
+            original_raw,
+        )
+        retained_rows.append(
+            {
+                "source": old.relative_to(rulespec).as_posix(),
+                "destination": successor.relative_to(rulespec).as_posix(),
+                "legacy_owner_class": "v1-manual-hmac-untrusted",
+                "legacy_manifest": evidence(old_manifest),
+                "legacy_files": [evidence(old), evidence(old_test)],
+                "successor_manifest": {
+                    **evidence(successor_manifest),
+                    "payload": original_payload,
+                },
+                "successor_files": successor_files,
+            }
+        )
+    subprocess.run(["git", "add", "."], cwd=rulespec, check=True)
+    subprocess.run(["git", "commit", "-qm", "base"], cwd=rulespec, check=True)
+    rulespec_ref = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=rulespec, text=True
+    ).strip()
+
+    main_old.unlink()
+    main_old_manifest.unlink()
+    for row in retained_rows:
+        for item in row["legacy_files"]:
+            (rulespec / item["path"]).unlink()
+        (rulespec / row["legacy_manifest"]["path"]).unlink()
+    main_live = write("us/statutes/47/32.yaml", b"new main\n")
+    citation = "us/statute/47:32"
+    review_content = "Retain the canonical successors.\n"
+    context_payload = {
+        "citation": citation,
+        "review_findings_files": [
+            {
+                "content": review_content,
+                "sha256": hashlib.sha256(review_content.encode()).hexdigest(),
+            }
+        ],
+    }
+    context_bytes = json.dumps(context_payload, sort_keys=True).encode()
+    context_path = tmp_path / "generated/target/context-manifest.json"
+    context_path.parent.mkdir(parents=True)
+    context_path.write_bytes(context_bytes)
+    nested = {
+        "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+        "tool": "axiom-encode encode --apply",
+        "backend": "codex",
+        "citation": citation,
+        "context_manifest_file": str(context_path),
+        "context_manifest_sha256": hashlib.sha256(context_bytes).hexdigest(),
+        "applied_files": [evidence(main_live)],
+    }
+    receipt_payload = {
+        "schema_version": "axiom-encode/legacy-fresh-reencode-receipt/v4",
+        "replacement": {
+            "source": "us/statutes/47:32.yaml",
+            "destination": "us/statutes/47/32.yaml",
+            "scheduled_dependents": [],
+            "exact_dependents": [],
+            "retained_successors": retained_rows,
+            "metadata_reconciliations": [],
+        },
+    }
+    receipt_path = rulespec / ".axiom/legacy-replacements" / f"{'a' * 64}.json"
+    receipt_path.parent.mkdir(parents=True)
+
+    if mutation == "tampered-evidence":
+        retained_rows[0]["legacy_files"][0]["sha256"] = "0" * 64
+    if mutation == "missing-deleted-manifest":
+        first_manifest = retained_rows[0]["legacy_manifest"]
+        (rulespec / first_manifest["path"]).write_text("old manifest 294\n")
+    if mutation == "extra-deleted-manifest":
+        unrelated_manifest.unlink()
+
+    receipt_path.write_text(json.dumps(receipt_payload, sort_keys=True) + "\n")
+    receipt_digest = hashlib.sha256(receipt_path.read_bytes()).hexdigest()
+    for row in retained_rows:
+        refreshed = {
+            "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+            "tool": (
+                "axiom-encode encode --apply --legacy-retained-successor-rulespec-path"
+            ),
+            "applied_files": row["successor_files"],
+            "retained_successor_manifest": row["successor_manifest"]["payload"],
+            "legacy_migration": {
+                "receipt_path": receipt_path.relative_to(rulespec).as_posix(),
+                "receipt_sha256": receipt_digest,
+                "source": row["source"],
+                "destination": row["destination"],
+                "legacy_manifest_path": row["legacy_manifest"]["path"],
+                "legacy_manifest_sha256": row["legacy_manifest"]["sha256"],
+                "successor_manifest_sha256": row["successor_manifest"]["sha256"],
+            },
+        }
+        (rulespec / row["successor_manifest"]["path"]).write_text(
+            json.dumps(refreshed, sort_keys=True) + "\n"
+        )
+    outer = {
+        "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+        "tool": "axiom-encode encode --apply --replace-legacy-rulespec-path",
+        "replacement_manifest": nested,
+        "replacement": {
+            "receipt_path": receipt_path.relative_to(rulespec).as_posix(),
+            "receipt_sha256": receipt_digest,
+        },
+    }
+    outer_path = write(
+        ".axiom/encoding-manifests/us/statutes/47/32.json",
+        (json.dumps(outer, sort_keys=True) + "\n").encode(),
+    )
+    (tmp_path / "source-bundle.json").write_text("[]\n")
+    selected_inputs = list(retained_sources)
+    if mutation == "missing-input":
+        selected_inputs.pop()
+    elif mutation == "extra-input":
+        selected_inputs.append("us/statutes/47:296.yaml")
+    elif mutation == "reordered-input":
+        selected_inputs.reverse()
+    packaged_context = tmp_path / "artifact/context-manifest.json"
+    packaged_inventory = tmp_path / "artifact/apply-manifests.json"
+    packaged_context.parent.mkdir()
+    completed = subprocess.run(
+        [sys.executable, "-", str(packaged_context), str(packaged_inventory)],
+        cwd=tmp_path,
+        input=script,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "CITATION": citation,
+            "PYTHONPATH": str(ROOT / "src"),
+            "REVIEW_FINDING_PRESENT": "true",
+            "RUNNER_TEMP": str(tmp_path),
+            "RULESPEC_CHECKOUT": "rulespec-us",
+            "RULESPEC_REF": rulespec_ref,
+            "REPLACE_LEGACY_RULESPEC_PATH": "us/statutes/47:32.yaml",
+            "REPLACE_RULESPEC_PATH": "us/statutes/47/32.yaml",
+            "LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON": json.dumps(
+                selected_inputs
+            ),
+        },
+    )
+
+    if error is not None:
+        assert completed.returncode != 0
+        assert error in completed.stderr
+        return
+    assert completed.returncode == 0, completed.stderr
+    inventory_paths = {
+        item["path"] for item in json.loads(packaged_inventory.read_text())["items"]
+    }
+    assert outer_path.relative_to(rulespec).as_posix() in inventory_paths
+    assert {str(row["successor_manifest"]["path"]) for row in retained_rows}.issubset(
+        inventory_paths
+    )
+
+
+@pytest.mark.parametrize("receipt_version", [1, 2, 3])
+def test_targeted_artifact_preserves_pre_v4_replacement_receipts(
+    tmp_path: Path,
+    receipt_version: int,
+) -> None:
+    script = _targeted_package_script()
+    rulespec = tmp_path / "rulespec-us"
+    rulespec.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=rulespec, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=rulespec,
+        check=True,
+    )
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=rulespec, check=True)
+    old = rulespec / "us/statutes/47:32.yaml"
+    old_manifest = rulespec / ".axiom/encoding-manifests/us/statutes/47:32.json"
+    old.parent.mkdir(parents=True)
+    old_manifest.parent.mkdir(parents=True)
+    old.write_text("old\n")
+    old_manifest.write_text("old manifest\n")
+    subprocess.run(["git", "add", "."], cwd=rulespec, check=True)
+    subprocess.run(["git", "commit", "-qm", "base"], cwd=rulespec, check=True)
+    rulespec_ref = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=rulespec, text=True
+    ).strip()
+    old.unlink()
+    old_manifest.unlink()
+    live = rulespec / "us/statutes/47/32.yaml"
+    live.parent.mkdir(parents=True)
+    live.write_text("new\n")
+    citation = "us/statute/47:32"
+    context_payload = {"citation": citation, "review_findings_files": []}
+    context_bytes = json.dumps(context_payload, sort_keys=True).encode()
+    context_path = tmp_path / "generated/target/context-manifest.json"
+    context_path.parent.mkdir(parents=True)
+    context_path.write_bytes(context_bytes)
+    nested = {
+        "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+        "tool": "axiom-encode encode --apply",
+        "backend": "codex",
+        "citation": citation,
+        "context_manifest_file": str(context_path),
+        "context_manifest_sha256": hashlib.sha256(context_bytes).hexdigest(),
+        "applied_files": [],
+    }
+    receipt_replacement = {
+        "source": "us/statutes/47:32.yaml",
+        "destination": "us/statutes/47/32.yaml",
+        "scheduled_dependents": [],
+    }
+    if receipt_version >= 2:
+        receipt_replacement["exact_dependents"] = []
+    if receipt_version >= 3:
+        receipt_replacement["destination_predecessor_class"] = (
+            "canonicalized-unowned-duplicate"
+        )
+        receipt_replacement["destination_predecessor_files"] = []
+    receipt_payload = {
+        "schema_version": (
+            f"axiom-encode/legacy-fresh-reencode-receipt/v{receipt_version}"
+        ),
+        "replacement": receipt_replacement,
+    }
+    receipt_path = rulespec / ".axiom/legacy-replacements" / f"{'b' * 64}.json"
+    receipt_path.parent.mkdir(parents=True)
+    receipt_path.write_text(json.dumps(receipt_payload) + "\n")
+    outer = {
+        "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+        "tool": "axiom-encode encode --apply --replace-legacy-rulespec-path",
+        "replacement_manifest": nested,
+        "replacement": {
+            "receipt_path": receipt_path.relative_to(rulespec).as_posix(),
+            "receipt_sha256": hashlib.sha256(receipt_path.read_bytes()).hexdigest(),
+        },
+    }
+    outer_path = rulespec / ".axiom/encoding-manifests/us/statutes/47/32.json"
+    outer_path.parent.mkdir(parents=True, exist_ok=True)
+    outer_path.write_text(json.dumps(outer) + "\n")
+    (tmp_path / "source-bundle.json").write_text("[]\n")
+    artifact = tmp_path / "artifact"
+    artifact.mkdir()
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-",
+            str(artifact / "context-manifest.json"),
+            str(artifact / "apply-manifests.json"),
+        ],
+        cwd=tmp_path,
+        input=script,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "CITATION": citation,
+            "PYTHONPATH": str(ROOT / "src"),
+            "REVIEW_FINDING_PRESENT": "false",
+            "RUNNER_TEMP": str(tmp_path),
+            "RULESPEC_CHECKOUT": "rulespec-us",
+            "RULESPEC_REF": rulespec_ref,
+            "REPLACE_LEGACY_RULESPEC_PATH": "us/statutes/47:32.yaml",
+            "REPLACE_RULESPEC_PATH": "us/statutes/47/32.yaml",
+        },
+    )
+
+    assert completed.returncode == 0, completed.stderr
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1443"
+version = "0.2.1444"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- add repeatable retained-successor replacement input and signed-v5 successor verification
- extend replacement receipts to v4 while preserving v1-v3 compatibility
- reconcile legacy groups, canonical predecessors, exact dependents, provision indexes, and metadata inventories as one authenticated closure
- persist verifier identity for backfill/tamper detection and preserve transactional rollback across overlay and live installs
- bump encoder to 0.2.1444

## Why
The Louisiana hard cut contains five noncanonical legacy primary modules that converge on retained canonical successors. A safe migration must verify the retained successor cryptographically, prove the full duplicate/dependent/index closure, authenticate exact workflow packaging and deletions, and install or roll back the whole replacement atomically. This implements that structure directly rather than bypassing duplicate ownership or weakening oracle checks.

## Review cycle
The implementation received an independent clean review before rebase. After NJ and strict-citation changes advanced main, it was replayed conflict-free and reviewed again. Hosted lint then found five feature-touched files needed current-Ruff formatting. Those files were mechanically formatted, the affected suite was rerun, and the required repeat independent review confirmed AST-identical semantics and no invariant changes. The final repeat review is CLEAN on exact commit 1e0fb5e05d7da5cfd99502ca49b90549c8e198f9 with no actionable findings.

## Checks
- full Python 3.13 suite before formatting-only amendment: 6,266 passed, 119 skipped
- affected CLI/legacy/backfill/signing suite after amendment: 1,330 passed, 61 skipped
- oracle and packaged version assertions: 27 passed
- independent pre-amendment focused checks: 85 passed
- independent post-amendment invariant slice: 7 passed
- hosted-equivalent Ruff check and format check, compileall, diff, exact-parent, version-pin, AST-identity, and range-diff checks pass

No protected signing workflow was dispatched and no RuleSpec repository was mutated by this change.