### PR TITLE
Improve formula output repair guidance

### DIFF
--- a/changelog.d/formula-output-binding-diagnostic.fixed.md
+++ b/changelog.d/formula-output-binding-diagnostic.fixed.md
@@ -1,0 +1,2 @@
+Improve formula-output validation feedback with the exact source span and safe
+principal-proof binding instructions needed to repair ambiguous source clauses.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1507"
+version = "0.2.1508"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1507"
+__version__ = "0.2.1508"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1521,6 +1521,16 @@ def _analyze_rulespec_payload(
                     "principal derived/relation output (`derived` or "
                     "`derived_relation`) and is not "
                     "precisely deferred; parameter-only representation is invalid."
+                    + _formula_output_binding_feedback(
+                        branch,
+                        corpus_citation_path=corpus_citation_path,
+                        has_path_covering_principal=bool(
+                            _rules_covering_branch(
+                                branch,
+                                principal_rule_paths,
+                            )
+                        ),
+                    )
                 )
         elif not all_formula_branches and not _path_covered(
             (), principal_paths, deferred_paths
@@ -10646,14 +10656,70 @@ def _collapse_text(value: str) -> str:
 def _bounded_source_feedback_excerpt(value: str, *, limit: int = 360) -> str:
     """Render bounded source-identifying feedback without changing its words."""
 
+    return _bounded_source_feedback_preview(value, limit=limit)[0]
+
+
+def _bounded_source_feedback_preview(
+    value: str,
+    *,
+    limit: int = 360,
+) -> tuple[str, bool]:
+    """Render a source preview and report whether it contains an ellipsis."""
+
     collapsed = _collapse_text(value).replace("`", "\\`")
     if len(collapsed) <= limit:
-        return collapsed
+        return collapsed, False
     marker = " ... "
     available = limit - len(marker)
     head_length = (available * 2) // 3
     tail_length = available - head_length
-    return collapsed[:head_length].rstrip() + marker + collapsed[-tail_length:].lstrip()
+    return (
+        collapsed[:head_length].rstrip() + marker + collapsed[-tail_length:].lstrip(),
+        True,
+    )
+
+
+def _formula_output_binding_feedback(
+    branch: SourceStructureBranch,
+    *,
+    corpus_citation_path: str,
+    has_path_covering_principal: bool,
+) -> str:
+    """Give a repair model the exact proof binding missing from a formula."""
+
+    source_excerpt, source_excerpt_was_truncated = _bounded_source_feedback_preview(
+        branch.text
+    )
+    principal_repair = (
+        "If an existing path-covering principal output's formula already "
+        "implements this computation, add the following proof atom to it. "
+        "Otherwise create a "
+        "principal `derived`/`derived_relation` output or precisely defer the "
+        "computation. The required binding is a"
+        if has_path_covering_principal
+        else "Create a principal `derived`/`derived_relation` output (or precisely "
+        "defer this computation); when adding the output, bind it with a"
+    )
+    bounded_preview_warning = (
+        " The displayed ` ... ` is only a bounded locator and is not source "
+        "text; copy one contiguous verbatim computation-bearing excerpt from "
+        "the cited character span instead."
+        if source_excerpt_was_truncated
+        else ""
+    )
+    return (
+        " The formula-clause number is an internal punctuation-span ordinal, "
+        "not a statutory paragraph number. "
+        f"{principal_repair} "
+        "`versions[N].formula` proof atom whose "
+        "`source.corpus_citation_path` is exactly "
+        f"`{corpus_citation_path}` and whose `source.excerpt` is one contiguous "
+        "verbatim excerpt that itself states the computation. Source locator at "
+        f"characters {branch.start}:{branch.end}: `{source_excerpt}`. A parameter "
+        "rule, a citation-only proof atom, a non-formula proof path, or a shorter "
+        "excerpt that does not itself state the computation cannot bind a "
+        f"principal output to this clause.{bounded_preview_warning}"
+    )
 
 
 def _bounded_period_feedback(periods: Sequence[str], *, limit: int = 8) -> str:

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1507"
+ENCODER_VERSION = "0.2.1508"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1507"
+ENCODER_VERSION = "0.2.1508"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1507"
+ENCODER_VERSION = "0.2.1508"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1507"
+ENCODER_VERSION = "0.2.1508"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1507"
+ENCODER_VERSION = "0.2.1508"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1507"
+ENCODER_VERSION = "0.2.1508"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1507"
+ENCODER_VERSION = "0.2.1508"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1507"')
+        .startswith('__version__ = "0.2.1508"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1507"
+    assert encoder_package["version"] == "0.2.1508"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1507"
+    assert project["project"]["version"] == "0.2.1508"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1507"')
+        .startswith('__version__ = "0.2.1508"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1507"
+    assert encoder_package["version"] == "0.2.1508"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1507"
+    assert project["project"]["version"] == "0.2.1508"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1507"')
+        .startswith('__version__ = "0.2.1508"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1507"
+ENCODER_VERSION = "0.2.1508"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -6302,6 +6302,144 @@ rules:
         "formula clause 2",
         "principal",
     )
+    issue = next(
+        issue
+        for issue in result.issues
+        if "formula-output" in issue and "formula clause 2" in issue
+    )
+    assert "internal punctuation-span ordinal" in issue
+    assert "not a statutory paragraph number" in issue
+    assert "existing path-covering principal output's formula" in issue
+    assert "Otherwise create a principal" in issue
+    assert "or precisely defer the computation" in issue
+    assert "`versions[N].formula` proof atom" in issue
+    assert "`source.corpus_citation_path` is exactly `de/statute/estg/32a`" in issue
+    assert "characters" in issue
+    assert "der zweite Betrag ist Einkommen * 3" in issue
+    assert "shorter excerpt that does not itself state the computation" in issue
+
+
+def test_formula_output_diagnostic_repairs_nj_shaped_root_schedule_binding():
+    schedule_clause = (
+        "(2) For the purposes of the calculation of the New Jersey earned "
+        "income tax credit, the percentage of the federal earned income tax "
+        "credit referred to in paragraph (1) of this subsection shall be: "
+        "(a) 10% for the taxable year beginning on or after January 1, 2000, "
+        "but before January 1, 2001;"
+    )
+    overpayment_clause = (
+        " If the credit exceeds the amount of tax otherwise due, that amount "
+        "of excess shall be an overpayment for the purposes of N.J.S.54A:9-7;"
+    )
+    source_prefix = "New Jersey earned income tax credit program. "
+    source = source_prefix + schedule_clause + overpayment_clause
+    short_schedule_excerpt = (
+        "10% for the taxable year beginning on or after January 1, 2000"
+    )
+
+    def content(derived_excerpt: str) -> str:
+        return f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-nj/statute/54a:4-7
+rules:
+  - name: credit_percentage
+    kind: parameter
+    dtype: Rate
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: "{schedule_clause}"
+    versions:
+      - effective_from: '2000-01-01'
+        formula: 0.10
+  - name: credit_amount
+    kind: derived
+    dtype: Money
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: "{derived_excerpt}"
+    versions:
+      - effective_from: '2000-01-01'
+        formula: federal_credit * credit_percentage
+  - name: credit_overpayment
+    kind: derived
+    dtype: Money
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: "{overpayment_clause.strip()}"
+    versions:
+      - effective_from: '2000-01-01'
+        formula: max(0, credit_amount - tax_due)
+"""
+
+    unbound = _analyze(
+        content(short_schedule_excerpt),
+        source,
+        corpus_citation_path="us-nj/statute/54a:4-7",
+        test_cases=[],
+    )
+    bound = _analyze(
+        content(schedule_clause),
+        source,
+        corpus_citation_path="us-nj/statute/54a:4-7",
+        test_cases=[],
+    )
+
+    issue = next(
+        issue
+        for issue in unbound.issues
+        if "formula-output" in issue and schedule_clause in issue
+    )
+    assert f"characters {len(source_prefix)}:" in issue
+    assert schedule_clause in issue
+    assert "A parameter rule" in issue
+    assert not _has_issue(bound, "formula-output")
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "The amount equals " + "income plus supplement, " * 30 + "income.",
+        "The amount equals " + "`income` plus " * 40 + "supplement.",
+    ],
+)
+def test_long_formula_output_locator_does_not_present_ellipsis_as_source_text(
+    source: str,
+):
+    branch = completeness_module.SourceStructureBranch(
+        (),
+        "formula-clause",
+        "source unit formula clause 1",
+        source,
+        10,
+        10 + len(source),
+    )
+
+    feedback = completeness_module._formula_output_binding_feedback(
+        branch,
+        corpus_citation_path=CORPUS_CITATION_PATH,
+        has_path_covering_principal=True,
+    )
+
+    assert " ... " in feedback
+    assert "only a bounded locator and is not source text" in feedback
+    assert "copy one contiguous verbatim" in feedback
 
 
 COMPANION_COVERAGE_SOURCE = """\

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -6416,7 +6416,7 @@ rules:
     "source",
     [
         "The amount equals " + "income plus supplement, " * 30 + "income.",
-        "The amount equals " + "`income` plus " * 40 + "supplement.",
+        "The amount equals " + "`" * 200 + " income.",
     ],
 )
 def test_long_formula_output_locator_does_not_present_ellipsis_as_source_text(
@@ -6436,7 +6436,14 @@ def test_long_formula_output_locator_does_not_present_ellipsis_as_source_text(
         corpus_citation_path=CORPUS_CITATION_PATH,
         has_path_covering_principal=True,
     )
+    preview, was_truncated = completeness_module._bounded_source_feedback_preview(
+        source
+    )
 
+    if "`" in source:
+        assert len(source) <= 360
+    assert was_truncated
+    assert " ... " in preview
     assert " ... " in feedback
     assert "only a bounded locator and is not source text" in feedback
     assert "copy one contiguous verbatim" in feedback

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1507"
+version = "0.2.1508"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- add precise formula-output binding repair feedback without weakening source completeness validation
- identify internal punctuation-span ordinals and exact source character spans
- distinguish parameter evidence, short non-computation excerpts, and computation-bearing formula proof atoms
- add NJ-shaped and escaped-preview regression coverage
- bump encoder version to 0.2.1455

## Review cycle
- independent review found two actionable issues: misleading existing-principal wording and truncation measured before escaping
- both were fixed and regression coverage was strengthened for raw length at most 360 with escaped length above 360
- final independent review on ad02c87ef: CLEAN

## Checks
- uvx --from ruff==0.16.1 ruff check pyproject.toml src/axiom_encode scripts tests
- uvx --from ruff==0.16.1 ruff format --check src/ tests/
- python -m compileall -q src/axiom_encode scripts
- affected suite: 3092 passed, 41 skipped
- full suite: 6468 passed, 119 skipped
- git diff --check