### PR TITLE
Allow repair replay across unchanged RuleSpec bases

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -461,20 +461,34 @@ jobs:
             --corpus-ref "$CORPUS_REF" \
             --rules-engine-ref "$RULES_ENGINE_REF" \
             --rulespec-ref "$RULESPEC_REF" \
+            --allow-rulespec-base-advance \
             --replace-rulespec-path "$REPLACE_RULESPEC_PATH" \
             --workflow-run-id "$REPAIR_RUN_ID" \
             > "$RUNNER_TEMP/repair-candidate.json"
           jq -e '
             (.root | type == "string" and length > 0)
             and (.path | type == "string" and length > 0)
+            and (.source_rulespec_ref | test("^[0-9a-f]{40}$"))
             and (.rulespec_sha256 | test("^[0-9a-f]{64}$"))
             and (.tests_sha256 | test("^[0-9a-f]{64}$"))
           ' "$RUNNER_TEMP/repair-candidate.json" > /dev/null
+          repair_source_rulespec_ref="$(jq -er '.source_rulespec_ref' \
+            "$RUNNER_TEMP/repair-candidate.json")"
+          repair_candidate_path="$(jq -er '.path' \
+            "$RUNNER_TEMP/repair-candidate.json")"
+          python3 axiom-encode/scripts/verify_repair_base_advance.py \
+            "$RULESPEC_CHECKOUT" \
+            --country "$COUNTRY" \
+            --source-ref "$repair_source_rulespec_ref" \
+            --current-ref "$RULESPEC_REF" \
+            --candidate-path "$repair_candidate_path"
           echo "root=$(jq -r '.root' "$RUNNER_TEMP/repair-candidate.json")" \
             >> "$GITHUB_OUTPUT"
           echo "path=$(jq -r '.path' "$RUNNER_TEMP/repair-candidate.json")" \
             >> "$GITHUB_OUTPUT"
           echo "runner=$(jq -r '.runner' "$RUNNER_TEMP/repair-candidate.json")" \
+            >> "$GITHUB_OUTPUT"
+          echo "source_rulespec_ref=$repair_source_rulespec_ref" \
             >> "$GITHUB_OUTPUT"
           echo "rulespec_sha256=$(jq -r '.rulespec_sha256' "$RUNNER_TEMP/repair-candidate.json")" \
             >> "$GITHUB_OUTPUT"
@@ -1426,6 +1440,7 @@ jobs:
           REPAIR_RUN_ID: ${{ inputs.repair_run_id }}
           REPAIR_CANDIDATE_PATH: ${{ steps.repair_candidate.outputs.path }}
           REPAIR_CANDIDATE_RUNNER: ${{ steps.repair_candidate.outputs.runner }}
+          REPAIR_CANDIDATE_SOURCE_RULESPEC_REF: ${{ steps.repair_candidate.outputs.source_rulespec_ref }}
           REPAIR_CANDIDATE_RULESPEC_SHA256: ${{ steps.repair_candidate.outputs.rulespec_sha256 }}
           REPAIR_CANDIDATE_TESTS_SHA256: ${{ steps.repair_candidate.outputs.tests_sha256 }}
           REPLACE_RULESPEC_PATH: ${{ inputs.replace_rulespec_path }}
@@ -2361,6 +2376,9 @@ jobs:
           if repair_run_id:
               consumed_path = os.environ.get("REPAIR_CANDIDATE_PATH", "")
               consumed_runner = os.environ.get("REPAIR_CANDIDATE_RUNNER", "")
+              consumed_source_rulespec_ref = os.environ.get(
+                  "REPAIR_CANDIDATE_SOURCE_RULESPEC_REF", ""
+              )
               consumed_rulespec_sha256 = os.environ.get(
                   "REPAIR_CANDIDATE_RULESPEC_SHA256", ""
               )
@@ -2373,6 +2391,10 @@ jobs:
                   raise SystemExit("repair candidate evidence path is malformed")
               if not re.fullmatch(r"[a-z0-9][a-z0-9._-]*", consumed_runner):
                   raise SystemExit("repair candidate evidence runner is malformed")
+              if not re.fullmatch(r"[0-9a-f]{40}", consumed_source_rulespec_ref):
+                  raise SystemExit(
+                      "repair candidate source RuleSpec ref is malformed"
+                  )
               if any(
                   re.fullmatch(r"[0-9a-f]{64}", digest) is None
                   for digest in (
@@ -2385,6 +2407,7 @@ jobs:
                   "run_id": repair_run_id,
                   "path": consumed_path,
                   "runner": consumed_runner,
+                  "source_rulespec_ref": consumed_source_rulespec_ref,
                   "rulespec_sha256": consumed_rulespec_sha256,
                   "tests_sha256": consumed_tests_sha256,
               }
@@ -2620,6 +2643,7 @@ jobs:
           REPAIR_CANDIDATE_OUTCOME: ${{ steps.repair_candidate.outcome }}
           REPAIR_CANDIDATE_PATH: ${{ steps.repair_candidate.outputs.path }}
           REPAIR_CANDIDATE_RUNNER: ${{ steps.repair_candidate.outputs.runner }}
+          REPAIR_CANDIDATE_SOURCE_RULESPEC_REF: ${{ steps.repair_candidate.outputs.source_rulespec_ref }}
           REPAIR_CANDIDATE_RULESPEC_SHA256: ${{ steps.repair_candidate.outputs.rulespec_sha256 }}
           REPAIR_CANDIDATE_TESTS_SHA256: ${{ steps.repair_candidate.outputs.tests_sha256 }}
           PROVISION_SIGNING_SUPERVISOR_CONCLUSION: ${{ steps.provision_signing_supervisor.conclusion }}
@@ -2909,6 +2933,9 @@ jobs:
           if os.environ.get("REPAIR_CANDIDATE_CONCLUSION") == "success":
               consumed_path = os.environ.get("REPAIR_CANDIDATE_PATH", "")
               consumed_runner = os.environ.get("REPAIR_CANDIDATE_RUNNER", "")
+              consumed_source_rulespec_ref = os.environ.get(
+                  "REPAIR_CANDIDATE_SOURCE_RULESPEC_REF", ""
+              )
               consumed_rulespec_sha256 = os.environ.get(
                   "REPAIR_CANDIDATE_RULESPEC_SHA256", ""
               )
@@ -2921,6 +2948,10 @@ jobs:
                   raise SystemExit("repair candidate evidence path is malformed")
               if not re.fullmatch(r"[a-z0-9][a-z0-9._-]*", consumed_runner):
                   raise SystemExit("repair candidate evidence runner is malformed")
+              if not re.fullmatch(r"[0-9a-f]{40}", consumed_source_rulespec_ref):
+                  raise SystemExit(
+                      "repair candidate source RuleSpec ref is malformed"
+                  )
               if any(
                   re.fullmatch(r"[0-9a-f]{64}", digest) is None
                   for digest in (
@@ -2933,6 +2964,7 @@ jobs:
                   "run_id": os.environ.get("REPAIR_RUN_ID") or None,
                   "path": consumed_path,
                   "runner": consumed_runner,
+                  "source_rulespec_ref": consumed_source_rulespec_ref,
                   "rulespec_sha256": consumed_rulespec_sha256,
                   "tests_sha256": consumed_tests_sha256,
               }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1537"
+version = "0.2.1538"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1536"
+version = "0.2.1537"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/extract_repair_candidate.py
+++ b/scripts/extract_repair_candidate.py
@@ -19,6 +19,7 @@ ATOMIC_ROOTS = frozenset(
 MAX_METADATA_BYTES = 4 * 1024 * 1024
 MAX_ARCHIVE_MEMBERS = 8192
 SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
+COMMIT_PATTERN = re.compile(r"[0-9a-f]{40}")
 RUNNER_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
 CONTRACT = runpy.run_path(
     Path(__file__).parents[1] / "src/axiom_encode/repair_candidate_contract.py"
@@ -164,7 +165,6 @@ def extract_candidate(args: argparse.Namespace) -> dict[str, str]:
         "encoder_commit": args.encoder_commit,
         "corpus_ref": args.corpus_ref,
         "rules_engine_ref": args.rules_engine_ref,
-        "rulespec_ref": args.rulespec_ref,
         "replace_rulespec_path": args.replace_rulespec_path,
         "workflow_run_id": args.workflow_run_id,
     }
@@ -188,6 +188,17 @@ def extract_candidate(args: argparse.Namespace) -> dict[str, str]:
         for field, expected in expected_fields.items():
             if field not in metadata or metadata[field] != expected:
                 raise ValueError(f"repair artifact metadata mismatch: {field}")
+        source_rulespec_ref = metadata.get("rulespec_ref")
+        if (
+            not isinstance(source_rulespec_ref, str)
+            or COMMIT_PATTERN.fullmatch(source_rulespec_ref) is None
+        ):
+            raise ValueError("repair artifact metadata mismatch: rulespec_ref")
+        if (
+            source_rulespec_ref != args.rulespec_ref
+            and not args.allow_rulespec_base_advance
+        ):
+            raise ValueError("repair artifact metadata mismatch: rulespec_ref")
         for field, expected in SINGLE_TARGET_MODE_FIELDS.items():
             if field not in metadata or metadata[field] != expected:
                 raise ValueError(
@@ -256,6 +267,7 @@ def extract_candidate(args: argparse.Namespace) -> dict[str, str]:
         "rulespec_sha256": hashlib.sha256(candidate).hexdigest(),
         "tests_sha256": hashlib.sha256(tests).hexdigest(),
         "runner": runner,
+        "source_rulespec_ref": source_rulespec_ref,
     }
 
 
@@ -269,6 +281,7 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--corpus-ref", required=True)
     parser.add_argument("--rules-engine-ref", required=True)
     parser.add_argument("--rulespec-ref", required=True)
+    parser.add_argument("--allow-rulespec-base-advance", action="store_true")
     parser.add_argument("--replace-rulespec-path", required=True)
     parser.add_argument("--workflow-run-id", required=True)
     return parser

--- a/scripts/verify_repair_base_advance.py
+++ b/scripts/verify_repair_base_advance.py
@@ -71,12 +71,13 @@ def verify_base_advance(
     if ancestor.returncode != 0:
         raise ValueError("repair source RuleSpec ref is not an ancestor of current")
 
+    rulespec_path = PurePosixPath(country, path)
     test_path = path.with_suffix(".test.yaml")
-    manifest_path = PurePosixPath(
-        ".axiom", "encoding-manifests", country, path.with_suffix("")
+    manifest_path = (
+        PurePosixPath(".axiom", "encoding-manifests") / rulespec_path
     ).with_suffix(".json")
     tracked_paths = (
-        PurePosixPath(country, path).as_posix(),
+        rulespec_path.as_posix(),
         PurePosixPath(country, test_path).as_posix(),
         manifest_path.as_posix(),
     )

--- a/scripts/verify_repair_base_advance.py
+++ b/scripts/verify_repair_base_advance.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Verify that a repair candidate's RuleSpec target survived a base advance."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+from pathlib import Path, PurePosixPath
+
+ATOMIC_ROOTS = frozenset(
+    {"guidance", "manuals", "policies", "programs", "regulations", "statutes"}
+)
+COMMIT_PATTERN = re.compile(r"[0-9a-f]{40}")
+
+
+def _git(
+    repository: Path, *arguments: str, check: bool = True
+) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(repository), *arguments],
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def verify_base_advance(
+    repository: Path,
+    *,
+    country: str,
+    source_ref: str,
+    current_ref: str,
+    candidate_path: str,
+) -> None:
+    repository = repository.resolve()
+    path = PurePosixPath(candidate_path)
+    if (
+        re.fullmatch(r"[a-z][a-z0-9-]*", country) is None
+        or path.is_absolute()
+        or len(path.parts) < 2
+        or path.parts[0] not in ATOMIC_ROOTS
+        or path.suffix != ".yaml"
+        or path.name.endswith(".test.yaml")
+        or any(part in {"", ".", ".."} for part in path.parts)
+    ):
+        raise ValueError("repair candidate path is not canonical")
+    for label, commit in (("source", source_ref), ("current", current_ref)):
+        if COMMIT_PATTERN.fullmatch(commit) is None:
+            raise ValueError(f"repair {label} RuleSpec ref is not a full commit SHA")
+
+    head = _git(repository, "rev-parse", "HEAD").stdout.strip()
+    if head != current_ref:
+        raise ValueError("repair current RuleSpec ref is not the checkout HEAD")
+    source_commit = _git(
+        repository,
+        "rev-parse",
+        "--verify",
+        f"{source_ref}^{{commit}}",
+    ).stdout.strip()
+    if source_commit != source_ref:
+        raise ValueError("repair source RuleSpec ref does not identify its commit")
+    ancestor = _git(
+        repository,
+        "merge-base",
+        "--is-ancestor",
+        source_ref,
+        current_ref,
+        check=False,
+    )
+    if ancestor.returncode != 0:
+        raise ValueError("repair source RuleSpec ref is not an ancestor of current")
+
+    test_path = path.with_suffix(".test.yaml")
+    manifest_path = PurePosixPath(
+        ".axiom", "encoding-manifests", country, path.with_suffix("")
+    ).with_suffix(".json")
+    tracked_paths = (
+        PurePosixPath(country, path).as_posix(),
+        PurePosixPath(country, test_path).as_posix(),
+        manifest_path.as_posix(),
+    )
+    unchanged = _git(
+        repository,
+        "diff",
+        "--quiet",
+        source_ref,
+        current_ref,
+        "--",
+        *tracked_paths,
+        check=False,
+    )
+    if unchanged.returncode == 1:
+        raise ValueError(
+            "repair replay target identity changed after its source RuleSpec base"
+        )
+    if unchanged.returncode != 0:
+        raise RuntimeError("could not compare repair replay target identity")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("repository", type=Path)
+    parser.add_argument("--country", required=True)
+    parser.add_argument("--source-ref", required=True)
+    parser.add_argument("--current-ref", required=True)
+    parser.add_argument("--candidate-path", required=True)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    verify_base_advance(
+        args.repository,
+        country=args.country,
+        source_ref=args.source_ref,
+        current_ref=args.current_ref,
+        candidate_path=args.candidate_path,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1536"
+__version__ = "0.2.1537"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1537"
+__version__ = "0.2.1538"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1536"
+ENCODER_VERSION = "0.2.1537"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1537"
+ENCODER_VERSION = "0.2.1538"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_extract_repair_candidate.py
+++ b/tests/test_extract_repair_candidate.py
@@ -96,6 +96,7 @@ def _args(tmp_path: Path, archive: Path, **overrides) -> Namespace:
         "corpus_ref": "b" * 40,
         "rules_engine_ref": "c" * 40,
         "rulespec_ref": "d" * 40,
+        "allow_rulespec_base_advance": False,
         "replace_rulespec_path": "us/statutes/42/1437c-1.yaml",
         "workflow_run_id": "1234",
     }
@@ -110,6 +111,7 @@ def test_extracts_checksum_bound_final_candidate(tmp_path):
 
     root = Path(result["root"])
     assert result["path"] == "statutes/42/1437c-1.yaml"
+    assert result["source_rulespec_ref"] == "d" * 40
     assert (root / result["path"]).read_text() == "format: rulespec/v1\nrules: []\n"
     assert (root / "statutes/42/1437c-1.test.yaml").read_text() == "[]\n"
 
@@ -119,6 +121,41 @@ def test_rejects_metadata_identity_mismatch(tmp_path):
 
     with pytest.raises(ValueError, match="metadata mismatch: rulespec_ref"):
         extract_candidate(_args(tmp_path, archive, rulespec_ref="e" * 40))
+
+
+def test_allows_explicit_rulespec_base_advance_for_later_workflow_proof(tmp_path):
+    archive, _ = _archive(tmp_path)
+
+    result = extract_candidate(
+        _args(
+            tmp_path,
+            archive,
+            rulespec_ref="e" * 40,
+            allow_rulespec_base_advance=True,
+        )
+    )
+
+    assert result["source_rulespec_ref"] == "d" * 40
+
+
+def test_rejects_malformed_source_rulespec_ref_during_base_advance(tmp_path):
+    archive, metadata = _archive(tmp_path)
+    metadata["rulespec_ref"] = "not-a-commit"
+    replacement = _rewrite_metadata(
+        archive,
+        tmp_path / "malformed-rulespec-ref.tar",
+        metadata,
+    )
+
+    with pytest.raises(ValueError, match="metadata mismatch: rulespec_ref"):
+        extract_candidate(
+            _args(
+                tmp_path,
+                replacement,
+                rulespec_ref="e" * 40,
+                allow_rulespec_base_advance=True,
+            )
+        )
 
 
 def test_rejects_candidate_digest_mismatch(tmp_path):

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1537"
+ENCODER_VERSION = "0.2.1538"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1536"
+ENCODER_VERSION = "0.2.1537"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1537"
+ENCODER_VERSION = "0.2.1538"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1536"
+ENCODER_VERSION = "0.2.1537"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1536"
+ENCODER_VERSION = "0.2.1537"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1537"
+ENCODER_VERSION = "0.2.1538"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1537"
+ENCODER_VERSION = "0.2.1538"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1536"
+ENCODER_VERSION = "0.2.1537"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1537"
+ENCODER_VERSION = "0.2.1538"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1536"
+ENCODER_VERSION = "0.2.1537"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1537"
+ENCODER_VERSION = "0.2.1538"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1536"
+ENCODER_VERSION = "0.2.1537"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1537"')
+        .startswith('__version__ = "0.2.1538"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1537"
+    assert encoder_package["version"] == "0.2.1538"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1537"
+    assert project["project"]["version"] == "0.2.1538"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1537"')
+        .startswith('__version__ = "0.2.1538"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1537"
+    assert encoder_package["version"] == "0.2.1538"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1537"
+    assert project["project"]["version"] == "0.2.1538"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1537"')
+        .startswith('__version__ = "0.2.1538"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1536"')
+        .startswith('__version__ = "0.2.1537"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1536"
+    assert encoder_package["version"] == "0.2.1537"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1536"
+    assert project["project"]["version"] == "0.2.1537"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1536"')
+        .startswith('__version__ = "0.2.1537"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1536"
+    assert encoder_package["version"] == "0.2.1537"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1536"
+    assert project["project"]["version"] == "0.2.1537"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1536"')
+        .startswith('__version__ = "0.2.1537"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1537"
+ENCODER_VERSION = "0.2.1538"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1536"
+ENCODER_VERSION = "0.2.1537"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2090,7 +2090,13 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         "--workflow-run-id",
     ):
         assert immutable_argument in repair_command
+    assert "--allow-rulespec-base-advance" in repair_command
+    assert "verify_repair_base_advance.py" in repair_command
+    assert '--source-ref "$repair_source_rulespec_ref"' in repair_command
+    assert '--current-ref "$RULESPEC_REF"' in repair_command
+    assert '--candidate-path "$repair_candidate_path"' in repair_command
     assert 'echo "runner=$(jq -r' in repair_command
+    assert 'echo "source_rulespec_ref=$repair_source_rulespec_ref"' in repair_command
 
     provision_step = next(
         step
@@ -2297,6 +2303,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         "REPAIR_CANDIDATE_OUTCOME",
         "REPAIR_CANDIDATE_PATH",
         "REPAIR_CANDIDATE_RUNNER",
+        "REPAIR_CANDIDATE_SOURCE_RULESPEC_REF",
         "REPAIR_CANDIDATE_RULESPEC_SHA256",
         "REPAIR_CANDIDATE_TESTS_SHA256",
         "REPAIR_RUN_ID",
@@ -2332,6 +2339,9 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     )
     assert failure_package_step["env"]["REPAIR_CANDIDATE_RUNNER"] == (
         "${{ steps.repair_candidate.outputs.runner }}"
+    )
+    assert failure_package_step["env"]["REPAIR_CANDIDATE_SOURCE_RULESPEC_REF"] == (
+        "${{ steps.repair_candidate.outputs.source_rulespec_ref }}"
     )
     assert failure_package_step["env"]["REPAIR_CANDIDATE_RULESPEC_SHA256"] == (
         "${{ steps.repair_candidate.outputs.rulespec_sha256 }}"
@@ -2419,6 +2429,9 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     )
     assert package_step["env"]["REPAIR_CANDIDATE_RUNNER"] == (
         "${{ steps.repair_candidate.outputs.runner }}"
+    )
+    assert package_step["env"]["REPAIR_CANDIDATE_SOURCE_RULESPEC_REF"] == (
+        "${{ steps.repair_candidate.outputs.source_rulespec_ref }}"
     )
     assert package_step["env"]["REPAIR_CANDIDATE_RULESPEC_SHA256"] == (
         "${{ steps.repair_candidate.outputs.rulespec_sha256 }}"
@@ -2781,6 +2794,7 @@ def test_failed_reencode_metadata_uses_consumed_identity_after_evidence_mutation
             "REPAIR_CANDIDATE_OUTCOME": "success",
             "REPAIR_CANDIDATE_PATH": "statutes/42/1437c-1.yaml",
             "REPAIR_CANDIDATE_RUNNER": "openai-gpt-5.6-sol",
+            "REPAIR_CANDIDATE_SOURCE_RULESPEC_REF": "f" * 40,
             "REPAIR_CANDIDATE_RULESPEC_SHA256": "d" * 64,
             "REPAIR_CANDIDATE_TESTS_SHA256": "e" * 64,
             "REPAIR_RUN_ID": "1234",
@@ -2801,6 +2815,7 @@ def test_failed_reencode_metadata_uses_consumed_identity_after_evidence_mutation
         "rulespec_sha256": "d" * 64,
         "run_id": "1234",
         "runner": "openai-gpt-5.6-sol",
+        "source_rulespec_ref": "f" * 40,
         "tests_sha256": "e" * 64,
     }
 
@@ -4190,6 +4205,7 @@ def test_targeted_metadata_uses_consumed_repair_identity_after_evidence_mutation
             "PR_BASE_BRANCH": "hard-cut/canonical-layout-us",
             "REPAIR_CANDIDATE_PATH": "statutes/42/1437c-1.yaml",
             "REPAIR_CANDIDATE_RUNNER": "openai-gpt-5.6-sol",
+            "REPAIR_CANDIDATE_SOURCE_RULESPEC_REF": "f" * 40,
             "REPAIR_CANDIDATE_RULESPEC_SHA256": "d" * 64,
             "REPAIR_CANDIDATE_TESTS_SHA256": "e" * 64,
             "REPAIR_RUN_ID": "1234",
@@ -4206,6 +4222,7 @@ def test_targeted_metadata_uses_consumed_repair_identity_after_evidence_mutation
         "rulespec_sha256": "d" * 64,
         "run_id": "1234",
         "runner": "openai-gpt-5.6-sol",
+        "source_rulespec_ref": "f" * 40,
         "tests_sha256": "e" * 64,
     }
 

--- a/tests/test_verify_repair_base_advance.py
+++ b/tests/test_verify_repair_base_advance.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.verify_repair_base_advance import verify_base_advance
+
+
+def _git(repository: Path, *arguments: str) -> str:
+    return subprocess.check_output(
+        ["git", "-C", str(repository), *arguments], text=True
+    ).strip()
+
+
+def _commit(repository: Path, message: str) -> str:
+    subprocess.run(["git", "-C", str(repository), "add", "-A"], check=True)
+    subprocess.run(["git", "-C", str(repository), "commit", "-qm", message], check=True)
+    return _git(repository, "rev-parse", "HEAD")
+
+
+def _repository(tmp_path: Path) -> tuple[Path, str]:
+    repository = tmp_path / "rulespec-us"
+    repository.mkdir()
+    subprocess.run(["git", "-C", str(repository), "init", "-q"], check=True)
+    _git(repository, "config", "user.email", "test@example.com")
+    _git(repository, "config", "user.name", "Test")
+    payloads = {
+        "us/statutes/42/1437c-1.yaml": "format: rulespec/v1\n",
+        "us/statutes/42/1437c-1.test.yaml": "tests: []\n",
+        ".axiom/encoding-manifests/us/statutes/42/1437c-1.json": "{}\n",
+    }
+    for relative_path, content in payloads.items():
+        destination = repository / relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(content, encoding="utf-8")
+    return repository, _commit(repository, "source")
+
+
+def test_accepts_ancestor_base_when_repair_target_identity_is_unchanged(
+    tmp_path: Path,
+) -> None:
+    repository, source_ref = _repository(tmp_path)
+    (repository / "unrelated.txt").write_text("advance\n", encoding="utf-8")
+    current_ref = _commit(repository, "unrelated advance")
+
+    verify_base_advance(
+        repository,
+        country="us",
+        source_ref=source_ref,
+        current_ref=current_ref,
+        candidate_path="statutes/42/1437c-1.yaml",
+    )
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "us/statutes/42/1437c-1.yaml",
+        "us/statutes/42/1437c-1.test.yaml",
+        ".axiom/encoding-manifests/us/statutes/42/1437c-1.json",
+    ],
+)
+def test_rejects_advance_that_changes_repair_target_identity(
+    tmp_path: Path,
+    relative_path: str,
+) -> None:
+    repository, source_ref = _repository(tmp_path)
+    (repository / relative_path).write_text("changed\n", encoding="utf-8")
+    current_ref = _commit(repository, "target changed")
+
+    with pytest.raises(ValueError, match="target identity changed"):
+        verify_base_advance(
+            repository,
+            country="us",
+            source_ref=source_ref,
+            current_ref=current_ref,
+            candidate_path="statutes/42/1437c-1.yaml",
+        )
+
+
+def test_rejects_source_ref_that_is_not_an_ancestor(tmp_path: Path) -> None:
+    repository, source_ref = _repository(tmp_path)
+    (repository / "source-only.txt").write_text("source\n", encoding="utf-8")
+    source_ref = _commit(repository, "source branch")
+    subprocess.run(
+        ["git", "-C", str(repository), "switch", "-qc", "other", f"{source_ref}^"],
+        check=True,
+    )
+    (repository / "other.txt").write_text("other\n", encoding="utf-8")
+    current_ref = _commit(repository, "other history")
+
+    with pytest.raises(ValueError, match="not an ancestor"):
+        verify_base_advance(
+            repository,
+            country="us",
+            source_ref=source_ref,
+            current_ref=current_ref,
+            candidate_path="statutes/42/1437c-1.yaml",
+        )
+
+
+def test_rejects_current_ref_that_is_not_checkout_head(tmp_path: Path) -> None:
+    repository, source_ref = _repository(tmp_path)
+    (repository / "unrelated.txt").write_text("advance\n", encoding="utf-8")
+    _commit(repository, "advance")
+
+    with pytest.raises(ValueError, match="not the checkout HEAD"):
+        verify_base_advance(
+            repository,
+            country="us",
+            source_ref=source_ref,
+            current_ref=source_ref,
+            candidate_path="statutes/42/1437c-1.yaml",
+        )
+
+
+@pytest.mark.parametrize(
+    ("country", "candidate_path"),
+    [
+        ("../us", "statutes/42/1437c-1.yaml"),
+        ("us", "../statutes/42/1437c-1.yaml"),
+        ("us", "/statutes/42/1437c-1.yaml"),
+        ("us", "statutes/42/1437c-1.test.yaml"),
+    ],
+)
+def test_rejects_noncanonical_identity_paths(
+    tmp_path: Path,
+    country: str,
+    candidate_path: str,
+) -> None:
+    repository, source_ref = _repository(tmp_path)
+
+    with pytest.raises(ValueError, match="path is not canonical"):
+        verify_base_advance(
+            repository,
+            country=country,
+            source_ref=source_ref,
+            current_ref=source_ref,
+            candidate_path=candidate_path,
+        )

--- a/tests/test_verify_repair_base_advance.py
+++ b/tests/test_verify_repair_base_advance.py
@@ -20,16 +20,21 @@ def _commit(repository: Path, message: str) -> str:
     return _git(repository, "rev-parse", "HEAD")
 
 
-def _repository(tmp_path: Path) -> tuple[Path, str]:
+def _repository(
+    tmp_path: Path,
+    *,
+    candidate_path: str = "statutes/42/1437c-1.yaml",
+) -> tuple[Path, str]:
     repository = tmp_path / "rulespec-us"
     repository.mkdir()
     subprocess.run(["git", "-C", str(repository), "init", "-q"], check=True)
     _git(repository, "config", "user.email", "test@example.com")
     _git(repository, "config", "user.name", "Test")
+    rulespec_path = Path("us") / candidate_path
     payloads = {
-        "us/statutes/42/1437c-1.yaml": "format: rulespec/v1\n",
-        "us/statutes/42/1437c-1.test.yaml": "tests: []\n",
-        ".axiom/encoding-manifests/us/statutes/42/1437c-1.json": "{}\n",
+        rulespec_path: "format: rulespec/v1\n",
+        rulespec_path.with_suffix(".test.yaml"): "tests: []\n",
+        Path(".axiom/encoding-manifests") / rulespec_path.with_suffix(".json"): "{}\n",
     }
     for relative_path, content in payloads.items():
         destination = repository / relative_path
@@ -77,6 +82,28 @@ def test_rejects_advance_that_changes_repair_target_identity(
             source_ref=source_ref,
             current_ref=current_ref,
             candidate_path="statutes/42/1437c-1.yaml",
+        )
+
+
+def test_rejects_dotted_section_manifest_change_at_real_manifest_path(
+    tmp_path: Path,
+) -> None:
+    candidate_path = "regulations/10-ccr/4.100.yaml"
+    repository, source_ref = _repository(
+        tmp_path,
+        candidate_path=candidate_path,
+    )
+    manifest = repository / ".axiom/encoding-manifests/us/regulations/10-ccr/4.100.json"
+    manifest.write_text("changed\n", encoding="utf-8")
+    current_ref = _commit(repository, "dotted manifest changed")
+
+    with pytest.raises(ValueError, match="target identity changed"):
+        verify_base_advance(
+            repository,
+            country="us",
+            source_ref=source_ref,
+            current_ref=current_ref,
+            candidate_path=candidate_path,
         )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1536"
+version = "0.2.1537"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1537"
+version = "0.2.1538"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- allow a checksum-bound repair candidate to identify an older RuleSpec source base
- require that source base to be an ancestor of the current protected checkout
- reject replay if the target RuleSpec, companion test, or signed encoding manifest changed across the advance
- preserve the source RuleSpec SHA in success and failure artifact provenance
- bump axiom-encode to 0.2.1538

## Validation
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run ruff format --check src/axiom_encode scripts tests` (154 files)
- `python -m compileall -q src/axiom_encode scripts`
- focused repair, workflow, provenance, and base-advance tests: 50 passed
- real run 30948607486 extracted against current hard-cut tip with expected hashes
- real history: source `b1a6e07` is an ancestor of `6535019`; target RuleSpec, test, and manifest are unchanged

## Cycle
- review of `d1512733e`: found dotted-section manifest path derivation bug
- fixed using the encoder's full RuleSpec relative path convention and added a `4.100.yaml` regression
- repeat independent review pending on exact head `4d7ee3472`

Tracks #1393.
