### PR TITLE
Raise OpenAI eval output budget

### DIFF
--- a/changelog.d/openai-eval-output-budget.fixed.md
+++ b/changelog.d/openai-eval-output-budget.fixed.md
@@ -1,1 +1,1 @@
-Raise the OpenAI prompt-eval output budget so complete RuleSpec encodings are not truncated at the previous 16,384-token boundary.
+Raise the OpenAI prompt-eval output budget for supported GPT-5 runners so complete RuleSpec encodings are not truncated at the previous 16,384-token boundary, while retaining a compatible fallback for other models.

--- a/changelog.d/openai-eval-output-budget.fixed.md
+++ b/changelog.d/openai-eval-output-budget.fixed.md
@@ -1,0 +1,1 @@
+Raise the OpenAI prompt-eval output budget so complete RuleSpec encodings are not truncated at the previous 16,384-token boundary.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1528"
+version = "0.2.1529"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1527"
+version = "0.2.1528"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1527"
+__version__ = "0.2.1528"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1528"
+__version__ = "0.2.1529"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -315,6 +315,7 @@ _OPENAI_REQUEST_CONNECT_TIMEOUT_SECONDS = 30
 _OPENAI_REQUEST_READ_TIMEOUT_SECONDS = 180
 _OPENAI_REQUEST_MAX_ATTEMPTS = 6
 _OPENAI_REQUEST_BACKOFF_SECONDS = (1, 2, 4, 8, 10)
+_OPENAI_PROMPT_MAX_OUTPUT_TOKENS = 32768
 EVAL_EXECUTION_IDENTITY_SCHEMA = "axiom-encode/eval-execution-identity/v3"
 _EVAL_CASE_DEADLINE_MONOTONIC: ContextVar[float | None] = ContextVar(
     "_EVAL_CASE_DEADLINE_MONOTONIC",
@@ -13940,7 +13941,7 @@ def _run_openai_prompt_eval(
     body = {
         "model": runner.model,
         "input": prompt,
-        "max_output_tokens": 16384,
+        "max_output_tokens": _OPENAI_PROMPT_MAX_OUTPUT_TOKENS,
         "reasoning": {
             "effort": "low",
             "summary": "auto",

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -315,7 +315,9 @@ _OPENAI_REQUEST_CONNECT_TIMEOUT_SECONDS = 30
 _OPENAI_REQUEST_READ_TIMEOUT_SECONDS = 180
 _OPENAI_REQUEST_MAX_ATTEMPTS = 6
 _OPENAI_REQUEST_BACKOFF_SECONDS = (1, 2, 4, 8, 10)
-_OPENAI_PROMPT_MAX_OUTPUT_TOKENS = 32768
+_OPENAI_DEFAULT_PROMPT_MAX_OUTPUT_TOKENS = 16384
+_OPENAI_EXTENDED_PROMPT_MAX_OUTPUT_TOKENS = 32768
+_OPENAI_EXTENDED_OUTPUT_MODEL_PREFIXES = ("gpt-5.4", "gpt-5.5", "gpt-5.6")
 EVAL_EXECUTION_IDENTITY_SCHEMA = "axiom-encode/eval-execution-identity/v3"
 _EVAL_CASE_DEADLINE_MONOTONIC: ContextVar[float | None] = ContextVar(
     "_EVAL_CASE_DEADLINE_MONOTONIC",
@@ -13919,6 +13921,15 @@ def _extract_openai_response_text(payload: dict) -> str:
     return "\n\n".join(texts).strip()
 
 
+def _openai_prompt_max_output_tokens(model: str) -> int:
+    if any(
+        model == prefix or model.startswith(f"{prefix}-")
+        for prefix in _OPENAI_EXTENDED_OUTPUT_MODEL_PREFIXES
+    ):
+        return _OPENAI_EXTENDED_PROMPT_MAX_OUTPUT_TOKENS
+    return _OPENAI_DEFAULT_PROMPT_MAX_OUTPUT_TOKENS
+
+
 def _run_openai_prompt_eval(
     runner: EvalRunnerSpec,
     workspace: EvalWorkspace,
@@ -13941,7 +13952,7 @@ def _run_openai_prompt_eval(
     body = {
         "model": runner.model,
         "input": prompt,
-        "max_output_tokens": _OPENAI_PROMPT_MAX_OUTPUT_TOKENS,
+        "max_output_tokens": _openai_prompt_max_output_tokens(runner.model),
         "reasoning": {
             "effort": "low",
             "summary": "auto",

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1527"
+ENCODER_VERSION = "0.2.1528"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1528"
+ENCODER_VERSION = "0.2.1529"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -13834,6 +13834,37 @@ rules:
 
 
 class TestOpenAIEvalRequest:
+    def test_openai_prompt_eval_requests_full_rulespec_output_budget(
+        self,
+        monkeypatch,
+    ):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        ok_response = Mock(status_code=200, headers={}, text="")
+        ok_response.json.return_value = {
+            "output_text": "format: rulespec/v1\nrules: []\n",
+            "usage": {},
+        }
+
+        with patch(
+            "axiom_encode.harness.evals._post_openai_eval_request",
+            return_value=ok_response,
+        ) as mock_post:
+            response = evals_module._run_openai_prompt_eval(
+                parse_runner_spec("openai:gpt-5.6"),
+                SimpleNamespace(),
+                "encode the complete provision",
+            )
+
+        expected_body = {
+            "model": "gpt-5.6",
+            "input": "encode the complete provision",
+            "max_output_tokens": 32768,
+            "reasoning": {"effort": "low", "summary": "auto"},
+        }
+        assert mock_post.call_args.kwargs["body"] == expected_body
+        assert response.trace["request_body"] == expected_body
+        assert response.error is None
+
     def test_post_openai_eval_request_retries_transient_status(self):
         error_response = Mock()
         error_response.status_code = 502

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -13834,9 +13834,16 @@ rules:
 
 
 class TestOpenAIEvalRequest:
+    @pytest.mark.parametrize(
+        ("model", "expected_max_output_tokens"),
+        [("gpt-5.6-sol", 32768), ("gpt-4o", 16384)],
+        ids=["extended-gpt-5", "compatible-fallback"],
+    )
     def test_openai_prompt_eval_requests_full_rulespec_output_budget(
         self,
         monkeypatch,
+        model,
+        expected_max_output_tokens,
     ):
         monkeypatch.setenv("OPENAI_API_KEY", "test-key")
         ok_response = Mock(status_code=200, headers={}, text="")
@@ -13850,15 +13857,15 @@ class TestOpenAIEvalRequest:
             return_value=ok_response,
         ) as mock_post:
             response = evals_module._run_openai_prompt_eval(
-                parse_runner_spec("openai:gpt-5.6"),
+                parse_runner_spec(f"openai:{model}"),
                 SimpleNamespace(),
                 "encode the complete provision",
             )
 
         expected_body = {
-            "model": "gpt-5.6",
+            "model": model,
             "input": "encode the complete provision",
-            "max_output_tokens": 32768,
+            "max_output_tokens": expected_max_output_tokens,
             "reasoning": {"effort": "low", "summary": "auto"},
         }
         assert mock_post.call_args.kwargs["body"] == expected_body

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1527"
+ENCODER_VERSION = "0.2.1528"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1528"
+ENCODER_VERSION = "0.2.1529"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1527"
+ENCODER_VERSION = "0.2.1528"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1528"
+ENCODER_VERSION = "0.2.1529"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1527"
+ENCODER_VERSION = "0.2.1528"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1528"
+ENCODER_VERSION = "0.2.1529"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1528"
+ENCODER_VERSION = "0.2.1529"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1527"
+ENCODER_VERSION = "0.2.1528"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1528"
+ENCODER_VERSION = "0.2.1529"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1527"
+ENCODER_VERSION = "0.2.1528"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1528"
+ENCODER_VERSION = "0.2.1529"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1527"
+ENCODER_VERSION = "0.2.1528"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1527"')
+        .startswith('__version__ = "0.2.1528"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1527"
+    assert encoder_package["version"] == "0.2.1528"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1527"
+    assert project["project"]["version"] == "0.2.1528"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1527"')
+        .startswith('__version__ = "0.2.1528"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1527"
+    assert encoder_package["version"] == "0.2.1528"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1527"
+    assert project["project"]["version"] == "0.2.1528"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1527"')
+        .startswith('__version__ = "0.2.1528"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1528"')
+        .startswith('__version__ = "0.2.1529"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1528"
+    assert encoder_package["version"] == "0.2.1529"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1528"
+    assert project["project"]["version"] == "0.2.1529"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1528"')
+        .startswith('__version__ = "0.2.1529"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1528"
+    assert encoder_package["version"] == "0.2.1529"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1528"
+    assert project["project"]["version"] == "0.2.1529"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1528"')
+        .startswith('__version__ = "0.2.1529"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1528"
+ENCODER_VERSION = "0.2.1529"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1527"
+ENCODER_VERSION = "0.2.1528"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1528"
+version = "0.2.1529"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1527"
+version = "0.2.1528"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- raise prompt-only OpenAI Responses output capacity from 16,384 to 32,768 tokens for the GPT-5.4, GPT-5.5, and GPT-5.6 model families
- preserve a 16,384-token fallback for other accepted OpenAI runner IDs, including GPT-4o
- assert exact extended and fallback request bodies in paired regression cases
- bump encoder to 0.2.1529 with production provenance intact

## Failure reproduced
Protected SNAP run 30937386012 exhausted four encoding attempts for `us/statute/42/1437c–1`. Its final durable trace reported `status: incomplete`, `reason: max_output_tokens`, and exactly 16,384 output tokens, leaving the generated RuleSpec truncated before completion.

## Checks
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- `python -m compileall -q src/axiom_encode scripts`
- `PYTHONPATH=src pytest -q --no-cov tests/test_evals.py::TestOpenAIEvalRequest` (14 passed)
- focused packaged-version tests (3 passed)
- affected oracle-registry suites (24 passed)
- production version-provenance guard -> version `0.2.1529`, version commit `0f877e7d6aa3`

## Cycle
Independent review of `18f015231f4afb0766999d435d87c777d1d35f8e` found that a global 32,768 cap exceeded GPT-4o compatibility. That was fixed at `82a8fa74c` with an explicit extended-output allowlist and fallback.

Post-fix review found that the compatibility commit followed the version bump, causing production provenance to fail closed. A final version bump now follows all encoder code at exact head `0f877e7d6aa3c6b11338bca495510c26da1efede`; the production provenance guard passes. Final independent re-review at that exact head found no actionable findings and independently passed 17 focused tests, 24 oracle-registry tests, differential model controls, provenance, Ruff, formatting, and diff checks.