### PR TITLE
Ignore legal title years in numeric recall

### DIFF
--- a/changelog.d/legal-title-year-numeric-recall.fixed.md
+++ b/changelog.d/legal-title-year-numeric-recall.fixed.md
@@ -1,0 +1,1 @@
+Exclude enactment-title years such as `Civil Rights Act of 1964` from complete-source numeric recall while preserving substantive values with the same number.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1524"
+version = "0.2.1525"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1524"
+__version__ = "0.2.1525"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -1182,9 +1182,13 @@ _STRUCTURAL_SOURCE_CODE_CITATION_PATTERN = re.compile(
     r"""(?=$|[\s,.;:)\]}\'"”’–—])""",
     re.IGNORECASE,
 )
-_STRUCTURAL_SOURCE_CODE_EDITION_PATTERN = re.compile(
-    r"\b(?:federal\s+)?Internal Revenue Code\s+of\s+(?:19|20)\d{2}\b",
-    re.IGNORECASE,
+_STRUCTURAL_SOURCE_LEGAL_EDITION_PATTERN = re.compile(
+    r"\b(?:"
+    r"(?i:(?:federal\s+)?Internal Revenue Code)|"
+    r"[A-Z][A-Za-z'-]*"
+    r"(?:\s+(?:[A-Z][A-Za-z'-]*|and|of|the|for|with|to|in)){0,10}"
+    r"\s+Act"
+    r")\s+of\s+(?:18|19|20)\d{2}\b"
 )
 _STRUCTURAL_SOURCE_STATE_CODE_CITATION_TARGET = (
     r"\d+[A-Za-z]?:\d+[A-Za-z]?-\d+[A-Za-z]?(?:\.\d+)*"
@@ -5032,7 +5036,7 @@ def _clean_source_text_for_numeric_extraction(text: str) -> str:
     cleaned = _STRUCTURAL_SOURCE_FORM_NUMBER_PATTERN.sub(" ", cleaned)
     cleaned = _STRUCTURAL_SOURCE_FORM_LINE_PATTERN.sub(" ", cleaned)
     cleaned = _STRUCTURAL_SOURCE_CODE_CITATION_PATTERN.sub(" ", cleaned)
-    cleaned = _STRUCTURAL_SOURCE_CODE_EDITION_PATTERN.sub(" ", cleaned)
+    cleaned = _STRUCTURAL_SOURCE_LEGAL_EDITION_PATTERN.sub(" ", cleaned)
     cleaned = _STRUCTURAL_SOURCE_STATE_CODE_CITATION_PATTERN.sub(" ", cleaned)
     cleaned = _STRUCTURAL_SOURCE_BARE_DOTTED_REFERENCE_PATTERN.sub(" ", cleaned)
     cleaned = _STRUCTURAL_SOURCE_SECTION_PATTERN.sub(" ", cleaned)

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1524"
+ENCODER_VERSION = "0.2.1525"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1524"
+ENCODER_VERSION = "0.2.1525"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1524"
+ENCODER_VERSION = "0.2.1525"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1524"
+ENCODER_VERSION = "0.2.1525"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1524"
+ENCODER_VERSION = "0.2.1525"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1524"
+ENCODER_VERSION = "0.2.1525"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1524"
+ENCODER_VERSION = "0.2.1525"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1524"')
+        .startswith('__version__ = "0.2.1525"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1524"
+    assert encoder_package["version"] == "0.2.1525"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1524"
+    assert project["project"]["version"] == "0.2.1525"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1524"')
+        .startswith('__version__ = "0.2.1525"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1524"
+    assert encoder_package["version"] == "0.2.1525"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1524"
+    assert project["project"]["version"] == "0.2.1525"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1524"')
+        .startswith('__version__ = "0.2.1525"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1524"
+ENCODER_VERSION = "0.2.1525"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -5468,6 +5468,38 @@ def test_en_us_internal_revenue_code_edition_year_is_structural():
     assert [(item.value, item.raw) for item in inventory] == [(1986.0, "1986")]
 
 
+@pytest.mark.parametrize("profile", ("legacy", "en-US"))
+def test_named_act_year_is_structural_but_equal_amount_is_preserved(profile):
+    source = (
+        "The certification must conform to title VI of the Civil Rights Act of "
+        "1964, while a separate program has a 1964 dollar threshold."
+    )
+
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        source,
+        profile=profile,
+    )
+
+    assert [(item.value, item.raw) for item in inventory] == [(1964.0, "1964")]
+
+
+@pytest.mark.parametrize("profile", ("legacy", "en-US"))
+@pytest.mark.parametrize(
+    "source",
+    (
+        "A household qualifies when its category has a code of 2000.",
+        "A household qualifies based on an act of 2000.",
+    ),
+)
+def test_common_noun_act_or_code_year_remains_substantive(source, profile):
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        source,
+        profile=profile,
+    )
+
+    assert [(item.value, item.raw) for item in inventory] == [(2000.0, "2000")]
+
+
 def test_en_us_inline_legal_ordinal_is_structural_after_collapsed_heading():
     source = (
         "54A:4-7 New Jersey Earned Income Tax Credit program. "

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1524"
+version = "0.2.1525"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- exclude edition years in capitalized named Acts, including `Civil Rights Act of 1964`, from complete-source numeric recall
- preserve existing Internal Revenue Code edition handling
- keep lowercase common-noun `act/code of YYYY` values and equal-valued substantive amounts in the recall inventory
- bump axiom-encode to 0.2.1525

## Incident evidence

Protected federal retry run 30932524977 failed closed after generation and review because complete-source numeric recall treated the year in `Civil Rights Act of 1964` as an unnamed executable scalar. The exact failed source now emits no `1964` recall obligation in either production `legacy` or strict `en-US`, while a separate `1964 dollar` value remains.

## Checks

- focused legal-title/common-noun regression matrix: 7 passed
- full source-completeness suite: 1,088 passed
- focused version and oracle registry checks: 16 passed
- Ruff and Ruff format checks
- compileall
- `uv lock --check`
- full local suite: 7,054 passed, 119 skipped

## Review cycle

Independent review of the first exact tip found an overbroad case-insensitive `Act|Code of YYYY` alternative that could hide a substantive common-noun value. The pattern was narrowed to explicit Internal Revenue Code references or capitalized, token-bounded named Acts, and common-noun controls were added for both numeric profiles. Re-review of exact tip c796f58bfd5611be334bec6a0a9f4e5b8eb03bde reported CLEAN with no actionable findings.