### PR TITLE
Reconcile metadata for primary legacy moves

### DIFF
--- a/changelog.d/legacy-primary-metadata-reconciliation.fixed.md
+++ b/changelog.d/legacy-primary-metadata-reconciliation.fixed.md
@@ -1,0 +1,1 @@
+Reconcile RuleSpec metadata for primary legacy path moves so atomic replacement removes stale validation waivers and rebinds the toolchain integrity digest before installation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1511"
+version = "0.2.1512"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1511"
+__version__ = "0.2.1512"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -25414,31 +25414,63 @@ def _line_preserving_yaml_mapping_removal(
 def _line_preserving_oracle_pending_removal(
     raw: bytes,
     *,
-    old_identities: set[str],
-    canonical_identities: set[str],
+    moves: Sequence[PlannedMove],
 ) -> tuple[bytes, int]:
     """Remove legacy pending records only when a canonical successor is present."""
+
+    old_identities = {rulespec_identity(move.source) for move in moves}
 
     try:
         text = raw.decode("utf-8")
         before = yaml.safe_load(text)
     except (UnicodeError, yaml.YAMLError, RecursionError) as exc:
         raise ValueError("legacy oracle metadata is not valid UTF-8 YAML") from exc
-    if not isinstance(before, list):
-        raise ValueError("legacy oracle metadata is not a YAML list")
-    canonical_present = {
+    if isinstance(before, list):
+        entries = before
+        mapping_schema = False
+        ceiling = None
+    elif isinstance(before, dict) and isinstance(before.get("entries"), list):
+        entries = before["entries"]
+        mapping_schema = True
+        ceiling = before.get("ceiling")
+        if ceiling is not None and (
+            not isinstance(ceiling, int) or isinstance(ceiling, bool) or ceiling < 0
+        ):
+            raise ValueError("legacy oracle metadata ceiling is invalid")
+    else:
+        raise ValueError(
+            "legacy oracle metadata is not a YAML list or canonical entries mapping"
+        )
+    source_to_canonical = {
+        rulespec_identity(move.source): rulespec_identity(move.destination)
+        for move in moves
+    }
+    removed_source_identities = {
         identity
-        for identity in canonical_identities
+        for identity in old_identities
         if any(
             isinstance(item, dict)
             and isinstance(item.get("legal_id"), str)
             and str(item["legal_id"]).startswith(f"{identity}#")
-            for item in before
+            for item in entries
         )
     }
-    expected = [
+    required_canonical_identities = {
+        source_to_canonical[identity] for identity in removed_source_identities
+    }
+    canonical_present = {
+        identity
+        for identity in required_canonical_identities
+        if any(
+            isinstance(item, dict)
+            and isinstance(item.get("legal_id"), str)
+            and str(item["legal_id"]).startswith(f"{identity}#")
+            for item in entries
+        )
+    }
+    expected_entries = [
         item
-        for item in before
+        for item in entries
         if not (
             isinstance(item, dict)
             and isinstance(item.get("legal_id"), str)
@@ -25448,11 +25480,22 @@ def _line_preserving_oracle_pending_removal(
             )
         )
     ]
-    removed = len(before) - len(expected)
-    if removed and canonical_present != canonical_identities:
+    removed = len(entries) - len(expected_entries)
+    if not removed:
+        return raw, 0
+    if removed and canonical_present != required_canonical_identities:
         raise ValueError(
             "legacy oracle metadata lacks an exact canonical successor record"
         )
+    if mapping_schema:
+        if ceiling is not None and ceiling < removed:
+            raise ValueError("legacy oracle metadata ceiling cannot be decremented")
+        expected = copy.deepcopy(before)
+        expected["entries"] = expected_entries
+        if ceiling is not None:
+            expected["ceiling"] = ceiling - removed
+    else:
+        expected = expected_entries
     lines = text.splitlines(keepends=True)
     starts = [
         index for index, line in enumerate(lines) if line.startswith("- legal_id:")
@@ -25467,16 +25510,27 @@ def _line_preserving_oracle_pending_removal(
             remove_indexes.update(range(start, end))
     rewritten = "".join(
         line for index, line in enumerate(lines) if index not in remove_indexes
-    ).encode("utf-8")
+    )
+    if mapping_schema and ceiling is not None:
+        ceiling_pattern = re.compile(r"(?m)^ceiling: [0-9]+$")
+        rewritten, ceiling_count = ceiling_pattern.subn(
+            f"ceiling: {ceiling - removed}",
+            rewritten,
+        )
+        if ceiling_count != 1:
+            raise ValueError(
+                "legacy oracle metadata ceiling is not one canonical entry"
+            )
+    rewritten_bytes = rewritten.encode("utf-8")
     try:
-        actual = yaml.safe_load(rewritten.decode("utf-8"))
+        actual = yaml.safe_load(rewritten_bytes.decode("utf-8"))
     except (UnicodeError, yaml.YAMLError, RecursionError) as exc:
         raise ValueError(
             "legacy oracle metadata removal produced invalid YAML"
         ) from exc
     if actual != expected or observed != removed:
         raise ValueError("legacy oracle metadata removal is not exact")
-    return rewritten, observed
+    return rewritten_bytes, observed
 
 
 def _legacy_metadata_reconciliation_bytes(
@@ -25490,7 +25544,6 @@ def _legacy_metadata_reconciliation_bytes(
 
     old_modules = {move.source.as_posix() for move in moves}
     old_identities = {rulespec_identity(move.source) for move in moves}
-    canonical_identities = {rulespec_identity(move.destination) for move in moves}
     old_manifests = {
         _applied_encoding_manifest_path(move.source).as_posix() for move in moves
     }
@@ -25553,8 +25606,7 @@ def _legacy_metadata_reconciliation_bytes(
     elif path == Path("oracle-coverage-pending.yaml"):
         rewritten, count = _line_preserving_oracle_pending_removal(
             raw,
-            old_identities=old_identities,
-            canonical_identities=canonical_identities,
+            moves=moves,
         )
         operations = ({"operation": "remove_legacy_oracle_pending", "count": count},)
     elif path == Path("tests/test_encoding_manifests.py"):
@@ -25593,17 +25645,29 @@ def _legacy_metadata_reconciliation_bytes(
     return rewritten, operations
 
 
-def _legacy_retained_metadata_reconciliations(
+def _legacy_metadata_reconciliations(
     *,
     checkout_root: Path,
     base_commit: str,
     tracked: Mapping[Path, str],
     moves: Sequence[PlannedMove],
 ) -> tuple[_LegacyReplacementRewrite, ...]:
-    """Build audited inventory removals and their derived toolchain binding."""
+    """Build audited path-move metadata and its derived toolchain binding."""
 
     if not moves:
         return ()
+    old_modules = {move.source.as_posix() for move in moves}
+    old_identities = {rulespec_identity(move.source) for move in moves}
+    old_manifests = {
+        _applied_encoding_manifest_path(move.source).as_posix() for move in moves
+    }
+    relevant_values = {
+        Path(".axiom/index/provisions_to_rules.json"): old_modules,
+        Path(".axiom/pending-validation-fingerprints.json"): old_modules,
+        Path("known-validation-gaps.yaml"): old_modules,
+        Path("oracle-coverage-pending.yaml"): old_identities,
+        Path("tests/test_encoding_manifests.py"): old_manifests,
+    }
     post_migration_waiver_sha256: str | None = None
     waiver_path = Path("known-validation-gaps.yaml")
     if waiver_path in tracked:
@@ -25638,6 +25702,10 @@ def _legacy_retained_metadata_reconciliations(
             max_bytes=16 * 1024 * 1024,
             required_mode=0o644,
         )
+        if path != Path(".axiom/toolchain.toml") and not any(
+            value.encode() in raw for value in relevant_values[path]
+        ):
+            continue
         if raw != _rulespec_migration_base_blob(checkout_root, base_commit, path):
             raise ValueError(
                 f"legacy metadata reconciliation differs from clean HEAD: {path}"
@@ -26430,11 +26498,11 @@ def _resolve_legacy_replacement_contract(
         ],
         *[item.successor_manifest.path for item in retained_successors],
     }
-    metadata_reconciliations = _legacy_retained_metadata_reconciliations(
+    metadata_reconciliations = _legacy_metadata_reconciliations(
         checkout_root=policy_checkout_path,
         base_commit=base_commit,
         tracked=tracked,
-        moves=all_moves if retained_successors else (),
+        moves=all_moves,
     )
     metadata_reconciliation_paths = {item.path for item in metadata_reconciliations}
     excluded.update(metadata_reconciliation_paths)

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1511"
+ENCODER_VERSION = "0.2.1512"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1511"
+ENCODER_VERSION = "0.2.1512"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1511"
+ENCODER_VERSION = "0.2.1512"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_legacy_replacement.py
+++ b/tests/test_legacy_replacement.py
@@ -568,6 +568,110 @@ def test_contract_absorbs_exact_unowned_canonical_destination_predecessor(
     ).exists()
 
 
+def test_primary_move_with_destination_predecessor_reconciles_metadata(
+    tmp_path: Path,
+) -> None:
+    checkout, content_root, source = _legacy_checkout(tmp_path)
+    legacy = checkout / "us-la/statutes/47:32.yaml"
+    legacy_test = legacy.with_name("47:32.test.yaml")
+    destination = checkout / "us-la/statutes/47/32.yaml"
+    destination_test = destination.with_name("32.test.yaml")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_bytes(legacy.read_bytes())
+    destination_test.write_bytes(legacy_test.read_bytes())
+
+    old_module = "us-la/statutes/47:32.yaml"
+    new_module = "us-la/statutes/47/32.yaml"
+    old_manifest = ".axiom/encoding-manifests/us-la/statutes/47:32.json"
+    index = checkout / ".axiom/index/provisions_to_rules.json"
+    index.write_text(
+        json.dumps(
+            {
+                "records": [
+                    {"module": old_module},
+                    {"module": new_module},
+                ]
+            }
+        )
+        + "\n"
+    )
+    pending = checkout / ".axiom/pending-validation-fingerprints.json"
+    pending.write_text(
+        json.dumps(
+            {
+                old_module: {"fingerprint": "legacy"},
+                new_module: {"fingerprint": "canonical"},
+            }
+        )
+        + "\n"
+    )
+    known_gaps = checkout / "known-validation-gaps.yaml"
+    known_gaps.write_text(
+        "validate_failures:\n"
+        f"  '{old_module}':\n"
+        "    pending:\n"
+        "      fingerprint: sha256:legacy\n"
+        "  'us-hi/statutes/example.yaml':\n"
+        "    pending:\n"
+        "      fingerprint: sha256:keep\n"
+    )
+    base_waiver_sha256 = hashlib.sha256(known_gaps.read_bytes()).hexdigest()
+    toolchain = checkout / ".axiom/toolchain.toml"
+    toolchain.write_text(
+        'rulespec_root = "rulespec-us"\n'
+        f'validation_waiver_set_sha256 = "{base_waiver_sha256}"\n'
+    )
+    oracle_pending = checkout / "oracle-coverage-pending.yaml"
+    oracle_pending.write_text(
+        "version: 1\n"
+        "ceiling: 1\n"
+        "entries:\n"
+        "- legal_id: us-hi:statutes/example#amount\n"
+        "  source: manual\n"
+        "  since: '2026-01-01'\n"
+    )
+    oracle_pending_before = oracle_pending.read_bytes()
+    manifest_inventory = checkout / "tests/test_encoding_manifests.py"
+    manifest_inventory.parent.mkdir(parents=True)
+    manifest_inventory.write_text(
+        f"ALLOW = {{\n    '{old_manifest}',\n    'keep.json',\n}}\n"
+    )
+    _git(checkout, "add", ".")
+    _git(checkout, "commit", "-qm", "canonical predecessor metadata")
+
+    with patch("axiom_encode.cli.resolve_corpus_source_unit", return_value=source):
+        contract = _resolve_legacy_replacement_contract(
+            source_raw=Path(old_module),
+            destination_raw=Path(new_module),
+            policy_checkout_path=checkout,
+            policy_repo_path=content_root,
+            source_unit=source,
+            corpus_release=SimpleNamespace(),
+        )
+
+    reconciled = {item.path: item for item in contract.metadata_reconciliations}
+    assert set(reconciled) == {
+        Path(".axiom/index/provisions_to_rules.json"),
+        Path(".axiom/pending-validation-fingerprints.json"),
+        Path(".axiom/toolchain.toml"),
+        Path("known-validation-gaps.yaml"),
+        Path("tests/test_encoding_manifests.py"),
+    }
+    assert Path("oracle-coverage-pending.yaml") not in reconciled
+    assert oracle_pending.read_bytes() == oracle_pending_before
+    assert all(item.path not in reconciled for item in contract.rewrites)
+
+    reconciled_waivers = reconciled[Path("known-validation-gaps.yaml")].raw
+    assert old_module.encode() not in reconciled_waivers
+    assert new_module.encode() not in reconciled_waivers
+    reconciled_waiver_sha256 = hashlib.sha256(reconciled_waivers).hexdigest()
+    reconciled_toolchain = reconciled[Path(".axiom/toolchain.toml")].raw.decode()
+    assert (
+        f'validation_waiver_set_sha256 = "{reconciled_waiver_sha256}"'
+        in reconciled_toolchain
+    )
+
+
 def test_contract_admits_cryptographically_verified_retained_successor(
     tmp_path: Path,
 ) -> None:
@@ -1466,6 +1570,128 @@ def test_toolchain_reconciliation_binds_exact_post_migration_waiver_digest() -> 
             moves=moves,
             validation_waiver_set_sha256=digest,
         )
+
+
+def test_oracle_reconciliation_supports_canonical_mapping_schema() -> None:
+    moves = (
+        PlannedMove(
+            source=Path("us-la/statutes/47:294.yaml"),
+            destination=Path("us-la/statutes/47/294.yaml"),
+        ),
+    )
+    raw = (
+        "version: 1\n"
+        "ceiling: 2\n"
+        "entries:\n"
+        "- legal_id: us-la:statutes/47:294#legacy_amount\n"
+        "  source: manual\n"
+        "  since: '2026-01-01'\n"
+        "- legal_id: us-la:statutes/47/294#canonical_amount\n"
+        "  source: manual\n"
+        "  since: '2026-01-01'\n"
+    ).encode()
+
+    rewritten, operations = _legacy_metadata_reconciliation_bytes(
+        Path("oracle-coverage-pending.yaml"),
+        raw,
+        moves=moves,
+    )
+
+    assert b"ceiling: 1\n" in rewritten
+    assert b"us-la:statutes/47:294#legacy_amount" not in rewritten
+    assert b"us-la:statutes/47/294#canonical_amount" in rewritten
+    assert operations == ({"operation": "remove_legacy_oracle_pending", "count": 1},)
+
+
+def test_oracle_reconciliation_no_match_preserves_mapping_bytes() -> None:
+    moves = (
+        PlannedMove(
+            source=Path("us-la/statutes/47:294.yaml"),
+            destination=Path("us-la/statutes/47/294.yaml"),
+        ),
+    )
+    raw = (
+        "version: 1\n"
+        "ceiling: 1\n"
+        "entries:\n"
+        "- legal_id: us-hi:statutes/example#amount\n"
+        "  source: manual\n"
+        "  since: '2026-01-01'\n"
+    ).encode()
+
+    rewritten, operations = _legacy_metadata_reconciliation_bytes(
+        Path("oracle-coverage-pending.yaml"),
+        raw,
+        moves=moves,
+    )
+
+    assert rewritten == raw
+    assert operations == ({"operation": "remove_legacy_oracle_pending", "count": 0},)
+
+
+def test_oracle_reconciliation_requires_successor_only_for_removed_source() -> None:
+    moves = (
+        PlannedMove(
+            source=Path("us-la/statutes/47:294.yaml"),
+            destination=Path("us-la/statutes/47/294.yaml"),
+        ),
+        PlannedMove(
+            source=Path("us-la/statutes/47:295.yaml"),
+            destination=Path("us-la/statutes/47/295.yaml"),
+        ),
+    )
+    raw = (
+        "version: 1\n"
+        "entries:\n"
+        "- legal_id: us-la:statutes/47:294#legacy_amount\n"
+        "  source: manual\n"
+        "  since: '2026-01-01'\n"
+        "- legal_id: us-la:statutes/47/294#canonical_amount\n"
+        "  source: manual\n"
+        "  since: '2026-01-01'\n"
+    ).encode()
+
+    rewritten, operations = _legacy_metadata_reconciliation_bytes(
+        Path("oracle-coverage-pending.yaml"),
+        raw,
+        moves=moves,
+    )
+
+    assert b"us-la:statutes/47:294#legacy_amount" not in rewritten
+    assert b"us-la:statutes/47/294#canonical_amount" in rewritten
+    assert b"ceiling:" not in rewritten
+    assert operations == ({"operation": "remove_legacy_oracle_pending", "count": 1},)
+
+
+def test_oracle_reconciliation_preserves_explicit_null_ceiling() -> None:
+    moves = (
+        PlannedMove(
+            source=Path("us-la/statutes/47:294.yaml"),
+            destination=Path("us-la/statutes/47/294.yaml"),
+        ),
+    )
+    raw = (
+        "version: 1\n"
+        "ceiling: null\n"
+        "entries:\n"
+        "- legal_id: us-la:statutes/47:294#legacy_amount\n"
+        "  source: manual\n"
+        "  since: '2026-01-01'\n"
+        "- legal_id: us-la:statutes/47/294#canonical_amount\n"
+        "  source: manual\n"
+        "  since: '2026-01-01'\n"
+    ).encode()
+
+    rewritten, operations = _legacy_metadata_reconciliation_bytes(
+        Path("oracle-coverage-pending.yaml"),
+        raw,
+        moves=moves,
+    )
+
+    assert b"ceiling: null\n" in rewritten
+    assert b"us-la:statutes/47:294#legacy_amount" not in rewritten
+    assert b"us-la:statutes/47/294#canonical_amount" in rewritten
+    assert operations == ({"operation": "remove_legacy_oracle_pending", "count": 1},)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1511"
+ENCODER_VERSION = "0.2.1512"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1511"
+ENCODER_VERSION = "0.2.1512"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1511"
+ENCODER_VERSION = "0.2.1512"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1511"
+ENCODER_VERSION = "0.2.1512"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1511"')
+        .startswith('__version__ = "0.2.1512"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1511"
+    assert encoder_package["version"] == "0.2.1512"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1511"
+    assert project["project"]["version"] == "0.2.1512"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1511"')
+        .startswith('__version__ = "0.2.1512"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1511"
+    assert encoder_package["version"] == "0.2.1512"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1511"
+    assert project["project"]["version"] == "0.2.1512"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1511"')
+        .startswith('__version__ = "0.2.1512"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1511"
+ENCODER_VERSION = "0.2.1512"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1511"
+version = "0.2.1512"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- run purpose-built RuleSpec metadata reconciliation for primary legacy path moves, not only retained successors
- remove stale validation waivers and atomically rebind the toolchain waiver digest
- support current oracle-pending mapping schema, including sparse cascades and omitted/null ceilings
- release encoder 0.2.1512

## Exact NJ regression evidence

Against RuleSpec base `1e04e456ab404860050586c34eef51321eea95e9` for `us-nj/statutes/54a:4-7.yaml` -> `us-nj/statutes/54a/4-7.yaml`:

- provision index: one legacy record removed
- pending fingerprint: one legacy record removed
- validation waiver digest: `827c551b...` -> `a3e25adc...`
- oracle pending: no match, byte-identical
- manifest allowance: one legacy record removed
- toolchain: atomically rebound to the exact post-removal waiver digest

## Review cycle

- independent implementation review found two actionable oracle-schema edge cases
- fixed sparse multi-move successor scoping and optional/null ceiling handling
- independent re-review: CLEAN
- rebased onto `d61e1ae7768ecf604f28eb7bd9e1ba067ee56c26`
- independent post-rebase review of `096ed4aa5`: CLEAN; stable implementation patch ID unchanged

## Checks

- `uvx --from ruff==0.16.1 ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `pytest tests/test_legacy_replacement.py`: 72 passed
- apply/rollback and related CLI focused tests: 9 passed
- combined legacy/precise-source-deferral/registry integration: 1,183 passed
- full post-rebase suite: 6,961 passed, 119 skipped
- `git diff --check origin/main...HEAD`
