### PR TITLE
Fix historical formula witness diagnostics

### DIFF
--- a/changelog.d/historical-formula-witnesses.fixed.md
+++ b/changelog.d/historical-formula-witnesses.fixed.md
@@ -1,0 +1,1 @@
+Validate formula witnesses against the rule version active in the companion case period and identify missing source computations with bounded exact excerpts and observed case periods.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1448"
+version = "0.2.1449"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1448"
+__version__ = "0.2.1449"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -9661,6 +9661,12 @@ Complete-source-unit mode is enabled for this request:
   applicable period. If an external oracle cannot evaluate that period, keep
   the source-faithful companion case and omit oracle inputs or expectations
   from that case; never move or omit the branch to gain oracle compatibility.
+- When a principal derived output combines an earlier operative path with a
+  later-added alternative, keep that output executable from the earliest
+  source-stated path date. Do not move the whole output's `effective_from` to
+  the later alternative; use effective-dated parameter/helper guards in the
+  single derived formula so every historical companion case executes an
+  applicable path.
 - A genuinely scalar-only source unit may remain parameter-only.
 """
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -2081,13 +2081,48 @@ def _companion_test_issues(
         formula_environment=formula_environment,
     )
     for branch in missing_formula_branches:
+        source_excerpt = _bounded_source_feedback_excerpt(branch.text)
+        source_location = f"characters {branch.start}:{branch.end}"
+        interval = _formula_branch_interval(
+            branch,
+            extract_numeric_occurrences=extract_numeric_occurrences,
+        )
+        witness_requirement = (
+            "The asserted principal formula must execute this source computation "
+            "in its legally applicable companion-case period."
+            if interval is None
+            else "The asserted principal formula must execute this source "
+            "computation in its legally applicable companion-case period, and "
+            "the case must supply a numeric selector inside the source-stated "
+            "range."
+        )
+        observed_periods = sorted(
+            {
+                period
+                for rule_name in principal_formula_clause_rules[branch]
+                for case in asserted_by_rule.get(rule_name, ())
+                if re.fullmatch(
+                    r"\d{4}-\d{2}-\d{2}",
+                    period := _normalized_case_period(case),
+                )
+            }
+        )
+        observed_period_detail = (
+            " Observed asserted candidate-case periods: "
+            + _bounded_period_feedback(observed_periods)
+            + "."
+            if observed_periods
+            else " No asserted candidate principal-output case has a usable period."
+        )
         issues.append(
             "[complete-source-unit:tests] Companion tests do not demonstrate "
             f"formula branch {branch.label} at "
-            f"{_branch_citation(corpus_citation_path, branch)} with a principal "
-            "output assertion and, when the branch states a range, a selector "
-            "input in that branch. Each formula branch needs distinct executed "
-            "test evidence."
+            f"{_branch_citation(corpus_citation_path, branch)}. Exact source "
+            f"computation ({source_location}): `{source_excerpt}`. "
+            f"{witness_requirement}{observed_period_detail} Each formula branch "
+            "needs distinct executed "
+            "test evidence; an internal formula-clause ordinal is not a legal "
+            "paragraph number."
         )
 
     boundary_branches = _active_or_root_source_branches(
@@ -7262,23 +7297,48 @@ def _rule_formula_text_for_case(
 ) -> str | None:
     """Resolve one temporal formula when the companion case identifies a period."""
 
-    unambiguous = _unambiguous_rule_formula_text(rule)
-    if unambiguous is not None:
-        return unambiguous
-    period = _normalized_case_period(case)
-    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", period):
-        return None
     versions = rule.get("versions")
     if not isinstance(versions, list):
         return None
+    unambiguous = _unambiguous_rule_formula_text(rule)
+    formula_versions = [
+        version
+        for version in versions
+        if isinstance(version, dict) and version.get("formula") is not None
+    ]
+    dated_versions = [
+        version
+        for version in formula_versions
+        if re.fullmatch(
+            r"\d{4}-\d{2}-\d{2}",
+            str(version.get("effective_from") or "").strip(),
+        )
+    ]
+    has_temporal_metadata = any(
+        str(version.get("effective_from") or "").strip()
+        or str(version.get("effective_to") or "").strip()
+        for version in formula_versions
+    )
+    if has_temporal_metadata and (
+        len(dated_versions) != len(formula_versions)
+        or any(
+            effective_to and not re.fullmatch(r"\d{4}-\d{2}-\d{2}", effective_to)
+            for version in formula_versions
+            if (effective_to := str(version.get("effective_to") or "").strip())
+        )
+    ):
+        return None
+    period = _normalized_case_period(case)
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", period):
+        if "period" not in case:
+            return unambiguous
+        return None if has_temporal_metadata else unambiguous
+    if not dated_versions:
+        return unambiguous
     candidates: list[tuple[str, str]] = []
-    for version in versions:
-        if not isinstance(version, dict) or version.get("formula") is None:
-            continue
+    for version in dated_versions:
         effective_from = str(version.get("effective_from") or "").strip()
         effective_to = str(version.get("effective_to") or "").strip()
-        if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", effective_from):
-            continue
         if effective_from > period or (effective_to and effective_to < period):
             continue
         candidates.append((effective_from, str(version["formula"])))
@@ -7392,3 +7452,31 @@ def _normalized_case_period(case: dict[str, Any]) -> str:
 
 def _collapse_text(value: str) -> str:
     return re.sub(r"\s+", " ", value).strip()
+
+
+def _bounded_source_feedback_excerpt(value: str, *, limit: int = 360) -> str:
+    """Render bounded source-identifying feedback without changing its words."""
+
+    collapsed = _collapse_text(value).replace("`", "\\`")
+    if len(collapsed) <= limit:
+        return collapsed
+    marker = " ... "
+    available = limit - len(marker)
+    head_length = (available * 2) // 3
+    tail_length = available - head_length
+    return collapsed[:head_length].rstrip() + marker + collapsed[-tail_length:].lstrip()
+
+
+def _bounded_period_feedback(periods: Sequence[str], *, limit: int = 8) -> str:
+    """Render bounded candidate periods while retaining both temporal extremes."""
+
+    if len(periods) <= limit:
+        return ", ".join(periods)
+    head_count = limit // 2
+    tail_count = limit - head_count
+    omitted = len(periods) - limit
+    return (
+        ", ".join(periods[:head_count])
+        + f", ... ({omitted} omitted) ..., "
+        + ", ".join(periods[-tail_count:])
+    )

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -1664,6 +1664,12 @@ Complete-source-unit mode is enabled for this request:
   applicable period. If an external oracle cannot evaluate that period, keep
   the source-faithful companion case and omit oracle inputs or expectations
   from that case; never move or omit the branch to gain oracle compatibility.
+- When a principal derived output combines an earlier operative path with a
+  later-added alternative, keep that output executable from the earliest
+  source-stated path date. Do not move the whole output's `effective_from` to
+  the later alternative; use effective-dated parameter/helper guards in the
+  single derived formula so every historical companion case executes an
+  applicable path.
 - A genuinely scalar-only source unit may remain parameter-only.
 """
 

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1448"
+ENCODER_VERSION = "0.2.1449"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_complete_source_mode_plumbing.py
+++ b/tests/test_complete_source_mode_plumbing.py
@@ -112,6 +112,8 @@ def test_generic_encoder_prompt_adds_completeness_only_when_enabled():
         "formula branch, boundary,\n  exception, and rounding rule" in complete_prompt
     )
     assert "historical branch's runtime evidence must use" in complete_prompt
+    assert "keep that output executable from the earliest" in complete_prompt
+    assert "parameter/helper guards in the\n  single derived formula" in complete_prompt
     assert "omit oracle inputs or expectations" in complete_prompt
     assert "scalar-only source unit may remain parameter-only" in complete_prompt
 

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -20741,6 +20741,8 @@ rules:
             "historical branch's runtime evidence must use that branch's legally"
             in prompt
         )
+        assert "keep that output executable from the earliest" in prompt
+        assert "parameter/helper guards in the\n  single derived formula" in prompt
         assert "omit oracle inputs or expectations" in prompt
 
     def test_policyengine_hint_upstream_composition_flags_broad_placeholders(self):

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1448"
+ENCODER_VERSION = "0.2.1449"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1448"
+ENCODER_VERSION = "0.2.1449"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1448"
+ENCODER_VERSION = "0.2.1449"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1448"
+ENCODER_VERSION = "0.2.1449"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1448"
+ENCODER_VERSION = "0.2.1449"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1448"
+ENCODER_VERSION = "0.2.1449"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1448"')
+        .startswith('__version__ = "0.2.1449"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1448"
+    assert encoder_package["version"] == "0.2.1449"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1448"
+    assert project["project"]["version"] == "0.2.1449"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1448"')
+        .startswith('__version__ = "0.2.1449"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1448"
+    assert encoder_package["version"] == "0.2.1449"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1448"
+    assert project["project"]["version"] == "0.2.1449"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1448"')
+        .startswith('__version__ = "0.2.1449"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1448"
+ENCODER_VERSION = "0.2.1449"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -1273,6 +1273,96 @@ rules:
         test_cases=test_cases[1:],
     )
     assert _has_issue(current_only, "formula branch", "test")
+    assert _has_issue(
+        current_only,
+        "exact source computation",
+        "taxable year 2000",
+        "10%",
+        "legally applicable companion-case period",
+        "observed asserted candidate-case periods: 2024-01-01",
+    )
+    long_excerpt = completeness_module._bounded_source_feedback_excerpt(
+        "head " + "x" * 500 + " operative tail"
+    )
+    assert len(long_excerpt) == 360
+    assert long_excerpt.startswith("head ")
+    assert long_excerpt.endswith(" operative tail")
+    assert completeness_module._bounded_period_feedback(
+        [f"{year}-01-01" for year in range(2000, 2020)]
+    ) == (
+        "2000-01-01, 2001-01-01, 2002-01-01, 2003-01-01, "
+        "... (12 omitted) ..., 2016-01-01, 2017-01-01, 2018-01-01, 2019-01-01"
+    )
+
+    premature_payload = yaml.safe_load(content)
+    premature_principal = next(
+        rule
+        for rule in premature_payload["rules"]
+        if rule["name"] == "nj_earned_income_tax_credit_before_proration"
+    )
+    premature_principal["versions"][0]["effective_from"] = "2020-01-01"
+    premature_principal_formula = premature_principal["versions"][0]["formula"]
+    assert (
+        completeness_module._rule_formula_text_for_case(
+            premature_principal,
+            test_cases[0],
+        )
+        is None
+    )
+    assert (
+        completeness_module._rule_formula_text_for_case(
+            premature_principal,
+            test_cases[1],
+        )
+        == premature_principal_formula
+    )
+    expired_principal = yaml.safe_load(yaml.safe_dump(premature_principal))
+    expired_principal["versions"][0]["effective_from"] = "2000-01-01"
+    expired_principal["versions"][0]["effective_to"] = "2000-12-31"
+    assert (
+        completeness_module._rule_formula_text_for_case(
+            expired_principal,
+            test_cases[1],
+        )
+        is None
+    )
+    undated_principal = {"versions": [{"formula": premature_principal_formula}]}
+    assert (
+        completeness_module._rule_formula_text_for_case(
+            undated_principal,
+            test_cases[0],
+        )
+        == premature_principal_formula
+    )
+    malformed_principal = {
+        "versions": [
+            {
+                "effective_from": "2020",
+                "formula": premature_principal_formula,
+            }
+        ]
+    }
+    assert (
+        completeness_module._rule_formula_text_for_case(
+            malformed_principal,
+            test_cases[1],
+        )
+        is None
+    )
+    assert (
+        completeness_module._rule_formula_text_for_case(
+            premature_principal,
+            {"period": "not-a-year"},
+        )
+        is None
+    )
+    premature = _analyze(
+        yaml.safe_dump(premature_payload, sort_keys=False),
+        source,
+        corpus_citation_path="us-nj/statute/54a:4-7",
+        test_cases=test_cases,
+    )
+    assert _has_issue(premature, "formula branch", "test")
 
 
 def test_colon_satz_markers_are_recognized_and_independently_required():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1448"
+version = "0.2.1449"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- resolve formula witness text against the rule version active in the companion-case period, including `effective_from` and `effective_to`
- fail closed for mixed or malformed temporal formula metadata and explicitly malformed case periods
- identify unwitnessed internal formula clauses with bounded exact source excerpts, character spans, and bounded observed candidate periods
- guide complete-source encoders to preserve the earliest operative derived-output date while using supported parameter/helper guards inside a single derived formula
- bump axiom-encode to 0.2.1449

## Motivation

Protected targeted re-encode run `30877946817` failed on New Jersey `54A:4-7`. Its opaque `formula clause 4` message was the fourth internal computation span—the 10% tax-year-2000 branch—not statutory paragraph (4). Both final repair attempts consequently targeted the age-18 paragraph and supplied only 2024 cases. The validator also allowed a unique formula effective from 2020 to be treated as executable for a 2000 case.

This is a general validator and encoder-guidance correction. It does not special-case New Jersey or weaken source-completeness evidence.

## Validation

- `uv run --no-sync ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- focused source/plumbing/eval suite: 1,197 passed
- full suite: 6,323 passed, 119 skipped
- exact failed SOL artifact reproduces an actionable diagnostic naming the 10% tax-year-2000 computation, source span `944:1236`, and observed 2024 period
- `git diff --check`

The shared Python 3.13 environment was selected explicitly with this worktree's `src` on `PYTHONPATH`; this avoids importing the sibling checkout's installed 0.2.1448 during the version-provenance test.

## Review cycle

Independent review found one actionable contradiction in the initial prompt wording: it suggested effective-dated derived formulas even though the runtime requires a single derived formula version. Both prompt surfaces and tests were changed to require effective-dated parameter/helper guards inside the single derived formula. The reviewer then re-reviewed exact commit `ef31f781974853b00dc3d348a4c1effb019a2a48` and reported CLEAN with no remaining actionable findings.
