### PR TITLE
Recognize nested alphabetic proof scope

### DIFF
--- a/changelog.d/nested-alpha-proof-scope.fixed.md
+++ b/changelog.d/nested-alpha-proof-scope.fixed.md
@@ -1,0 +1,1 @@
+Allow proof excerpts from alphabetic lists nested inside an explicitly cited numeric paragraph.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1521"
+version = "0.2.1522"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -1449,9 +1449,7 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                             Path(metadata_path),
                             base_raw,
                             moves=primary_moves,
-                            validation_waiver_set_sha256=(
-                                post_migration_waiver_sha256
-                            ),
+                            validation_waiver_set_sha256=(post_migration_waiver_sha256),
                         )
                     )
                 except ValueError as exc:
@@ -1464,19 +1462,16 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                     or reconciliation.get("after_sha256")
                     != hashlib.sha256(live_raw).hexdigest()
                     or live_raw != expected_live
-                    or reconciliation.get("operations")
-                    != list(expected_operations)
+                    or reconciliation.get("operations") != list(expected_operations)
                 ):
                     raise ValueError(
                         f"legacy metadata reconciliation[{index}] state differs"
-                )
+                    )
                 metadata_paths.add(metadata_path)
             expected_metadata_paths: set[PurePosixPath] = set()
             for metadata_path in LEGACY_REPLACEMENT_METADATA_PATHS:
                 try:
-                    base_raw = _git(
-                        repo, "show", f"HEAD:{metadata_path.as_posix()}"
-                    )
+                    base_raw = _git(repo, "show", f"HEAD:{metadata_path.as_posix()}")
                 except subprocess.CalledProcessError:
                     continue
                 try:
@@ -1485,9 +1480,7 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                             Path(metadata_path),
                             base_raw,
                             moves=primary_moves,
-                            validation_waiver_set_sha256=(
-                                post_migration_waiver_sha256
-                            ),
+                            validation_waiver_set_sha256=(post_migration_waiver_sha256),
                         )
                     )
                 except ValueError:

--- a/scripts/prepare_signed_queue.py
+++ b/scripts/prepare_signed_queue.py
@@ -605,9 +605,7 @@ def build_all_state_snap_queue(
     if not isinstance(states, list) or len(states) != 51:
         raise ValueError("state SNAP source inventory must contain 51 jurisdictions")
 
-    release_path = (
-        corpus_root / "manifests/releases" / f"{release_name}.json"
-    )
+    release_path = corpus_root / "manifests/releases" / f"{release_name}.json"
     release = _load_json(release_path)
     release_scopes = release.get("scopes")
     if not isinstance(release_scopes, list):
@@ -646,9 +644,7 @@ def build_all_state_snap_queue(
             if scope is None:
                 continue
             if not isinstance(scope, dict):
-                raise ValueError(
-                    f"{jurisdiction} {scope_field} is malformed"
-                )
+                raise ValueError(f"{jurisdiction} {scope_field} is malformed")
             scope_key = (
                 scope.get("jurisdiction"),
                 scope.get("document_class"),
@@ -1259,7 +1255,9 @@ def verify_activation_evidence(
     activation = queue["activation"]
     _require_sha(expected_base_sha, "expected_base_sha")
     if activation["finalizer_head_sha"] != expected_base_sha:
-        raise ValueError("activation finalizer head does not match the pull request base")
+        raise ValueError(
+            "activation finalizer head does not match the pull request base"
+        )
     if activation["previous_queue_object_sha256"] != _json_sha256(previous_queue):
         raise ValueError("activation base queue digest does not match")
     if activation["check_runs_sha256"] != _json_sha256(check_runs):
@@ -1333,8 +1331,7 @@ def verify_activation_commit(
     }
     if (
         set(provenance) != expected_fields
-        or provenance.get("schema")
-        != "axiom-encode/snap-queue-activation-commit/v1"
+        or provenance.get("schema") != "axiom-encode/snap-queue-activation-commit/v1"
         or provenance.get("repository") != "TheAxiomFoundation/axiom-encode"
         or provenance.get("queue_path") != activation_changed_files[0]
         or provenance.get("queue_sha256") != queue_file_sha256(queue_path)
@@ -1420,8 +1417,7 @@ def verify_merge_authorization(
     ):
         raise ValueError("merge authorization identifiers are malformed")
     expected_run_url = (
-        "https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/"
-        f"{run_id}"
+        f"https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/{run_id}"
     )
     if authorization.get("merge_workflow_run_url") != expected_run_url:
         raise ValueError("merge authorization workflow URL is malformed")
@@ -1462,7 +1458,9 @@ def verify_merge_authorization(
         or not isinstance(merged_by, dict)
         or merged_by.get("login") != "github-actions[bot]"
     ):
-        raise ValueError("activation pull request was not merged by the trusted workflow")
+        raise ValueError(
+            "activation pull request was not merged by the trusted workflow"
+        )
     if queue_change_sha != authorization["merge_commit"]:
         raise ValueError("active queue was changed outside its authorized merge commit")
 
@@ -1512,13 +1510,9 @@ def verify_paused_transition(
         if any(current[field] != prior[field] for field in immutable_fields):
             raise ValueError(f"paused queue transition rewrote item {item_id}")
         if current["status"] == "completed" and prior["status"] != "completed":
-            raise ValueError(
-                f"paused queue transition cannot complete item {item_id}"
-            )
+            raise ValueError(f"paused queue transition cannot complete item {item_id}")
         if prior["status"] in TERMINAL_STATUSES and current != prior:
-            raise ValueError(
-                f"paused queue transition rewrote terminal item {item_id}"
-            )
+            raise ValueError(f"paused queue transition rewrote terminal item {item_id}")
         if current["attempt"] < prior["attempt"]:
             raise ValueError(
                 f"paused queue transition decreased attempt for item {item_id}"
@@ -1527,7 +1521,10 @@ def verify_paused_transition(
             raise ValueError(
                 f"paused queue transition skipped an attempt for item {item_id}"
             )
-        if current["attempt"] == prior["attempt"] + 1 and current["status"] != "retryable":
+        if (
+            current["attempt"] == prior["attempt"] + 1
+            and current["status"] != "retryable"
+        ):
             raise ValueError(
                 f"paused queue transition changed attempt without retrying {item_id}"
             )
@@ -1546,7 +1543,9 @@ def verify_paused_transition(
             active_queue_sha256=queue_file_sha256(previous_queue_path),
         )
         if queue != expected:
-            raise ValueError("active queue pause transition changed queue items or trust")
+            raise ValueError(
+                "active queue pause transition changed queue items or trust"
+            )
 
 
 def _flatten_pull_requests(payload: object) -> list[dict[str, Any]]:
@@ -1635,9 +1634,9 @@ def _verify_attempt_one_job(
     ):
         raise ValueError(f"{label} job history is incomplete")
     first = by_attempt[1][0]
-    first_success = first.get("status") == "completed" and first.get(
-        "conclusion"
-    ) == "success"
+    first_success = (
+        first.get("status") == "completed" and first.get("conclusion") == "success"
+    )
     first_in_progress = (
         not require_success
         and run_attempt == 1
@@ -1746,9 +1745,7 @@ def reconcile_candidates(
                 None,
             )
             actor = (
-                candidate_run.get("actor")
-                if isinstance(candidate_run, dict)
-                else None
+                candidate_run.get("actor") if isinstance(candidate_run, dict) else None
             )
             if (
                 isinstance(candidate_run, dict)
@@ -1763,8 +1760,7 @@ def reconcile_candidates(
                 == ".github/workflows/targeted-signed-reencode.yml"
                 and isinstance(actor, dict)
                 and actor.get("login") == "github-actions[bot]"
-                and run_marker
-                in str(candidate_run.get("display_title") or "")
+                and run_marker in str(candidate_run.get("display_title") or "")
             ):
                 merged_pr = pr
                 target_run = candidate_run
@@ -1932,8 +1928,7 @@ def _verify_target_evidence(
     artifact_pr = evidence["pull_request"]
     inventory = evidence["apply_manifests"]
     if not all(
-        isinstance(value, dict)
-        for value in (run, metadata, artifact_pr, inventory)
+        isinstance(value, dict) for value in (run, metadata, artifact_pr, inventory)
     ):
         raise ValueError(f"{item['id']} target evidence contains a non-object")
     actor = run.get("actor")
@@ -1993,9 +1988,10 @@ def _verify_target_evidence(
     ):
         raise ValueError(f"{item['id']} target artifact PR identity does not match")
     inventory_items = inventory.get("items")
-    if (
-        inventory.get("schema") != "axiom-encode/applied-manifest-inventory/v1"
-        or not isinstance(inventory_items, list)
+    if inventory.get(
+        "schema"
+    ) != "axiom-encode/applied-manifest-inventory/v1" or not isinstance(
+        inventory_items, list
     ):
         raise ValueError(f"{item['id']} applied manifest inventory is malformed")
     matches = [
@@ -2004,9 +2000,7 @@ def _verify_target_evidence(
         if isinstance(value, dict) and value.get("citation") == item["citation"]
     ]
     if len(matches) != 1:
-        raise ValueError(
-            f"{item['id']} target artifact lacks one applied manifest"
-        )
+        raise ValueError(f"{item['id']} target artifact lacks one applied manifest")
     applied = matches[0]
     relative_path = applied.get("path")
     digest = _require_digest(
@@ -2173,10 +2167,7 @@ def finalize_and_repin(
         expected_markers = (
             f"Queue item: `{payload['queue_id']}/{item['id']}`",
             f"Citation: `{item['citation']}`",
-            (
-                "Queue generation SHA-256: "
-                f"`{evidence['generation_sha256']}`"
-            ),
+            (f"Queue generation SHA-256: `{evidence['generation_sha256']}`"),
             f"Axiom Encode run: {evidence['target_run_url']}",
         )
         pr_head = pr.get("head") if isinstance(pr, dict) else None
@@ -2658,9 +2649,7 @@ def main() -> None:
                 ),
                 merge_run=json.loads(args.merge_run.read_text(encoding="utf-8")),
                 merge_jobs=json.loads(args.merge_jobs.read_text(encoding="utf-8")),
-                pull_request=json.loads(
-                    args.pull_request.read_text(encoding="utf-8")
-                ),
+                pull_request=json.loads(args.pull_request.read_text(encoding="utf-8")),
                 current_head_sha=args.current_head_sha,
                 queue_change_sha=args.queue_change_sha,
             )
@@ -2669,9 +2658,7 @@ def main() -> None:
             verify_activation_commit(
                 args.queue,
                 provenance=json.loads(args.provenance.read_text(encoding="utf-8")),
-                pull_request=json.loads(
-                    args.pull_request.read_text(encoding="utf-8")
-                ),
+                pull_request=json.loads(args.pull_request.read_text(encoding="utf-8")),
                 current_base_sha=args.current_base_sha,
                 current_head_sha=args.current_head_sha,
                 current_tree_sha=args.current_tree_sha,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1521"
+__version__ = "0.2.1522"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/proof_validator.py
+++ b/src/axiom_encode/harness/proof_validator.py
@@ -499,6 +499,7 @@ def _validate_source_proof_atom(
                 else:
                     issues.extend(
                         _proof_excerpt_subsection_scope_issues(
+                            source_text=resolved_text,
                             evidence_text=evidence_text,
                             rule_source=rule_source,
                             label=label,
@@ -938,6 +939,7 @@ def _is_hyphen_marker(character: str) -> bool:
 
 def _proof_excerpt_subsection_scope_issues(
     *,
+    source_text: str,
     evidence_text: str,
     rule_source: Any,
     label: str,
@@ -954,6 +956,13 @@ def _proof_excerpt_subsection_scope_issues(
     excerpt_marker = re.match(r"^\s*\((?P<marker>[a-z])\)(?:\s|$)", evidence_text)
     marker = excerpt_marker.group("marker") if excerpt_marker is not None else None
     if declared and marker is not None and marker not in declared:
+        if _is_nested_alpha_marker_in_declared_numeric_scope(
+            source_text=source_text,
+            evidence_text=evidence_text,
+            marker=marker,
+            scope=scope,
+        ):
+            return []
         return [
             "Proof source evidence not found: "
             f"{label} `source.{field}` appears outside the rule's declared "
@@ -979,6 +988,298 @@ def _proof_excerpt_subsection_scope_issues(
         f"{label} `source.{field}` appears outside the rule's declared "
         f"subsection scope `{rule_source}` (excerpt begins at `({numeric})`)."
     ]
+
+
+def _is_nested_alpha_marker_in_declared_numeric_scope(
+    *,
+    source_text: str,
+    evidence_text: str,
+    marker: str,
+    scope: Mapping[str, frozenset[str] | None],
+) -> bool:
+    """Recognize an alphabetic list nested inside a cited numeric paragraph."""
+    if not any(children for children in scope.values()):
+        return False
+
+    words = re.split(r"\s+", evidence_text.strip())
+    evidence_pattern = r"\s+".join(re.escape(word) for word in words)
+    reference_context_cache: dict[int, bool] = {}
+    for evidence_match in re.finditer(evidence_pattern, source_text):
+        if not _source_evidence_span_is_bounded(
+            evidence_text=evidence_text,
+            source_text=source_text,
+            start=evidence_match.start(),
+            end=evidence_match.end(),
+        ):
+            continue
+        prefix = source_text[: evidence_match.start()]
+        numeric_matches = [
+            match
+            for match in re.finditer(r"\((?P<marker>\d+)\)", prefix)
+            if _source_marker_has_numeric_paragraph_context(
+                source_text,
+                match.start(),
+                reference_context_cache=reference_context_cache,
+            )
+        ]
+        if not numeric_matches:
+            continue
+        numeric_parent = numeric_matches[-1]
+        top_level_scope = _source_top_level_marker_for_numeric_parent(
+            source_text, numeric_parent.start()
+        )
+        if top_level_scope is None:
+            continue
+        top_level, top_level_style = top_level_scope
+        declared_children = scope.get(top_level)
+        if (
+            declared_children is None
+            or numeric_parent.group("marker") not in declared_children
+        ):
+            continue
+
+        nested_matches = list(
+            re.finditer(
+                r"\((?P<marker>[a-z])\)(?:\s|$)",
+                source_text[numeric_parent.end() : evidence_match.start()],
+            )
+        )
+        nested_markers = []
+        for nested_match in nested_matches:
+            nested_start = numeric_parent.end() + nested_match.start()
+            if _source_marker_has_nested_list_context(
+                source_text,
+                start=nested_start,
+                lower_bound=numeric_parent.end(),
+                allow_period=(bool(nested_markers) and top_level_style == "dotted"),
+            ):
+                nested_markers.append(nested_match.group("marker"))
+        if not _source_marker_has_nested_list_context(
+            source_text,
+            start=evidence_match.start(),
+            lower_bound=numeric_parent.end(),
+            allow_period=bool(nested_markers) and top_level_style == "dotted",
+        ):
+            continue
+        nested_markers.append(marker)
+        expected = [chr(ord("a") + index) for index in range(len(nested_markers))]
+        if nested_markers == expected:
+            return True
+    return False
+
+
+def _source_top_level_marker_for_numeric_parent(
+    source_text: str, numeric_start: int
+) -> tuple[str, str] | None:
+    """Resolve alpha parents from one ordered structural-marker stream."""
+    numeric_end = source_text.find(")", numeric_start)
+    end_position = len(source_text) if numeric_end < 0 else numeric_end + 1
+    events = [
+        *(
+            (match.start(), "dotted", match)
+            for match in re.compile(r"(?<![A-Za-z])(?P<marker>[a-z])\.(?=\s)").finditer(
+                source_text, 0, end_position
+            )
+        ),
+        *(
+            (match.start(), "parenthesized", match)
+            for match in re.compile(r"\((?P<marker>[a-z])\)(?=\s)").finditer(
+                source_text, 0, end_position
+            )
+        ),
+        *(
+            (match.start(), "numeric", match)
+            for match in re.compile(r"\(\d+\)").finditer(source_text, 0, end_position)
+        ),
+    ]
+    events.sort(key=lambda event: event[0])
+
+    current_parent: tuple[str, str] | None = None
+    numeric_parent_end: int | None = None
+    numeric_parent_scope: tuple[str, str] | None = None
+    nested_markers: list[str] = []
+    reference_context_cache: dict[int, bool] = {}
+    for start, kind, match in events:
+        if start > numeric_start:
+            break
+        if kind == "numeric":
+            if not _source_marker_has_numeric_paragraph_context(
+                source_text,
+                start,
+                reference_context_cache=reference_context_cache,
+            ):
+                continue
+            if start == numeric_start:
+                return current_parent
+            numeric_parent_end = match.end()
+            numeric_parent_scope = current_parent
+            nested_markers = []
+            continue
+
+        if kind == "dotted":
+            if _source_marker_has_top_level_context(source_text, start):
+                current_parent = (match.group("marker"), "dotted")
+            continue
+
+        is_subordinate = False
+        if numeric_parent_end is not None and numeric_parent_scope is not None:
+            _, numeric_parent_style = numeric_parent_scope
+            if _source_marker_has_nested_list_context(
+                source_text,
+                start=start,
+                lower_bound=numeric_parent_end,
+                allow_period=(
+                    bool(nested_markers) and numeric_parent_style == "dotted"
+                ),
+            ):
+                nested_markers.append(match.group("marker"))
+                expected = [
+                    chr(ord("a") + index) for index in range(len(nested_markers))
+                ]
+                is_subordinate = nested_markers == expected
+        if not is_subordinate and _source_marker_has_top_level_context(
+            source_text, start
+        ):
+            current_parent = (match.group("marker"), "parenthesized")
+    return None
+
+
+def _source_marker_has_top_level_context(source_text: str, start: int) -> bool:
+    line_start = source_text.rfind("\n", 0, start)
+    index = start - 1
+    while index >= 0 and source_text[index].isspace():
+        index -= 1
+    if index < 0 or index <= line_start:
+        return True
+    return source_text[index] in ".?!:"
+
+
+def _source_marker_has_numeric_paragraph_context(
+    source_text: str,
+    start: int,
+    *,
+    reference_context_cache: dict[int, bool] | None = None,
+) -> bool:
+    if _source_position_follows_reference_word(
+        source_text, start, cache=reference_context_cache
+    ):
+        return False
+    index = start - 1
+    while index >= 0 and source_text[index].isspace():
+        index -= 1
+    context_index = index
+    line_start = source_text.rfind("\n", 0, start)
+    if context_index < 0 or context_index <= line_start:
+        return True
+    follows_parenthesized_alpha = (
+        source_text[context_index] == ")"
+        and context_index >= 2
+        and source_text[context_index - 2] == "("
+        and source_text[context_index - 1].islower()
+        and source_text[context_index - 1].isalpha()
+    )
+    follows_dotted_alpha = (
+        source_text[context_index] == "."
+        and context_index >= 1
+        and source_text[context_index - 1].islower()
+        and source_text[context_index - 1].isalpha()
+        and (context_index < 2 or not source_text[context_index - 2].isalpha())
+    )
+    return (
+        source_text[context_index] in ".?!:;"
+        or follows_parenthesized_alpha
+        or follows_dotted_alpha
+    )
+
+
+def _source_position_follows_reference_word(
+    source_text: str,
+    start: int,
+    *,
+    cache: dict[int, bool] | None = None,
+) -> bool:
+    if cache is not None and start in cache:
+        return cache[start]
+    chain_starts = [start]
+    current_start = start
+    result: bool | None = None
+    while True:
+        index = current_start - 1
+        while index >= 0 and source_text[index].isspace():
+            index -= 1
+        if index >= 0 and source_text[index] == ")":
+            marker_start = source_text.rfind("(", 0, index)
+            if marker_start >= 0 and re.fullmatch(
+                r"(?:[a-z]|\d+)", source_text[marker_start + 1 : index]
+            ):
+                if cache is not None and marker_start in cache:
+                    result = cache[marker_start]
+                    break
+                chain_starts.append(marker_start)
+                current_start = marker_start
+                continue
+        if (
+            index >= 1
+            and source_text[index] == "."
+            and source_text[index - 1].islower()
+            and source_text[index - 1].isalpha()
+            and (index < 2 or not source_text[index - 2].isalpha())
+        ):
+            marker_start = index - 1
+            if cache is not None and marker_start in cache:
+                result = cache[marker_start]
+                break
+            chain_starts.append(marker_start)
+            current_start = marker_start
+            continue
+        break
+    if result is None:
+        word_end = index + 1
+        while index >= 0 and source_text[index].isalpha():
+            index -= 1
+        result = source_text[index + 1 : word_end].lower() in {
+            "paragraph",
+            "paragraphs",
+            "subparagraph",
+            "subparagraphs",
+            "subsection",
+            "subsections",
+            "section",
+            "sections",
+            "clause",
+            "clauses",
+            "item",
+            "items",
+        }
+    if cache is not None:
+        cache.update(dict.fromkeys(chain_starts, result))
+    return result
+
+
+def _source_marker_has_nested_list_context(
+    source_text: str,
+    *,
+    start: int,
+    lower_bound: int,
+    allow_period: bool,
+) -> bool:
+    line_start = source_text.rfind("\n", lower_bound, start)
+    if line_start >= lower_bound:
+        line_prefix = source_text[line_start + 1 : start]
+        if line_prefix and not line_prefix.strip():
+            return len(line_prefix.expandtabs(2)) >= 2
+
+    index = start - 1
+    while index >= lower_bound and source_text[index].isspace():
+        index -= 1
+    word_end = index + 1
+    while index >= lower_bound and source_text[index].isalpha():
+        index -= 1
+    if source_text[index + 1 : word_end].lower() in {"and", "or"}:
+        while index >= lower_bound and source_text[index].isspace():
+            index -= 1
+    punctuation = (":", ";", ",", ".") if allow_period else (":", ";", ",")
+    return index >= lower_bound and source_text[index] in punctuation
 
 
 def _rule_source_subsection_scope(

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1521"
+ENCODER_VERSION = "0.2.1522"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1521"
+ENCODER_VERSION = "0.2.1522"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1521"
+ENCODER_VERSION = "0.2.1522"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1521"
+ENCODER_VERSION = "0.2.1522"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1521"
+ENCODER_VERSION = "0.2.1522"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1521"
+ENCODER_VERSION = "0.2.1522"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1521"
+ENCODER_VERSION = "0.2.1522"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -10,6 +10,7 @@ import tempfile
 import textwrap
 from decimal import Decimal
 from pathlib import Path
+from time import monotonic
 from unittest.mock import patch
 
 import pytest
@@ -32,6 +33,7 @@ from axiom_encode.harness.policyengine_runtime import (
     PolicyEngineRuntimeError,
 )
 from axiom_encode.harness.proof_validator import (
+    _source_top_level_marker_for_numeric_parent,
     find_rulespec_proof_issues,
     validate_rulespec_proofs,
 )
@@ -5923,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1521"')
+        .startswith('__version__ = "0.2.1522"')
     )
 
 
@@ -6155,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1521"
+    assert encoder_package["version"] == "0.2.1522"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1521"
+    assert project["project"]["version"] == "0.2.1522"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1521"')
+        .startswith('__version__ = "0.2.1522"')
     )
 
 
@@ -6423,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1521"
+    assert encoder_package["version"] == "0.2.1522"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1521"
+    assert project["project"]["version"] == "0.2.1522"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1521"')
+        .startswith('__version__ = "0.2.1522"')
     )
 
 
@@ -13174,6 +13176,436 @@ rules:
         "outside the rule's declared subsection scope" in issue
         and "(7)" in issue
         and "(f)(1)" in issue
+        for issue in result.issues
+    )
+
+
+def _proof_scope_fixture(*, rule_source: str, excerpt: str) -> str:
+    return f"""format: rulespec/v1
+rules:
+  - name: credit_before_proration
+    kind: derived
+    dtype: Money
+    source: {rule_source}
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: {excerpt!r}
+    versions:
+      - effective_from: '2026-01-01'
+        formula: federal_credit * state_percentage
+"""
+
+
+def test_rulespec_proof_validator_allows_nested_alpha_band_in_numeric_paragraph():
+    source_text = (
+        "a. (1) A resident individual shall be allowed a credit, subject to "
+        "this subsection and subsections b., c., d. and e. of this section. "
+        "(2) The percentage referred to in paragraph (1) shall be: "
+        "(a) 10% for the first taxable year; "
+        "(b) 15% for the second taxable year; (c) 17.5% thereafter. "
+        "(3) A married claimant shall file a joint return."
+    )
+    excerpt = "(b) 15% for the second taxable year;"
+    content = f"""format: rulespec/v1
+rules:
+  - name: credit_before_proration
+    kind: derived
+    dtype: Money
+    source: N.J.S.54A:4-7(a)(1), (a)(2), (a)(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: {excerpt!r}
+    versions:
+      - effective_from: '2026-01-01'
+        formula: federal_credit * state_percentage
+"""
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_allows_inline_parenthesized_top_level_parent():
+    source_text = (
+        "The resident rules are: (a) Resident credit. "
+        "(2) The percentage shall be: "
+        "(a) 10% for year one; (b) 15% for year two."
+    )
+    excerpt = "(b) 15% for year two."
+    content = _proof_scope_fixture(rule_source="N.J.S.54A:4-7(a)(2)", excerpt=excerpt)
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_allows_period_terminated_nested_items():
+    source_text = (
+        "a. Resident credit. (2) Requirements are: "
+        "(a) First requirement. (b) Second requirement."
+    )
+    excerpt = "(b) Second requirement."
+    content = _proof_scope_fixture(rule_source="N.J.S.54A:4-7(a)(2)", excerpt=excerpt)
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_keeps_dotted_parent_after_prior_nested_item():
+    source_text = (
+        "a. (1) Prior requirements are: (a) Prior item. "
+        "(2) Current requirements are: (a) First. (b) Second."
+    )
+    excerpt = "(b) Second."
+    content = _proof_scope_fixture(rule_source="N.J.S.54A:4-7(a)(2)", excerpt=excerpt)
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_rejects_stale_parent_after_new_inline_parent():
+    source_text = (
+        "a. (1) Previous resident rule. The nonresident rules are:\n"
+        "(c) Nonresident credit. (2) Schedule: (a) First; (b) Second."
+    )
+    excerpt = "(b) Second."
+    content = _proof_scope_fixture(rule_source="N.J.S.54A:4-7(a)(2)", excerpt=excerpt)
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any("outside" in issue for issue in result.issues)
+
+
+def test_rulespec_proof_validator_allows_inline_parent_after_prior_numeric():
+    source_text = (
+        "(1) Introductory provision. The resident rules are:\n"
+        "(a) Resident credit. (2) Schedule: (a) First; (b) Second."
+    )
+    excerpt = "(b) Second."
+    content = _proof_scope_fixture(rule_source="N.J.S.54A:4-7(a)(2)", excerpt=excerpt)
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_keeps_parent_across_abbreviation_period():
+    source_text = (
+        "c. (1) Benefits for U.S. residents include: (a) First category. "
+        "(2) Schedule: (a) First; (b) Second."
+    )
+    excerpt = "(b) Second."
+    correct_content = _proof_scope_fixture(
+        rule_source="N.J.S.54A:4-7(c)(2)", excerpt=excerpt
+    )
+    stale_content = _proof_scope_fixture(
+        rule_source="N.J.S.54A:4-7(a)(2)", excerpt=excerpt
+    )
+
+    correct_result = validate_rulespec_proofs(
+        correct_content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+    stale_result = validate_rulespec_proofs(
+        stale_content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert correct_result.passed is True
+    assert correct_result.issues == []
+    assert stale_result.passed is False
+    assert any("outside" in issue for issue in stale_result.issues)
+
+
+def test_rulespec_proof_parent_resolution_is_bounded_for_repeated_lists():
+    def resolve_repeated_lists(count: int) -> tuple[tuple[str, str] | None, float]:
+        source_text = " ".join("a. (1) Items: (a) Item." for _ in range(count))
+        numeric_start = source_text.rfind("(1)")
+        started = monotonic()
+        result = _source_top_level_marker_for_numeric_parent(source_text, numeric_start)
+        return result, monotonic() - started
+
+    small_result, small_elapsed = resolve_repeated_lists(192)
+    large_result, large_elapsed = resolve_repeated_lists(768)
+
+    assert small_result == large_result == ("a", "dotted")
+    assert large_elapsed < 1.0
+    assert large_elapsed < max(small_elapsed * 16, 0.05)
+
+
+def test_rulespec_proof_reference_chain_resolution_is_bounded():
+    def resolve_reference_chain(count: int) -> float:
+        source_text = "paragraph " + "".join(
+            f"({index})" for index in range(1, count + 1)
+        )
+        numeric_start = source_text.rfind(f"({count})")
+        started = monotonic()
+        result = _source_top_level_marker_for_numeric_parent(source_text, numeric_start)
+        elapsed = monotonic() - started
+        assert result is None
+        return elapsed
+
+    small_elapsed = resolve_reference_chain(800)
+    large_elapsed = resolve_reference_chain(3200)
+
+    assert large_elapsed < 1.0
+    assert large_elapsed < max(small_elapsed * 10, 0.05)
+
+
+def test_rulespec_proof_parent_resolution_supports_multi_digit_paragraphs():
+    source_text = "a. (12) Categories: (a) First. (13) Current requirement."
+
+    result = _source_top_level_marker_for_numeric_parent(
+        source_text, source_text.rfind("(13)")
+    )
+
+    assert result == ("a", "dotted")
+
+
+def test_rulespec_proof_validator_allows_aligned_parenthesized_parent():
+    source_text = "(a)      (12) Categories: (a) First; (b) Second."
+    excerpt = "(b) Second."
+    content = _proof_scope_fixture(rule_source="N.J.S.54A:4-7(a)(12)", excerpt=excerpt)
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_rejects_wrapped_numeric_cross_reference():
+    source_text = (
+        f"a. (2) Existing rule. See paragraph\n{' ' * 40}(9): (a) First; (b) Second."
+    )
+    excerpt = "(b) Second."
+    content = _proof_scope_fixture(rule_source="N.J.S.54A:4-7(a)(9)", excerpt=excerpt)
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any("outside" in issue for issue in result.issues)
+
+
+@pytest.mark.parametrize("separator", ["", "      "])
+def test_rulespec_proof_validator_rejects_hierarchical_cross_reference(
+    separator: str,
+):
+    source_text = (
+        "c. Existing rule. See subsection "
+        f"(a){separator}(12) for categories:\n"
+        "(a) First; (b) Second."
+    )
+    excerpt = "(b) Second."
+    content = _proof_scope_fixture(rule_source="N.J.S.54A:4-7(c)(12)", excerpt=excerpt)
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any("outside" in issue for issue in result.issues)
+
+
+@pytest.mark.parametrize("separator", ["", "      "])
+def test_rulespec_proof_validator_rejects_long_hierarchical_cross_reference(
+    separator: str,
+):
+    source_text = (
+        "c. Existing rule. See paragraph "
+        f"(1){separator}(a){separator}(12) for categories:\n"
+        "(a) First; (b) Second."
+    )
+    excerpt = "(b) Second."
+    content = _proof_scope_fixture(rule_source="N.J.S.54A:4-7(c)(12)", excerpt=excerpt)
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any("outside" in issue for issue in result.issues)
+
+
+def test_rulespec_proof_validator_rejects_ambiguous_period_top_level_transition():
+    source_text = (
+        "(a) Resident credit. (2) Requirement: (a) First requirement. "
+        "(b) Part-year resident credits are prorated."
+    )
+    excerpt = "(b) Part-year resident credits are prorated."
+    content = _proof_scope_fixture(rule_source="N.J.S.54A:4-7(a)(2)", excerpt=excerpt)
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue and "(b)" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_rejects_nested_band_under_uncited_top_level():
+    source_text = (
+        "a. (2) The resident percentage shall be: (a) 10% for year one; "
+        "(b) 15% for year two. "
+        "c. (2) The nonresident percentage shall be: (a) 25% for year one; "
+        "(b) 30% for year two."
+    )
+    excerpt = "(b) 30% for year two."
+    content = _proof_scope_fixture(rule_source="N.J.S.54A:4-7(a)(2)", excerpt=excerpt)
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue and "(b)" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_checks_all_duplicate_nested_band_occurrences():
+    excerpt = "(b) 15% for year two."
+    source_text = (
+        "c. (3) The other percentage shall be: (a) 10% for year one; "
+        f"{excerpt} "
+        "a. (2) The resident percentage shall be: (a) 10% for year one; "
+        f"{excerpt}"
+    )
+    content = _proof_scope_fixture(rule_source="N.J.S.54A:4-7(a)(2)", excerpt=excerpt)
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is True
+    assert result.issues == []
+
+
+def test_rulespec_proof_validator_ignores_unbounded_in_scope_occurrence():
+    excerpt = "(b) 15 percent"
+    source_text = (
+        "a. (2) The resident percentage shall be: (a) 10 percent; "
+        "(b) 15 percentage points. "
+        "c. (2) The other percentage shall be: (a) 10 percent; "
+        "(b) 15 percent."
+    )
+    content = _proof_scope_fixture(rule_source="N.J.S.54A:4-7(a)(2)", excerpt=excerpt)
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue and "(b)" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_rejects_cross_reference_as_nested_list_marker():
+    source_text = (
+        "(a) Resident credit. (2) See subsection (a) for the percentage. "
+        "(b) Part-year resident credits are prorated."
+    )
+    excerpt = "(b) Part-year resident credits are prorated."
+    content = _proof_scope_fixture(rule_source="N.J.S.54A:4-7(a)(2)", excerpt=excerpt)
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue and "(b)" in issue
+        for issue in result.issues
+    )
+
+
+def test_rulespec_proof_validator_still_rejects_top_level_alpha_after_numeric_child():
+    source_text = (
+        "(a) Resident credit. (2) The percentage is determined by the director. "
+        "(b) Part-year resident credits are prorated."
+    )
+    excerpt = "(b) Part-year resident credits are prorated."
+    content = f"""format: rulespec/v1
+rules:
+  - name: resident_credit
+    kind: derived
+    dtype: Money
+    source: N.J.S.54A:4-7(a)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nj/statute/54a:4-7
+              excerpt: {excerpt!r}
+    versions:
+      - effective_from: '2026-01-01'
+        formula: federal_credit * state_percentage
+"""
+
+    result = validate_rulespec_proofs(
+        content,
+        source_texts={"us-nj/statute/54a:4-7": source_text},
+    )
+
+    assert result.passed is False
+    assert any(
+        "outside the rule's declared subsection scope" in issue and "(b)" in issue
         for issue in result.issues
     )
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1521"
+ENCODER_VERSION = "0.2.1522"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1521"
+version = "0.2.1522"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- recognize nested alphabetic source lists such as `(a)` through `(l)` inside a cited numeric paragraph
- keep true top-level subsection mismatches fail-closed
- classify all evidence occurrences using one structurally bounded marker stream with memoized reference-chain detection
- bump axiom-encode to 0.2.1522

## Why

The protected NJ 54A:4-7 encoding passed generation, review, RuleSpec validation, and apply, but failed the proof-scope validator because percentage clauses `(a)` through `(l)` are nested under numeric paragraph `a(2)`. The validator treated those nested markers as competing top-level subsection boundaries. This change distinguishes nested alphabetic enumerations from true top-level scope while preserving strict rejection of mismatched source sections.

## Review cycle

- Fifteen independent review/fix iterations covered all evidence occurrences, direct/wrapped/compact/multicomponent legal-reference chains, ordered parent/nested marker tracking, dotted-versus-parenthesized ambiguity, and linear-time scaling.
- Final independent review: CLEAN on `a74170e9cd0864aef8e2b7fefab56291db37cee0`.
- Differential checks: 5,000 randomized memo-cache cases and 3,000 recursive-reference cases with zero mismatches.
- Production replay: all 12 NJ percentage proof excerpts pass; genuine top-level mismatch controls remain rejected.

## Checks

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv lock --check`
- `uv run pytest` - 7,044 passed, 119 skipped
- `uv run pytest tests/test_rulespec_validation.py` - 1,429 passed, 31 skipped
- `git diff --check`