### PR TITLE
Fix historical source branch encoding retries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1447"
+version = "0.2.1448"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1447"
+__version__ = "0.2.1448"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -26752,7 +26752,11 @@ def _next_encode_attempt_model(
         and config.escalation_model != config.initial_model
     )
     if already_escalated:
-        return None
+        return (
+            config.escalation_model
+            if failures_after_current == config.escalate_after + 1
+            else None
+        )
     if failures_after_current < config.escalate_after:
         return config.initial_model
     if config.escalation_model == config.initial_model:
@@ -26839,9 +26843,7 @@ def _cmd_encode_with_authoritative_rulespec_roots(
                 error=_encode_outcome_issue(execution.result, execution.outcome),
             )
             failed_attempts = (*failed_attempts, failure)
-            action = (
-                "escalating" if next_model == config.escalation_model else "retrying"
-            )
+            action = "retrying" if next_model == current_model else "escalating"
             print(
                 f"  generation={action} failed_attempts={len(failed_attempts)} "
                 f"from_model={current_model} to_model={next_model}"

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -9549,7 +9549,13 @@ Preferred principal output:
   legal facts directly, add `oracle_inputs.policyengine` with equivalent
   PolicyEngine-native scenario inputs instead of weakening the RuleSpec `input:`
   coverage.
-- Prefer a contemporary monthly `.test.yaml` period like `2022-01` or `2024-01` when the source is current-effective and lacks a better effective date; avoid pre-2015 historical periods that PolicyEngine US cannot evaluate.
+- For PolicyEngine oracle-comparison cases covering current-effective source text
+  with no better effective date, prefer a contemporary monthly `.test.yaml`
+  period like `2022-01` or `2024-01`. Avoid pre-2015 periods only for cases
+  intended to supply PolicyEngine oracle evidence. Never replace or omit a
+  source-required historical branch merely to make it oracle-comparable; keep
+  its companion case at the legally applicable period even when it cannot
+  contribute oracle evidence.
 - If that output has a durable `jurisdiction:path#rule` id, key the test by that id rather than the friendly local name.
 - Key inputs by their resolving legal RuleSpec target too, e.g. `jurisdiction:path#input.fact`, `jurisdiction:path#relation.name`, or `jurisdiction:path#upstream_rule`.
 - If a copied downstream output with the oracle hint's local name is available, assert that canonical copied output rather than replacing it with a helper-only local test.
@@ -9651,6 +9657,10 @@ Complete-source-unit mode is enabled for this request:
   exception, and rounding rule with assertions on the affected principal
   output. Each branch needs distinct runtime evidence; descriptive test
   metadata is not coverage evidence.
+- A historical branch's runtime evidence must use that branch's legally
+  applicable period. If an external oracle cannot evaluate that period, keep
+  the source-faithful companion case and omit oracle inputs or expectations
+  from that case; never move or omit the branch to gain oracle compatibility.
 - A genuinely scalar-only source unit may remain parameter-only.
 """
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -9,6 +9,7 @@ from the source-unit admission policy implemented here.
 from __future__ import annotations
 
 import ast
+import bisect
 import contextlib
 import math
 import re
@@ -427,6 +428,53 @@ _STRUCTURAL_REFERENCE = re.compile(
     r"Nummer(?:n)?|Nr\.|Buchstabe(?:n)?|Buchst\."
     r")\s*\d*[a-z]?"
     r"(?:\s*(?:,|und|bis|[-–—])\s*\d+[a-z]?)*\b",
+    flags=re.IGNORECASE,
+)
+_SESSION_LAW_TAIL_START = re.compile(
+    r"(?:(?P<history_label>history|source)\s*[:.\-–—]+\s*|"
+    r"(?P<action>amended(?:\s+by)?|as\s+amended|added|supplemented|repealed)"
+    r"\s+)?"
+    r"(?:(?:P\.?\s*L\.?|L\.)\s*)?"
+    r"\d{4}\s*,\s*c\.\s*\d+",
+    flags=re.IGNORECASE,
+)
+_SESSION_LAW_ENTRY = re.compile(
+    r"\s*"
+    r"(?:(?P<history_label>history|source)\s*[:.\-–—]+\s*)?"
+    r"(?:(?P<action>amended(?:\s+by)?|as\s+amended|added|supplemented|repealed)"
+    r"\s+)?"
+    r"(?:(?:P\.?\s*L\.?|L\.)\s*)?"
+    r"\d{4}\s*,\s*c\.\s*\d+"
+    r"(?:\s*(?:,|\.)\s*(?:s|ss)\.\s*[A-Za-z0-9]+"
+    r"(?:[.:\-–—][A-Za-z0-9]+)*"
+    r"(?:\s*(?:through|to|[-–—])\s*[A-Za-z0-9]+)?)?"
+    r"(?:\s*,\s*eff(?:ective)?\.\s*"
+    r"(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|June?|July?|"
+    r"Aug(?:ust)?|Sept(?:ember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)"
+    r"\.?\s+\d{1,2}\s*,\s*\d{4})?"
+    r"(?:\s*,\s*operative\s+"
+    r"(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|June?|July?|"
+    r"Aug(?:ust)?|Sept(?:ember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)"
+    r"\.?\s+\d{1,2}\s*,\s*\d{4})?"
+    r"\s*\.?\s*",
+    flags=re.IGNORECASE,
+)
+_SESSION_LAW_SENTENCE_SEPARATOR = re.compile(
+    r"(?<=\d)\.\s+(?=(?:(?:amended(?:\s+by)?|as\s+amended|added|supplemented|repealed)"
+    r"\s+)?(?:(?:P\.?\s*L\.?|L\.)\s*)?\d{4}\s*,\s*c\.)",
+    flags=re.IGNORECASE,
+)
+_STANDALONE_HISTORY_LEADER = re.compile(
+    r"(?:(?:history|source)\s*[:.\-–—]+\s*"
+    r"(?:(?:P\.?\s*L\.?|L\.)\s*)?|"
+    r"(?:amended(?:\s+by)?|as\s+amended|added|supplemented|repealed)\s+"
+    r"(?:(?:P\.?\s*L\.?|L\.)\s*)?|"
+    r"(?:P\.?\s*L\.?|L\.)\s*)"
+    r"\d{4}\s*,\s*c\.\s*\d+",
+    flags=re.IGNORECASE,
+)
+_SESSION_LAW_YEAR_CHAPTER = re.compile(
+    r"(?:(?:P\.?\s*L\.?|L\.)\s*)?\d{4}\s*,\s*c\.\s*\d+",
     flags=re.IGNORECASE,
 )
 _FORMULA_IDENTIFIER = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\b")
@@ -854,7 +902,9 @@ def _analyze_rulespec_payload(
             "parameter-only representation is invalid."
         )
 
-    source_occurrences = tuple(extract_numeric_occurrences(source_text))
+    source_occurrences = tuple(
+        extract_numeric_occurrences(authoritative_numeric_recall_text(source_text))
+    )
     named_values = (
         tuple(float(value) for value in artifact_numeric_values)
         if artifact_numeric_values is not None
@@ -1756,10 +1806,92 @@ def _branch_citation(
     return f"{citation}({branch.path[0]}) [{', '.join(components)}]"
 
 
+def _strip_terminal_session_law_history(source_text: str) -> str:
+    """Remove only a fully validated terminal session-law history chain."""
+
+    blank_lines = tuple(re.finditer(r"\n[ \t]*\n", source_text))
+    if blank_lines:
+        block_start = blank_lines[-1].end()
+        history_block = source_text[block_start:].lstrip()
+        normalized_history_block = _SESSION_LAW_SENTENCE_SEPARATOR.sub(
+            "; ",
+            history_block,
+        )
+        history_entries = tuple(
+            _SESSION_LAW_ENTRY.fullmatch(part)
+            for part in normalized_history_block.split(";")
+        )
+        if (
+            _STANDALONE_HISTORY_LEADER.match(history_block)
+            and _SESSION_LAW_YEAR_CHAPTER.search(history_block)
+            and history_entries
+            and all(entry is not None for entry in history_entries)
+        ):
+            return source_text[: blank_lines[-1].start()].rstrip()
+
+    separators = tuple(match.start() for match in re.finditer(";", source_text))
+    segment_starts = (0, *(position + 1 for position in separators))
+    segment_ends = (*separators, len(source_text))
+    segment_matches = tuple(
+        _SESSION_LAW_ENTRY.fullmatch(source_text[start:end])
+        for start, end in zip(segment_starts, segment_ends)
+    )
+    suffix_is_valid = [False] * (len(segment_matches) + 1)
+    suffix_has_action = [False] * (len(segment_matches) + 1)
+    suffix_is_valid[-1] = True
+    for index in range(len(segment_matches) - 1, -1, -1):
+        entry = segment_matches[index]
+        suffix_is_valid[index] = entry is not None and suffix_is_valid[index + 1]
+        suffix_has_action[index] = (
+            entry is not None and entry.group("action") is not None
+        ) or suffix_has_action[index + 1]
+
+    last_candidate_by_segment: dict[int, re.Match[str]] = {}
+    for candidate in _SESSION_LAW_TAIL_START.finditer(source_text):
+        segment_index = bisect.bisect_right(separators, candidate.start())
+        last_candidate_by_segment[segment_index] = candidate
+
+    for segment_index, candidate in sorted(last_candidate_by_segment.items()):
+        first_entry = _SESSION_LAW_ENTRY.fullmatch(
+            source_text[candidate.start() : segment_ends[segment_index]]
+        )
+        if first_entry is None or not suffix_is_valid[segment_index + 1]:
+            continue
+
+        explicitly_labeled = first_entry.group("history_label") is not None
+        has_action = (
+            first_entry.group("action") is not None
+            or suffix_has_action[segment_index + 1]
+        )
+        entry_count = len(segment_matches) - segment_index
+
+        prefix = source_text[: candidate.start()]
+        preceding = prefix.rstrip()
+        separator = prefix[len(preceding) :]
+        strong_layout = not preceding or "\n" in separator
+        if (
+            not explicitly_labeled
+            and not strong_layout
+            and (entry_count < 2 or not has_action)
+        ):
+            continue
+        if (
+            not explicitly_labeled
+            and not strong_layout
+            and preceding
+            and preceding[-1] not in ".!?"
+        ):
+            continue
+        return source_text[: candidate.start()].rstrip()
+
+    return source_text
+
+
 def authoritative_numeric_recall_text(source_text: str) -> str:
     """Remove structural/citation ordinals, never substantive source values."""
 
-    cleaned = _GERMAN_LEGAL_CITATION.sub("", source_text)
+    cleaned = _strip_terminal_session_law_history(source_text)
+    cleaned = _GERMAN_LEGAL_CITATION.sub("", cleaned)
     cleaned = _ENGLISH_LEGAL_CITATION.sub("", cleaned)
     cleaned = _STRUCTURAL_REFERENCE.sub("", cleaned)
     cleaned = re.sub(
@@ -4107,7 +4239,10 @@ def _evaluate_formula_selector(
     try:
         expression = ast.parse(selector.strip(), mode="eval").body
     except SyntaxError:
-        return _UNRESOLVED_CONDITION_VALUE
+        try:
+            expression = ast.parse(f"(\n{selector.strip()}\n)", mode="eval").body
+        except SyntaxError:
+            return _UNRESOLVED_CONDITION_VALUE
     return _evaluate_condition_expression(expression, environment)
 
 
@@ -5044,7 +5179,7 @@ def _formula_branch_interval(
     extract_numeric_occurrences: NumericOccurrenceExtractor,
 ) -> _NumericInterval | None:
     first_line = branch.text.splitlines()[0] if branch.text.splitlines() else ""
-    range_text = authoritative_numeric_recall_text(first_line.split(":", 1)[0])
+    range_text = authoritative_numeric_recall_text(first_line)
     return _formula_interval_from_text(
         range_text,
         extract_numeric_occurrences=extract_numeric_occurrences,
@@ -7242,7 +7377,12 @@ def _formula_environment_for_case(
 
 
 def _normalized_case_period(case: dict[str, Any]) -> str:
-    period = str(case.get("period") or "").strip()
+    raw_period = case.get("period")
+    if isinstance(raw_period, dict):
+        start = raw_period.get("start")
+        period = str(start or "").strip()
+    else:
+        period = str(raw_period or "").strip()
     if re.fullmatch(r"\d{4}", period):
         return f"{period}-01-01"
     if re.fullmatch(r"\d{4}-\d{2}", period):

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -1660,6 +1660,10 @@ Complete-source-unit mode is enabled for this request:
   exception, and rounding rule with assertions on the affected principal
   output. Each branch needs distinct runtime evidence; descriptive test
   metadata is not coverage evidence.
+- A historical branch's runtime evidence must use that branch's legally
+  applicable period. If an external oracle cannot evaluate that period, keep
+  the source-faithful companion case and omit oracle inputs or expectations
+  from that case; never move or omit the branch to gain oracle compatibility.
 - A genuinely scalar-only source unit may remain parameter-only.
 """
 

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1447"
+ENCODER_VERSION = "0.2.1448"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12410,8 +12410,12 @@ class TestCmdEncode:
 
         def validate(result, **_kwargs):
             validated_models.append(result.model)
-            passed = remaining_outcomes.pop(0)
-            issues = [] if passed else ["validator rejected generated section"]
+            outcome = remaining_outcomes.pop(0)
+            if isinstance(outcome, tuple):
+                passed, issues = outcome
+            else:
+                passed = outcome
+                issues = [] if passed else ["validator rejected generated section"]
             return passed, issues, {}
 
         applied_file = args.policy_repo_path / "us/statutes/26/1/j/2.yaml"
@@ -12775,6 +12779,45 @@ class TestCmdEncode:
                 f"invalid:{dependent_relative.as_posix()}"
             ]
 
+    @pytest.mark.parametrize(
+        ("enabled", "initial", "escalation", "current", "prior", "expected"),
+        (
+            (True, "terra", "sol", "terra", 0, "terra"),
+            (True, "terra", "sol", "terra", 1, "sol"),
+            (True, "terra", "sol", "sol", 2, "sol"),
+            (True, "terra", "sol", "sol", 3, None),
+            (True, "same", "same", "same", 0, "same"),
+            (True, "same", "same", "same", 1, None),
+            (False, "terra", "sol", "terra", 0, None),
+        ),
+    )
+    def test_encode_retry_model_schedule(
+        self,
+        enabled,
+        initial,
+        escalation,
+        current,
+        prior,
+        expected,
+    ):
+        import axiom_encode.cli as cli_module
+
+        config = cli_module._EncodeEscalationConfig(
+            enabled=enabled,
+            initial_model=initial,
+            escalation_model=escalation,
+            escalate_after=2,
+        )
+
+        assert (
+            cli_module._next_encode_attempt_model(
+                config,
+                current_model=current,
+                failed_attempt_count=prior,
+            )
+            == expected
+        )
+
     def test_encode_escalates_after_n_validator_failures(self, tmp_path):
         args = self._make_args(
             tmp_path,
@@ -12785,7 +12828,15 @@ class TestCmdEncode:
         )
 
         exit_code, generated, validated, mock_run, mock_validate, mock_apply = (
-            self._run_validator_escalation_case(args, [False, False, True])
+            self._run_validator_escalation_case(
+                args,
+                [
+                    (False, ["terra-1"]),
+                    (False, ["terra-2"]),
+                    (False, ["sol-1"]),
+                    (True, []),
+                ],
+            )
         )
 
         assert exit_code == 0
@@ -12793,22 +12844,25 @@ class TestCmdEncode:
             DEFAULT_OPENAI_MODEL,
             DEFAULT_OPENAI_MODEL,
             DEFAULT_OPENAI_ESCALATION_MODEL,
+            DEFAULT_OPENAI_ESCALATION_MODEL,
         ]
         assert validated == generated
-        assert mock_run.call_count == 3
+        assert mock_run.call_count == 4
         assert [
             call.kwargs["validation_retry_feedback"] for call in mock_run.call_args_list
         ] == [
             (),
-            ("validator rejected generated section",),
-            ("validator rejected generated section",),
+            ("terra-1",),
+            ("terra-2", "terra-1"),
+            ("sol-1", "terra-2", "terra-1"),
         ]
-        assert mock_validate.call_count == 3
+        assert mock_validate.call_count == 4
         mock_apply.assert_called_once()
         assert mock_apply.call_args.args[0].model == DEFAULT_OPENAI_ESCALATION_MODEL
         run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
-        assert len(run.iterations) == 3
+        assert len(run.iterations) == 4
         assert [iteration.success for iteration in run.iterations] == [
+            False,
             False,
             False,
             True,
@@ -12816,7 +12870,7 @@ class TestCmdEncode:
         assert run.agent_model == DEFAULT_OPENAI_ESCALATION_MODEL
         assert run.outcome["generation_escalation"] == {
             "escalated": True,
-            "failed_attempt_count": 2,
+            "failed_attempt_count": 3,
             "initial_model": DEFAULT_OPENAI_MODEL,
             "escalation_model": DEFAULT_OPENAI_ESCALATION_MODEL,
         }
@@ -12907,6 +12961,29 @@ class TestCmdEncode:
         run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
         assert "generation_escalation" not in run.outcome
 
+    def test_encode_equal_models_stop_after_bounded_retry(self, tmp_path):
+        args = self._make_args(
+            tmp_path,
+            model="same-model",
+            escalation_model="same-model",
+            apply=True,
+            sync=False,
+            escalation_enabled=True,
+        )
+
+        exit_code, generated, validated, _run, mock_validate, mock_apply = (
+            self._run_validator_escalation_case(args, [False, False])
+        )
+
+        assert exit_code == 1
+        assert generated == ["same-model", "same-model"]
+        assert validated == generated
+        assert mock_validate.call_count == 2
+        mock_apply.assert_not_called()
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert [iteration.success for iteration in run.iterations] == [False, False]
+        assert "generation_escalation" not in run.outcome
+
     def test_encode_no_escalation_preserves_single_attempt(self, tmp_path):
         args = self._make_args(
             tmp_path,
@@ -12972,7 +13049,7 @@ class TestCmdEncode:
         )
 
         exit_code, generated, validated, _run, mock_validate, mock_apply = (
-            self._run_validator_escalation_case(args, [False, False, False])
+            self._run_validator_escalation_case(args, [False, False, False, False])
         )
 
         assert exit_code == 1
@@ -12980,14 +13057,16 @@ class TestCmdEncode:
             DEFAULT_OPENAI_MODEL,
             DEFAULT_OPENAI_MODEL,
             DEFAULT_OPENAI_ESCALATION_MODEL,
+            DEFAULT_OPENAI_ESCALATION_MODEL,
         ]
         assert validated == generated
-        assert mock_validate.call_count == 3
+        assert mock_validate.call_count == 4
         assert mock_validate.call_args.args[0].model == DEFAULT_OPENAI_ESCALATION_MODEL
         mock_apply.assert_not_called()
         run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
-        assert run.outcome["generation_escalation"]["failed_attempt_count"] == 2
+        assert run.outcome["generation_escalation"]["failed_attempt_count"] == 3
         assert [iteration.success for iteration in run.iterations] == [
+            False,
             False,
             False,
             False,

--- a/tests/test_complete_source_mode_plumbing.py
+++ b/tests/test_complete_source_mode_plumbing.py
@@ -111,6 +111,8 @@ def test_generic_encoder_prompt_adds_completeness_only_when_enabled():
     assert (
         "formula branch, boundary,\n  exception, and rounding rule" in complete_prompt
     )
+    assert "historical branch's runtime evidence must use" in complete_prompt
+    assert "omit oracle inputs or expectations" in complete_prompt
     assert "scalar-only source unit may remain parameter-only" in complete_prompt
 
 

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -20697,6 +20697,7 @@ rules:
             include_tests=True,
             runner_backend="openai",
             policyengine_rule_hint="uc_standard_allowance_single_claimant_aged_under_25",
+            require_complete_source_unit=True,
         )
 
         assert "uc_standard_allowance_single_claimant_aged_under_25" in prompt
@@ -20710,10 +20711,8 @@ rules:
         assert "concrete output instead of leaving the broad phrase" in prompt
         assert "person_is_in_*_category" in prompt
         assert "Keep `.test.yaml` inputs oracle-comparable" in prompt
-        assert (
-            "Prefer a contemporary monthly `.test.yaml` period like `2022-01` or `2024-01`"
-            in prompt
-        )
+        assert "prefer a contemporary monthly `.test.yaml`" in prompt
+        assert "period like `2022-01` or `2024-01`" in prompt
         assert (
             "canonical RuleSpec output whose local name is `uc_standard_allowance_single_claimant_aged_under_25`"
             in prompt
@@ -20734,10 +20733,15 @@ rules:
         assert "us:regulations/42-cfr/435/119#adult_group_eligible" in prompt
         assert "person_covered_by_*category" in prompt
         assert "Do not let the oracle-facing hinted" in prompt
+        assert "Avoid pre-2015 periods only for cases" in prompt
+        assert "intended to supply PolicyEngine oracle evidence" in prompt
+        assert "Never replace or omit a" in prompt
+        assert "source-required historical branch" in prompt
         assert (
-            "avoid pre-2015 historical periods that PolicyEngine US cannot evaluate"
+            "historical branch's runtime evidence must use that branch's legally"
             in prompt
         )
+        assert "omit oracle inputs or expectations" in prompt
 
     def test_policyengine_hint_upstream_composition_flags_broad_placeholders(self):
         content = """

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1447"
+ENCODER_VERSION = "0.2.1448"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1447"
+ENCODER_VERSION = "0.2.1448"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1447"
+ENCODER_VERSION = "0.2.1448"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1447"
+ENCODER_VERSION = "0.2.1448"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1447"
+ENCODER_VERSION = "0.2.1448"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1447"
+ENCODER_VERSION = "0.2.1448"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1447"')
+        .startswith('__version__ = "0.2.1448"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1447"
+    assert encoder_package["version"] == "0.2.1448"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1447"
+    assert project["project"]["version"] == "0.2.1448"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1447"')
+        .startswith('__version__ = "0.2.1448"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1447"
+    assert encoder_package["version"] == "0.2.1448"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1447"
+    assert project["project"]["version"] == "0.2.1448"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1447"')
+        .startswith('__version__ = "0.2.1448"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1447"
+ENCODER_VERSION = "0.2.1448"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -5,6 +5,7 @@ import hashlib
 from pathlib import Path
 
 import pytest
+import yaml
 
 from axiom_encode.harness import source_completeness as completeness_module
 from axiom_encode.harness import validator_pipeline as validator_pipeline_module
@@ -31,6 +32,10 @@ CORPUS_CITATION_PATH = "de/statute/estg/32a"
 DE_NUMERIC_OCCURRENCE_EXTRACTOR = functools.partial(
     extract_typed_numeric_inventory_occurrences_from_text,
     profile="de-DE",
+)
+EN_NUMERIC_OCCURRENCE_EXTRACTOR = functools.partial(
+    extract_typed_numeric_inventory_occurrences_from_text,
+    profile="en-US",
 )
 
 
@@ -1155,6 +1160,121 @@ def test_nj_historical_rate_remains_a_source_unit_formula_obligation():
     ]
 
 
+def test_nj_historical_rate_has_source_faithful_runtime_witness():
+    source = (
+        "For taxable year 2000, an eligible resident's New Jersey earned income "
+        "tax credit is 10% of the federal earned income tax credit. "
+        "L.2000, c.80, s.2; amended 2007, c.109; 2020, c.98; 2021, c.130."
+    )
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-nj/statute/54a:4-7
+rules:
+  - name: nj_earned_income_tax_credit_percentage
+    kind: parameter
+    dtype: Rate
+    source: us-nj/statute/54a:4-7
+    versions:
+      - effective_from: '2000-01-01'
+        effective_to: '2000-12-31'
+        formula: 0.10
+      - effective_from: '2020-01-01'
+        formula: 0.40
+  - name: nj_earned_income_tax_credit_before_proration
+    kind: derived
+    dtype: Money
+    source: us-nj/statute/54a:4-7
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: >-
+                For taxable year 2000, an eligible resident's New Jersey earned
+                income tax credit is 10% of the federal earned income tax credit.
+    versions:
+      - effective_from: '2000-01-01'
+        formula: |-
+          if regular_nj_earned_income_tax_credit_eligible: federal_earned_income_tax_credit * nj_earned_income_tax_credit_percentage else: 0
+  - name: regular_nj_earned_income_tax_credit_eligible
+    kind: derived
+    dtype: Judgment
+    source: us-nj/statute/54a:4-7
+    versions:
+      - effective_from: '2000-01-01'
+        formula: |-
+          claimant_is_resident
+          and eligible_for_federal_earned_income_tax_credit
+"""
+    test_cases = [
+        {
+            "name": "historical 10 percent branch",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2000-01-01",
+                "end": "2000-12-31",
+            },
+            "input": {
+                "claimant_is_resident": True,
+                "eligible_for_federal_earned_income_tax_credit": True,
+                "federal_earned_income_tax_credit": 1000,
+            },
+            "output": {
+                "regular_nj_earned_income_tax_credit_eligible": "holds",
+                "nj_earned_income_tax_credit_before_proration": 100,
+            },
+        },
+        {
+            "name": "current 40 percent branch",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2024-01-01",
+                "end": "2024-12-31",
+            },
+            "input": {
+                "claimant_is_resident": True,
+                "eligible_for_federal_earned_income_tax_credit": True,
+                "federal_earned_income_tax_credit": 1000,
+            },
+            "output": {
+                "regular_nj_earned_income_tax_credit_eligible": "holds",
+                "nj_earned_income_tax_credit_before_proration": 400,
+            },
+        },
+    ]
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us-nj/statute/54a:4-7",
+        test_cases=test_cases,
+    )
+
+    assert not _has_issue(result, "formula branch", "test")
+    environment = completeness_module._constant_rule_environment(
+        yaml.safe_load(content)
+    )
+    assert completeness_module._formula_environment_for_case(
+        environment,
+        test_cases[0],
+    )["nj_earned_income_tax_credit_percentage"] == pytest.approx(0.10)
+    assert completeness_module._formula_environment_for_case(
+        environment,
+        test_cases[1],
+    )["nj_earned_income_tax_credit_percentage"] == pytest.approx(0.40)
+    current_only = _analyze(
+        content,
+        source,
+        corpus_citation_path="us-nj/statute/54a:4-7",
+        test_cases=test_cases[1:],
+    )
+    assert _has_issue(current_only, "formula branch", "test")
+
+
 def test_colon_satz_markers_are_recognized_and_independently_required():
     source = "(1) Satz 1: Die Hauptregel gilt. Satz 2: Die Sonderregel gilt."
     branches = recognize_source_structure(source)
@@ -2189,6 +2309,137 @@ def test_en_us_inline_legal_ordinal_is_structural_after_collapsed_heading():
     )
 
     assert [(item.value, item.raw) for item in inventory] == [(2.0, "2")]
+
+
+@pytest.mark.parametrize(
+    "history_tail",
+    (
+        "L.2000, c.80, s.2; amended 2007, c.109; 2020, c.98; 2021, c.130.",
+        "\nL.2000, c.80, s.2; amended by L.2007, c.109; 2021, c.130.",
+        "History: 2020, c.98.",
+        "Source.— L.2020, c.98.",
+        "L.2000, c.80; as amended L.2021, c.130.",
+        "\n\nL.2000,c.80,s.1.",
+        "\n\nL.1976, c.47, s.54A:1-1, eff. July 8, 1976, operative Aug. 30, 1976.",
+        "\n\namended 1982, c.229, s.1; 2020, c.94, s.1.",
+        "\n\nL.1976, c.47, s.54A:9-14, eff. July 8, 1976. "
+        "Amended by L.1983, c.36, s.49, eff. Jan. 26, 1983.",
+        "\n\nL. 1976, c.47, s.54A:9-14, eff. July 8, 1976. "
+        "Amended by L. 1983, c.36, s.49, eff. Jan. 26, 1983.",
+        "\n\nP. L. 1976, c.73, s.3. Amended by L. 1978, c.66, s.1, eff. July 3, 1978.",
+        "\n\namended 1977, c.40, s.1; 1998, c.57, s.1. "
+        "2017, c.313, s.5; 2018, c.131, s.8.",
+    ),
+)
+def test_terminal_session_law_history_is_not_numeric_recall(history_tail):
+    operative = "The credit is 40% for 12 months."
+
+    cleaned = authoritative_numeric_recall_text(f"{operative} {history_tail}")
+
+    assert cleaned == operative
+
+
+@pytest.mark.parametrize(
+    "source_text",
+    (
+        "The credit is 40% for taxable year 2020 and the amount is $2,020.",
+        "The governing act is L.2020, c.98.",
+        "The governing acts are L.2020, c.98; 2021, c.130.",
+        "L.2020, c.98; amended prose does not identify another session law.",
+        "L.2020, c.98; amended 2021, c.130. Operative text follows.",
+    ),
+)
+def test_numeric_recall_preserves_non_history_session_law_text(source_text):
+    assert authoritative_numeric_recall_text(source_text) == source_text
+
+
+@pytest.mark.parametrize(
+    "terminal_block",
+    (
+        "L.2020, c.98. The same block creates a $500 refundable credit.",
+        "L.2020, c.98 governs only citations, but taxable year 2024 is operative.",
+        "L.2020, c.98; malformed tail; the benefit is 12 months.",
+        "History: 2020, c.98. Operative amount: $500.",
+    ),
+)
+def test_blank_line_history_leader_does_not_hide_operative_text(terminal_block):
+    source = f"The credit is 40%.\n\n{terminal_block}"
+
+    assert authoritative_numeric_recall_text(source) == source
+
+
+def test_formula_branch_interval_reads_range_after_chapeau_colon():
+    text = "The amount shall be: for income up to 100 dollars, income * 3"
+    branch = completeness_module.SourceStructureBranch(
+        path=("1",),
+        kind="paragraph",
+        label="1.",
+        text=text,
+        start=0,
+        end=len(text),
+    )
+
+    interval = completeness_module._formula_branch_interval(
+        branch,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+
+    assert interval is not None
+    assert interval.lower is None
+    assert interval.upper is not None
+    assert interval.upper.value == 100
+    assert interval.upper_inclusive is True
+
+
+def test_formula_branch_interval_ignores_formula_constant_after_range():
+    text = "Between 10 and 20 dollars: amount * 5"
+    branch = completeness_module.SourceStructureBranch(
+        path=("1",),
+        kind="paragraph",
+        label="1.",
+        text=text,
+        start=0,
+        end=len(text),
+    )
+
+    interval = completeness_module._formula_branch_interval(
+        branch,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+
+    assert interval is not None
+    assert interval.lower is not None
+    assert interval.lower.value == 10
+    assert interval.upper is not None
+    assert interval.upper.value == 20
+
+
+def test_formula_selector_supports_parenthesized_multiline_continuation():
+    selector = "eligible\nand resident\nand not disqualified"
+
+    assert (
+        completeness_module._evaluate_formula_selector(
+            selector,
+            {"eligible": True, "resident": True, "disqualified": False},
+        )
+        is True
+    )
+    assert (
+        completeness_module._evaluate_formula_selector(
+            selector,
+            {"eligible": True, "resident": False, "disqualified": False},
+        )
+        is False
+    )
+
+
+def test_formula_selector_keeps_adjacent_multiline_statements_unresolved():
+    result = completeness_module._evaluate_formula_selector(
+        "eligible\nresident",
+        {"eligible": True, "resident": True},
+    )
+
+    assert result is completeness_module._UNRESOLVED_CONDITION_VALUE
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1447"
+version = "0.2.1448"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Outcome

Fix the causal historical-source validation and retry gaps exposed by the protected New Jersey PIT encode. This is a shared RuleSpec/oracle architecture change, not a target-specific bypass.

## Changes

- remove only fully validated terminal session-law history from complete-source numeric recall, including real NJ Title 54A layout and malformed-but-bounded history separators;
- keep operative citation-led prose and numeric obligations intact through anchored negative cases;
- use the cleaned authoritative source for complete-source numeric inventory;
- preserve range text after chapeau/code colons;
- evaluate valid multiline formula selectors with a parenthesized AST fallback;
- resolve mapped tax-year test periods from their exact start date;
- require legally applicable historical companion periods even when PolicyEngine cannot supply oracle evidence, in both encoder prompt paths;
- allow exactly one validation-informed repair by the escalated model (`terra, terra, sol, sol` by default), while retaining the existing one-attempt disabled and bounded equal-model behavior;
- bump encoder identity and registry pins to `0.2.1448`.

## Corpus evidence

Against pinned NJ Title 54A corpus commit `24dcfb21f4ae8e85831071cd9bf4c8d19caddc70`, all 238 `metadata.source_history` values that are exact appended body suffixes are removed at the exact operative boundary, with zero misses. Three adapter-metadata anomalies were also checked, including the real `54A:5-1` `. 2017, c.313` separator. All operative/malformed false-positive probes remain byte-for-byte preserved.

The malformed-chain diagnostic scales near-linearly (about 0.27 seconds at 30,000 entries; the first draft took about 1.9 seconds at 3,000).

## Review/fix cycle

Independent review was repeated after each substantive fix. Findings addressed included:

- missing historical-period precedence in the generic prompt;
- incomplete `Source:` / `as amended` and real corpus history handling;
- a non-discriminating temporal regression;
- quadratic candidate processing;
- over-broad blank-line deletion;
- the real NJ `54A:5-1` malformed separator;
- spaced `L. 1976` / `P. L. 1976` abbreviation ambiguity.

Final independent and adversarial reviews are CLEAN on exact head `dbcdc854f4dc40751dd8f39be08d52a212be7f67`.

## Checks

- `ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- full Python 3.13 suite: `6,323 passed, 119 skipped`
- completeness + plumbing: `467 passed`
- focused retry schedule: `10 passed`
- focused PolicyEngine/complete-source prompt: `1 passed`
