### PR TITLE
Preserve retry findings across encode attempts

### DIFF
--- a/changelog.d/retry-feedback-round-robin.fixed.md
+++ b/changelog.d/retry-feedback-round-robin.fixed.md
@@ -1,0 +1,1 @@
+Interleave bounded validator findings from recent failed encode attempts so one diagnostic flood cannot evict all earlier rejected patterns.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1513"
+version = "0.2.1514"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1513"
+__version__ = "0.2.1514"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -25098,29 +25098,57 @@ def _latest_validation_retry_candidate(
 def _encode_validation_retry_feedback(
     prior_attempts: Sequence[_FailedEncodeAttempt],
 ) -> tuple[str, ...]:
-    """Return bounded, deduplicated validator guidance for the next attempt."""
+    """Return bounded validator guidance without starving older attempts."""
+
+    feedback_limit = 12
+    attempt_feedback: list[list[str]] = []
+
+    for failed_attempt in reversed(prior_attempts[-feedback_limit:]):
+        items: list[str] = []
+        seen_in_attempt: set[str] = set()
+
+        def add_attempt_item(raw_item: object) -> None:
+            if len(items) >= feedback_limit or not isinstance(raw_item, str):
+                return
+            item = raw_item.strip()[:2000]
+            if not item or item in seen_in_attempt:
+                return
+            seen_in_attempt.add(item)
+            items.append(item)
+
+        add_attempt_item(failed_attempt.error)
+        metrics = getattr(failed_attempt.result, "metrics", None)
+        inspected_issues = 0
+        for attribute in ("compile_issues", "ci_issues"):
+            issues = getattr(metrics, attribute, ())
+            if isinstance(issues, Sequence) and not isinstance(issues, (str, bytes)):
+                issue_iterator = iter(issues)
+                for _ in range(feedback_limit - inspected_issues):
+                    try:
+                        issue = next(issue_iterator)
+                    except StopIteration:
+                        break
+                    inspected_issues += 1
+                    add_attempt_item(issue)
+            if inspected_issues >= feedback_limit:
+                break
+        if items:
+            attempt_feedback.append(items)
 
     feedback: list[str] = []
     seen: set[str] = set()
 
-    def add(raw_item: object) -> None:
-        if len(feedback) >= 12 or not isinstance(raw_item, str):
+    def add(raw_item: str) -> None:
+        if len(feedback) >= feedback_limit or raw_item in seen:
             return
-        item = raw_item.strip()[:2000]
-        if not item or item in seen:
-            return
-        seen.add(item)
-        feedback.append(item)
+        seen.add(raw_item)
+        feedback.append(raw_item)
 
-    for failed_attempt in reversed(prior_attempts):
-        add(failed_attempt.error)
-        metrics = getattr(failed_attempt.result, "metrics", None)
-        for attribute in ("compile_issues", "ci_issues"):
-            issues = getattr(metrics, attribute, ())
-            if isinstance(issues, Sequence) and not isinstance(issues, (str, bytes)):
-                for issue in issues:
-                    add(issue)
-        if len(feedback) >= 12:
+    for item_index in range(max((len(items) for items in attempt_feedback), default=0)):
+        for items in attempt_feedback:
+            if item_index < len(items):
+                add(items[item_index])
+        if len(feedback) >= feedback_limit:
             break
     return tuple(feedback)
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -25098,7 +25098,7 @@ def _latest_validation_retry_candidate(
 def _encode_validation_retry_feedback(
     prior_attempts: Sequence[_FailedEncodeAttempt],
 ) -> tuple[str, ...]:
-    """Return bounded validator guidance without starving older attempts."""
+    """Interleave bounded validator guidance across recent failed attempts."""
 
     feedback_limit = 12
     attempt_feedback: list[list[str]] = []

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1513"
+ENCODER_VERSION = "0.2.1514"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12938,6 +12938,77 @@ class TestCmdEncode:
             hint,
         )
 
+    def test_encode_retry_feedback_round_robins_across_failed_attempts(self):
+        import axiom_encode.cli as cli_module
+
+        generic_error = "Generated RuleSpec failed CI validation"
+
+        def failed_attempt(*issues):
+            return cli_module._FailedEncodeAttempt(
+                result=SimpleNamespace(
+                    metrics=SimpleNamespace(
+                        compile_issues=[],
+                        ci_issues=list(issues),
+                    )
+                ),
+                error=generic_error,
+            )
+
+        formula_output = (
+            "[complete-source-unit:formula-output] parameter-only representation "
+            "is invalid; bind the computation to a principal derived output"
+        )
+        latest_flood = tuple(
+            f"latest test execution failure {index}" for index in range(20)
+        )
+        feedback = cli_module._encode_validation_retry_feedback(
+            [
+                failed_attempt(formula_output),
+                failed_attempt("middle companion-test failure"),
+                failed_attempt("latest branch-test failure", *latest_flood),
+            ]
+        )
+
+        assert len(feedback) == 12
+        assert feedback[:4] == (
+            generic_error,
+            "latest branch-test failure",
+            "middle companion-test failure",
+            formula_output,
+        )
+        assert feedback.index(formula_output) < feedback.index(latest_flood[0])
+
+    def test_encode_retry_feedback_bounds_diagnostic_flood_inspection(self):
+        import axiom_encode.cli as cli_module
+
+        class CountingIssues(list):
+            def __init__(self):
+                super().__init__()
+                self.inspected = 0
+
+            def __iter__(self):
+                for index in range(10_000):
+                    self.inspected += 1
+                    yield f"unique validator diagnostic {index} {'x' * 3000}"
+
+        issues = CountingIssues()
+        failed_attempt = cli_module._FailedEncodeAttempt(
+            result=SimpleNamespace(
+                metrics=SimpleNamespace(
+                    compile_issues=[],
+                    ci_issues=issues,
+                )
+            ),
+            error="Generated RuleSpec failed CI validation",
+        )
+
+        feedback = cli_module._encode_validation_retry_feedback([failed_attempt])
+
+        assert issues.inspected == 12
+        assert len(feedback) == 12
+        assert feedback[0] == "Generated RuleSpec failed CI validation"
+        assert all(len(item) <= 2000 for item in feedback)
+
     def test_encode_retry_candidate_capture_preserves_rulespec_and_tests(
         self, tmp_path
     ):

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1513"
+ENCODER_VERSION = "0.2.1514"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1513"
+ENCODER_VERSION = "0.2.1514"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1513"
+ENCODER_VERSION = "0.2.1514"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1513"
+ENCODER_VERSION = "0.2.1514"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1513"
+ENCODER_VERSION = "0.2.1514"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1513"
+ENCODER_VERSION = "0.2.1514"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5753,7 +5753,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1513"')
+        .startswith('__version__ = "0.2.1514"')
     )
 
 
@@ -5985,13 +5985,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1513"
+    assert encoder_package["version"] == "0.2.1514"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1513"
+    assert project["project"]["version"] == "0.2.1514"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1513"')
+        .startswith('__version__ = "0.2.1514"')
     )
 
 
@@ -6253,13 +6253,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1513"
+    assert encoder_package["version"] == "0.2.1514"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1513"
+    assert project["project"]["version"] == "0.2.1514"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1513"')
+        .startswith('__version__ = "0.2.1514"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1513"
+ENCODER_VERSION = "0.2.1514"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1513"
+version = "0.2.1514"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- bound retry-feedback inspection to the 12 most recent attempts and 12 diagnostics per attempt
- retain and deduplicate bounded normalized findings per attempt, then interleave them round-robin into the 12-item repair-prompt budget
- add regressions proving an execution-diagnostic flood cannot evict the earlier formula-output requirement and that a 13th diagnostic is never fetched
- release encoder 0.2.1514

## NJ failure evidence

Protected run 30908186848 failed closed with zero signatures and no branch or RuleSpec PR. Its first attempt reported the required formula-output binding, but later test/execution failures filled the newest-first feedback budget. The final repair prompt no longer included the earlier formula-output rejection and the final candidate regressed to a parameter-only representation. This change repairs the general scheduler; it does not special-case NJ or relax validation.

## Review cycle

- pre-rebase independent review found one resource-bound issue and one wording issue; both were fixed
- post-fix independent review: CLEAN
- rebased onto main 7e07efea1, which includes the multiline formula-witness repair
- fresh post-rebase independent review: CLEAN at 3cc269cdea5473d8e698f65b15a347840129f995
- reviewer verified patch identity, integration with multiline witness diagnostics, no 13th fetch, version consistency, and no conflict drift

## Checks

- `uvx --from ruff==0.16.1 ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- broad affected slice: 2,237 passed, 10 skipped
- full suite: 6,970 passed, 119 skipped
- diff check and version/lock consistency
