### PR TITLE
Recognize constant-false RuleSpec judgments

### DIFF
--- a/changelog.d/constant-false-literal-comparisons.fixed.md
+++ b/changelog.d/constant-false-literal-comparisons.fixed.md
@@ -1,1 +1,1 @@
-Treat literal-only false comparisons as constant-false Judgment formulas so source-stated unconditional prohibitions do not receive impossible positive-test requirements.
+Treat literal-only false comparisons as constant-false Judgment formulas so source-stated unconditional prohibitions do not receive impossible positive-test requirements, while bounding heuristic parsing depth and handling wrapped literals in linear time.

--- a/changelog.d/constant-false-literal-comparisons.fixed.md
+++ b/changelog.d/constant-false-literal-comparisons.fixed.md
@@ -1,0 +1,1 @@
+Treat literal-only false comparisons as constant-false Judgment formulas so source-stated unconditional prohibitions do not receive impossible positive-test requirements.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1514"
+version = "0.2.1515"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1516"
+version = "0.2.1517"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1515"
+version = "0.2.1516"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1516"
+__version__ = "0.2.1517"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1514"
+__version__ = "0.2.1515"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1515"
+__version__ = "0.2.1516"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -11453,19 +11453,25 @@ def _rule_versions_are_constant_false(versions: list[Any]) -> bool:
 
 
 def _formula_is_syntactically_unsatisfiable_false(formula: str) -> bool:
-    exact = _strip_balanced_outer_parentheses(formula.strip())
-    if exact in {"false", "False"}:
-        return True
-    literal_comparison = _literal_comparison_truth_value(exact)
-    if literal_comparison is not None:
-        return not literal_comparison
-    if len(_split_top_level_boolean_operator(exact, "or")) > 1:
+    if not _rulespec_expression_nesting_within_limit(formula):
         return False
-    conjuncts = _split_top_level_boolean_operator(exact, "and")
-    return len(conjuncts) > 1 and any(
-        _formula_is_syntactically_unsatisfiable_false(conjunct)
-        for conjunct in conjuncts
-    )
+
+    pending = [formula]
+    while pending:
+        exact = _strip_balanced_outer_parentheses(pending.pop().strip())
+        if exact in {"false", "False"}:
+            return True
+        literal_comparison = _literal_comparison_truth_value(exact)
+        if literal_comparison is not None:
+            if not literal_comparison:
+                return True
+            continue
+        if len(_split_top_level_boolean_operator(exact, "or")) > 1:
+            continue
+        conjuncts = _split_top_level_boolean_operator(exact, "and")
+        if len(conjuncts) > 1:
+            pending.extend(conjuncts)
+    return False
 
 
 def _literal_comparison_truth_value(expression: str) -> bool | None:
@@ -11639,37 +11645,79 @@ def _rulespec_literal_value(
 
 def _strip_balanced_outer_parentheses(expression: str) -> str:
     stripped = expression.strip()
-    while stripped.startswith("(") and stripped.endswith(")"):
-        depth = 0
-        encloses_all = True
-        quote: str | None = None
-        escaped = False
-        for index, char in enumerate(stripped):
-            if quote is not None:
-                if escaped:
-                    escaped = False
-                elif char == "\\":
-                    escaped = True
-                elif char == quote:
-                    quote = None
-                continue
-            if char in {'"', "'"}:
-                quote = char
-                continue
-            if char == "(":
-                depth += 1
-            elif char == ")":
-                depth -= 1
-                if depth == 0 and index != len(stripped) - 1:
-                    encloses_all = False
-                    break
+    if not stripped.startswith("(") or not stripped.endswith(")"):
+        return stripped
+
+    matching_parentheses: dict[int, int] = {}
+    opening_parentheses: list[int] = []
+    quote: str | None = None
+    escaped = False
+    for index, char in enumerate(stripped):
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+        if char in {'"', "'"}:
+            quote = char
+            continue
+        if char == "(":
+            opening_parentheses.append(index)
+            continue
+        if char != ")":
+            continue
+        if not opening_parentheses:
+            return stripped
+        matching_parentheses[opening_parentheses.pop()] = index
+    if quote is not None or opening_parentheses:
+        return stripped
+
+    start = 0
+    end = len(stripped) - 1
+    while start < end and matching_parentheses.get(start) == end:
+        start += 1
+        end -= 1
+        while start <= end and stripped[start].isspace():
+            start += 1
+        while end >= start and stripped[end].isspace():
+            end -= 1
+    return stripped[start : end + 1]
+
+
+def _rulespec_expression_nesting_within_limit(
+    expression: str,
+    *,
+    max_depth: int = 256,
+) -> bool:
+    """Bound heuristic-only parsing and reject malformed delimiters safely."""
+
+    depth = 0
+    quote: str | None = None
+    escaped = False
+    for char in expression:
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+        if char in {'"', "'"}:
+            quote = char
+            continue
+        if char == "(":
+            depth += 1
+            if depth > max_depth:
+                return False
+        elif char == ")":
+            depth -= 1
             if depth < 0:
-                encloses_all = False
-                break
-        if not encloses_all or depth != 0 or quote is not None:
-            break
-        stripped = stripped[1:-1].strip()
-    return stripped
+                return False
+    return quote is None and depth == 0
 
 
 def _split_top_level_boolean_operator(expression: str, operator: str) -> list[str]:

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -11457,11 +11457,58 @@ def _formula_is_syntactically_unsatisfiable_false(formula: str) -> bool:
     normalized = _strip_balanced_outer_parentheses(normalized)
     if normalized == "false":
         return True
+    literal_comparison = _literal_comparison_truth_value(normalized)
+    if literal_comparison is not None:
+        return not literal_comparison
     conjuncts = _split_top_level_boolean_operator(normalized, "and")
     return len(conjuncts) > 1 and any(
         _formula_is_syntactically_unsatisfiable_false(conjunct)
         for conjunct in conjuncts
     )
+
+
+def _literal_comparison_truth_value(expression: str) -> bool | None:
+    """Evaluate a side-effect-free comparison whose operands are literals."""
+
+    try:
+        parsed = ast.parse(expression, mode="eval").body
+    except SyntaxError:
+        return None
+    if not isinstance(parsed, ast.Compare):
+        return None
+
+    operands = (parsed.left, *parsed.comparators)
+    values: list[bool | int | float | str | None] = []
+    for operand in operands:
+        try:
+            value = ast.literal_eval(operand)
+        except (ValueError, SyntaxError):
+            return None
+        if not isinstance(value, (bool, int, float, str, type(None))):
+            return None
+        values.append(value)
+
+    results: list[bool] = []
+    for left, operation, right in zip(values, parsed.ops, values[1:]):
+        try:
+            if isinstance(operation, ast.Eq):
+                result = left == right
+            elif isinstance(operation, ast.NotEq):
+                result = left != right
+            elif isinstance(operation, ast.Lt):
+                result = left < right
+            elif isinstance(operation, ast.LtE):
+                result = left <= right
+            elif isinstance(operation, ast.Gt):
+                result = left > right
+            elif isinstance(operation, ast.GtE):
+                result = left >= right
+            else:
+                return None
+        except TypeError:
+            return None
+        results.append(result)
+    return all(results)
 
 
 def _strip_balanced_outer_parentheses(expression: str) -> str:

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -11459,8 +11459,7 @@ def _formula_is_syntactically_unsatisfiable_false(formula: str) -> bool:
     literal_comparison = _literal_comparison_truth_value(exact)
     if literal_comparison is not None:
         return not literal_comparison
-    normalized = re.sub(r"\s+", " ", exact.lower())
-    conjuncts = _split_top_level_boolean_operator(normalized, "and")
+    conjuncts = _split_top_level_boolean_operator(exact, "and")
     return len(conjuncts) > 1 and any(
         _formula_is_syntactically_unsatisfiable_false(conjunct)
         for conjunct in conjuncts
@@ -11653,11 +11652,26 @@ def _strip_balanced_outer_parentheses(expression: str) -> str:
 def _split_top_level_boolean_operator(expression: str, operator: str) -> list[str]:
     parts: list[str] = []
     depth = 0
+    quote: str | None = None
+    escaped = False
     start = 0
     index = 0
     pattern = re.compile(rf"\b{re.escape(operator)}\b")
     while index < len(expression):
         char = expression[index]
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            index += 1
+            continue
+        if char in {'"', "'"}:
+            quote = char
+            index += 1
+            continue
         if char == "(":
             depth += 1
             index += 1

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -11443,7 +11443,7 @@ def find_synthetic_source_authorized_input_issues(content: str) -> list[str]:
 
 def _rule_versions_are_constant_false(versions: list[Any]) -> bool:
     formulas = [
-        str(version.get("formula") or "").strip().lower()
+        str(version.get("formula") or "").strip()
         for version in versions
         if isinstance(version, dict) and isinstance(version.get("formula"), str)
     ]
@@ -11453,13 +11453,13 @@ def _rule_versions_are_constant_false(versions: list[Any]) -> bool:
 
 
 def _formula_is_syntactically_unsatisfiable_false(formula: str) -> bool:
-    normalized = re.sub(r"\s+", " ", formula.strip().lower())
-    normalized = _strip_balanced_outer_parentheses(normalized)
-    if normalized == "false":
+    exact = _strip_balanced_outer_parentheses(formula.strip())
+    if exact in {"false", "False"}:
         return True
-    literal_comparison = _literal_comparison_truth_value(normalized)
+    literal_comparison = _literal_comparison_truth_value(exact)
     if literal_comparison is not None:
         return not literal_comparison
+    normalized = re.sub(r"\s+", " ", exact.lower())
     conjuncts = _split_top_level_boolean_operator(normalized, "and")
     return len(conjuncts) > 1 and any(
         _formula_is_syntactically_unsatisfiable_false(conjunct)
@@ -11468,47 +11468,164 @@ def _formula_is_syntactically_unsatisfiable_false(formula: str) -> bool:
 
 
 def _literal_comparison_truth_value(expression: str) -> bool | None:
-    """Evaluate a side-effect-free comparison whose operands are literals."""
+    """Evaluate one comparison using RuleSpec literal and operator semantics."""
 
-    try:
-        parsed = ast.parse(expression, mode="eval").body
-    except SyntaxError:
+    split = _split_rulespec_literal_comparison(expression)
+    if split is None:
         return None
-    if not isinstance(parsed, ast.Compare):
+    left_text, operator, right_text = split
+    left = _rulespec_literal_value(left_text)
+    right = _rulespec_literal_value(right_text)
+    if left is None or right is None:
+        return None
+    left_kind, left_value = left
+    right_kind, right_value = right
+
+    if left_kind in {"integer", "decimal"} and right_kind in {
+        "integer",
+        "decimal",
+    }:
+        left_value = Decimal(left_value)
+        right_value = Decimal(right_value)
+    elif left_kind == right_kind and left_kind in {"boolean", "text"}:
+        if operator not in {"==", "!="}:
+            return None
+    else:
         return None
 
-    operands = (parsed.left, *parsed.comparators)
-    values: list[bool | int | float | str | None] = []
-    for operand in operands:
-        try:
-            value = ast.literal_eval(operand)
-        except (ValueError, SyntaxError):
-            return None
-        if not isinstance(value, (bool, int, float, str, type(None))):
-            return None
-        values.append(value)
+    if operator == "==":
+        return left_value == right_value
+    if operator == "!=":
+        return left_value != right_value
+    if operator == "<":
+        return left_value < right_value
+    if operator == "<=":
+        return left_value <= right_value
+    if operator == ">":
+        return left_value > right_value
+    if operator == ">=":
+        return left_value >= right_value
+    return None
 
-    results: list[bool] = []
-    for left, operation, right in zip(values, parsed.ops, values[1:]):
-        try:
-            if isinstance(operation, ast.Eq):
-                result = left == right
-            elif isinstance(operation, ast.NotEq):
-                result = left != right
-            elif isinstance(operation, ast.Lt):
-                result = left < right
-            elif isinstance(operation, ast.LtE):
-                result = left <= right
-            elif isinstance(operation, ast.Gt):
-                result = left > right
-            elif isinstance(operation, ast.GtE):
-                result = left >= right
-            else:
+
+def _split_rulespec_literal_comparison(
+    expression: str,
+) -> tuple[str, str, str] | None:
+    """Split exactly one top-level RuleSpec comparison outside quoted text."""
+
+    operators: list[tuple[int, str]] = []
+    depth = 0
+    quote: str | None = None
+    escaped = False
+    index = 0
+    while index < len(expression):
+        char = expression[index]
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            index += 1
+            continue
+        if char in {'"', "'"}:
+            quote = char
+            index += 1
+            continue
+        if char == "(":
+            depth += 1
+            index += 1
+            continue
+        if char == ")":
+            depth -= 1
+            if depth < 0:
                 return None
-        except TypeError:
+            index += 1
+            continue
+        if depth == 0:
+            operator = next(
+                (
+                    candidate
+                    for candidate in ("<=", ">=", "==", "!=", "<", ">")
+                    if expression.startswith(candidate, index)
+                ),
+                None,
+            )
+            if operator is not None:
+                operators.append((index, operator))
+                index += len(operator)
+                continue
+        index += 1
+    if quote is not None or depth != 0 or len(operators) != 1:
+        return None
+    operator_index, operator = operators[0]
+    left = expression[:operator_index].strip()
+    right = expression[operator_index + len(operator) :].strip()
+    if not left or not right:
+        return None
+    return left, operator, right
+
+
+def _rulespec_literal_value(
+    expression: str,
+) -> tuple[str, bool | int | Decimal | str] | None:
+    """Parse the literal subset accepted by the RuleSpec formula lexer."""
+
+    literal = _strip_balanced_outer_parentheses(expression.strip())
+    if literal in {"true", "True"}:
+        return "boolean", True
+    if literal in {"false", "False"}:
+        return "boolean", False
+
+    if re.fullmatch(r"-?[0-9][0-9_]*", literal):
+        value = int(literal.replace("_", ""))
+        if -(2**63) <= value <= 2**63 - 1:
+            return "integer", value
+        return None
+
+    if re.fullmatch(r"-?[0-9][0-9_]*\.[0-9][0-9_]*", literal):
+        exact = literal.replace("_", "")
+        unsigned = exact.removeprefix("-")
+        whole, fractional = unsigned.split(".", 1)
+        coefficient = int(f"{whole}{fractional}")
+        if len(fractional) > 28 or coefficient > 2**96 - 1:
             return None
-        results.append(result)
-    return all(results)
+        try:
+            return "decimal", Decimal(exact)
+        except InvalidOperation:
+            return None
+
+    if len(literal) < 2 or literal[0] not in {'"', "'"}:
+        return None
+    quote = literal[0]
+    if literal[-1] != quote:
+        return None
+    value: list[str] = []
+    index = 1
+    while index < len(literal) - 1:
+        char = literal[index]
+        if char == quote:
+            return None
+        if char != "\\":
+            value.append(char)
+            index += 1
+            continue
+        if index + 1 >= len(literal) - 1:
+            return None
+        escaped = literal[index + 1]
+        value.append(
+            {
+                "\\": "\\",
+                '"': '"',
+                "'": "'",
+                "n": "\n",
+                "r": "\r",
+                "t": "\t",
+            }.get(escaped, escaped)
+        )
+        index += 2
+    return "text", "".join(value)
 
 
 def _strip_balanced_outer_parentheses(expression: str) -> str:

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -11582,10 +11582,11 @@ def _rulespec_literal_value(
         magnitude = exact.removeprefix("-").lstrip("0") or "0"
         if len(magnitude) > 19:
             return None
-        value = int(exact)
-        if -(2**63) <= value <= 2**63 - 1:
-            return "integer", value
-        return None
+        unsigned_value = int(magnitude)
+        if unsigned_value > 2**63 - 1:
+            return None
+        value = -unsigned_value if exact.startswith("-") else unsigned_value
+        return "integer", value
 
     if re.fullmatch(r"-?[0-9][0-9_]*\.[0-9][0-9_]*", literal):
         exact = literal.replace("_", "")

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -11632,7 +11632,20 @@ def _strip_balanced_outer_parentheses(expression: str) -> str:
     while stripped.startswith("(") and stripped.endswith(")"):
         depth = 0
         encloses_all = True
+        quote: str | None = None
+        escaped = False
         for index, char in enumerate(stripped):
+            if quote is not None:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == quote:
+                    quote = None
+                continue
+            if char in {'"', "'"}:
+                quote = char
+                continue
             if char == "(":
                 depth += 1
             elif char == ")":
@@ -11643,7 +11656,7 @@ def _strip_balanced_outer_parentheses(expression: str) -> str:
             if depth < 0:
                 encloses_all = False
                 break
-        if not encloses_all or depth != 0:
+        if not encloses_all or depth != 0 or quote is not None:
             break
         stripped = stripped[1:-1].strip()
     return stripped

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -11459,6 +11459,8 @@ def _formula_is_syntactically_unsatisfiable_false(formula: str) -> bool:
     literal_comparison = _literal_comparison_truth_value(exact)
     if literal_comparison is not None:
         return not literal_comparison
+    if len(_split_top_level_boolean_operator(exact, "or")) > 1:
+        return False
     conjuncts = _split_top_level_boolean_operator(exact, "and")
     return len(conjuncts) > 1 and any(
         _formula_is_syntactically_unsatisfiable_false(conjunct)

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -11578,7 +11578,11 @@ def _rulespec_literal_value(
         return "boolean", False
 
     if re.fullmatch(r"-?[0-9][0-9_]*", literal):
-        value = int(literal.replace("_", ""))
+        exact = literal.replace("_", "")
+        magnitude = exact.removeprefix("-").lstrip("0") or "0"
+        if len(magnitude) > 19:
+            return None
+        value = int(exact)
         if -(2**63) <= value <= 2**63 - 1:
             return "integer", value
         return None
@@ -11587,8 +11591,11 @@ def _rulespec_literal_value(
         exact = literal.replace("_", "")
         unsigned = exact.removeprefix("-")
         whole, fractional = unsigned.split(".", 1)
-        coefficient = int(f"{whole}{fractional}")
-        if len(fractional) > 28 or coefficient > 2**96 - 1:
+        coefficient_text = f"{whole}{fractional}".lstrip("0") or "0"
+        if len(fractional) > 28 or len(coefficient_text) > 29:
+            return None
+        coefficient = int(coefficient_text)
+        if coefficient > 2**96 - 1:
             return None
         try:
             return "decimal", Decimal(exact)

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1516"
+ENCODER_VERSION = "0.2.1517"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1515"
+ENCODER_VERSION = "0.2.1516"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1514"
+ENCODER_VERSION = "0.2.1515"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27844,6 +27844,55 @@ rules:
             "us-co:regulations/10-ccr-2506-1/4.801.43#voluntary_payment_reactivates_terminated_claim": "not_holds"
         }
 
+    def test_judgment_positive_test_repair_skips_false_literal_comparison(
+        self, tmp_path
+    ):
+        repo_path = _canonical_rulespec_content_root(tmp_path, "us-nj")
+        rules_file = repo_path / "statutes" / "54a" / "4-7.yaml"
+        test_file = repo_path / "statutes" / "54a" / "4-7.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: subsection_f_applies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '2000-01-01'
+        formula: 1 == 0
+"""
+        )
+        test_file.write_text(
+            """- name: subsection_f_does_not_apply
+  period: 2026
+  input: {}
+  output:
+    us-nj:statutes/54a/4-7#subsection_f_applies: not_holds
+"""
+        )
+
+        repaired = _append_generated_judgment_positive_tests_if_missing(
+            rules_file=rules_file,
+            test_file=test_file,
+            repo_path=repo_path,
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+            relative_output=Path("statutes/54a/4-7.yaml"),
+            issues=[
+                "Judgment rule missing positive companion output coverage: "
+                "`us-nj:statutes/54a/4-7#subsection_f_applies` is not asserted "
+                "as `holds` by the companion `.test.yaml` file."
+            ],
+        )
+
+        assert repaired == []
+        test_payload = yaml.safe_load(test_file.read_text())
+        assert len(test_payload) == 1
+        assert test_payload[0]["output"] == {
+            "us-nj:statutes/54a/4-7#subsection_f_applies": "not_holds"
+        }
+
     def test_judgment_positive_test_repair_synthesizes_formula_inputs(self, tmp_path):
         repo_path = tmp_path / "rulespec-us" / "us"
         rules_file = repo_path / "statutes" / "26" / "3303.yaml"

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1514"
+ENCODER_VERSION = "0.2.1515"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1515"
+ENCODER_VERSION = "0.2.1516"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1516"
+ENCODER_VERSION = "0.2.1517"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1514"
+ENCODER_VERSION = "0.2.1515"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1516"
+ENCODER_VERSION = "0.2.1517"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1515"
+ENCODER_VERSION = "0.2.1516"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1515"
+ENCODER_VERSION = "0.2.1516"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1514"
+ENCODER_VERSION = "0.2.1515"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1516"
+ENCODER_VERSION = "0.2.1517"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1515"
+ENCODER_VERSION = "0.2.1516"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1514"
+ENCODER_VERSION = "0.2.1515"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1516"
+ENCODER_VERSION = "0.2.1517"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1516"
+ENCODER_VERSION = "0.2.1517"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1514"
+ENCODER_VERSION = "0.2.1515"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1515"
+ENCODER_VERSION = "0.2.1516"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1514"
+ENCODER_VERSION = "0.2.1515"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1515"
+ENCODER_VERSION = "0.2.1516"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1516"
+ENCODER_VERSION = "0.2.1517"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2567,6 +2567,84 @@ rules:
     assert issues == []
 
 
+def test_judgment_positive_companion_output_allows_false_literal_comparison(
+    tmp_path,
+):
+    policy_repo = _canonical_rulespec_content_root(tmp_path, "us-nj")
+    rules_file = policy_repo / "statutes" / "54a" / "4-7.yaml"
+    rules_file.parent.mkdir(parents=True)
+    content = """format: rulespec/v1
+rules:
+  - name: subsection_f_applies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: N.J.S.54A:4-7
+    versions:
+      - effective_from: '2000-01-01'
+        formula: 1 == 0
+"""
+    cases = [
+        {
+            "name": "subsection_f_does_not_apply",
+            "period": "2026",
+            "input": {},
+            "output": {"us-nj:statutes/54a/4-7#subsection_f_applies": "not_holds"},
+        }
+    ]
+
+    issues = find_judgment_positive_companion_output_issues(
+        content,
+        cases,
+        rules_file=rules_file,
+        policy_repo_path=policy_repo,
+    )
+
+    assert issues == []
+
+
+def test_judgment_positive_companion_output_requires_positive_for_true_literal_comparison(
+    tmp_path,
+):
+    policy_repo = _canonical_rulespec_content_root(tmp_path, "us-nj")
+    rules_file = policy_repo / "statutes" / "54a" / "4-7.yaml"
+    rules_file.parent.mkdir(parents=True)
+    content = """format: rulespec/v1
+rules:
+  - name: subsection_f_applies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: N.J.S.54A:4-7
+    versions:
+      - effective_from: '2000-01-01'
+        formula: 1 == 1
+"""
+    cases = [
+        {
+            "name": "incorrect_negative_only_case",
+            "period": "2026",
+            "input": {},
+            "output": {"us-nj:statutes/54a/4-7#subsection_f_applies": "not_holds"},
+        }
+    ]
+
+    issues = find_judgment_positive_companion_output_issues(
+        content,
+        cases,
+        rules_file=rules_file,
+        policy_repo_path=policy_repo,
+    )
+
+    assert issues == [
+        "Judgment rule missing positive companion output coverage: "
+        "`us-nj:statutes/54a/4-7#subsection_f_applies` is not asserted as "
+        "`holds` by the companion `.test.yaml` file."
+    ]
+
+
 def test_synthetic_source_authorized_input_rejected_for_prohibition():
     content = """format: rulespec/v1
 rules:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2701,6 +2701,7 @@ def test_literal_comparison_truth_value_matches_rulespec_semantics(formula, expe
         "1e3 == 1000",
         '"unterminated == 1',
         "9223372036854775808 == 0",
+        "-9223372036854775808 == 0",
         f"{'9' * 5000} == 0",
         "0.00000000000000000000000000001 == 0.0",
         f"{'9' * 5000}.0 == 0.0",

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2697,6 +2697,22 @@ def test_constant_false_detection_respects_rulespec_boolean_precedence():
     assert _formula_is_syntactically_unsatisfiable_false("(true or false) and false")
 
 
+def test_constant_false_detection_fails_closed_above_nesting_limit():
+    deeply_wrapped_false = f"{'(' * 300}1 == 0{')' * 300}"
+    deeply_nested_conjunction = "false"
+    for _ in range(300):
+        deeply_nested_conjunction = f"true and ({deeply_nested_conjunction})"
+
+    assert not _formula_is_syntactically_unsatisfiable_false(deeply_wrapped_false)
+    assert not _formula_is_syntactically_unsatisfiable_false(deeply_nested_conjunction)
+
+
+def test_literal_comparison_handles_deep_parentheses_without_recursive_parsing():
+    deeply_wrapped_false = f"{'(' * 10_000}1{')' * 10_000} == 0"
+
+    assert _literal_comparison_truth_value(deeply_wrapped_false) is False
+
+
 @pytest.mark.parametrize(
     "formula",
     [

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5923,7 +5923,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1516"')
+        .startswith('__version__ = "0.2.1517"')
     )
 
 
@@ -6155,13 +6155,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1516"
+    assert encoder_package["version"] == "0.2.1517"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1516"
+    assert project["project"]["version"] == "0.2.1517"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1516"')
+        .startswith('__version__ = "0.2.1517"')
     )
 
 
@@ -6423,13 +6423,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1516"
+    assert encoder_package["version"] == "0.2.1517"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1516"
+    assert project["project"]["version"] == "0.2.1517"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1516"')
+        .startswith('__version__ = "0.2.1517"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2575,6 +2575,7 @@ rules:
         "true == false",
         '"same" != "same"',
         "9007199254740992.0 == 9007199254740993.0",
+        'source_condition and "same" != "same"',
     ],
 )
 def test_judgment_positive_companion_output_allows_false_literal_comparison(
@@ -2621,6 +2622,7 @@ rules:
         "1 == 1",
         '"A" != "a"',
         "9007199254740992.0 != 9007199254740993.0",
+        'source_condition and "A" != "a"',
     ],
 )
 def test_judgment_positive_companion_output_requires_positive_for_true_literal_comparison(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2701,7 +2701,9 @@ def test_literal_comparison_truth_value_matches_rulespec_semantics(formula, expe
         "1e3 == 1000",
         '"unterminated == 1',
         "9223372036854775808 == 0",
+        f"{'9' * 5000} == 0",
         "0.00000000000000000000000000001 == 0.0",
+        f"{'9' * 5000}.0 == 0.0",
     ],
 )
 def test_literal_comparison_truth_value_rejects_unsupported_rulespec_forms(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5831,7 +5831,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1514"')
+        .startswith('__version__ = "0.2.1515"')
     )
 
 
@@ -6063,13 +6063,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1514"
+    assert encoder_package["version"] == "0.2.1515"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1514"
+    assert project["project"]["version"] == "0.2.1515"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1514"')
+        .startswith('__version__ = "0.2.1515"')
     )
 
 
@@ -6331,13 +6331,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1514"
+    assert encoder_package["version"] == "0.2.1515"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1514"
+    assert project["project"]["version"] == "0.2.1515"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1514"')
+        .startswith('__version__ = "0.2.1515"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -41,6 +41,7 @@ from axiom_encode.harness.validator_pipeline import (
     _corpus_citation_to_normalized_target,
     _extract_json_object,
     _infer_us_state_code_from_rulespec_path,
+    _literal_comparison_truth_value,
     _normalize_us_tax_filing_status,
     _normalize_validation_staging_text,
     _policyengine_expected_float,
@@ -2567,13 +2568,22 @@ rules:
     assert issues == []
 
 
+@pytest.mark.parametrize(
+    "formula",
+    [
+        "1 == 0",
+        "true == false",
+        '"same" != "same"',
+        "9007199254740992.0 == 9007199254740993.0",
+    ],
+)
 def test_judgment_positive_companion_output_allows_false_literal_comparison(
-    tmp_path,
+    tmp_path, formula
 ):
     policy_repo = _canonical_rulespec_content_root(tmp_path, "us-nj")
     rules_file = policy_repo / "statutes" / "54a" / "4-7.yaml"
     rules_file.parent.mkdir(parents=True)
-    content = """format: rulespec/v1
+    content = f"""format: rulespec/v1
 rules:
   - name: subsection_f_applies
     kind: derived
@@ -2583,7 +2593,8 @@ rules:
     source: N.J.S.54A:4-7
     versions:
       - effective_from: '2000-01-01'
-        formula: 1 == 0
+        formula: |-
+          {formula}
 """
     cases = [
         {
@@ -2604,13 +2615,21 @@ rules:
     assert issues == []
 
 
+@pytest.mark.parametrize(
+    "formula",
+    [
+        "1 == 1",
+        '"A" != "a"',
+        "9007199254740992.0 != 9007199254740993.0",
+    ],
+)
 def test_judgment_positive_companion_output_requires_positive_for_true_literal_comparison(
-    tmp_path,
+    tmp_path, formula
 ):
     policy_repo = _canonical_rulespec_content_root(tmp_path, "us-nj")
     rules_file = policy_repo / "statutes" / "54a" / "4-7.yaml"
     rules_file.parent.mkdir(parents=True)
-    content = """format: rulespec/v1
+    content = f"""format: rulespec/v1
 rules:
   - name: subsection_f_applies
     kind: derived
@@ -2620,7 +2639,8 @@ rules:
     source: N.J.S.54A:4-7
     versions:
       - effective_from: '2000-01-01'
-        formula: 1 == 1
+        formula: |-
+          {formula}
 """
     cases = [
         {
@@ -2643,6 +2663,47 @@ rules:
         "`us-nj:statutes/54a/4-7#subsection_f_applies` is not asserted as "
         "`holds` by the companion `.test.yaml` file."
     ]
+
+
+@pytest.mark.parametrize(
+    ("formula", "expected"),
+    [
+        ("1 == 0", False),
+        ("1 != 0", True),
+        ("1 < 2", True),
+        ("2 <= 1", False),
+        ("2 > 1", True),
+        ("2 >= 3", False),
+        ('"A" != "a"', True),
+        ("9007199254740992.0 != 9007199254740993.0", True),
+        ("true == false", False),
+        ("False != false", False),
+        (r'"line\n" == "line\n"', True),
+    ],
+)
+def test_literal_comparison_truth_value_matches_rulespec_semantics(formula, expected):
+    assert _literal_comparison_truth_value(formula) is expected
+
+
+@pytest.mark.parametrize(
+    "formula",
+    [
+        '"a" < "b"',
+        "true > false",
+        "1 == true",
+        "1 < 2 < 3",
+        "None == None",
+        "claim_count == 0",
+        "1e3 == 1000",
+        '"unterminated == 1',
+        "9223372036854775808 == 0",
+        "0.00000000000000000000000000001 == 0.0",
+    ],
+)
+def test_literal_comparison_truth_value_rejects_unsupported_rulespec_forms(
+    formula,
+):
+    assert _literal_comparison_truth_value(formula) is None
 
 
 def test_synthetic_source_authorized_input_rejected_for_prohibition():

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2681,6 +2681,8 @@ rules:
         ("true == false", False),
         ("False != false", False),
         (r'"line\n" == "line\n"', True),
+        ('(")") == (")")', True),
+        ('("(") == (")")', False),
     ],
 )
 def test_literal_comparison_truth_value_matches_rulespec_semantics(formula, expected):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5907,7 +5907,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1515"')
+        .startswith('__version__ = "0.2.1516"')
     )
 
 
@@ -6139,13 +6139,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1515"
+    assert encoder_package["version"] == "0.2.1516"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1515"
+    assert project["project"]["version"] == "0.2.1516"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1515"')
+        .startswith('__version__ = "0.2.1516"')
     )
 
 
@@ -6407,13 +6407,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1515"
+    assert encoder_package["version"] == "0.2.1516"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1515"
+    assert project["project"]["version"] == "0.2.1516"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1515"')
+        .startswith('__version__ = "0.2.1516"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -40,6 +40,7 @@ from axiom_encode.harness.validator_pipeline import (
     OracleSubprocessResult,
     _corpus_citation_to_normalized_target,
     _extract_json_object,
+    _formula_is_syntactically_unsatisfiable_false,
     _infer_us_state_code_from_rulespec_path,
     _literal_comparison_truth_value,
     _normalize_us_tax_filing_status,
@@ -2576,6 +2577,7 @@ rules:
         '"same" != "same"',
         "9007199254740992.0 == 9007199254740993.0",
         'source_condition and "same" != "same"',
+        "(true or false) and false",
     ],
 )
 def test_judgment_positive_companion_output_allows_false_literal_comparison(
@@ -2623,6 +2625,7 @@ rules:
         '"A" != "a"',
         "9007199254740992.0 != 9007199254740993.0",
         'source_condition and "A" != "a"',
+        "true or false and false",
     ],
 )
 def test_judgment_positive_companion_output_requires_positive_for_true_literal_comparison(
@@ -2687,6 +2690,11 @@ rules:
 )
 def test_literal_comparison_truth_value_matches_rulespec_semantics(formula, expected):
     assert _literal_comparison_truth_value(formula) is expected
+
+
+def test_constant_false_detection_respects_rulespec_boolean_precedence():
+    assert not _formula_is_syntactically_unsatisfiable_false("true or false and false")
+    assert _formula_is_syntactically_unsatisfiable_false("(true or false) and false")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1514"
+ENCODER_VERSION = "0.2.1515"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1515"
+ENCODER_VERSION = "0.2.1516"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1516"
+ENCODER_VERSION = "0.2.1517"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1515"
+version = "0.2.1516"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1516"
+version = "0.2.1517"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1514"
+version = "0.2.1515"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- recognize exact RuleSpec literal-only false comparisons as constant-false Judgment formulas
- preserve RuleSpec integer, decimal, Boolean, text, comparison, and Boolean-precedence semantics
- fail closed on malformed or over-nested heuristic inputs, use iterative conjunction traversal, and strip wrapped literals in linear time
- skip impossible generated positive-test repairs for unconditional statutory prohibitions
- release encoder 0.2.1517

## NJ failure replay

The protected NJ retry 30913123642 encoded the source-stated subsection (f) prohibition as `1 == 0` with a `not_holds` companion case. Before this fix, validation demanded an impossible `holds` case. The exact retained candidate now reports no positive-companion issue.

## Independent review cycle

An independent review found and drove fixes for:

- RuleSpec top-level `or` precedence
- exact literal/parser semantic parity
- quoted-parenthesis handling
- bounded integer/decimal parsing
- quadratic outer-parenthesis stripping
- recursive nested-conjunction failure

Repeat review at exact head 45d5b90e8d5b3f943631bb7698552f68ccc50e8e is CLEAN with no actionable findings.

## Checks

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest`: 7,011 passed, 119 skipped
- broad shared slice: 3,283 passed, 41 skipped
- focused constant-false/positive-companion tests: 44 passed
- version provenance guard: passed
- exact NJ failed-candidate replay: zero positive-companion issues
- 10,000-parenthesis adversarial benchmark: about 0.003 seconds (previously about 4.1 seconds)

No generated RuleSpec concepts or acronym tokens are introduced by this encoder-only change.