### PR TITLE
Package diagnostics before runtime provisioning

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -2444,7 +2444,12 @@ jobs:
           generated="$RUNNER_TEMP/generated"
           artifact="$RUNNER_TEMP/targeted-reencode-failure"
           mkdir -p "$artifact"
-          /opt/axiom-verification/python/bin/python -I - \
+          workflow_python=/opt/axiom-verification/python/bin/python
+          if [ ! -x "$workflow_python" ]; then
+            workflow_python=/usr/bin/python3
+          fi
+          test -x "$workflow_python"
+          "$workflow_python" -I - \
             "$generated" "$artifact" \
             "$RUNNER_TEMP" <<'PY'
           import hashlib
@@ -2454,10 +2459,88 @@ jobs:
           import sys
           from pathlib import Path
 
-          from axiom_encode.corpus_resolver import (
-              UnsafeCorpusPathError,
-              read_bounded_regular_file,
-          )
+          class UnsafeDiagnosticPathError(Exception):
+              pass
+
+
+          def read_bounded_regular_file(root, candidate, *, label, max_bytes):
+              nofollow = getattr(os, "O_NOFOLLOW", None)
+              directory = getattr(os, "O_DIRECTORY", None)
+              if nofollow is None or directory is None:
+                  raise UnsafeDiagnosticPathError(
+                      f"{label} cannot be opened safely on this platform"
+                  )
+              raw_root = Path(os.path.abspath(root))
+              raw_candidate = Path(os.path.abspath(candidate))
+              try:
+                  relative = raw_candidate.relative_to(raw_root)
+              except ValueError as exc:
+                  raise UnsafeDiagnosticPathError(
+                      f"{label} is outside {raw_root}: {candidate}"
+                  ) from exc
+              if not relative.parts:
+                  raise UnsafeDiagnosticPathError(
+                      f"{label} is not a file: {candidate}"
+                  )
+
+              base_flags = os.O_RDONLY | nofollow | getattr(os, "O_CLOEXEC", 0)
+              nonblocking = getattr(os, "O_NONBLOCK", 0)
+              descriptors = []
+              file_descriptor = None
+              try:
+                  parent_descriptor = os.open(raw_root, base_flags | directory)
+                  descriptors.append(parent_descriptor)
+                  for part in relative.parts[:-1]:
+                      parent_descriptor = os.open(
+                          part,
+                          base_flags | directory,
+                          dir_fd=parent_descriptor,
+                      )
+                      descriptors.append(parent_descriptor)
+                  file_descriptor = os.open(
+                      relative.parts[-1],
+                      base_flags | nonblocking,
+                      dir_fd=parent_descriptor,
+                  )
+                  file_stat = os.fstat(file_descriptor)
+                  if not stat.S_ISREG(file_stat.st_mode):
+                      raise UnsafeDiagnosticPathError(
+                          f"{label} is not a regular file: {candidate}"
+                      )
+                  if file_stat.st_size > max_bytes:
+                      raise UnsafeDiagnosticPathError(
+                          f"{label} exceeds the {max_bytes}-byte safety limit: "
+                          f"{candidate}"
+                      )
+                  chunks = []
+                  remaining = max_bytes + 1
+                  while remaining:
+                      chunk = os.read(
+                          file_descriptor,
+                          min(1024 * 1024, remaining),
+                      )
+                      if not chunk:
+                          break
+                      chunks.append(chunk)
+                      remaining -= len(chunk)
+                  raw = b"".join(chunks)
+                  if len(raw) > max_bytes:
+                      raise UnsafeDiagnosticPathError(
+                          f"{label} exceeds the {max_bytes}-byte safety limit: "
+                          f"{candidate}"
+                      )
+                  return raw
+              except UnsafeDiagnosticPathError:
+                  raise
+              except OSError as exc:
+                  raise UnsafeDiagnosticPathError(
+                      f"Could not safely open {label}: {candidate}"
+                  ) from exc
+              finally:
+                  if file_descriptor is not None:
+                      os.close(file_descriptor)
+                  for descriptor in reversed(descriptors):
+                      os.close(descriptor)
 
           generated = Path(os.path.abspath(sys.argv[1]))
           artifact = Path(os.path.abspath(sys.argv[2]))
@@ -2509,7 +2592,7 @@ jobs:
                               label="failed re-encode diagnostic",
                               max_bytes=max_file_bytes,
                           )
-                      except UnsafeCorpusPathError as exc:
+                      except UnsafeDiagnosticPathError as exc:
                           raise SystemExit(str(exc)) from exc
                       total_bytes += len(payload)
                       if total_bytes > max_total_bytes:
@@ -2545,7 +2628,7 @@ jobs:
                       label="generated provenance guard diagnostics",
                       max_bytes=1024 * 1024,
                   )
-              except UnsafeCorpusPathError as exc:
+              except UnsafeDiagnosticPathError as exc:
                   raise SystemExit(str(exc)) from exc
               try:
                   parsed_guard = json.loads(guard_payload)

--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -522,6 +522,7 @@ jobs:
           }
 
       - name: Provision protected signing supervisor
+        id: provision_signing_supervisor
         working-directory: axiom-encode
         env:
           TRUST_APPLY_ROOT: ${{ vars.AXIOM_ENCODE_APPLY_SIGNING_PUBLIC_KEY }}
@@ -2419,6 +2420,7 @@ jobs:
           COMMIT_REVIEWED_LANE_CHANGES_CONCLUSION: ${{ steps.commit_reviewed_lane_changes.conclusion }}
           COMMIT_REVIEWED_LANE_CHANGES_OUTCOME: ${{ steps.commit_reviewed_lane_changes.outcome }}
           PR_BASE_BRANCH: ${{ inputs.pr_base_branch }}
+          PROVISION_SIGNING_SUPERVISOR_CONCLUSION: ${{ steps.provision_signing_supervisor.conclusion }}
           PUBLISH_LANE_PULL_REQUEST_CONCLUSION: ${{ steps.publish_lane_pull_request.conclusion }}
           PUBLISH_LANE_PULL_REQUEST_OUTCOME: ${{ steps.publish_lane_pull_request.outcome }}
           QUEUE_DISPATCHER_RUN_ID: ${{ inputs.queue_dispatcher_run_id }}
@@ -2444,9 +2446,10 @@ jobs:
           generated="$RUNNER_TEMP/generated"
           artifact="$RUNNER_TEMP/targeted-reencode-failure"
           mkdir -p "$artifact"
-          workflow_python=/opt/axiom-verification/python/bin/python
-          if [ ! -x "$workflow_python" ]; then
-            workflow_python=/usr/bin/python3
+          workflow_python=/usr/bin/python3
+          if [ "${PROVISION_SIGNING_SUPERVISOR_CONCLUSION:-}" = success ] && \
+             [ -x /opt/axiom-verification/python/bin/python ]; then
+            workflow_python=/opt/axiom-verification/python/bin/python
           fi
           test -x "$workflow_python"
           "$workflow_python" -I - \

--- a/changelog.d/portable-early-failure-diagnostics.fixed.md
+++ b/changelog.d/portable-early-failure-diagnostics.fixed.md
@@ -1,0 +1,1 @@
+Package bounded signed re-encode diagnostics even when a setup failure occurs before the protected Python runtime is provisioned.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1530"
+version = "0.2.1531"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1531"
+version = "0.2.1532"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1530"
+__version__ = "0.2.1531"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1531"
+__version__ = "0.2.1532"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1531"
+ENCODER_VERSION = "0.2.1532"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1530"
+ENCODER_VERSION = "0.2.1531"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1531"
+ENCODER_VERSION = "0.2.1532"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1530"
+ENCODER_VERSION = "0.2.1531"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1531"
+ENCODER_VERSION = "0.2.1532"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1530"
+ENCODER_VERSION = "0.2.1531"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1530"
+ENCODER_VERSION = "0.2.1531"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1531"
+ENCODER_VERSION = "0.2.1532"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1531"
+ENCODER_VERSION = "0.2.1532"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1530"
+ENCODER_VERSION = "0.2.1531"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1530"
+ENCODER_VERSION = "0.2.1531"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1531"
+ENCODER_VERSION = "0.2.1532"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1531"
+ENCODER_VERSION = "0.2.1532"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1530"
+ENCODER_VERSION = "0.2.1531"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1531"')
+        .startswith('__version__ = "0.2.1532"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1531"
+    assert encoder_package["version"] == "0.2.1532"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1531"
+    assert project["project"]["version"] == "0.2.1532"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1531"')
+        .startswith('__version__ = "0.2.1532"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1531"
+    assert encoder_package["version"] == "0.2.1532"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1531"
+    assert project["project"]["version"] == "0.2.1532"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1531"')
+        .startswith('__version__ = "0.2.1532"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1530"')
+        .startswith('__version__ = "0.2.1531"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1530"
+    assert encoder_package["version"] == "0.2.1531"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1530"
+    assert project["project"]["version"] == "0.2.1531"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1530"')
+        .startswith('__version__ = "0.2.1531"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1530"
+    assert encoder_package["version"] == "0.2.1531"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1530"
+    assert project["project"]["version"] == "0.2.1531"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1530"')
+        .startswith('__version__ = "0.2.1531"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1531"
+ENCODER_VERSION = "0.2.1532"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1530"
+ENCODER_VERSION = "0.2.1531"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2256,7 +2256,12 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "toJSON(steps)" not in json.dumps(failure_package_step)
     assert ".outputs" not in json.dumps(failure_package_step["env"])
     failure_package_command = failure_package_step["run"]
-    assert "/opt/axiom-verification/python/bin/python -I -" in (failure_package_command)
+    assert "workflow_python=/opt/axiom-verification/python/bin/python" in (
+        failure_package_command
+    )
+    assert "workflow_python=/usr/bin/python3" in failure_package_command
+    assert 'test -x "$workflow_python"' in failure_package_command
+    assert '"$workflow_python" -I -' in failure_package_command
     assert "read_bounded_regular_file" in failure_package_command
     assert "followlinks=False" in failure_package_command
     assert "generated diagnostics exceed entry limit" in failure_package_command
@@ -2463,8 +2468,8 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
         if item.get("name") == "Package failed re-encode diagnostics"
     )
     command = step["run"].replace(
-        "/opt/axiom-verification/python/bin/python",
-        sys.executable,
+        "workflow_python=/opt/axiom-verification/python/bin/python",
+        f"workflow_python={tmp_path / 'missing-protected-python'}",
     )
     generated = tmp_path / "generated" / "target" / "model"
     generated.mkdir(parents=True)

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shlex
 import shutil
 import socket
 import struct
@@ -2055,6 +2056,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         for step in steps
         if step.get("name") == "Provision protected signing supervisor"
     )
+    assert provision_step["id"] == "provision_signing_supervisor"
     assert "sudo chown 0:0 /opt" in provision_step["run"]
     assert "sudo chmod go-w /opt" in provision_step["run"]
     assert "--git /usr/bin/git" in provision_step["run"]
@@ -2254,6 +2256,10 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         "VERIFY_GENERATED_PROVENANCE_CONCLUSION",
         "VERIFY_GENERATED_PROVENANCE_OUTCOME",
     }
+    assert (
+        failure_package_step["env"]["PROVISION_SIGNING_SUPERVISOR_CONCLUSION"]
+        == "${{ steps.provision_signing_supervisor.conclusion }}"
+    )
     assert "toJSON(steps)" not in json.dumps(failure_package_step)
     assert ".outputs" not in json.dumps(failure_package_step["env"])
     failure_package_command = failure_package_step["run"]
@@ -2482,11 +2488,17 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
         if item.get("name") == "Package failed re-encode diagnostics"
     )
     protected_python = tmp_path / "protected-python"
+    protected_runtime_marker = tmp_path / "protected-runtime-invoked"
     if protected_runtime_state == "executable-remnant":
         protected_python.write_text("#!/bin/sh\nexit 127\n")
         protected_python.chmod(0o755)
     elif protected_runtime_state == "trusted":
-        protected_python = Path(sys.executable)
+        protected_python.write_text(
+            "#!/bin/sh\n"
+            ': > "$PROTECTED_RUNTIME_MARKER"\n'
+            f'exec {shlex.quote(sys.executable)} "$@"\n'
+        )
+        protected_python.chmod(0o755)
     command = step["run"].replace(
         "/opt/axiom-verification/python/bin/python",
         str(protected_python),
@@ -2535,9 +2547,11 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
         "QUEUE_ITEM_ID": "us/statute/42/1437c-1",
         "QUEUE_MANIFEST_SHA256": "manifest-sha",
         "PROVISION_SIGNING_SUPERVISOR_CONCLUSION": provision_conclusion,
+        "PROTECTED_RUNTIME_MARKER": str(protected_runtime_marker),
     }
 
     subprocess.run(["bash", "-c", command], env=env, check=True)
+    assert protected_runtime_marker.exists() is (protected_runtime_state == "trusted")
 
     archive = tmp_path / "targeted-reencode-failure.tar"
     with tarfile.open(archive, mode="r") as bundle:

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2232,6 +2232,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         "COMMIT_REVIEWED_LANE_CHANGES_CONCLUSION",
         "COMMIT_REVIEWED_LANE_CHANGES_OUTCOME",
         "PR_BASE_BRANCH",
+        "PROVISION_SIGNING_SUPERVISOR_CONCLUSION",
         "PUBLISH_LANE_PULL_REQUEST_CONCLUSION",
         "PUBLISH_LANE_PULL_REQUEST_OUTCOME",
         "QUEUE_DISPATCHER_RUN_ID",
@@ -2256,10 +2257,13 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "toJSON(steps)" not in json.dumps(failure_package_step)
     assert ".outputs" not in json.dumps(failure_package_step["env"])
     failure_package_command = failure_package_step["run"]
+    assert "workflow_python=/usr/bin/python3" in failure_package_command
+    assert '"${PROVISION_SIGNING_SUPERVISOR_CONCLUSION:-}" = success' in (
+        failure_package_command
+    )
     assert "workflow_python=/opt/axiom-verification/python/bin/python" in (
         failure_package_command
     )
-    assert "workflow_python=/usr/bin/python3" in failure_package_command
     assert 'test -x "$workflow_python"' in failure_package_command
     assert '"$workflow_python" -I -' in failure_package_command
     assert "read_bounded_regular_file" in failure_package_command
@@ -2456,8 +2460,18 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert steps.index(failure_upload_step) == len(steps) - 1
 
 
+@pytest.mark.parametrize(
+    ("provision_conclusion", "protected_runtime_state"),
+    [
+        ("skipped", "missing"),
+        ("failure", "executable-remnant"),
+        ("success", "trusted"),
+    ],
+)
 def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
     tmp_path: Path,
+    provision_conclusion: str,
+    protected_runtime_state: str,
 ) -> None:
     workflow = yaml.safe_load(
         (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
@@ -2467,9 +2481,15 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
         for item in workflow["jobs"]["encode"]["steps"]
         if item.get("name") == "Package failed re-encode diagnostics"
     )
+    protected_python = tmp_path / "protected-python"
+    if protected_runtime_state == "executable-remnant":
+        protected_python.write_text("#!/bin/sh\nexit 127\n")
+        protected_python.chmod(0o755)
+    elif protected_runtime_state == "trusted":
+        protected_python = Path(sys.executable)
     command = step["run"].replace(
-        "workflow_python=/opt/axiom-verification/python/bin/python",
-        f"workflow_python={tmp_path / 'missing-protected-python'}",
+        "/opt/axiom-verification/python/bin/python",
+        str(protected_python),
     )
     generated = tmp_path / "generated" / "target" / "model"
     generated.mkdir(parents=True)
@@ -2514,6 +2534,7 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
         "QUEUE_ITEM_GENERATION_SHA256": "generation-sha",
         "QUEUE_ITEM_ID": "us/statute/42/1437c-1",
         "QUEUE_MANIFEST_SHA256": "manifest-sha",
+        "PROVISION_SIGNING_SUPERVISOR_CONCLUSION": provision_conclusion,
     }
 
     subprocess.run(["bash", "-c", command], env=env, check=True)

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1530"
+version = "0.2.1531"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1531"
+version = "0.2.1532"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- prefer the protected verification Python runtime only after its provisioning step concludes successfully
- use fixed `/usr/bin/python3` for pre-provision failures and failed provisioning even when an executable remnant exists
- make bounded diagnostic reads standard-library-only while preserving descriptor-relative `O_NOFOLLOW`, regular-file, entry, file, and byte limits
- bump encoder to 0.2.1532 with production provenance intact

## Failure reproduced
Protected runs 30944627207 and 30944803027 failed during immutable RuleSpec base validation before supervisor provisioning. Their diagnostic step then failed with exit 127 because `/opt/axiom-verification/python/bin/python` did not exist, suppressing the failure artifact.

Closes #1391.

## Checks
- `PYTHONPATH=src pytest -q --no-cov tests/test_signing_supervisor.py` (54 passed, 51 skipped before final tests-only evidence commit)
- final focused workflow/runtime/guard suite (13 passed independently)
- `ruff check src/ scripts/ tests/`
- `ruff format --check src/ scripts/ tests/`
- `python -m compileall -q src/axiom_encode scripts`
- production version-provenance guard -> version `0.2.1532`, version commit `9809c143a57f`

## Cycle
Independent review of `2c1009117` found that an interrupted provision could leave an executable but unvalidated protected interpreter. The selection now requires both provisioning conclusion `success` and an executable interpreter; no retry downgrade is performed.

Post-fix review of `9809c143a` found a test-evidence gap. Exact head `56580713b91c7022ec8aac8b8c661f0fc7fb0495` now uses an invocation-recording trusted wrapper and pins the provisioning step ID and GitHub expression. Final independent re-review found no actionable findings; 13 focused tests, Ruff, formatting, compileall, provenance, and diff checks passed.