### PR TITLE
Archive failed re-encode diagnostics for upload

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -2563,6 +2563,8 @@ jobs:
               encoding="utf-8",
           )
           PY
+          tar -cf "$RUNNER_TEMP/targeted-reencode-failure.tar" \
+            -C "$artifact" .
 
       - name: Upload failed re-encode diagnostics
         if: >-
@@ -2571,6 +2573,6 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: targeted-reencode-failure-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ runner.temp }}/targeted-reencode-failure
+          path: ${{ runner.temp }}/targeted-reencode-failure.tar
           if-no-files-found: error
           retention-days: 90

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1446"
+version = "0.2.1447"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1446"
+__version__ = "0.2.1447"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1446"
+ENCODER_VERSION = "0.2.1447"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1446"
+ENCODER_VERSION = "0.2.1447"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1446"
+ENCODER_VERSION = "0.2.1447"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1446"
+ENCODER_VERSION = "0.2.1447"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1446"
+ENCODER_VERSION = "0.2.1447"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1446"
+ENCODER_VERSION = "0.2.1447"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1446"
+ENCODER_VERSION = "0.2.1447"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1446"')
+        .startswith('__version__ = "0.2.1447"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1446"
+    assert encoder_package["version"] == "0.2.1447"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1446"
+    assert project["project"]["version"] == "0.2.1447"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1446"')
+        .startswith('__version__ = "0.2.1447"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1446"
+    assert encoder_package["version"] == "0.2.1447"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1446"
+    assert project["project"]["version"] == "0.2.1447"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1446"')
+        .startswith('__version__ = "0.2.1447"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1446"
+ENCODER_VERSION = "0.2.1447"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -10,6 +10,7 @@ import socket
 import struct
 import subprocess
 import sys
+import tarfile
 import threading
 from base64 import b64decode, b64encode
 from contextlib import contextmanager
@@ -2246,6 +2247,10 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "generated diagnostics exceed entry limit" in failure_package_command
     assert "generated diagnostics exceed file limit" in failure_package_command
     assert "generated diagnostics exceed size limit" in failure_package_command
+    assert 'tar -cf "$RUNNER_TEMP/targeted-reencode-failure.tar"' in (
+        failure_package_command
+    )
+    assert '-C "$artifact" .' in failure_package_command
     assert '"failed_steps": failed_steps' in failure_package_command
     assert '"generated_lanes": generated_lanes' in failure_package_command
     assert '"queue_item_generation_sha256"' in failure_package_command
@@ -2269,7 +2274,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         "name": (
             "targeted-reencode-failure-${{ github.run_id }}-${{ github.run_attempt }}"
         ),
-        "path": "${{ runner.temp }}/targeted-reencode-failure",
+        "path": "${{ runner.temp }}/targeted-reencode-failure.tar",
         "if-no-files-found": "error",
         "retention-days": 90,
     }
@@ -2449,7 +2454,7 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
     generated = tmp_path / "generated" / "target" / "model"
     generated.mkdir(parents=True)
     (generated / "statutes").mkdir()
-    (generated / "statutes/target.yaml").write_text("format: rulespec/v1\n")
+    (generated / "statutes/54a:4-7.test.yaml").write_text("format: rulespec/v1\n")
     (generated / "target.repair.json").write_text('{"outcome": "blocked"}\n')
     (generated / "ignored.bin").write_bytes(b"not diagnostic output")
     env = {
@@ -2476,15 +2481,30 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
 
     subprocess.run(["bash", "-c", command], env=env, check=True)
 
-    artifact = tmp_path / "targeted-reencode-failure"
-    assert (
-        artifact / "generated/target/model/statutes/target.yaml"
-    ).read_text() == "format: rulespec/v1\n"
-    assert json.loads(
-        (artifact / "generated/target/model/target.repair.json").read_text()
-    ) == {"outcome": "blocked"}
-    assert not (artifact / "generated/target/model/ignored.bin").exists()
-    metadata = json.loads((artifact / "metadata.json").read_text())
+    archive = tmp_path / "targeted-reencode-failure.tar"
+    with tarfile.open(archive, mode="r") as bundle:
+        file_member_names = {
+            member.name.removeprefix("./")
+            for member in bundle.getmembers()
+            if member.isfile()
+        }
+        assert file_member_names == {
+            "generated/target/model/statutes/54a:4-7.test.yaml",
+            "generated/target/model/target.repair.json",
+            "metadata.json",
+        }
+        assert "generated/target/model/ignored.bin" not in file_member_names
+        target = bundle.extractfile(
+            "./generated/target/model/statutes/54a:4-7.test.yaml"
+        )
+        repair = bundle.extractfile("./generated/target/model/target.repair.json")
+        metadata_file = bundle.extractfile("./metadata.json")
+        assert target is not None
+        assert repair is not None
+        assert metadata_file is not None
+        assert target.read() == b"format: rulespec/v1\n"
+        assert json.loads(repair.read()) == {"outcome": "blocked"}
+        metadata = json.loads(metadata_file.read())
     assert metadata["schema"] == "axiom-encode/failed-reencode-diagnostics/v1"
     assert metadata["workflow_run_id"] == "1234"
     assert metadata["failed_steps"] == ["encode_apply"]
@@ -2504,9 +2524,15 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
         },
     }
     assert [item["path"] for item in metadata["files"]] == [
-        "target/model/statutes/target.yaml",
+        "target/model/statutes/54a:4-7.test.yaml",
         "target/model/target.repair.json",
     ]
+    target_inventory = metadata["files"][0]
+    assert target_inventory["size"] == len(b"format: rulespec/v1\n")
+    assert (
+        target_inventory["sha256"]
+        == hashlib.sha256(b"format: rulespec/v1\n").hexdigest()
+    )
 
 
 def test_targeted_signed_reencode_rejects_symlinked_failure_diagnostics(
@@ -2556,6 +2582,7 @@ def test_targeted_signed_reencode_rejects_symlinked_failure_diagnostics(
     assert not (
         tmp_path / "targeted-reencode-failure/generated/candidate.yaml"
     ).exists()
+    assert not (tmp_path / "targeted-reencode-failure.tar").exists()
 
 
 def test_signed_snap_queue_dispatcher_is_bounded_and_idempotent() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1446"
+version = "0.2.1447"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- preserve the bounded failed re-encode diagnostics tree behind an uncompressed tar transport boundary
- upload only the portable safe-named tar so legacy citation paths containing artifact-forbidden characters remain lossless
- cover the production `54a:4-7.test.yaml` failure, filtered-file exclusion, and symlink fail-closed boundaries

## Validation
- independent review/fix/re-review cycle: CLEAN
- `ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `pytest --no-cov tests/test_signing_supervisor.py`: 41 passed, 51 skipped
- focused archive/symlink/workflow tests: 3 passed
- `git diff --check`

A local full-suite attempt was interrupted by host disk exhaustion after 144 passes; the focused/shared workflow suite is green and hosted CI is required to provide the clean broad result before readiness or merge.

## Production evidence
Run 30873828845 packaged 26 failure-diagnostic files but `upload-artifact@v4.6.2` rejected the preserved legacy path `context/statutes/54a:4-7.test.yaml`. No artifact or RuleSpec PR was published, and the signer produced zero signatures.