### PR TITLE
Persist failed targeted re-encode diagnostics

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -2347,10 +2347,21 @@ jobs:
           CORPUS_REF: ${{ inputs.corpus_ref }}
           COUNTRY: ${{ inputs.country }}
           DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
+          ENCODE_APPLY_CONCLUSION: ${{ steps.encode_apply.conclusion }}
+          ENCODE_APPLY_OUTCOME: ${{ steps.encode_apply.outcome }}
           EXISTING_SIGNED_IMPORTS_JSON: ${{ inputs.existing_signed_imports_json }}
+          FINALIZE_SIGNED_REENCODE_ARTIFACT_CONCLUSION: ${{ steps.finalize_signed_reencode_artifact.conclusion }}
+          FINALIZE_SIGNED_REENCODE_ARTIFACT_OUTCOME: ${{ steps.finalize_signed_reencode_artifact.outcome }}
           LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.legacy_exact_dependent_rulespec_path }}
+          LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON: ${{ inputs.legacy_retained_successor_rulespec_paths_json }}
           OPEN_PR: ${{ inputs.open_pr }}
+          PACKAGE_EXACT_GENERATED_CHANGES_CONCLUSION: ${{ steps.package_exact_generated_changes.conclusion }}
+          PACKAGE_EXACT_GENERATED_CHANGES_OUTCOME: ${{ steps.package_exact_generated_changes.outcome }}
+          COMMIT_REVIEWED_LANE_CHANGES_CONCLUSION: ${{ steps.commit_reviewed_lane_changes.conclusion }}
+          COMMIT_REVIEWED_LANE_CHANGES_OUTCOME: ${{ steps.commit_reviewed_lane_changes.outcome }}
           PR_BASE_BRANCH: ${{ inputs.pr_base_branch }}
+          PUBLISH_LANE_PULL_REQUEST_CONCLUSION: ${{ steps.publish_lane_pull_request.conclusion }}
+          PUBLISH_LANE_PULL_REQUEST_OUTCOME: ${{ steps.publish_lane_pull_request.outcome }}
           QUEUE_DISPATCHER_RUN_ID: ${{ inputs.queue_dispatcher_run_id }}
           QUEUE_ID: ${{ inputs.queue_id }}
           QUEUE_ITEM_GENERATION_SHA256: ${{ inputs.queue_item_generation_sha256 }}
@@ -2363,7 +2374,12 @@ jobs:
           SECOND_DEPENDENT_CITATION: ${{ inputs.second_dependent_citation }}
           SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.second_legacy_exact_dependent_rulespec_path }}
           SOURCE_BUNDLE_JSON: ${{ inputs.source_bundle_json }}
-          STEP_CONTEXT_JSON: ${{ toJSON(steps) }}
+          UPLOAD_SIGNED_REENCODE_ARTIFACT_CONCLUSION: ${{ steps.upload_signed_reencode_artifact.conclusion }}
+          UPLOAD_SIGNED_REENCODE_ARTIFACT_OUTCOME: ${{ steps.upload_signed_reencode_artifact.outcome }}
+          VERIFY_EXISTING_SIGNED_IMPORT_INTEGRITY_CONCLUSION: ${{ steps.verify_existing_signed_import_integrity.conclusion }}
+          VERIFY_EXISTING_SIGNED_IMPORT_INTEGRITY_OUTCOME: ${{ steps.verify_existing_signed_import_integrity.outcome }}
+          VERIFY_GENERATED_PROVENANCE_CONCLUSION: ${{ steps.verify_generated_provenance.conclusion }}
+          VERIFY_GENERATED_PROVENANCE_OUTCOME: ${{ steps.verify_generated_provenance.outcome }}
         run: |
           set -euo pipefail
           generated="$RUNNER_TEMP/generated"
@@ -2449,19 +2465,28 @@ jobs:
                       )
 
           inventory.sort(key=lambda item: item["path"])
-          raw_step_context = json.loads(os.environ["STEP_CONTEXT_JSON"])
-          if not isinstance(raw_step_context, dict):
-              raise SystemExit("workflow step context is malformed")
+          step_env_prefixes = {
+              "commit_reviewed_lane_changes": "COMMIT_REVIEWED_LANE_CHANGES",
+              "encode_apply": "ENCODE_APPLY",
+              "finalize_signed_reencode_artifact": (
+                  "FINALIZE_SIGNED_REENCODE_ARTIFACT"
+              ),
+              "package_exact_generated_changes": "PACKAGE_EXACT_GENERATED_CHANGES",
+              "publish_lane_pull_request": "PUBLISH_LANE_PULL_REQUEST",
+              "upload_signed_reencode_artifact": (
+                  "UPLOAD_SIGNED_REENCODE_ARTIFACT"
+              ),
+              "verify_existing_signed_import_integrity": (
+                  "VERIFY_EXISTING_SIGNED_IMPORT_INTEGRITY"
+              ),
+              "verify_generated_provenance": "VERIFY_GENERATED_PROVENANCE",
+          }
           step_outcomes = {}
-          for step_id, payload in sorted(raw_step_context.items()):
-              if not isinstance(step_id, str) or not isinstance(payload, dict):
-                  raise SystemExit("workflow step context entry is malformed")
-              outcome = payload.get("outcome")
-              conclusion = payload.get("conclusion")
-              if outcome is not None and not isinstance(outcome, str):
-                  raise SystemExit("workflow step outcome is malformed")
-              if conclusion is not None and not isinstance(conclusion, str):
-                  raise SystemExit("workflow step conclusion is malformed")
+          for step_id, env_prefix in step_env_prefixes.items():
+              outcome = os.environ.get(f"{env_prefix}_OUTCOME") or None
+              conclusion = os.environ.get(f"{env_prefix}_CONCLUSION") or None
+              if outcome is None and conclusion is None:
+                  continue
               step_outcomes[step_id] = {
                   "conclusion": conclusion,
                   "outcome": outcome,
@@ -2495,6 +2520,9 @@ jobs:
                   "LEGACY_EXACT_DEPENDENT_RULESPEC_PATH"
               )
               or None,
+              "legacy_retained_successor_rulespec_paths_input": os.environ.get(
+                  "LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON", "[]"
+              ),
               "open_pr": os.environ.get("OPEN_PR") == "true",
               "pr_base_branch": os.environ.get("PR_BASE_BRANCH") or None,
               "queue_dispatcher_run_id": os.environ.get(

--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -765,6 +765,7 @@ jobs:
           fi
 
       - name: Encode, review, validate, and apply
+        id: encode_apply
         env:
           AXIOM_ENCODE_APPLY_SIGNING_KEY: ${{ secrets.AXIOM_ENCODE_APPLY_SIGNING_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -1140,128 +1141,8 @@ jobs:
               "Compose signed source bundle for ${CITATION}"
           fi
 
-      - name: Package failed re-encode diagnostics
-        id: package_failed_reencode_diagnostics
-        if: ${{ failure() && !cancelled() }}
-        env:
-          CITATION: ${{ inputs.citation }}
-          CORPUS_REF: ${{ inputs.corpus_ref }}
-          RULES_ENGINE_REF: ${{ inputs.rules_engine_ref }}
-          RULESPEC_REF: ${{ inputs.rulespec_ref }}
-        run: |
-          set -euo pipefail
-          generated="$RUNNER_TEMP/generated"
-          artifact="$RUNNER_TEMP/targeted-reencode-failure"
-          mkdir -p "$artifact"
-          /opt/axiom-verification/python/bin/python -I - \
-            "$generated" "$artifact" <<'PY'
-          import hashlib
-          import json
-          import os
-          import stat
-          import sys
-          from pathlib import Path
-
-          from axiom_encode.corpus_resolver import (
-              UnsafeCorpusPathError,
-              read_bounded_regular_file,
-          )
-
-          generated = Path(os.path.abspath(sys.argv[1]))
-          artifact = Path(os.path.abspath(sys.argv[2]))
-          allowed_suffixes = {".json", ".log", ".txt", ".yaml", ".yml"}
-          max_entries = 4096
-          max_files = 1024
-          max_file_bytes = 16 * 1024 * 1024
-          max_total_bytes = 64 * 1024 * 1024
-          entry_count = 0
-          total_bytes = 0
-          inventory = []
-
-          if generated.exists():
-              root_stat = os.lstat(generated)
-              if not stat.S_ISDIR(root_stat.st_mode):
-                  raise SystemExit("generated diagnostic root is not a directory")
-              for directory, dirnames, filenames in os.walk(
-                  generated,
-                  topdown=True,
-                  followlinks=False,
-              ):
-                  entry_count += len(dirnames) + len(filenames)
-                  if entry_count > max_entries:
-                      raise SystemExit("generated diagnostics exceed entry limit")
-                  current = Path(directory)
-                  for name in dirnames:
-                      mode = os.lstat(current / name).st_mode
-                      if not stat.S_ISDIR(mode):
-                          raise SystemExit(
-                              "generated diagnostics contain a non-directory entry"
-                          )
-                  for name in sorted(filenames):
-                      source = current / name
-                      mode = os.lstat(source).st_mode
-                      if not stat.S_ISREG(mode):
-                          raise SystemExit(
-                              "generated diagnostics contain a non-regular file"
-                          )
-                      relative = source.relative_to(generated)
-                      if source.suffix.lower() not in allowed_suffixes:
-                          continue
-                      if len(inventory) >= max_files:
-                          raise SystemExit("generated diagnostics exceed file limit")
-                      try:
-                          payload = read_bounded_regular_file(
-                              generated,
-                              source,
-                              label="failed re-encode diagnostic",
-                              max_bytes=max_file_bytes,
-                          )
-                      except UnsafeCorpusPathError as exc:
-                          raise SystemExit(str(exc)) from exc
-                      total_bytes += len(payload)
-                      if total_bytes > max_total_bytes:
-                          raise SystemExit("generated diagnostics exceed size limit")
-                      destination = artifact / "generated" / relative
-                      destination.parent.mkdir(parents=True, exist_ok=True)
-                      destination.write_bytes(payload)
-                      inventory.append(
-                          {
-                              "path": relative.as_posix(),
-                              "sha256": hashlib.sha256(payload).hexdigest(),
-                              "size": len(payload),
-                          }
-                      )
-
-          inventory.sort(key=lambda item: item["path"])
-          metadata = {
-              "schema": "axiom-encode/failed-reencode-diagnostics/v1",
-              "citation": os.environ["CITATION"],
-              "corpus_ref": os.environ["CORPUS_REF"],
-              "encoder_commit": os.environ["GITHUB_SHA"],
-              "files": inventory,
-              "rules_engine_ref": os.environ["RULES_ENGINE_REF"],
-              "rulespec_ref": os.environ["RULESPEC_REF"],
-              "workflow_run_attempt": int(os.environ["GITHUB_RUN_ATTEMPT"]),
-              "workflow_run_id": os.environ["GITHUB_RUN_ID"],
-          }
-          (artifact / "metadata.json").write_text(
-              json.dumps(metadata, indent=2, sort_keys=True) + "\n",
-              encoding="utf-8",
-          )
-          PY
-
-      - name: Upload failed re-encode diagnostics
-        if: >-
-          ${{ failure() && !cancelled()
-              && steps.package_failed_reencode_diagnostics.outcome == 'success' }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: targeted-reencode-failure-${{ github.run_id }}
-          path: ${{ runner.temp }}/targeted-reencode-failure
-          if-no-files-found: error
-          retention-days: 90
-
       - name: Verify generated provenance
+        id: verify_generated_provenance
         env:
           RULESPEC_CHECKOUT: ${{ github.workspace }}/rulespec-${{ inputs.country }}
           RULESPEC_REF: ${{ inputs.rulespec_ref }}
@@ -1284,6 +1165,7 @@ jobs:
           git -C "$RULESPEC_CHECKOUT" diff --check
 
       - name: Verify existing signed import integrity
+        id: verify_existing_signed_import_integrity
         env:
           RULESPEC_CHECKOUT: ${{ github.workspace }}/rulespec-${{ inputs.country }}
           RULESPEC_REF: ${{ inputs.rulespec_ref }}
@@ -1318,6 +1200,7 @@ jobs:
             "$RUNNER_TEMP/existing-signed-import-inventory-final.json"
 
       - name: Package exact generated changes
+        id: package_exact_generated_changes
         env:
           CITATION: ${{ inputs.citation }}
           DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
@@ -2321,6 +2204,7 @@ jobs:
           test -s "$artifact/status.txt"
 
       - name: Commit reviewed lane changes locally
+        id: commit_reviewed_lane_changes
         if: ${{ inputs.open_pr }}
         env:
           COUNTRY: ${{ inputs.country }}
@@ -2351,6 +2235,7 @@ jobs:
           fi
 
       - name: Push lane branch and open draft pull request
+        id: publish_lane_pull_request
         if: ${{ inputs.open_pr }}
         env:
           GH_TOKEN: ${{ secrets.AXIOM_REPO_TOKEN }}
@@ -2436,6 +2321,7 @@ jobs:
             "$RUNNER_TEMP/targeted-reencode/lane-pull-request.json"
 
       - name: Finalize signed re-encode artifact checksums
+        id: finalize_signed_reencode_artifact
         run: |
           set -euo pipefail
           artifact="$RUNNER_TEMP/targeted-reencode"
@@ -2445,9 +2331,218 @@ jobs:
           )
 
       - name: Upload signed re-encode artifact
+        id: upload_signed_reencode_artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: targeted-reencode-${{ github.run_id }}
+          name: targeted-reencode-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/targeted-reencode
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Package failed re-encode diagnostics
+        id: package_failed_reencode_diagnostics
+        if: ${{ failure() && !cancelled() }}
+        env:
+          CITATION: ${{ inputs.citation }}
+          CORPUS_REF: ${{ inputs.corpus_ref }}
+          COUNTRY: ${{ inputs.country }}
+          DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
+          EXISTING_SIGNED_IMPORTS_JSON: ${{ inputs.existing_signed_imports_json }}
+          LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.legacy_exact_dependent_rulespec_path }}
+          OPEN_PR: ${{ inputs.open_pr }}
+          PR_BASE_BRANCH: ${{ inputs.pr_base_branch }}
+          QUEUE_DISPATCHER_RUN_ID: ${{ inputs.queue_dispatcher_run_id }}
+          QUEUE_ID: ${{ inputs.queue_id }}
+          QUEUE_ITEM_GENERATION_SHA256: ${{ inputs.queue_item_generation_sha256 }}
+          QUEUE_ITEM_ID: ${{ inputs.queue_item_id }}
+          QUEUE_MANIFEST_SHA256: ${{ inputs.queue_manifest_sha256 }}
+          REPLACE_LEGACY_RULESPEC_PATH: ${{ inputs.replace_legacy_rulespec_path }}
+          REPLACE_RULESPEC_PATH: ${{ inputs.replace_rulespec_path }}
+          RULES_ENGINE_REF: ${{ inputs.rules_engine_ref }}
+          RULESPEC_REF: ${{ inputs.rulespec_ref }}
+          SECOND_DEPENDENT_CITATION: ${{ inputs.second_dependent_citation }}
+          SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.second_legacy_exact_dependent_rulespec_path }}
+          SOURCE_BUNDLE_JSON: ${{ inputs.source_bundle_json }}
+          STEP_CONTEXT_JSON: ${{ toJSON(steps) }}
+        run: |
+          set -euo pipefail
+          generated="$RUNNER_TEMP/generated"
+          artifact="$RUNNER_TEMP/targeted-reencode-failure"
+          mkdir -p "$artifact"
+          /opt/axiom-verification/python/bin/python -I - \
+            "$generated" "$artifact" <<'PY'
+          import hashlib
+          import json
+          import os
+          import stat
+          import sys
+          from pathlib import Path
+
+          from axiom_encode.corpus_resolver import (
+              UnsafeCorpusPathError,
+              read_bounded_regular_file,
+          )
+
+          generated = Path(os.path.abspath(sys.argv[1]))
+          artifact = Path(os.path.abspath(sys.argv[2]))
+          allowed_suffixes = {".json", ".log", ".txt", ".yaml", ".yml"}
+          max_entries = 4096
+          max_files = 1024
+          max_file_bytes = 16 * 1024 * 1024
+          max_total_bytes = 64 * 1024 * 1024
+          entry_count = 0
+          total_bytes = 0
+          inventory = []
+
+          if generated.exists():
+              root_stat = os.lstat(generated)
+              if not stat.S_ISDIR(root_stat.st_mode):
+                  raise SystemExit("generated diagnostic root is not a directory")
+              for directory, dirnames, filenames in os.walk(
+                  generated,
+                  topdown=True,
+                  followlinks=False,
+              ):
+                  entry_count += len(dirnames) + len(filenames)
+                  if entry_count > max_entries:
+                      raise SystemExit("generated diagnostics exceed entry limit")
+                  current = Path(directory)
+                  for name in dirnames:
+                      mode = os.lstat(current / name).st_mode
+                      if not stat.S_ISDIR(mode):
+                          raise SystemExit(
+                              "generated diagnostics contain a non-directory entry"
+                          )
+                  for name in sorted(filenames):
+                      source = current / name
+                      mode = os.lstat(source).st_mode
+                      if not stat.S_ISREG(mode):
+                          raise SystemExit(
+                              "generated diagnostics contain a non-regular file"
+                          )
+                      relative = source.relative_to(generated)
+                      if source.suffix.lower() not in allowed_suffixes:
+                          continue
+                      if len(inventory) >= max_files:
+                          raise SystemExit("generated diagnostics exceed file limit")
+                      try:
+                          payload = read_bounded_regular_file(
+                              generated,
+                              source,
+                              label="failed re-encode diagnostic",
+                              max_bytes=max_file_bytes,
+                          )
+                      except UnsafeCorpusPathError as exc:
+                          raise SystemExit(str(exc)) from exc
+                      total_bytes += len(payload)
+                      if total_bytes > max_total_bytes:
+                          raise SystemExit("generated diagnostics exceed size limit")
+                      destination = artifact / "generated" / relative
+                      destination.parent.mkdir(parents=True, exist_ok=True)
+                      destination.write_bytes(payload)
+                      inventory.append(
+                          {
+                              "path": relative.as_posix(),
+                              "sha256": hashlib.sha256(payload).hexdigest(),
+                              "size": len(payload),
+                          }
+                      )
+
+          inventory.sort(key=lambda item: item["path"])
+          raw_step_context = json.loads(os.environ["STEP_CONTEXT_JSON"])
+          if not isinstance(raw_step_context, dict):
+              raise SystemExit("workflow step context is malformed")
+          step_outcomes = {}
+          for step_id, payload in sorted(raw_step_context.items()):
+              if not isinstance(step_id, str) or not isinstance(payload, dict):
+                  raise SystemExit("workflow step context entry is malformed")
+              outcome = payload.get("outcome")
+              conclusion = payload.get("conclusion")
+              if outcome is not None and not isinstance(outcome, str):
+                  raise SystemExit("workflow step outcome is malformed")
+              if conclusion is not None and not isinstance(conclusion, str):
+                  raise SystemExit("workflow step conclusion is malformed")
+              step_outcomes[step_id] = {
+                  "conclusion": conclusion,
+                  "outcome": outcome,
+              }
+          failed_steps = sorted(
+              step_id
+              for step_id, payload in step_outcomes.items()
+              if "failure" in {payload["outcome"], payload["conclusion"]}
+          )
+          generated_lanes = sorted(
+              {
+                  Path(item["path"]).parts[0]
+                  for item in inventory
+                  if len(Path(item["path"]).parts) > 1
+              }
+          )
+          metadata = {
+              "schema": "axiom-encode/failed-reencode-diagnostics/v1",
+              "citation": os.environ["CITATION"],
+              "corpus_ref": os.environ["CORPUS_REF"],
+              "country": os.environ["COUNTRY"],
+              "dependent_citation": os.environ.get("DEPENDENT_CITATION") or None,
+              "encoder_commit": os.environ["GITHUB_SHA"],
+              "existing_signed_imports_input": os.environ.get(
+                  "EXISTING_SIGNED_IMPORTS_JSON", "[]"
+              ),
+              "failed_steps": failed_steps,
+              "files": inventory,
+              "generated_lanes": generated_lanes,
+              "legacy_exact_dependent_rulespec_path": os.environ.get(
+                  "LEGACY_EXACT_DEPENDENT_RULESPEC_PATH"
+              )
+              or None,
+              "open_pr": os.environ.get("OPEN_PR") == "true",
+              "pr_base_branch": os.environ.get("PR_BASE_BRANCH") or None,
+              "queue_dispatcher_run_id": os.environ.get(
+                  "QUEUE_DISPATCHER_RUN_ID"
+              )
+              or None,
+              "queue_id": os.environ.get("QUEUE_ID") or None,
+              "queue_item_generation_sha256": os.environ.get(
+                  "QUEUE_ITEM_GENERATION_SHA256"
+              )
+              or None,
+              "queue_item_id": os.environ.get("QUEUE_ITEM_ID") or None,
+              "queue_manifest_sha256": os.environ.get("QUEUE_MANIFEST_SHA256")
+              or None,
+              "replace_legacy_rulespec_path": os.environ.get(
+                  "REPLACE_LEGACY_RULESPEC_PATH"
+              )
+              or None,
+              "replace_rulespec_path": os.environ.get("REPLACE_RULESPEC_PATH")
+              or None,
+              "rules_engine_ref": os.environ["RULES_ENGINE_REF"],
+              "rulespec_ref": os.environ["RULESPEC_REF"],
+              "second_dependent_citation": os.environ.get(
+                  "SECOND_DEPENDENT_CITATION"
+              )
+              or None,
+              "second_legacy_exact_dependent_rulespec_path": os.environ.get(
+                  "SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH"
+              )
+              or None,
+              "source_bundle_input": os.environ.get("SOURCE_BUNDLE_JSON", "[]"),
+              "step_outcomes": step_outcomes,
+              "workflow_run_attempt": int(os.environ["GITHUB_RUN_ATTEMPT"]),
+              "workflow_run_id": os.environ["GITHUB_RUN_ID"],
+          }
+          (artifact / "metadata.json").write_text(
+              json.dumps(metadata, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Upload failed re-encode diagnostics
+        if: >-
+          ${{ failure() && !cancelled()
+              && steps.package_failed_reencode_diagnostics.outcome == 'success' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: targeted-reencode-failure-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/targeted-reencode-failure
           if-no-files-found: error
           retention-days: 90

--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -1140,6 +1140,127 @@ jobs:
               "Compose signed source bundle for ${CITATION}"
           fi
 
+      - name: Package failed re-encode diagnostics
+        id: package_failed_reencode_diagnostics
+        if: ${{ failure() && !cancelled() }}
+        env:
+          CITATION: ${{ inputs.citation }}
+          CORPUS_REF: ${{ inputs.corpus_ref }}
+          RULES_ENGINE_REF: ${{ inputs.rules_engine_ref }}
+          RULESPEC_REF: ${{ inputs.rulespec_ref }}
+        run: |
+          set -euo pipefail
+          generated="$RUNNER_TEMP/generated"
+          artifact="$RUNNER_TEMP/targeted-reencode-failure"
+          mkdir -p "$artifact"
+          /opt/axiom-verification/python/bin/python -I - \
+            "$generated" "$artifact" <<'PY'
+          import hashlib
+          import json
+          import os
+          import stat
+          import sys
+          from pathlib import Path
+
+          from axiom_encode.corpus_resolver import (
+              UnsafeCorpusPathError,
+              read_bounded_regular_file,
+          )
+
+          generated = Path(os.path.abspath(sys.argv[1]))
+          artifact = Path(os.path.abspath(sys.argv[2]))
+          allowed_suffixes = {".json", ".log", ".txt", ".yaml", ".yml"}
+          max_entries = 4096
+          max_files = 1024
+          max_file_bytes = 16 * 1024 * 1024
+          max_total_bytes = 64 * 1024 * 1024
+          entry_count = 0
+          total_bytes = 0
+          inventory = []
+
+          if generated.exists():
+              root_stat = os.lstat(generated)
+              if not stat.S_ISDIR(root_stat.st_mode):
+                  raise SystemExit("generated diagnostic root is not a directory")
+              for directory, dirnames, filenames in os.walk(
+                  generated,
+                  topdown=True,
+                  followlinks=False,
+              ):
+                  entry_count += len(dirnames) + len(filenames)
+                  if entry_count > max_entries:
+                      raise SystemExit("generated diagnostics exceed entry limit")
+                  current = Path(directory)
+                  for name in dirnames:
+                      mode = os.lstat(current / name).st_mode
+                      if not stat.S_ISDIR(mode):
+                          raise SystemExit(
+                              "generated diagnostics contain a non-directory entry"
+                          )
+                  for name in sorted(filenames):
+                      source = current / name
+                      mode = os.lstat(source).st_mode
+                      if not stat.S_ISREG(mode):
+                          raise SystemExit(
+                              "generated diagnostics contain a non-regular file"
+                          )
+                      relative = source.relative_to(generated)
+                      if source.suffix.lower() not in allowed_suffixes:
+                          continue
+                      if len(inventory) >= max_files:
+                          raise SystemExit("generated diagnostics exceed file limit")
+                      try:
+                          payload = read_bounded_regular_file(
+                              generated,
+                              source,
+                              label="failed re-encode diagnostic",
+                              max_bytes=max_file_bytes,
+                          )
+                      except UnsafeCorpusPathError as exc:
+                          raise SystemExit(str(exc)) from exc
+                      total_bytes += len(payload)
+                      if total_bytes > max_total_bytes:
+                          raise SystemExit("generated diagnostics exceed size limit")
+                      destination = artifact / "generated" / relative
+                      destination.parent.mkdir(parents=True, exist_ok=True)
+                      destination.write_bytes(payload)
+                      inventory.append(
+                          {
+                              "path": relative.as_posix(),
+                              "sha256": hashlib.sha256(payload).hexdigest(),
+                              "size": len(payload),
+                          }
+                      )
+
+          inventory.sort(key=lambda item: item["path"])
+          metadata = {
+              "schema": "axiom-encode/failed-reencode-diagnostics/v1",
+              "citation": os.environ["CITATION"],
+              "corpus_ref": os.environ["CORPUS_REF"],
+              "encoder_commit": os.environ["GITHUB_SHA"],
+              "files": inventory,
+              "rules_engine_ref": os.environ["RULES_ENGINE_REF"],
+              "rulespec_ref": os.environ["RULESPEC_REF"],
+              "workflow_run_attempt": int(os.environ["GITHUB_RUN_ATTEMPT"]),
+              "workflow_run_id": os.environ["GITHUB_RUN_ID"],
+          }
+          (artifact / "metadata.json").write_text(
+              json.dumps(metadata, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Upload failed re-encode diagnostics
+        if: >-
+          ${{ failure() && !cancelled()
+              && steps.package_failed_reencode_diagnostics.outcome == 'success' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: targeted-reencode-failure-${{ github.run_id }}
+          path: ${{ runner.temp }}/targeted-reencode-failure
+          if-no-files-found: error
+          retention-days: 90
+
       - name: Verify generated provenance
         env:
           RULESPEC_CHECKOUT: ${{ github.workspace }}/rulespec-${{ inputs.country }}

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2119,6 +2119,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         for step in steps
         if step.get("name") == "Encode, review, validate, and apply"
     )
+    assert apply_step["id"] == "encode_apply"
     assert apply_step["env"]["AXIOM_ENCODE_APPLY_SIGNING_KEY"] == (
         "${{ secrets.AXIOM_ENCODE_APPLY_SIGNING_KEY }}"
     )
@@ -2189,14 +2190,38 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         for step in steps
         if step.get("name") == "Package failed re-encode diagnostics"
     )
-    assert steps.index(apply_step) + 1 == steps.index(failure_package_step)
+    assert steps.index(
+        upload_step := next(
+            step
+            for step in steps
+            if step.get("name") == "Upload signed re-encode artifact"
+        )
+    ) + 1 == steps.index(failure_package_step)
     assert failure_package_step["if"] == "${{ failure() && !cancelled() }}"
     assert set(failure_package_step["env"]) == {
         "CITATION",
         "CORPUS_REF",
+        "COUNTRY",
+        "DEPENDENT_CITATION",
+        "EXISTING_SIGNED_IMPORTS_JSON",
+        "LEGACY_EXACT_DEPENDENT_RULESPEC_PATH",
+        "OPEN_PR",
+        "PR_BASE_BRANCH",
+        "QUEUE_DISPATCHER_RUN_ID",
+        "QUEUE_ID",
+        "QUEUE_ITEM_GENERATION_SHA256",
+        "QUEUE_ITEM_ID",
+        "QUEUE_MANIFEST_SHA256",
+        "REPLACE_LEGACY_RULESPEC_PATH",
+        "REPLACE_RULESPEC_PATH",
         "RULES_ENGINE_REF",
         "RULESPEC_REF",
+        "SECOND_DEPENDENT_CITATION",
+        "SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH",
+        "SOURCE_BUNDLE_JSON",
+        "STEP_CONTEXT_JSON",
     }
+    assert failure_package_step["env"]["STEP_CONTEXT_JSON"] == "${{ toJSON(steps) }}"
     failure_package_command = failure_package_step["run"]
     assert "/opt/axiom-verification/python/bin/python -I -" in (failure_package_command)
     assert "read_bounded_regular_file" in failure_package_command
@@ -2204,6 +2229,10 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "generated diagnostics exceed entry limit" in failure_package_command
     assert "generated diagnostics exceed file limit" in failure_package_command
     assert "generated diagnostics exceed size limit" in failure_package_command
+    assert '"failed_steps": failed_steps' in failure_package_command
+    assert '"generated_lanes": generated_lanes' in failure_package_command
+    assert '"queue_item_generation_sha256"' in failure_package_command
+    assert '"step_outcomes": step_outcomes' in failure_package_command
     assert '"schema": "axiom-encode/failed-reencode-diagnostics/v1"' in (
         failure_package_command
     )
@@ -2220,7 +2249,9 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         in (failure_upload_step["if"])
     )
     assert failure_upload_step["with"] == {
-        "name": "targeted-reencode-failure-${{ github.run_id }}",
+        "name": (
+            "targeted-reencode-failure-${{ github.run_id }}-${{ github.run_attempt }}"
+        ),
         "path": "${{ runner.temp }}/targeted-reencode-failure",
         "if-no-files-found": "error",
         "retention-days": 90,
@@ -2231,6 +2262,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         for step in steps
         if step.get("name") == "Verify existing signed import integrity"
     )
+    assert integrity_step["id"] == "verify_existing_signed_import_integrity"
     integrity_command = integrity_step["run"]
     assert steps.index(apply_step) < steps.index(integrity_step)
     assert "signed-import-inventory" in integrity_command
@@ -2240,6 +2272,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     package_step = next(
         step for step in steps if step.get("name") == "Package exact generated changes"
     )
+    assert package_step["id"] == "package_exact_generated_changes"
     package_command = package_step["run"]
     assert package_step["env"]["REVIEW_FINDING_PRESENT"] == (
         "${{ inputs.review_finding != '' }}"
@@ -2297,6 +2330,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         for step in steps
         if step.get("name") == "Commit reviewed lane changes locally"
     )
+    assert commit_step["id"] == "commit_reviewed_lane_changes"
     assert f"workflow_python=({trusted_python} -I)" in commit_step["run"]
     assert '"${workflow_python[@]}" \\\n' in commit_step["run"]
     assert (
@@ -2307,6 +2341,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     guard_step = next(
         step for step in steps if step.get("name") == "Verify generated provenance"
     )
+    assert guard_step["id"] == "verify_generated_provenance"
     assert "guard-generated" in guard_step["run"]
     assert 'guard_ref_args+=(--base-ref "$RULESPEC_REF")' in guard_step["run"]
     assert (
@@ -2325,6 +2360,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         for step in steps
         if step.get("name") == "Push lane branch and open draft pull request"
     )
+    assert publish_step["id"] == "publish_lane_pull_request"
     assert publish_step["if"] == "${{ inputs.open_pr }}"
     assert publish_step["env"]["GH_TOKEN"] == "${{ secrets.AXIOM_REPO_TOKEN }}"
     assert publish_step["env"]["PR_BASE_BRANCH"] == ("${{ inputs.pr_base_branch }}")
@@ -2363,16 +2399,19 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         for step in steps
         if step.get("name") == "Finalize signed re-encode artifact checksums"
     )
+    assert checksum_step["id"] == "finalize_signed_reencode_artifact"
     assert "if" not in checksum_step
     checksum_command = checksum_step["run"]
     assert 'artifact="$RUNNER_TEMP/targeted-reencode"' in checksum_command
     assert 'cd "$artifact"' in checksum_command
     assert "sha256sum * > SHA256SUMS" in checksum_command
     assert 'sha256sum "$RUNNER_TEMP/targeted-reencode"/*' not in checksum_command
-    upload_step = next(
-        step for step in steps if step.get("name") == "Upload signed re-encode artifact"
+    assert upload_step["id"] == "upload_signed_reencode_artifact"
+    assert upload_step["with"]["name"] == (
+        "targeted-reencode-${{ github.run_id }}-${{ github.run_attempt }}"
     )
     assert steps.index(checksum_step) + 1 == steps.index(upload_step)
+    assert steps.index(failure_upload_step) == len(steps) - 1
 
 
 def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
@@ -2400,12 +2439,30 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
         **os.environ,
         "CITATION": "us/statute/42/1437c-1",
         "CORPUS_REF": "corpus-ref",
+        "COUNTRY": "us",
         "GITHUB_RUN_ATTEMPT": "1",
         "GITHUB_RUN_ID": "1234",
         "GITHUB_SHA": "encoder-ref",
         "RULES_ENGINE_REF": "rules-engine-ref",
         "RULESPEC_REF": "rulespec-ref",
         "RUNNER_TEMP": str(tmp_path),
+        "STEP_CONTEXT_JSON": json.dumps(
+            {
+                "encode_apply": {
+                    "conclusion": "failure",
+                    "outcome": "failure",
+                    "outputs": {"sensitive": "must-not-be-copied"},
+                },
+                "verify_generated_provenance": {
+                    "conclusion": "skipped",
+                    "outcome": "skipped",
+                },
+            }
+        ),
+        "QUEUE_ID": "us-snap-all-states-2026-07",
+        "QUEUE_ITEM_GENERATION_SHA256": "generation-sha",
+        "QUEUE_ITEM_ID": "us/statute/42/1437c-1",
+        "QUEUE_MANIFEST_SHA256": "manifest-sha",
     }
 
     subprocess.run(["bash", "-c", command], env=env, check=True)
@@ -2421,6 +2478,19 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
     metadata = json.loads((artifact / "metadata.json").read_text())
     assert metadata["schema"] == "axiom-encode/failed-reencode-diagnostics/v1"
     assert metadata["workflow_run_id"] == "1234"
+    assert metadata["failed_steps"] == ["encode_apply"]
+    assert metadata["generated_lanes"] == ["target"]
+    assert metadata["queue_id"] == "us-snap-all-states-2026-07"
+    assert metadata["queue_item_generation_sha256"] == "generation-sha"
+    assert metadata["queue_item_id"] == "us/statute/42/1437c-1"
+    assert metadata["queue_manifest_sha256"] == "manifest-sha"
+    assert metadata["step_outcomes"] == {
+        "encode_apply": {"conclusion": "failure", "outcome": "failure"},
+        "verify_generated_provenance": {
+            "conclusion": "skipped",
+            "outcome": "skipped",
+        },
+    }
     assert [item["path"] for item in metadata["files"]] == [
         "target/model/statutes/target.yaml",
         "target/model/target.repair.json",
@@ -2451,12 +2521,21 @@ def test_targeted_signed_reencode_rejects_symlinked_failure_diagnostics(
         **os.environ,
         "CITATION": "us/statute/42/1437c-1",
         "CORPUS_REF": "corpus-ref",
+        "COUNTRY": "us",
         "GITHUB_RUN_ATTEMPT": "1",
         "GITHUB_RUN_ID": "1234",
         "GITHUB_SHA": "encoder-ref",
         "RULES_ENGINE_REF": "rules-engine-ref",
         "RULESPEC_REF": "rulespec-ref",
         "RUNNER_TEMP": str(tmp_path),
+        "STEP_CONTEXT_JSON": json.dumps(
+            {
+                "encode_apply": {
+                    "conclusion": "failure",
+                    "outcome": "failure",
+                }
+            }
+        ),
     }
 
     completed = subprocess.run(

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2184,6 +2184,48 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert steps.index(cascade_step) < steps.index(apply_step)
     assert steps.index(signed_import_step) < steps.index(apply_step)
 
+    failure_package_step = next(
+        step
+        for step in steps
+        if step.get("name") == "Package failed re-encode diagnostics"
+    )
+    assert steps.index(apply_step) + 1 == steps.index(failure_package_step)
+    assert failure_package_step["if"] == "${{ failure() && !cancelled() }}"
+    assert set(failure_package_step["env"]) == {
+        "CITATION",
+        "CORPUS_REF",
+        "RULES_ENGINE_REF",
+        "RULESPEC_REF",
+    }
+    failure_package_command = failure_package_step["run"]
+    assert "/opt/axiom-verification/python/bin/python -I -" in (failure_package_command)
+    assert "read_bounded_regular_file" in failure_package_command
+    assert "followlinks=False" in failure_package_command
+    assert "generated diagnostics exceed entry limit" in failure_package_command
+    assert "generated diagnostics exceed file limit" in failure_package_command
+    assert "generated diagnostics exceed size limit" in failure_package_command
+    assert '"schema": "axiom-encode/failed-reencode-diagnostics/v1"' in (
+        failure_package_command
+    )
+
+    failure_upload_step = next(
+        step
+        for step in steps
+        if step.get("name") == "Upload failed re-encode diagnostics"
+    )
+    assert steps.index(failure_package_step) + 1 == steps.index(failure_upload_step)
+    assert "failure() && !cancelled()" in failure_upload_step["if"]
+    assert (
+        "steps.package_failed_reencode_diagnostics.outcome == 'success'"
+        in (failure_upload_step["if"])
+    )
+    assert failure_upload_step["with"] == {
+        "name": "targeted-reencode-failure-${{ github.run_id }}",
+        "path": "${{ runner.temp }}/targeted-reencode-failure",
+        "if-no-files-found": "error",
+        "retention-days": 90,
+    }
+
     integrity_step = next(
         step
         for step in steps
@@ -2331,6 +2373,104 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         step for step in steps if step.get("name") == "Upload signed re-encode artifact"
     )
     assert steps.index(checksum_step) + 1 == steps.index(upload_step)
+
+
+def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
+    tmp_path: Path,
+) -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
+    )
+    step = next(
+        item
+        for item in workflow["jobs"]["encode"]["steps"]
+        if item.get("name") == "Package failed re-encode diagnostics"
+    )
+    command = step["run"].replace(
+        "/opt/axiom-verification/python/bin/python",
+        sys.executable,
+    )
+    generated = tmp_path / "generated" / "target" / "model"
+    generated.mkdir(parents=True)
+    (generated / "statutes").mkdir()
+    (generated / "statutes/target.yaml").write_text("format: rulespec/v1\n")
+    (generated / "target.repair.json").write_text('{"outcome": "blocked"}\n')
+    (generated / "ignored.bin").write_bytes(b"not diagnostic output")
+    env = {
+        **os.environ,
+        "CITATION": "us/statute/42/1437c-1",
+        "CORPUS_REF": "corpus-ref",
+        "GITHUB_RUN_ATTEMPT": "1",
+        "GITHUB_RUN_ID": "1234",
+        "GITHUB_SHA": "encoder-ref",
+        "RULES_ENGINE_REF": "rules-engine-ref",
+        "RULESPEC_REF": "rulespec-ref",
+        "RUNNER_TEMP": str(tmp_path),
+    }
+
+    subprocess.run(["bash", "-c", command], env=env, check=True)
+
+    artifact = tmp_path / "targeted-reencode-failure"
+    assert (
+        artifact / "generated/target/model/statutes/target.yaml"
+    ).read_text() == "format: rulespec/v1\n"
+    assert json.loads(
+        (artifact / "generated/target/model/target.repair.json").read_text()
+    ) == {"outcome": "blocked"}
+    assert not (artifact / "generated/target/model/ignored.bin").exists()
+    metadata = json.loads((artifact / "metadata.json").read_text())
+    assert metadata["schema"] == "axiom-encode/failed-reencode-diagnostics/v1"
+    assert metadata["workflow_run_id"] == "1234"
+    assert [item["path"] for item in metadata["files"]] == [
+        "target/model/statutes/target.yaml",
+        "target/model/target.repair.json",
+    ]
+
+
+def test_targeted_signed_reencode_rejects_symlinked_failure_diagnostics(
+    tmp_path: Path,
+) -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
+    )
+    step = next(
+        item
+        for item in workflow["jobs"]["encode"]["steps"]
+        if item.get("name") == "Package failed re-encode diagnostics"
+    )
+    command = step["run"].replace(
+        "/opt/axiom-verification/python/bin/python",
+        sys.executable,
+    )
+    generated = tmp_path / "generated"
+    generated.mkdir()
+    outside = tmp_path / "outside.yaml"
+    outside.write_text("secret\n")
+    (generated / "candidate.yaml").symlink_to(outside)
+    env = {
+        **os.environ,
+        "CITATION": "us/statute/42/1437c-1",
+        "CORPUS_REF": "corpus-ref",
+        "GITHUB_RUN_ATTEMPT": "1",
+        "GITHUB_RUN_ID": "1234",
+        "GITHUB_SHA": "encoder-ref",
+        "RULES_ENGINE_REF": "rules-engine-ref",
+        "RULESPEC_REF": "rulespec-ref",
+        "RUNNER_TEMP": str(tmp_path),
+    }
+
+    completed = subprocess.run(
+        ["bash", "-c", command],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert "non-regular file" in completed.stderr
+    assert not (
+        tmp_path / "targeted-reencode-failure/generated/candidate.yaml"
+    ).exists()
 
 
 def test_signed_snap_queue_dispatcher_is_bounded_and_idempotent() -> None:

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2203,10 +2203,21 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         "CORPUS_REF",
         "COUNTRY",
         "DEPENDENT_CITATION",
+        "ENCODE_APPLY_CONCLUSION",
+        "ENCODE_APPLY_OUTCOME",
         "EXISTING_SIGNED_IMPORTS_JSON",
+        "FINALIZE_SIGNED_REENCODE_ARTIFACT_CONCLUSION",
+        "FINALIZE_SIGNED_REENCODE_ARTIFACT_OUTCOME",
         "LEGACY_EXACT_DEPENDENT_RULESPEC_PATH",
+        "LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON",
         "OPEN_PR",
+        "PACKAGE_EXACT_GENERATED_CHANGES_CONCLUSION",
+        "PACKAGE_EXACT_GENERATED_CHANGES_OUTCOME",
+        "COMMIT_REVIEWED_LANE_CHANGES_CONCLUSION",
+        "COMMIT_REVIEWED_LANE_CHANGES_OUTCOME",
         "PR_BASE_BRANCH",
+        "PUBLISH_LANE_PULL_REQUEST_CONCLUSION",
+        "PUBLISH_LANE_PULL_REQUEST_OUTCOME",
         "QUEUE_DISPATCHER_RUN_ID",
         "QUEUE_ID",
         "QUEUE_ITEM_GENERATION_SHA256",
@@ -2219,9 +2230,15 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         "SECOND_DEPENDENT_CITATION",
         "SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH",
         "SOURCE_BUNDLE_JSON",
-        "STEP_CONTEXT_JSON",
+        "UPLOAD_SIGNED_REENCODE_ARTIFACT_CONCLUSION",
+        "UPLOAD_SIGNED_REENCODE_ARTIFACT_OUTCOME",
+        "VERIFY_EXISTING_SIGNED_IMPORT_INTEGRITY_CONCLUSION",
+        "VERIFY_EXISTING_SIGNED_IMPORT_INTEGRITY_OUTCOME",
+        "VERIFY_GENERATED_PROVENANCE_CONCLUSION",
+        "VERIFY_GENERATED_PROVENANCE_OUTCOME",
     }
-    assert failure_package_step["env"]["STEP_CONTEXT_JSON"] == "${{ toJSON(steps) }}"
+    assert "toJSON(steps)" not in json.dumps(failure_package_step)
+    assert ".outputs" not in json.dumps(failure_package_step["env"])
     failure_package_command = failure_package_step["run"]
     assert "/opt/axiom-verification/python/bin/python -I -" in (failure_package_command)
     assert "read_bounded_regular_file" in failure_package_command
@@ -2443,22 +2460,14 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
         "GITHUB_RUN_ATTEMPT": "1",
         "GITHUB_RUN_ID": "1234",
         "GITHUB_SHA": "encoder-ref",
+        "ENCODE_APPLY_CONCLUSION": "failure",
+        "ENCODE_APPLY_OUTCOME": "failure",
+        "LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON": '["us/statutes/old.yaml"]',
         "RULES_ENGINE_REF": "rules-engine-ref",
         "RULESPEC_REF": "rulespec-ref",
         "RUNNER_TEMP": str(tmp_path),
-        "STEP_CONTEXT_JSON": json.dumps(
-            {
-                "encode_apply": {
-                    "conclusion": "failure",
-                    "outcome": "failure",
-                    "outputs": {"sensitive": "must-not-be-copied"},
-                },
-                "verify_generated_provenance": {
-                    "conclusion": "skipped",
-                    "outcome": "skipped",
-                },
-            }
-        ),
+        "VERIFY_GENERATED_PROVENANCE_CONCLUSION": "skipped",
+        "VERIFY_GENERATED_PROVENANCE_OUTCOME": "skipped",
         "QUEUE_ID": "us-snap-all-states-2026-07",
         "QUEUE_ITEM_GENERATION_SHA256": "generation-sha",
         "QUEUE_ITEM_ID": "us/statute/42/1437c-1",
@@ -2480,6 +2489,9 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
     assert metadata["workflow_run_id"] == "1234"
     assert metadata["failed_steps"] == ["encode_apply"]
     assert metadata["generated_lanes"] == ["target"]
+    assert metadata["legacy_retained_successor_rulespec_paths_input"] == (
+        '["us/statutes/old.yaml"]'
+    )
     assert metadata["queue_id"] == "us-snap-all-states-2026-07"
     assert metadata["queue_item_generation_sha256"] == "generation-sha"
     assert metadata["queue_item_id"] == "us/statute/42/1437c-1"
@@ -2525,17 +2537,11 @@ def test_targeted_signed_reencode_rejects_symlinked_failure_diagnostics(
         "GITHUB_RUN_ATTEMPT": "1",
         "GITHUB_RUN_ID": "1234",
         "GITHUB_SHA": "encoder-ref",
+        "ENCODE_APPLY_CONCLUSION": "failure",
+        "ENCODE_APPLY_OUTCOME": "failure",
         "RULES_ENGINE_REF": "rules-engine-ref",
         "RULESPEC_REF": "rulespec-ref",
         "RUNNER_TEMP": str(tmp_path),
-        "STEP_CONTEXT_JSON": json.dumps(
-            {
-                "encode_apply": {
-                    "conclusion": "failure",
-                    "outcome": "failure",
-                }
-            }
-        ),
     }
 
     completed = subprocess.run(


### PR DESCRIPTION
## Summary
- package bounded generated YAML/JSON/log/text diagnostics whenever targeted signed re-encoding fails
- run the collector as the terminal failure handler and use run-attempt-specific artifact names
- record sanitized step outcomes plus queue, lane, dependency, and pinned provenance metadata
- reject symlinks, non-regular entries, oversized files, and oversized trees before upload
- add workflow contract and runtime security tests

## Why
The protected repair run for `us/statute/42/1437c–1` failed closed, but its generated candidates and traces were discarded because normal artifact packaging was success-only. This preserves evidence needed for encoder repair without exposing signing secrets or weakening failure behavior.

## Verification
- `uv run --python 3.13 ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run --python 3.13 ruff format --check src/axiom_encode tests`
- `python3.13 -m compileall -q src/axiom_encode scripts`
- `uv run --python 3.13 pytest tests/test_signing_supervisor.py tests/test_signed_apply_reusable.py` (58 passed, 51 skipped)
- `uv run --python 3.13 pytest` (6,268 passed, 119 skipped)

## Cycle
First exact-head review found three actionable persistence/provenance issues. All were fixed and retested. Second independent review is pending at rebased exact head `55837362`.