### PR TITLE
Fix source exception witness classification

### DIFF
--- a/changelog.d/source-exception-witness-classification.fixed.md
+++ b/changelog.d/source-exception-witness-classification.fixed.md
@@ -1,0 +1,4 @@
+Classify complete-source exception evidence by executable obligation type,
+including multiline selectors, enabling eligibility conditions, asserted
+unconditional non-applicability, formal cross-references, and arithmetic
+formula clauses. Diagnostics now identify each missing isolated case pair.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1453"
+version = "0.2.1454"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1452"
+version = "0.2.1453"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1452"
+__version__ = "0.2.1453"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1453"
+__version__ = "0.2.1454"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -6468,27 +6468,32 @@ def _source_exception_requires_paired_witness(text: str) -> bool:
         r"\bexcept\s+as\s+[^.;]{0,100}\bprovided\b",
         collapsed,
         flags=re.IGNORECASE,
-    ):
+    ) and _source_reference_reservation_is_only_references(collapsed):
         return False
-    if (
-        _NEGATIVE_NONAPPLICABILITY_LANGUAGE.search(collapsed)
-        and _LOCAL_CONDITION_LANGUAGE.search(collapsed) is None
-    ):
+    if _source_unconditional_nonapplicability(collapsed):
         return False
     if re.search(
         r"\b(?:subject\s+to|vorbehaltlich)\b",
         collapsed,
         flags=re.IGNORECASE,
-    ) and _source_has_formal_cross_reference(collapsed):
+    ) and _source_reference_reservation_is_only_references(collapsed):
         return False
     return True
 
 
 def _source_has_formal_cross_reference(text: str) -> bool:
+    target = (
+        r"(?:chapter|title|article|part|subchapter|subtitle|division|section|"
+        r"subsection|paragraph|act|law|code|gesetz|absatz|absätze)"
+    )
+    label = r"(?:\(?\d+[A-Za-z0-9.-]*\)?|\(?[A-Za-z]\)?|[IVXLCDM]+)"
+    deictic = r"(?:this|that|the|these|those|dies(?:e[rmns]?))"
     if re.search(
-        r"\b(?:all\s+)?(?:provisions?|restrictions?|subsections?|paragraphs?|"
-        r"sections?|chapters?|vorschriften?|bestimmungen?|absätze?|paragraphen?)"
-        r"\b|§",
+        r"\b(?:all\s+)?(?:provisions?|restrictions?|vorschriften?|bestimmungen?)"
+        rf"\s+(?:of|in|under|nach|gemäß)\s+(?:{deictic}\s+{target}"
+        rf"(?:\s+{label})?|{target}\s+{label})(?=\W|$)|"
+        rf"\b{deictic}\s+{target}\b|"
+        rf"\b{target}\s+{label}(?=\W|$)|§",
         text,
         flags=re.IGNORECASE,
     ):
@@ -6516,12 +6521,213 @@ def _source_has_formal_cross_reference(text: str) -> bool:
     )
 
 
-def _source_unconditional_nonapplicability(text: str) -> bool:
-    collapsed = _collapse_text(text)
-    return bool(
-        _NEGATIVE_NONAPPLICABILITY_LANGUAGE.search(collapsed)
-        and _LOCAL_CONDITION_LANGUAGE.search(collapsed) is None
+def _source_is_simple_main_proposition(text: str) -> bool:
+    proposition = text.strip(" \t,;:.")
+    determiner = r"(?:(?:a|an|the|this|that|such)\s+)?"
+    program_modifier = (
+        r"(?:(?:income|earned|child|dependent|property|sales|use|tax|"
+        r"refundable|nonrefundable|standard|itemized|personal|business|"
+        r"corporate|individual|state|federal|local|earned-income|child-tax|"
+        r"income-tax|property-tax|sales-tax|use-tax)\s+)"
     )
+    program_subject = (
+        rf"(?:{program_modifier})*"
+        r"(?:credit|claim|benefit|deduction|exemption|allowance|provision|"
+        r"section|subsection|paragraph|rule)"
+    )
+    program_predicate = (
+        r"(?:applies|shall\s+apply|is\s+applicable|is\s+allowed|is\s+available)"
+    )
+    eligible_subject = r"(?:claimant|taxpayer|person|individual)"
+    german_subject = r"(?:der|die|das)\s+(?:anspruch|leistung|regel|vorschrift)"
+    return bool(
+        re.fullmatch(
+            rf"(?:{determiner}{program_subject}\s+{program_predicate}|"
+            rf"{determiner}{eligible_subject}\s+is\s+eligible|"
+            rf"{german_subject}\s+(?:gilt|besteht)|"
+            rf"(?:gilt|besteht)\s+{german_subject})",
+            proposition,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _source_reference_reservation_is_only_references(text: str) -> bool:
+    clause = _strip_source_clause_marker(_collapse_text(text)).strip()
+    marker = re.search(
+        r"\b(?P<marker>subject\s+to|vorbehaltlich|except\s+as)\b",
+        clause,
+        flags=re.IGNORECASE,
+    )
+    if marker is None:
+        return False
+    complement = clause[marker.end() :].strip(" \t,;:.")
+    if marker.start() == 0:
+        tail = clause[marker.end() :]
+        delimiter = re.search(r"[,;]", tail)
+        if delimiter is not None and _source_is_simple_main_proposition(
+            tail[delimiter.end() :]
+        ):
+            complement = tail[: delimiter.start()].strip(" \t,;:.")
+        elif delimiter is None:
+            for proposition_start in re.finditer(
+                r"\b(?:a|an|the|this|that|such|der|die|das|gilt|besteht)\b",
+                tail,
+                flags=re.IGNORECASE,
+            ):
+                if _source_is_simple_main_proposition(
+                    tail[proposition_start.start() :]
+                ):
+                    complement = tail[: proposition_start.start()].strip(" \t,;:.")
+                    break
+    if marker.group("marker").lower().startswith("except") and re.fullmatch(
+        r"(?:(?:may|might)\s+)?(?:otherwise\s+)?(?:specifically\s+)?"
+        r"(?:be\s+)?provided(?:\s+by\s+law)?",
+        complement,
+        flags=re.IGNORECASE,
+    ):
+        return True
+    if not _source_has_formal_cross_reference(complement):
+        return False
+    target = (
+        r"(?:chapters?|titles?|articles?|parts?|subchapters?|subtitles?|"
+        r"divisions?|sections?|subsections?|paragraphs?|acts?|laws?|codes?|"
+        r"gesetz|absatz|absätze)"
+    )
+    label = r"(?:\(?\d+[A-Za-z0-9.-]*\)?|\(?[A-Za-z]\)?|[IVXLCDM]+)"
+    deictic = r"(?:this|that|the|these|those|dies(?:e[rmns]?))"
+    remainder = complement
+    for pattern in (
+        _GERMAN_LEGAL_CITATION,
+        _ENGLISH_LEGAL_CITATION,
+        _STRUCTURAL_REFERENCE,
+    ):
+        remainder = pattern.sub(" ", remainder)
+    for pattern in (
+        rf"\b{deictic}\s+{target}(?:\s+{label})?\b",
+        rf"\b{target}\s+{label}(?=\W|$)",
+        r"\b\d+\s+U\.?\s*S\.?\s*C\.?\s*(?:§|s\.)?\s*\d+[a-z0-9.-]*\b",
+    ):
+        remainder = re.sub(pattern, " ", remainder, flags=re.IGNORECASE)
+    remainder = re.sub(
+        r"\b[A-Z][A-Z.]{1,8}\s*\d+[A-Za-z0-9:.-]*",
+        " ",
+        remainder,
+    )
+    allowed_words = (
+        r"all|the|this|that|these|those|provisions?|restrictions?|"
+        r"modifications?|requirements?|limitations?|of|in|under|and|or|except|"
+        r"as|may|might|be|otherwise|specifically|provided|by|law|code|act|et|al|"
+        r"seq|chapters?|titles?|articles?|parts?|subchapters?|subtitles?|"
+        r"divisions?|sections?|subsections?|paragraphs?|vorschriften?|"
+        r"bestimmungen?|dies(?:e[rmns]?)|gemäß|nach|und|oder|gesetz|absatz|absätze"
+    )
+    remainder = re.sub(
+        rf"\b(?:{allowed_words})\b",
+        " ",
+        remainder,
+        flags=re.IGNORECASE,
+    )
+    remainder = re.sub(
+        r"(?<![A-Za-z0-9])(?:\(?\d+[A-Za-z0-9.-]*\)?|\(?[A-Za-z]\)?|"
+        r"[IVXLCDM]+)(?![A-Za-z0-9])",
+        " ",
+        remainder,
+    )
+    return re.fullmatch(r"[\s.,;:()§'/-]*", remainder) is not None
+
+
+def _source_unconditional_nonapplicability(text: str) -> bool:
+    clause = _strip_source_clause_marker(_collapse_text(text)).strip()
+    clause = re.sub(
+        r"^provided\s+however\s*,?\s+(?:that\s+)?",
+        "",
+        clause,
+        count=1,
+        flags=re.IGNORECASE,
+    )
+    negative_matches = tuple(_NEGATIVE_NONAPPLICABILITY_LANGUAGE.finditer(clause))
+    if not negative_matches:
+        return False
+    negative = negative_matches[-1]
+    if (
+        re.match(r"gilt\b", negative.group(0), flags=re.IGNORECASE)
+        and re.fullmatch(
+            r"gilt\s+nicht",
+            negative.group(0),
+            flags=re.IGNORECASE,
+        )
+        is None
+    ):
+        return False
+    if clause[negative.end() :].strip(" \t,;:."):
+        return False
+    subject = clause[: negative.start()].strip(" \t,;:")
+    return _source_is_unconditional_subject(subject)
+
+
+def _source_is_unconditional_subject(text: str) -> bool:
+    """Accept only bare subjects or explicit legal-reference noun phrases."""
+
+    subject = re.sub(
+        r"^(?:the|this|that|such|der|die|das|dies(?:e[rmns]?))\s+",
+        "",
+        text.strip(),
+        count=1,
+        flags=re.IGNORECASE,
+    )
+    bare_subjects = (
+        r"claimants?|persons?|individuals?|taxpayers?|residents?|claims?|credits?|"
+        r"benefits?|payments?|deductions?|exemptions?|rules?|anspr(?:uch|üche)|"
+        r"leistungen?|regeln?"
+    )
+    if re.fullmatch(bare_subjects, subject, flags=re.IGNORECASE):
+        return True
+    if re.fullmatch(
+        r"(?:preceding|previous|following|vorherige[rmns]?|folgende[rmns]?)\s+"
+        r"(?:sentence|paragraph|clause|satz|absatz)",
+        subject,
+        flags=re.IGNORECASE,
+    ):
+        return True
+    reference_head = (
+        r"provisions?|requirements?|limitations?|subsections?|sections?|"
+        r"paragraphs?|clauses?|sentences?|chapters?|titles?|articles?|parts?|"
+        r"subchapters?|subtitles?|divisions?|absatz|absätze|satz|sätze|nummern?"
+    )
+    head = re.match(rf"^(?P<head>{reference_head})\b", subject, flags=re.IGNORECASE)
+    if head is None:
+        return False
+    tail = subject[head.end() :].strip()
+    if not tail:
+        return True
+    reference_split = re.fullmatch(
+        r"(?:(?P<labels>.*?)\s+)?(?:of|under|des|der)\s+(?P<reference>.+)",
+        tail,
+        flags=re.IGNORECASE,
+    )
+    if reference_split is not None:
+        labels = (reference_split.group("labels") or "").strip()
+        return (
+            not labels or _source_reference_labels_are_structural(labels)
+        ) and _source_has_formal_cross_reference(reference_split.group("reference"))
+    return _source_reference_labels_are_structural(tail)
+
+
+def _source_reference_labels_are_structural(text: str) -> bool:
+    if re.fullmatch(r"[A-Za-z0-9()., -]+", text) is None:
+        return False
+    connectors = {"and", "or", "through", "to", "und", "oder", "bis"}
+    for token in re.findall(r"[A-Za-z0-9]+", text):
+        if (
+            token.lower() in connectors
+            or len(token) == 1
+            or any(character.isdigit() for character in token)
+            or re.fullmatch(r"[IVXLCDM]+", token) is not None
+        ):
+            continue
+        return False
+    return True
 
 
 def _source_rounding_obligations(
@@ -6817,6 +7023,18 @@ def _source_exception_effect_requirement(text: str) -> str:
         ):
             return "enable"
         if (
+            negative_proposition
+            and not positive_proposition
+            and re.fullmatch(
+                r"(?:if|when|wenn|falls|sofern|soweit|"
+                r"vorausgesetzt\s*,?\s*dass|"
+                r"unter\s+der\s+voraussetzung\s*,?\s+dass)",
+                cue,
+                flags=re.IGNORECASE,
+            )
+        ):
+            return "exclude"
+        if (
             not negative_proposition
             and not positive_proposition
             and re.fullmatch(
@@ -6892,7 +7110,8 @@ def _source_positive_effect_matches(text: str) -> tuple[re.Match[str], ...]:
             r"\b(?:shall|is|are|will|may)\s+be\s+"
             r"(?:eligible|qualified|allowed|entitled)\b|"
             r"\b(?:is|are)\s+(?:eligible|qualified|allowed|entitled)\b|"
-            r"\b(?:claim|credit|benefit|provision)\s+applies\b",
+            r"\b(?:claim|credit|benefit|provision)\s+applies\b|"
+            r"\b(?:ist|sind|wird|werden)\s+(?:\w+\s+){0,2}berechtigt\b",
             text,
             flags=re.IGNORECASE,
         )
@@ -6904,7 +7123,8 @@ def _source_negative_effect_matches(text: str) -> tuple[re.Match[str], ...]:
         re.finditer(
             r"\b(?:shall|does|is|are)\s+not\s+(?:apply|eligible|qualified|"
             r"allowed|entitled)\b|"
-            r"\b(?:ineligible|excluded|disqualified|unqualified)\b",
+            r"\b(?:ineligible|excluded|disqualified|unqualified)\b|"
+            r"\bnicht\s+berechtigt\b",
             text,
             flags=re.IGNORECASE,
         )

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -6356,6 +6356,7 @@ def _source_exception_branches(
                 branch_text = source_text[branch_start:branch_end]
             if (
                 _EXCEPTION_LANGUAGE.search(branch_text) is None
+                and _source_has_arithmetic_comparison_condition(branch_text)
                 and any(
                     formula_branch.start == branch_start
                     and formula_branch.end == branch_end
@@ -6377,6 +6378,29 @@ def _source_exception_branches(
         {
             (branch.path, branch.start, branch.end): branch for branch in obligations
         }.values()
+    )
+
+
+def _source_has_arithmetic_comparison_condition(text: str) -> bool:
+    """Identify an arithmetic ``if/when`` already owned by formula coverage."""
+
+    collapsed = _collapse_text(text)
+    condition = re.search(
+        r"\b(?:if|when|wenn|falls)\b(?P<body>[^,;.]*)",
+        collapsed,
+        flags=re.IGNORECASE,
+    )
+    if condition is None:
+        return False
+    return bool(
+        re.search(
+            r"\b(?:exceeds?|exceeded|greater\s+than|less\s+than|more\s+than|"
+            r"at\s+least|at\s+most|above|below|over|under|"
+            r"übersteigt|überschreitet|mehr\s+als|weniger\s+als|"
+            r"mindestens|höchstens|über|unter)\b|[<>]=?",
+            condition.group("body"),
+            flags=re.IGNORECASE,
+        )
     )
 
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -291,6 +291,7 @@ _COMPUTATION_LANGUAGE = re.compile(
     r"splitting-verfahren|verfahren\s+nach\s+absatz|"
     r"calculated|computed|computation|multiplied|divided|"
     r"sum\s+of|difference\s+between|product\s+of|twice|half\s+of|"
+    r"amount\s+of\s+(?:the\s+)?excess|"
     r"\d+(?:[.,]\d+)?\s+times\b|"
     r"percentage\s+of|in\s+excess\s+of|"
     r"equals?[^.;]{0,100}\b(?:plus|minus|times)\b"
@@ -377,6 +378,25 @@ _APPLICABILITY_LANGUAGE = re.compile(
     r"wenn|falls|sofern|soweit|when|if|"
     r"bei\s+(?:(?:vorliegen|bestehen)\b|"
     r"(?:(?:einer?|bestehender)\s+)?(?:anspruchsberechtigung|berechtigung)\b)"
+    r")\b",
+    flags=re.IGNORECASE,
+)
+_NEGATIVE_NONAPPLICABILITY_LANGUAGE = re.compile(
+    r"\b(?:"
+    r"(?:shall|does)\s+not\s+apply|"
+    r"(?:is|are)\s+not\s+(?:eligible|qualified|allowed|entitled)|"
+    r"findet\s+keine\s+anwendung|"
+    r"gilt\b[^.;]{0,80}\bnicht|"
+    r"nicht\s+berechtigt|"
+    r"kein(?:e|en|em|er|es)?\s+(?:anspruch|berechtigung)"
+    r")\b",
+    flags=re.IGNORECASE,
+)
+_LOCAL_CONDITION_LANGUAGE = re.compile(
+    r"\b(?:"
+    r"if|when|where|unless|except|in\s+the\s+case\s+of|"
+    r"wenn|falls|sofern|soweit|bei|ohne|mangels|im\s+falle|"
+    r"au(?:ß|ss)er|es\s+sei\s+denn"
     r")\b",
     flags=re.IGNORECASE,
 )
@@ -2223,32 +2243,68 @@ def _companion_test_issues(
         branches=branches,
         active_branches=active_branches,
         deferred_paths=deferred_paths,
+        formula_branches=formula_branches,
     )
     if exception_branches:
+        paired_exception_branches = tuple(
+            branch
+            for branch in exception_branches
+            if _source_exception_requires_paired_witness(branch.text)
+        )
+        unconditional_nonapplicability_branches = tuple(
+            branch
+            for branch in exception_branches
+            if _source_unconditional_nonapplicability(branch.text)
+        )
         toggled_exception_selectors = _toggled_formula_boolean_selectors(
             principal_rules,
             asserted_by_rule=asserted_by_rule,
             formula_environment=formula_environment,
         )
         missing_exception_branches = _unwitnessed_exception_branches(
-            exception_branches,
+            paired_exception_branches,
             principal_rule_paths=principal_rule_paths,
             toggled_exception_selectors=toggled_exception_selectors,
             extract_numeric_occurrences=extract_numeric_occurrences,
         )
         if missing_exception_branches:
-            missing_citations = ", ".join(
-                dict.fromkeys(
-                    _branch_citation(corpus_citation_path, branch)
-                    for branch in missing_exception_branches
-                )
+            missing_conditions = "; ".join(
+                f"{_branch_citation(corpus_citation_path, branch)} "
+                f"[{_source_exception_effect_requirement(branch.text)}]: `"
+                f"{_bounded_source_feedback_excerpt(branch.text, limit=220)}`"
+                for branch in missing_exception_branches
             )
             issues.append(
                 "[complete-source-unit:tests] Source-stated exceptions or "
                 "applicability conditions require paired positive/blocking cases "
                 "that assert the affected principal output and toggle its "
-                "controlling formula selector; missing at "
-                f"{missing_citations}."
+                "controlling formula selector. Each listed condition needs its "
+                "own same-period case pair differing in exactly that one input; "
+                f"missing: {missing_conditions}."
+            )
+        missing_unconditional_branches = tuple(
+            branch
+            for branch in unconditional_nonapplicability_branches
+            if not _unconditional_nonapplicability_is_asserted(
+                branch,
+                corpus_citation_path=corpus_citation_path,
+                principal_rules=principal_rules,
+                principal_rule_paths=principal_rule_paths,
+                asserted_by_rule=asserted_by_rule,
+                formula_environment=formula_environment,
+            )
+        )
+        if missing_unconditional_branches:
+            missing_conditions = "; ".join(
+                f"{_branch_citation(corpus_citation_path, branch)}: `"
+                f"{_bounded_source_feedback_excerpt(branch.text, limit=220)}`"
+                for branch in missing_unconditional_branches
+            )
+            issues.append(
+                "[complete-source-unit:tests] Unconditional source-stated "
+                "non-applicability requires a source-bound principal Judgment "
+                "output whose formula executes to false and is asserted false "
+                f"by a companion case; missing: {missing_conditions}."
             )
 
     rounding_obligations = _source_rounding_obligations(
@@ -2428,6 +2484,7 @@ def _source_control_branches(
             branches=branches,
             active_branches=active_branches,
             deferred_paths=deferred_paths,
+            formula_branches=formula_branches,
         )
     )
     return tuple(
@@ -6229,6 +6286,7 @@ def _source_exception_branches(
     branches: Sequence[SourceStructureBranch],
     active_branches: Sequence[SourceStructureBranch],
     deferred_paths: set[tuple[str, ...]],
+    formula_branches: Sequence[SourceStructureBranch] = (),
 ) -> tuple[SourceStructureBranch, ...]:
     obligations: list[SourceStructureBranch] = []
     source_clauses = tuple(_source_clause_spans(source_text, branches=branches))
@@ -6295,6 +6353,12 @@ def _source_exception_branches(
                     else clause_end
                 )
                 branch_text = source_text[branch_start:branch_end]
+            if any(
+                formula_branch.start == branch_start
+                and formula_branch.end == branch_end
+                for formula_branch in formula_branches
+            ):
+                continue
             obligations.append(
                 SourceStructureBranch(
                     owner.path,
@@ -6360,6 +6424,50 @@ def _exception_cues_have_distinct_conditions(between: str) -> bool:
             flags=re.IGNORECASE,
         )
         is not None
+    )
+
+
+def _source_exception_requires_paired_witness(text: str) -> bool:
+    """Return whether a source condition has two locally testable states.
+
+    Cross-reference reservations and unconditional non-applicability rules are
+    still validated as source structure and formula/output coverage.  They do
+    not, however, describe a local condition that companion cases can toggle.
+    """
+
+    collapsed = _collapse_text(text)
+    if re.search(
+        r"\bexcept\s+as\s+(?:may|might|otherwise\b|[^.;]{0,40}\botherwise\b)"
+        r"[^.;]{0,80}\bprovided\b",
+        collapsed,
+        flags=re.IGNORECASE,
+    ):
+        return False
+    if (
+        _NEGATIVE_NONAPPLICABILITY_LANGUAGE.search(collapsed)
+        and _LOCAL_CONDITION_LANGUAGE.search(collapsed) is None
+    ):
+        return False
+    if re.search(
+        r"\b(?:subject\s+to|vorbehaltlich)\b",
+        collapsed,
+        flags=re.IGNORECASE,
+    ) and re.search(
+        r"\b(?:all\s+)?(?:provisions?|restrictions?|subsections?|paragraphs?|"
+        r"sections?|chapters?|vorschriften?|bestimmungen?|absätze?|paragraphen?)"
+        r"\b|§",
+        collapsed,
+        flags=re.IGNORECASE,
+    ):
+        return False
+    return True
+
+
+def _source_unconditional_nonapplicability(text: str) -> bool:
+    collapsed = _collapse_text(text)
+    return bool(
+        _NEGATIVE_NONAPPLICABILITY_LANGUAGE.search(collapsed)
+        and _LOCAL_CONDITION_LANGUAGE.search(collapsed) is None
     )
 
 
@@ -6487,6 +6595,58 @@ def _unwitnessed_exception_branches(
     return _unmatched_evidence_obligations(candidate_witnesses)
 
 
+def _unconditional_nonapplicability_is_asserted(
+    branch: SourceStructureBranch,
+    *,
+    corpus_citation_path: str,
+    principal_rules: dict[str, dict[str, Any]],
+    principal_rule_paths: dict[str, set[tuple[str, ...]]],
+    asserted_by_rule: dict[str, list[dict[str, Any]]],
+    formula_environment: dict[str, Any],
+) -> bool:
+    """Require executable false evidence for an unconditional negative rule."""
+
+    branch_text = _collapse_text(branch.text).lower()
+    for rule_name in _rules_covering_branch(branch, principal_rule_paths):
+        rule = principal_rules[rule_name]
+        if str(rule.get("dtype", "")).strip().lower() not in {
+            "bool",
+            "judgment",
+        }:
+            continue
+        if not any(
+            citation_path == corpus_citation_path
+            and (excerpt_text := _collapse_text(excerpt).lower())
+            and excerpt_text in branch_text
+            for citation_path, excerpt in _rule_source_excerpts(rule)
+        ):
+            continue
+        for case in asserted_by_rule.get(rule_name, ()):
+            asserted = _test_case_asserted_output_value(case, rule_name)
+            if _boolean_value(asserted) is not False:
+                continue
+            dependencies = _case_asserted_dependency_environment(
+                principal_rules,
+                case,
+                formula_environment=formula_environment,
+            )
+            execution = _case_formula_execution(
+                rule,
+                case,
+                formula_environment=formula_environment,
+                dependency_environment=dependencies,
+            )
+            if execution is None:
+                continue
+            runtime = _formula_execution_runtime_value(execution)
+            if _boolean_value(runtime) is False and _formula_runtime_values_equal(
+                runtime,
+                asserted,
+            ):
+                return True
+    return False
+
+
 def _exception_witnesses_for_branch(
     branch: SourceStructureBranch,
     *,
@@ -6581,6 +6741,53 @@ def _source_exception_effect_requirement(text: str) -> str:
         return "zero"
     if _exception_reverses_negative_proposition(collapsed):
         return "enable"
+    condition = next(
+        iter(_source_exception_or_applicability_matches(collapsed)),
+        None,
+    )
+    if condition is not None:
+        cue = condition.group(0).strip().lower()
+        proposition = collapsed[: condition.start()]
+        negative_proposition = re.search(
+            r"\b(?:shall|does|is|are)\s+not\s+(?:apply|eligible|qualified|"
+            r"allowed|entitled)\b|\b(?:ineligible|excluded)\b",
+            proposition,
+            flags=re.IGNORECASE,
+        )
+        positive_proposition = re.search(
+            r"\bto\s+qualify\b|"
+            r"\b(?:shall|is|are|will|may)\s+be\s+"
+            r"(?:eligible|qualified|allowed|entitled)\b|"
+            r"\b(?:is|are)\s+(?:eligible|qualified|allowed|entitled)\b",
+            proposition,
+            flags=re.IGNORECASE,
+        )
+        if (
+            negative_proposition is None
+            and positive_proposition is not None
+            and re.fullmatch(
+                r"(?:if|when|wenn|falls|sofern|soweit|"
+                r"vorausgesetzt\s*,?\s*dass|"
+                r"unter\s+der\s+voraussetzung\s*,?\s+dass)",
+                cue,
+                flags=re.IGNORECASE,
+            )
+        ):
+            return "enable"
+        if (
+            cue.startswith("except")
+            and re.search(
+                r"\b(?:qualifications?|requirements?|conditions?)\b",
+                proposition,
+                flags=re.IGNORECASE,
+            )
+            and re.search(
+                r"\b(?:eligible|qualif(?:y|ied|ication))\b",
+                collapsed[condition.end() :],
+                flags=re.IGNORECASE,
+            )
+        ):
+            return "enable"
     if re.search(
         r"\b(?:"
         r"gilt\b[^.;]{0,80}\bnicht|"
@@ -6637,8 +6844,6 @@ def _source_exception_selector_is_relevant(text: str, name: str) -> bool:
     """Reject formula toggles with no semantic link to the source exception."""
 
     normalized_name = _normalized_selector_name(name)
-    if _exception_semantic_identifier(normalized_name):
-        return True
     collapsed = _collapse_text(text).lower()
     if _source_selector_concept_matches(collapsed, normalized_name):
         return True
@@ -6716,7 +6921,11 @@ def _source_selector_concept_matches(
         "income": r"\b(?:income|einkommen)\w*",
         "qualified": r"\b(?:qualified|berechtig|anspruch)\w*",
         "exempt": r"\b(?:exempt|befrei)\w*",
-        "exception": r"\b(?:exception|ausnahme)\w*",
+        "exception": r"\b(?:exception|ausnahme|abweich|befrei)\w*",
+        "barred": r"\b(?:barred|sperr)\w*",
+        "excluded": r"\b(?:excluded|ausgeschlossen|ausgenommen)\w*",
+        "remarried": r"\b(?:remarri|wiederverheirat)\w*",
+        "waiver": r"\b(?:waiver|waived|verzicht)\w*",
         "surcharge": r"\b(?:surcharge|zuschlag)\w*",
         "status": r"\bstatus\w*",
     }
@@ -6761,7 +6970,12 @@ def _source_selector_concept_polarity(
         before = text[max(0, match.start() - 48) : match.start()]
         after = text[match.end() : min(len(text), match.end() + 48)]
         negative = bool(
-            re.search(
+            re.fullmatch(
+                r"(?:ineligible|disqualified|unqualified)",
+                match.group(0),
+                flags=re.IGNORECASE,
+            )
+            or re.search(
                 r"\b(?:kein(?:e|en|em|er|es)?|fehlend\w*|ohne|mangels|"
                 r"no|without|lack(?:ing)?(?:\s+of)?|absence\s+of)"
                 r"\b[^.;]{0,40}$|"
@@ -7349,26 +7563,25 @@ def _rule_exception_selector_names(rule: dict[str, Any]) -> set[str]:
         selector_names.add(name)
 
     def inspect_expression(text: str) -> None:
-        with contextlib.suppress(SyntaxError):
-            expression = ast.parse(text.strip(), mode="eval").body
-            if not isinstance(
-                expression,
-                (ast.BoolOp, ast.Compare, ast.Name, ast.UnaryOp),
-            ):
-                return
-            function_names = {
-                node.func.id
-                for node in ast.walk(expression)
-                if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
-            }
-            for name in {
-                node.id
-                for node in ast.walk(expression)
-                if isinstance(node, ast.Name)
-                and node.id.lower() not in {"true", "false", "holds", "not_holds"}
-                and node.id not in function_names
-            }:
-                record(name)
+        expression = _parse_formula_expression(text)
+        if not isinstance(
+            expression,
+            (ast.BoolOp, ast.Compare, ast.Name, ast.UnaryOp),
+        ):
+            return
+        function_names = {
+            node.func.id
+            for node in ast.walk(expression)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+        for name in {
+            node.id
+            for node in ast.walk(expression)
+            if isinstance(node, ast.Name)
+            and node.id.lower() not in {"true", "false", "holds", "not_holds"}
+            and node.id not in function_names
+        }:
+            record(name)
 
     def inspect(text: str, *, depth: int = 0) -> None:
         if depth > 32:
@@ -7424,17 +7637,6 @@ def _exception_selector_semantic_active_value(name: str) -> bool:
 
 def _formula_indent_width(value: str) -> int:
     return len(value.expandtabs(4))
-
-
-def _exception_semantic_identifier(identifier: str) -> bool:
-    return bool(
-        re.search(
-            r"(?:exception|exempt|exclud|disqual|inelig|remarri|"
-            r"barred|blocking|waiver|befrei|ausnahme)",
-            identifier,
-            flags=re.IGNORECASE,
-        )
-    )
 
 
 def _ordinary_semantic_identifier(identifier: str) -> bool:

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -2282,17 +2282,18 @@ def _companion_test_issues(
                 "own same-period case pair differing in exactly that one input; "
                 f"missing: {missing_conditions}."
             )
-        missing_unconditional_branches = tuple(
-            branch
-            for branch in unconditional_nonapplicability_branches
-            if not _unconditional_nonapplicability_is_asserted(
-                branch,
-                corpus_citation_path=corpus_citation_path,
-                principal_rules=principal_rules,
-                principal_rule_paths=principal_rule_paths,
-                asserted_by_rule=asserted_by_rule,
-                formula_environment=formula_environment,
-            )
+        missing_unconditional_branches = _unmatched_evidence_obligations(
+            {
+                branch: _unconditional_nonapplicability_witnesses(
+                    branch,
+                    corpus_citation_path=corpus_citation_path,
+                    principal_rules=principal_rules,
+                    principal_rule_paths=principal_rule_paths,
+                    asserted_by_rule=asserted_by_rule,
+                    formula_environment=formula_environment,
+                )
+                for branch in unconditional_nonapplicability_branches
+            }
         )
         if missing_unconditional_branches:
             missing_conditions = "; ".join(
@@ -6353,10 +6354,13 @@ def _source_exception_branches(
                     else clause_end
                 )
                 branch_text = source_text[branch_start:branch_end]
-            if any(
-                formula_branch.start == branch_start
-                and formula_branch.end == branch_end
-                for formula_branch in formula_branches
+            if (
+                _EXCEPTION_LANGUAGE.search(branch_text) is None
+                and any(
+                    formula_branch.start == branch_start
+                    and formula_branch.end == branch_end
+                    for formula_branch in formula_branches
+                )
             ):
                 continue
             obligations.append(
@@ -6437,8 +6441,7 @@ def _source_exception_requires_paired_witness(text: str) -> bool:
 
     collapsed = _collapse_text(text)
     if re.search(
-        r"\bexcept\s+as\s+(?:may|might|otherwise\b|[^.;]{0,40}\botherwise\b)"
-        r"[^.;]{0,80}\bprovided\b",
+        r"\bexcept\s+as\s+[^.;]{0,100}\bprovided\b",
         collapsed,
         flags=re.IGNORECASE,
     ):
@@ -6452,15 +6455,41 @@ def _source_exception_requires_paired_witness(text: str) -> bool:
         r"\b(?:subject\s+to|vorbehaltlich)\b",
         collapsed,
         flags=re.IGNORECASE,
-    ) and re.search(
+    ) and _source_has_formal_cross_reference(collapsed):
+        return False
+    return True
+
+
+def _source_has_formal_cross_reference(text: str) -> bool:
+    if re.search(
         r"\b(?:all\s+)?(?:provisions?|restrictions?|subsections?|paragraphs?|"
         r"sections?|chapters?|vorschriften?|bestimmungen?|absätze?|paragraphen?)"
         r"\b|§",
-        collapsed,
+        text,
         flags=re.IGNORECASE,
     ):
-        return False
-    return True
+        return True
+    if any(
+        pattern.search(text)
+        for pattern in (
+            _PRECISE_DEFERRAL_DEPENDENCY,
+            _GERMAN_LEGAL_CITATION,
+            _ENGLISH_LEGAL_CITATION,
+            _STRUCTURAL_REFERENCE,
+        )
+    ):
+        return True
+    return bool(
+        re.search(
+            r"\b\d+\s+U\.?\s*S\.?\s*C\.?\s*(?:§|s\.)?\s*\d+[a-z0-9.-]*\b",
+            text,
+            flags=re.IGNORECASE,
+        )
+        or re.search(
+            r"\b[A-Z][A-Z.]{1,8}\s*\d+[A-Za-z0-9:.-]*",
+            text,
+        )
+    )
 
 
 def _source_unconditional_nonapplicability(text: str) -> bool:
@@ -6595,7 +6624,7 @@ def _unwitnessed_exception_branches(
     return _unmatched_evidence_obligations(candidate_witnesses)
 
 
-def _unconditional_nonapplicability_is_asserted(
+def _unconditional_nonapplicability_witnesses(
     branch: SourceStructureBranch,
     *,
     corpus_citation_path: str,
@@ -6603,10 +6632,11 @@ def _unconditional_nonapplicability_is_asserted(
     principal_rule_paths: dict[str, set[tuple[str, ...]]],
     asserted_by_rule: dict[str, list[dict[str, Any]]],
     formula_environment: dict[str, Any],
-) -> bool:
-    """Require executable false evidence for an unconditional negative rule."""
+) -> set[tuple[str, int]]:
+    """Return unique executable-false evidence for an unconditional rule."""
 
     branch_text = _collapse_text(branch.text).lower()
+    witnesses: set[tuple[str, int]] = set()
     for rule_name in _rules_covering_branch(branch, principal_rule_paths):
         rule = principal_rules[rule_name]
         if str(rule.get("dtype", "")).strip().lower() not in {
@@ -6621,7 +6651,7 @@ def _unconditional_nonapplicability_is_asserted(
             for citation_path, excerpt in _rule_source_excerpts(rule)
         ):
             continue
-        for case in asserted_by_rule.get(rule_name, ()):
+        for case_index, case in enumerate(asserted_by_rule.get(rule_name, ())):
             asserted = _test_case_asserted_output_value(case, rule_name)
             if _boolean_value(asserted) is not False:
                 continue
@@ -6643,8 +6673,8 @@ def _unconditional_nonapplicability_is_asserted(
                 runtime,
                 asserted,
             ):
-                return True
-    return False
+                witnesses.add((rule_name, case_index))
+    return witnesses
 
 
 def _exception_witnesses_for_branch(
@@ -6748,23 +6778,11 @@ def _source_exception_effect_requirement(text: str) -> str:
     if condition is not None:
         cue = condition.group(0).strip().lower()
         proposition = collapsed[: condition.start()]
-        negative_proposition = re.search(
-            r"\b(?:shall|does|is|are)\s+not\s+(?:apply|eligible|qualified|"
-            r"allowed|entitled)\b|\b(?:ineligible|excluded)\b",
-            proposition,
-            flags=re.IGNORECASE,
-        )
-        positive_proposition = re.search(
-            r"\bto\s+qualify\b|"
-            r"\b(?:shall|is|are|will|may)\s+be\s+"
-            r"(?:eligible|qualified|allowed|entitled)\b|"
-            r"\b(?:is|are)\s+(?:eligible|qualified|allowed|entitled)\b",
-            proposition,
-            flags=re.IGNORECASE,
-        )
+        negative_proposition = _source_negative_effect_matches(proposition)
+        positive_proposition = _source_positive_effect_matches(proposition)
         if (
-            negative_proposition is None
-            and positive_proposition is not None
+            not negative_proposition
+            and positive_proposition
             and re.fullmatch(
                 r"(?:if|when|wenn|falls|sofern|soweit|"
                 r"vorausgesetzt\s*,?\s*dass|"
@@ -6774,6 +6792,32 @@ def _source_exception_effect_requirement(text: str) -> str:
             )
         ):
             return "enable"
+        if (
+            not negative_proposition
+            and not positive_proposition
+            and re.fullmatch(
+                r"(?:if|when|wenn|falls|sofern|soweit|"
+                r"vorausgesetzt\s*,?\s*dass|"
+                r"unter\s+der\s+voraussetzung\s*,?\s+dass)",
+                cue,
+                flags=re.IGNORECASE,
+            )
+        ):
+            tail = collapsed[condition.end() :]
+            positive_tail = _source_positive_effect_matches(tail)
+            negative_tail = _source_negative_effect_matches(tail)
+            latest_positive = max(
+                (match.start() for match in positive_tail),
+                default=-1,
+            )
+            latest_negative = max(
+                (match.start() for match in negative_tail),
+                default=-1,
+            )
+            if latest_positive > latest_negative:
+                return "enable"
+            if latest_negative > latest_positive:
+                return "exclude"
         if (
             cue.startswith("except")
             and re.search(
@@ -6817,6 +6861,32 @@ def _source_exception_effect_requirement(text: str) -> str:
     return "change"
 
 
+def _source_positive_effect_matches(text: str) -> tuple[re.Match[str], ...]:
+    return tuple(
+        re.finditer(
+            r"\bto\s+qualify\b|"
+            r"\b(?:shall|is|are|will|may)\s+be\s+"
+            r"(?:eligible|qualified|allowed|entitled)\b|"
+            r"\b(?:is|are)\s+(?:eligible|qualified|allowed|entitled)\b|"
+            r"\b(?:claim|credit|benefit|provision)\s+applies\b",
+            text,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _source_negative_effect_matches(text: str) -> tuple[re.Match[str], ...]:
+    return tuple(
+        re.finditer(
+            r"\b(?:shall|does|is|are)\s+not\s+(?:apply|eligible|qualified|"
+            r"allowed|entitled)\b|"
+            r"\b(?:ineligible|excluded|disqualified|unqualified)\b",
+            text,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
 def _exception_reverses_negative_proposition(text: str) -> bool:
     reversal = re.search(
         r"\b(?:außer|ausser|es\s+sei\s+denn|unless|except)\b",
@@ -6832,6 +6902,7 @@ def _exception_reverses_negative_proposition(text: str) -> bool:
             r"\bfindet\s+keine\s+anwendung\b|"
             r"\b(?:does|shall)\s+not\s+apply\b|"
             r"\b(?:is|are)\s+not\s+(?:eligible|qualified|entitled)\b|"
+            r"\b(?:ineligible|excluded|disqualified|unqualified)\b|"
             r"\bkein(?:e|en|em|er|es)?\s+(?:anspruch|berechtigung)\b",
             proposition,
             flags=re.IGNORECASE,

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1453"
+ENCODER_VERSION = "0.2.1454"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1452"
+ENCODER_VERSION = "0.2.1453"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1453"
+ENCODER_VERSION = "0.2.1454"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1452"
+ENCODER_VERSION = "0.2.1453"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1452"
+ENCODER_VERSION = "0.2.1453"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1453"
+ENCODER_VERSION = "0.2.1454"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1452"
+ENCODER_VERSION = "0.2.1453"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1453"
+ENCODER_VERSION = "0.2.1454"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1453"
+ENCODER_VERSION = "0.2.1454"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1452"
+ENCODER_VERSION = "0.2.1453"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1453"
+ENCODER_VERSION = "0.2.1454"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1452"
+ENCODER_VERSION = "0.2.1453"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1453"
+ENCODER_VERSION = "0.2.1454"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1452"
+ENCODER_VERSION = "0.2.1453"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1452"')
+        .startswith('__version__ = "0.2.1453"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1452"
+    assert encoder_package["version"] == "0.2.1453"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1452"
+    assert project["project"]["version"] == "0.2.1453"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1452"')
+        .startswith('__version__ = "0.2.1453"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1452"
+    assert encoder_package["version"] == "0.2.1453"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1452"
+    assert project["project"]["version"] == "0.2.1453"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1452"')
+        .startswith('__version__ = "0.2.1453"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1453"')
+        .startswith('__version__ = "0.2.1454"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1453"
+    assert encoder_package["version"] == "0.2.1454"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1453"
+    assert project["project"]["version"] == "0.2.1454"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1453"')
+        .startswith('__version__ = "0.2.1454"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1453"
+    assert encoder_package["version"] == "0.2.1454"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1453"
+    assert project["project"]["version"] == "0.2.1454"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1453"')
+        .startswith('__version__ = "0.2.1454"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1453"
+ENCODER_VERSION = "0.2.1454"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1452"
+ENCODER_VERSION = "0.2.1453"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -8280,6 +8280,29 @@ def test_arithmetic_if_clause_is_formula_evidence_not_exception_toggle():
     assert not exception_branches
 
 
+def test_formula_clause_with_explicit_carveout_keeps_exception_obligation():
+    source = """\
+(1) The amount is computed from income, except when exempt, when it is zero.
+"""
+    branches = recognize_source_structure(source)
+    formula_branches = completeness_module._source_formula_branches(
+        source,
+        branches=branches,
+        active_branches=branches,
+        deferred_paths=set(),
+    )
+    exception_branches = completeness_module._source_exception_branches(
+        source,
+        branches=branches,
+        active_branches=branches,
+        deferred_paths=set(),
+        formula_branches=formula_branches,
+    )
+
+    assert len(formula_branches) == 1
+    assert len(exception_branches) == 1
+
+
 def test_positive_eligibility_condition_requires_enabling_effect():
     source = """\
 (1) The claimant shall be eligible if the claimant is ineligible due to age.
@@ -8320,6 +8343,23 @@ def test_positive_eligibility_condition_requires_enabling_effect():
 
     assert not correct_result.issues
     assert _has_issue(wrong_result, "exception", "test")
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "(1) The claimant is ineligible unless an exception applies.",
+        "(1) The claim is excluded except when a waiver applies.",
+        (
+            "(1) If the claimant is ineligible solely due to age, "
+            "the claimant shall be eligible."
+        ),
+    ],
+)
+def test_enabling_effect_is_independent_of_proposition_order(source: str):
+    assert completeness_module._source_exception_effect_requirement(source) == (
+        "enable"
+    )
 
 
 def test_qualification_exception_requires_enabling_effect():
@@ -8367,6 +8407,20 @@ def test_non_toggleable_cross_reference_does_not_require_paired_cases(
     result = _analyze(content, source, test_cases=[case])
 
     assert not _has_issue(result, "exception", "test")
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "(1) The credit applies except as provided in section 5.",
+        "(1) The credit is subject to section 32.",
+        "(1) The credit is subject to 26 U.S.C. 32.",
+    ],
+)
+def test_formal_cross_reference_does_not_require_synthetic_toggle(source: str):
+    assert not completeness_module._source_exception_requires_paired_witness(
+        source
+    )
 
 
 @pytest.mark.parametrize(
@@ -8443,6 +8497,47 @@ rules:
     result = _analyze(content, source, test_cases=[case])
 
     assert not result.issues
+
+
+def test_one_false_case_cannot_cover_two_unconditional_obligations():
+    source = """\
+(1) Subsection (a) shall not apply; subsection (b) shall not apply.
+"""
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: both_subsections_apply
+    kind: derived
+    dtype: Judgment
+    source: de/statute/estg/32a(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: de/statute/estg/32a
+              excerpt: Subsection (a) shall not apply
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: de/statute/estg/32a
+              excerpt: subsection (b) shall not apply
+    versions:
+      - formula: 'false'
+"""
+    case = {
+        "name": "aggregate false assertion",
+        "input": {},
+        "output": {"both_subsections_apply": False},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert _has_issue(result, "non-applicability", "tests")
 
 
 def test_conditional_nonapplicability_still_requires_paired_cases():

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -8303,6 +8303,29 @@ def test_formula_clause_with_explicit_carveout_keeps_exception_obligation():
     assert len(exception_branches) == 1
 
 
+def test_formula_clause_keeps_nonarithmetic_applicability_obligation():
+    source = """\
+(1) If the claimant is eligible, the credit is computed as income * 10 percent.
+"""
+    branches = recognize_source_structure(source)
+    formula_branches = completeness_module._source_formula_branches(
+        source,
+        branches=branches,
+        active_branches=branches,
+        deferred_paths=set(),
+    )
+    exception_branches = completeness_module._source_exception_branches(
+        source,
+        branches=branches,
+        active_branches=branches,
+        deferred_paths=set(),
+        formula_branches=formula_branches,
+    )
+
+    assert len(formula_branches) == 1
+    assert len(exception_branches) == 1
+
+
 def test_positive_eligibility_condition_requires_enabling_effect():
     source = """\
 (1) The claimant shall be eligible if the claimant is ineligible due to age.

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -8203,6 +8203,258 @@ def test_compound_direct_exception_expression_is_discovered():
     assert not result.issues
 
 
+def test_multiline_boolean_applicability_selector_is_discovered():
+    source = "(1) The claimant is eligible if a certificate is present."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: result
+    kind: derived
+    source: de/statute/estg/32a(1)
+    versions:
+      - formula: |-
+          claimant_is_resident
+          and has_certificate
+"""
+    cases = [
+        {
+            "name": "without certificate",
+            "input": {"claimant_is_resident": True, "has_certificate": False},
+            "output": {"result": False},
+        },
+        {
+            "name": "with certificate",
+            "input": {"claimant_is_resident": True, "has_certificate": True},
+            "output": {"result": True},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert not result.issues
+
+
+def test_multiline_direct_formula_returns_every_boolean_selector_name():
+    rule = {
+        "versions": [
+            {
+                "formula": (
+                    "eligible\n"
+                    "and resident\n"
+                    "and not disqualified"
+                )
+            }
+        ]
+    }
+
+    assert completeness_module._rule_exception_selector_names(rule) == {
+        "eligible",
+        "resident",
+        "disqualified",
+    }
+
+
+def test_arithmetic_if_clause_is_formula_evidence_not_exception_toggle():
+    source = """\
+(1) If the credit exceeds the tax due, the amount of the excess is an overpayment.
+"""
+    branches = recognize_source_structure(source)
+    formula_branches = completeness_module._source_formula_branches(
+        source,
+        branches=branches,
+        active_branches=branches,
+        deferred_paths=set(),
+    )
+    exception_branches = completeness_module._source_exception_branches(
+        source,
+        branches=branches,
+        active_branches=branches,
+        deferred_paths=set(),
+        formula_branches=formula_branches,
+    )
+
+    assert len(formula_branches) == 1
+    assert not exception_branches
+
+
+def test_positive_eligibility_condition_requires_enabling_effect():
+    source = """\
+(1) The claimant shall be eligible if the claimant is ineligible due to age.
+"""
+    correct = _exception_control_content(
+        "if ineligible_due_to_age: true else: false"
+    )
+    wrong = _exception_control_content(
+        "if ineligible_due_to_age: false else: true"
+    )
+    correct_cases = [
+        {
+            "name": "ordinary",
+            "input": {"ineligible_due_to_age": False},
+            "output": {"result": False},
+        },
+        {
+            "name": "age modification",
+            "input": {"ineligible_due_to_age": True},
+            "output": {"result": True},
+        },
+    ]
+    wrong_cases = [
+        {
+            "name": "ordinary",
+            "input": {"ineligible_due_to_age": False},
+            "output": {"result": True},
+        },
+        {
+            "name": "age modification",
+            "input": {"ineligible_due_to_age": True},
+            "output": {"result": False},
+        },
+    ]
+
+    correct_result = _analyze(correct, source, test_cases=correct_cases)
+    wrong_result = _analyze(wrong, source, test_cases=wrong_cases)
+
+    assert not correct_result.issues
+    assert _has_issue(wrong_result, "exception", "test")
+
+
+def test_qualification_exception_requires_enabling_effect():
+    source = """\
+(1) The claimant shall meet all qualifications, except the age requirement, in
+order to be eligible for the credit.
+"""
+    content = _exception_control_content(
+        "if age_requirement_exception_applies: true else: false"
+    )
+    cases = [
+        {
+            "name": "ordinary qualification path",
+            "input": {"age_requirement_exception_applies": False},
+            "output": {"result": False},
+        },
+        {
+            "name": "age qualification exception",
+            "input": {"age_requirement_exception_applies": True},
+            "output": {"result": True},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert not result.issues
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "(1) The credit is subject to the provisions of this chapter.",
+        (
+            "(1) The credit is subject to all provisions of this chapter, "
+            "except as may otherwise be provided."
+        ),
+    ],
+)
+def test_non_toggleable_cross_reference_does_not_require_paired_cases(
+    source: str,
+):
+    content = _exception_control_content("false")
+    case = {"name": "nonapplicable", "input": {}, "output": {"result": False}}
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert not _has_issue(result, "exception", "test")
+
+
+@pytest.mark.parametrize(
+    ("formula", "output", "expected_issue"),
+    [("false", False, False), ("true", True, True)],
+)
+def test_unconditional_nonapplicability_requires_asserted_false_output(
+    formula: str,
+    output: bool,
+    expected_issue: bool,
+):
+    source = "(1) Subsection (f) shall not apply."
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: subsection_f_applies
+    kind: derived
+    dtype: Judgment
+    source: de/statute/estg/32a(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: de/statute/estg/32a
+              excerpt: Subsection (f) shall not apply
+    versions:
+      - formula: '{formula}'
+"""
+    case = {
+        "name": "subsection f treatment",
+        "input": {},
+        "output": {"subsection_f_applies": output},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert _has_issue(result, "non-applicability", "tests") is expected_issue
+
+
+def test_german_unconditional_nonapplicability_requires_false_output():
+    source = "(1) Absatz 2 findet keine Anwendung."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: absatz_2_applies
+    kind: derived
+    dtype: Judgment
+    source: de/statute/estg/32a(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: de/statute/estg/32a
+              excerpt: Absatz 2 findet keine Anwendung
+    versions:
+      - formula: 'false'
+"""
+    case = {
+        "name": "absatz 2 treatment",
+        "input": {},
+        "output": {"absatz_2_applies": False},
+    }
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert not result.issues
+
+
+def test_conditional_nonapplicability_still_requires_paired_cases():
+    source = "(1) The credit shall not apply if an exemption applies."
+    content = _exception_control_content("false")
+    case = {"name": "blocked", "input": {}, "output": {"result": False}}
+
+    result = _analyze(content, source, test_cases=[case])
+
+    assert _has_issue(result, "exception", "tests")
+
+
 @pytest.mark.parametrize(
     ("formula", "ordinary_output", "exception_output", "expected_issue"),
     [
@@ -8734,8 +8986,31 @@ def test_unrelated_excluding_selector_cannot_witness_source_exception():
     assert _has_issue(result, "exception", "test")
 
 
+def test_generic_exception_name_cannot_witness_unrelated_source_condition():
+    source = "(1) The claim does not apply when a certificate is absent."
+    content = _exception_control_content(
+        "if age_requirement_exception_applies: false else: true"
+    )
+    cases = [
+        {
+            "name": "ordinary age rule",
+            "input": {"age_requirement_exception_applies": False},
+            "output": {"result": True},
+        },
+        {
+            "name": "age exception",
+            "input": {"age_requirement_exception_applies": True},
+            "output": {"result": False},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert _has_issue(result, "exception", "test")
+
+
 def test_selector_relevance_uses_tokens_not_substrings():
-    source = "(1) The claim does not apply at a separate status."
+    source = "(1) The claim does not apply when a separate status exists."
     content = _exception_control_content("if rate: false else: true")
     cases = [
         {
@@ -8752,6 +9027,10 @@ def test_selector_relevance_uses_tokens_not_substrings():
 
     result = _analyze(content, source, test_cases=cases)
 
+    assert not completeness_module._source_exception_selector_is_relevant(
+        "at a separate status",
+        "rate",
+    )
     assert _has_issue(result, "exception", "test")
 
 

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -8238,17 +8238,7 @@ rules:
 
 
 def test_multiline_direct_formula_returns_every_boolean_selector_name():
-    rule = {
-        "versions": [
-            {
-                "formula": (
-                    "eligible\n"
-                    "and resident\n"
-                    "and not disqualified"
-                )
-            }
-        ]
-    }
+    rule = {"versions": [{"formula": ("eligible\nand resident\nand not disqualified")}]}
 
     assert completeness_module._rule_exception_selector_names(rule) == {
         "eligible",
@@ -8330,12 +8320,8 @@ def test_positive_eligibility_condition_requires_enabling_effect():
     source = """\
 (1) The claimant shall be eligible if the claimant is ineligible due to age.
 """
-    correct = _exception_control_content(
-        "if ineligible_due_to_age: true else: false"
-    )
-    wrong = _exception_control_content(
-        "if ineligible_due_to_age: false else: true"
-    )
+    correct = _exception_control_content("if ineligible_due_to_age: true else: false")
+    wrong = _exception_control_content("if ineligible_due_to_age: false else: true")
     correct_cases = [
         {
             "name": "ordinary",
@@ -8382,6 +8368,30 @@ def test_positive_eligibility_condition_requires_enabling_effect():
 def test_enabling_effect_is_independent_of_proposition_order(source: str):
     assert completeness_module._source_exception_effect_requirement(source) == (
         "enable"
+    )
+
+
+def test_preposed_german_negative_condition_enables_positive_result():
+    source = """\
+(1) Wenn der Antragsteller nicht berechtigt ist, ist er ausnahmsweise berechtigt.
+"""
+
+    assert completeness_module._source_exception_effect_requirement(source) == (
+        "enable"
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "(1) The claimant is not allowed if a disqualification applies.",
+        "(1) The claimant is not qualified when a disqualification applies.",
+        "(1) The claimant is not entitled if a disqualification applies.",
+    ],
+)
+def test_explicit_negative_eligibility_condition_is_excluding(source: str):
+    assert completeness_module._source_exception_effect_requirement(source) == (
+        "exclude"
     )
 
 
@@ -8441,9 +8451,7 @@ def test_non_toggleable_cross_reference_does_not_require_paired_cases(
     ],
 )
 def test_formal_cross_reference_does_not_require_synthetic_toggle(source: str):
-    assert not completeness_module._source_exception_requires_paired_witness(
-        source
-    )
+    assert not completeness_module._source_exception_requires_paired_witness(source)
 
 
 @pytest.mark.parametrize(
@@ -8488,6 +8496,24 @@ rules:
     assert _has_issue(result, "non-applicability", "tests") is expected_issue
 
 
+@pytest.mark.parametrize(
+    "source",
+    [
+        "(1) The provisions of section 5 shall not apply.",
+        "(1) The requirements of section 5 shall not apply.",
+        "(1) The limitations under subsection (b) shall not apply.",
+        "(1) The preceding sentence shall not apply.",
+        "(1) Subsections (a) and (b) shall not apply.",
+        "(1) Subsections (a), (b), and (c) shall not apply.",
+        "(1) Section 5 of this title shall not apply.",
+        "(1) Paragraphs (1) through (3) shall not apply.",
+    ],
+)
+def test_unconditional_legal_reference_subject_is_recognized(source: str):
+    assert completeness_module._source_unconditional_nonapplicability(source)
+    assert not completeness_module._source_exception_requires_paired_witness(source)
+
+
 def test_german_unconditional_nonapplicability_requires_false_output():
     source = "(1) Absatz 2 findet keine Anwendung."
     content = """\
@@ -8520,6 +8546,183 @@ rules:
     result = _analyze(content, source, test_cases=[case])
 
     assert not result.issues
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "(1) The credit shall not apply to nonresidents.",
+        "(1) The credit shall not apply after December 31.",
+        "(1) The credit shall not apply for taxpayers with income over 100.",
+        "(1) The credit shall not apply until the claimant reaches age 65.",
+        "(1) The credit shall not apply while the claimant is incarcerated.",
+        "(1) The credit shall not apply on a joint return.",
+        "(1) The credit shall not apply in respect of foreign income.",
+        "(1) The credit shall not apply under subsection (b).",
+        "(1) The credit shall not apply in taxable years ending in 2025.",
+        "(1) The credit shall not apply whenever the claimant is married.",
+        "(1) After December 31, the credit shall not apply.",
+        "(1) After December 31 the credit shall not apply.",
+        "(1) Taxpayers earning more than 100 dollars are not eligible.",
+        "(1) Credits exceeding 100 shall not apply.",
+        "(1) Credits claimed by nonresidents shall not apply.",
+        "(1) Individuals aged 65 or older are not eligible.",
+        "(1) The married taxpayers are not eligible.",
+        "(1) The nonresident taxpayer is not eligible.",
+        "(1) The taxpayer, a nonresident, is not eligible.",
+        "(1) Der Anspruch gilt für Nichtansässige nicht.",
+    ],
+)
+def test_scoped_nonapplicability_is_not_treated_as_unconditional(source: str):
+    assert not completeness_module._source_unconditional_nonapplicability(source)
+    assert completeness_module._source_exception_requires_paired_witness(source)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "(1) The credit is subject to income restrictions.",
+        "(1) The credit is subject to residency restrictions.",
+        "(1) The credit is subject to restrictions on married taxpayers.",
+    ],
+)
+def test_local_restrictions_are_not_treated_as_formal_cross_references(source: str):
+    assert completeness_module._source_exception_requires_paired_witness(source)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "(1) The credit is subject to this chapter.",
+        "(1) The credit is subject to chapter 5.",
+        "(1) The credit is subject to title 54A.",
+        "(1) The credit is subject to the provisions of chapter 5.",
+        "(1) The credit is subject to the provisions of title 54A.",
+        "(1) The credit is subject to this article.",
+        "(1) The credit is subject to Article IV.",
+        "(1) The credit is subject to this part.",
+        "(1) The credit is subject to Part II.",
+        "(1) The credit is subject to subchapter B.",
+        "(1) The credit is subject to subtitle A.",
+        "(1) The credit is subject to division 2.",
+        "(1) The credit is subject to the provisions of Article IV.",
+        (
+            "(1) The credit is subject to the restrictions of this subsection "
+            "and subsections b., c., d. and e. of this section."
+        ),
+        (
+            "(1) The credit is subject to all provisions of N.J.S.54A:1-1 et "
+            "seq., except as may be otherwise specifically provided in "
+            "P.L.2000, c.80 (C.54A:4-6 et al.)."
+        ),
+    ],
+)
+def test_direct_chapter_and_title_cross_references_are_formal(source: str):
+    assert not completeness_module._source_exception_requires_paired_witness(source)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        ("(1) The credit is subject to section 5 and the claimant must be a resident."),
+        "(1) The credit is subject to section 5 and residency restrictions.",
+        ("(1) The credit is subject to chapter 5, but only for married taxpayers."),
+        (
+            "(1) The credit is subject to the provisions of chapter 5 and an "
+            "income limit."
+        ),
+        ("(1) The credit is subject to section 5, the claimant must be a resident."),
+        ("(1) The credit is subject to section 5; the claimant must be a resident."),
+        "(1) The credit is subject to section 5 with an income limit.",
+        "(1) The credit is subject to section 5 for married taxpayers.",
+        (
+            "(1) The credit is subject to section 5 as modified by residency "
+            "requirements."
+        ),
+        "(1) The credit is subject to section 5 or residency restrictions.",
+        "(1) The credit is subject to section 5 except for nonresidents.",
+    ],
+)
+def test_mixed_reference_and_local_condition_requires_paired_evidence(source: str):
+    assert completeness_module._source_exception_requires_paired_witness(source)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "part time employment",
+        "division of income",
+        "title requirements",
+        "article requirements",
+        "section eligibility rules",
+        "part ownership",
+    ],
+)
+def test_ordinary_language_is_not_a_formal_structural_reference(text: str):
+    assert not completeness_module._source_has_formal_cross_reference(text)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "(1) The credit applies except as otherwise provided.",
+        "(1) The credit applies except as may otherwise be provided.",
+        "(1) The credit applies except as may be provided.",
+        "(1) The credit applies except as provided by law.",
+    ],
+)
+def test_terminal_boilerplate_reservation_does_not_require_toggle(source: str):
+    assert not completeness_module._source_exception_requires_paired_witness(source)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "(1) Except as otherwise provided, the credit applies.",
+        "(1) Except as may otherwise be provided by law, the credit applies.",
+        "(1) Except as provided in section 5, the credit applies.",
+        "(1) Subject to section 5, the credit applies.",
+        "(1) Subject to the provisions of this chapter, the credit applies.",
+        "(1) Vorbehaltlich § 5 gilt der Anspruch.",
+        "(1) Subject to section 5, a credit applies.",
+        "(1) Subject to section 5, such credit applies.",
+        "(1) Subject to section 5, the tax credit applies.",
+        ("(1) Subject to section 5, the state earned income tax credit applies."),
+        ("(1) Subject to section 5, the federal earned income tax credit applies."),
+        "(1) Subject to section 5, the claimant is eligible.",
+        "(1) Subject to section 5, the deduction is allowed.",
+        "(1) Except as provided in section 5, a benefit is available.",
+        "(1) Vorbehaltlich § 5 besteht der Anspruch.",
+    ],
+)
+def test_preposed_reference_reservation_does_not_require_toggle(source: str):
+    assert not completeness_module._source_exception_requires_paired_witness(source)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        (
+            "(1) Subject to section 5, but only for married taxpayers, "
+            "the credit applies."
+        ),
+        "(1) Subject to section 5, the claimant must be a resident.",
+        ("(1) Subject to section 5 and residency restrictions, the credit applies."),
+        ("(1) Except as provided in section 5, the credit applies only to residents."),
+        "(1) Subject to section 5, the credit applies if income is low.",
+        "(1) Subject to section 5, the credit applies to residents.",
+        "(1) Subject to section 5, the credit applies only when married.",
+        "(1) Subject to section 5, if eligible the credit applies.",
+        "(1) Subject to section 5, when eligible the credit applies.",
+        "(1) Subject to section 5, if resident the benefit is available.",
+        "(1) Subject to section 5, while eligible the credit applies.",
+        "(1) Subject to section 5, once eligible the credit applies.",
+        "(1) Subject to section 5, assuming eligibility the credit applies.",
+        "(1) Subject to section 5, the resident-only credit applies.",
+    ],
+)
+def test_preposed_reference_with_local_condition_requires_toggle(source: str):
+    assert completeness_module._source_exception_requires_paired_witness(source)
 
 
 def test_one_false_case_cannot_cover_two_unconditional_obligations():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1453"
+version = "0.2.1454"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1452"
+version = "0.2.1453"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- parse multiline formula expressions when identifying exception selectors
- classify conditional enabling exceptions, unconditional legal negatives, formula-owned arithmetic comparisons, and reference-only reservations with distinct evidence requirements
- require one-to-one paired or false-case evidence for executable exception obligations while keeping closed formal cross-references structural
- improve clause-specific diagnostics and bump the encoder to 0.2.1454

## Review cycle

Independent review/fix loop completed. Findings around preposed reservations, ordinary propositions, conditional-cue bypasses, and compound state-tax program names were fixed and re-reviewed. Final semantic review on `ee9f63590`: **CLEAN**.

Hosted CI then identified Ruff 0.16.1 formatting drift. The two affected files were formatted and independently re-reviewed on `2eccc9bc3`: **CLEAN**; normalized Python ASTs were identical before and after formatting.

## Validation

- focused source-completeness/provenance rerun after formatting: 582 passed
- affected suite before the formatting-only update (`test_source_completeness.py`, `test_rulespec_validation.py`, `test_cli.py`): 3,089 passed, 41 skipped
- full suite before the formatting-only update: 6,465 passed, 119 skipped
- Ruff 0.16.1 check and format check
- repository-wide Ruff check
- `python -m compileall -q src/axiom_encode scripts`
- version provenance guard
- `git diff --check`

The full-suite rerun used an isolated temp directory after an initial host disk-exhaustion interruption; the isolated rerun completed green.