### PR TITLE
Preserve complete validator retry diagnostics

### DIFF
--- a/changelog.d/complete-validator-retry-feedback.fixed.md
+++ b/changelog.d/complete-validator-retry-feedback.fixed.md
@@ -1,0 +1,1 @@
+Preserve complete bounded validator diagnostics in encode retry prompts so long source-control inventories reach later repair attempts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1517"
+version = "0.2.1518"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1517"
+__version__ = "0.2.1518"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -366,6 +366,11 @@ from .repo_routing import (
     jurisdiction_subdir_names,
     monorepo_checkout_name,
 )
+from .retry_feedback import (
+    VALIDATION_RETRY_FEEDBACK_MAX_ITEMS,
+    VALIDATION_RETRY_FEEDBACK_MAX_TOTAL_CHARS,
+    bounded_validation_retry_feedback_item,
+)
 from .rules_engine_compat import run_rulespec_compile
 from .rulespec_path_migration import (
     MIGRATION_TOOL as APPLIED_ENCODING_PATH_MIGRATION_TOOL,
@@ -25100,7 +25105,7 @@ def _encode_validation_retry_feedback(
 ) -> tuple[str, ...]:
     """Interleave bounded validator guidance across recent failed attempts."""
 
-    feedback_limit = 12
+    feedback_limit = VALIDATION_RETRY_FEEDBACK_MAX_ITEMS
     attempt_feedback: list[list[str]] = []
 
     for failed_attempt in reversed(prior_attempts[-feedback_limit:]):
@@ -25110,7 +25115,7 @@ def _encode_validation_retry_feedback(
         def add_attempt_item(raw_item: object) -> None:
             if len(items) >= feedback_limit or not isinstance(raw_item, str):
                 return
-            item = raw_item.strip()[:2000]
+            item = bounded_validation_retry_feedback_item(raw_item)
             if not item or item in seen_in_attempt:
                 return
             seen_in_attempt.add(item)
@@ -25136,13 +25141,21 @@ def _encode_validation_retry_feedback(
             attempt_feedback.append(items)
 
     feedback: list[str] = []
+    feedback_chars = 0
     seen: set[str] = set()
 
     def add(raw_item: str) -> None:
-        if len(feedback) >= feedback_limit or raw_item in seen:
+        nonlocal feedback_chars
+        if (
+            len(feedback) >= feedback_limit
+            or raw_item in seen
+            or feedback_chars + len(raw_item)
+            > VALIDATION_RETRY_FEEDBACK_MAX_TOTAL_CHARS
+        ):
             return
         seen.add(raw_item)
         feedback.append(raw_item)
+        feedback_chars += len(raw_item)
 
     for item_index in range(max((len(items) for items in attempt_feedback), default=0)):
         for items in attempt_feedback:

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -58,6 +58,11 @@ from axiom_encode.repo_routing import (
     jurisdiction_subdir_names,
     monorepo_checkout_name,
 )
+from axiom_encode.retry_feedback import (
+    VALIDATION_RETRY_FEEDBACK_MAX_ITEMS,
+    VALIDATION_RETRY_FEEDBACK_MAX_TOTAL_CHARS,
+    bounded_validation_retry_feedback_item,
+)
 from axiom_encode.signing_broker import SigningBroker
 from axiom_encode.statute import (
     CitationParts,
@@ -9080,13 +9085,19 @@ def _format_validation_retry_feedback(feedback: Sequence[str]) -> str:
     """Render bounded prior-attempt validator output as non-authority guidance."""
 
     rendered_items: list[str] = []
+    rendered_chars = 0
     seen: set[str] = set()
-    for raw_item in feedback[:12]:
-        item = str(raw_item).strip()[:2000]
-        if not item or item in seen:
+    for raw_item in feedback[:VALIDATION_RETRY_FEEDBACK_MAX_ITEMS]:
+        item = bounded_validation_retry_feedback_item(str(raw_item))
+        if (
+            not item
+            or item in seen
+            or rendered_chars + len(item) > VALIDATION_RETRY_FEEDBACK_MAX_TOTAL_CHARS
+        ):
             continue
         seen.add(item)
         rendered_items.append(f"- {json.dumps(item, ensure_ascii=False)}")
+        rendered_chars += len(item)
     if not rendered_items:
         return ""
     return f"""

--- a/src/axiom_encode/retry_feedback.py
+++ b/src/axiom_encode/retry_feedback.py
@@ -1,0 +1,19 @@
+"""Shared resource bounds for validator feedback carried into model retries."""
+
+VALIDATION_RETRY_FEEDBACK_MAX_ITEMS = 12
+VALIDATION_RETRY_FEEDBACK_MAX_ITEM_CHARS = 16_000
+VALIDATION_RETRY_FEEDBACK_MAX_TOTAL_CHARS = 64_000
+VALIDATION_RETRY_FEEDBACK_ELISION = "\n...[diagnostic middle elided]...\n"
+
+
+def bounded_validation_retry_feedback_item(raw_item: str) -> str:
+    """Retain both ends of one validator diagnostic within its prompt budget."""
+
+    item = raw_item.strip()
+    limit = VALIDATION_RETRY_FEEDBACK_MAX_ITEM_CHARS
+    if len(item) <= limit:
+        return item
+    available = limit - len(VALIDATION_RETRY_FEEDBACK_ELISION)
+    head_chars = available // 2
+    tail_chars = available - head_chars
+    return item[:head_chars] + VALIDATION_RETRY_FEEDBACK_ELISION + item[-tail_chars:]

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1517"
+ENCODER_VERSION = "0.2.1518"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13007,7 +13007,33 @@ class TestCmdEncode:
         assert issues.inspected == 12
         assert len(feedback) == 12
         assert feedback[0] == "Generated RuleSpec failed CI validation"
-        assert all(len(item) <= 2000 for item in feedback)
+        assert all(len(item) <= 16_000 for item in feedback)
+        assert sum(map(len, feedback)) <= 64_000
+
+    def test_encode_retry_feedback_retains_compound_diagnostic_tail(self):
+        import axiom_encode.cli as cli_module
+
+        final_control = "FINAL_REQUIRED_CONTROL_PAIR_MUST_SURVIVE"
+        diagnostic = (
+            "[complete-source-unit:tests] missing controls: "
+            + "; ".join(f"control-{index}-{'x' * 900}" for index in range(20))
+            + f"; {final_control}"
+        )
+        failed_attempt = cli_module._FailedEncodeAttempt(
+            result=SimpleNamespace(
+                metrics=SimpleNamespace(
+                    compile_issues=[],
+                    ci_issues=[diagnostic],
+                )
+            ),
+            error="Generated RuleSpec failed CI validation",
+        )
+
+        feedback = cli_module._encode_validation_retry_feedback([failed_attempt])
+
+        assert len(feedback[1]) == 16_000
+        assert "diagnostic middle elided" in feedback[1]
+        assert final_control in feedback[1]
 
     def test_encode_retry_candidate_capture_preserves_rulespec_and_tests(
         self, tmp_path

--- a/tests/test_complete_source_mode_plumbing.py
+++ b/tests/test_complete_source_mode_plumbing.py
@@ -298,6 +298,32 @@ def test_eval_prompt_adds_prior_validation_feedback_only_when_supplied(tmp_path)
     assert feedback[0] in retry_prompt
 
 
+def test_eval_prompt_preserves_compound_validation_feedback_tail(tmp_path):
+    source_file = tmp_path / "source.txt"
+    source_file.write_text("The annual amount is 73 800.")
+    workspace = EvalWorkspace(
+        root=tmp_path,
+        source_text_file=source_file,
+        manifest_file=tmp_path / "context-manifest.json",
+    )
+    final_control = "FINAL_REQUIRED_CONTROL_PAIR_MUST_REACH_MODEL"
+    feedback = ("missing controls: " + "x" * 5_000 + final_control,)
+
+    prompt = evals._build_eval_prompt(
+        citation="de/regulation/example/1",
+        mode="cold",
+        workspace=workspace,
+        context_files=[],
+        target_file_name="1.yaml",
+        include_tests=True,
+        runner_backend="openai",
+        validation_retry_feedback=feedback,
+    )
+
+    assert feedback[0] in prompt
+    assert final_control in prompt
+
+
 def test_run_model_eval_forces_tests_and_forwards_complete_mode(tmp_path):
     source_unit = object()
     result = object()

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1517"
+ENCODER_VERSION = "0.2.1518"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1517"
+ENCODER_VERSION = "0.2.1518"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1517"
+ENCODER_VERSION = "0.2.1518"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1517"
+ENCODER_VERSION = "0.2.1518"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1517"
+ENCODER_VERSION = "0.2.1518"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1517"
+ENCODER_VERSION = "0.2.1518"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5923,7 +5923,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1517"')
+        .startswith('__version__ = "0.2.1518"')
     )
 
 
@@ -6155,13 +6155,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1517"
+    assert encoder_package["version"] == "0.2.1518"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1517"
+    assert project["project"]["version"] == "0.2.1518"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1517"')
+        .startswith('__version__ = "0.2.1518"')
     )
 
 
@@ -6423,13 +6423,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1517"
+    assert encoder_package["version"] == "0.2.1518"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1517"
+    assert project["project"]["version"] == "0.2.1518"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1517"')
+        .startswith('__version__ = "0.2.1518"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1517"
+ENCODER_VERSION = "0.2.1518"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1517"
+version = "0.2.1518"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- preserve complete-source validator diagnostics through both collection and retry-prompt rendering
- share deterministic per-item and total bounds between the CLI collector and eval harness
- add production-shaped coverage proving a 5,135-character validator finding reaches the rendered retry prompt intact
- bump the encoder to 0.2.1518

## Production evidence
Protected run `30913245185` failed closed after producing a 5,135-character compound complete-source diagnostic. The collector retained it, but `_format_validation_retry_feedback` truncated the actual retry prompt to 2,000 characters. This change removes that second truncation while retaining bounded, deterministic feedback.

## Review cycle
Initial independent review found the downstream 2,000-character renderer truncation; it was fixed and the exact amended commit was re-reviewed CLEAN.

Main advanced before merge, so the patch was rebased onto `c5514a0342206ccb739439b14622e046ae6ecf11` and advanced to version 0.2.1518. Required post-rebase independent review on exact commit `30234a1c64853ede5f9125a88aa61ad310117e70`: CLEAN. The reviewer verified the main parser blob is byte-identical, ran 40 parser regression tests, and independently reproduced all 5,135 feedback characters reaching the rendered prompt.

No new acronym token is introduced.

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv lock --check`
- `git diff --check`
- post-rebase affected suite: 2,592 passed, 41 skipped
- pre-rebase full suite: 6,972 passed, 119 skipped
- hosted full suite: pending on rebased head