### PR TITLE
Normalize completeness target path dashes

### DIFF
--- a/changelog.d/unicode-completeness-target-paths.fixed.md
+++ b/changelog.d/unicode-completeness-target-paths.fixed.md
@@ -1,0 +1,1 @@
+Normalize legal citation dash variants when matching complete-source deferrals to RuleSpec target paths.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1444"
+version = "0.2.1445"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1444"
+__version__ = "0.2.1445"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -20,6 +20,8 @@ from typing import Any, Protocol
 
 import yaml
 
+from axiom_encode.statute import normalize_rulespec_path_segment
+
 
 class NumericOccurrenceLike(Protocol):
     """Typed numeric source evidence consumed from the shared extractor."""
@@ -1672,7 +1674,11 @@ def _reason_names_external_dependency(
 
 
 def _rulespec_target_base(corpus_citation_path: str) -> str:
-    parts = [part for part in corpus_citation_path.strip("/").split("/") if part]
+    parts = [
+        normalize_rulespec_path_segment(part)
+        for part in corpus_citation_path.strip("/").split("/")
+        if part
+    ]
     if len(parts) < 3:
         return corpus_citation_path
     jurisdiction, document_class, *tail = parts

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -14391,7 +14391,10 @@ _RULESPEC_DOCUMENT_CLASS_DIRS = {
 
 
 def _rulespec_base_parts_for_corpus_path(citation_path: str) -> tuple[str, ...]:
-    parts = citation_path.strip("/").split("/")
+    parts = [
+        normalize_rulespec_path_segment(part)
+        for part in citation_path.strip("/").split("/")
+    ]
     if (
         len(parts) >= 4
         and parts[1] == "statute"

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1444"
+ENCODER_VERSION = "0.2.1445"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1444"
+ENCODER_VERSION = "0.2.1445"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1444"
+ENCODER_VERSION = "0.2.1445"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1444"
+ENCODER_VERSION = "0.2.1445"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1444"
+ENCODER_VERSION = "0.2.1445"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1444"
+ENCODER_VERSION = "0.2.1445"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1444"
+ENCODER_VERSION = "0.2.1445"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1444"')
+        .startswith('__version__ = "0.2.1445"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1444"
+    assert encoder_package["version"] == "0.2.1445"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1444"
+    assert project["project"]["version"] == "0.2.1445"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1444"')
+        .startswith('__version__ = "0.2.1445"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1444"
+    assert encoder_package["version"] == "0.2.1445"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1444"
+    assert project["project"]["version"] == "0.2.1445"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1444"')
+        .startswith('__version__ = "0.2.1445"')
     )
 
 
@@ -9548,6 +9548,35 @@ def test_deferred_outputs_cover_subparagraphs_for_unitary_jurisdictions():
         payload, "ug/statute/act-2008-8/local-governments-amendment-no2-2008"
     )
     assert ("f",) in covered
+
+
+@pytest.mark.parametrize("corpus_dash", ("‐", "‑", "‒", "–", "—", "−"))
+def test_deferred_outputs_cover_subparagraphs_normalizes_section_dash_variants(
+    corpus_dash,
+):
+    from axiom_encode.harness.validator_pipeline import (
+        _deferred_output_covered_subparagraphs,
+        _rulespec_base_parts_for_corpus_path,
+    )
+
+    citation_path = f"us/statute/42/1437c{corpus_dash}1"
+    assert _rulespec_base_parts_for_corpus_path(citation_path) == (
+        "statutes",
+        "42",
+        "1437c-1",
+    )
+    payload = {
+        "module": {
+            "deferred_outputs": [
+                {
+                    "output": ("us:statutes/42/1437c-1/a#public_housing_agency_plan"),
+                    "reason": "Requires section 1437f assistance eligibility.",
+                }
+            ]
+        }
+    }
+
+    assert _deferred_output_covered_subparagraphs(payload, citation_path) == {("a",)}
 
 
 def test_deferred_outputs_cover_subparagraphs_for_local_authority_jurisdictions():

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1444"
+ENCODER_VERSION = "0.2.1445"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -328,6 +328,36 @@ def test_precise_typed_absatz_6_deferral_passes():
     )
 
 
+@pytest.mark.parametrize("corpus_dash", ("‐", "‑", "‒", "–", "—", "−"))
+def test_ascii_rulespec_deferral_covers_unicode_dash_corpus_section(corpus_dash):
+    citation_path = f"us/statute/42/1437c{corpus_dash}1"
+    source = (
+        "(a) The public housing agency shall submit a plan for assistance "
+        "under section 1437f."
+    )
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: {citation_path}
+  deferred_outputs:
+    - output: us:statutes/42/1437c-1/a#public_housing_agency_plan
+      reason: >-
+        Subsection (a) cannot be encoded until assistance eligibility under
+        section 1437f is available.
+rules: []
+"""
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path=citation_path,
+        test_cases=[],
+    )
+
+    assert not result.issues
+
+
 def test_scalar_only_source_passes_with_parameter_snapshot():
     source = "(1) Der Freibetrag beträgt 259 Euro."
     content = """\

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1444"
+version = "0.2.1445"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- normalize Unicode legal dash variants only while deriving RuleSpec target paths for complete-source deferral accounting
- apply the same normalization to the general deferred subparagraph matcher
- cover all six supported dash variants and bump the encoder to `0.2.1445`

## Failure Evidence

Protected run [30871063604](https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/30871063604) preserved both model candidates after PR #1363. Each candidate correctly emitted branch-specific RuleSpec deferrals under ASCII path `us:statutes/42/1437c-1/<branch>#...`, but complete-source accounting derived `us:statutes/42/1437c–1` from the corpus citation and therefore recognized zero paths. The validator then reported subsection (a) as absent instead of evaluating the deferrals.

This change preserves the exact Unicode corpus citation in proof metadata and normalizes only the derived filesystem/RuleSpec target comparison.

## Checks

- `uv run --python 3.13 pytest tests/test_source_completeness.py tests/test_rulespec_validation.py`: 1,784 passed, 31 skipped
- focused dash regressions: 18 passed across complete-source, deferred subparagraph, and existing out-of-scope coverage
- `uv run --python 3.13 ruff check pyproject.toml src/axiom_encode scripts tests`: passed
- changed-file Ruff format check: passed
- `python -m compileall -q src/axiom_encode scripts`: passed
- `.venv/bin/python -m towncrier build --draft --version 0.0.0`: passed
- `uv lock --check`: passed
- `git diff --check`: passed

## Cycle

Draft pending independent review and hosted CI.