### PR TITLE
Fix source condition witness attribution

### DIFF
--- a/changelog.d/explicit-paired-gate-tests.fixed.md
+++ b/changelog.d/explicit-paired-gate-tests.fixed.md
@@ -1,0 +1,1 @@
+Prevent generic `federal` and `except` tokens from assigning an exception witness to an unrelated source condition, and require mechanically cloned, single-input test pairs for every source-stated boolean gate in complete-source encoder prompts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1519"
+version = "0.2.1520"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1520"
+version = "0.2.1521"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1519"
+__version__ = "0.2.1520"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1520"
+__version__ = "0.2.1521"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -9556,10 +9556,12 @@ Test file rules:
   untested just because another negative case toggles a different gate.
 - Build those boolean-gate witnesses mechanically. First emit a minimal
   all-gates-positive case whose `input:` contains exactly the local facts
-  reached by that one asserted principal output and whose `output:` asserts
-  only that principal output. Clone the complete case once per gate, changing
-  exactly one input value and the expected value of the same single output.
-  Every member of the pair must have the identical input-key set; put helper,
+  reached by that one asserted principal output. Its `output:` must assert the
+  principal output plus every reached local derived dependency required for
+  corroboration, but no unrelated output. Clone the complete case once per
+  gate, changing exactly one input value and the expected principal output plus
+  any asserted reached dependency whose value also changes. Every member of the
+  pair must have identical input-key and output-key sets; put unrelated helper,
   amount, and downstream-output demonstrations in separate cases.
 - If a formula negates multiple exception predicates, include a separate companion test for each predicate that sets that exception input true and expects the directly affected Judgment rule to be `not_holds`.
 - For any negated exception predicate, include a paired positive case with the same output rule where only the exception input changes from `false` to `true`; do not combine the exception test with another branch change.
@@ -10426,10 +10428,12 @@ RuleSpec requirements:
   untested just because another negative case toggles a different gate.
 - Build those boolean-gate witnesses mechanically. First emit a minimal
   all-gates-positive case whose `input:` contains exactly the local facts
-  reached by that one asserted principal output and whose `output:` asserts
-  only that principal output. Clone the complete case once per gate, changing
-  exactly one input value and the expected value of the same single output.
-  Every member of the pair must have the identical input-key set; put helper,
+  reached by that one asserted principal output. Its `output:` must assert the
+  principal output plus every reached local derived dependency required for
+  corroboration, but no unrelated output. Clone the complete case once per
+  gate, changing exactly one input value and the expected principal output plus
+  any asserted reached dependency whose value also changes. Every member of the
+  pair must have identical input-key and output-key sets; put unrelated helper,
   amount, and downstream-output demonstrations in separate cases.
 - If a formula negates multiple exception predicates, include a separate companion test for each predicate that sets that exception input true and expects the directly affected Judgment rule to be `not_holds`.
 - For any negated exception predicate, include a paired positive case with the same output rule where only the exception input changes from `false` to `true`; do not combine the exception test with another branch change.

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -9554,6 +9554,13 @@ Test file rules:
   gates joined by `and`, include one all-gates-positive case and enough negative
   cases to toggle each gate at least once. Do not leave a source-stated gate
   untested just because another negative case toggles a different gate.
+- Build those boolean-gate witnesses mechanically. First emit a minimal
+  all-gates-positive case whose `input:` contains exactly the local facts
+  reached by that one asserted principal output and whose `output:` asserts
+  only that principal output. Clone the complete case once per gate, changing
+  exactly one input value and the expected value of the same single output.
+  Every member of the pair must have the identical input-key set; put helper,
+  amount, and downstream-output demonstrations in separate cases.
 - If a formula negates multiple exception predicates, include a separate companion test for each predicate that sets that exception input true and expects the directly affected Judgment rule to be `not_holds`.
 - For any negated exception predicate, include a paired positive case with the same output rule where only the exception input changes from `false` to `true`; do not combine the exception test with another branch change.
 - Validation fails if a direct local `#input.*_exception_applies` or
@@ -10417,6 +10424,13 @@ RuleSpec requirements:
   gates joined by `and`, include one all-gates-positive case and enough negative
   cases to toggle each gate at least once. Do not leave a source-stated gate
   untested just because another negative case toggles a different gate.
+- Build those boolean-gate witnesses mechanically. First emit a minimal
+  all-gates-positive case whose `input:` contains exactly the local facts
+  reached by that one asserted principal output and whose `output:` asserts
+  only that principal output. Clone the complete case once per gate, changing
+  exactly one input value and the expected value of the same single output.
+  Every member of the pair must have the identical input-key set; put helper,
+  amount, and downstream-output demonstrations in separate cases.
 - If a formula negates multiple exception predicates, include a separate companion test for each predicate that sets that exception input true and expects the directly affected Judgment rule to be `not_holds`.
 - For any negated exception predicate, include a paired positive case with the same output rule where only the exception input changes from `false` to `true`; do not combine the exception test with another branch change.
 - Every local executable `kind: derived` or `kind: derived_relation` rule must

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -386,6 +386,26 @@ _APPLICABILITY_LANGUAGE = re.compile(
     r")\b",
     flags=re.IGNORECASE,
 )
+_SOURCE_SELECTOR_TOKEN_STOPWORDS = frozenset(
+    {
+        "applies",
+        "apply",
+        "case",
+        "condition",
+        "except",
+        "federal",
+        "flag",
+        "for",
+        "has",
+        "is",
+        "no",
+        "non",
+        "not",
+        "status",
+        "the",
+        "without",
+    }
+)
 _NEGATIVE_NONAPPLICABILITY_LANGUAGE = re.compile(
     r"\b(?:"
     r"(?:shall|does)\s+not\s+apply|"
@@ -8905,6 +8925,8 @@ def _source_exception_condition_text(text: str) -> str:
     if marker is None:
         return clause
     suffix = clause[marker.start() :]
+    if _source_qualification_exception_idiom(clause, marker):
+        return clause
     condition_cue = re.search(
         r"\b(?:vorausgesetzt\s*,?\s+dass|"
         r"unter\s+der\s+voraussetzung\s*,?\s+dass|"
@@ -8929,6 +8951,27 @@ def _source_exception_condition_text(text: str) -> str:
     if preposed is not None:
         return preposed.group("condition")
     return suffix
+
+
+def _source_qualification_exception_idiom(
+    text: str,
+    marker: re.Match[str],
+) -> bool:
+    """Recognize qualifications preserved except for one stated criterion."""
+
+    return bool(
+        marker.group(0).strip().lower().startswith("except")
+        and re.search(
+            r"\b(?:qualifications?|requirements?|conditions?)\b",
+            text[: marker.start()],
+            flags=re.IGNORECASE,
+        )
+        and re.search(
+            r"\b(?:eligible|qualif(?:y|ied|ication))\b",
+            text[marker.end() :],
+            flags=re.IGNORECASE,
+        )
+    )
 
 
 def _source_exception_effect_requirement(text: str) -> str:
@@ -9008,19 +9051,7 @@ def _source_exception_effect_requirement(text: str) -> str:
                 return "enable"
             if latest_negative > latest_positive:
                 return "exclude"
-        if (
-            cue.startswith("except")
-            and re.search(
-                r"\b(?:qualifications?|requirements?|conditions?)\b",
-                proposition,
-                flags=re.IGNORECASE,
-            )
-            and re.search(
-                r"\b(?:eligible|qualif(?:y|ied|ication))\b",
-                collapsed[condition.end() :],
-                flags=re.IGNORECASE,
-            )
-        ):
+        if _source_qualification_exception_idiom(collapsed, condition):
             return "enable"
     if re.search(
         r"\b(?:"
@@ -9110,20 +9141,9 @@ def _source_exception_selector_is_relevant(text: str, name: str) -> bool:
     collapsed = _collapse_text(text).lower()
     if _source_selector_concept_matches(collapsed, normalized_name):
         return True
-    ignored = {
-        "applies",
-        "apply",
-        "case",
-        "condition",
-        "flag",
-        "has",
-        "is",
-        "status",
-        "the",
-    }
     return any(
         len(token) >= 4
-        and token not in ignored
+        and token not in _SOURCE_SELECTOR_TOKEN_STOPWORDS
         and re.search(rf"\b{re.escape(token)}\w*", collapsed) is not None
         for token in normalized_name.split("_")
     )
@@ -9195,26 +9215,10 @@ def _source_selector_concept_matches(
     for concept, pattern in concept_patterns.items():
         if concept in normalized_name:
             patterns.append(pattern)
-    ignored = {
-        "applies",
-        "apply",
-        "case",
-        "condition",
-        "flag",
-        "for",
-        "has",
-        "is",
-        "no",
-        "non",
-        "not",
-        "status",
-        "the",
-        "without",
-    }
     patterns.extend(
         rf"\b{re.escape(token)}\w*"
         for token in normalized_name.split("_")
-        if len(token) >= 4 and token not in ignored
+        if len(token) >= 4 and token not in _SOURCE_SELECTOR_TOKEN_STOPWORDS
     )
     matches = {
         (match.start(), match.end(), match.group(0)): match

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -1041,10 +1041,12 @@ _TESTS_PROTOCOL = """- Emit only RuleSpec YAML; use `.test.yaml` companions when
   untested just because another negative case toggles a different gate.
 - Build those boolean-gate witnesses mechanically. First emit a minimal
   all-gates-positive case whose `input:` contains exactly the local facts
-  reached by that one asserted principal output and whose `output:` asserts
-  only that principal output. Clone the complete case once per gate, changing
-  exactly one input value and the expected value of the same single output.
-  Every member of the pair must have the identical input-key set; put helper,
+  reached by that one asserted principal output. Its `output:` must assert the
+  principal output plus every reached local derived dependency required for
+  corroboration, but no unrelated output. Clone the complete case once per
+  gate, changing exactly one input value and the expected principal output plus
+  any asserted reached dependency whose value also changes. Every member of the
+  pair must have identical input-key and output-key sets; put unrelated helper,
   amount, and downstream-output demonstrations in separate cases.
 - If a formula negates multiple exception predicates, include a separate
   companion test for each predicate that sets that exception input true and

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -1039,6 +1039,13 @@ _TESTS_PROTOCOL = """- Emit only RuleSpec YAML; use `.test.yaml` companions when
   gates joined by `and`, include one all-gates-positive case and enough negative
   cases to toggle each gate at least once. Do not leave a source-stated gate
   untested just because another negative case toggles a different gate.
+- Build those boolean-gate witnesses mechanically. First emit a minimal
+  all-gates-positive case whose `input:` contains exactly the local facts
+  reached by that one asserted principal output and whose `output:` asserts
+  only that principal output. Clone the complete case once per gate, changing
+  exactly one input value and the expected value of the same single output.
+  Every member of the pair must have the identical input-key set; put helper,
+  amount, and downstream-output demonstrations in separate cases.
 - If a formula negates multiple exception predicates, include a separate
   companion test for each predicate that sets that exception input true and
   expects the directly affected Judgment rule to be `not_holds`.

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1519"
+ENCODER_VERSION = "0.2.1520"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1520"
+ENCODER_VERSION = "0.2.1521"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_complete_source_mode_plumbing.py
+++ b/tests/test_complete_source_mode_plumbing.py
@@ -131,6 +131,10 @@ def test_generic_encoder_prompt_adds_completeness_only_when_enabled():
     assert "scalar-only source unit may remain parameter-only" in complete_prompt
     assert "single-principal-output case pairs" in complete_prompt
     assert "one large omnibus case" in complete_prompt
+    assert "Build those boolean-gate witnesses mechanically" in complete_prompt
+    assert "Every member of the pair must have the identical input-key set" in (
+        complete_prompt
+    )
 
 
 def test_validator_pipeline_complete_source_mode_is_default_off(tmp_path):

--- a/tests/test_complete_source_mode_plumbing.py
+++ b/tests/test_complete_source_mode_plumbing.py
@@ -132,9 +132,8 @@ def test_generic_encoder_prompt_adds_completeness_only_when_enabled():
     assert "single-principal-output case pairs" in complete_prompt
     assert "one large omnibus case" in complete_prompt
     assert "Build those boolean-gate witnesses mechanically" in complete_prompt
-    assert "Every member of the pair must have the identical input-key set" in (
-        complete_prompt
-    )
+    assert "plus every reached local derived dependency required for" in complete_prompt
+    assert "identical input-key and output-key sets" in complete_prompt
 
 
 def test_validator_pipeline_complete_source_mode_is_default_off(tmp_path):

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1519"
+ENCODER_VERSION = "0.2.1520"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1520"
+ENCODER_VERSION = "0.2.1521"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1520"
+ENCODER_VERSION = "0.2.1521"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1519"
+ENCODER_VERSION = "0.2.1520"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1519"
+ENCODER_VERSION = "0.2.1520"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1520"
+ENCODER_VERSION = "0.2.1521"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1520"
+ENCODER_VERSION = "0.2.1521"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1519"
+ENCODER_VERSION = "0.2.1520"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1520"
+ENCODER_VERSION = "0.2.1521"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1519"
+ENCODER_VERSION = "0.2.1520"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1520"
+ENCODER_VERSION = "0.2.1521"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1519"
+ENCODER_VERSION = "0.2.1520"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5923,7 +5923,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1519"')
+        .startswith('__version__ = "0.2.1520"')
     )
 
 
@@ -6155,13 +6155,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1519"
+    assert encoder_package["version"] == "0.2.1520"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1519"
+    assert project["project"]["version"] == "0.2.1520"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1519"')
+        .startswith('__version__ = "0.2.1520"')
     )
 
 
@@ -6423,13 +6423,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1519"
+    assert encoder_package["version"] == "0.2.1520"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1519"
+    assert project["project"]["version"] == "0.2.1520"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1519"')
+        .startswith('__version__ = "0.2.1520"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5923,7 +5923,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1520"')
+        .startswith('__version__ = "0.2.1521"')
     )
 
 
@@ -6155,13 +6155,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1520"
+    assert encoder_package["version"] == "0.2.1521"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1520"
+    assert project["project"]["version"] == "0.2.1521"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1520"')
+        .startswith('__version__ = "0.2.1521"')
     )
 
 
@@ -6423,13 +6423,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1520"
+    assert encoder_package["version"] == "0.2.1521"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1520"
+    assert project["project"]["version"] == "0.2.1521"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1520"')
+        .startswith('__version__ = "0.2.1521"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1520"
+ENCODER_VERSION = "0.2.1521"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1519"
+ENCODER_VERSION = "0.2.1520"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -12182,6 +12182,100 @@ def test_generic_exception_name_cannot_witness_unrelated_source_condition():
     assert _has_issue(result, "exception", "test")
 
 
+def test_federal_except_tokens_cannot_bind_age_witness_to_joint_return_clause():
+    age_selector = (
+        "resident_individual_meets_all_federal_eitc_qualifications_except_age"
+    )
+    joint_return_condition = (
+        "if the claimant is married, except for a claimant who files as a head "
+        "of household or surviving spouse for federal income tax purposes, the "
+        "claimant shall file a joint return"
+    )
+    age_qualification_condition = (
+        "The resident individual shall meet all qualifications, except for the "
+        "minimum or maximum age, for the federal earned income tax credit in "
+        "order to be eligible for the credit"
+    )
+
+    assert not completeness_module._source_exception_selector_is_relevant(
+        joint_return_condition,
+        age_selector,
+    )
+    assert completeness_module._source_exception_selector_is_relevant(
+        age_qualification_condition,
+        age_selector,
+    )
+    assert (
+        completeness_module._source_exception_condition_text(
+            age_qualification_condition
+        )
+        == age_qualification_condition
+    )
+
+
+@pytest.mark.parametrize("reverse_clause_order", [False, True])
+def test_age_qualification_witness_is_not_allocated_to_joint_return_clause(
+    reverse_clause_order: bool,
+):
+    joint_selector = "married_claimant_joint_return_requirement_satisfied"
+    age_selector = (
+        "resident_individual_meets_all_federal_eitc_qualifications_except_age"
+    )
+    joint_clause = (
+        "To qualify for the credit, if the claimant is married, except for a "
+        "claimant who files as a head of household or surviving spouse for "
+        "federal income tax purposes, the claimant shall file a joint return."
+    )
+    age_clause = (
+        "The resident individual shall meet all qualifications, except for the "
+        "minimum or maximum age, for the federal earned income tax credit in "
+        "order to be eligible for the credit."
+    )
+    ordered_clauses = (age_clause, joint_clause) if reverse_clause_order else (
+        joint_clause,
+        age_clause,
+    )
+    source = "(1) " + " ".join(ordered_clauses)
+    content = _exception_control_content(f"{joint_selector} and {age_selector}")
+    positive = {
+        joint_selector: True,
+        age_selector: True,
+    }
+    cases = [
+        {
+            "name": "all qualifications met",
+            "input": positive,
+            "output": {"result": True},
+        },
+        {
+            "name": "non-age qualification not met",
+            "input": {**positive, age_selector: False},
+            "output": {"result": False},
+        },
+    ]
+
+    missing_joint = _analyze(content, source, test_cases=cases)
+    exception_issue = next(
+        issue
+        for issue in missing_joint.issues
+        if "[complete-source-unit:tests] Source-stated exceptions" in issue
+    )
+
+    assert "joint return" in exception_issue
+    assert "meet all qualifications" not in exception_issue
+
+    cases.append(
+        {
+            "name": "joint return requirement not met",
+            "input": {**positive, joint_selector: False},
+            "output": {"result": False},
+        }
+    )
+    complete = _analyze(content, source, test_cases=cases)
+
+    assert not _has_issue(complete, "exception", "test")
+
+
 def test_selector_relevance_uses_tokens_not_substrings():
     source = "(1) The claim does not apply when a separate status exists."
     content = _exception_control_content("if rate: false else: true")

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -12231,9 +12231,13 @@ def test_age_qualification_witness_is_not_allocated_to_joint_return_clause(
         "minimum or maximum age, for the federal earned income tax credit in "
         "order to be eligible for the credit."
     )
-    ordered_clauses = (age_clause, joint_clause) if reverse_clause_order else (
-        joint_clause,
-        age_clause,
+    ordered_clauses = (
+        (age_clause, joint_clause)
+        if reverse_clause_order
+        else (
+            joint_clause,
+            age_clause,
+        )
     )
     source = "(1) " + " ".join(ordered_clauses)
     content = _exception_control_content(f"{joint_selector} and {age_selector}")

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1520"
+version = "0.2.1521"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1519"
+version = "0.2.1520"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- prevent generic `federal` and `except` tokens from binding a source-condition witness to an unrelated clause
- preserve the full `qualifications, except ...` clause for semantic witness matching
- teach all complete-source encoder prompt paths to construct exact one-input gate pairs while retaining required reached-derived-dependency assertions
- bump axiom-encode to 0.2.1521

## Why

NJ 54A:4-7 retry run 30922655370 ended with a genuine missing minimal positive age-gate pair. The preceding candidate had that pair, but complete-source matching incorrectly let its age-qualification witness satisfy the unrelated joint-return clause based only on generic `federal`/`except` overlap. Maximum one-witness-per-obligation matching then reported the wrong clause missing and induced repair churn.

This fixes the semantic attribution rather than weakening exact-pair validation. Regression coverage uses the NJ-shaped joint-return and age-qualification clauses in both orders.

## Review cycle

- Independent diagnosis confirmed the final rejection was valid and reproduced the earlier witness-attribution false positive.
- First independent review found the new prompt's single-output wording conflicted with required reached-derived-dependency corroboration.
- Fixed all three prompt copies to require identical output-key sets containing the principal output plus every reached local derived dependency, excluding only unrelated outputs.
- Independent re-review: CLEAN on f77963bb9f4f38ca6038f4eaadd60a543313131c.
- Metadata-only final review: CLEAN on c6d9e01aeb059f6c340de6e56df47852f7d29c22.

## Checks

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest` — 7,022 passed, 119 skipped
- `uv run pytest -q --no-cov tests/test_source_completeness.py` — 1,082 passed before the final prompt-only correction; independent review reran the affected source-completeness set cleanly
- `uv run pytest -q --no-cov tests/test_complete_source_mode_plumbing.py` — 16 passed
- version provenance guard passed at final head
