### PR TITLE
Clarify precise complete-source deferrals

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1508"
+version = "0.2.1509"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1507"
+version = "0.2.1508"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1509"
+version = "0.2.1510"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1510"
+version = "0.2.1511"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1510"
+__version__ = "0.2.1511"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1507"
+__version__ = "0.2.1508"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1509"
+__version__ = "0.2.1510"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1508"
+__version__ = "0.2.1509"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -9734,7 +9734,10 @@ Complete-source-unit mode is enabled for this request:
   contributes nothing to completeness accounting.
 - Every explicit computation stated in the source unit must have a principal
   `kind: derived` or `kind: derived_relation` output. Naming its constants as
-  parameters without encoding the stated formula is invalid.
+  parameters without encoding the stated formula is invalid. Do not defer an
+  explicit computation merely because its source-stated facts are not already
+  represented in the module; declare those facts as explicit local RuleSpec
+  inputs and encode the principal output.
 - When the source states both a base value and its converted result, encode both
   values as separate grounded `kind: parameter` rules. Result wording such as
   "converted to the month, this gives ..." states a scalar result; it does not
@@ -9752,7 +9755,11 @@ Complete-source-unit mode is enabled for this request:
   path (for example, `de:statutes/estg/32a/6#surviving_spouse_tariff`). Include
   `blocked_by` only for known exact RuleSpec targets with a `#rule_fragment`;
   otherwise omit `blocked_by` and name the exact missing legal dependency or
-  citation in `reason`. Never guess a blocker target.
+  citation in `reason`. For a runtime-gap deferral of a current-source branch,
+  the `reason` itself must literally cite the complete legal branch (for
+  example, `42 U.S.C. 1437c-1(c)`) and name a concrete source-stated missing
+  input or runtime capability. The output path alone is not that citation.
+  Never guess a blocker target.
 - Companion tests must execute every source-stated formula branch, boundary,
   exception, and rounding rule with assertions on the affected principal
   output. Each branch needs distinct runtime evidence; descriptive test

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -9757,7 +9757,7 @@ Complete-source-unit mode is enabled for this request:
   otherwise omit `blocked_by` and name the exact missing legal dependency or
   citation in `reason`. For a runtime-gap deferral of a current-source branch,
   the `reason` itself must literally cite the complete legal branch (for
-  example, `42 U.S.C. 1437c-1(c)`) and name a concrete source-stated missing
+  example, `42 U.S.C. 1437c-1(f)`) and name a concrete source-stated missing
   input or runtime capability. The output path alone is not that citation.
   Never guess a blocker target.
 - Companion tests must execute every source-stated formula branch, boundary,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -9756,9 +9756,10 @@ Complete-source-unit mode is enabled for this request:
   `blocked_by` only for known exact RuleSpec targets with a `#rule_fragment`;
   otherwise omit `blocked_by` and name the exact missing legal dependency or
   citation in `reason`. For a runtime-gap deferral of a current-source branch,
-  the `reason` itself must literally cite the complete legal branch (for
-  example, `42 U.S.C. 1437c-1(f)`) and name a concrete source-stated missing
-  input or runtime capability. The output path alone is not that citation.
+  the `reason` itself must literally cite the complete legal branch, including
+  every subsection marker represented by the output branch, and name a
+  concrete source-stated missing input or runtime capability. The output path
+  is not a source citation.
   Never guess a blocker target.
 - Companion tests must execute every source-stated formula branch, boundary,
   exception, and rounding rule with assertions on the affected principal

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1025,18 +1025,36 @@ module:
   deferred_outputs:
     - output: de:statutes/estg/32a/6#surviving_spouse_splitting_tax
       reason: Cannot be computed until the joint-assessment conditions cited in EStG § 26 are encoded.
-For a current-source administrative runtime gap, use this shape instead:
-module:
-  deferred_outputs:
-    - output: us:statutes/42/1437c-1/f#public_hearing_process
-      reason: >-
-        Cannot be computed until the public-hearing event and governing-body
-        consultation records required by 42 U.S.C. 1437c-1(f) are available at runtime.
 `output` and `reason` are required; `blocked_by` is optional and, when present, \
 must list exact absolute upstream RuleSpec outputs. When no external legal dependency \
 exists, cite the exact current source branch and name its concrete source-stated missing \
 input or runtime capability in the `reason` itself; the output path is not a source \
 citation, and a generic claim that the branch is unavailable is invalid."""
+
+
+def _imprecise_deferral_retry_shape(
+    *,
+    corpus_citation_path: str,
+    path: tuple[str, ...],
+) -> str:
+    """Render branch-specific retry guidance without inventing source facts."""
+
+    branch_hint = ""
+    if path and corpus_citation_path.startswith("us/statute/"):
+        with contextlib.suppress(ValueError):
+            citation = parse_usc_citation(corpus_citation_path)
+            section = normalize_rulespec_path_segment(citation.section)
+            fragments = "".join(
+                f"({normalize_rulespec_path_segment(part)})" for part in path
+            )
+            branch_hint = (
+                "\nFor this rejected current-source branch, the literal citation "
+                f"required in `reason` is `{citation.title} U.S.C. "
+                f"{section}{fragments}`."
+            )
+    return f"{_IMPRECISE_DEFERRAL_RETRY_SHAPE}{branch_hint}"
+
+
 _ABSATZ_REFERENCE = re.compile(
     r"\b(?:Absatz(?:es)?|Absätze(?:n)?|Abs\.)\s*(?P<label>\d+[a-z]?)\b",
     flags=re.IGNORECASE,
@@ -2067,12 +2085,16 @@ def _deferred_coverage(
         else:
             branch_label = path[0] if path else "source unit"
             rendered_path = "/".join(path) or "<source-unit>"
+            retry_shape = _imprecise_deferral_retry_shape(
+                corpus_citation_path=corpus_citation_path,
+                path=path,
+            )
             issues.append(
                 "[complete-source-unit:deferral] "
                 f"`module.deferred_outputs[{index}]` identifies source branch "
                 f"({branch_label}) (`{rendered_path}`) but its deferral does not "
                 "name an exact missing dependency, input, or runtime capability.\n"
-                f"{_IMPRECISE_DEFERRAL_RETRY_SHAPE}"
+                f"{retry_shape}"
             )
     return covered, issues
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1028,10 +1028,10 @@ module:
 For a current-source administrative runtime gap, use this shape instead:
 module:
   deferred_outputs:
-    - output: us:statutes/42/1437c-1/c#plan_submission_procedures
+    - output: us:statutes/42/1437c-1/f#public_hearing_process
       reason: >-
-        Cannot be computed until the plan-submission procedure, timing, and form
-        required by 42 U.S.C. 1437c-1(c) are available at runtime.
+        Cannot be computed until the public-hearing event and governing-body
+        consultation records required by 42 U.S.C. 1437c-1(f) are available at runtime.
 `output` and `reason` are required; `blocked_by` is optional and, when present, \
 must list exact absolute upstream RuleSpec outputs. When no external legal dependency \
 exists, cite the exact current source branch and name its concrete source-stated missing \

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1045,7 +1045,8 @@ def _imprecise_deferral_retry_shape(
             citation = parse_usc_citation(corpus_citation_path)
             section = normalize_rulespec_path_segment(citation.section)
             fragments = "".join(
-                f"({normalize_rulespec_path_segment(part)})" for part in path
+                f"({normalize_rulespec_path_segment(part)})"
+                for part in (*citation.fragments, *path)
             )
             branch_hint = (
                 "\nFor this rejected current-source branch, the literal citation "
@@ -2005,14 +2006,15 @@ def _deferred_coverage(
         output = str(record.get("output") or "").strip()
         output_path = output.split("#", 1)[0]
         path: tuple[str, ...] | None = None
+        display_path: tuple[str, ...] | None = None
         if output_path == base_target:
             path = ()
+            display_path = ()
         elif output_path.startswith(f"{base_target}/"):
-            path = tuple(
-                part.lower()
-                for part in output_path[len(base_target) + 1 :].split("/")
-                if part
+            display_path = tuple(
+                part for part in output_path[len(base_target) + 1 :].split("/") if part
             )
+            path = tuple(part.lower() for part in display_path)
         if path is None:
             continue
         reason = str(record.get("reason") or "").strip()
@@ -2087,7 +2089,7 @@ def _deferred_coverage(
             rendered_path = "/".join(path) or "<source-unit>"
             retry_shape = _imprecise_deferral_retry_shape(
                 corpus_citation_path=corpus_citation_path,
-                path=path,
+                path=display_path or path,
             )
             issues.append(
                 "[complete-source-unit:deferral] "
@@ -3643,11 +3645,12 @@ def _reason_names_source_bound_runtime_gap(
     section_pattern = re.escape(
         normalize_rulespec_path_segment(citation.section)
     ).replace(r"\-", dash_pattern)
+    complete_branch = (*citation.fragments, *path)
     branch_pattern = r"\s*".join(
         rf"\(\s*{re.escape(normalize_rulespec_path_segment(part))}\s*\)"
-        for part in path
+        for part in complete_branch
     )
-    descendant_guard = r"(?!\s*\()" if len(path) > 1 else ""
+    descendant_guard = r"(?!\s*\()" if len(complete_branch) > 1 else ""
     exact_branch_citation = re.compile(
         rf"\b{re.escape(citation.title)}\s+U\.?\s*S\.?\s*C\.?\s*"
         rf"(?:§{{1,2}}\s*)?{section_pattern}\s*{branch_pattern}{descendant_guard}",

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1025,10 +1025,18 @@ module:
   deferred_outputs:
     - output: de:statutes/estg/32a/6#surviving_spouse_splitting_tax
       reason: Cannot be computed until the joint-assessment conditions cited in EStG § 26 are encoded.
+For a current-source administrative runtime gap, use this shape instead:
+module:
+  deferred_outputs:
+    - output: us:statutes/42/1437c-1/c#plan_submission_procedures
+      reason: >-
+        Cannot be computed until the plan-submission procedure, timing, and form
+        required by 42 U.S.C. 1437c-1(c) are available at runtime.
 `output` and `reason` are required; `blocked_by` is optional and, when present, \
 must list exact absolute upstream RuleSpec outputs. When no external legal dependency \
 exists, cite the exact current source branch and name its concrete source-stated missing \
-input or runtime capability; a generic claim that the branch is unavailable is invalid."""
+input or runtime capability in the `reason` itself; the output path is not a source \
+citation, and a generic claim that the branch is unavailable is invalid."""
 _ABSATZ_REFERENCE = re.compile(
     r"\b(?:Absatz(?:es)?|Absätze(?:n)?|Abs\.)\s*(?P<label>\d+[a-z]?)\b",
     flags=re.IGNORECASE,

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -1652,9 +1652,10 @@ Complete-source-unit mode is enabled for this request:
   `blocked_by` only for known exact RuleSpec targets with a `#rule_fragment`;
   otherwise omit `blocked_by` and name the exact missing legal dependency or
   citation in `reason`. For a runtime-gap deferral of a current-source branch,
-  the `reason` itself must literally cite the complete legal branch (for
-  example, `42 U.S.C. 1437c-1(f)`) and name a concrete source-stated missing
-  input or runtime capability. The output path alone is not that citation.
+  the `reason` itself must literally cite the complete legal branch, including
+  every subsection marker represented by the output branch, and name a
+  concrete source-stated missing input or runtime capability. The output path
+  is not a source citation.
   Never guess a blocker target.
 - Before returning YAML, inventory every top-level structural branch in the
   authoritative source and verify that each branch has either an executable

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -1630,7 +1630,10 @@ Complete-source-unit mode is enabled for this request:
   nothing to completeness accounting.
 - Every explicit computation stated in the source unit must have a principal
   `kind: derived` or `kind: derived_relation` output. Naming its constants as
-  parameters without encoding the stated formula is invalid.
+  parameters without encoding the stated formula is invalid. Do not defer an
+  explicit computation merely because its source-stated facts are not already
+  represented in the module; declare those facts as explicit local RuleSpec
+  inputs and encode the principal output.
 - When the source states both a base value and its converted result, encode both
   values as separate grounded `kind: parameter` rules. Result wording such as
   "converted to the month, this gives ..." states a scalar result; it does not
@@ -1648,7 +1651,11 @@ Complete-source-unit mode is enabled for this request:
   path (for example, `de:statutes/estg/32a/6#surviving_spouse_tariff`). Include
   `blocked_by` only for known exact RuleSpec targets with a `#rule_fragment`;
   otherwise omit `blocked_by` and name the exact missing legal dependency or
-  citation in `reason`. Never guess a blocker target.
+  citation in `reason`. For a runtime-gap deferral of a current-source branch,
+  the `reason` itself must literally cite the complete legal branch (for
+  example, `42 U.S.C. 1437c-1(c)`) and name a concrete source-stated missing
+  input or runtime capability. The output path alone is not that citation.
+  Never guess a blocker target.
 - Before returning YAML, inventory every top-level structural branch in the
   authoritative source and verify that each branch has either an executable
   rule whose `source:` cites that branch or one `module.deferred_outputs` entry

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -1653,7 +1653,7 @@ Complete-source-unit mode is enabled for this request:
   otherwise omit `blocked_by` and name the exact missing legal dependency or
   citation in `reason`. For a runtime-gap deferral of a current-source branch,
   the `reason` itself must literally cite the complete legal branch (for
-  example, `42 U.S.C. 1437c-1(c)`) and name a concrete source-stated missing
+  example, `42 U.S.C. 1437c-1(f)`) and name a concrete source-stated missing
   input or runtime capability. The output path alone is not that citation.
   Never guess a blocker target.
 - Before returning YAML, inventory every top-level structural branch in the

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1510"
+ENCODER_VERSION = "0.2.1511"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1507"
+ENCODER_VERSION = "0.2.1508"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1508"
+ENCODER_VERSION = "0.2.1509"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1509"
+ENCODER_VERSION = "0.2.1510"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_complete_source_mode_plumbing.py
+++ b/tests/test_complete_source_mode_plumbing.py
@@ -96,6 +96,7 @@ def test_generic_encoder_prompt_adds_completeness_only_when_enabled():
     assert (
         "parameters without encoding the stated formula is invalid" in complete_prompt
     )
+    assert "declare those facts as explicit local RuleSpec\n  inputs" in complete_prompt
     assert (
         "encode both\n  values as separate grounded `kind: parameter` rules"
         in complete_prompt
@@ -104,6 +105,10 @@ def test_generic_encoder_prompt_adds_completeness_only_when_enabled():
     assert "companion-test assertions on both\n  parameter outputs" in complete_prompt
     assert "separate grounded `kind: parameter` rules" not in default_prompt
     assert "missing dependency or citation" in complete_prompt
+    assert "the `reason` itself must literally cite the complete legal branch" in (
+        complete_prompt
+    )
+    assert "The output path alone is not that citation" in complete_prompt
     assert "exact missing RuleSpec targets under `blocked_by`" not in complete_prompt
     assert (
         "Only include `blocked_by` entries when you know the exact" in complete_prompt
@@ -234,6 +239,7 @@ def test_eval_prompt_adds_completeness_only_when_enabled(tmp_path):
     assert (
         "parameters without encoding the stated formula is invalid" in complete_prompt
     )
+    assert "declare those facts as explicit local RuleSpec\n  inputs" in complete_prompt
     assert (
         "encode both\n  values as separate grounded `kind: parameter` rules"
         in complete_prompt
@@ -242,6 +248,10 @@ def test_eval_prompt_adds_completeness_only_when_enabled(tmp_path):
     assert "companion-test assertions on both\n  parameter outputs" in complete_prompt
     assert "separate grounded `kind: parameter` rules" not in default_prompt
     assert "exact missing RuleSpec targets under `blocked_by`" not in complete_prompt
+    assert "the `reason` itself must literally cite the complete legal branch" in (
+        complete_prompt
+    )
+    assert "The output path alone is not that citation" in complete_prompt
     assert (
         "Only include `blocked_by` entries when you know the exact" in complete_prompt
     )

--- a/tests/test_complete_source_mode_plumbing.py
+++ b/tests/test_complete_source_mode_plumbing.py
@@ -108,7 +108,7 @@ def test_generic_encoder_prompt_adds_completeness_only_when_enabled():
     assert "the `reason` itself must literally cite the complete legal branch" in (
         complete_prompt
     )
-    assert "The output path alone is not that citation" in complete_prompt
+    assert "The output path\n  is not a source citation" in complete_prompt
     assert "exact missing RuleSpec targets under `blocked_by`" not in complete_prompt
     assert (
         "Only include `blocked_by` entries when you know the exact" in complete_prompt
@@ -251,7 +251,7 @@ def test_eval_prompt_adds_completeness_only_when_enabled(tmp_path):
     assert "the `reason` itself must literally cite the complete legal branch" in (
         complete_prompt
     )
-    assert "The output path alone is not that citation" in complete_prompt
+    assert "The output path\n  is not a source citation" in complete_prompt
     assert (
         "Only include `blocked_by` entries when you know the exact" in complete_prompt
     )

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1507"
+ENCODER_VERSION = "0.2.1508"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1508"
+ENCODER_VERSION = "0.2.1509"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1510"
+ENCODER_VERSION = "0.2.1511"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1509"
+ENCODER_VERSION = "0.2.1510"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1510"
+ENCODER_VERSION = "0.2.1511"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1507"
+ENCODER_VERSION = "0.2.1508"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1509"
+ENCODER_VERSION = "0.2.1510"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1508"
+ENCODER_VERSION = "0.2.1509"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1507"
+ENCODER_VERSION = "0.2.1508"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1508"
+ENCODER_VERSION = "0.2.1509"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1510"
+ENCODER_VERSION = "0.2.1511"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1509"
+ENCODER_VERSION = "0.2.1510"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1508"
+ENCODER_VERSION = "0.2.1509"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1510"
+ENCODER_VERSION = "0.2.1511"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1507"
+ENCODER_VERSION = "0.2.1508"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1509"
+ENCODER_VERSION = "0.2.1510"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1508"
+ENCODER_VERSION = "0.2.1509"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1509"
+ENCODER_VERSION = "0.2.1510"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1507"
+ENCODER_VERSION = "0.2.1508"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1510"
+ENCODER_VERSION = "0.2.1511"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1510"
+ENCODER_VERSION = "0.2.1511"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1508"
+ENCODER_VERSION = "0.2.1509"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1507"
+ENCODER_VERSION = "0.2.1508"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1509"
+ENCODER_VERSION = "0.2.1510"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1507"')
+        .startswith('__version__ = "0.2.1508"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1507"
+    assert encoder_package["version"] == "0.2.1508"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1507"
+    assert project["project"]["version"] == "0.2.1508"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1507"')
+        .startswith('__version__ = "0.2.1508"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1507"
+    assert encoder_package["version"] == "0.2.1508"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1507"
+    assert project["project"]["version"] == "0.2.1508"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1507"')
+        .startswith('__version__ = "0.2.1508"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1508"')
+        .startswith('__version__ = "0.2.1509"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1508"
+    assert encoder_package["version"] == "0.2.1509"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1508"
+    assert project["project"]["version"] == "0.2.1509"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1508"')
+        .startswith('__version__ = "0.2.1509"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1508"
+    assert encoder_package["version"] == "0.2.1509"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1508"
+    assert project["project"]["version"] == "0.2.1509"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1508"')
+        .startswith('__version__ = "0.2.1509"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1510"')
+        .startswith('__version__ = "0.2.1511"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1510"
+    assert encoder_package["version"] == "0.2.1511"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1510"
+    assert project["project"]["version"] == "0.2.1511"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1510"')
+        .startswith('__version__ = "0.2.1511"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1510"
+    assert encoder_package["version"] == "0.2.1511"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1510"
+    assert project["project"]["version"] == "0.2.1511"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1510"')
+        .startswith('__version__ = "0.2.1511"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1509"')
+        .startswith('__version__ = "0.2.1510"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1509"
+    assert encoder_package["version"] == "0.2.1510"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1509"
+    assert project["project"]["version"] == "0.2.1510"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1509"')
+        .startswith('__version__ = "0.2.1510"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1509"
+    assert encoder_package["version"] == "0.2.1510"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1509"
+    assert project["project"]["version"] == "0.2.1510"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1509"')
+        .startswith('__version__ = "0.2.1510"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1508"
+ENCODER_VERSION = "0.2.1509"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1507"
+ENCODER_VERSION = "0.2.1508"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1509"
+ENCODER_VERSION = "0.2.1510"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1510"
+ENCODER_VERSION = "0.2.1511"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -1949,6 +1949,8 @@ rules: []
     )
     assert "Required shape" in issue
     assert "module:\n  deferred_outputs:" in issue
+    assert "42 U.S.C. 1437c-1(c)" in issue
+    assert "the output path is not a source citation" in issue.lower()
     assert "output: de:statutes/estg/32a/6#surviving_spouse_splitting_tax" in issue
     assert "reason: Cannot be computed until" in issue
     assert "EStG § 26" in issue

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -2048,6 +2048,50 @@ rules: []
     assert "`42 U.S.C. 1437c-1(a)`" in issue
 
 
+@pytest.mark.parametrize(
+    ("terminal_fragment", "accepted"),
+    [("A", True), ("B", False)],
+)
+def test_subsection_scoped_runtime_gap_requires_exact_terminal_branch(
+    terminal_fragment: str,
+    accepted: bool,
+):
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/42/1396a/a/10
+  deferred_outputs:
+    - output: us:statutes/42/1396a/a/10/A#hearing_process
+      reason: >-
+        Cannot be computed until the hearing event and notice record required by
+        42 U.S.C. 1396a(a)(10)({terminal_fragment}) are available at runtime.
+rules: []
+"""
+    source = (
+        "(A) The State agency shall conduct a hearing and provide notice of "
+        "the hearing."
+    )
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us/statute/42/1396a/a/10",
+        test_cases=[],
+    )
+
+    if accepted:
+        assert not result.issues
+    else:
+        assert _has_issue(result, "(a)", "deferral", "runtime capability")
+        issue = next(
+            issue
+            for issue in result.issues
+            if issue.startswith("[complete-source-unit:deferral]")
+        )
+        assert "`42 U.S.C. 1396a(a)(10)(A)`" in issue
+
+
 def test_current_usc_branch_cannot_defer_directly_computable_source():
     content = """\
 format: rulespec/v1

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -1949,40 +1949,11 @@ rules: []
     )
     assert "Required shape" in issue
     assert "module:\n  deferred_outputs:" in issue
-    assert "42 U.S.C. 1437c-1(f)" in issue
     assert "the output path is not a source citation" in issue.lower()
     assert "output: de:statutes/estg/32a/6#surviving_spouse_splitting_tax" in issue
     assert "reason: Cannot be computed until" in issue
     assert "EStG § 26" in issue
     assert "`blocked_by` is optional" in issue
-
-
-def test_imprecise_deferral_retry_runtime_gap_example_is_validator_accepted():
-    content = """\
-format: rulespec/v1
-module:
-  source_verification:
-    corpus_citation_path: us/statute/42/1437c–1
-  deferred_outputs:
-    - output: us:statutes/42/1437c-1/f#public_hearing_process
-      reason: >-
-        Cannot be computed until the public-hearing event and governing-body
-        consultation records required by 42 U.S.C. 1437c-1(f) are available at runtime.
-rules: []
-"""
-    source = """\
-(f) Public hearings The agency shall conduct a public hearing and consult with
-its governing body.
-"""
-
-    result = _analyze(
-        content,
-        source,
-        corpus_citation_path="us/statute/42/1437c–1",
-        test_cases=[],
-    )
-
-    assert not result.issues
 
 
 def test_deferral_cannot_name_its_own_branch_as_missing_dependency():
@@ -2069,6 +2040,12 @@ rules: []
     )
 
     assert _has_issue(result, "(a)", "deferral", "runtime capability")
+    issue = next(
+        issue
+        for issue in result.issues
+        if issue.startswith("[complete-source-unit:deferral]")
+    )
+    assert "`42 U.S.C. 1437c-1(a)`" in issue
 
 
 def test_current_usc_branch_cannot_defer_directly_computable_source():

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -1949,12 +1949,40 @@ rules: []
     )
     assert "Required shape" in issue
     assert "module:\n  deferred_outputs:" in issue
-    assert "42 U.S.C. 1437c-1(c)" in issue
+    assert "42 U.S.C. 1437c-1(f)" in issue
     assert "the output path is not a source citation" in issue.lower()
     assert "output: de:statutes/estg/32a/6#surviving_spouse_splitting_tax" in issue
     assert "reason: Cannot be computed until" in issue
     assert "EStG § 26" in issue
     assert "`blocked_by` is optional" in issue
+
+
+def test_imprecise_deferral_retry_runtime_gap_example_is_validator_accepted():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/42/1437c–1
+  deferred_outputs:
+    - output: us:statutes/42/1437c-1/f#public_hearing_process
+      reason: >-
+        Cannot be computed until the public-hearing event and governing-body
+        consultation records required by 42 U.S.C. 1437c-1(f) are available at runtime.
+rules: []
+"""
+    source = """\
+(f) Public hearings The agency shall conduct a public hearing and consult with
+its governing body.
+"""
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us/statute/42/1437c–1",
+        test_cases=[],
+    )
+
+    assert not result.issues
 
 
 def test_deferral_cannot_name_its_own_branch_as_missing_dependency():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1507"
+version = "0.2.1508"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1510"
+version = "0.2.1511"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1508"
+version = "0.2.1509"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1509"
+version = "0.2.1510"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- require explicit source computations to become derived outputs over explicit local facts instead of being deferred because facts are absent
- require current-source runtime deferral reasons to literally cite their complete legal branch
- render retry guidance from the actual corpus citation and output path
- prevent a sibling subsection from satisfying the exact runtime-gap citation requirement when the corpus path already contains subsection fragments

## Evidence
- protected replay run 30902313052 produced 13 concrete administrative deferrals whose reasons omitted literal branch citations, so deterministic complete-source validation rejected all of them
- focused source/prompt/provenance suite: 1,088 passed
- adversarial exact-terminal-branch and broader focused suite before the formatting-only final amendment: 1,112 passed
- isolated rerun of the nine routing/temporary-checkout cases that failed during a disk-constrained local broad run: 9 passed
- hosted CI test (Python 3.13): passed on exact head
- signing supervisor build-and-test: passed on exact head on Ubuntu and macOS
- Ruff check and touched-file format check: passed
- compileall: passed

## Cycle
Independent review found and drove fixes for reflow-sensitive hard-coded examples, dynamically rendered citation hints, and incomplete subsection matching. The final exact-head review found no actionable issues. The final commit after substantive review contains only the requested formatting correction; focused checks and all hosted checks are green on `13c14c2a068ec16b1b674f0f5a6240b0260c1d4b`.