### PR TITLE
Fix formula source binding diagnostics

### DIFF
--- a/changelog.d/formula-source-binding-diagnostics.fixed.md
+++ b/changelog.d/formula-source-binding-diagnostics.fixed.md
@@ -1,0 +1,1 @@
+Identify asserted principal formulas that execute a missing source computation but lack clause-specific source binding, and direct encoders to add canonical formula-proof excerpts. Preserve multiline formula comparisons in boundary evidence and the legal windows of singleton effective-dated constants.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1449"
+version = "0.2.1450"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1449"
+__version__ = "0.2.1450"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -9657,6 +9657,13 @@ Complete-source-unit mode is enabled for this request:
   exception, and rounding rule with assertions on the affected principal
   output. Each branch needs distinct runtime evidence; descriptive test
   metadata is not coverage evidence.
+- When an implementing principal rule is not unambiguously bound by a canonical
+  structural source path, add a `versions[N].formula` source proof atom using
+  the exact canonical `source.corpus_citation_path` and a short verbatim
+  `source.excerpt` identifying its computation. This is mandatory when multiple
+  computations share one structural path. A citation-only proof atom,
+  human-readable rule-level `source:`, or self-import is not an unambiguous
+  formula-clause binding.
 - A historical branch's runtime evidence must use that branch's legally
   applicable period. If an external oracle cannot evaluate that period, keep
   the source-faithful companion case and omit oracle inputs or expectations

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -23,6 +23,9 @@ import yaml
 
 from axiom_encode.statute import normalize_rulespec_path_segment
 
+_UNBOUND_FORMULA_DIAGNOSTIC_RULE_LIMIT = 32
+_UNBOUND_FORMULA_DIAGNOSTIC_CASE_LIMIT = 8
+
 
 class NumericOccurrenceLike(Protocol):
     """Typed numeric source evidence consumed from the shared extractor."""
@@ -116,6 +119,14 @@ class _FormulaExecution:
     evaluated_value: tuple[str, str] | None
     evaluates_to_zero: bool
     constant_environment: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class _UnboundFormulaDiagnostic:
+    """Best-effort unbound formula matches and scan completeness."""
+
+    rule_names: tuple[str, ...]
+    scan_capped: bool
 
 
 @dataclass(frozen=True)
@@ -2066,6 +2077,8 @@ def _companion_test_issues(
                 f"`{name}` is never asserted by a companion test."
             )
 
+    formula_dependency_cache: dict[int, dict[str, Any]] = {}
+    formula_execution_cache: dict[tuple[str, int], _FormulaExecution | None] = {}
     active_branches = [
         branch
         for branch in branches
@@ -2079,10 +2092,27 @@ def _companion_test_issues(
         extract_numeric_occurrences=extract_numeric_occurrences,
         numeric_value_is_grounded=numeric_value_is_grounded,
         formula_environment=formula_environment,
+        dependency_cache=formula_dependency_cache,
+        execution_cache=formula_execution_cache,
     )
     for branch in missing_formula_branches:
         source_excerpt = _bounded_source_feedback_excerpt(branch.text)
         source_location = f"characters {branch.start}:{branch.end}"
+        unbound_diagnostic = _unbound_matching_formula_rules(
+            branch,
+            principal_rules=principal_rules,
+            bound_rule_names=principal_formula_clause_rules[branch],
+            asserted_by_rule=asserted_by_rule,
+            extract_numeric_occurrences=extract_numeric_occurrences,
+            numeric_value_is_grounded=numeric_value_is_grounded,
+            formula_environment=formula_environment,
+            dependency_cache=formula_dependency_cache,
+            execution_cache=formula_execution_cache,
+        )
+        source_binding_detail = _unbound_formula_binding_feedback(
+            unbound_diagnostic,
+            corpus_citation_path=corpus_citation_path,
+        )
         interval = _formula_branch_interval(
             branch,
             extract_numeric_occurrences=extract_numeric_occurrences,
@@ -2119,7 +2149,8 @@ def _companion_test_issues(
             f"formula branch {branch.label} at "
             f"{_branch_citation(corpus_citation_path, branch)}. Exact source "
             f"computation ({source_location}): `{source_excerpt}`. "
-            f"{witness_requirement}{observed_period_detail} Each formula branch "
+            f"{witness_requirement}{observed_period_detail}"
+            f"{source_binding_detail} Each formula branch "
             "needs distinct executed "
             "test evidence; an internal formula-clause ordinal is not a legal "
             "paragraph number."
@@ -2527,6 +2558,8 @@ def _unwitnessed_formula_branches(
     extract_numeric_occurrences: NumericOccurrenceExtractor,
     numeric_value_is_grounded: NumericGroundingPredicate,
     formula_environment: dict[str, Any],
+    dependency_cache: dict[int, dict[str, Any]],
+    execution_cache: dict[tuple[str, int], _FormulaExecution | None],
 ) -> tuple[SourceStructureBranch, ...]:
     """Consume each executed rule/case witness for at most one source formula."""
 
@@ -2539,6 +2572,8 @@ def _unwitnessed_formula_branches(
             extract_numeric_occurrences=extract_numeric_occurrences,
             numeric_value_is_grounded=numeric_value_is_grounded,
             formula_environment=formula_environment,
+            dependency_cache=dependency_cache,
+            execution_cache=execution_cache,
         )
         for branch in branches
     }
@@ -2582,6 +2617,9 @@ def _formula_branch_test_witnesses(
     extract_numeric_occurrences: NumericOccurrenceExtractor,
     numeric_value_is_grounded: NumericGroundingPredicate,
     formula_environment: dict[str, Any],
+    dependency_cache: dict[int, dict[str, Any]],
+    execution_cache: dict[tuple[str, int], _FormulaExecution | None],
+    max_cases_per_rule: int | None = None,
 ) -> set[tuple[str, str]]:
     interval = _formula_branch_interval(
         branch,
@@ -2592,18 +2630,27 @@ def _formula_branch_test_witnesses(
         rule = principal_rules[rule_name]
         selector_names = _rule_numeric_selector_names(rule)
         has_branching_formula = _rule_has_branching_formula(rule)
-        for case in asserted_by_rule.get(rule_name, ()):
-            dependency_environment = _case_asserted_dependency_environment(
-                principal_rules,
-                case,
-                formula_environment=formula_environment,
-            )
-            execution = _case_formula_execution(
-                rule,
-                case,
-                formula_environment=formula_environment,
-                dependency_environment=dependency_environment,
-            )
+        asserted_cases = asserted_by_rule.get(rule_name, ())
+        if max_cases_per_rule is not None:
+            asserted_cases = asserted_cases[:max_cases_per_rule]
+        for case in asserted_cases:
+            case_key = id(case)
+            if case_key not in dependency_cache:
+                dependency_cache[case_key] = _case_asserted_dependency_environment(
+                    principal_rules,
+                    case,
+                    formula_environment=formula_environment,
+                )
+            dependency_environment = dependency_cache[case_key]
+            execution_key = (rule_name, case_key)
+            if execution_key not in execution_cache:
+                execution_cache[execution_key] = _case_formula_execution(
+                    rule,
+                    case,
+                    formula_environment=formula_environment,
+                    dependency_environment=dependency_environment,
+                )
+            execution = execution_cache[execution_key]
             if (
                 execution is None
                 or not _formula_execution_leaf_is_computational(execution)
@@ -2646,6 +2693,80 @@ def _formula_branch_test_witnesses(
             ):
                 witnesses.add((rule_name, f"case:{id(case)}"))
     return witnesses
+
+
+def _unbound_matching_formula_rules(
+    branch: SourceStructureBranch,
+    *,
+    principal_rules: dict[str, dict[str, Any]],
+    bound_rule_names: set[str],
+    asserted_by_rule: dict[str, list[dict[str, Any]]],
+    extract_numeric_occurrences: NumericOccurrenceExtractor,
+    numeric_value_is_grounded: NumericGroundingPredicate,
+    formula_environment: dict[str, Any],
+    dependency_cache: dict[int, dict[str, Any]],
+    execution_cache: dict[tuple[str, int], _FormulaExecution | None],
+) -> _UnboundFormulaDiagnostic:
+    """Find asserted formulas that match a clause but lack its source binding."""
+
+    eligible_rule_names = [
+        rule_name
+        for rule_name in sorted(principal_rules)
+        if rule_name not in bound_rule_names and asserted_by_rule.get(rule_name)
+    ]
+    scanned_rule_names = eligible_rule_names[:_UNBOUND_FORMULA_DIAGNOSTIC_RULE_LIMIT]
+    scan_capped = len(scanned_rule_names) < len(eligible_rule_names) or any(
+        len(asserted_by_rule[rule_name]) > _UNBOUND_FORMULA_DIAGNOSTIC_CASE_LIMIT
+        for rule_name in scanned_rule_names
+    )
+    witnesses = _formula_branch_test_witnesses(
+        branch,
+        principal_rules=principal_rules,
+        rule_names=set(scanned_rule_names),
+        asserted_by_rule=asserted_by_rule,
+        extract_numeric_occurrences=extract_numeric_occurrences,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+        formula_environment=formula_environment,
+        dependency_cache=dependency_cache,
+        execution_cache=execution_cache,
+        max_cases_per_rule=_UNBOUND_FORMULA_DIAGNOSTIC_CASE_LIMIT,
+    )
+    return _UnboundFormulaDiagnostic(
+        rule_names=tuple(sorted({rule_name for rule_name, _witness in witnesses})),
+        scan_capped=scan_capped,
+    )
+
+
+def _unbound_formula_binding_feedback(
+    diagnostic: _UnboundFormulaDiagnostic,
+    *,
+    corpus_citation_path: str,
+) -> str:
+    """Render source-binding repair guidance without overstating scan coverage."""
+
+    detail = ""
+    if diagnostic.rule_names:
+        detail = (
+            " Asserted principal formula(s) already execute this computation "
+            "but are excluded from source-bound evidence: "
+            + _bounded_identifier_feedback(diagnostic.rule_names)
+            + ". To bind each named rule unambiguously, add a "
+            "`versions[N].formula` proof atom whose "
+            "`source.corpus_citation_path` is exactly "
+            f"`{corpus_citation_path}` and whose short `source.excerpt` quotes "
+            "this computation. A citation-only proof atom, human-readable "
+            "rule-level `source:`, or self-import does not distinguish one "
+            "internal formula clause from another."
+        )
+    if diagnostic.scan_capped:
+        detail += (
+            " The best-effort unbound-formula diagnostic scan was capped at "
+            f"{_UNBOUND_FORMULA_DIAGNOSTIC_RULE_LIMIT} rules and "
+            f"{_UNBOUND_FORMULA_DIAGNOSTIC_CASE_LIMIT} cases per rule; "
+            "additional matching principal formulas may exist beyond the "
+            "reported names."
+        )
+    return detail
 
 
 def _formula_execution_matches_source_branch(
@@ -4271,13 +4392,9 @@ def _evaluate_formula_selector(
     selector: str,
     environment: dict[str, Any],
 ) -> Any:
-    try:
-        expression = ast.parse(selector.strip(), mode="eval").body
-    except SyntaxError:
-        try:
-            expression = ast.parse(f"(\n{selector.strip()}\n)", mode="eval").body
-        except SyntaxError:
-            return _UNRESOLVED_CONDITION_VALUE
+    expression = _parse_formula_expression(selector)
+    if expression is None:
+        return _UNRESOLVED_CONDITION_VALUE
     return _evaluate_condition_expression(expression, environment)
 
 
@@ -4688,8 +4805,8 @@ def _formula_text_has_boundary_comparison(
     extract_numeric_occurrences: NumericOccurrenceExtractor | None,
     numeric_value_is_grounded: NumericGroundingPredicate,
 ) -> bool:
-    with contextlib.suppress(SyntaxError):
-        expression = ast.parse(text.strip(), mode="eval").body
+    expression = _parse_formula_expression(text)
+    if expression is not None:
         for comparison, negated in _formula_comparisons_with_polarity(expression):
             operands = (comparison.left, *comparison.comparators)
             for operator, left, right in zip(
@@ -4735,6 +4852,19 @@ def _formula_text_has_boundary_comparison(
                 ):
                     return True
     return False
+
+
+def _parse_formula_expression(text: str) -> ast.expr | None:
+    """Parse one expression, including Axiom's multiline continuations."""
+
+    stripped = text.strip()
+    try:
+        return ast.parse(stripped, mode="eval").body
+    except SyntaxError:
+        try:
+            return ast.parse(f"(\n{stripped}\n)", mode="eval").body
+        except SyntaxError:
+            return None
 
 
 def _formula_comparisons_with_polarity(
@@ -7390,18 +7520,26 @@ def _constant_rule_environment(payload: dict[str, Any]) -> dict[str, Any]:
                     )
         if len(entries) != formula_version_count:
             continue
+        has_temporal_metadata = any(start or end for start, end, _value in entries)
+        if (
+            has_temporal_metadata
+            and entries
+            and all(
+                re.fullmatch(r"\d{4}-\d{2}-\d{2}", start)
+                and (not end or re.fullmatch(r"\d{4}-\d{2}-\d{2}", end))
+                for start, end, _value in entries
+            )
+        ):
+            environment[name] = _TemporalFormulaValue(tuple(entries))
+            continue
+        if has_temporal_metadata:
+            continue
         values = [value for _start, _end, value in entries]
         if values and all(
             type(value) is type(values[0]) and value == values[0]
             for value in values[1:]
         ):
             environment[name] = values[0]
-        elif entries and all(
-            re.fullmatch(r"\d{4}-\d{2}-\d{2}", start)
-            and (not end or re.fullmatch(r"\d{4}-\d{2}-\d{2}", end))
-            for start, end, _value in entries
-        ):
-            environment[name] = _TemporalFormulaValue(tuple(entries))
     return environment
 
 
@@ -7416,6 +7554,14 @@ def _formula_environment_for_case(
             resolved[name] = value
             continue
         if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", period):
+            if "period" not in case:
+                candidates = [candidate for _start, _end, candidate in value.versions]
+                if candidates and all(
+                    type(candidate) is type(candidates[0])
+                    and candidate == candidates[0]
+                    for candidate in candidates[1:]
+                ):
+                    resolved[name] = candidates[0]
             continue
         candidates = [
             (start, candidate)
@@ -7480,3 +7626,15 @@ def _bounded_period_feedback(periods: Sequence[str], *, limit: int = 8) -> str:
         + f", ... ({omitted} omitted) ..., "
         + ", ".join(periods[-tail_count:])
     )
+
+
+def _bounded_identifier_feedback(values: Sequence[str], *, limit: int = 6) -> str:
+    """Render a bounded, deterministic list of diagnostic identifiers."""
+
+    identifiers = sorted(
+        {_collapse_text(value).replace("`", "\\`") for value in values}
+    )
+    rendered = [f"`{value}`" for value in identifiers[:limit]]
+    if len(identifiers) > limit:
+        rendered.append(f"... ({len(identifiers) - limit} omitted)")
+    return ", ".join(rendered)

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -1660,6 +1660,13 @@ Complete-source-unit mode is enabled for this request:
   exception, and rounding rule with assertions on the affected principal
   output. Each branch needs distinct runtime evidence; descriptive test
   metadata is not coverage evidence.
+- When an implementing principal rule is not unambiguously bound by a canonical
+  structural source path, add a `versions[N].formula` source proof atom using
+  the exact canonical `source.corpus_citation_path` and a short verbatim
+  `source.excerpt` identifying its computation. This is mandatory when multiple
+  computations share one structural path. A citation-only proof atom,
+  human-readable rule-level `source:`, or self-import is not an unambiguous
+  formula-clause binding.
 - A historical branch's runtime evidence must use that branch's legally
   applicable period. If an external oracle cannot evaluate that period, keep
   the source-faithful companion case and omit oracle inputs or expectations

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1449"
+ENCODER_VERSION = "0.2.1450"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_complete_source_mode_plumbing.py
+++ b/tests/test_complete_source_mode_plumbing.py
@@ -112,6 +112,11 @@ def test_generic_encoder_prompt_adds_completeness_only_when_enabled():
         "formula branch, boundary,\n  exception, and rounding rule" in complete_prompt
     )
     assert "historical branch's runtime evidence must use" in complete_prompt
+    assert "not unambiguously bound by a canonical\n  structural source path" in (
+        complete_prompt
+    )
+    assert "mandatory when multiple\n  computations share" in complete_prompt
+    assert "citation-only proof atom" in complete_prompt
     assert "keep that output executable from the earliest" in complete_prompt
     assert "parameter/helper guards in the\n  single derived formula" in complete_prompt
     assert "omit oracle inputs or expectations" in complete_prompt

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -20741,6 +20741,11 @@ rules:
             "historical branch's runtime evidence must use that branch's legally"
             in prompt
         )
+        assert "not unambiguously bound by a canonical\n  structural source path" in (
+            prompt
+        )
+        assert "mandatory when multiple\n  computations share" in prompt
+        assert "citation-only proof atom" in prompt
         assert "keep that output executable from the earliest" in prompt
         assert "parameter/helper guards in the\n  single derived formula" in prompt
         assert "omit oracle inputs or expectations" in prompt

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1449"
+ENCODER_VERSION = "0.2.1450"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1449"
+ENCODER_VERSION = "0.2.1450"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1449"
+ENCODER_VERSION = "0.2.1450"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1449"
+ENCODER_VERSION = "0.2.1450"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1449"
+ENCODER_VERSION = "0.2.1450"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1449"
+ENCODER_VERSION = "0.2.1450"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1449"')
+        .startswith('__version__ = "0.2.1450"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1449"
+    assert encoder_package["version"] == "0.2.1450"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1449"
+    assert project["project"]["version"] == "0.2.1450"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1449"')
+        .startswith('__version__ = "0.2.1450"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1449"
+    assert encoder_package["version"] == "0.2.1450"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1449"
+    assert project["project"]["version"] == "0.2.1450"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1449"')
+        .startswith('__version__ = "0.2.1450"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1449"
+ENCODER_VERSION = "0.2.1450"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -1281,6 +1281,48 @@ rules:
         "legally applicable companion-case period",
         "observed asserted candidate-case periods: 2024-01-01",
     )
+    unbound_payload = yaml.safe_load(content)
+    unbound_principal = next(
+        rule
+        for rule in unbound_payload["rules"]
+        if rule["name"] == "nj_earned_income_tax_credit_before_proration"
+    )
+    unbound_principal["source"] = "N.J.S.54A:4-7(a)(1), (a)(2)"
+    unbound_principal["metadata"]["proof"]["atoms"] = [
+        {
+            "path": "versions[0].formula",
+            "kind": "formula",
+            "source": {
+                "corpus_citation_path": "us-nj/statute/54a:4-7",
+            },
+        },
+        {
+            "path": "versions[0].formula",
+            "kind": "parameter",
+            "import": {
+                "target": (
+                    "us-nj:statutes/54a/4-7#nj_earned_income_tax_credit_percentage"
+                ),
+                "output": "nj_earned_income_tax_credit_percentage",
+                "hash": "sha256:local",
+            },
+        },
+    ]
+    unbound = _analyze(
+        yaml.safe_dump(unbound_payload, sort_keys=False),
+        source,
+        corpus_citation_path="us-nj/statute/54a:4-7",
+        test_cases=test_cases,
+    )
+    assert _has_issue(
+        unbound,
+        "already execute this computation",
+        "nj_earned_income_tax_credit_before_proration",
+        "excluded from source-bound evidence",
+        "versions[n].formula",
+        "short `source.excerpt`",
+        "self-import",
+    )
     long_excerpt = completeness_module._bounded_source_feedback_excerpt(
         "head " + "x" * 500 + " operative tail"
     )
@@ -1292,6 +1334,12 @@ rules:
     ) == (
         "2000-01-01, 2001-01-01, 2002-01-01, 2003-01-01, "
         "... (12 omitted) ..., 2016-01-01, 2017-01-01, 2018-01-01, 2019-01-01"
+    )
+    assert completeness_module._bounded_identifier_feedback(
+        [f"rule_{index}" for index in range(8)] + ["rule_0", "rule`escaped"]
+    ) == (
+        "`rule\\`escaped`, `rule_0`, `rule_1`, `rule_2`, `rule_3`, `rule_4`, "
+        "... (3 omitted)"
     )
 
     premature_payload = yaml.safe_load(content)
@@ -1363,6 +1411,108 @@ rules:
         test_cases=test_cases,
     )
     assert _has_issue(premature, "formula branch", "test")
+
+
+def test_unbound_formula_diagnostics_cache_case_execution(monkeypatch):
+    rule_count = 40
+    case_count = 12
+    branch_count = 12
+    principal_rules = {
+        f"amount_{index}": {
+            "name": f"amount_{index}",
+            "kind": "derived",
+            "dtype": "Money",
+            "versions": [{"formula": "input_amount * 2"}],
+        }
+        for index in range(rule_count)
+    }
+    cases = [
+        {
+            "name": f"shared asserted case {case_index}",
+            "input": {"input_amount": 10},
+            "output": {f"amount_{index}": 20 for index in range(rule_count)},
+        }
+        for case_index in range(case_count)
+    ]
+    asserted_by_rule = {name: cases for name in principal_rules}
+    dependency_cache = {}
+    execution_cache = {}
+    dependency_calls = 0
+    execution_calls = 0
+    original_dependency = completeness_module._case_asserted_dependency_environment
+    original_execution = completeness_module._case_formula_execution
+
+    def counted_dependency(*args, **kwargs):
+        nonlocal dependency_calls
+        dependency_calls += 1
+        return original_dependency(*args, **kwargs)
+
+    def counted_execution(*args, **kwargs):
+        nonlocal execution_calls
+        execution_calls += 1
+        return original_execution(*args, **kwargs)
+
+    monkeypatch.setattr(
+        completeness_module,
+        "_case_asserted_dependency_environment",
+        counted_dependency,
+    )
+    monkeypatch.setattr(
+        completeness_module,
+        "_case_formula_execution",
+        counted_execution,
+    )
+
+    for index in range(branch_count):
+        text = "The amount is input_amount * 2."
+        branch = completeness_module.SourceStructureBranch(
+            path=(),
+            kind="root",
+            label=f"formula {index}",
+            text=text,
+            start=index * len(text),
+            end=(index + 1) * len(text),
+        )
+        diagnostic = completeness_module._unbound_matching_formula_rules(
+            branch,
+            principal_rules=principal_rules,
+            bound_rule_names=set(),
+            asserted_by_rule=asserted_by_rule,
+            extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+            numeric_value_is_grounded=numeric_value_is_grounded,
+            formula_environment={},
+            dependency_cache=dependency_cache,
+            execution_cache=execution_cache,
+        )
+        assert len(diagnostic.rule_names) == (
+            completeness_module._UNBOUND_FORMULA_DIAGNOSTIC_RULE_LIMIT
+        )
+        assert diagnostic.scan_capped is True
+
+    feedback = completeness_module._unbound_formula_binding_feedback(
+        diagnostic,
+        corpus_citation_path="us/example/statute/1",
+    )
+    assert "diagnostic scan was capped at 32 rules and 8 cases per rule" in feedback
+    assert "additional matching principal formulas may exist" in feedback
+    capped_without_scanned_match = (
+        completeness_module._unbound_formula_binding_feedback(
+            completeness_module._UnboundFormulaDiagnostic((), True),
+            corpus_citation_path="us/example/statute/1",
+        )
+    )
+    assert "diagnostic scan was capped" in capped_without_scanned_match
+    assert "additional matching principal formulas may exist" in (
+        capped_without_scanned_match
+    )
+
+    assert dependency_calls == (
+        completeness_module._UNBOUND_FORMULA_DIAGNOSTIC_CASE_LIMIT
+    )
+    assert execution_calls == (
+        completeness_module._UNBOUND_FORMULA_DIAGNOSTIC_RULE_LIMIT
+        * completeness_module._UNBOUND_FORMULA_DIAGNOSTIC_CASE_LIMIT
+    )
 
 
 def test_colon_satz_markers_are_recognized_and_independently_required():
@@ -6147,6 +6297,46 @@ rules:
     assert _has_issue(result, "formula branch")
 
 
+def test_singleton_effective_dated_constant_is_not_timeless():
+    payload = {
+        "rules": [
+            {
+                "name": "minimum_age",
+                "versions": [
+                    {
+                        "effective_from": "2020-01-01",
+                        "effective_to": "2024-12-31",
+                        "formula": 18,
+                    }
+                ],
+            }
+        ]
+    }
+    environment = completeness_module._constant_rule_environment(payload)
+
+    assert (
+        completeness_module._formula_environment_for_case(environment, {})[
+            "minimum_age"
+        ]
+        == 18
+    )
+    assert "minimum_age" not in completeness_module._formula_environment_for_case(
+        environment,
+        {"period": "2019"},
+    )
+    assert (
+        completeness_module._formula_environment_for_case(
+            environment,
+            {"period": "2022"},
+        )["minimum_age"]
+        == 18
+    )
+    assert "minimum_age" not in completeness_module._formula_environment_for_case(
+        environment,
+        {"period": "2026"},
+    )
+
+
 def _boundary_control_content(
     *,
     formula: str,
@@ -6201,6 +6391,34 @@ def test_boundary_requires_one_operative_input_threshold_comparison():
 
     assert _has_issue(inert_result, "boundary", "100")
     assert not operative_result.issues
+
+
+def test_multiline_boundary_conjunction_binds_named_threshold():
+    source = "(1) Die Regel gilt ab einem Alter von 18 Jahren."
+    content = _boundary_control_content(
+        formula="claimant_age >= income_limit\n          and claimant_is_resident",
+        limit_versions="""\
+      - effective_from: '2026-01-01'
+        formula: 18""",
+    )
+    cases = [
+        {
+            "name": "at age threshold",
+            "period": "2026",
+            "input": {"claimant_age": 18, "claimant_is_resident": True},
+            "output": {"eligible": True},
+        },
+        {
+            "name": "below age threshold",
+            "period": "2026",
+            "input": {"claimant_age": 17, "claimant_is_resident": True},
+            "output": {"eligible": False},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert not result.issues
 
 
 def test_adjacent_integral_boundary_requires_the_equivalent_comparator():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1449"
+version = "0.2.1450"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- name asserted principal formulas that execute a missing source computation but lack direct canonical formula-clause binding, with exact proof/excerpt repair guidance
- proactively require formula proof excerpts whenever a canonical structural path does not unambiguously bind the implementing principal rule
- share and bound diagnostic execution work, with explicit disclosure whenever the best-effort scan is capped
- parse multiline Axiom continuations consistently for boundary evidence
- preserve effective windows for singleton dated constants while retaining unambiguous undated-case behavior

## Review cycle

An independent full-diff review found performance, prompt-scope, and cap-disclosure issues. Each was fixed and regression-tested. The repeat review is CLEAN on the committed tree.

## Validation

- `ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- affected suites: 1,200 passed
- exact NJ failed-artifact replay: intended before-proration formula is named as unbound; false age-18 boundary issue is cleared; valid paired-exception obligation remains
- full Python 3.13 suite: 6,326 passed, 119 skipped
