### PR TITLE
Fix multiline formula witness validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1512"
+version = "0.2.1513"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1512"
+__version__ = "0.2.1513"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -9516,6 +9516,11 @@ Test file rules:
   including `subject to` carve-outs, include companion tests for the positive
   path and the carve-out path so exclusions and override conditions cannot be
   silently dropped.
+- When a complete source unit has many such controls, the source-driven
+  coverage rule overrides the 1-4 case default. Emit as many compact,
+  single-principal-output case pairs as required, keep each pair to the inputs
+  reached by that output, and vary only its controlling selector; do not
+  replace required pairs with one large omnibus case.
 - When a source says a subsection, paragraph, payment, credit, benefit,
   eligibility path, or other output "shall not apply" or "does not apply",
   the exported rule that says that target applies, is allowed, is included, or

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1088,6 +1088,15 @@ _ENGLISH_LEGAL_CITATION = re.compile(
     r"\d+(?:\.\d+)*(?:\s*(?:through|to|[-–—]|and|,)\s*\d+(?:\.\d+)*)*",
     flags=re.IGNORECASE,
 )
+_TITLE_SUFFIX_LEGAL_CITATION = re.compile(
+    r"\b(?:sections?\s+)?(?:\d+)?[a-z]\s*"
+    r"[-\u2010\u2011\u2012\u2013\u2014\u2015\u2212\ufe58\ufe63\uff0d]"
+    r"\s*\d+[a-z]?(?:\s*(?:,\s*(?:(?:and|or)\s+)?|"
+    r"(?:and|or|through|to)\s+)(?:\d+)?[a-z]\s*"
+    r"[-\u2010\u2011\u2012\u2013\u2014\u2015\u2212\ufe58\ufe63\uff0d]"
+    r"\s*\d+[a-z]?)*\s+of\s+this\s+title\b",
+    flags=re.IGNORECASE,
+)
 _STRUCTURAL_REFERENCE = re.compile(
     r"\b(?:"
     r"Artikel(?:s|n)?|Art\.|"
@@ -3840,6 +3849,7 @@ def authoritative_numeric_recall_text(source_text: str) -> str:
 
     cleaned = _strip_terminal_session_law_history(source_text)
     cleaned = _GERMAN_LEGAL_CITATION.sub("", cleaned)
+    cleaned = _TITLE_SUFFIX_LEGAL_CITATION.sub("", cleaned)
     cleaned = _ENGLISH_LEGAL_CITATION.sub("", cleaned)
     cleaned = _STRUCTURAL_REFERENCE.sub("", cleaned)
     cleaned = re.sub(
@@ -4689,14 +4699,21 @@ def _formula_execution_is_source_branch_witness(
 ) -> bool:
     """Return whether one resolved execution proves the exact source branch."""
 
+    execution_environment = _case_formula_identifier_environment(
+        case,
+        formula_environment=formula_environment,
+        dependency_environment=dependency_environment,
+    )
     if (
         execution is None
+        or execution_environment is None
         or not _formula_execution_leaf_is_computational(execution)
         or not _formula_execution_matches_source_branch(
             execution,
             branch,
             interval=interval,
             formula_environment=formula_environment,
+            execution_environment=execution_environment,
             extract_numeric_occurrences=extract_numeric_occurrences,
             numeric_value_is_grounded=numeric_value_is_grounded,
         )
@@ -5402,6 +5419,7 @@ def _formula_execution_matches_source_branch(
     *,
     interval: _NumericInterval | None,
     formula_environment: dict[str, Any],
+    execution_environment: dict[str, Any] | None = None,
     extract_numeric_occurrences: NumericOccurrenceExtractor,
     numeric_value_is_grounded: NumericGroundingPredicate,
 ) -> bool:
@@ -5424,7 +5442,10 @@ def _formula_execution_matches_source_branch(
         environment=binding_environment,
     ):
         return False
-    artifact_operations = _formula_ast_operation_kinds(operative_leaf)
+    artifact_operations = _formula_ast_operation_kinds(
+        operative_leaf,
+        environment=execution_environment,
+    )
     if not _formula_operations_are_compatible(
         source_operations,
         artifact_operations,
@@ -5766,13 +5787,17 @@ def _canonicalize_topology_variables(topology: Any) -> Any:
     return canonicalize(topology)
 
 
-def _formula_ast_operation_kinds(text: str) -> set[str]:
+def _formula_ast_operation_kinds(
+    text: str,
+    *,
+    environment: dict[str, Any] | None = None,
+) -> set[str]:
     operations: set[str] = set()
-    try:
-        expression = ast.parse(text.strip(), mode="eval").body
-    except SyntaxError:
+    expression = _parse_formula_expression(text)
+    if expression is None:
         return operations
-    for node in ast.walk(expression):
+
+    def visit(node: ast.AST) -> None:
         if isinstance(node, ast.BinOp):
             if isinstance(node.op, ast.Add):
                 operations.add("add")
@@ -5788,6 +5813,21 @@ def _formula_ast_operation_kinds(text: str) -> set[str]:
                 operations.add("add")
             elif "product" in lowered:
                 operations.add("multiply")
+        if isinstance(node, ast.BoolOp) and environment is not None:
+            for item in node.values:
+                visit(item)
+                value = _evaluate_condition_expression(item, environment)
+                if value is _UNRESOLVED_CONDITION_VALUE:
+                    return
+                if isinstance(node.op, ast.And) and not bool(value):
+                    return
+                if isinstance(node.op, ast.Or) and bool(value):
+                    return
+            return
+        for child in ast.iter_child_nodes(node):
+            visit(child)
+
+    visit(expression)
     return operations
 
 
@@ -6123,14 +6163,14 @@ def _simplified_formula_text(
     *,
     environment: dict[str, Any],
 ) -> str:
-    with contextlib.suppress(SyntaxError):
-        expression = ast.parse(text.strip(), mode="eval").body
-        simplified = _simplify_formula_expression(
-            expression,
-            environment=environment,
-        )
-        return ast.unparse(ast.fix_missing_locations(simplified))
-    return text
+    expression = _parse_formula_expression(text)
+    if expression is None:
+        return text
+    simplified = _simplify_formula_expression(
+        expression,
+        environment=environment,
+    )
+    return ast.unparse(ast.fix_missing_locations(simplified))
 
 
 def _simplify_formula_expression(

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -1013,6 +1013,10 @@ _TESTS_PROTOCOL = """- Emit only RuleSpec YAML; use `.test.yaml` companions when
 - For every encoded `except`, `unless`, `subject to`, or `notwithstanding`
   carve-out, include companion tests for the positive path and the carve-out
   path so exclusions and override conditions cannot be silently dropped.
+- When a complete source unit has many such controls, emit as many compact,
+  single-principal-output case pairs as the source requires. Keep each pair to
+  the inputs reached by that output and vary only its controlling selector;
+  do not replace required pairs with one large omnibus case.
 - When a source says a subsection, paragraph, payment, credit, benefit,
   eligibility path, or other output "shall not apply" or "does not apply",
   the exported rule that says that target applies, is allowed, is included, or

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1512"
+ENCODER_VERSION = "0.2.1513"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_complete_source_mode_plumbing.py
+++ b/tests/test_complete_source_mode_plumbing.py
@@ -129,6 +129,8 @@ def test_generic_encoder_prompt_adds_completeness_only_when_enabled():
     assert "parameter/helper guards in the\n  single derived formula" in complete_prompt
     assert "omit oracle inputs or expectations" in complete_prompt
     assert "scalar-only source unit may remain parameter-only" in complete_prompt
+    assert "single-principal-output case pairs" in complete_prompt
+    assert "one large omnibus case" in complete_prompt
 
 
 def test_validator_pipeline_complete_source_mode_is_default_off(tmp_path):
@@ -255,6 +257,10 @@ def test_eval_prompt_adds_completeness_only_when_enabled(tmp_path):
     assert (
         "Only include `blocked_by` entries when you know the exact" in complete_prompt
     )
+    assert "source-driven\n  coverage rule overrides the 1-4 case default" in (
+        complete_prompt
+    )
+    assert "one large omnibus case" in complete_prompt
 
 
 def test_eval_prompt_adds_prior_validation_feedback_only_when_supplied(tmp_path):

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1512"
+ENCODER_VERSION = "0.2.1513"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1512"
+ENCODER_VERSION = "0.2.1513"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1512"
+ENCODER_VERSION = "0.2.1513"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1512"
+ENCODER_VERSION = "0.2.1513"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1512"
+ENCODER_VERSION = "0.2.1513"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1512"
+ENCODER_VERSION = "0.2.1513"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1512"')
+        .startswith('__version__ = "0.2.1513"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1512"
+    assert encoder_package["version"] == "0.2.1513"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1512"
+    assert project["project"]["version"] == "0.2.1513"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1512"')
+        .startswith('__version__ = "0.2.1513"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1512"
+    assert encoder_package["version"] == "0.2.1513"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1512"
+    assert project["project"]["version"] == "0.2.1513"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1512"')
+        .startswith('__version__ = "0.2.1513"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1512"
+ENCODER_VERSION = "0.2.1513"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -5513,6 +5513,30 @@ def test_terminal_session_law_history_is_not_numeric_recall(history_tail):
 
 
 @pytest.mark.parametrize(
+    "references",
+    (
+        "under z-4 of this title and pursuant to z–3 of this title",
+        "under sections 1437z-3 and 1437z-4 of this title",
+        "under section 1437z-3 or 1437z-4 of this title",
+        "under sections 1437z-3, 1437z-4, and 1437z-5 of this title",
+        "under sections 1437z-3 through 1437z-5 of this title",
+        "under sections 1437z-3 to 1437z-5 of this title",
+    ),
+)
+def test_us_title_suffix_cross_references_are_not_numeric_recall_values(
+    references: str,
+):
+    source = f"A program operates {references}. The agency must provide 45 days notice."
+
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        authoritative_numeric_recall_text(source),
+        profile="en-US",
+    )
+
+    assert [(item.value, item.raw) for item in inventory] == [(45.0, "45")]
+
+
+@pytest.mark.parametrize(
     "source_text",
     (
         "The credit is 40% for taxable year 2020 and the amount is $2,020.",
@@ -9497,6 +9521,78 @@ def test_multiline_boundary_conjunction_binds_named_threshold():
     result = _analyze(content, source, test_cases=cases)
 
     assert not result.issues
+
+
+def test_multiline_arithmetic_conjunction_witnesses_source_sum_formula():
+    source = "(1) The sum of dwelling units and vouchers is 550 or fewer."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: de/statute/estg/32a
+rules:
+  - name: combined_unit_and_voucher_limit
+    kind: parameter
+    dtype: Count
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 550
+  - name: qualified_agency
+    kind: derived
+    dtype: Judgment
+    source: de/statute/estg/32a(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          dwelling_units + vouchers <= combined_unit_and_voucher_limit
+          and agency_is_not_troubled
+"""
+    cases = [
+        {
+            "name": "at combined limit",
+            "period": "2026",
+            "input": {
+                "dwelling_units": 250,
+                "vouchers": 300,
+                "agency_is_not_troubled": True,
+            },
+            "output": {"qualified_agency": "holds"},
+        },
+        {
+            "name": "above combined limit",
+            "period": "2026",
+            "input": {
+                "dwelling_units": 250,
+                "vouchers": 301,
+                "agency_is_not_troubled": True,
+            },
+            "output": {"qualified_agency": "not_holds"},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert not _has_issue(result, "formula branch", "test")
+
+    bypassed_content = content.replace(
+        "dwelling_units + vouchers <= combined_unit_and_voucher_limit\n"
+        "          and agency_is_not_troubled",
+        "agency_override\n"
+        "          or dwelling_units + vouchers <= combined_unit_and_voucher_limit",
+    )
+    bypassed_cases = [
+        {
+            **case,
+            "input": {**case["input"], "agency_override": True},
+            "output": {"qualified_agency": "holds"},
+        }
+        for case in cases
+    ]
+
+    bypassed = _analyze(bypassed_content, source, test_cases=bypassed_cases)
+
+    assert _has_issue(bypassed, "formula branch", "test")
 
 
 def test_adjacent_integral_boundary_requires_the_equivalent_comparator():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1512"
+version = "0.2.1513"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- parse Axiom multiline formula continuations consistently when simplifying formulas and extracting arithmetic operations for complete-source witnesses
- honor case-runtime boolean short-circuiting so unreachable arithmetic cannot satisfy a formula witness
- exclude singular, coordinated, serial, and ranged USC title-suffix cross-references from substantive numeric recall
- direct complete-source generation to use compact single-output control pairs when source-driven coverage exceeds the normal case count

## Failure evidence
Protected run 30906695785 compiled and grounded its final candidate but failed formula witness validation even though its companion tests executed `250 + 300 <= 550`. Local replay showed execution used the multiline-aware parser while operation matching used raw `ast.parse` and therefore observed no addition. The same replay showed numeric values 3 and 4 came only from `z-3` and `z-4` legal cross-references.

With this patch, replay removes both false-positive classes. The preserved candidate then has one genuine residual: source-driven paired exception/applicability coverage, which the prompt repair addresses.

## Checks
- source completeness and complete-source prompt/plumbing: 1,094 passed
- version/provenance focused checks: 8 passed
- version-bound state oracle registry checks: 24 passed
- Ruff: passed
- touched-file format check: passed
- compileall: passed
- independent exact-head review: CLEAN after three review-fix cycles
- hosted CI: running on `0ddc7512b2493714eaef1836e47890d30b23216b`

## Cycle
Independent review found an unreachable arithmetic witness bypass and incomplete coordinated citation filtering. Both were fixed with adversarial coverage; the final exact-head review is clean. This PR remains draft until all hosted checks are green on the exact head.