### PR TITLE
Preserve validator repair candidates across runs

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -2618,6 +2618,10 @@ jobs:
           PR_BASE_BRANCH: ${{ inputs.pr_base_branch }}
           REPAIR_CANDIDATE_CONCLUSION: ${{ steps.repair_candidate.conclusion }}
           REPAIR_CANDIDATE_OUTCOME: ${{ steps.repair_candidate.outcome }}
+          REPAIR_CANDIDATE_PATH: ${{ steps.repair_candidate.outputs.path }}
+          REPAIR_CANDIDATE_RUNNER: ${{ steps.repair_candidate.outputs.runner }}
+          REPAIR_CANDIDATE_RULESPEC_SHA256: ${{ steps.repair_candidate.outputs.rulespec_sha256 }}
+          REPAIR_CANDIDATE_TESTS_SHA256: ${{ steps.repair_candidate.outputs.tests_sha256 }}
           PROVISION_SIGNING_SUPERVISOR_CONCLUSION: ${{ steps.provision_signing_supervisor.conclusion }}
           PUBLISH_LANE_PULL_REQUEST_CONCLUSION: ${{ steps.publish_lane_pull_request.conclusion }}
           PUBLISH_LANE_PULL_REQUEST_OUTCOME: ${{ steps.publish_lane_pull_request.outcome }}
@@ -2657,6 +2661,7 @@ jobs:
           import hashlib
           import json
           import os
+          import re
           import stat
           import sys
           from pathlib import Path
@@ -2901,36 +2906,35 @@ jobs:
               }
           )
           repair_candidate = None
-          repair_candidate_path = guard_root / "repair-candidate.json"
           if os.environ.get("REPAIR_CANDIDATE_CONCLUSION") == "success":
-              try:
-                  repair_candidate_raw = read_bounded_regular_file(
-                      guard_root,
-                      repair_candidate_path,
-                      label="repair candidate evidence",
-                      max_bytes=16 * 1024,
-                  )
-              except UnsafeDiagnosticPathError as exc:
-                  raise SystemExit(str(exc)) from exc
-              repair_candidate_payload = json.loads(repair_candidate_raw)
-              if (
-                  not isinstance(repair_candidate_payload, dict)
-                  or set(repair_candidate_payload)
-                  != {"path", "root", "rulespec_sha256", "runner", "tests_sha256"}
-                  or any(
-                      not isinstance(repair_candidate_payload.get(key), str)
-                      or len(repair_candidate_payload[key]) != 64
-                      or any(character not in "0123456789abcdef" for character in repair_candidate_payload[key])
-                      for key in ("rulespec_sha256", "tests_sha256")
+              consumed_path = os.environ.get("REPAIR_CANDIDATE_PATH", "")
+              consumed_runner = os.environ.get("REPAIR_CANDIDATE_RUNNER", "")
+              consumed_rulespec_sha256 = os.environ.get(
+                  "REPAIR_CANDIDATE_RULESPEC_SHA256", ""
+              )
+              consumed_tests_sha256 = os.environ.get(
+                  "REPAIR_CANDIDATE_TESTS_SHA256", ""
+              )
+              if not consumed_path or not re.fullmatch(
+                  r"[a-z0-9][a-z0-9._:/-]*\.yaml", consumed_path
+              ):
+                  raise SystemExit("repair candidate evidence path is malformed")
+              if not re.fullmatch(r"[a-z0-9][a-z0-9._-]*", consumed_runner):
+                  raise SystemExit("repair candidate evidence runner is malformed")
+              if any(
+                  re.fullmatch(r"[0-9a-f]{64}", digest) is None
+                  for digest in (
+                      consumed_rulespec_sha256,
+                      consumed_tests_sha256,
                   )
               ):
                   raise SystemExit("repair candidate evidence is malformed")
               repair_candidate = {
                   "run_id": os.environ.get("REPAIR_RUN_ID") or None,
-                  "path": repair_candidate_payload["path"],
-                  "runner": repair_candidate_payload["runner"],
-                  "rulespec_sha256": repair_candidate_payload["rulespec_sha256"],
-                  "tests_sha256": repair_candidate_payload["tests_sha256"],
+                  "path": consumed_path,
+                  "runner": consumed_runner,
+                  "rulespec_sha256": consumed_rulespec_sha256,
+                  "tests_sha256": consumed_tests_sha256,
               }
           metadata = {
               "schema": "axiom-encode/failed-reencode-diagnostics/v1",

--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -474,6 +474,8 @@ jobs:
             >> "$GITHUB_OUTPUT"
           echo "path=$(jq -r '.path' "$RUNNER_TEMP/repair-candidate.json")" \
             >> "$GITHUB_OUTPUT"
+          echo "runner=$(jq -r '.runner' "$RUNNER_TEMP/repair-candidate.json")" \
+            >> "$GITHUB_OUTPUT"
           echo "rulespec_sha256=$(jq -r '.rulespec_sha256' "$RUNNER_TEMP/repair-candidate.json")" \
             >> "$GITHUB_OUTPUT"
           echo "tests_sha256=$(jq -r '.tests_sha256' "$RUNNER_TEMP/repair-candidate.json")" \
@@ -1422,6 +1424,10 @@ jobs:
           QUEUE_MANIFEST_SHA256: ${{ inputs.queue_manifest_sha256 }}
           REVIEW_FINDING_PRESENT: ${{ inputs.review_finding != '' }}
           REPAIR_RUN_ID: ${{ inputs.repair_run_id }}
+          REPAIR_CANDIDATE_PATH: ${{ steps.repair_candidate.outputs.path }}
+          REPAIR_CANDIDATE_RUNNER: ${{ steps.repair_candidate.outputs.runner }}
+          REPAIR_CANDIDATE_RULESPEC_SHA256: ${{ steps.repair_candidate.outputs.rulespec_sha256 }}
+          REPAIR_CANDIDATE_TESTS_SHA256: ${{ steps.repair_candidate.outputs.tests_sha256 }}
           REPLACE_RULESPEC_PATH: ${{ inputs.replace_rulespec_path }}
           REPLACE_LEGACY_RULESPEC_PATH: ${{ inputs.replace_legacy_rulespec_path }}
           LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.legacy_exact_dependent_rulespec_path }}
@@ -2352,30 +2358,35 @@ jobs:
 
           repair_run_id = os.environ.get("REPAIR_RUN_ID") or None
           repair_candidate = None
-          repair_candidate_path = (
-              Path(os.environ["RUNNER_TEMP"]) / "repair-candidate.json"
-          )
           if repair_run_id:
-              repair_candidate_payload = json.loads(
-                  repair_candidate_path.read_text(encoding="utf-8")
+              consumed_path = os.environ.get("REPAIR_CANDIDATE_PATH", "")
+              consumed_runner = os.environ.get("REPAIR_CANDIDATE_RUNNER", "")
+              consumed_rulespec_sha256 = os.environ.get(
+                  "REPAIR_CANDIDATE_RULESPEC_SHA256", ""
               )
-              if (
-                  not isinstance(repair_candidate_payload, dict)
-                  or set(repair_candidate_payload)
-                  != {"path", "root", "rulespec_sha256", "runner", "tests_sha256"}
-                  or any(
-                      re.fullmatch(r"[0-9a-f]{64}", str(repair_candidate_payload[key]))
-                      is None
-                      for key in ("rulespec_sha256", "tests_sha256")
+              consumed_tests_sha256 = os.environ.get(
+                  "REPAIR_CANDIDATE_TESTS_SHA256", ""
+              )
+              if not consumed_path or not re.fullmatch(
+                  r"[a-z0-9][a-z0-9._:/-]*\.yaml", consumed_path
+              ):
+                  raise SystemExit("repair candidate evidence path is malformed")
+              if not re.fullmatch(r"[a-z0-9][a-z0-9._-]*", consumed_runner):
+                  raise SystemExit("repair candidate evidence runner is malformed")
+              if any(
+                  re.fullmatch(r"[0-9a-f]{64}", digest) is None
+                  for digest in (
+                      consumed_rulespec_sha256,
+                      consumed_tests_sha256,
                   )
               ):
                   raise SystemExit("repair candidate evidence is malformed")
               repair_candidate = {
                   "run_id": repair_run_id,
-                  "path": repair_candidate_payload["path"],
-                  "runner": repair_candidate_payload["runner"],
-                  "rulespec_sha256": repair_candidate_payload["rulespec_sha256"],
-                  "tests_sha256": repair_candidate_payload["tests_sha256"],
+                  "path": consumed_path,
+                  "runner": consumed_runner,
+                  "rulespec_sha256": consumed_rulespec_sha256,
+                  "tests_sha256": consumed_tests_sha256,
               }
 
           payload = {

--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -923,6 +923,8 @@ jobs:
           REVIEW_FINDING: ${{ inputs.review_finding }}
           REPAIR_CANDIDATE_PATH: ${{ steps.repair_candidate.outputs.path }}
           REPAIR_CANDIDATE_ROOT: ${{ steps.repair_candidate.outputs.root }}
+          REPAIR_CANDIDATE_RULESPEC_SHA256: ${{ steps.repair_candidate.outputs.rulespec_sha256 }}
+          REPAIR_CANDIDATE_TESTS_SHA256: ${{ steps.repair_candidate.outputs.tests_sha256 }}
           REPLACE_RULESPEC_PATH: ${{ inputs.replace_rulespec_path }}
           REPLACE_LEGACY_RULESPEC_PATH: ${{ inputs.replace_legacy_rulespec_path }}
           LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.legacy_exact_dependent_rulespec_path }}
@@ -1039,10 +1041,16 @@ jobs:
               args+=(--review-findings "$review_finding_path")
             fi
             if [ -n "${REPAIR_CANDIDATE_ROOT:-}" ]; then
-              test -n "${REPAIR_CANDIDATE_PATH:-}"
+              test -n "${REPAIR_CANDIDATE_PATH:-}" \
+                && test -n "${REPAIR_CANDIDATE_RULESPEC_SHA256:-}" \
+                && test -n "${REPAIR_CANDIDATE_TESTS_SHA256:-}"
               args+=(
                 --repair-candidate-root "$REPAIR_CANDIDATE_ROOT"
                 --repair-candidate-path "$REPAIR_CANDIDATE_PATH"
+                --repair-candidate-rulespec-sha256 \
+                  "$REPAIR_CANDIDATE_RULESPEC_SHA256"
+                --repair-candidate-tests-sha256 \
+                  "$REPAIR_CANDIDATE_TESTS_SHA256"
               )
             fi
             args+=("$citation")

--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -34,6 +34,10 @@ on:
         description: Validator or independent-review finding to address
         required: false
         type: string
+      repair_run_id:
+        description: Prior failed protected run whose final candidate is replayed as untrusted repair context
+        required: false
+        type: string
       source_bundle_json:
         description: JSON array of additional same-jurisdiction citations to encode as signed atomic imports
         required: false
@@ -344,6 +348,136 @@ jobs:
             "$RULESPEC_REF" "$OPEN_PR" "$PR_BASE_BRANCH"
           git -C axiom-corpus merge-base --is-ancestor HEAD refs/remotes/origin/main
           git -C axiom-rules-engine merge-base --is-ancestor HEAD refs/remotes/origin/main
+
+      - name: Resolve trusted prior-run repair candidate
+        id: repair_candidate
+        if: ${{ inputs.repair_run_id != '' }}
+        env:
+          CITATION: ${{ inputs.citation }}
+          CORPUS_REF: ${{ inputs.corpus_ref }}
+          COUNTRY: ${{ inputs.country }}
+          DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
+          EXISTING_SIGNED_IMPORTS_JSON: ${{ inputs.existing_signed_imports_json }}
+          GH_TOKEN: ${{ github.token }}
+          LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.legacy_exact_dependent_rulespec_path }}
+          LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON: ${{ inputs.legacy_retained_successor_rulespec_paths_json }}
+          QUEUE_ID: ${{ inputs.queue_id }}
+          REPAIR_RUN_ID: ${{ inputs.repair_run_id }}
+          REPLACE_LEGACY_RULESPEC_PATH: ${{ inputs.replace_legacy_rulespec_path }}
+          REPLACE_RULESPEC_PATH: ${{ inputs.replace_rulespec_path }}
+          RULES_ENGINE_REF: ${{ inputs.rules_engine_ref }}
+          RULESPEC_REF: ${{ inputs.rulespec_ref }}
+          SECOND_DEPENDENT_CITATION: ${{ inputs.second_dependent_citation }}
+          SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.second_legacy_exact_dependent_rulespec_path }}
+          SOURCE_BUNDLE_JSON: ${{ inputs.source_bundle_json }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$REPAIR_RUN_ID" =~ ^[0-9]+$ ]] || \
+             [ "$REPAIR_RUN_ID" = "$GITHUB_RUN_ID" ]; then
+            echo "repair_run_id must identify a different decimal workflow run" >&2
+            exit 1
+          fi
+          if [ -z "$REPLACE_RULESPEC_PATH" ] || \
+             [ -n "$REPLACE_LEGACY_RULESPEC_PATH" ] || \
+             [ -n "$LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" ] || \
+             [ -n "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" ] || \
+             [ -n "$DEPENDENT_CITATION" ] || \
+             [ -n "$SECOND_DEPENDENT_CITATION" ] || \
+             [ -n "$QUEUE_ID" ] || \
+             ! jq -e 'type == "array" and length == 0' \
+               <<< "${SOURCE_BUNDLE_JSON:-[]}" > /dev/null || \
+             ! jq -e 'type == "array" and length == 0' \
+               <<< "${EXISTING_SIGNED_IMPORTS_JSON:-[]}" > /dev/null || \
+             ! jq -e 'type == "array" and length == 0' \
+               <<< "${LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON:-[]}" \
+               > /dev/null; then
+            echo "repair replay is limited to one non-legacy target without bundles, imports, dependents, or queue authorization" >&2
+            exit 1
+          fi
+
+          api_version="2026-03-10"
+          gh api \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: $api_version" \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$REPAIR_RUN_ID" \
+            > "$RUNNER_TEMP/repair-run.json"
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --argjson run_id "$REPAIR_RUN_ID" '
+              .id == $run_id
+              and .status == "completed"
+              and .conclusion == "failure"
+              and .event == "workflow_dispatch"
+              and .head_branch == "main"
+              and .run_attempt == 1
+              and .repository.full_name == $repository
+              and .path == ".github/workflows/targeted-signed-reencode.yml"
+            ' "$RUNNER_TEMP/repair-run.json" > /dev/null
+          repair_encoder_commit="$(jq -er '.head_sha' \
+            "$RUNNER_TEMP/repair-run.json")"
+          git -C axiom-encode merge-base --is-ancestor \
+            "$repair_encoder_commit" "$GITHUB_SHA"
+
+          gh api --paginate --slurp \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: $api_version" \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$REPAIR_RUN_ID/jobs?filter=all&per_page=100" \
+            > "$RUNNER_TEMP/repair-jobs.json"
+          jq -e '
+            [.[].jobs[] | select(
+              .name == "Queue protected signed RuleSpec re-encode"
+              and .run_attempt == 1
+              and .status == "completed"
+              and .conclusion == "failure"
+            )] | length == 1
+          ' "$RUNNER_TEMP/repair-jobs.json" > /dev/null
+
+          gh api \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: $api_version" \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$REPAIR_RUN_ID/artifacts?per_page=100" \
+            > "$RUNNER_TEMP/repair-artifacts.json"
+          artifact_name="targeted-reencode-failure-${REPAIR_RUN_ID}-1"
+          jq -e --arg name "$artifact_name" --argjson run_id "$REPAIR_RUN_ID" '
+            [.artifacts[] | select(
+              .name == $name
+              and .expired == false
+              and .workflow_run.id == $run_id
+            )] | length == 1
+          ' "$RUNNER_TEMP/repair-artifacts.json" > /dev/null
+          repair_download="$RUNNER_TEMP/repair-download"
+          mkdir "$repair_download"
+          gh run download "$REPAIR_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "$artifact_name" \
+            --dir "$repair_download"
+          repair_archive="$repair_download/targeted-reencode-failure.tar"
+          test -f "$repair_archive" && test ! -L "$repair_archive"
+          python3 axiom-encode/scripts/extract_repair_candidate.py \
+            "$repair_archive" "$RUNNER_TEMP/repair-candidate" \
+            --citation "$CITATION" \
+            --country "$COUNTRY" \
+            --encoder-commit "$repair_encoder_commit" \
+            --corpus-ref "$CORPUS_REF" \
+            --rules-engine-ref "$RULES_ENGINE_REF" \
+            --rulespec-ref "$RULESPEC_REF" \
+            --replace-rulespec-path "$REPLACE_RULESPEC_PATH" \
+            --workflow-run-id "$REPAIR_RUN_ID" \
+            > "$RUNNER_TEMP/repair-candidate.json"
+          jq -e '
+            (.root | type == "string" and length > 0)
+            and (.path | type == "string" and length > 0)
+            and (.rulespec_sha256 | test("^[0-9a-f]{64}$"))
+            and (.tests_sha256 | test("^[0-9a-f]{64}$"))
+          ' "$RUNNER_TEMP/repair-candidate.json" > /dev/null
+          echo "root=$(jq -r '.root' "$RUNNER_TEMP/repair-candidate.json")" \
+            >> "$GITHUB_OUTPUT"
+          echo "path=$(jq -r '.path' "$RUNNER_TEMP/repair-candidate.json")" \
+            >> "$GITHUB_OUTPUT"
+          echo "rulespec_sha256=$(jq -r '.rulespec_sha256' "$RUNNER_TEMP/repair-candidate.json")" \
+            >> "$GITHUB_OUTPUT"
+          echo "tests_sha256=$(jq -r '.tests_sha256' "$RUNNER_TEMP/repair-candidate.json")" \
+            >> "$GITHUB_OUTPUT"
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
@@ -787,6 +921,8 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CITATION: ${{ inputs.citation }}
           REVIEW_FINDING: ${{ inputs.review_finding }}
+          REPAIR_CANDIDATE_PATH: ${{ steps.repair_candidate.outputs.path }}
+          REPAIR_CANDIDATE_ROOT: ${{ steps.repair_candidate.outputs.root }}
           REPLACE_RULESPEC_PATH: ${{ inputs.replace_rulespec_path }}
           REPLACE_LEGACY_RULESPEC_PATH: ${{ inputs.replace_legacy_rulespec_path }}
           LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.legacy_exact_dependent_rulespec_path }}
@@ -901,6 +1037,13 @@ jobs:
               review_finding_path="$review_finding_dir/review-finding.txt"
               printf '%s\n' "$review_finding" > "$review_finding_path"
               args+=(--review-findings "$review_finding_path")
+            fi
+            if [ -n "${REPAIR_CANDIDATE_ROOT:-}" ]; then
+              test -n "${REPAIR_CANDIDATE_PATH:-}"
+              args+=(
+                --repair-candidate-root "$REPAIR_CANDIDATE_ROOT"
+                --repair-candidate-path "$REPAIR_CANDIDATE_PATH"
+              )
             fi
             args+=("$citation")
 
@@ -1270,6 +1413,7 @@ jobs:
           QUEUE_ITEM_GENERATION_SHA256: ${{ inputs.queue_item_generation_sha256 }}
           QUEUE_MANIFEST_SHA256: ${{ inputs.queue_manifest_sha256 }}
           REVIEW_FINDING_PRESENT: ${{ inputs.review_finding != '' }}
+          REPAIR_RUN_ID: ${{ inputs.repair_run_id }}
           REPLACE_RULESPEC_PATH: ${{ inputs.replace_rulespec_path }}
           REPLACE_LEGACY_RULESPEC_PATH: ${{ inputs.replace_legacy_rulespec_path }}
           LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.legacy_exact_dependent_rulespec_path }}
@@ -2188,6 +2332,7 @@ jobs:
           import hashlib
           import json
           import os
+          import re
           import subprocess
           import sys
           from pathlib import Path
@@ -2196,6 +2341,34 @@ jobs:
               return subprocess.check_output(
                   ["git", "-C", path, "rev-parse", "HEAD"], text=True
               ).strip()
+
+          repair_run_id = os.environ.get("REPAIR_RUN_ID") or None
+          repair_candidate = None
+          repair_candidate_path = (
+              Path(os.environ["RUNNER_TEMP"]) / "repair-candidate.json"
+          )
+          if repair_run_id:
+              repair_candidate_payload = json.loads(
+                  repair_candidate_path.read_text(encoding="utf-8")
+              )
+              if (
+                  not isinstance(repair_candidate_payload, dict)
+                  or set(repair_candidate_payload)
+                  != {"path", "root", "rulespec_sha256", "runner", "tests_sha256"}
+                  or any(
+                      re.fullmatch(r"[0-9a-f]{64}", str(repair_candidate_payload[key]))
+                      is None
+                      for key in ("rulespec_sha256", "tests_sha256")
+                  )
+              ):
+                  raise SystemExit("repair candidate evidence is malformed")
+              repair_candidate = {
+                  "run_id": repair_run_id,
+                  "path": repair_candidate_payload["path"],
+                  "runner": repair_candidate_payload["runner"],
+                  "rulespec_sha256": repair_candidate_payload["rulespec_sha256"],
+                  "tests_sha256": repair_candidate_payload["tests_sha256"],
+              }
 
           payload = {
               "schema": "axiom-encode/targeted-reencode-artifact/v1",
@@ -2241,6 +2414,8 @@ jobs:
                   )
               ),
               "pr_base_branch": os.environ["PR_BASE_BRANCH"],
+              "repair_candidate": repair_candidate,
+              "repair_run_id": os.environ.get("REPAIR_RUN_ID") or None,
               "queue_id": os.environ.get("QUEUE_ID") or None,
               "queue_item_id": os.environ.get("QUEUE_ITEM_ID") or None,
               "queue_item_generation_sha256": (
@@ -2312,6 +2487,7 @@ jobs:
           QUEUE_ITEM_ID: ${{ inputs.queue_item_id }}
           QUEUE_ITEM_GENERATION_SHA256: ${{ inputs.queue_item_generation_sha256 }}
           QUEUE_MANIFEST_SHA256: ${{ inputs.queue_manifest_sha256 }}
+          REPAIR_RUN_ID: ${{ inputs.repair_run_id }}
           RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
         run: |
           set -euo pipefail
@@ -2342,6 +2518,7 @@ jobs:
             "Exact legacy dependent: \`${LEGACY_EXACT_DEPENDENT_RULESPEC_PATH:-n/a}\`" \
             "Second exact legacy dependent: \`${SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH:-n/a}\`" \
             "Retained successor legacy paths: \`${LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON:-[]}\`" \
+            "Repair candidate run: \`${REPAIR_RUN_ID:-n/a}\`" \
             "Base commit: \`${RULESPEC_REF}\`" \
             "Base branch: \`${PR_BASE_BRANCH}\`" \
             "Queue item: \`${QUEUE_ID:-ad-hoc}/${QUEUE_ITEM_ID:-ad-hoc}\`" \
@@ -2420,6 +2597,8 @@ jobs:
           COMMIT_REVIEWED_LANE_CHANGES_CONCLUSION: ${{ steps.commit_reviewed_lane_changes.conclusion }}
           COMMIT_REVIEWED_LANE_CHANGES_OUTCOME: ${{ steps.commit_reviewed_lane_changes.outcome }}
           PR_BASE_BRANCH: ${{ inputs.pr_base_branch }}
+          REPAIR_CANDIDATE_CONCLUSION: ${{ steps.repair_candidate.conclusion }}
+          REPAIR_CANDIDATE_OUTCOME: ${{ steps.repair_candidate.outcome }}
           PROVISION_SIGNING_SUPERVISOR_CONCLUSION: ${{ steps.provision_signing_supervisor.conclusion }}
           PUBLISH_LANE_PULL_REQUEST_CONCLUSION: ${{ steps.publish_lane_pull_request.conclusion }}
           PUBLISH_LANE_PULL_REQUEST_OUTCOME: ${{ steps.publish_lane_pull_request.outcome }}
@@ -2428,6 +2607,7 @@ jobs:
           QUEUE_ITEM_GENERATION_SHA256: ${{ inputs.queue_item_generation_sha256 }}
           QUEUE_ITEM_ID: ${{ inputs.queue_item_id }}
           QUEUE_MANIFEST_SHA256: ${{ inputs.queue_manifest_sha256 }}
+          REPAIR_RUN_ID: ${{ inputs.repair_run_id }}
           REPLACE_LEGACY_RULESPEC_PATH: ${{ inputs.replace_legacy_rulespec_path }}
           REPLACE_RULESPEC_PATH: ${{ inputs.replace_rulespec_path }}
           RULES_ENGINE_REF: ${{ inputs.rules_engine_ref }}
@@ -2670,6 +2850,7 @@ jobs:
               ),
               "package_exact_generated_changes": "PACKAGE_EXACT_GENERATED_CHANGES",
               "publish_lane_pull_request": "PUBLISH_LANE_PULL_REQUEST",
+              "repair_candidate": "REPAIR_CANDIDATE",
               "upload_signed_reencode_artifact": (
                   "UPLOAD_SIGNED_REENCODE_ARTIFACT"
               ),
@@ -2700,6 +2881,38 @@ jobs:
                   if len(Path(item["path"]).parts) > 1
               }
           )
+          repair_candidate = None
+          repair_candidate_path = guard_root / "repair-candidate.json"
+          if os.environ.get("REPAIR_CANDIDATE_CONCLUSION") == "success":
+              try:
+                  repair_candidate_raw = read_bounded_regular_file(
+                      guard_root,
+                      repair_candidate_path,
+                      label="repair candidate evidence",
+                      max_bytes=16 * 1024,
+                  )
+              except UnsafeDiagnosticPathError as exc:
+                  raise SystemExit(str(exc)) from exc
+              repair_candidate_payload = json.loads(repair_candidate_raw)
+              if (
+                  not isinstance(repair_candidate_payload, dict)
+                  or set(repair_candidate_payload)
+                  != {"path", "root", "rulespec_sha256", "runner", "tests_sha256"}
+                  or any(
+                      not isinstance(repair_candidate_payload.get(key), str)
+                      or len(repair_candidate_payload[key]) != 64
+                      or any(character not in "0123456789abcdef" for character in repair_candidate_payload[key])
+                      for key in ("rulespec_sha256", "tests_sha256")
+                  )
+              ):
+                  raise SystemExit("repair candidate evidence is malformed")
+              repair_candidate = {
+                  "run_id": os.environ.get("REPAIR_RUN_ID") or None,
+                  "path": repair_candidate_payload["path"],
+                  "runner": repair_candidate_payload["runner"],
+                  "rulespec_sha256": repair_candidate_payload["rulespec_sha256"],
+                  "tests_sha256": repair_candidate_payload["tests_sha256"],
+              }
           metadata = {
               "schema": "axiom-encode/failed-reencode-diagnostics/v1",
               "citation": os.environ["CITATION"],
@@ -2741,6 +2954,8 @@ jobs:
               or None,
               "replace_rulespec_path": os.environ.get("REPLACE_RULESPEC_PATH")
               or None,
+              "repair_candidate": repair_candidate,
+              "repair_run_id": os.environ.get("REPAIR_RUN_ID") or None,
               "rules_engine_ref": os.environ["RULES_ENGINE_REF"],
               "rulespec_ref": os.environ["RULESPEC_REF"],
               "second_dependent_citation": os.environ.get(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1533"
+version = "0.2.1534"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1535"
+version = "0.2.1536"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1534"
+version = "0.2.1535"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1532"
+version = "0.2.1533"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/extract_repair_candidate.py
+++ b/scripts/extract_repair_candidate.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Verify and extract one preserved targeted-reencode repair candidate."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import tarfile
+from pathlib import Path, PurePosixPath
+
+SCHEMA = "axiom-encode/failed-reencode-diagnostics/v1"
+ATOMIC_ROOTS = frozenset(
+    {"guidance", "manuals", "policies", "programs", "regulations", "statutes"}
+)
+MAX_METADATA_BYTES = 4 * 1024 * 1024
+MAX_CANDIDATE_BYTES = 2 * 1024 * 1024
+MAX_ARCHIVE_MEMBERS = 8192
+SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
+RUNNER_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+
+
+def _normalized_member_name(raw_name: str) -> str:
+    name = raw_name.removeprefix("./")
+    path = PurePosixPath(name)
+    if (
+        not name
+        or path.is_absolute()
+        or any(part in {"", ".", ".."} for part in path.parts)
+    ):
+        raise ValueError("repair artifact contains an unsafe member path")
+    return path.as_posix()
+
+
+def _member_index(bundle: tarfile.TarFile) -> dict[str, tarfile.TarInfo]:
+    index: dict[str, tarfile.TarInfo] = {}
+    for member_number, member in enumerate(bundle, start=1):
+        if member_number > MAX_ARCHIVE_MEMBERS:
+            raise ValueError("repair artifact exceeds its member limit")
+        name = _normalized_member_name(member.name)
+        if name in index:
+            raise ValueError("repair artifact contains a duplicate member path")
+        index[name] = member
+    return index
+
+
+def _regular_member(
+    members: dict[str, tarfile.TarInfo], expected: str
+) -> tarfile.TarInfo:
+    member = members.get(expected)
+    if member is None or not member.isfile():
+        raise ValueError(f"repair artifact must contain one regular {expected}")
+    return member
+
+
+def _read_member(
+    bundle: tarfile.TarFile,
+    member: tarfile.TarInfo,
+    *,
+    max_bytes: int,
+) -> bytes:
+    if member.size < 0 or member.size > max_bytes:
+        raise ValueError(
+            f"repair artifact member exceeds its size limit: {member.name}"
+        )
+    source = bundle.extractfile(member)
+    if source is None:
+        raise ValueError(f"repair artifact member is unreadable: {member.name}")
+    data = source.read(max_bytes + 1)
+    if len(data) != member.size or len(data) > max_bytes:
+        raise ValueError(
+            f"repair artifact member size changed while reading: {member.name}"
+        )
+    return data
+
+
+def _metadata_file_map(metadata: dict[str, object]) -> dict[str, dict[str, object]]:
+    raw_files = metadata.get("files")
+    if not isinstance(raw_files, list):
+        raise ValueError("repair metadata files must be an array")
+    files: dict[str, dict[str, object]] = {}
+    for raw_entry in raw_files:
+        if not isinstance(raw_entry, dict):
+            raise ValueError("repair metadata file entries must be objects")
+        raw_path = raw_entry.get("path")
+        digest = raw_entry.get("sha256")
+        size = raw_entry.get("size")
+        if (
+            not isinstance(raw_path, str)
+            or _normalized_member_name(raw_path) != raw_path
+            or not isinstance(digest, str)
+            or SHA256_PATTERN.fullmatch(digest) is None
+            or not isinstance(size, int)
+            or isinstance(size, bool)
+            or size < 0
+            or raw_path in files
+        ):
+            raise ValueError("repair metadata contains an invalid file entry")
+        files[raw_path] = raw_entry
+    return files
+
+
+def _verified_generated_file(
+    bundle: tarfile.TarFile,
+    members: dict[str, tarfile.TarInfo],
+    files: dict[str, dict[str, object]],
+    relative_path: str,
+) -> bytes:
+    entry = files.get(relative_path)
+    if entry is None:
+        raise ValueError(f"repair metadata does not bind {relative_path}")
+    member = _regular_member(members, f"generated/{relative_path}")
+    data = _read_member(bundle, member, max_bytes=MAX_CANDIDATE_BYTES)
+    if (
+        len(data) != entry["size"]
+        or hashlib.sha256(data).hexdigest() != entry["sha256"]
+    ):
+        raise ValueError(f"repair candidate digest mismatch: {relative_path}")
+    return data
+
+
+def _expected_module_path(country: str, replace_rulespec_path: str) -> str:
+    path = PurePosixPath(replace_rulespec_path)
+    if (
+        path.is_absolute()
+        or len(path.parts) < 3
+        or path.parts[0] != country
+        or path.parts[1] not in ATOMIC_ROOTS
+        or path.suffix != ".yaml"
+        or path.name.endswith(".test.yaml")
+        or any(part in {"", ".", ".."} for part in path.parts)
+    ):
+        raise ValueError("replace RuleSpec path is not canonical for the country")
+    return PurePosixPath(*path.parts[1:]).as_posix()
+
+
+def extract_candidate(args: argparse.Namespace) -> dict[str, str]:
+    destination = Path(args.destination).resolve()
+    destination.mkdir(parents=True, exist_ok=False)
+    expected_fields = {
+        "citation": args.citation,
+        "country": args.country,
+        "encoder_commit": args.encoder_commit,
+        "corpus_ref": args.corpus_ref,
+        "rules_engine_ref": args.rules_engine_ref,
+        "rulespec_ref": args.rulespec_ref,
+        "replace_rulespec_path": args.replace_rulespec_path,
+        "workflow_run_id": args.workflow_run_id,
+    }
+    expected_module = _expected_module_path(
+        args.country,
+        args.replace_rulespec_path,
+    )
+
+    with tarfile.open(args.archive, mode="r:") as bundle:
+        members = _member_index(bundle)
+        metadata_member = _regular_member(members, "metadata.json")
+        metadata = json.loads(
+            _read_member(
+                bundle,
+                metadata_member,
+                max_bytes=MAX_METADATA_BYTES,
+            ).decode("utf-8", errors="strict")
+        )
+        if not isinstance(metadata, dict) or metadata.get("schema") != SCHEMA:
+            raise ValueError("repair artifact metadata schema is invalid")
+        for field, expected in expected_fields.items():
+            if metadata.get(field) != expected:
+                raise ValueError(f"repair artifact metadata mismatch: {field}")
+        if metadata.get("workflow_run_attempt") != 1:
+            raise ValueError("repair artifact must come from workflow attempt 1")
+        if metadata.get("failed_steps") != ["encode_apply"]:
+            raise ValueError(
+                "repair artifact is not an encode/apply validation failure"
+            )
+        if metadata.get("generated_lanes") != ["target"]:
+            raise ValueError("repair artifact must contain only the target lane")
+
+        files = _metadata_file_map(metadata)
+        repair_pattern = re.compile(
+            rf"target/({RUNNER_PATTERN.pattern})/{re.escape(expected_module[:-5])}\.repair\.json"
+        )
+        repair_matches = [
+            (path, repair_pattern.fullmatch(path))
+            for path in files
+            if repair_pattern.fullmatch(path) is not None
+        ]
+        if len(repair_matches) != 1:
+            raise ValueError("repair artifact must bind one final repair manifest")
+        repair_path, repair_match = repair_matches[0]
+        assert repair_match is not None
+        runner = repair_match.group(1)
+        repair_payload = json.loads(
+            _verified_generated_file(bundle, members, files, repair_path).decode(
+                "utf-8", errors="strict"
+            )
+        )
+        if (
+            not isinstance(repair_payload, dict)
+            or repair_payload.get("schema_version") != "axiom-encode/repair-manifest/v1"
+            or repair_payload.get("citation") != args.citation
+            or repair_payload.get("runner") != runner
+        ):
+            raise ValueError("final repair manifest identity is invalid")
+
+        candidate_path = f"target/{runner}/{expected_module}"
+        test_path = candidate_path.removesuffix(".yaml") + ".test.yaml"
+        candidate = _verified_generated_file(
+            bundle, members, files, candidate_path
+        )
+        tests = _verified_generated_file(bundle, members, files, test_path)
+
+    root = destination / runner
+    output = root / expected_module
+    test_output = output.with_suffix(".test.yaml")
+    output.parent.mkdir(parents=True, exist_ok=False)
+    for path, data in ((output, candidate), (test_output, tests)):
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            with os.fdopen(descriptor, "wb", closefd=True) as target:
+                descriptor = -1
+                target.write(data)
+                target.flush()
+                os.fsync(target.fileno())
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+
+    return {
+        "root": str(root),
+        "path": expected_module,
+        "rulespec_sha256": hashlib.sha256(candidate).hexdigest(),
+        "tests_sha256": hashlib.sha256(tests).hexdigest(),
+        "runner": runner,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("archive", type=Path)
+    parser.add_argument("destination", type=Path)
+    parser.add_argument("--citation", required=True)
+    parser.add_argument("--country", required=True)
+    parser.add_argument("--encoder-commit", required=True)
+    parser.add_argument("--corpus-ref", required=True)
+    parser.add_argument("--rules-engine-ref", required=True)
+    parser.add_argument("--rulespec-ref", required=True)
+    parser.add_argument("--replace-rulespec-path", required=True)
+    parser.add_argument("--workflow-run-id", required=True)
+    return parser
+
+
+def main() -> int:
+    print(json.dumps(extract_candidate(_parser().parse_args()), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/extract_repair_candidate.py
+++ b/scripts/extract_repair_candidate.py
@@ -186,10 +186,10 @@ def extract_candidate(args: argparse.Namespace) -> dict[str, str]:
         if not isinstance(metadata, dict) or metadata.get("schema") != SCHEMA:
             raise ValueError("repair artifact metadata schema is invalid")
         for field, expected in expected_fields.items():
-            if metadata.get(field) != expected:
+            if field not in metadata or metadata[field] != expected:
                 raise ValueError(f"repair artifact metadata mismatch: {field}")
         for field, expected in SINGLE_TARGET_MODE_FIELDS.items():
-            if metadata.get(field) != expected:
+            if field not in metadata or metadata[field] != expected:
                 raise ValueError(
                     f"repair artifact is not a compatible single-target run: {field}"
                 )

--- a/scripts/extract_repair_candidate.py
+++ b/scripts/extract_repair_candidate.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import os
 import re
+import runpy
 import tarfile
 from pathlib import Path, PurePosixPath
 
@@ -16,10 +17,28 @@ ATOMIC_ROOTS = frozenset(
     {"guidance", "manuals", "policies", "programs", "regulations", "statutes"}
 )
 MAX_METADATA_BYTES = 4 * 1024 * 1024
-MAX_CANDIDATE_BYTES = 2 * 1024 * 1024
 MAX_ARCHIVE_MEMBERS = 8192
 SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
 RUNNER_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+CONTRACT = runpy.run_path(
+    Path(__file__).parents[1] / "src/axiom_encode/repair_candidate_contract.py"
+)
+MAX_CANDIDATE_BYTES = CONTRACT["VALIDATION_RETRY_CANDIDATE_MAX_FILE_BYTES"]
+SINGLE_TARGET_MODE_FIELDS = {
+    "dependent_citation": None,
+    "existing_signed_imports_input": "[]",
+    "legacy_exact_dependent_rulespec_path": None,
+    "legacy_retained_successor_rulespec_paths_input": "[]",
+    "queue_dispatcher_run_id": None,
+    "queue_id": None,
+    "queue_item_generation_sha256": None,
+    "queue_item_id": None,
+    "queue_manifest_sha256": None,
+    "replace_legacy_rulespec_path": None,
+    "second_dependent_citation": None,
+    "second_legacy_exact_dependent_rulespec_path": None,
+    "source_bundle_input": "[]",
+}
 
 
 def _normalized_member_name(raw_name: str) -> str:
@@ -169,6 +188,11 @@ def extract_candidate(args: argparse.Namespace) -> dict[str, str]:
         for field, expected in expected_fields.items():
             if metadata.get(field) != expected:
                 raise ValueError(f"repair artifact metadata mismatch: {field}")
+        for field, expected in SINGLE_TARGET_MODE_FIELDS.items():
+            if metadata.get(field) != expected:
+                raise ValueError(
+                    f"repair artifact is not a compatible single-target run: {field}"
+                )
         if metadata.get("workflow_run_attempt") != 1:
             raise ValueError("repair artifact must come from workflow attempt 1")
         if metadata.get("failed_steps") != ["encode_apply"]:
@@ -207,9 +231,7 @@ def extract_candidate(args: argparse.Namespace) -> dict[str, str]:
 
         candidate_path = f"target/{runner}/{expected_module}"
         test_path = candidate_path.removesuffix(".yaml") + ".test.yaml"
-        candidate = _verified_generated_file(
-            bundle, members, files, candidate_path
-        )
+        candidate = _verified_generated_file(bundle, members, files, candidate_path)
         tests = _verified_generated_file(bundle, members, files, test_path)
 
     root = destination / runner

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1535"
+__version__ = "0.2.1536"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1532"
+__version__ = "0.2.1533"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1533"
+__version__ = "0.2.1534"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1534"
+__version__ = "0.2.1535"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -2226,6 +2226,14 @@ def main():
         ),
     )
     encode_parser.add_argument(
+        "--repair-candidate-rulespec-sha256",
+        help="Expected SHA-256 of the preserved repair candidate RuleSpec",
+    )
+    encode_parser.add_argument(
+        "--repair-candidate-tests-sha256",
+        help="Expected SHA-256 of the preserved repair candidate companion tests",
+    )
+    encode_parser.add_argument(
         "--policyengine-rule-hint",
         dest="policyengine_rule_hint",
         default=None,
@@ -25185,13 +25193,26 @@ def _load_initial_validation_retry_candidate(
 
     raw_root = getattr(args, "repair_candidate_root", None)
     raw_relative_output = getattr(args, "repair_candidate_path", None)
-    if (raw_root is None) != (raw_relative_output is None):
-        raise ValueError(
-            "encode --repair-candidate-root and --repair-candidate-path must be "
-            "supplied together"
-        )
-    if raw_root is None:
+    expected_rulespec_sha256 = getattr(args, "repair_candidate_rulespec_sha256", None)
+    expected_tests_sha256 = getattr(args, "repair_candidate_tests_sha256", None)
+    identity = (
+        raw_root,
+        raw_relative_output,
+        expected_rulespec_sha256,
+        expected_tests_sha256,
+    )
+    if all(value is None for value in identity):
         return None
+    if any(value is None for value in identity):
+        raise ValueError(
+            "encode repair candidate root, path, RuleSpec SHA-256, and tests "
+            "SHA-256 must be supplied together"
+        )
+    if any(
+        not isinstance(digest, str) or re.fullmatch(r"[0-9a-f]{64}", digest) is None
+        for digest in (expected_rulespec_sha256, expected_tests_sha256)
+    ):
+        raise ValueError("encode repair candidate SHA-256 values must be lowercase hex")
 
     generated_root = Path(os.path.abspath(Path(raw_root)))
     relative_output = Path(raw_relative_output)
@@ -25222,24 +25243,27 @@ def _load_initial_validation_retry_candidate(
         )
 
     output_file = generated_root / relative_output
-    rulespec = read_bounded_regular_file(
+    rulespec_bytes = read_bounded_regular_file(
         generated_root,
         output_file,
         label="preserved validator-rejected RuleSpec",
         max_bytes=VALIDATION_RETRY_CANDIDATE_MAX_FILE_BYTES,
-    ).decode("utf-8", errors="strict")
-    test_file = generated_root / _rulespec_test_path(relative_output)
-    tests = (
-        read_bounded_regular_file(
-            generated_root,
-            test_file,
-            label="preserved validator-rejected companion tests",
-            max_bytes=VALIDATION_RETRY_CANDIDATE_MAX_FILE_BYTES,
-        ).decode("utf-8", errors="strict")
-        if test_file.exists() or test_file.is_symlink()
-        else None
     )
-    return ValidationRetryCandidate(rulespec=rulespec, tests=tests)
+    if hashlib.sha256(rulespec_bytes).hexdigest() != expected_rulespec_sha256:
+        raise ValueError("preserved repair candidate RuleSpec SHA-256 mismatch")
+    test_file = generated_root / _rulespec_test_path(relative_output)
+    tests_bytes = read_bounded_regular_file(
+        generated_root,
+        test_file,
+        label="preserved validator-rejected companion tests",
+        max_bytes=VALIDATION_RETRY_CANDIDATE_MAX_FILE_BYTES,
+    )
+    if hashlib.sha256(tests_bytes).hexdigest() != expected_tests_sha256:
+        raise ValueError("preserved repair candidate tests SHA-256 mismatch")
+    return ValidationRetryCandidate(
+        rulespec=rulespec_bytes.decode("utf-8", errors="strict"),
+        tests=tests_bytes.decode("utf-8", errors="strict"),
+    )
 
 
 def _latest_validation_retry_candidate(

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -2210,6 +2210,22 @@ def main():
         ),
     )
     encode_parser.add_argument(
+        "--repair-candidate-root",
+        type=Path,
+        help=(
+            "Root containing one preserved validator-rejected generated candidate; "
+            "requires --repair-candidate-path"
+        ),
+    )
+    encode_parser.add_argument(
+        "--repair-candidate-path",
+        type=Path,
+        help=(
+            "Canonical RuleSpec path relative to --repair-candidate-root to use "
+            "as untrusted cross-run repair context"
+        ),
+    )
+    encode_parser.add_argument(
         "--policyengine-rule-hint",
         dest="policyengine_rule_hint",
         default=None,
@@ -25162,6 +25178,70 @@ def _capture_validation_retry_candidate(
     return ValidationRetryCandidate(rulespec=rulespec, tests=tests)
 
 
+def _load_initial_validation_retry_candidate(
+    args: Any,
+) -> ValidationRetryCandidate | None:
+    """Load one explicitly bounded rejected candidate for cross-run repair."""
+
+    raw_root = getattr(args, "repair_candidate_root", None)
+    raw_relative_output = getattr(args, "repair_candidate_path", None)
+    if (raw_root is None) != (raw_relative_output is None):
+        raise ValueError(
+            "encode --repair-candidate-root and --repair-candidate-path must be "
+            "supplied together"
+        )
+    if raw_root is None:
+        return None
+
+    generated_root = Path(os.path.abspath(Path(raw_root)))
+    relative_output = Path(raw_relative_output)
+    if (
+        relative_output.is_absolute()
+        or not relative_output.parts
+        or any(part in {"", ".", ".."} for part in relative_output.parts)
+    ):
+        raise ValueError("encode --repair-candidate-path must be a safe relative path")
+    parts = relative_output.parts
+    if parts[0] in RULESPEC_ATOMIC_MODULE_ROOTS:
+        module_parts = parts
+    elif (
+        len(parts) >= 2
+        and re.fullmatch(r"[a-z]{2}(?:-[a-z0-9_]+)*", parts[0]) is not None
+        and parts[1] in RULESPEC_ATOMIC_MODULE_ROOTS
+    ):
+        module_parts = parts[1:]
+    else:
+        module_parts = ()
+    if (
+        len(module_parts) < 2
+        or relative_output.suffix != RULESPEC_FILE_SUFFIX
+        or relative_output.name.endswith(RULESPEC_TEST_FILE_SUFFIX)
+    ):
+        raise ValueError(
+            "encode --repair-candidate-path must name a canonical RuleSpec module"
+        )
+
+    output_file = generated_root / relative_output
+    rulespec = read_bounded_regular_file(
+        generated_root,
+        output_file,
+        label="preserved validator-rejected RuleSpec",
+        max_bytes=VALIDATION_RETRY_CANDIDATE_MAX_FILE_BYTES,
+    ).decode("utf-8", errors="strict")
+    test_file = generated_root / _rulespec_test_path(relative_output)
+    tests = (
+        read_bounded_regular_file(
+            generated_root,
+            test_file,
+            label="preserved validator-rejected companion tests",
+            max_bytes=VALIDATION_RETRY_CANDIDATE_MAX_FILE_BYTES,
+        ).decode("utf-8", errors="strict")
+        if test_file.exists() or test_file.is_symlink()
+        else None
+    )
+    return ValidationRetryCandidate(rulespec=rulespec, tests=tests)
+
+
 def _latest_validation_retry_candidate(
     prior_attempts: Sequence[_FailedEncodeAttempt],
 ) -> ValidationRetryCandidate | None:
@@ -27087,6 +27167,7 @@ def _cmd_encode_with_authoritative_rulespec_roots(
             backend=args.backend,
             model=config.escalation_model,
         )
+    initial_retry_candidate = _load_initial_validation_retry_candidate(args)
     failed_attempts: tuple[_FailedEncodeAttempt, ...] = ()
     current_model = config.initial_model
 
@@ -27095,6 +27176,7 @@ def _cmd_encode_with_authoritative_rulespec_roots(
             args,
             model=current_model,
             prior_attempts=failed_attempts,
+            initial_retry_candidate=initial_retry_candidate,
             defer_logging=config.enabled,
             apply_signing_broker=apply_signing_broker,
             resolved_policy_checkout_path=resolved_policy_checkout_path,
@@ -27226,6 +27308,7 @@ def _run_encode_attempt(
     *,
     model: str,
     prior_attempts: Sequence[_FailedEncodeAttempt] = (),
+    initial_retry_candidate: ValidationRetryCandidate | None = None,
     defer_logging: bool = True,
     apply_signing_broker: SigningBroker | None = None,
     resolved_policy_checkout_path: Path | None = None,
@@ -27354,7 +27437,11 @@ def _run_encode_attempt(
             else None
         ),
         validation_retry_feedback=_encode_validation_retry_feedback(prior_attempts),
-        validation_retry_candidate=_latest_validation_retry_candidate(prior_attempts),
+        validation_retry_candidate=(
+            _latest_validation_retry_candidate(prior_attempts)
+            if prior_attempts
+            else initial_retry_candidate
+        ),
         required_import_targets=required_import_targets,
         legacy_replacement=(
             replacement_target.legacy_replacement

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -51,6 +51,10 @@ from axiom_encode.legacy_replacement_overlay import (
     stage_legacy_replacement_overlay,
 )
 from axiom_encode.prompts.encoder import SOURCE_SCOPE_PROTOCOL
+from axiom_encode.repair_candidate_contract import (
+    VALIDATION_RETRY_CANDIDATE_MAX_FILE_BYTES,
+    VALIDATION_RETRY_CANDIDATE_MAX_TOTAL_BYTES,
+)
 from axiom_encode.repo_routing import (
     canonical_rulespec_repo_name,
     canonical_rulespec_root_identity,
@@ -149,8 +153,6 @@ from .validator_pipeline import (
 EvalMode = Literal["cold", "repo-augmented"]
 EvalOracleMode = Literal["none", "policyengine"]
 EvalFailureKind = Literal["timeout", "validation", "error"]
-VALIDATION_RETRY_CANDIDATE_MAX_FILE_BYTES = 512 * 1024
-VALIDATION_RETRY_CANDIDATE_MAX_TOTAL_BYTES = 1024 * 1024
 
 
 @dataclass(frozen=True)

--- a/src/axiom_encode/repair_candidate_contract.py
+++ b/src/axiom_encode/repair_candidate_contract.py
@@ -1,0 +1,4 @@
+"""Shared bounds for validator-rejected repair candidates."""
+
+VALIDATION_RETRY_CANDIDATE_MAX_FILE_BYTES = 512 * 1024
+VALIDATION_RETRY_CANDIDATE_MAX_TOTAL_BYTES = 1024 * 1024

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1534"
+ENCODER_VERSION = "0.2.1535"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1535"
+ENCODER_VERSION = "0.2.1536"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1533"
+ENCODER_VERSION = "0.2.1534"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1532"
+ENCODER_VERSION = "0.2.1533"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12241,6 +12241,8 @@ class TestCmdEncode:
         args.mode = overrides.get("mode", "repo-augmented")
         args.allow_context = overrides.get("allow_context", [])
         args.review_findings = overrides.get("review_findings", [])
+        args.repair_candidate_root = overrides.get("repair_candidate_root", None)
+        args.repair_candidate_path = overrides.get("repair_candidate_path", None)
         args.policyengine_rule_hint = overrides.get("policyengine_rule_hint", None)
         args.db = overrides.get("db", tmp_path / "encodings.db")
         args.sync = overrides.get("sync", True)
@@ -13076,6 +13078,91 @@ class TestCmdEncode:
         )
 
         assert candidate.tests is None
+
+    def test_encode_loads_bounded_cross_run_repair_candidate(self, tmp_path):
+        import axiom_encode.cli as cli_module
+
+        candidate_root = tmp_path / "preserved-candidate"
+        candidate_path = Path("statutes/42/1437c-1.yaml")
+        output_file = candidate_root / candidate_path
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text("format: rulespec/v1\n# preserved-rule\nrules: []\n")
+        output_file.with_suffix(".test.yaml").write_text("# preserved-companion\n[]\n")
+
+        candidate = cli_module._load_initial_validation_retry_candidate(
+            SimpleNamespace(
+                repair_candidate_root=candidate_root,
+                repair_candidate_path=candidate_path,
+            )
+        )
+
+        assert candidate is not None
+        assert "preserved-rule" in candidate.rulespec
+        assert candidate.tests is not None
+        assert "preserved-companion" in candidate.tests
+
+    def test_encode_passes_cross_run_repair_candidate_to_first_attempt(self, tmp_path):
+        candidate_root = tmp_path / "preserved-candidate"
+        candidate_path = Path("statutes/26/1/j/2.yaml")
+        output_file = candidate_root / candidate_path
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text("format: rulespec/v1\n# preserved-rule\nrules: []\n")
+        output_file.with_suffix(".test.yaml").write_text("# preserved-companion\n[]\n")
+        args = self._make_args(
+            tmp_path,
+            repair_candidate_root=candidate_root,
+            repair_candidate_path=candidate_path,
+        )
+
+        mock_run, exit_code = self._run_encode(args, self._make_eval_result(True))
+
+        assert exit_code == 0
+        candidate = mock_run.call_args.kwargs["validation_retry_candidate"]
+        assert candidate is not None
+        assert "preserved-rule" in candidate.rulespec
+        assert candidate.tests is not None
+        assert "preserved-companion" in candidate.tests
+
+    @pytest.mark.parametrize(
+        ("root", "relative_path", "message"),
+        [
+            (Path("candidate"), None, "must be supplied together"),
+            (None, Path("statutes/26/1.yaml"), "must be supplied together"),
+            (Path("candidate"), Path("../1.yaml"), "safe relative path"),
+            (Path("candidate"), Path("metrics/1.yaml"), "canonical RuleSpec"),
+        ],
+    )
+    def test_encode_rejects_invalid_cross_run_repair_candidate_identity(
+        self, tmp_path, root, relative_path, message
+    ):
+        import axiom_encode.cli as cli_module
+
+        with pytest.raises(ValueError, match=message):
+            cli_module._load_initial_validation_retry_candidate(
+                SimpleNamespace(
+                    repair_candidate_root=tmp_path / root if root else None,
+                    repair_candidate_path=relative_path,
+                )
+            )
+
+    def test_encode_rejects_symlinked_cross_run_repair_candidate(self, tmp_path):
+        import axiom_encode.cli as cli_module
+
+        candidate_root = tmp_path / "preserved-candidate"
+        candidate_path = Path("statutes/26/1.yaml")
+        output_file = candidate_root / candidate_path
+        output_file.parent.mkdir(parents=True)
+        external = tmp_path / "external.yaml"
+        external.write_text("secret material must not be prompt context\n")
+        output_file.symlink_to(external)
+
+        with pytest.raises(UnsafeCorpusPathError, match="safely open"):
+            cli_module._load_initial_validation_retry_candidate(
+                SimpleNamespace(
+                    repair_candidate_root=candidate_root,
+                    repair_candidate_path=candidate_path,
+                )
+            )
 
     @pytest.mark.parametrize("unsafe_kind", ["symlink", "invalid-utf8", "oversize"])
     def test_encode_retry_candidate_capture_rejects_unsafe_content(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12243,6 +12243,12 @@ class TestCmdEncode:
         args.review_findings = overrides.get("review_findings", [])
         args.repair_candidate_root = overrides.get("repair_candidate_root", None)
         args.repair_candidate_path = overrides.get("repair_candidate_path", None)
+        args.repair_candidate_rulespec_sha256 = overrides.get(
+            "repair_candidate_rulespec_sha256", None
+        )
+        args.repair_candidate_tests_sha256 = overrides.get(
+            "repair_candidate_tests_sha256", None
+        )
         args.policyengine_rule_hint = overrides.get("policyengine_rule_hint", None)
         args.db = overrides.get("db", tmp_path / "encodings.db")
         args.sync = overrides.get("sync", True)
@@ -13088,11 +13094,17 @@ class TestCmdEncode:
         output_file.parent.mkdir(parents=True)
         output_file.write_text("format: rulespec/v1\n# preserved-rule\nrules: []\n")
         output_file.with_suffix(".test.yaml").write_text("# preserved-companion\n[]\n")
+        rulespec_sha256 = hashlib.sha256(output_file.read_bytes()).hexdigest()
+        tests_sha256 = hashlib.sha256(
+            output_file.with_suffix(".test.yaml").read_bytes()
+        ).hexdigest()
 
         candidate = cli_module._load_initial_validation_retry_candidate(
             SimpleNamespace(
                 repair_candidate_root=candidate_root,
                 repair_candidate_path=candidate_path,
+                repair_candidate_rulespec_sha256=rulespec_sha256,
+                repair_candidate_tests_sha256=tests_sha256,
             )
         )
 
@@ -13112,6 +13124,12 @@ class TestCmdEncode:
             tmp_path,
             repair_candidate_root=candidate_root,
             repair_candidate_path=candidate_path,
+            repair_candidate_rulespec_sha256=hashlib.sha256(
+                output_file.read_bytes()
+            ).hexdigest(),
+            repair_candidate_tests_sha256=hashlib.sha256(
+                output_file.with_suffix(".test.yaml").read_bytes()
+            ).hexdigest(),
         )
 
         mock_run, exit_code = self._run_encode(args, self._make_eval_result(True))
@@ -13142,6 +13160,8 @@ class TestCmdEncode:
                 SimpleNamespace(
                     repair_candidate_root=tmp_path / root if root else None,
                     repair_candidate_path=relative_path,
+                    repair_candidate_rulespec_sha256=("a" * 64 if root else None),
+                    repair_candidate_tests_sha256=("b" * 64 if root else None),
                 )
             )
 
@@ -13161,8 +13181,37 @@ class TestCmdEncode:
                 SimpleNamespace(
                     repair_candidate_root=candidate_root,
                     repair_candidate_path=candidate_path,
+                    repair_candidate_rulespec_sha256="a" * 64,
+                    repair_candidate_tests_sha256="b" * 64,
                 )
             )
+
+    def test_encode_rejects_mutated_cross_run_candidate_before_model_call(
+        self, tmp_path
+    ):
+        candidate_root = tmp_path / "preserved-candidate"
+        candidate_path = Path("statutes/26/1/j/2.yaml")
+        output_file = candidate_root / candidate_path
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text("format: rulespec/v1\nrules: []\n")
+        test_file = output_file.with_suffix(".test.yaml")
+        test_file.write_text("[]\n")
+        expected_rulespec_sha256 = hashlib.sha256(output_file.read_bytes()).hexdigest()
+        expected_tests_sha256 = hashlib.sha256(test_file.read_bytes()).hexdigest()
+        output_file.write_text("format: rulespec/v1\n# mutated\nrules: []\n")
+        args = self._make_args(
+            tmp_path,
+            repair_candidate_root=candidate_root,
+            repair_candidate_path=candidate_path,
+            repair_candidate_rulespec_sha256=expected_rulespec_sha256,
+            repair_candidate_tests_sha256=expected_tests_sha256,
+        )
+
+        with patch("axiom_encode.cli.run_model_eval") as model_call:
+            with pytest.raises(ValueError, match="RuleSpec SHA-256 mismatch"):
+                cmd_encode(args)
+
+        model_call.assert_not_called()
 
     @pytest.mark.parametrize("unsafe_kind", ["symlink", "invalid-utf8", "oversize"])
     def test_encode_retry_candidate_capture_rejects_unsafe_content(

--- a/tests/test_extract_repair_candidate.py
+++ b/tests/test_extract_repair_candidate.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import tarfile
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from scripts.extract_repair_candidate import MAX_ARCHIVE_MEMBERS, extract_candidate
+
+
+def _archive(tmp_path: Path, *, candidate: bytes | None = None) -> tuple[Path, dict]:
+    candidate = candidate or b"format: rulespec/v1\nrules: []\n"
+    tests = b"[]\n"
+    repair = json.dumps(
+        {
+            "schema_version": "axiom-encode/repair-manifest/v1",
+            "citation": "us/statute/42/1437c\u20131",
+            "runner": "openai-gpt-5.6-sol",
+        }
+    ).encode()
+    payloads = {
+        "target/openai-gpt-5.6-sol/statutes/42/1437c-1.yaml": candidate,
+        "target/openai-gpt-5.6-sol/statutes/42/1437c-1.test.yaml": tests,
+        "target/openai-gpt-5.6-sol/statutes/42/1437c-1.repair.json": repair,
+    }
+    metadata = {
+        "schema": "axiom-encode/failed-reencode-diagnostics/v1",
+        "citation": "us/statute/42/1437c\u20131",
+        "country": "us",
+        "encoder_commit": "a" * 40,
+        "corpus_ref": "b" * 40,
+        "rules_engine_ref": "c" * 40,
+        "rulespec_ref": "d" * 40,
+        "replace_rulespec_path": "us/statutes/42/1437c-1.yaml",
+        "workflow_run_id": "1234",
+        "workflow_run_attempt": 1,
+        "failed_steps": ["encode_apply"],
+        "generated_lanes": ["target"],
+        "files": [
+            {
+                "path": path,
+                "size": len(body),
+                "sha256": hashlib.sha256(body).hexdigest(),
+            }
+            for path, body in sorted(payloads.items())
+        ],
+    }
+    archive = tmp_path / "failure.tar"
+    with tarfile.open(archive, "w") as bundle:
+        members = {"metadata.json": json.dumps(metadata).encode()}
+        members.update({f"generated/{path}": body for path, body in payloads.items()})
+        for name, body in members.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(body)
+            bundle.addfile(info, io.BytesIO(body))
+    return archive, metadata
+
+
+def _args(tmp_path: Path, archive: Path, **overrides) -> Namespace:
+    values = {
+        "archive": archive,
+        "destination": tmp_path / "extracted",
+        "citation": "us/statute/42/1437c\u20131",
+        "country": "us",
+        "encoder_commit": "a" * 40,
+        "corpus_ref": "b" * 40,
+        "rules_engine_ref": "c" * 40,
+        "rulespec_ref": "d" * 40,
+        "replace_rulespec_path": "us/statutes/42/1437c-1.yaml",
+        "workflow_run_id": "1234",
+    }
+    values.update(overrides)
+    return Namespace(**values)
+
+
+def test_extracts_checksum_bound_final_candidate(tmp_path):
+    archive, _ = _archive(tmp_path)
+
+    result = extract_candidate(_args(tmp_path, archive))
+
+    root = Path(result["root"])
+    assert result["path"] == "statutes/42/1437c-1.yaml"
+    assert (root / result["path"]).read_text() == "format: rulespec/v1\nrules: []\n"
+    assert (root / "statutes/42/1437c-1.test.yaml").read_text() == "[]\n"
+
+
+def test_rejects_metadata_identity_mismatch(tmp_path):
+    archive, _ = _archive(tmp_path)
+
+    with pytest.raises(ValueError, match="metadata mismatch: rulespec_ref"):
+        extract_candidate(_args(tmp_path, archive, rulespec_ref="e" * 40))
+
+
+def test_rejects_candidate_digest_mismatch(tmp_path):
+    archive, metadata = _archive(tmp_path)
+    candidate_entry = next(
+        item for item in metadata["files"] if item["path"].endswith("1437c-1.yaml")
+    )
+    candidate_entry["sha256"] = "0" * 64
+    replacement = tmp_path / "tampered.tar"
+    with tarfile.open(archive, "r") as source, tarfile.open(replacement, "w") as target:
+        for member in source.getmembers():
+            body = source.extractfile(member).read()
+            if member.name == "metadata.json":
+                body = json.dumps(metadata).encode()
+                member.size = len(body)
+            target.addfile(member, io.BytesIO(body))
+
+    with pytest.raises(ValueError, match="digest mismatch"):
+        extract_candidate(_args(tmp_path, replacement))
+
+
+def test_rejects_duplicate_archive_member(tmp_path):
+    archive, _ = _archive(tmp_path)
+    replacement = tmp_path / "duplicate.tar"
+    with tarfile.open(archive, "r") as source, tarfile.open(replacement, "w") as target:
+        for member in source.getmembers():
+            body = source.extractfile(member).read()
+            target.addfile(member, io.BytesIO(body))
+            if member.name == "metadata.json":
+                target.addfile(member, io.BytesIO(body))
+
+    with pytest.raises(ValueError, match="duplicate member path"):
+        extract_candidate(_args(tmp_path, replacement))
+
+
+def test_rejects_archive_member_flood(tmp_path):
+    archive = tmp_path / "flood.tar"
+    with tarfile.open(archive, "w") as bundle:
+        for index in range(MAX_ARCHIVE_MEMBERS + 1):
+            info = tarfile.TarInfo(f"entry-{index}.txt")
+            bundle.addfile(info, io.BytesIO())
+
+    with pytest.raises(ValueError, match="member limit"):
+        extract_candidate(_args(tmp_path, archive))

--- a/tests/test_extract_repair_candidate.py
+++ b/tests/test_extract_repair_candidate.py
@@ -196,6 +196,20 @@ def test_rejects_incompatible_prior_run_mode(tmp_path, field, value):
         extract_candidate(_args(tmp_path, replacement))
 
 
+@pytest.mark.parametrize("field", sorted(SINGLE_TARGET_MODE_FIELDS))
+def test_rejects_missing_prior_run_mode_field(tmp_path, field):
+    archive, metadata = _archive(tmp_path)
+    del metadata[field]
+    replacement = _rewrite_metadata(
+        archive,
+        tmp_path / "missing-mode-field.tar",
+        metadata,
+    )
+
+    with pytest.raises(ValueError, match=f"single-target run: {field}"):
+        extract_candidate(_args(tmp_path, replacement))
+
+
 def test_candidate_size_bound_is_shared_at_exact_limit(tmp_path):
     archive, _ = _archive(tmp_path, candidate=b"x" * MAX_CANDIDATE_BYTES)
 

--- a/tests/test_extract_repair_candidate.py
+++ b/tests/test_extract_repair_candidate.py
@@ -9,7 +9,12 @@ from pathlib import Path
 
 import pytest
 
-from scripts.extract_repair_candidate import MAX_ARCHIVE_MEMBERS, extract_candidate
+from scripts.extract_repair_candidate import (
+    MAX_ARCHIVE_MEMBERS,
+    MAX_CANDIDATE_BYTES,
+    SINGLE_TARGET_MODE_FIELDS,
+    extract_candidate,
+)
 
 
 def _archive(tmp_path: Path, *, candidate: bytes | None = None) -> tuple[Path, dict]:
@@ -40,6 +45,7 @@ def _archive(tmp_path: Path, *, candidate: bytes | None = None) -> tuple[Path, d
         "workflow_run_attempt": 1,
         "failed_steps": ["encode_apply"],
         "generated_lanes": ["target"],
+        **SINGLE_TARGET_MODE_FIELDS,
         "files": [
             {
                 "path": path,
@@ -58,6 +64,26 @@ def _archive(tmp_path: Path, *, candidate: bytes | None = None) -> tuple[Path, d
             info.size = len(body)
             bundle.addfile(info, io.BytesIO(body))
     return archive, metadata
+
+
+def _rewrite_metadata(
+    source_archive: Path,
+    destination: Path,
+    metadata: dict,
+) -> Path:
+    with (
+        tarfile.open(source_archive, "r") as source,
+        tarfile.open(destination, "w") as target,
+    ):
+        for member in source.getmembers():
+            extracted = source.extractfile(member)
+            assert extracted is not None
+            body = extracted.read()
+            if member.name == "metadata.json":
+                body = json.dumps(metadata).encode()
+                member.size = len(body)
+            target.addfile(member, io.BytesIO(body))
+    return destination
 
 
 def _args(tmp_path: Path, archive: Path, **overrides) -> Namespace:
@@ -101,14 +127,11 @@ def test_rejects_candidate_digest_mismatch(tmp_path):
         item for item in metadata["files"] if item["path"].endswith("1437c-1.yaml")
     )
     candidate_entry["sha256"] = "0" * 64
-    replacement = tmp_path / "tampered.tar"
-    with tarfile.open(archive, "r") as source, tarfile.open(replacement, "w") as target:
-        for member in source.getmembers():
-            body = source.extractfile(member).read()
-            if member.name == "metadata.json":
-                body = json.dumps(metadata).encode()
-                member.size = len(body)
-            target.addfile(member, io.BytesIO(body))
+    replacement = _rewrite_metadata(
+        archive,
+        tmp_path / "tampered.tar",
+        metadata,
+    )
 
     with pytest.raises(ValueError, match="digest mismatch"):
         extract_candidate(_args(tmp_path, replacement))
@@ -136,4 +159,53 @@ def test_rejects_archive_member_flood(tmp_path):
             bundle.addfile(info, io.BytesIO())
 
     with pytest.raises(ValueError, match="member limit"):
+        extract_candidate(_args(tmp_path, archive))
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("dependent_citation", "us/statute/42/other"),
+        ("existing_signed_imports_input", '["us/statutes/import.yaml"]'),
+        ("legacy_exact_dependent_rulespec_path", "us/statutes/dependent.yaml"),
+        ("legacy_retained_successor_rulespec_paths_input", '["old.yaml"]'),
+        ("queue_dispatcher_run_id", "999"),
+        ("queue_id", "queue"),
+        ("queue_item_generation_sha256", "a" * 64),
+        ("queue_item_id", "item"),
+        ("queue_manifest_sha256", "b" * 64),
+        ("replace_legacy_rulespec_path", "us/statutes/old.yaml"),
+        ("second_dependent_citation", "us/statute/42/second"),
+        (
+            "second_legacy_exact_dependent_rulespec_path",
+            "us/statutes/second.yaml",
+        ),
+        ("source_bundle_input", '["us/statute/42/source"]'),
+    ],
+)
+def test_rejects_incompatible_prior_run_mode(tmp_path, field, value):
+    archive, metadata = _archive(tmp_path)
+    metadata[field] = value
+    replacement = _rewrite_metadata(
+        archive,
+        tmp_path / "incompatible.tar",
+        metadata,
+    )
+
+    with pytest.raises(ValueError, match=f"single-target run: {field}"):
+        extract_candidate(_args(tmp_path, replacement))
+
+
+def test_candidate_size_bound_is_shared_at_exact_limit(tmp_path):
+    archive, _ = _archive(tmp_path, candidate=b"x" * MAX_CANDIDATE_BYTES)
+
+    result = extract_candidate(_args(tmp_path, archive))
+
+    assert Path(result["root"], result["path"]).stat().st_size == MAX_CANDIDATE_BYTES
+
+
+def test_candidate_size_bound_rejects_limit_plus_one(tmp_path):
+    archive, _ = _archive(tmp_path, candidate=b"x" * (MAX_CANDIDATE_BYTES + 1))
+
+    with pytest.raises(ValueError, match="exceeds its size limit"):
         extract_candidate(_args(tmp_path, archive))

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1534"
+ENCODER_VERSION = "0.2.1535"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1532"
+ENCODER_VERSION = "0.2.1533"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1535"
+ENCODER_VERSION = "0.2.1536"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1533"
+ENCODER_VERSION = "0.2.1534"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1535"
+ENCODER_VERSION = "0.2.1536"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1532"
+ENCODER_VERSION = "0.2.1533"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1534"
+ENCODER_VERSION = "0.2.1535"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1533"
+ENCODER_VERSION = "0.2.1534"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1533"
+ENCODER_VERSION = "0.2.1534"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1534"
+ENCODER_VERSION = "0.2.1535"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1535"
+ENCODER_VERSION = "0.2.1536"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1532"
+ENCODER_VERSION = "0.2.1533"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1533"
+ENCODER_VERSION = "0.2.1534"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1534"
+ENCODER_VERSION = "0.2.1535"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1535"
+ENCODER_VERSION = "0.2.1536"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1532"
+ENCODER_VERSION = "0.2.1533"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1532"
+ENCODER_VERSION = "0.2.1533"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1535"
+ENCODER_VERSION = "0.2.1536"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1534"
+ENCODER_VERSION = "0.2.1535"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1533"
+ENCODER_VERSION = "0.2.1534"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1535"
+ENCODER_VERSION = "0.2.1536"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1532"
+ENCODER_VERSION = "0.2.1533"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1533"
+ENCODER_VERSION = "0.2.1534"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1534"
+ENCODER_VERSION = "0.2.1535"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1534"')
+        .startswith('__version__ = "0.2.1535"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1534"
+    assert encoder_package["version"] == "0.2.1535"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1534"
+    assert project["project"]["version"] == "0.2.1535"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1534"')
+        .startswith('__version__ = "0.2.1535"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1534"
+    assert encoder_package["version"] == "0.2.1535"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1534"
+    assert project["project"]["version"] == "0.2.1535"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1534"')
+        .startswith('__version__ = "0.2.1535"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1532"')
+        .startswith('__version__ = "0.2.1533"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1532"
+    assert encoder_package["version"] == "0.2.1533"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1532"
+    assert project["project"]["version"] == "0.2.1533"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1532"')
+        .startswith('__version__ = "0.2.1533"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1532"
+    assert encoder_package["version"] == "0.2.1533"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1532"
+    assert project["project"]["version"] == "0.2.1533"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1532"')
+        .startswith('__version__ = "0.2.1533"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1533"')
+        .startswith('__version__ = "0.2.1534"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1533"
+    assert encoder_package["version"] == "0.2.1534"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1533"
+    assert project["project"]["version"] == "0.2.1534"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1533"')
+        .startswith('__version__ = "0.2.1534"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1533"
+    assert encoder_package["version"] == "0.2.1534"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1533"
+    assert project["project"]["version"] == "0.2.1534"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1533"')
+        .startswith('__version__ = "0.2.1534"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1535"')
+        .startswith('__version__ = "0.2.1536"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1535"
+    assert encoder_package["version"] == "0.2.1536"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1535"
+    assert project["project"]["version"] == "0.2.1536"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1535"')
+        .startswith('__version__ = "0.2.1536"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1535"
+    assert encoder_package["version"] == "0.2.1536"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1535"
+    assert project["project"]["version"] == "0.2.1536"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1535"')
+        .startswith('__version__ = "0.2.1536"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1535"
+ENCODER_VERSION = "0.2.1536"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1532"
+ENCODER_VERSION = "0.2.1533"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1533"
+ENCODER_VERSION = "0.2.1534"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1534"
+ENCODER_VERSION = "0.2.1535"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2194,11 +2194,21 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert 'args+=(--review-findings "$review_finding_path")' in command
     assert '--repair-candidate-root "$REPAIR_CANDIDATE_ROOT"' in command
     assert '--repair-candidate-path "$REPAIR_CANDIDATE_PATH"' in command
+    assert "--repair-candidate-rulespec-sha256" in command
+    assert '"$REPAIR_CANDIDATE_RULESPEC_SHA256"' in command
+    assert "--repair-candidate-tests-sha256" in command
+    assert '"$REPAIR_CANDIDATE_TESTS_SHA256"' in command
     assert apply_step["env"]["REPAIR_CANDIDATE_ROOT"] == (
         "${{ steps.repair_candidate.outputs.root }}"
     )
     assert apply_step["env"]["REPAIR_CANDIDATE_PATH"] == (
         "${{ steps.repair_candidate.outputs.path }}"
+    )
+    assert apply_step["env"]["REPAIR_CANDIDATE_RULESPEC_SHA256"] == (
+        "${{ steps.repair_candidate.outputs.rulespec_sha256 }}"
+    )
+    assert apply_step["env"]["REPAIR_CANDIDATE_TESTS_SHA256"] == (
+        "${{ steps.repair_candidate.outputs.tests_sha256 }}"
     )
     assert "args+=(--apply-target-only)" in command
     assert 'args+=(--replace-rulespec-path "$replacement_path")' in command

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2295,6 +2295,10 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         "PR_BASE_BRANCH",
         "REPAIR_CANDIDATE_CONCLUSION",
         "REPAIR_CANDIDATE_OUTCOME",
+        "REPAIR_CANDIDATE_PATH",
+        "REPAIR_CANDIDATE_RUNNER",
+        "REPAIR_CANDIDATE_RULESPEC_SHA256",
+        "REPAIR_CANDIDATE_TESTS_SHA256",
         "REPAIR_RUN_ID",
         "PROVISION_SIGNING_SUPERVISOR_CONCLUSION",
         "PUBLISH_LANE_PULL_REQUEST_CONCLUSION",
@@ -2323,7 +2327,18 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         == "${{ steps.provision_signing_supervisor.conclusion }}"
     )
     assert "toJSON(steps)" not in json.dumps(failure_package_step)
-    assert ".outputs" not in json.dumps(failure_package_step["env"])
+    assert failure_package_step["env"]["REPAIR_CANDIDATE_PATH"] == (
+        "${{ steps.repair_candidate.outputs.path }}"
+    )
+    assert failure_package_step["env"]["REPAIR_CANDIDATE_RUNNER"] == (
+        "${{ steps.repair_candidate.outputs.runner }}"
+    )
+    assert failure_package_step["env"]["REPAIR_CANDIDATE_RULESPEC_SHA256"] == (
+        "${{ steps.repair_candidate.outputs.rulespec_sha256 }}"
+    )
+    assert failure_package_step["env"]["REPAIR_CANDIDATE_TESTS_SHA256"] == (
+        "${{ steps.repair_candidate.outputs.tests_sha256 }}"
+    )
     failure_package_command = failure_package_step["run"]
     assert "workflow_python=/usr/bin/python3" in failure_package_command
     assert '"${PROVISION_SIGNING_SUPERVISOR_CONCLUSION:-}" = success' in (
@@ -2350,6 +2365,9 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert '"schema": "axiom-encode/failed-reencode-diagnostics/v1"' in (
         failure_package_command
     )
+    assert 'guard_root / "repair-candidate.json"' not in failure_package_command
+    assert "consumed_rulespec_sha256 = os.environ.get(" in failure_package_command
+    assert "consumed_tests_sha256 = os.environ.get(" in failure_package_command
 
     failure_upload_step = next(
         step
@@ -2716,6 +2734,75 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
         target_inventory["sha256"]
         == hashlib.sha256(b"format: rulespec/v1\n").hexdigest()
     )
+
+
+def test_failed_reencode_metadata_uses_consumed_identity_after_evidence_mutation(
+    tmp_path: Path,
+) -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
+    )
+    step = next(
+        item
+        for item in workflow["jobs"]["encode"]["steps"]
+        if item.get("name") == "Package failed re-encode diagnostics"
+    )
+    command = step["run"].replace(
+        "/opt/axiom-verification/python/bin/python",
+        sys.executable,
+    )
+    (tmp_path / "generated").mkdir()
+    (tmp_path / "repair-candidate.json").write_text(
+        json.dumps(
+            {
+                "path": "statutes/42/mutated.yaml",
+                "root": "/mutated",
+                "rulespec_sha256": "b" * 64,
+                "runner": "mutated-runner",
+                "tests_sha256": "c" * 64,
+            }
+        ),
+        encoding="utf-8",
+    )
+    completed = subprocess.run(
+        ["bash", "-c", command],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "CITATION": "us/statute/42/1437c-1",
+            "CORPUS_REF": "corpus-ref",
+            "COUNTRY": "us",
+            "GITHUB_RUN_ATTEMPT": "1",
+            "GITHUB_RUN_ID": "5678",
+            "GITHUB_SHA": "encoder-ref",
+            "REPAIR_CANDIDATE_CONCLUSION": "success",
+            "REPAIR_CANDIDATE_OUTCOME": "success",
+            "REPAIR_CANDIDATE_PATH": "statutes/42/1437c-1.yaml",
+            "REPAIR_CANDIDATE_RUNNER": "openai-gpt-5.6-sol",
+            "REPAIR_CANDIDATE_RULESPEC_SHA256": "d" * 64,
+            "REPAIR_CANDIDATE_TESTS_SHA256": "e" * 64,
+            "REPAIR_RUN_ID": "1234",
+            "RULES_ENGINE_REF": "rules-engine-ref",
+            "RULESPEC_REF": "rulespec-ref",
+            "RUNNER_TEMP": str(tmp_path),
+        },
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    archive = tmp_path / "targeted-reencode-failure.tar"
+    with tarfile.open(archive, mode="r") as bundle:
+        metadata_file = bundle.extractfile("./metadata.json")
+        assert metadata_file is not None
+        metadata = json.loads(metadata_file.read())
+    assert metadata["repair_candidate"] == {
+        "path": "statutes/42/1437c-1.yaml",
+        "rulespec_sha256": "d" * 64,
+        "run_id": "1234",
+        "runner": "openai-gpt-5.6-sol",
+        "tests_sha256": "e" * 64,
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2090,6 +2090,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         "--workflow-run-id",
     ):
         assert immutable_argument in repair_command
+    assert 'echo "runner=$(jq -r' in repair_command
 
     provision_step = next(
         step
@@ -2395,6 +2396,18 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     )
     assert package_step["env"]["PR_BASE_BRANCH"] == ("${{ inputs.pr_base_branch }}")
     assert package_step["env"]["RULESPEC_REF"] == "${{ inputs.rulespec_ref }}"
+    assert package_step["env"]["REPAIR_CANDIDATE_PATH"] == (
+        "${{ steps.repair_candidate.outputs.path }}"
+    )
+    assert package_step["env"]["REPAIR_CANDIDATE_RUNNER"] == (
+        "${{ steps.repair_candidate.outputs.runner }}"
+    )
+    assert package_step["env"]["REPAIR_CANDIDATE_RULESPEC_SHA256"] == (
+        "${{ steps.repair_candidate.outputs.rulespec_sha256 }}"
+    )
+    assert package_step["env"]["REPAIR_CANDIDATE_TESTS_SHA256"] == (
+        "${{ steps.repair_candidate.outputs.tests_sha256 }}"
+    )
     assert '"$RULESPEC_REF" > "$artifact/tracked.patch"' in package_command
     assert '"$RULESPEC_REF" HEAD >> "$artifact/status.txt"' in package_command
     assert "diff --binary --full-index HEAD" not in package_command
@@ -2432,6 +2445,11 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert '"queue_item_generation_sha256": (' in package_command
     assert '"queue_manifest_sha256": (' in package_command
     assert '"repair_candidate": repair_candidate' in package_command
+    assert 'Path(os.environ["RUNNER_TEMP"]) / "repair-candidate.json"' not in (
+        package_command
+    )
+    assert "consumed_rulespec_sha256 = os.environ.get(" in package_command
+    assert "consumed_tests_sha256 = os.environ.get(" in package_command
     assert '"repair_run_id": os.environ.get("REPAIR_RUN_ID") or None' in (
         package_command
     )
@@ -4006,6 +4024,103 @@ def _targeted_package_script() -> str:
     return package_command.split(marker, 1)[1].split(
         '\nPY\n"${workflow_python[@]}" - "$artifact/metadata.json"', 1
     )[0]
+
+
+def _targeted_metadata_script() -> str:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
+    )
+    package_command = next(
+        step
+        for step in workflow["jobs"]["encode"]["steps"]
+        if step.get("name") == "Package exact generated changes"
+    )["run"]
+    marker = '"${workflow_python[@]}" - "$artifact/metadata.json" <<\'PY\'\n'
+    return package_command.split(marker, 1)[1].split(
+        '\nPY\ntest -s "$artifact/status.txt"', 1
+    )[0]
+
+
+def test_targeted_metadata_uses_consumed_repair_identity_after_evidence_mutation(
+    tmp_path: Path,
+) -> None:
+    script = _targeted_metadata_script()
+    heads: dict[str, str] = {}
+    for name in ("axiom-encode", "axiom-corpus", "axiom-rules-engine", "rulespec-us"):
+        repository = tmp_path / name
+        repository.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repository, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=repository,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            cwd=repository,
+            check=True,
+        )
+        (repository / "README.md").write_text("fixture\n", encoding="utf-8")
+        subprocess.run(["git", "add", "README.md"], cwd=repository, check=True)
+        subprocess.run(["git", "commit", "-qm", "fixture"], cwd=repository, check=True)
+        heads[name] = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=repository, text=True
+        ).strip()
+
+    runner_temp = tmp_path / "runner-temp"
+    runner_temp.mkdir()
+    (runner_temp / "source-bundle.json").write_text("[]\n", encoding="utf-8")
+    (runner_temp / "existing-signed-imports.json").write_text("[]\n", encoding="utf-8")
+    (runner_temp / "existing-signed-import-inventory.json").write_text(
+        "{}\n", encoding="utf-8"
+    )
+    (runner_temp / "repair-candidate.json").write_text(
+        json.dumps(
+            {
+                "path": "statutes/42/mutated.yaml",
+                "root": "/mutated",
+                "rulespec_sha256": "b" * 64,
+                "runner": "mutated-runner",
+                "tests_sha256": "c" * 64,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    metadata_path = tmp_path / "metadata.json"
+    completed = subprocess.run(
+        [sys.executable, "-", str(metadata_path)],
+        cwd=tmp_path,
+        input=script,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "CITATION": "us/statute/42/1437c\u20131",
+            "GITHUB_RUN_ATTEMPT": "1",
+            "GITHUB_RUN_ID": "5678",
+            "PR_BASE_BRANCH": "hard-cut/canonical-layout-us",
+            "REPAIR_CANDIDATE_PATH": "statutes/42/1437c-1.yaml",
+            "REPAIR_CANDIDATE_RUNNER": "openai-gpt-5.6-sol",
+            "REPAIR_CANDIDATE_RULESPEC_SHA256": "d" * 64,
+            "REPAIR_CANDIDATE_TESTS_SHA256": "e" * 64,
+            "REPAIR_RUN_ID": "1234",
+            "RULESPEC_CHECKOUT": str(tmp_path / "rulespec-us"),
+            "RULESPEC_REF": heads["rulespec-us"],
+            "RUNNER_TEMP": str(runner_temp),
+        },
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+    assert payload["repair_candidate"] == {
+        "path": "statutes/42/1437c-1.yaml",
+        "rulespec_sha256": "d" * 64,
+        "run_id": "1234",
+        "runner": "openai-gpt-5.6-sol",
+        "tests_sha256": "e" * 64,
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1880,6 +1880,14 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     }
     assert inputs["open_pr"]["type"] == "boolean"
     assert inputs["open_pr"]["default"] is False
+    assert inputs["repair_run_id"] == {
+        "description": (
+            "Prior failed protected run whose final candidate is replayed as "
+            "untrusted repair context"
+        ),
+        "required": False,
+        "type": "string",
+    }
     assert inputs["pr_base_branch"]["type"] == "string"
     assert inputs["pr_base_branch"]["default"] == "main"
     assert inputs["source_bundle_json"] == {
@@ -2051,6 +2059,41 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "--corpus-root axiom-corpus" in release_command
     assert 'merge-base --is-ancestor "$release_commit" HEAD' in release_command
 
+    repair_step = next(
+        step
+        for step in steps
+        if step.get("name") == "Resolve trusted prior-run repair candidate"
+    )
+    assert repair_step["id"] == "repair_candidate"
+    assert repair_step["if"] == "${{ inputs.repair_run_id != '' }}"
+    assert repair_step["env"]["GH_TOKEN"] == "${{ github.token }}"
+    repair_command = repair_step["run"]
+    assert '.conclusion == "failure"' in repair_command
+    assert '.event == "workflow_dispatch"' in repair_command
+    assert '.head_branch == "main"' in repair_command
+    assert '.run_attempt == 1' in repair_command
+    assert (
+        '.path == ".github/workflows/targeted-signed-reencode.yml"'
+        in repair_command
+    )
+    assert "merge-base --is-ancestor" in repair_command
+    assert '"$repair_encoder_commit" "$GITHUB_SHA"' in repair_command
+    assert "repair replay is limited to one non-legacy target" in repair_command
+    assert 'test -n "$REPLACE_RULESPEC_PATH"' not in repair_command
+    assert 'targeted-reencode-failure-${REPAIR_RUN_ID}-1' in repair_command
+    assert "extract_repair_candidate.py" in repair_command
+    for immutable_argument in (
+        "--citation",
+        "--country",
+        "--encoder-commit",
+        "--corpus-ref",
+        "--rules-engine-ref",
+        "--rulespec-ref",
+        "--replace-rulespec-path",
+        "--workflow-run-id",
+    ):
+        assert immutable_argument in repair_command
+
     provision_step = next(
         step
         for step in steps
@@ -2152,6 +2195,14 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "$GITHUB_WORKSPACE/axiom-rules-engine/.axiom-targeted" not in command
     assert "printf '%s\\n' \"$review_finding\"" in command
     assert 'args+=(--review-findings "$review_finding_path")' in command
+    assert '--repair-candidate-root "$REPAIR_CANDIDATE_ROOT"' in command
+    assert '--repair-candidate-path "$REPAIR_CANDIDATE_PATH"' in command
+    assert apply_step["env"]["REPAIR_CANDIDATE_ROOT"] == (
+        "${{ steps.repair_candidate.outputs.root }}"
+    )
+    assert apply_step["env"]["REPAIR_CANDIDATE_PATH"] == (
+        "${{ steps.repair_candidate.outputs.path }}"
+    )
     assert "args+=(--apply-target-only)" in command
     assert 'args+=(--replace-rulespec-path "$replacement_path")' in command
     assert 'local require_direct_imports="$7"' in command
@@ -2234,6 +2285,9 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         "COMMIT_REVIEWED_LANE_CHANGES_CONCLUSION",
         "COMMIT_REVIEWED_LANE_CHANGES_OUTCOME",
         "PR_BASE_BRANCH",
+        "REPAIR_CANDIDATE_CONCLUSION",
+        "REPAIR_CANDIDATE_OUTCOME",
+        "REPAIR_RUN_ID",
         "PROVISION_SIGNING_SUPERVISOR_CONCLUSION",
         "PUBLISH_LANE_PULL_REQUEST_CONCLUSION",
         "PUBLISH_LANE_PULL_REQUEST_OUTCOME",
@@ -2370,6 +2424,10 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     )
     assert '"queue_item_generation_sha256": (' in package_command
     assert '"queue_manifest_sha256": (' in package_command
+    assert '"repair_candidate": repair_candidate' in package_command
+    assert '"repair_run_id": os.environ.get("REPAIR_RUN_ID") or None' in (
+        package_command
+    )
     assert '"workflow_run_attempt": int(os.environ["GITHUB_RUN_ATTEMPT"])' in (
         package_command
     )
@@ -2526,6 +2584,9 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
     }
     preflight_guard_raw = json.dumps(preflight_guard_payload) + "\n"
     (tmp_path / "target-preflight-guard-generated.json").write_text(preflight_guard_raw)
+    # A failed resolver can leave the shell redirection target empty. Failure
+    # packaging must preserve that resolver failure without parsing partial evidence.
+    (tmp_path / "repair-candidate.json").write_text("")
     env = {
         **os.environ,
         "CITATION": "us/statute/42/1437c-1",

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2071,16 +2071,13 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert '.conclusion == "failure"' in repair_command
     assert '.event == "workflow_dispatch"' in repair_command
     assert '.head_branch == "main"' in repair_command
-    assert '.run_attempt == 1' in repair_command
-    assert (
-        '.path == ".github/workflows/targeted-signed-reencode.yml"'
-        in repair_command
-    )
+    assert ".run_attempt == 1" in repair_command
+    assert '.path == ".github/workflows/targeted-signed-reencode.yml"' in repair_command
     assert "merge-base --is-ancestor" in repair_command
     assert '"$repair_encoder_commit" "$GITHUB_SHA"' in repair_command
     assert "repair replay is limited to one non-legacy target" in repair_command
     assert 'test -n "$REPLACE_RULESPEC_PATH"' not in repair_command
-    assert 'targeted-reencode-failure-${REPAIR_RUN_ID}-1' in repair_command
+    assert "targeted-reencode-failure-${REPAIR_RUN_ID}-1" in repair_command
     assert "extract_repair_candidate.py" in repair_command
     for immutable_argument in (
         "--citation",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1534"
+version = "0.2.1535"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1532"
+version = "0.2.1533"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1533"
+version = "0.2.1534"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1535"
+version = "0.2.1536"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- replay one checksum-bound validator-rejected candidate from a prior protected workflow run
- verify prior-run workflow, branch, commit ancestry, immutable pins, target scope, artifact identity, mode identity, and file digests before prompt use
- bind both success and failure artifact provenance to the exact candidate hashes consumed by the encoder
- bump axiom-encode to 0.2.1536

## Validation
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run ruff format --check src/axiom_encode scripts tests` (152 files)
- `python -m compileall -q src/axiom_encode scripts`
- focused repair, CLI, workflow, signing, version, and mutation tests: passing
- real run `30948607486` extraction: passing with expected candidate/test hashes
- exact-head local full run reached 3,964 passed before local disk exhaustion caused temp-directory errors; hosted full-suite CI is the merge gate

## Cycle
- review of `86627f2cb`: four findings fixed (consumption hashes, prior mode binding, shared size bound, formatting)
- repeat review of `757997abc`: successful artifact and mode-field fixes verified; one failure-artifact provenance finding fixed
- repeat review of exact head `a61d2d385`: clean, no actionable findings

Tracks #1393.
