### PR TITLE
Authenticate generated provenance across base and worktree

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -1147,10 +1147,7 @@ jobs:
           RULESPEC_CHECKOUT: ${{ github.workspace }}/rulespec-${{ inputs.country }}
           RULESPEC_REF: ${{ inputs.rulespec_ref }}
         run: |
-          guard_ref_args=()
-          if jq -e 'length > 0' "$RUNNER_TEMP/source-bundle.json" > /dev/null; then
-            guard_ref_args+=(--base-ref "$RULESPEC_REF")
-          fi
+          set +e
           /opt/axiom-verification/axiom-encode-signing-supervisor \
             --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
             --trusted-python-runtime-root /opt/axiom-verification/python \
@@ -1160,8 +1157,16 @@ jobs:
             --repo "$RULESPEC_CHECKOUT" \
             --corpus-path "$GITHUB_WORKSPACE/axiom-corpus" \
             --expected-encoder-checkout "$GITHUB_WORKSPACE/axiom-encode" \
-            "${guard_ref_args[@]}" \
+            --base-ref "$RULESPEC_REF" \
             --json > "$RUNNER_TEMP/guard-generated.json"
+          guard_status="$?"
+          set -e
+          if [ "$guard_status" -ne 0 ]; then
+            if ! jq . "$RUNNER_TEMP/guard-generated.json" >&2; then
+              echo "generated provenance guard returned malformed diagnostics" >&2
+            fi
+            exit "$guard_status"
+          fi
           git -C "$RULESPEC_CHECKOUT" diff --check
 
       - name: Verify existing signed import integrity
@@ -2386,7 +2391,8 @@ jobs:
           artifact="$RUNNER_TEMP/targeted-reencode-failure"
           mkdir -p "$artifact"
           /opt/axiom-verification/python/bin/python -I - \
-            "$generated" "$artifact" <<'PY'
+            "$generated" "$artifact" \
+            "$RUNNER_TEMP/guard-generated.json" <<'PY'
           import hashlib
           import json
           import os
@@ -2401,6 +2407,7 @@ jobs:
 
           generated = Path(os.path.abspath(sys.argv[1]))
           artifact = Path(os.path.abspath(sys.argv[2]))
+          guard_generated = Path(os.path.abspath(sys.argv[3]))
           allowed_suffixes = {".json", ".log", ".txt", ".yaml", ".yml"}
           max_entries = 4096
           max_files = 1024
@@ -2463,6 +2470,35 @@ jobs:
                               "size": len(payload),
                           }
                       )
+
+          if guard_generated.exists() or guard_generated.is_symlink():
+              try:
+                  guard_payload = read_bounded_regular_file(
+                      guard_generated.parent,
+                      guard_generated,
+                      label="generated provenance guard diagnostics",
+                      max_bytes=1024 * 1024,
+                  )
+              except UnsafeCorpusPathError as exc:
+                  raise SystemExit(str(exc)) from exc
+              try:
+                  parsed_guard = json.loads(guard_payload)
+              except (json.JSONDecodeError, UnicodeDecodeError, RecursionError) as exc:
+                  raise SystemExit(
+                      "generated provenance guard diagnostics are not valid JSON"
+                  ) from exc
+              if (
+                  not isinstance(parsed_guard, dict)
+                  or set(parsed_guard) != {"repo", "passed", "issues"}
+                  or not isinstance(parsed_guard["repo"], str)
+                  or not isinstance(parsed_guard["passed"], bool)
+                  or not isinstance(parsed_guard["issues"], list)
+                  or any(not isinstance(issue, str) for issue in parsed_guard["issues"])
+              ):
+                  raise SystemExit(
+                      "generated provenance guard diagnostics have invalid shape"
+                  )
+              (artifact / "guard-generated.json").write_bytes(guard_payload)
 
           inventory.sort(key=lambda item: item["path"])
           step_env_prefixes = {

--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -1080,6 +1080,7 @@ jobs:
 
           checkpoint_signed_changes() {
             local message="$1"
+            set +e
             /opt/axiom-verification/axiom-encode-signing-supervisor \
               --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
               --trusted-python-runtime-root /opt/axiom-verification/python \
@@ -1090,6 +1091,14 @@ jobs:
               --corpus-path "$GITHUB_WORKSPACE/axiom-corpus" \
               --expected-encoder-checkout "$GITHUB_WORKSPACE/axiom-encode" \
               --json > "$RUNNER_TEMP/checkpoint-guard-generated.json"
+            local guard_status="$?"
+            set -e
+            if [ "$guard_status" -ne 0 ]; then
+              if ! jq . "$RUNNER_TEMP/checkpoint-guard-generated.json" >&2; then
+                echo "checkpoint provenance guard returned malformed diagnostics" >&2
+              fi
+              return "$guard_status"
+            fi
             git -C "$RULESPEC_CHECKOUT" diff --check
             "$workflow_python" "$backfill_helper" stage "$RULESPEC_CHECKOUT"
             git -C "$RULESPEC_CHECKOUT" \
@@ -2392,7 +2401,7 @@ jobs:
           mkdir -p "$artifact"
           /opt/axiom-verification/python/bin/python -I - \
             "$generated" "$artifact" \
-            "$RUNNER_TEMP/guard-generated.json" <<'PY'
+            "$RUNNER_TEMP" <<'PY'
           import hashlib
           import json
           import os
@@ -2407,7 +2416,7 @@ jobs:
 
           generated = Path(os.path.abspath(sys.argv[1]))
           artifact = Path(os.path.abspath(sys.argv[2]))
-          guard_generated = Path(os.path.abspath(sys.argv[3]))
+          guard_root = Path(os.path.abspath(sys.argv[3]))
           allowed_suffixes = {".json", ".log", ".txt", ".yaml", ".yml"}
           max_entries = 4096
           max_files = 1024
@@ -2471,10 +2480,20 @@ jobs:
                           }
                       )
 
-          if guard_generated.exists() or guard_generated.is_symlink():
+          guard_candidates = [
+              guard_root / "guard-generated.json",
+              guard_root / "checkpoint-guard-generated.json",
+              *[
+                  guard_root / f"source-{index:02d}-guard-generated.json"
+                  for index in range(1, 17)
+              ],
+          ]
+          for guard_generated in guard_candidates:
+              if not guard_generated.exists() and not guard_generated.is_symlink():
+                  continue
               try:
                   guard_payload = read_bounded_regular_file(
-                      guard_generated.parent,
+                      guard_root,
                       guard_generated,
                       label="generated provenance guard diagnostics",
                       max_bytes=1024 * 1024,
@@ -2498,7 +2517,9 @@ jobs:
                   raise SystemExit(
                       "generated provenance guard diagnostics have invalid shape"
                   )
-              (artifact / "guard-generated.json").write_bytes(guard_payload)
+              guard_destination = artifact / "guards" / guard_generated.name
+              guard_destination.parent.mkdir(parents=True, exist_ok=True)
+              guard_destination.write_bytes(guard_payload)
 
           inventory.sort(key=lambda item: item["path"])
           step_env_prefixes = {

--- a/changelog.d/guard-generated-working-base.fixed.md
+++ b/changelog.d/guard-generated-working-base.fixed.md
@@ -1,0 +1,1 @@
+Authenticate both reviewed-base commits and live worktree changes during generated-provenance checks, and retain bounded guard diagnostics when a protected encode fails closed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1518"
+version = "0.2.1519"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1518"
+__version__ = "0.2.1519"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -19948,7 +19948,11 @@ def guard_generated_change_issues(
         return [f"RuleSpec corpus/toolchain binding is invalid: {exc}"]
     if all_files:
         changed = (
-            _git_changed_files(repo_path, base_ref=base_ref, head_ref=head_ref)
+            _git_guard_changed_files(
+                repo_path,
+                base_ref=base_ref,
+                head_ref=head_ref,
+            )
             if base_ref is not None
             else []
         )
@@ -19968,7 +19972,11 @@ def guard_generated_change_issues(
         changed = (
             changed_files
             if changed_files is not None
-            else _git_changed_files(repo_path, base_ref=base_ref, head_ref=head_ref)
+            else _git_guard_changed_files(
+                repo_path,
+                base_ref=base_ref,
+                head_ref=head_ref,
+            )
         )
         protected = [
             path
@@ -20383,6 +20391,20 @@ def _git_changed_files(
             os.fsdecode(path) for path in untracked.stdout.split(b"\0") if path
         )
     return sorted(set(changed))
+
+
+def _git_guard_changed_files(
+    repo_path: Path,
+    *,
+    base_ref: str | None,
+    head_ref: str,
+) -> list[str]:
+    """Union reviewed-base commits with uncommitted and untracked changes."""
+
+    changed = set(_git_changed_files(repo_path, base_ref=base_ref, head_ref=head_ref))
+    if base_ref is not None:
+        changed.update(_git_changed_files(repo_path, base_ref=None, head_ref=head_ref))
+    return sorted(changed)
 
 
 def _protected_rulespec_root_index(path: Path, *, roots: tuple[str, ...]) -> int | None:

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1518"
+ENCODER_VERSION = "0.2.1519"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36858,6 +36858,36 @@ class TestGuardGenerated:
         assert len(issues) == 1
         assert "RuleSpec corpus/toolchain binding is invalid" in issues[0]
 
+    def test_base_guard_includes_committed_and_worktree_changes(self, tmp_path):
+        repo = self._canonical_guard_repo(tmp_path)
+        _git(repo, "init")
+        _git(repo, "config", "user.email", "test@example.com")
+        _git(repo, "config", "user.name", "Test User")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "initialize guard checkout")
+        base_ref = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+        committed_rule = repo / "us/regulations/committed.yaml"
+        self._source_backed_rule(committed_rule)
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "add committed candidate")
+        worktree_rule = repo / "us/regulations/worktree.yaml"
+        self._source_backed_rule(worktree_rule)
+
+        issues = guard_generated_change_issues(
+            repo,
+            corpus_path=self.corpus_path,
+            base_ref=base_ref,
+            roots=("regulations",),
+        )
+
+        assert issues == [
+            "us/regulations/committed.yaml changed without a matching "
+            ".axiom/encoding-manifests manifest",
+            "us/regulations/worktree.yaml changed without a matching "
+            ".axiom/encoding-manifests manifest",
+        ]
+
     def test_rejects_rulespec_change_without_encoder_manifest(self, tmp_path):
         rule = tmp_path / "us/regulations/example.yaml"
         rule.parent.mkdir(parents=True)

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1518"
+ENCODER_VERSION = "0.2.1519"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1518"
+ENCODER_VERSION = "0.2.1519"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1518"
+ENCODER_VERSION = "0.2.1519"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1518"
+ENCODER_VERSION = "0.2.1519"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1518"
+ENCODER_VERSION = "0.2.1519"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1518"
+ENCODER_VERSION = "0.2.1519"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5923,7 +5923,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1518"')
+        .startswith('__version__ = "0.2.1519"')
     )
 
 
@@ -6155,13 +6155,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1518"
+    assert encoder_package["version"] == "0.2.1519"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1518"
+    assert project["project"]["version"] == "0.2.1519"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1518"')
+        .startswith('__version__ = "0.2.1519"')
     )
 
 
@@ -6423,13 +6423,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1518"
+    assert encoder_package["version"] == "0.2.1519"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1518"
+    assert project["project"]["version"] == "0.2.1519"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1518"')
+        .startswith('__version__ = "0.2.1519"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1518"
+ENCODER_VERSION = "0.2.1519"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2172,6 +2172,8 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert 'source_lane="$(printf \'source-%02d\' "$source_index")"' in command
     assert '"$source_citation" "" true "$source_lane" "" "" false' in command
     assert "checkpoint_signed_changes()" in command
+    assert 'local guard_status="$?"' in command
+    assert 'jq . "$RUNNER_TEMP/checkpoint-guard-generated.json" >&2' in command
     assert '"$workflow_python" "$backfill_helper" stage "$RULESPEC_CHECKOUT"' in (
         command
     )
@@ -2501,7 +2503,7 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
         assert file_member_names == {
             "generated/target/model/statutes/54a:4-7.test.yaml",
             "generated/target/model/target.repair.json",
-            "guard-generated.json",
+            "guards/guard-generated.json",
             "metadata.json",
         }
         assert "generated/target/model/ignored.bin" not in file_member_names
@@ -2509,7 +2511,7 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
             "./generated/target/model/statutes/54a:4-7.test.yaml"
         )
         repair = bundle.extractfile("./generated/target/model/target.repair.json")
-        guard = bundle.extractfile("./guard-generated.json")
+        guard = bundle.extractfile("./guards/guard-generated.json")
         metadata_file = bundle.extractfile("./metadata.json")
         assert target is not None
         assert repair is not None
@@ -2551,6 +2553,134 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
         target_inventory["sha256"]
         == hashlib.sha256(b"format: rulespec/v1\n").hexdigest()
     )
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected_error"),
+    [
+        ("symlink", "Could not safely open"),
+        ("oversize", "safety limit"),
+        ("malformed", "not valid JSON"),
+        ("wrong_shape", "invalid shape"),
+    ],
+)
+def test_targeted_signed_reencode_rejects_unsafe_guard_diagnostics(
+    tmp_path: Path,
+    mutation: str,
+    expected_error: str,
+) -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
+    )
+    step = next(
+        item
+        for item in workflow["jobs"]["encode"]["steps"]
+        if item.get("name") == "Package failed re-encode diagnostics"
+    )
+    command = step["run"].replace(
+        "/opt/axiom-verification/python/bin/python",
+        sys.executable,
+    )
+    (tmp_path / "generated").mkdir()
+    guard = tmp_path / "guard-generated.json"
+    if mutation == "symlink":
+        outside = tmp_path / "outside.json"
+        outside.write_text('{"repo":"outside","passed":false,"issues":[]}\n')
+        guard.symlink_to(outside)
+    elif mutation == "oversize":
+        guard.write_bytes(b"x" * (1024 * 1024 + 1))
+    elif mutation == "malformed":
+        guard.write_text("{\n")
+    else:
+        guard.write_text(
+            json.dumps(
+                {
+                    "repo": "/runner/rulespec-us",
+                    "passed": False,
+                    "issues": [],
+                    "unexpected": True,
+                }
+            )
+            + "\n"
+        )
+
+    completed = subprocess.run(
+        ["bash", "-c", command],
+        env={
+            **os.environ,
+            "CITATION": "us/statute/42/1437c-1",
+            "CORPUS_REF": "corpus-ref",
+            "COUNTRY": "us",
+            "GITHUB_RUN_ATTEMPT": "1",
+            "GITHUB_RUN_ID": "1234",
+            "GITHUB_SHA": "encoder-ref",
+            "RULES_ENGINE_REF": "rules-engine-ref",
+            "RULESPEC_REF": "rulespec-ref",
+            "RUNNER_TEMP": str(tmp_path),
+        },
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert expected_error in completed.stderr
+    assert not (tmp_path / "targeted-reencode-failure.tar").exists()
+
+
+def test_targeted_signed_reencode_preserves_checkpoint_guard_failure(
+    tmp_path: Path,
+) -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
+    )
+    command = next(
+        step["run"]
+        for step in workflow["jobs"]["encode"]["steps"]
+        if step.get("name") == "Encode, review, validate, and apply"
+    )
+    checkpoint = command.split("checkpoint_signed_changes() {", 1)[1].split(
+        "\n}\n\nsource_index=0",
+        1,
+    )[0]
+    guard_stub = tmp_path / "guard-stub"
+    guard_stub.write_text(
+        "#!/bin/sh\n"
+        "printf '%s\\n' "
+        '\'{"repo":"/runner/rulespec-us","passed":false,'
+        '"issues":["checkpoint manifest mismatch"]}\'\n'
+        "exit 7\n"
+    )
+    guard_stub.chmod(0o700)
+    script = (
+        "set -euo pipefail\n"
+        "checkpoint_signed_changes() {"
+        + checkpoint.replace(
+            "/opt/axiom-verification/axiom-encode-signing-supervisor",
+            '"$GUARD_STUB"',
+        )
+        + "\n}\ncheckpoint_signed_changes test\n"
+    )
+
+    completed = subprocess.run(
+        ["bash", "-c", script],
+        env={
+            **os.environ,
+            "GITHUB_WORKSPACE": str(tmp_path),
+            "GUARD_STUB": str(guard_stub),
+            "RULESPEC_CHECKOUT": str(tmp_path / "rulespec-us"),
+            "RUNNER_TEMP": str(tmp_path),
+        },
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 7
+    assert "checkpoint manifest mismatch" in completed.stderr
+    assert json.loads((tmp_path / "checkpoint-guard-generated.json").read_text()) == {
+        "repo": "/runner/rulespec-us",
+        "passed": False,
+        "issues": ["checkpoint manifest mismatch"],
+    }
 
 
 def test_targeted_signed_reencode_rejects_symlinked_failure_diagnostics(

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2365,10 +2365,10 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     )
     assert guard_step["id"] == "verify_generated_provenance"
     assert "guard-generated" in guard_step["run"]
-    assert 'guard_ref_args+=(--base-ref "$RULESPEC_REF")' in guard_step["run"]
-    assert (
-        "jq -e 'length > 0' \"$RUNNER_TEMP/source-bundle.json\"" in (guard_step["run"])
-    )
+    assert '--base-ref "$RULESPEC_REF"' in guard_step["run"]
+    assert "guard_ref_args" not in guard_step["run"]
+    assert 'guard_status="$?"' in guard_step["run"]
+    assert 'jq . "$RUNNER_TEMP/guard-generated.json" >&2' in guard_step["run"]
 
     secret_steps = [
         step
@@ -2457,6 +2457,16 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
     (generated / "statutes/54a:4-7.test.yaml").write_text("format: rulespec/v1\n")
     (generated / "target.repair.json").write_text('{"outcome": "blocked"}\n')
     (generated / "ignored.bin").write_bytes(b"not diagnostic output")
+    (tmp_path / "guard-generated.json").write_text(
+        json.dumps(
+            {
+                "repo": "/runner/rulespec-us",
+                "passed": False,
+                "issues": ["waiver transition requires protected base"],
+            }
+        )
+        + "\n"
+    )
     env = {
         **os.environ,
         "CITATION": "us/statute/42/1437c-1",
@@ -2491,6 +2501,7 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
         assert file_member_names == {
             "generated/target/model/statutes/54a:4-7.test.yaml",
             "generated/target/model/target.repair.json",
+            "guard-generated.json",
             "metadata.json",
         }
         assert "generated/target/model/ignored.bin" not in file_member_names
@@ -2498,12 +2509,19 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
             "./generated/target/model/statutes/54a:4-7.test.yaml"
         )
         repair = bundle.extractfile("./generated/target/model/target.repair.json")
+        guard = bundle.extractfile("./guard-generated.json")
         metadata_file = bundle.extractfile("./metadata.json")
         assert target is not None
         assert repair is not None
+        assert guard is not None
         assert metadata_file is not None
         assert target.read() == b"format: rulespec/v1\n"
         assert json.loads(repair.read()) == {"outcome": "blocked"}
+        assert json.loads(guard.read()) == {
+            "repo": "/runner/rulespec-us",
+            "passed": False,
+            "issues": ["waiver transition requires protected base"],
+        }
         metadata = json.loads(metadata_file.read())
     assert metadata["schema"] == "axiom-encode/failed-reencode-diagnostics/v1"
     assert metadata["workflow_run_id"] == "1234"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1518"
+version = "0.2.1519"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- authenticate generated RuleSpec changes across both the frozen reviewed base-to-HEAD range and live staged, unstaged, and untracked worktree changes
- always bind the protected targeted re-encode provenance guard to the frozen RuleSpec base
- print and retain bounded, nofollow, exact-shape guard diagnostics for final, checkpoint, and source-lane failures
- release encoder 0.2.1519

## Review cycle

Independent review completed twice before rebase. The first pass identified missing checkpoint diagnostic preservation and adversarial diagnostic tests. Those findings were fixed, and repeat review was clean. After a conflict-free rebase onto main 3809215eb4ce451183705f0b95f12c21ea3a8cc7, an additional independent review was CLEAN at exact head dbd886aa32a614595fa056376ba221d78ffcbae8 with no actionable findings. Range-diff confirms the substantive fix commits are patch-identical across the rebase.

## Checks

- uv run ruff check pyproject.toml src/axiom_encode scripts tests
- python -m compileall -q src/axiom_encode scripts
- rebased focused guard/workflow/provenance slice: 88 passed
- pre-rebase full suite on patch-identical changes: 7,017 passed, 119 skipped
- independent post-rebase focused suites: 23 + 8 + 16 + 27 passed