### PR TITLE
Authorize reviewed US hardcut tip

### DIFF
--- a/changelog.d/reviewed-hardcut-b1a6.fixed.md
+++ b/changelog.d/reviewed-hardcut-b1a6.fixed.md
@@ -1,0 +1,1 @@
+Authorize the independently reviewed current US hardcut tip for protected signed re-encode runs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1529"
+version = "0.2.1530"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -63,6 +63,10 @@ REVIEWED_RULESPEC_REFS = frozenset(
             "1e04e456ab404860050586c34eef51321eea95e9",
         ),
         (
+            "us",
+            "b1a6e07af093d62f613f83afe26fcb4dd87de491",
+        ),
+        (
             "ca",
             "f60f7a84c30e38c7d4961d70647eb0457e7d76c2",
         ),

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1529"
+__version__ = "0.2.1530"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1529"
+ENCODER_VERSION = "0.2.1530"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1529"
+ENCODER_VERSION = "0.2.1530"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1529"
+ENCODER_VERSION = "0.2.1530"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1529"
+ENCODER_VERSION = "0.2.1530"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1529"
+ENCODER_VERSION = "0.2.1530"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1529"
+ENCODER_VERSION = "0.2.1530"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1529"
+ENCODER_VERSION = "0.2.1530"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -2109,6 +2109,7 @@ def test_validate_rulespec_base_rejects_stale_main_pr_base(
         ("us", "251d8d66dabdebcb763d9e7c9b8322a281440c36"),
         ("us", "68cca4a6fa806b63f95277c129575d88d2ac07f1"),
         ("us", "1e04e456ab404860050586c34eef51321eea95e9"),
+        ("us", "b1a6e07af093d62f613f83afe26fcb4dd87de491"),
         ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
     ],
 )
@@ -2125,6 +2126,7 @@ def test_validate_rulespec_base_accepts_exact_reviewed_head_artifact_only(
             ("us", "251d8d66dabdebcb763d9e7c9b8322a281440c36"),
             ("us", "68cca4a6fa806b63f95277c129575d88d2ac07f1"),
             ("us", "1e04e456ab404860050586c34eef51321eea95e9"),
+            ("us", "b1a6e07af093d62f613f83afe26fcb4dd87de491"),
             ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
         }
     )
@@ -2154,7 +2156,7 @@ def test_validate_rulespec_base_accepts_exact_reviewed_protected_branch_tip(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repo = tmp_path / "rulespec-us"
-    reviewed_ref = "b61918da93fe8a1a29b35b9330aef2085291a5d0"
+    reviewed_ref = "b1a6e07af093d62f613f83afe26fcb4dd87de491"
     git_calls: list[tuple[str, ...]] = []
 
     def fake_git(_repo: Path, *args: str) -> bytes:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1529"')
+        .startswith('__version__ = "0.2.1530"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1529"
+    assert encoder_package["version"] == "0.2.1530"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1529"
+    assert project["project"]["version"] == "0.2.1530"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1529"')
+        .startswith('__version__ = "0.2.1530"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1529"
+    assert encoder_package["version"] == "0.2.1530"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1529"
+    assert project["project"]["version"] == "0.2.1530"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1529"')
+        .startswith('__version__ = "0.2.1530"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1529"
+ENCODER_VERSION = "0.2.1530"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1529"
+version = "0.2.1530"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- admit exact RuleSpec US hardcut merge `b1a6e07af093d62f613f83afe26fcb4dd87de491` for protected signed runs
- exercise that exact SHA as both an artifact-only reviewed head and the protected PR base tip
- bump encoder to 0.2.1530 with production provenance intact

## Review provenance
The admitted SHA is the merge of RuleSpec PR #1216 into `hard-cut/canonical-layout-us`. Its parents are prior reviewed tip `1e04e456` and independently reviewed head `919c6639`; its tree matches the reviewed head, it carries a verified GitHub merge signature, and it remains the exact protected branch tip. PR #1216 records a clean independent cycle with 16 focused tests.

## Failure reproduced
Federal SNAP repair runs 30944627207 and 30944803027 failed closed before model work because the prior reviewed SHA was no longer the exact protected branch tip and the merged reviewed tip was not yet in this immutable allowlist.

## Checks
- `PYTHONPATH=src pytest -q --no-cov tests/test_prepare_signed_backfill.py -k validate_rulespec_base` (18 passed)
- `ruff check src/ scripts/ tests/`
- `ruff format --check src/ scripts/ tests/`
- `python -m compileall -q src/axiom_encode scripts`
- production version-provenance guard -> version `0.2.1530`, commit `3c4b90806e16`

## Cycle
Independent review at exact head `3c4b90806e169176b183c4db1062537cb1146ebf` found no actionable findings. The reviewer verified the RuleSpec merge graph, tree identity, signature, exact remote tip, fail-closed branch checks, complete allowlist tests, and version topology; 18 base tests, 27 packaged/oracle tests, provenance, Ruff, formatting, and diff checks passed.