### PR TITLE
Preserve reverse-index Unicode during legacy reconciliation

### DIFF
--- a/changelog.d/legacy-index-unicode-serialization.fixed.md
+++ b/changelog.d/legacy-index-unicode-serialization.fixed.md
@@ -1,0 +1,1 @@
+Legacy replacement metadata reconciliation now preserves the RuleSpec reverse index's canonical literal-Unicode JSON serialization instead of escaping unrelated citation keys.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1525"
+version = "0.2.1526"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1525"
+__version__ = "0.2.1526"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -25701,7 +25701,7 @@ def _legacy_metadata_reconciliation_bytes(
         after, count = _remove_index_module_records(before, old_modules=old_modules)
         if count != sum(module_counts[module] for module in old_modules):
             raise ValueError("legacy provision index removal count is inconsistent")
-        rewritten = (json.dumps(after, indent=2, ensure_ascii=True) + "\n").encode()
+        rewritten = (json.dumps(after, indent=2, ensure_ascii=False) + "\n").encode()
         operations = ({"operation": "remove_legacy_module_records", "count": count},)
     elif path == Path(".axiom/pending-validation-fingerprints.json"):
         try:

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1525"
+ENCODER_VERSION = "0.2.1526"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1525"
+ENCODER_VERSION = "0.2.1526"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1525"
+ENCODER_VERSION = "0.2.1526"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_legacy_replacement.py
+++ b/tests/test_legacy_replacement.py
@@ -1749,6 +1749,35 @@ def test_provision_index_rejects_out_of_band_structured_successor_field() -> Non
         )
 
 
+def test_provision_index_reconciliation_preserves_literal_unicode() -> None:
+    moves = (
+        PlannedMove(
+            source=Path("us-la/statutes/47:294.yaml"),
+            destination=Path("us-la/statutes/47/294.yaml"),
+        ),
+    )
+    unrelated_citation = "us/statute/42/1437c–1"
+    payload = {
+        "records": [
+            {"module": "us-la/statutes/47:294.yaml"},
+            {"module": "us-la/statutes/47/294.yaml"},
+        ],
+        unrelated_citation: [{"module": "us/statutes/42/1437c-1.yaml"}],
+    }
+    raw = (json.dumps(payload, indent=2, ensure_ascii=False) + "\n").encode()
+
+    rewritten, operations = _legacy_metadata_reconciliation_bytes(
+        Path(".axiom/index/provisions_to_rules.json"),
+        raw,
+        moves=moves,
+    )
+
+    assert operations == ({"operation": "remove_legacy_module_records", "count": 1},)
+    assert unrelated_citation.encode() in rewritten
+    assert b"\\u2013" not in rewritten
+    assert json.loads(rewritten)[unrelated_citation] == payload[unrelated_citation]
+
+
 def test_retained_successor_overlay_preflights_then_removes_one_composite(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1525"
+ENCODER_VERSION = "0.2.1526"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1525"
+ENCODER_VERSION = "0.2.1526"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1525"
+ENCODER_VERSION = "0.2.1526"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1525"
+ENCODER_VERSION = "0.2.1526"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1525"')
+        .startswith('__version__ = "0.2.1526"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1525"
+    assert encoder_package["version"] == "0.2.1526"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1525"
+    assert project["project"]["version"] == "0.2.1526"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1525"')
+        .startswith('__version__ = "0.2.1526"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1525"
+    assert encoder_package["version"] == "0.2.1526"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1525"
+    assert project["project"]["version"] == "0.2.1526"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1525"')
+        .startswith('__version__ = "0.2.1526"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1525"
+ENCODER_VERSION = "0.2.1526"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1525"
+version = "0.2.1526"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- serialize legacy replacement reverse-index reconciliation with the same literal-Unicode contract as the RuleSpec canonical generator
- add a regression that removes only the authorized legacy record while preserving an unrelated en-dash citation key
- integrate current main, then bump coordinated encoder version pins to 0.2.1526 in a separate provenance commit

## Root cause
NJ signed RuleSpec PR TheAxiomFoundation/rulespec-us#1213 passed the protected provenance guard but failed the repository reverse-index freshness test because v0.2.1524 reserialized an unrelated literal en dash as `\u2013`. The signed PR was closed rather than hand-edited.

## Review cycle
- Initial independent review: CLEAN. Reviewer reproduced the actual NJ reconciliation and confirmed byte-exact canonical output, unchanged fail-closed hash/signature binding, coordinated version pins, and no naming/acronym impact.
- Hosted lint exposed only Ruff formatting in the new regression; the commit was amended and independently re-reviewed CLEAN as formatting-only.
- Hosted full CI then exposed version-provenance ambiguity after main independently advanced to the same 0.2.1525 version. The branch was rebased onto current main `b3bffbf557ae6c3f3d70058fafb0095f13378eb8` and now has a separate coordinated 0.2.1526 bump after the semantic commit.
- Final independent re-review at exact rebased tip `b927047f5f7239f967f785124fbdf1de4181dc3d`: CLEAN, no actionable findings. Reviewer independently reproduced a first-parent synthetic merge and confirmed provenance resolves exactly to bump commit `b927047f5`.

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests` — passed
- `python -m compileall -q src/axiom_encode scripts` — passed
- focused legacy replacement plus current version provenance — 74 passed
- independent focused legacy/version/provenance/oracle suite — 103 passed
- synthetic GitHub-style merge checkout provenance test — passed locally and independently
- prescribed full `uv run pytest` at exact rebased tip — 7055 passed, 119 skipped
- fresh hosted Python 3.13, lint, Ubuntu, and macOS checks — passed
