### PR TITLE
Validate replacement targets before source bundles

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -445,6 +445,16 @@ jobs:
             fi
           done
           normalized_existing_imports="$("${existing_import_args[@]}")"
+          if [ "$normalized_source_bundle" != "[]" ] && \
+             [ -n "$REPLACE_RULESPEC_PATH" ] && \
+             { [ -n "$DEPENDENT_CITATION" ] || \
+               [ -n "$SECOND_DEPENDENT_CITATION" ] || \
+               [ -n "$LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" ] || \
+               [ -n "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" ] || \
+               [ "${#retained_successor_paths[@]}" -gt 0 ]; }; then
+            echo "source-bundle replacements cannot include dependent migrations" >&2
+            exit 1
+          fi
           if [ -n "$QUEUE_ID" ] && \
             { [ "$normalized_source_bundle" != "[]" ] || \
               [ "$normalized_existing_imports" != "[]" ]; }; then
@@ -1077,6 +1087,16 @@ jobs:
           if [ $((source_bundle_count + existing_import_count)) -gt 0 ]; then
             required_imports_enabled=true
           fi
+          if [ "$source_bundle_enabled" = "true" ] && \
+             [ -n "$REPLACE_RULESPEC_PATH" ] && \
+             { [ -n "$DEPENDENT_CITATION" ] || \
+               [ -n "$SECOND_DEPENDENT_CITATION" ] || \
+               [ -n "$LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" ] || \
+               [ -n "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" ] || \
+               [ "$retained_successor_count" -gt 0 ]; }; then
+            echo "source-bundle replacements cannot include dependent migrations" >&2
+            exit 1
+          fi
 
           checkpoint_signed_changes() {
             local message="$1"
@@ -1108,16 +1128,18 @@ jobs:
               commit -m "$message"
           }
 
+          final_legacy_source_path="$REPLACE_LEGACY_RULESPEC_PATH"
           if [ "$source_bundle_enabled" = "true" ] && \
-             [ -n "$REPLACE_RULESPEC_PATH" ] && \
-             [ -z "$REPLACE_LEGACY_RULESPEC_PATH" ]; then
+             [ -n "$REPLACE_RULESPEC_PATH" ]; then
             run_signed_encode \
-              "$CITATION" "" true target-preflight \
-              "$REPLACE_RULESPEC_PATH" "" false
+              "$CITATION" "" false target-preflight \
+              "$REPLACE_RULESPEC_PATH" \
+              "$REPLACE_LEGACY_RULESPEC_PATH" false
             checkpoint_signed_changes \
               "Canonicalize signed replacement target before source bundle"
             cp "$RUNNER_TEMP/checkpoint-guard-generated.json" \
               "$RUNNER_TEMP/target-preflight-guard-generated.json"
+            final_legacy_source_path=""
           fi
 
           source_index=0
@@ -1135,7 +1157,7 @@ jobs:
           if [ -n "$DEPENDENT_CITATION" ]; then
             run_signed_encode \
               "$CITATION" "$REVIEW_FINDING" true target \
-              "$REPLACE_RULESPEC_PATH" "$REPLACE_LEGACY_RULESPEC_PATH" \
+              "$REPLACE_RULESPEC_PATH" "$final_legacy_source_path" \
               "$required_imports_enabled"
             dependent_target_only=false
             if [ -n "$SECOND_DEPENDENT_CITATION" ]; then
@@ -1153,7 +1175,7 @@ jobs:
             run_signed_encode \
               "$CITATION" "$REVIEW_FINDING" false \
               target "$REPLACE_RULESPEC_PATH" \
-              "$REPLACE_LEGACY_RULESPEC_PATH" \
+              "$final_legacy_source_path" \
               "$required_imports_enabled"
           fi
 

--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -446,6 +446,11 @@ jobs:
           done
           normalized_existing_imports="$("${existing_import_args[@]}")"
           if [ "$normalized_source_bundle" != "[]" ] && \
+             [ -n "$REPLACE_LEGACY_RULESPEC_PATH" ]; then
+            echo "source bundles require legacy replacements to merge first" >&2
+            exit 1
+          fi
+          if [ "$normalized_source_bundle" != "[]" ] && \
              [ -n "$REPLACE_RULESPEC_PATH" ] && \
              { [ -n "$DEPENDENT_CITATION" ] || \
                [ -n "$SECOND_DEPENDENT_CITATION" ] || \
@@ -1088,6 +1093,11 @@ jobs:
             required_imports_enabled=true
           fi
           if [ "$source_bundle_enabled" = "true" ] && \
+             [ -n "$REPLACE_LEGACY_RULESPEC_PATH" ]; then
+            echo "source bundles require legacy replacements to merge first" >&2
+            exit 1
+          fi
+          if [ "$source_bundle_enabled" = "true" ] && \
              [ -n "$REPLACE_RULESPEC_PATH" ] && \
              { [ -n "$DEPENDENT_CITATION" ] || \
                [ -n "$SECOND_DEPENDENT_CITATION" ] || \
@@ -1128,18 +1138,16 @@ jobs:
               commit -m "$message"
           }
 
-          final_legacy_source_path="$REPLACE_LEGACY_RULESPEC_PATH"
           if [ "$source_bundle_enabled" = "true" ] && \
-             [ -n "$REPLACE_RULESPEC_PATH" ]; then
+             [ -n "$REPLACE_RULESPEC_PATH" ] && \
+             [ -z "$REPLACE_LEGACY_RULESPEC_PATH" ]; then
             run_signed_encode \
               "$CITATION" "" false target-preflight \
-              "$REPLACE_RULESPEC_PATH" \
-              "$REPLACE_LEGACY_RULESPEC_PATH" false
+              "$REPLACE_RULESPEC_PATH" "" false
             checkpoint_signed_changes \
               "Canonicalize signed replacement target before source bundle"
             cp "$RUNNER_TEMP/checkpoint-guard-generated.json" \
               "$RUNNER_TEMP/target-preflight-guard-generated.json"
-            final_legacy_source_path=""
           fi
 
           source_index=0
@@ -1157,7 +1165,7 @@ jobs:
           if [ -n "$DEPENDENT_CITATION" ]; then
             run_signed_encode \
               "$CITATION" "$REVIEW_FINDING" true target \
-              "$REPLACE_RULESPEC_PATH" "$final_legacy_source_path" \
+              "$REPLACE_RULESPEC_PATH" "$REPLACE_LEGACY_RULESPEC_PATH" \
               "$required_imports_enabled"
             dependent_target_only=false
             if [ -n "$SECOND_DEPENDENT_CITATION" ]; then
@@ -1175,7 +1183,7 @@ jobs:
             run_signed_encode \
               "$CITATION" "$REVIEW_FINDING" false \
               target "$REPLACE_RULESPEC_PATH" \
-              "$final_legacy_source_path" \
+              "$REPLACE_LEGACY_RULESPEC_PATH" \
               "$required_imports_enabled"
           fi
 
@@ -2520,11 +2528,13 @@ jobs:
           guard_candidates = [
               guard_root / "guard-generated.json",
               guard_root / "checkpoint-guard-generated.json",
+              guard_root / "target-preflight-guard-generated.json",
               *[
                   guard_root / f"source-{index:02d}-guard-generated.json"
                   for index in range(1, 17)
               ],
           ]
+          guard_inventory = []
           for guard_generated in guard_candidates:
               if not guard_generated.exists() and not guard_generated.is_symlink():
                   continue
@@ -2557,6 +2567,13 @@ jobs:
               guard_destination = artifact / "guards" / guard_generated.name
               guard_destination.parent.mkdir(parents=True, exist_ok=True)
               guard_destination.write_bytes(guard_payload)
+              guard_inventory.append(
+                  {
+                      "path": f"guards/{guard_generated.name}",
+                      "sha256": hashlib.sha256(guard_payload).hexdigest(),
+                      "size": len(guard_payload),
+                  }
+              )
 
           inventory.sort(key=lambda item: item["path"])
           step_env_prefixes = {
@@ -2610,6 +2627,7 @@ jobs:
               "failed_steps": failed_steps,
               "files": inventory,
               "generated_lanes": generated_lanes,
+              "guards": sorted(guard_inventory, key=lambda item: item["path"]),
               "legacy_exact_dependent_rulespec_path": os.environ.get(
                   "LEGACY_EXACT_DEPENDENT_RULESPEC_PATH"
               )

--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -1108,6 +1108,18 @@ jobs:
               commit -m "$message"
           }
 
+          if [ "$source_bundle_enabled" = "true" ] && \
+             [ -n "$REPLACE_RULESPEC_PATH" ] && \
+             [ -z "$REPLACE_LEGACY_RULESPEC_PATH" ]; then
+            run_signed_encode \
+              "$CITATION" "" true target-preflight \
+              "$REPLACE_RULESPEC_PATH" "" false
+            checkpoint_signed_changes \
+              "Canonicalize signed replacement target before source bundle"
+            cp "$RUNNER_TEMP/checkpoint-guard-generated.json" \
+              "$RUNNER_TEMP/target-preflight-guard-generated.json"
+          fi
+
           source_index=0
           while IFS= read -r source_citation; do
             source_index=$((source_index + 1))
@@ -1260,6 +1272,9 @@ jobs:
               cp "$source_guard" "$artifact/"
             fi
           done
+          if [ -f "$RUNNER_TEMP/target-preflight-guard-generated.json" ]; then
+            cp "$RUNNER_TEMP/target-preflight-guard-generated.json" "$artifact/"
+          fi
           "${workflow_python[@]}" - \
             "$artifact/context-manifest.json" \
             "$artifact/apply-manifests.json" <<'PY'

--- a/changelog.d/source-bundle-replacement-preflight.fixed.md
+++ b/changelog.d/source-bundle-replacement-preflight.fixed.md
@@ -1,0 +1,1 @@
+Canonicalize signed replacement targets before applying source bundles so legacy path duplicates cannot invalidate source-module compilation.

--- a/changelog.d/source-bundle-replacement-preflight.fixed.md
+++ b/changelog.d/source-bundle-replacement-preflight.fixed.md
@@ -1,1 +1,1 @@
-Canonicalize signed replacement targets before applying source bundles so legacy path duplicates cannot invalidate source-module compilation.
+Validate and checkpoint signed canonical replacement targets before applying source bundles, while requiring legacy path migrations to complete in a separate signed transaction.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1526"
+version = "0.2.1527"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1526"
+__version__ = "0.2.1527"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1526"
+ENCODER_VERSION = "0.2.1527"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1526"
+ENCODER_VERSION = "0.2.1527"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1526"
+ENCODER_VERSION = "0.2.1527"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1526"
+ENCODER_VERSION = "0.2.1527"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1526"
+ENCODER_VERSION = "0.2.1527"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1526"
+ENCODER_VERSION = "0.2.1527"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1526"
+ENCODER_VERSION = "0.2.1527"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1526"')
+        .startswith('__version__ = "0.2.1527"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1526"
+    assert encoder_package["version"] == "0.2.1527"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1526"
+    assert project["project"]["version"] == "0.2.1527"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1526"')
+        .startswith('__version__ = "0.2.1527"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1526"
+    assert encoder_package["version"] == "0.2.1527"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1526"
+    assert project["project"]["version"] == "0.2.1527"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1526"')
+        .startswith('__version__ = "0.2.1527"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1526"
+ENCODER_VERSION = "0.2.1527"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1989,6 +1989,10 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         "queue-authorized re-encodes cannot add source inputs until queue "
         "generation identity binds them"
     ) in source_bundle_command
+    assert (
+        "source-bundle replacements cannot include dependent migrations"
+        in source_bundle_command
+    )
     assert steps.index(source_bundle_step) > next(
         index
         for index, step in enumerate(steps)
@@ -2160,7 +2164,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert '"$SECOND_DEPENDENT_REVIEW_FINDING" false dependent-2 "" "" false' in command
     assert '"$CITATION" "$REVIEW_FINDING" true target \\\n' in command
     assert '"$DEPENDENT_CITATION" "$DEPENDENT_REVIEW_FINDING" \\\n' in command
-    assert '"$REPLACE_RULESPEC_PATH" "$REPLACE_LEGACY_RULESPEC_PATH"' in command
+    assert '"$REPLACE_RULESPEC_PATH" "$final_legacy_source_path"' in command
     assert '"$CITATION" "$REVIEW_FINDING" false \\\n' in command
     assert "dependent review finding is required with dependent citation" in command
     assert "parse-source-bundle" in command
@@ -2171,7 +2175,12 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert '> "$RUNNER_TEMP/source-bundle-citations.txt"' in command
     assert 'source_lane="$(printf \'source-%02d\' "$source_index")"' in command
     assert '"$source_citation" "" true "$source_lane" "" "" false' in command
-    assert '"$CITATION" "" true target-preflight \\' in command
+    assert '"$CITATION" "" false target-preflight \\' in command
+    assert '"$REPLACE_LEGACY_RULESPEC_PATH" false' in command
+    assert 'final_legacy_source_path=""' in command
+    assert (
+        "source-bundle replacements cannot include dependent migrations" in command
+    )
     assert "Canonicalize signed replacement target before source bundle" in command
     assert "checkpoint_signed_changes()" in command
     assert 'local guard_status="$?"' in command
@@ -2641,7 +2650,7 @@ def test_targeted_signed_reencode_preserves_checkpoint_guard_failure(
         if step.get("name") == "Encode, review, validate, and apply"
     )
     checkpoint = command.split("checkpoint_signed_changes() {", 1)[1].split(
-        '\n}\n\nif [ "$source_bundle_enabled"',
+        '\n}\n\nfinal_legacy_source_path=',
         1,
     )[0]
     guard_stub = tmp_path / "guard-stub"
@@ -3162,7 +3171,7 @@ def test_targeted_signed_reencode_composes_nonempty_source_bundle(
         1,
     )
     _checkpoint_body, after_checkpoint = checkpoint_and_after.split(
-        '\n}\n\nif [ "$source_bundle_enabled"',
+        '\n}\n\nfinal_legacy_source_path=',
         1,
     )
     command = (
@@ -3170,7 +3179,7 @@ def test_targeted_signed_reencode_composes_nonempty_source_bundle(
         + "checkpoint_signed_changes() {\n"
         + '  printf \'%s\\n\' "$1" >> "$CHECKPOINTS_PATH"\n'
         + '  : > "$RUNNER_TEMP/checkpoint-guard-generated.json"\n'
-        + '}\n\nif [ "$source_bundle_enabled"'
+        + '}\n\nfinal_legacy_source_path='
         + after_checkpoint
     )
 
@@ -3184,6 +3193,20 @@ import os
 import sys
 from pathlib import Path
 
+args = sys.argv[sys.argv.index("--") + 1:]
+checkout = Path(os.environ["RULESPEC_CHECKOUT"])
+legacy = checkout / os.environ["LEGACY_REPLACEMENT_FILE"]
+legacy_test = legacy.with_name(f"{legacy.stem}.test.yaml")
+if "--replace-legacy-rulespec-path" in args:
+    if "--apply-target-only" in args:
+        raise SystemExit("legacy preflight must validate the complete checkout")
+    if not legacy.is_file() or not legacy_test.is_file():
+        raise SystemExit("legacy predecessor was not present for preflight")
+    legacy.unlink()
+    legacy_test.unlink()
+elif legacy.exists() or legacy_test.exists():
+    raise SystemExit("source encoding started before legacy predecessor retirement")
+
 with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
     stream.write(json.dumps(sys.argv[1:]) + "\\n")
 """,
@@ -3195,6 +3218,15 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
     _prepare_empty_signed_import_inputs(runner_temp)
     primary = "us-ri/statute/44-30-2.6"
     replacement_path = "us-ri/statutes/44-30-2.6.yaml"
+    legacy_replacement_path = "us-ri/statutes/44:30-2.6.yaml"
+    checkout = tmp_path / "rulespec-us"
+    canonical = checkout / replacement_path
+    legacy = checkout / legacy_replacement_path
+    canonical.parent.mkdir(parents=True)
+    canonical.write_text("format: rulespec/v1\nrules: []\n")
+    canonical.with_name(f"{canonical.stem}.test.yaml").write_text("[]\n")
+    legacy.write_text("format: rulespec/v1\nrules: []\n")
+    legacy.with_name(f"{legacy.stem}.test.yaml").write_text("[]\n")
     sources = [
         "us-ri/statute/44-30-1",
         "us-ri/guidance/revenue/2026/rate-schedule",
@@ -3213,7 +3245,8 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
             "DEPENDENT_CITATION": "",
             "DEPENDENT_REVIEW_FINDING": "",
             "GITHUB_WORKSPACE": str(tmp_path),
-            "REPLACE_LEGACY_RULESPEC_PATH": "",
+            "LEGACY_REPLACEMENT_FILE": legacy_replacement_path,
+            "REPLACE_LEGACY_RULESPEC_PATH": legacy_replacement_path,
             "REPLACE_RULESPEC_PATH": replacement_path,
             "REVIEW_FINDING": "Preserve the composed target semantics.",
             "RULESPEC_CHECKOUT": str(tmp_path / "rulespec-us"),
@@ -3233,10 +3266,12 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
     encode_args = [call[call.index("--") + 1 :] for call in calls]
     preflight_args = encode_args[0]
     assert preflight_args[-1] == primary
-    assert "--apply-target-only" in preflight_args
+    assert "--apply-target-only" not in preflight_args
     assert "--review-findings" not in preflight_args
     replacement_index = preflight_args.index("--replace-rulespec-path")
     assert preflight_args[replacement_index + 1] == replacement_path
+    legacy_index = preflight_args.index("--replace-legacy-rulespec-path")
+    assert preflight_args[legacy_index + 1] == legacy_replacement_path
     assert "--required-import-rulespec-path" not in preflight_args
 
     for index, source in enumerate(sources, start=1):
@@ -3247,6 +3282,7 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
     primary_args = encode_args[-1]
     assert primary_args[-1] == primary
     assert "--apply-target-only" not in primary_args
+    assert "--replace-legacy-rulespec-path" not in primary_args
     required_indexes = [
         index
         for index, value in enumerate(primary_args)
@@ -3262,6 +3298,53 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
         f"Add signed source module for {sources[1]}",
         f"Compose signed source bundle for {primary}",
     ]
+    assert canonical.is_file()
+    assert not legacy.exists()
+    assert not legacy.with_name(f"{legacy.stem}.test.yaml").exists()
+
+
+def test_targeted_signed_reencode_rejects_source_bundle_replacement_dependents_early(
+    tmp_path: Path,
+) -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
+    )
+    command = next(
+        step["run"]
+        for step in workflow["jobs"]["encode"]["steps"]
+        if step.get("name") == "Validate atomic source inputs"
+    )
+    checkout = tmp_path / "rulespec-us"
+    checkout.mkdir()
+
+    completed = subprocess.run(
+        ["bash", "-c", command],
+        cwd=ROOT.parent,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "CITATION": "us-ri/statute/44-30-2.6",
+            "DEPENDENT_CITATION": "us-ri/statute/44-30-2.7",
+            "EXISTING_SIGNED_IMPORTS_JSON": "[]",
+            "LEGACY_EXACT_DEPENDENT_RULESPEC_PATH": "",
+            "LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON": "[]",
+            "QUEUE_ID": "",
+            "REPLACE_LEGACY_RULESPEC_PATH": "us-ri/statutes/44:30-2.6.yaml",
+            "REPLACE_RULESPEC_PATH": "us-ri/statutes/44-30-2.6.yaml",
+            "RULESPEC_CHECKOUT": str(checkout),
+            "SECOND_DEPENDENT_CITATION": "",
+            "SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH": "",
+            "SOURCE_BUNDLE_JSON": '["us-ri/statute/44-30-1"]',
+        },
+    )
+
+    assert completed.returncode != 0
+    assert (
+        "source-bundle replacements cannot include dependent migrations"
+        in completed.stderr
+    )
 
 
 def test_targeted_signed_reencode_reuses_verified_existing_import(

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2178,9 +2178,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert '"$CITATION" "" false target-preflight \\' in command
     assert '"$REPLACE_LEGACY_RULESPEC_PATH" false' in command
     assert 'final_legacy_source_path=""' in command
-    assert (
-        "source-bundle replacements cannot include dependent migrations" in command
-    )
+    assert "source-bundle replacements cannot include dependent migrations" in command
     assert "Canonicalize signed replacement target before source bundle" in command
     assert "checkpoint_signed_changes()" in command
     assert 'local guard_status="$?"' in command
@@ -2650,7 +2648,7 @@ def test_targeted_signed_reencode_preserves_checkpoint_guard_failure(
         if step.get("name") == "Encode, review, validate, and apply"
     )
     checkpoint = command.split("checkpoint_signed_changes() {", 1)[1].split(
-        '\n}\n\nfinal_legacy_source_path=',
+        "\n}\n\nfinal_legacy_source_path=",
         1,
     )[0]
     guard_stub = tmp_path / "guard-stub"
@@ -3171,7 +3169,7 @@ def test_targeted_signed_reencode_composes_nonempty_source_bundle(
         1,
     )
     _checkpoint_body, after_checkpoint = checkpoint_and_after.split(
-        '\n}\n\nfinal_legacy_source_path=',
+        "\n}\n\nfinal_legacy_source_path=",
         1,
     )
     command = (
@@ -3179,7 +3177,7 @@ def test_targeted_signed_reencode_composes_nonempty_source_bundle(
         + "checkpoint_signed_changes() {\n"
         + '  printf \'%s\\n\' "$1" >> "$CHECKPOINTS_PATH"\n'
         + '  : > "$RUNNER_TEMP/checkpoint-guard-generated.json"\n'
-        + '}\n\nfinal_legacy_source_path='
+        + "}\n\nfinal_legacy_source_path="
         + after_checkpoint
     )
 

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1993,6 +1993,10 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         "source-bundle replacements cannot include dependent migrations"
         in source_bundle_command
     )
+    assert (
+        "source bundles require legacy replacements to merge first"
+        in source_bundle_command
+    )
     assert steps.index(source_bundle_step) > next(
         index
         for index, step in enumerate(steps)
@@ -2164,7 +2168,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert '"$SECOND_DEPENDENT_REVIEW_FINDING" false dependent-2 "" "" false' in command
     assert '"$CITATION" "$REVIEW_FINDING" true target \\\n' in command
     assert '"$DEPENDENT_CITATION" "$DEPENDENT_REVIEW_FINDING" \\\n' in command
-    assert '"$REPLACE_RULESPEC_PATH" "$final_legacy_source_path"' in command
+    assert '"$REPLACE_RULESPEC_PATH" "$REPLACE_LEGACY_RULESPEC_PATH"' in command
     assert '"$CITATION" "$REVIEW_FINDING" false \\\n' in command
     assert "dependent review finding is required with dependent citation" in command
     assert "parse-source-bundle" in command
@@ -2176,8 +2180,8 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert 'source_lane="$(printf \'source-%02d\' "$source_index")"' in command
     assert '"$source_citation" "" true "$source_lane" "" "" false' in command
     assert '"$CITATION" "" false target-preflight \\' in command
-    assert '"$REPLACE_LEGACY_RULESPEC_PATH" false' in command
-    assert 'final_legacy_source_path=""' in command
+    assert '"$REPLACE_RULESPEC_PATH" "" false' in command
+    assert "source bundles require legacy replacements to merge first" in command
     assert "source-bundle replacements cannot include dependent migrations" in command
     assert "Canonicalize signed replacement target before source bundle" in command
     assert "checkpoint_signed_changes()" in command
@@ -2478,6 +2482,13 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
         )
         + "\n"
     )
+    preflight_guard_payload = {
+        "repo": "/runner/rulespec-us",
+        "passed": True,
+        "issues": [],
+    }
+    preflight_guard_raw = json.dumps(preflight_guard_payload) + "\n"
+    (tmp_path / "target-preflight-guard-generated.json").write_text(preflight_guard_raw)
     env = {
         **os.environ,
         "CITATION": "us/statute/42/1437c-1",
@@ -2513,6 +2524,7 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
             "generated/target/model/statutes/54a:4-7.test.yaml",
             "generated/target/model/target.repair.json",
             "guards/guard-generated.json",
+            "guards/target-preflight-guard-generated.json",
             "metadata.json",
         }
         assert "generated/target/model/ignored.bin" not in file_member_names
@@ -2521,10 +2533,14 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
         )
         repair = bundle.extractfile("./generated/target/model/target.repair.json")
         guard = bundle.extractfile("./guards/guard-generated.json")
+        preflight_guard = bundle.extractfile(
+            "./guards/target-preflight-guard-generated.json"
+        )
         metadata_file = bundle.extractfile("./metadata.json")
         assert target is not None
         assert repair is not None
         assert guard is not None
+        assert preflight_guard is not None
         assert metadata_file is not None
         assert target.read() == b"format: rulespec/v1\n"
         assert json.loads(repair.read()) == {"outcome": "blocked"}
@@ -2533,11 +2549,23 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
             "passed": False,
             "issues": ["waiver transition requires protected base"],
         }
+        assert json.loads(preflight_guard.read()) == preflight_guard_payload
         metadata = json.loads(metadata_file.read())
     assert metadata["schema"] == "axiom-encode/failed-reencode-diagnostics/v1"
     assert metadata["workflow_run_id"] == "1234"
     assert metadata["failed_steps"] == ["encode_apply"]
     assert metadata["generated_lanes"] == ["target"]
+    guards_by_path = {item["path"]: item for item in metadata["guards"]}
+    assert set(guards_by_path) == {
+        "guards/guard-generated.json",
+        "guards/target-preflight-guard-generated.json",
+    }
+    preflight_inventory = guards_by_path["guards/target-preflight-guard-generated.json"]
+    assert preflight_inventory["size"] == len(preflight_guard_raw.encode())
+    assert (
+        preflight_inventory["sha256"]
+        == hashlib.sha256(preflight_guard_raw.encode()).hexdigest()
+    )
     assert metadata["legacy_retained_successor_rulespec_paths_input"] == (
         '["us/statutes/old.yaml"]'
     )
@@ -2573,10 +2601,15 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
         ("wrong_shape", "invalid shape"),
     ],
 )
+@pytest.mark.parametrize(
+    "guard_name",
+    ["guard-generated.json", "target-preflight-guard-generated.json"],
+)
 def test_targeted_signed_reencode_rejects_unsafe_guard_diagnostics(
     tmp_path: Path,
     mutation: str,
     expected_error: str,
+    guard_name: str,
 ) -> None:
     workflow = yaml.safe_load(
         (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
@@ -2591,7 +2624,7 @@ def test_targeted_signed_reencode_rejects_unsafe_guard_diagnostics(
         sys.executable,
     )
     (tmp_path / "generated").mkdir()
-    guard = tmp_path / "guard-generated.json"
+    guard = tmp_path / guard_name
     if mutation == "symlink":
         outside = tmp_path / "outside.json"
         outside.write_text('{"repo":"outside","passed":false,"issues":[]}\n')
@@ -2648,7 +2681,7 @@ def test_targeted_signed_reencode_preserves_checkpoint_guard_failure(
         if step.get("name") == "Encode, review, validate, and apply"
     )
     checkpoint = command.split("checkpoint_signed_changes() {", 1)[1].split(
-        "\n}\n\nfinal_legacy_source_path=",
+        '\n}\n\nif [ "$source_bundle_enabled"',
         1,
     )[0]
     guard_stub = tmp_path / "guard-stub"
@@ -3169,7 +3202,7 @@ def test_targeted_signed_reencode_composes_nonempty_source_bundle(
         1,
     )
     _checkpoint_body, after_checkpoint = checkpoint_and_after.split(
-        "\n}\n\nfinal_legacy_source_path=",
+        '\n}\n\nif [ "$source_bundle_enabled"',
         1,
     )
     command = (
@@ -3177,7 +3210,7 @@ def test_targeted_signed_reencode_composes_nonempty_source_bundle(
         + "checkpoint_signed_changes() {\n"
         + '  printf \'%s\\n\' "$1" >> "$CHECKPOINTS_PATH"\n'
         + '  : > "$RUNNER_TEMP/checkpoint-guard-generated.json"\n'
-        + "}\n\nfinal_legacy_source_path="
+        + '}\n\nif [ "$source_bundle_enabled"'
         + after_checkpoint
     )
 
@@ -3192,18 +3225,11 @@ import sys
 from pathlib import Path
 
 args = sys.argv[sys.argv.index("--") + 1:]
-checkout = Path(os.environ["RULESPEC_CHECKOUT"])
-legacy = checkout / os.environ["LEGACY_REPLACEMENT_FILE"]
-legacy_test = legacy.with_name(f"{legacy.stem}.test.yaml")
-if "--replace-legacy-rulespec-path" in args:
+if "target-preflight" in args[args.index("--output") + 1]:
     if "--apply-target-only" in args:
-        raise SystemExit("legacy preflight must validate the complete checkout")
-    if not legacy.is_file() or not legacy_test.is_file():
-        raise SystemExit("legacy predecessor was not present for preflight")
-    legacy.unlink()
-    legacy_test.unlink()
-elif legacy.exists() or legacy_test.exists():
-    raise SystemExit("source encoding started before legacy predecessor retirement")
+        raise SystemExit("replacement preflight must validate the complete checkout")
+    if "--replace-legacy-rulespec-path" in args:
+        raise SystemExit("source bundle preflight cannot perform legacy migration")
 
 with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
     stream.write(json.dumps(sys.argv[1:]) + "\\n")
@@ -3216,15 +3242,11 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
     _prepare_empty_signed_import_inputs(runner_temp)
     primary = "us-ri/statute/44-30-2.6"
     replacement_path = "us-ri/statutes/44-30-2.6.yaml"
-    legacy_replacement_path = "us-ri/statutes/44:30-2.6.yaml"
     checkout = tmp_path / "rulespec-us"
     canonical = checkout / replacement_path
-    legacy = checkout / legacy_replacement_path
     canonical.parent.mkdir(parents=True)
     canonical.write_text("format: rulespec/v1\nrules: []\n")
     canonical.with_name(f"{canonical.stem}.test.yaml").write_text("[]\n")
-    legacy.write_text("format: rulespec/v1\nrules: []\n")
-    legacy.with_name(f"{legacy.stem}.test.yaml").write_text("[]\n")
     sources = [
         "us-ri/statute/44-30-1",
         "us-ri/guidance/revenue/2026/rate-schedule",
@@ -3243,8 +3265,7 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
             "DEPENDENT_CITATION": "",
             "DEPENDENT_REVIEW_FINDING": "",
             "GITHUB_WORKSPACE": str(tmp_path),
-            "LEGACY_REPLACEMENT_FILE": legacy_replacement_path,
-            "REPLACE_LEGACY_RULESPEC_PATH": legacy_replacement_path,
+            "REPLACE_LEGACY_RULESPEC_PATH": "",
             "REPLACE_RULESPEC_PATH": replacement_path,
             "REVIEW_FINDING": "Preserve the composed target semantics.",
             "RULESPEC_CHECKOUT": str(tmp_path / "rulespec-us"),
@@ -3268,8 +3289,7 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
     assert "--review-findings" not in preflight_args
     replacement_index = preflight_args.index("--replace-rulespec-path")
     assert preflight_args[replacement_index + 1] == replacement_path
-    legacy_index = preflight_args.index("--replace-legacy-rulespec-path")
-    assert preflight_args[legacy_index + 1] == legacy_replacement_path
+    assert "--replace-legacy-rulespec-path" not in preflight_args
     assert "--required-import-rulespec-path" not in preflight_args
 
     for index, source in enumerate(sources, start=1):
@@ -3297,12 +3317,28 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
         f"Compose signed source bundle for {primary}",
     ]
     assert canonical.is_file()
-    assert not legacy.exists()
-    assert not legacy.with_name(f"{legacy.stem}.test.yaml").exists()
 
 
-def test_targeted_signed_reencode_rejects_source_bundle_replacement_dependents_early(
+@pytest.mark.parametrize(
+    ("legacy_source", "dependent_citation", "expected_error"),
+    [
+        (
+            "us-ri/statutes/44:30-2.6.yaml",
+            "",
+            "source bundles require legacy replacements to merge first",
+        ),
+        (
+            "",
+            "us-ri/statute/44-30-2.7",
+            "source-bundle replacements cannot include dependent migrations",
+        ),
+    ],
+)
+def test_targeted_signed_reencode_rejects_nonatomic_source_bundle_replacements_early(
     tmp_path: Path,
+    legacy_source: str,
+    dependent_citation: str,
+    expected_error: str,
 ) -> None:
     workflow = yaml.safe_load(
         (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
@@ -3324,12 +3360,12 @@ def test_targeted_signed_reencode_rejects_source_bundle_replacement_dependents_e
         env={
             **os.environ,
             "CITATION": "us-ri/statute/44-30-2.6",
-            "DEPENDENT_CITATION": "us-ri/statute/44-30-2.7",
+            "DEPENDENT_CITATION": dependent_citation,
             "EXISTING_SIGNED_IMPORTS_JSON": "[]",
             "LEGACY_EXACT_DEPENDENT_RULESPEC_PATH": "",
             "LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON": "[]",
             "QUEUE_ID": "",
-            "REPLACE_LEGACY_RULESPEC_PATH": "us-ri/statutes/44:30-2.6.yaml",
+            "REPLACE_LEGACY_RULESPEC_PATH": legacy_source,
             "REPLACE_RULESPEC_PATH": "us-ri/statutes/44-30-2.6.yaml",
             "RULESPEC_CHECKOUT": str(checkout),
             "SECOND_DEPENDENT_CITATION": "",
@@ -3339,10 +3375,7 @@ def test_targeted_signed_reencode_rejects_source_bundle_replacement_dependents_e
     )
 
     assert completed.returncode != 0
-    assert (
-        "source-bundle replacements cannot include dependent migrations"
-        in completed.stderr
-    )
+    assert expected_error in completed.stderr
 
 
 def test_targeted_signed_reencode_reuses_verified_existing_import(

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2171,6 +2171,8 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert '> "$RUNNER_TEMP/source-bundle-citations.txt"' in command
     assert 'source_lane="$(printf \'source-%02d\' "$source_index")"' in command
     assert '"$source_citation" "" true "$source_lane" "" "" false' in command
+    assert '"$CITATION" "" true target-preflight \\' in command
+    assert "Canonicalize signed replacement target before source bundle" in command
     assert "checkpoint_signed_changes()" in command
     assert 'local guard_status="$?"' in command
     assert 'jq . "$RUNNER_TEMP/checkpoint-guard-generated.json" >&2' in command
@@ -2639,7 +2641,7 @@ def test_targeted_signed_reencode_preserves_checkpoint_guard_failure(
         if step.get("name") == "Encode, review, validate, and apply"
     )
     checkpoint = command.split("checkpoint_signed_changes() {", 1)[1].split(
-        "\n}\n\nsource_index=0",
+        '\n}\n\nif [ "$source_bundle_enabled"',
         1,
     )[0]
     guard_stub = tmp_path / "guard-stub"
@@ -3160,7 +3162,7 @@ def test_targeted_signed_reencode_composes_nonempty_source_bundle(
         1,
     )
     _checkpoint_body, after_checkpoint = checkpoint_and_after.split(
-        "\n}\n\nsource_index=0",
+        '\n}\n\nif [ "$source_bundle_enabled"',
         1,
     )
     command = (
@@ -3168,7 +3170,7 @@ def test_targeted_signed_reencode_composes_nonempty_source_bundle(
         + "checkpoint_signed_changes() {\n"
         + '  printf \'%s\\n\' "$1" >> "$CHECKPOINTS_PATH"\n'
         + '  : > "$RUNNER_TEMP/checkpoint-guard-generated.json"\n'
-        + "}\n\nsource_index=0"
+        + '}\n\nif [ "$source_bundle_enabled"'
         + after_checkpoint
     )
 
@@ -3192,6 +3194,7 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
     runner_temp.mkdir()
     _prepare_empty_signed_import_inputs(runner_temp)
     primary = "us-ri/statute/44-30-2.6"
+    replacement_path = "us-ri/statutes/44-30-2.6.yaml"
     sources = [
         "us-ri/statute/44-30-1",
         "us-ri/guidance/revenue/2026/rate-schedule",
@@ -3210,6 +3213,8 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
             "DEPENDENT_CITATION": "",
             "DEPENDENT_REVIEW_FINDING": "",
             "GITHUB_WORKSPACE": str(tmp_path),
+            "REPLACE_LEGACY_RULESPEC_PATH": "",
+            "REPLACE_RULESPEC_PATH": replacement_path,
             "REVIEW_FINDING": "Preserve the composed target semantics.",
             "RULESPEC_CHECKOUT": str(tmp_path / "rulespec-us"),
             "RULESPEC_REF": "a" * 40,
@@ -3224,9 +3229,17 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
     calls = [
         json.loads(line) for line in calls_path.read_text(encoding="utf-8").splitlines()
     ]
-    assert len(calls) == 3
+    assert len(calls) == 4
     encode_args = [call[call.index("--") + 1 :] for call in calls]
-    for index, source in enumerate(sources):
+    preflight_args = encode_args[0]
+    assert preflight_args[-1] == primary
+    assert "--apply-target-only" in preflight_args
+    assert "--review-findings" not in preflight_args
+    replacement_index = preflight_args.index("--replace-rulespec-path")
+    assert preflight_args[replacement_index + 1] == replacement_path
+    assert "--required-import-rulespec-path" not in preflight_args
+
+    for index, source in enumerate(sources, start=1):
         assert encode_args[index][-1] == source
         assert "--apply-target-only" in encode_args[index]
         assert "--required-import-rulespec-path" not in encode_args[index]
@@ -3244,6 +3257,7 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
         "us-ri/policies/revenue/2026/rate-schedule.yaml",
     ]
     assert checkpoints_path.read_text(encoding="utf-8").splitlines() == [
+        "Canonicalize signed replacement target before source bundle",
         f"Add signed source module for {sources[0]}",
         f"Add signed source module for {sources[1]}",
         f"Compose signed source bundle for {primary}",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1526"
+version = "0.2.1527"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- run a signed full-checkout preflight before applying a source bundle to an existing canonical replacement target
- checkpoint that validated target and preserve the preflight guard in bounded failure diagnostics
- reject source bundles combined with legacy-path or dependent migrations before model or signing work; those migrations must merge as separate signed transactions
- cover source composition, early rejection, checkpoint propagation, and normal/preflight guard safety
- bump encoder to 0.2.1527

## Failure reproduced
Protected run 30938820980 could not compile `us-nj/statute/54a:9-7` because the base still contained the pending noncanonical `us-nj/statutes/54a:4-7.yaml` duplicate. A combined source-bundle/legacy flow is not atomic: the final normal apply can overwrite the authenticated migration manifest and orphan its receipt. This change fails that combination before model work. The legacy migration must merge first; a subsequent canonical source-bundle re-encode then uses the clean base.

## Checks
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- `python -m compileall -q src/axiom_encode scripts`
- `pytest -q tests/test_signing_supervisor.py` (52 passed, 51 skipped)

## Cycle
Independent review of `ca6332de6bbce783cee719d956674f4924860efc` found two actionable issues: the combined legacy/source flow could overwrite the migration transaction, and the preflight guard was omitted from failure diagnostics. Both were fixed.

Post-fix independent re-review at exact head `4c47d0c544e6d84033dfccfba104c024f4033cd5` found no actionable issues. The reviewer independently ran the full signing-supervisor test file (52 passed, 51 skipped), a 34-test focused workflow/security suite, Ruff, formatting, and `git diff --check`.