### PR TITLE
Fix NJ source structure classification

### DIFF
--- a/changelog.d/named-code-edition-numeric-recall.fixed.md
+++ b/changelog.d/named-code-edition-numeric-recall.fixed.md
@@ -1,0 +1,1 @@
+Treat formal Internal Revenue Code edition years as structural, prevent title-54A citations from becoming German sentence markers, and exclude head-of-household filing status from Household unit detection.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1445"
+version = "0.2.1446"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1445"
+__version__ = "0.2.1446"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -168,7 +168,7 @@ _LETTER_MARKER = re.compile(
     r"(?m)^[ \t]*(?P<marker>(?P<label>[a-z]{1,2})\))[ \t]+",
     flags=re.IGNORECASE,
 )
-_GLUED_SENTENCE_MARKER = re.compile(r"(?<![\w])(?P<label>[1-9]\d?)(?=[A-ZÄÖÜ])")
+_GLUED_SENTENCE_MARKER = re.compile(r"(?<![\w])(?P<label>[1-9]\d?)(?=[A-ZÄÖÜ](?!:))")
 _EXPLICIT_SENTENCE_MARKER = re.compile(
     r"(?:(?<=^)|(?<=[.;])|(?<=\)))[ \t]*Satz[ \t]+"
     r"(?P<label>[1-9]\d?)(?:[ \t]*:[ \t]*|[ \t]+)(?=[A-ZÄÖÜ])",

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -1182,6 +1182,10 @@ _STRUCTURAL_SOURCE_CODE_CITATION_PATTERN = re.compile(
     r"""(?=$|[\s,.;:)\]}\'"”’–—])""",
     re.IGNORECASE,
 )
+_STRUCTURAL_SOURCE_CODE_EDITION_PATTERN = re.compile(
+    r"\b(?:federal\s+)?Internal Revenue Code\s+of\s+(?:19|20)\d{2}\b",
+    re.IGNORECASE,
+)
 _STRUCTURAL_SOURCE_STATE_CODE_CITATION_TARGET = (
     r"\d+[A-Za-z]?:\d+[A-Za-z]?-\d+[A-Za-z]?(?:\.\d+)*"
     r"(?:\([A-Za-z0-9]+\)[A-Za-z0-9]*)*"
@@ -5028,6 +5032,7 @@ def _clean_source_text_for_numeric_extraction(text: str) -> str:
     cleaned = _STRUCTURAL_SOURCE_FORM_NUMBER_PATTERN.sub(" ", cleaned)
     cleaned = _STRUCTURAL_SOURCE_FORM_LINE_PATTERN.sub(" ", cleaned)
     cleaned = _STRUCTURAL_SOURCE_CODE_CITATION_PATTERN.sub(" ", cleaned)
+    cleaned = _STRUCTURAL_SOURCE_CODE_EDITION_PATTERN.sub(" ", cleaned)
     cleaned = _STRUCTURAL_SOURCE_STATE_CODE_CITATION_PATTERN.sub(" ", cleaned)
     cleaned = _STRUCTURAL_SOURCE_BARE_DOTTED_REFERENCE_PATTERN.sub(" ", cleaned)
     cleaned = _STRUCTURAL_SOURCE_SECTION_PATTERN.sub(" ", cleaned)
@@ -12280,17 +12285,28 @@ _PERSON_SCOPE_SOURCE_PATTERN = re.compile(
     r"allowed\s+(?:a\s+)?credit)",
     flags=re.IGNORECASE,
 )
+_HEAD_OF_HOUSEHOLD_FILING_STATUS_PATTERN = re.compile(
+    r"\bhead(?:\s+|\s*[-‐‑‒–—―−]\s*)of"
+    r"(?:\s+|\s*[-‐‑‒–—―−]\s*)household\b",
+    flags=re.IGNORECASE,
+)
+_HOUSEHOLD_UNIT_SOURCE_TOKEN = r"\bhousehold\b(?!\s+member\b)"
 _UNIT_SCOPE_SOURCE_PATTERN = re.compile(
-    r"\b(?:household\b(?!\s+member\b)|snap\s+unit|food\s+assistance\s+unit|"
-    r"assistance\s+unit|tax\s+unit|filing\s+unit|family\b(?!\s+member\b)|"
-    r"spm\s+unit)\b"
+    r"(?:"
+    + _HOUSEHOLD_UNIT_SOURCE_TOKEN
+    + r"|\bsnap\s+unit|\bfood\s+assistance\s+unit|"
+    r"\bassistance\s+unit|\btax\s+unit|\bfiling\s+unit|"
+    r"\bfamily\b(?!\s+member\b)|\bspm\s+unit\b)"
     r"[\s\S]{0,180}\b"
     r"(?:eligible|eligibility|test|requirement|resources?|income|standard|"
     r"benefit|allotment)\b",
     flags=re.IGNORECASE,
 )
 _UNIT_SOURCE_ENTITY_PATTERNS = (
-    ("household", re.compile(r"\bhousehold\b(?!\s+member\b)", flags=re.IGNORECASE)),
+    (
+        "household",
+        re.compile(_HOUSEHOLD_UNIT_SOURCE_TOKEN, flags=re.IGNORECASE),
+    ),
     (
         "snapunit",
         re.compile(r"\b(?:snap|food\s+assistance)\s+unit\b", flags=re.IGNORECASE),
@@ -12515,14 +12531,22 @@ def find_empty_rules_module_issues(content: str) -> list[str]:
     ]
 
 
+def _mask_household_filing_statuses(text: str) -> str:
+    """Hide filing-status phrases without changing classification distances."""
+    return _HEAD_OF_HOUSEHOLD_FILING_STATUS_PATTERN.sub(
+        lambda match: " " * len(match.group(0)), text
+    )
+
+
 def _classify_source_scope(text: str) -> str | None:
     """Return a clear source scope, or None when the text is mixed/vague."""
-    person_scoped = _PERSON_SCOPE_SOURCE_PATTERN.search(text) is not None
+    classification_text = _mask_household_filing_statuses(text)
+    person_scoped = _PERSON_SCOPE_SOURCE_PATTERN.search(classification_text) is not None
     unit_scoped = (
-        _UNIT_SCOPE_SOURCE_PATTERN.search(text) is not None
-        or _TAXPAYER_TAX_UNIT_SOURCE_PATTERN.search(text) is not None
+        _UNIT_SCOPE_SOURCE_PATTERN.search(classification_text) is not None
+        or _TAXPAYER_TAX_UNIT_SOURCE_PATTERN.search(classification_text) is not None
     )
-    if _HOUSEHOLD_MEMBER_MIXED_SCOPE_PATTERN.search(text):
+    if _HOUSEHOLD_MEMBER_MIXED_SCOPE_PATTERN.search(classification_text):
         return None
     if person_scoped == unit_scoped:
         return None
@@ -12531,12 +12555,13 @@ def _classify_source_scope(text: str) -> str | None:
 
 def _classify_source_unit_entity(text: str) -> str | None:
     """Return a clear unit entity from source text, or None when generic/mixed."""
-    if _TAXPAYER_TAX_UNIT_SOURCE_PATTERN.search(text):
+    classification_text = _mask_household_filing_statuses(text)
+    if _TAXPAYER_TAX_UNIT_SOURCE_PATTERN.search(classification_text):
         return "taxunit"
     matches = {
         entity
         for entity, pattern in _UNIT_SOURCE_ENTITY_PATTERNS
-        if pattern.search(text)
+        if pattern.search(classification_text)
     }
     if len(matches) != 1:
         return None

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1445"
+ENCODER_VERSION = "0.2.1446"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1445"
+ENCODER_VERSION = "0.2.1446"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1445"
+ENCODER_VERSION = "0.2.1446"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1445"
+ENCODER_VERSION = "0.2.1446"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1445"
+ENCODER_VERSION = "0.2.1446"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1445"
+ENCODER_VERSION = "0.2.1446"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1445"
+ENCODER_VERSION = "0.2.1446"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1445"')
+        .startswith('__version__ = "0.2.1446"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1445"
+    assert encoder_package["version"] == "0.2.1446"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1445"
+    assert project["project"]["version"] == "0.2.1446"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1445"')
+        .startswith('__version__ = "0.2.1446"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1445"
+    assert encoder_package["version"] == "0.2.1446"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1445"
+    assert project["project"]["version"] == "0.2.1446"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1445"')
+        .startswith('__version__ = "0.2.1446"')
     )
 
 
@@ -23903,6 +23903,61 @@ rules:
         "`Person`, but the embedded source states a `Household` unit-scoped test. "
         "Encode the rule at the source-stated unit scope or cite source text "
         "that states the person-level test."
+    ]
+
+
+@pytest.mark.parametrize(
+    "filing_status",
+    [
+        "head of household",
+        "head-of-household",
+        "head  of  household",
+        "head of\n    household",
+        "head‑of‑household",
+    ],
+)
+def test_source_scope_consistency_does_not_treat_tax_filing_status_as_household(
+    filing_status: str,
+):
+    content = f"""format: rulespec/v1
+module:
+  summary: |-
+    A claimant who files as a {filing_status} or surviving spouse for federal
+    income tax purposes may claim the credit.
+rules:
+  - name: claimant_files_under_eligible_status
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    source: state statute
+    versions:
+      - effective_from: '2026-01-01'
+        formula: true
+"""
+
+    assert find_source_scope_consistency_issues(content) == []
+
+
+def test_source_scope_consistency_still_distinguishes_genuine_household_source():
+    content = """format: rulespec/v1
+module:
+  summary: The household is eligible when household income is below the standard.
+rules:
+  - name: tax_unit_eligible
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    source: state statute
+    versions:
+      - effective_from: '2026-01-01'
+        formula: true
+"""
+
+    assert find_source_scope_consistency_issues(content) == [
+        "Source scope mismatch: `tax_unit_eligible` is declared on `TaxUnit`, "
+        "but the embedded source states a `Household` unit-scoped test. Encode "
+        "the rule at the source-stated unit scope or cite source text that "
+        "states the declared unit scope."
     ]
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1445"
+ENCODER_VERSION = "0.2.1446"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -1121,6 +1121,40 @@ def test_explicit_satz_markers_after_absatz_are_recognized():
     }
 
 
+def test_nj_title_54a_citations_are_not_glued_german_sentence_markers():
+    branches = recognize_source_structure(
+        "54A:4-7 New Jersey credit. N.J.S.54A:1-1 applies. "
+        "C.54A:4-6 controls. 1Das ist Satz eins.2Voraussetzung zwei gilt."
+    )
+
+    assert [branch.label for branch in branches if branch.kind == "sentence"] == [
+        "Satz 1",
+        "Satz 2",
+    ]
+
+
+def test_nj_historical_rate_remains_a_source_unit_formula_obligation():
+    source = (
+        "54A:4-7 New Jersey credit. (2) For the purposes of the calculation of "
+        "the New Jersey earned income tax credit, the percentage of the federal "
+        "earned income tax credit referred to in paragraph (1) shall be: "
+        "(a) 10% for the taxable year beginning on or after January 1, 2000, "
+        "but before January 1, 2001;"
+    )
+    branches = recognize_source_structure(source)
+
+    formula_branches = completeness_module._source_formula_branches(
+        source,
+        branches=branches,
+        active_branches=branches,
+        deferred_paths=set(),
+    )
+
+    assert [(branch.label, branch.path) for branch in formula_branches] == [
+        ("source unit formula clause 2", ()),
+    ]
+
+
 def test_colon_satz_markers_are_recognized_and_independently_required():
     source = "(1) Satz 1: Die Hauptregel gilt. Satz 2: Die Sonderregel gilt."
     branches = recognize_source_structure(source)
@@ -2125,6 +2159,20 @@ def test_en_us_post_code_section_marker_citations_are_structural():
     )
 
     assert [(item.value, item.raw) for item in inventory] == [(26.0, "26")]
+
+
+def test_en_us_internal_revenue_code_edition_year_is_structural():
+    source = (
+        "Eligible under section 32 of the federal Internal Revenue Code of 1986 "
+        "(26 U.S.C. s.32), with a 1986 dollar threshold in taxable year 1986."
+    )
+
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        source,
+        profile="en-US",
+    )
+
+    assert [(item.value, item.raw) for item in inventory] == [(1986.0, "1986")]
 
 
 def test_en_us_inline_legal_ordinal_is_structural_after_collapsed_heading():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1445"
+version = "0.2.1446"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- treat formal Internal Revenue Code edition years as structural citation text without suppressing equal-valued policy numbers
- prevent New Jersey title-54A citations from becoming German glued-sentence branches while preserving genuine glued Satz markers
- mask whitespace- and dash-variant `head of household` filing statuses during unit classification while preserving genuine Household evidence and regex distance semantics
- advance encoder provenance to `0.2.1445`

## Why

Protected NJ encode run `30867412169` failed closed with zero signatures after exposing three independent structural-classification defects. This change fixes those shared classifier boundaries. It does not add a target-specific waiver, relax complete-source coverage, equate TaxUnit with Household, or remove the real historical 10% formula/test obligation.

## Validation

- `PYTHONPATH=src:. /Users/pavelmakarchuk/axiom-encode/.venv/bin/python -m pytest -q --no-cov`: 6,275 passed, 119 skipped
- affected source-completeness and RuleSpec validation suites: 1,781 passed, 31 skipped
- exact focused NJ/German/IRC and unit-scope regressions pass
- `ruff check pyproject.toml src/axiom_encode scripts tests`
- `ruff format --check src/ tests/`
- `python -m compileall -q src/axiom_encode scripts`
- version/oracle provenance checks and `git diff --check`

The repository Python 3.13 environment was used explicitly because an unpinned temporary-worktree `uv run` selected local Python 3.14, where the transitive `pyroaring` dependency cannot build.

## Review cycle

Independent review found one P2: exact fixed-width filing-status exclusions did not cover wrapped, repeated-whitespace, or typographic-dash forms. The fix now uses a shared variable-whitespace/dash recognizer and equal-length masking. Repeat independent review on exact head `12d5f281a13c6dfe3c713bb53b7c8fccd07bb3b5` is CLEAN; probes confirm later genuine Household evidence still triggers the expected mismatch.
