### PR TITLE
Fix pending waiver retirement for legacy replacements

### DIFF
--- a/changelog.d/pending-validation-waiver-retirement.fixed.md
+++ b/changelog.d/pending-validation-waiver-retirement.fixed.md
@@ -1,0 +1,1 @@
+Allow authenticated generated deletions to retire matching pending validation-waiver state while continuing to reject pending retirement for live modules and unrelated waiver removals.

--- a/changelog.d/pending-validation-waiver-retirement.fixed.md
+++ b/changelog.d/pending-validation-waiver-retirement.fixed.md
@@ -1,1 +1,1 @@
-Allow authenticated generated deletions to retire matching pending validation-waiver state while continuing to reject pending retirement for live modules and unrelated waiver removals.
+Allow authenticated legacy-replacement deletions to retire matching pending validation-waiver state with distinct pre- and post-migration bindings, while continuing to reject live, unrelated, and symlink-aliased retirement paths.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1523"
+version = "0.2.1524"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1521"
+version = "0.2.1522"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1522"
+version = "0.2.1523"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1522"
+__version__ = "0.2.1523"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1523"
+__version__ = "0.2.1524"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1521"
+__version__ = "0.2.1522"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -20131,7 +20131,10 @@ def _guard_manifest_waiver_set_identity(
 
     Model manifests bind the policy state immediately before apply. A pull
     request may then retire active waivers made obsolete by those generated
-    files, but only as an exact decrement from the protected base.
+    files, but only as an exact decrement from the protected base. Pending
+    state may also be retired when its exact protected module was deleted;
+    retaining it would leave a waiver for a nonexistent path, while removing it
+    cannot authorize a validation failure.
     """
 
     waiver_path = _validation_waivers.DEFAULT_WAIVER_PATH
@@ -20212,23 +20215,23 @@ def _guard_manifest_waiver_set_identity(
         return current_waiver_set_sha256, [
             prefix + "the waiver set did not remove any protected-base entry"
         ]
-    invalid_states = [
-        path
-        for path in removed
-        if base_entries[path].active is None or base_entries[path].pending is not None
-    ]
-    if invalid_states:
-        return current_waiver_set_sha256, [
-            prefix
-            + "only active entries without pending state may be removed: "
-            + ", ".join(invalid_states)
-        ]
     unrelated = sorted(set(removed) - set(protected))
     if unrelated:
         return current_waiver_set_sha256, [
             prefix
             + "removed entries must name changed protected RuleSpec modules: "
             + ", ".join(unrelated)
+        ]
+    invalid_states = [
+        path
+        for path in removed
+        if (base_entries[path].active is None or base_entries[path].pending is not None)
+        and ((repo_path / path).exists() or (repo_path / path).is_symlink())
+    ]
+    if invalid_states:
+        return current_waiver_set_sha256, [
+            prefix + "pending state may be removed only with its deleted protected "
+            "RuleSpec module: " + ", ".join(invalid_states)
         ]
     return base_sha256, []
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -20063,6 +20063,7 @@ def guard_generated_change_issues(
         local_corpus_release=local_corpus_release,
         expected_encoder_identity=expected_encoder_identity,
         expected_waiver_set_sha256=expected_manifest_waiver_set_sha256,
+        expected_legacy_replacement_waiver_set_sha256=(current_waiver_set_sha256),
         path_migration_receipt_proof_cache=path_migration_receipt_proof_cache,
     )
     if manifest_issues:
@@ -20083,7 +20084,7 @@ def guard_generated_change_issues(
             continue
         current_path = repo_path / path
         if APPLIED_ENCODING_DELETED_MARKER in expected_hashes:
-            if current_path.exists():
+            if not _is_unambiguously_absent_repo_path(repo_path, Path(path)):
                 issues.append(
                     f"{path} is listed as deleted in an encoder apply manifest "
                     "but still exists in the working tree"
@@ -20107,6 +20108,7 @@ def guard_generated_change_issues(
             local_corpus_release=local_corpus_release,
             expected_encoder_identity=expected_encoder_identity,
             expected_waiver_set_sha256=expected_manifest_waiver_set_sha256,
+            expected_legacy_replacement_waiver_set_sha256=(current_waiver_set_sha256),
             path_migration_receipt_proof_cache=(path_migration_receipt_proof_cache),
         )
     )
@@ -20117,6 +20119,25 @@ def guard_generated_change_issues(
             for path in missing_manifest_paths
         )
     return issues
+
+
+def _is_unambiguously_absent_repo_path(repo_path: Path, relative: Path) -> bool:
+    """Return true only when a canonical repo path is absent without symlinks."""
+
+    cursor = repo_path
+    for index, part in enumerate(relative.parts):
+        cursor /= part
+        try:
+            metadata = cursor.lstat()
+        except FileNotFoundError:
+            return True
+        except OSError:
+            return False
+        if stat.S_ISLNK(metadata.st_mode):
+            return False
+        if index < len(relative.parts) - 1 and not stat.S_ISDIR(metadata.st_mode):
+            return False
+    return False
 
 
 def _guard_manifest_waiver_set_identity(
@@ -20226,7 +20247,7 @@ def _guard_manifest_waiver_set_identity(
         path
         for path in removed
         if (base_entries[path].active is None or base_entries[path].pending is not None)
-        and ((repo_path / path).exists() or (repo_path / path).is_symlink())
+        and not _is_unambiguously_absent_repo_path(repo_path, Path(path))
     ]
     if invalid_states:
         return current_waiver_set_sha256, [
@@ -20245,6 +20266,7 @@ def _generated_provenance_gate_issues(
     local_corpus_release: LocalCorpusRelease,
     expected_encoder_identity: Mapping[str, str],
     expected_waiver_set_sha256: str,
+    expected_legacy_replacement_waiver_set_sha256: str,
     path_migration_receipt_proof_cache: dict[tuple[str, str], tuple[str, ...]],
 ) -> list[str]:
     """Reject protected files authorized only by manual attestations."""
@@ -20256,6 +20278,9 @@ def _generated_provenance_gate_issues(
         local_corpus_release=local_corpus_release,
         expected_encoder_identity=expected_encoder_identity,
         expected_waiver_set_sha256=expected_waiver_set_sha256,
+        expected_legacy_replacement_waiver_set_sha256=(
+            expected_legacy_replacement_waiver_set_sha256
+        ),
         path_migration_receipt_proof_cache=path_migration_receipt_proof_cache,
     )
     issues: list[str] = []
@@ -20468,6 +20493,7 @@ def _manifest_coverage_by_file(
     local_corpus_release: LocalCorpusRelease | None = None,
     expected_encoder_identity: Mapping[str, str] | None = None,
     expected_waiver_set_sha256: str | None = None,
+    expected_legacy_replacement_waiver_set_sha256: str | None = None,
     path_migration_receipt_proof_cache: dict[tuple[str, str], tuple[str, ...]]
     | None = None,
 ) -> dict[str, list[dict[str, object]]]:
@@ -20495,6 +20521,9 @@ def _manifest_coverage_by_file(
                 local_corpus_release=local_corpus_release,
                 expected_encoder_identity=expected_encoder_identity,
                 expected_waiver_set_sha256=expected_waiver_set_sha256,
+                expected_legacy_replacement_waiver_set_sha256=(
+                    expected_legacy_replacement_waiver_set_sha256
+                ),
                 path_migration_receipt_proof_cache=(path_migration_receipt_proof_cache),
             )
         )
@@ -24041,6 +24070,7 @@ def _load_verified_applied_encoding_manifest_payload(
     roots: tuple[str, ...] = tuple(sorted(RULESPEC_ATOMIC_MODULE_ROOTS)),
     signing_broker: SigningBroker | Ed25519PublicKey | None = None,
     expected_waiver_set_sha256: str | None = None,
+    expected_legacy_replacement_waiver_set_sha256: str | None = None,
     local_corpus_release: LocalCorpusRelease | None = None,
     expected_encoder_identity: Mapping[str, str] | None = None,
     path_migration_receipt_proof_cache: dict[tuple[str, str], tuple[str, ...]]
@@ -24137,6 +24167,15 @@ def _load_verified_applied_encoding_manifest_payload(
             [f"{manifest_label} {signature_issue}"],
         )
 
+    if expected_legacy_replacement_waiver_set_sha256 is not None and payload.get(
+        "tool"
+    ) in {
+        APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL,
+        APPLIED_ENCODING_LEGACY_EXACT_DEPENDENT_TOOL,
+        APPLIED_ENCODING_LEGACY_RETAINED_SUCCESSOR_TOOL,
+    }:
+        expected_waiver_set_sha256 = expected_legacy_replacement_waiver_set_sha256
+
     issues: list[str] = []
     applied_file_snapshots: dict[str, bytes] = {}
     backend = payload.get("backend")
@@ -24228,7 +24267,9 @@ def _load_verified_applied_encoding_manifest_payload(
             current_file = repo_root / prefixed_path
             deleted = item.get("deleted") is True
             if deleted:
-                if current_file.exists() or current_file.is_symlink():
+                if not _is_unambiguously_absent_repo_path(
+                    repo_root, Path(prefixed_path)
+                ):
                     issues.append(
                         f"{manifest_label} lists {prefixed_path} as deleted but it exists"
                     )
@@ -24355,6 +24396,7 @@ def _load_applied_encoding_manifest_entries(
     local_corpus_release: LocalCorpusRelease | None = None,
     expected_encoder_identity: Mapping[str, str] | None = None,
     expected_waiver_set_sha256: str | None = None,
+    expected_legacy_replacement_waiver_set_sha256: str | None = None,
     path_migration_receipt_proof_cache: dict[tuple[str, str], tuple[str, ...]]
     | None = None,
 ) -> tuple[dict[str, set[str]], list[str]]:
@@ -24397,6 +24439,9 @@ def _load_applied_encoding_manifest_entries(
                 roots=roots,
                 signing_broker=signing_broker,
                 expected_waiver_set_sha256=expected_waiver_set_sha256,
+                expected_legacy_replacement_waiver_set_sha256=(
+                    expected_legacy_replacement_waiver_set_sha256
+                ),
                 local_corpus_release=local_corpus_release,
                 expected_encoder_identity=expected_encoder_identity,
                 path_migration_receipt_proof_cache=(path_migration_receipt_proof_cache),

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1521"
+ENCODER_VERSION = "0.2.1522"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1522"
+ENCODER_VERSION = "0.2.1523"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1523"
+ENCODER_VERSION = "0.2.1524"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36188,6 +36188,7 @@ class TestGuardGenerated:
         *,
         base_waiver_text: str,
         head_waiver_text: str = TEST_VALIDATION_WAIVER_TEXT,
+        delete_rule: bool = False,
     ) -> tuple[Path, str]:
         repo = self._canonical_guard_repo(tmp_path)
         _git(repo, "init")
@@ -36203,24 +36204,43 @@ class TestGuardGenerated:
             repo,
             release_content_sha256=self.corpus_release.content_sha256,
         )
+        base_rule_sha256 = _sha256_file(rule)
         base_waiver_sha256 = hashlib.sha256(waiver.read_bytes()).hexdigest()
         _git(repo, "add", ".")
         _git(repo, "commit", "-m", "add protected-base waiver")
         base_ref = _git(repo, "rev-parse", "HEAD").stdout.strip()
 
-        self._source_backed_rule(rule)
+        if delete_rule:
+            rule.unlink()
+        else:
+            self._source_backed_rule(rule)
         waiver.write_text(head_waiver_text)
         _write_test_rulespec_toolchain(
             repo,
             release_content_sha256=self.corpus_release.content_sha256,
         )
-        payload = self._model_manifest(
-            [{"path": relative, "sha256": _sha256_file(rule)}]
-        )
-        payload["validation_waiver_set_sha256"] = base_waiver_sha256
-        payload["validation_execution"]["policy_pre_apply"][
-            "validation_waiver_set_sha256"
-        ] = base_waiver_sha256
+        if delete_rule:
+            prior = self._model_manifest(
+                [{"path": relative, "sha256": base_rule_sha256}]
+            )
+            prior["validation_waiver_set_sha256"] = base_waiver_sha256
+            prior["validation_execution"]["policy_pre_apply"][
+                "validation_waiver_set_sha256"
+            ] = base_waiver_sha256
+            _sign_applied_encoding_manifest(prior, TEST_APPLY_SIGNING_BROKER)
+            payload = self._retirement_manifest(
+                [relative],
+                retired_manifest=prior,
+            )
+            payload["validation_waiver_set_sha256"] = base_waiver_sha256
+        else:
+            payload = self._model_manifest(
+                [{"path": relative, "sha256": _sha256_file(rule)}]
+            )
+            payload["validation_waiver_set_sha256"] = base_waiver_sha256
+            payload["validation_execution"]["policy_pre_apply"][
+                "validation_waiver_set_sha256"
+            ] = base_waiver_sha256
         _sign_applied_encoding_manifest(payload, TEST_APPLY_SIGNING_BROKER)
         manifest = repo / ".axiom/encoding-manifests/us/regulations/example.json"
         manifest.parent.mkdir(parents=True)
@@ -37208,6 +37228,53 @@ class TestGuardGenerated:
 
         assert issues == []
 
+    def test_accepts_pending_waiver_retirement_with_matching_deletion(self, tmp_path):
+        relative = "us/regulations/example.yaml"
+        repo, base_ref = self._waiver_retirement_repo(
+            tmp_path,
+            base_waiver_text=(
+                "validate_failures:\n"
+                + self._waiver_entry_text(relative, state="pending")
+            ),
+            delete_rule=True,
+        )
+
+        issues = guard_generated_change_issues(
+            repo,
+            corpus_path=self.corpus_path,
+            base_ref=base_ref,
+            head_ref="HEAD",
+        )
+
+        assert issues == []
+
+    def test_rejects_pending_waiver_retirement_with_symlinked_module(self, tmp_path):
+        relative = "us/regulations/example.yaml"
+        repo, base_ref = self._waiver_retirement_repo(
+            tmp_path,
+            base_waiver_text=(
+                "validate_failures:\n"
+                + self._waiver_entry_text(relative, state="pending")
+            ),
+            delete_rule=True,
+        )
+        (repo / relative).symlink_to("missing.yaml")
+        _git(repo, "add", relative)
+        _git(repo, "commit", "--amend", "--no-edit")
+
+        issues = guard_generated_change_issues(
+            repo,
+            corpus_path=self.corpus_path,
+            base_ref=base_ref,
+            head_ref="HEAD",
+        )
+
+        assert any(
+            "pending state may be removed only with its deleted protected "
+            "RuleSpec module" in issue
+            for issue in issues
+        )
+
     def test_preexisting_guard_accepts_post_apply_waiver_retirement(self, tmp_path):
         relative = "us/regulations/example.yaml"
         repo = self._canonical_guard_repo(tmp_path)
@@ -37253,29 +37320,24 @@ class TestGuardGenerated:
         )
 
     @pytest.mark.parametrize(
-        ("base_waiver_text", "expected_issue"),
+        ("waiver_path", "state", "expected_issue"),
         [
             (
+                "us/regulations/example.yaml",
                 "pending",
-                "only active entries without pending state may be removed",
+                "pending state may be removed only with its deleted protected "
+                "RuleSpec module",
             ),
             (
-                "unrelated",
+                "us/statutes/26/99.yaml",
+                "active",
                 "removed entries must name changed protected RuleSpec modules",
             ),
         ],
     )
     def test_rejects_unsafe_post_apply_waiver_retirement(
-        self,
-        tmp_path,
-        base_waiver_text,
-        expected_issue,
+        self, tmp_path, waiver_path, state, expected_issue
     ):
-        target = "us/regulations/example.yaml"
-        waiver_path = (
-            target if base_waiver_text == "pending" else "us/statutes/26/99.yaml"
-        )
-        state = "pending" if base_waiver_text == "pending" else "active"
         repo, base_ref = self._waiver_retirement_repo(
             tmp_path,
             base_waiver_text=(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14337,10 +14337,16 @@ class TestCmdEncode:
             + "\n"
         )
         known_gaps = checkout / "known-validation-gaps.yaml"
+        waiver_expiry = (date.today() + timedelta(days=30)).isoformat()
         known_gaps.write_text(
-            "".join(
-                f"'{module}':\n  reason: "
-                f"{'legacy' if module in old_modules else 'canonical'}\n"
+            "validate_failures:\n"
+            + "".join(
+                f"  {module}:\n"
+                f"    {'pending' if module == source_relative.as_posix() else 'active'}:\n"
+                f"      fingerprint: sha256:{hashlib.sha256(module.encode()).hexdigest()}\n"
+                "      owner: '@axiom-test'\n"
+                "      issue: https://github.com/TheAxiomFoundation/axiom-encode/issues/1\n"
+                f"      expires: '{waiver_expiry}'\n"
                 for module in [*old_modules, *canonical_modules]
             )
         )
@@ -14400,6 +14406,7 @@ class TestCmdEncode:
         _git(checkout, "config", "user.name", "Test User")
         _git(checkout, "add", ".")
         _git(checkout, "commit", "-m", "legacy cascade base")
+        base_ref = _git(checkout, "rev-parse", "HEAD").stdout.strip()
         with patch.dict(
             os.environ,
             {"AXIOM_CORPUS_RELEASE_PUBLIC_KEY": TEST_RELEASE_PUBLIC_KEY},
@@ -14812,6 +14819,33 @@ class TestCmdEncode:
             )
             assert issues == [], "\n".join(issues)
             assert verified is not None
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    APPLIED_ENCODING_SIGNING_PUBLIC_KEY_ENV: (
+                        TEST_APPLY_PUBLIC_KEY_B64
+                    ),
+                    "AXIOM_CORPUS_RELEASE_PUBLIC_KEY": TEST_RELEASE_PUBLIC_KEY,
+                },
+            ),
+            patch(
+                "axiom_encode.cli._read_only_guard_encoder_execution_identity",
+                return_value=TEST_PINNED_ENCODER_IDENTITY,
+            ),
+            patch(
+                "axiom_encode.cli._applied_encoding_manifest_verifier",
+                return_value=TEST_APPLY_SIGNING_BROKER,
+            ),
+        ):
+            guard_issues = guard_generated_change_issues(
+                checkout,
+                corpus_path=corpus_path,
+                base_ref=base_ref,
+                head_ref="HEAD",
+            )
+        assert guard_issues == [], "\n".join(guard_issues)
 
         from scripts.prepare_signed_backfill import authorized_changed_paths
 
@@ -37275,6 +37309,35 @@ class TestGuardGenerated:
             for issue in issues
         )
 
+    def test_rejects_pending_waiver_retirement_with_symlinked_ancestor(self, tmp_path):
+        relative = "us/regulations/example.yaml"
+        repo, base_ref = self._waiver_retirement_repo(
+            tmp_path,
+            base_waiver_text=(
+                "validate_failures:\n"
+                + self._waiver_entry_text(relative, state="pending")
+            ),
+            delete_rule=True,
+        )
+        parent = (repo / relative).parent
+        parent.rmdir()
+        parent.symlink_to("missing-regulations")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "--amend", "--no-edit")
+
+        issues = guard_generated_change_issues(
+            repo,
+            corpus_path=self.corpus_path,
+            base_ref=base_ref,
+            head_ref="HEAD",
+        )
+
+        assert any(
+            "pending state may be removed only with its deleted protected "
+            "RuleSpec module" in issue
+            for issue in issues
+        )
+
     def test_preexisting_guard_accepts_post_apply_waiver_retirement(self, tmp_path):
         relative = "us/regulations/example.yaml"
         repo = self._canonical_guard_repo(tmp_path)
@@ -38336,6 +38399,33 @@ rules: []
         rule = tmp_path / "us/regulations/example.yaml"
         rule.parent.mkdir(parents=True)
         rule.write_text("format: rulespec/v1\nrules: []\n")
+        manifest = tmp_path / ".axiom/encoding-manifests/us/regulations/removal.json"
+        manifest.parent.mkdir(parents=True)
+        manifest_payload = self._retirement_manifest(["us/regulations/example.yaml"])
+        manifest.write_text(json.dumps(manifest_payload) + "\n")
+
+        with patch.dict(
+            os.environ,
+            {APPLIED_ENCODING_SIGNING_PUBLIC_KEY_ENV: TEST_APPLY_PUBLIC_KEY_B64},
+        ):
+            issues = guard_generated_change_issues(
+                tmp_path,
+                corpus_path=self.corpus_path,
+                changed_files=[
+                    "us/regulations/example.yaml",
+                    ".axiom/encoding-manifests/us/regulations/removal.json",
+                ],
+            )
+
+        assert issues == [
+            ".axiom/encoding-manifests/us/regulations/removal.json lists "
+            "us/regulations/example.yaml as deleted but it exists"
+        ]
+
+    def test_rejects_deletion_entry_with_symlinked_ancestor(self, tmp_path):
+        regulations = tmp_path / "us/regulations"
+        regulations.parent.mkdir(parents=True, exist_ok=True)
+        regulations.symlink_to("missing-regulations")
         manifest = tmp_path / ".axiom/encoding-manifests/us/regulations/removal.json"
         manifest.parent.mkdir(parents=True)
         manifest_payload = self._retirement_manifest(["us/regulations/example.yaml"])

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1523"
+ENCODER_VERSION = "0.2.1524"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1522"
+ENCODER_VERSION = "0.2.1523"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1521"
+ENCODER_VERSION = "0.2.1522"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1523"
+ENCODER_VERSION = "0.2.1524"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1522"
+ENCODER_VERSION = "0.2.1523"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1521"
+ENCODER_VERSION = "0.2.1522"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1521"
+ENCODER_VERSION = "0.2.1522"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1522"
+ENCODER_VERSION = "0.2.1523"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1523"
+ENCODER_VERSION = "0.2.1524"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1523"
+ENCODER_VERSION = "0.2.1524"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1521"
+ENCODER_VERSION = "0.2.1522"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1522"
+ENCODER_VERSION = "0.2.1523"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1522"
+ENCODER_VERSION = "0.2.1523"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1521"
+ENCODER_VERSION = "0.2.1522"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1523"
+ENCODER_VERSION = "0.2.1524"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1523"
+ENCODER_VERSION = "0.2.1524"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1521"
+ENCODER_VERSION = "0.2.1522"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1522"
+ENCODER_VERSION = "0.2.1523"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1523"')
+        .startswith('__version__ = "0.2.1524"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1523"
+    assert encoder_package["version"] == "0.2.1524"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1523"
+    assert project["project"]["version"] == "0.2.1524"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1523"')
+        .startswith('__version__ = "0.2.1524"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1523"
+    assert encoder_package["version"] == "0.2.1524"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1523"
+    assert project["project"]["version"] == "0.2.1524"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1523"')
+        .startswith('__version__ = "0.2.1524"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5923,7 +5923,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1521"')
+        .startswith('__version__ = "0.2.1522"')
     )
 
 
@@ -6155,13 +6155,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1521"
+    assert encoder_package["version"] == "0.2.1522"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1521"
+    assert project["project"]["version"] == "0.2.1522"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1521"')
+        .startswith('__version__ = "0.2.1522"')
     )
 
 
@@ -6423,13 +6423,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1521"
+    assert encoder_package["version"] == "0.2.1522"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1521"
+    assert project["project"]["version"] == "0.2.1522"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1521"')
+        .startswith('__version__ = "0.2.1522"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5923,7 +5923,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1522"')
+        .startswith('__version__ = "0.2.1523"')
     )
 
 
@@ -6155,13 +6155,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1522"
+    assert encoder_package["version"] == "0.2.1523"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1522"
+    assert project["project"]["version"] == "0.2.1523"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1522"')
+        .startswith('__version__ = "0.2.1523"')
     )
 
 
@@ -6423,13 +6423,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1522"
+    assert encoder_package["version"] == "0.2.1523"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1522"
+    assert project["project"]["version"] == "0.2.1523"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1522"')
+        .startswith('__version__ = "0.2.1523"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1522"
+ENCODER_VERSION = "0.2.1523"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1521"
+ENCODER_VERSION = "0.2.1522"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1523"
+ENCODER_VERSION = "0.2.1524"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1523"
+version = "0.2.1524"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1522"
+version = "0.2.1523"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1521"
+version = "0.2.1522"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- permit a pending validation-waiver entry to retire only when its exact protected RuleSpec module is unambiguously absent
- keep ordinary model and retirement manifests bound to the protected-base waiver digest while authenticated legacy-replacement wrappers bind the post-migration digest and prove the nested transition
- reject leaf and ancestor symlink aliases in both waiver retirement and signed deletion verification
- bump axiom-encode to 0.2.1524 after integrating current main

## Incident evidence

NJ retry run 30927644759 completed encode, review, validate, and apply, then failed the final provenance guard because the deleted legacy path us-nj/statutes/54a:4-7.yaml had a pending-only waiver. The first state fix exposed a second composition issue: legacy replacement wrappers intentionally bind the post-migration waiver digest, unlike ordinary model and retirement manifests.

The regression now exercises the real v4 legacy-replacement cascade with a strict pending source waiver and runs guard_generated_change_issues against the original protected base.

## Checks

- uv run ruff check pyproject.toml src/axiom_encode scripts tests
- python -m compileall -q src/axiom_encode scripts
- integrated uv run pytest: 7048 passed, 119 skipped
- focused waiver and symlink boundaries: 7 passed
- full legacy cascade in both dependent-owner modes: 2 passed
- exact version provenance passes after the post-merge 0.2.1524 bump

## Review cycle

Independent review found and drove fixes for live-module over-breadth, pre/post waiver digest selection, missing full-cascade guard coverage, ancestor-symlink handling, and post-merge version provenance. Each actionable finding was fixed and retested. The final exact-tip review reported no actionable findings.

The branch integrates origin/main at e6433f7becbbdebaf8185373b15eec6726cae231. Final branch tip: d1a50c8df8ca37ff276333da73c459dd72738eba.