### PR TITLE
Add atomic canonical refresh bundles

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -43,6 +43,11 @@ on:
         required: false
         default: "[]"
         type: string
+      canonical_refresh_bundle_json:
+        description: JSON array of {citation,replace_rulespec_path} additions to fresh-encode independently with the primary in one signed transaction
+        required: false
+        default: "[]"
+        type: string
       existing_signed_imports_json:
         description: JSON array of tracked same-jurisdiction signed-v5 modules to reuse as direct imports
         required: false
@@ -353,6 +358,7 @@ jobs:
         id: repair_candidate
         if: ${{ inputs.repair_run_id != '' }}
         env:
+          CANONICAL_REFRESH_BUNDLE_JSON: ${{ inputs.canonical_refresh_bundle_json }}
           CITATION: ${{ inputs.citation }}
           CORPUS_REF: ${{ inputs.corpus_ref }}
           COUNTRY: ${{ inputs.country }}
@@ -385,6 +391,8 @@ jobs:
              [ -n "$DEPENDENT_CITATION" ] || \
              [ -n "$SECOND_DEPENDENT_CITATION" ] || \
              [ -n "$QUEUE_ID" ] || \
+             ! jq -e 'type == "array" and length == 0' \
+               <<< "${CANONICAL_REFRESH_BUNDLE_JSON:-[]}" > /dev/null || \
              ! jq -e 'type == "array" and length == 0' \
                <<< "${SOURCE_BUNDLE_JSON:-[]}" > /dev/null || \
              ! jq -e 'type == "array" and length == 0' \
@@ -529,12 +537,14 @@ jobs:
 
       - name: Validate atomic source inputs
         env:
+          CANONICAL_REFRESH_BUNDLE_JSON: ${{ inputs.canonical_refresh_bundle_json }}
           CITATION: ${{ inputs.citation }}
           DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
           EXISTING_SIGNED_IMPORTS_JSON: ${{ inputs.existing_signed_imports_json }}
           LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.legacy_exact_dependent_rulespec_path }}
           LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON: ${{ inputs.legacy_retained_successor_rulespec_paths_json }}
           QUEUE_ID: ${{ inputs.queue_id }}
+          REPAIR_RUN_ID: ${{ inputs.repair_run_id }}
           REPLACE_LEGACY_RULESPEC_PATH: ${{ inputs.replace_legacy_rulespec_path }}
           REPLACE_RULESPEC_PATH: ${{ inputs.replace_rulespec_path }}
           RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
@@ -556,6 +566,14 @@ jobs:
             source_bundle_args+=(--exclude-citation "$SECOND_DEPENDENT_CITATION")
           fi
           normalized_source_bundle="$("${source_bundle_args[@]}")"
+          normalized_canonical_refresh_bundle="$(
+            axiom-encode/.venv/bin/python \
+              axiom-encode/scripts/prepare_signed_backfill.py \
+              parse-canonical-refresh-bundle "$RULESPEC_CHECKOUT" \
+              "${CANONICAL_REFRESH_BUNDLE_JSON:-[]}" \
+              --primary-citation "$CITATION" \
+              --primary-rulespec-path "$REPLACE_RULESPEC_PATH"
+          )"
           existing_import_args=(
             axiom-encode/.venv/bin/python
             axiom-encode/scripts/prepare_signed_backfill.py
@@ -596,6 +614,20 @@ jobs:
             fi
           done
           normalized_existing_imports="$("${existing_import_args[@]}")"
+          if [ "$normalized_canonical_refresh_bundle" != "[]" ] && \
+            { [ "$normalized_source_bundle" != "[]" ] || \
+              [ "$normalized_existing_imports" != "[]" ] || \
+              [ -n "$REPLACE_LEGACY_RULESPEC_PATH" ] || \
+              [ -n "$LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" ] || \
+              [ -n "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" ] || \
+              [ "${#retained_successor_paths[@]}" -gt 0 ] || \
+              [ -n "$DEPENDENT_CITATION" ] || \
+              [ -n "$SECOND_DEPENDENT_CITATION" ] || \
+              [ -n "$REPAIR_RUN_ID" ] || \
+              [ -n "$QUEUE_ID" ]; }; then
+            echo "canonical refresh bundles cannot mix with imports, composition bundles, legacy/dependent migration, repair replay, or queue authorization" >&2
+            exit 1
+          fi
           if [ "$normalized_source_bundle" != "[]" ] && \
              [ -n "$REPLACE_LEGACY_RULESPEC_PATH" ]; then
             echo "source bundles require legacy replacements to merge first" >&2
@@ -612,7 +644,8 @@ jobs:
             exit 1
           fi
           if [ -n "$QUEUE_ID" ] && \
-            { [ "$normalized_source_bundle" != "[]" ] || \
+            { [ "$normalized_canonical_refresh_bundle" != "[]" ] || \
+              [ "$normalized_source_bundle" != "[]" ] || \
               [ "$normalized_existing_imports" != "[]" ]; }; then
             echo "queue-authorized re-encodes cannot add source inputs until queue generation identity binds them" >&2
             exit 1
@@ -813,6 +846,7 @@ jobs:
 
       - name: Verify existing signed imports
         env:
+          CANONICAL_REFRESH_BUNDLE_JSON: ${{ inputs.canonical_refresh_bundle_json }}
           CITATION: ${{ inputs.citation }}
           DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
           EXISTING_SIGNED_IMPORTS_JSON: ${{ inputs.existing_signed_imports_json }}
@@ -842,6 +876,15 @@ jobs:
           normalized_source_bundle="$("${source_bundle_args[@]}")"
           printf '%s\n' "$normalized_source_bundle" \
             > "$RUNNER_TEMP/source-bundle.json"
+          normalized_canonical_refresh_bundle="$(
+            "$workflow_python" -I "$backfill_helper" \
+              parse-canonical-refresh-bundle "$RULESPEC_CHECKOUT" \
+              "${CANONICAL_REFRESH_BUNDLE_JSON:-[]}" \
+              --primary-citation "$CITATION" \
+              --primary-rulespec-path "$REPLACE_RULESPEC_PATH"
+          )"
+          printf '%s\n' "$normalized_canonical_refresh_bundle" \
+            > "$RUNNER_TEMP/canonical-refresh-bundle.json"
 
           existing_import_args=(
             "$workflow_python" -I "$backfill_helper"
@@ -935,6 +978,7 @@ jobs:
         id: encode_apply
         env:
           AXIOM_ENCODE_APPLY_SIGNING_KEY: ${{ secrets.AXIOM_ENCODE_APPLY_SIGNING_KEY }}
+          CANONICAL_REFRESH_BUNDLE_JSON: ${{ inputs.canonical_refresh_bundle_json }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CITATION: ${{ inputs.citation }}
           REVIEW_FINDING: ${{ inputs.review_finding }}
@@ -1197,6 +1241,20 @@ jobs:
             source_bundle_args+=(--exclude-citation "$SECOND_DEPENDENT_CITATION")
           fi
           normalized_source_bundle="$("${source_bundle_args[@]}")"
+          normalized_canonical_refresh_bundle="$(
+            "$workflow_python" "$backfill_helper" \
+              parse-canonical-refresh-bundle "$RULESPEC_CHECKOUT" \
+              "${CANONICAL_REFRESH_BUNDLE_JSON:-[]}" \
+              --primary-citation "$CITATION" \
+              --primary-rulespec-path "$REPLACE_RULESPEC_PATH"
+          )"
+          verified_canonical_refresh_bundle="$(tr -d '\n' \
+            < "$RUNNER_TEMP/canonical-refresh-bundle.json")"
+          if [ "$normalized_canonical_refresh_bundle" != \
+               "$verified_canonical_refresh_bundle" ]; then
+            echo "verified canonical refresh bundle changed before apply" >&2
+            exit 1
+          fi
           existing_import_args=(
             "$workflow_python" "$backfill_helper"
             parse-existing-signed-imports "$RULESPEC_CHECKOUT"
@@ -1251,15 +1309,35 @@ jobs:
             > "$RUNNER_TEMP/required-import-rulespec-paths.txt"
           source_bundle_count="$(jq -er 'length' \
             "$RUNNER_TEMP/source-bundle.json")"
+          canonical_refresh_count="$(jq -er 'length' \
+            "$RUNNER_TEMP/canonical-refresh-bundle.json")"
           existing_import_count="$(jq -er 'length' \
             "$RUNNER_TEMP/existing-signed-imports.json")"
           source_bundle_enabled=false
           if [ "$source_bundle_count" -gt 0 ]; then
             source_bundle_enabled=true
           fi
+          canonical_refresh_enabled=false
+          if [ "$canonical_refresh_count" -gt 0 ]; then
+            canonical_refresh_enabled=true
+          fi
           required_imports_enabled=false
           if [ $((source_bundle_count + existing_import_count)) -gt 0 ]; then
             required_imports_enabled=true
+          fi
+          if [ "$canonical_refresh_enabled" = "true" ] && \
+            { [ "$source_bundle_enabled" = "true" ] || \
+              [ "$existing_import_count" -gt 0 ] || \
+              [ -n "$REPLACE_LEGACY_RULESPEC_PATH" ] || \
+              [ -n "$LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" ] || \
+              [ -n "$SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH" ] || \
+              [ "$retained_successor_count" -gt 0 ] || \
+              [ -n "$DEPENDENT_CITATION" ] || \
+              [ -n "$SECOND_DEPENDENT_CITATION" ] || \
+              [ -n "${REPAIR_CANDIDATE_ROOT:-}" ] || \
+              [ -n "$QUEUE_ID" ]; }; then
+            echo "canonical refresh bundles cannot mix with imports, composition bundles, legacy/dependent migration, repair replay, or queue authorization" >&2
+            exit 1
           fi
           if [ "$source_bundle_enabled" = "true" ] && \
              [ -n "$REPLACE_LEGACY_RULESPEC_PATH" ]; then
@@ -1307,58 +1385,87 @@ jobs:
               commit -m "$message"
           }
 
-          if [ "$source_bundle_enabled" = "true" ] && \
-             [ -n "$REPLACE_RULESPEC_PATH" ] && \
-             [ -z "$REPLACE_LEGACY_RULESPEC_PATH" ]; then
-            run_signed_encode \
-              "$CITATION" "" false target-preflight \
-              "$REPLACE_RULESPEC_PATH" "" false
-            checkpoint_signed_changes \
-              "Canonicalize signed replacement target before source bundle"
-            cp "$RUNNER_TEMP/checkpoint-guard-generated.json" \
-              "$RUNNER_TEMP/target-preflight-guard-generated.json"
-          fi
-
-          source_index=0
-          while IFS= read -r source_citation; do
-            source_index=$((source_index + 1))
-            source_lane="$(printf 'source-%02d' "$source_index")"
-            run_signed_encode \
-              "$source_citation" "" true "$source_lane" "" "" false
-            checkpoint_signed_changes \
-              "Add signed source module for ${source_citation}"
-            cp "$RUNNER_TEMP/checkpoint-guard-generated.json" \
-              "$RUNNER_TEMP/${source_lane}-guard-generated.json"
-          done < "$RUNNER_TEMP/source-bundle-citations.txt"
-
-          if [ -n "$DEPENDENT_CITATION" ]; then
-            run_signed_encode \
-              "$CITATION" "$REVIEW_FINDING" true target \
-              "$REPLACE_RULESPEC_PATH" "$REPLACE_LEGACY_RULESPEC_PATH" \
-              "$required_imports_enabled"
-            dependent_target_only=false
-            if [ -n "$SECOND_DEPENDENT_CITATION" ]; then
-              dependent_target_only=true
-            fi
-            run_signed_encode \
-              "$DEPENDENT_CITATION" "$DEPENDENT_REVIEW_FINDING" \
-              "$dependent_target_only" dependent "" "" false
-            if [ -n "$SECOND_DEPENDENT_CITATION" ]; then
+          if [ "$canonical_refresh_enabled" = "true" ]; then
+            refresh_index=0
+            while IFS= read -r refresh_item; do
+              while IFS= read -r pending_refresh_item; do
+                "$workflow_python" "$backfill_helper" \
+                  verify-canonical-refresh-target "$RULESPEC_CHECKOUT" \
+                  "$pending_refresh_item" > /dev/null
+              done < <(jq -c ".[$refresh_index:][]" \
+                "$RUNNER_TEMP/canonical-refresh-bundle.json")
+              refresh_citation="$(jq -er '.citation' <<< "$refresh_item")"
+              refresh_rulespec_path="$(jq -er '.rulespec_path' <<< "$refresh_item")"
+              refresh_lane=target
+              refresh_finding="$REVIEW_FINDING"
+              if [ "$refresh_index" -gt 0 ]; then
+                refresh_lane="$(printf 'canonical-refresh-%02d' "$refresh_index")"
+                refresh_finding=""
+              fi
               run_signed_encode \
-                "$SECOND_DEPENDENT_CITATION" \
-                "$SECOND_DEPENDENT_REVIEW_FINDING" false dependent-2 "" "" false
-            fi
+                "$refresh_citation" "$refresh_finding" false "$refresh_lane" \
+                "$refresh_rulespec_path" "" false
+              checkpoint_signed_changes \
+                "Refresh signed canonical module for ${refresh_citation}"
+              cp "$RUNNER_TEMP/checkpoint-guard-generated.json" \
+                "$RUNNER_TEMP/${refresh_lane}-guard-generated.json"
+              refresh_index=$((refresh_index + 1))
+            done < <(jq -c '.[]' \
+              "$RUNNER_TEMP/canonical-refresh-bundle.json")
           else
-            run_signed_encode \
-              "$CITATION" "$REVIEW_FINDING" false \
-              target "$REPLACE_RULESPEC_PATH" \
-              "$REPLACE_LEGACY_RULESPEC_PATH" \
-              "$required_imports_enabled"
-          fi
+            if [ "$source_bundle_enabled" = "true" ] && \
+               [ -n "$REPLACE_RULESPEC_PATH" ] && \
+               [ -z "$REPLACE_LEGACY_RULESPEC_PATH" ]; then
+              run_signed_encode \
+                "$CITATION" "" false target-preflight \
+                "$REPLACE_RULESPEC_PATH" "" false
+              checkpoint_signed_changes \
+                "Canonicalize signed replacement target before source bundle"
+              cp "$RUNNER_TEMP/checkpoint-guard-generated.json" \
+                "$RUNNER_TEMP/target-preflight-guard-generated.json"
+            fi
 
-          if [ "$source_bundle_enabled" = "true" ]; then
-            checkpoint_signed_changes \
-              "Compose signed source bundle for ${CITATION}"
+            source_index=0
+            while IFS= read -r source_citation; do
+              source_index=$((source_index + 1))
+              source_lane="$(printf 'source-%02d' "$source_index")"
+              run_signed_encode \
+                "$source_citation" "" true "$source_lane" "" "" false
+              checkpoint_signed_changes \
+                "Add signed source module for ${source_citation}"
+              cp "$RUNNER_TEMP/checkpoint-guard-generated.json" \
+                "$RUNNER_TEMP/${source_lane}-guard-generated.json"
+            done < "$RUNNER_TEMP/source-bundle-citations.txt"
+
+            if [ -n "$DEPENDENT_CITATION" ]; then
+              run_signed_encode \
+                "$CITATION" "$REVIEW_FINDING" true target \
+                "$REPLACE_RULESPEC_PATH" "$REPLACE_LEGACY_RULESPEC_PATH" \
+                "$required_imports_enabled"
+              dependent_target_only=false
+              if [ -n "$SECOND_DEPENDENT_CITATION" ]; then
+                dependent_target_only=true
+              fi
+              run_signed_encode \
+                "$DEPENDENT_CITATION" "$DEPENDENT_REVIEW_FINDING" \
+                "$dependent_target_only" dependent "" "" false
+              if [ -n "$SECOND_DEPENDENT_CITATION" ]; then
+                run_signed_encode \
+                  "$SECOND_DEPENDENT_CITATION" \
+                  "$SECOND_DEPENDENT_REVIEW_FINDING" false dependent-2 "" "" false
+              fi
+            else
+              run_signed_encode \
+                "$CITATION" "$REVIEW_FINDING" false \
+                target "$REPLACE_RULESPEC_PATH" \
+                "$REPLACE_LEGACY_RULESPEC_PATH" \
+                "$required_imports_enabled"
+            fi
+
+            if [ "$source_bundle_enabled" = "true" ]; then
+              checkpoint_signed_changes \
+                "Compose signed source bundle for ${CITATION}"
+            fi
           fi
 
       - name: Verify generated provenance
@@ -1468,6 +1575,8 @@ jobs:
             "$RULESPEC_REF" HEAD >> "$artifact/status.txt"
           cp "$RUNNER_TEMP/guard-generated.json" "$artifact/guard-generated.json"
           cp "$RUNNER_TEMP/source-bundle.json" "$artifact/source-bundle.json"
+          cp "$RUNNER_TEMP/canonical-refresh-bundle.json" \
+            "$artifact/canonical-refresh-bundle.json"
           cp "$RUNNER_TEMP/existing-signed-imports.json" \
             "$artifact/existing-signed-imports.json"
           cp "$RUNNER_TEMP/existing-signed-import-inventory.json" \
@@ -1477,6 +1586,15 @@ jobs:
               cp "$source_guard" "$artifact/"
             fi
           done
+          for refresh_guard in \
+            "$RUNNER_TEMP"/canonical-refresh-*-guard-generated.json; do
+            if [ -f "$refresh_guard" ]; then
+              cp "$refresh_guard" "$artifact/"
+            fi
+          done
+          if [ -f "$RUNNER_TEMP/target-guard-generated.json" ]; then
+            cp "$RUNNER_TEMP/target-guard-generated.json" "$artifact/"
+          fi
           if [ -f "$RUNNER_TEMP/target-preflight-guard-generated.json" ]; then
             cp "$RUNNER_TEMP/target-preflight-guard-generated.json" "$artifact/"
           fi
@@ -1636,6 +1754,47 @@ jobs:
                   )
               normalized_replacement_path = candidate.as_posix()
           expected_citations = {os.environ["CITATION"]}
+          canonical_refresh_path = (
+              Path(os.environ["RUNNER_TEMP"])
+              / "canonical-refresh-bundle.json"
+          )
+          canonical_refresh_items = json.loads(
+              canonical_refresh_path.read_text()
+          )
+          if not isinstance(canonical_refresh_items, list) or not all(
+              isinstance(item, dict)
+              and set(item)
+              == {
+                  "citation",
+                  "rulespec_path",
+                  "rulespec_sha256",
+                  "companion_path",
+                  "companion_sha256",
+                  "manifest_path",
+                  "manifest_sha256",
+              }
+              and isinstance(item["citation"], str)
+              and item["citation"]
+              and isinstance(item["rulespec_path"], str)
+              and item["rulespec_path"]
+              and isinstance(item["companion_path"], str)
+              and item["companion_path"]
+              and (
+                  item["companion_sha256"] is None
+                  or (
+                      isinstance(item["companion_sha256"], str)
+                      and re.fullmatch(
+                          r"[0-9a-f]{64}", item["companion_sha256"]
+                      )
+                      is not None
+                  )
+              )
+              for item in canonical_refresh_items
+          ):
+              raise SystemExit("normalized canonical refresh bundle is malformed")
+          expected_citations.update(
+              item["citation"] for item in canonical_refresh_items
+          )
           source_bundle_path = Path(os.environ["RUNNER_TEMP"]) / "source-bundle.json"
           source_bundle_citations = json.loads(source_bundle_path.read_text())
           if not isinstance(source_bundle_citations, list) or not all(
@@ -1678,14 +1837,61 @@ jobs:
                       (relative_path, payload, effective)
                   )
 
-          expected = [
-              (
-                  os.environ["CITATION"],
-                  os.environ["REVIEW_FINDING_PRESENT"] == "true",
-                  Path(sys.argv[1]),
-                  "target",
+          if canonical_refresh_items:
+              requested_manifest_paths = {
+                  Path(item["manifest_path"])
+                  for item in canonical_refresh_items
+              }
+              if (
+                  len(requested_manifest_paths) != len(canonical_refresh_items)
+                  or requested_manifest_paths != manifest_paths
+                  or deleted_manifest_paths
+              ):
+                  raise SystemExit(
+                      "canonical refresh changed manifest inventory differs "
+                      "from its exact requested targets"
+                  )
+
+          expected = []
+          if canonical_refresh_items:
+              for refresh_index, refresh_item in enumerate(
+                  canonical_refresh_items
+              ):
+                  refresh_lane = (
+                      "target"
+                      if refresh_index == 0
+                      else f"canonical-refresh-{refresh_index:02d}"
+                  )
+                  expected.append(
+                      (
+                          refresh_item["citation"],
+                          refresh_index == 0
+                          and os.environ["REVIEW_FINDING_PRESENT"] == "true",
+                          (
+                              Path(sys.argv[1])
+                              if refresh_index == 0
+                              else Path(sys.argv[1]).with_name(
+                                  f"{refresh_lane}-context-manifest.json"
+                              )
+                          ),
+                          refresh_lane,
+                          refresh_item["rulespec_path"],
+                          refresh_item["companion_path"],
+                          refresh_item["manifest_path"],
+                      )
+                  )
+          else:
+              expected.append(
+                  (
+                      os.environ["CITATION"],
+                      os.environ["REVIEW_FINDING_PRESENT"] == "true",
+                      Path(sys.argv[1]),
+                      "target",
+                      normalized_replacement_path or None,
+                      None,
+                      None,
+                  )
               )
-          ]
           for source_index, source_citation in enumerate(
               source_bundle_citations, start=1
           ):
@@ -1698,6 +1904,9 @@ jobs:
                           f"{source_lane}-context-manifest.json"
                       ),
                       source_lane,
+                      None,
+                      None,
+                      None,
                   )
               )
           if dependent_citation:
@@ -1707,6 +1916,9 @@ jobs:
                       os.environ["DEPENDENT_REVIEW_FINDING_PRESENT"] == "true",
                       Path(sys.argv[1]).with_name("dependent-context-manifest.json"),
                       "dependent",
+                      None,
+                      None,
+                      None,
                   )
               )
           if second_dependent_citation:
@@ -1721,12 +1933,23 @@ jobs:
                           "dependent-2-context-manifest.json"
                       ),
                       "dependent-2",
+                      None,
+                      None,
+                      None,
                   )
               )
 
           generated_root = (Path(os.environ["RUNNER_TEMP"]) / "generated").resolve()
           applied_inventory = []
-          for citation, finding_required, destination, lane in expected:
+          for (
+              citation,
+              finding_required,
+              destination,
+              lane,
+              expected_primary_path,
+              expected_companion_path,
+              expected_manifest_path,
+          ) in expected:
               citation_matches = matches.get(citation, [])
               if len(citation_matches) != 1:
                   raise SystemExit(
@@ -1737,7 +1960,34 @@ jobs:
                   citation_matches[0]
               )
               manifest_path = Path(os.environ["RULESPEC_CHECKOUT"]) / relative_path
-              if lane == "target" and legacy_source_path:
+              if canonical_refresh_items:
+                  applied_files = applied_manifest.get("applied_files")
+                  applied_paths = [
+                      item.get("path")
+                      for item in applied_files or []
+                      if isinstance(item, dict)
+                      and isinstance(item.get("path"), str)
+                  ]
+                  applied_path_set = set(applied_paths)
+                  allowed_paths = {
+                      expected_primary_path,
+                      expected_companion_path,
+                  }
+                  if (
+                      relative_path.as_posix() != expected_manifest_path
+                      or applied_manifest.get("tool")
+                      != "axiom-encode encode --apply"
+                      or not isinstance(applied_files, list)
+                      or len(applied_paths) != len(applied_files)
+                      or len(applied_path_set) != len(applied_paths)
+                      or expected_primary_path not in applied_path_set
+                      or not applied_path_set.issubset(allowed_paths)
+                  ):
+                      raise SystemExit(
+                          "canonical refresh apply manifest does not match its "
+                          "exact requested target"
+                      )
+              elif lane == "target" and legacy_source_path:
                   if (
                       applied_manifest.get("tool")
                       != "axiom-encode encode --apply "
@@ -2416,6 +2666,12 @@ jobs:
           payload = {
               "schema": "axiom-encode/targeted-reencode-artifact/v1",
               "citation": os.environ["CITATION"],
+              "canonical_refresh_bundle": json.loads(
+                  (
+                      Path(os.environ["RUNNER_TEMP"])
+                      / "canonical-refresh-bundle.json"
+                  ).read_text(encoding="utf-8")
+              ),
               "source_bundle": json.loads(
                   (
                       Path(os.environ["RUNNER_TEMP"]) / "source-bundle.json"
@@ -2499,7 +2755,9 @@ jobs:
             "$COUNTRY" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT")"
           git -C "$RULESPEC_CHECKOUT" switch -c "$branch"
           if jq -e 'length > 0' \
-            "$RUNNER_TEMP/source-bundle.json" > /dev/null; then
+               "$RUNNER_TEMP/source-bundle.json" > /dev/null || \
+             jq -e 'length > 0' \
+               "$RUNNER_TEMP/canonical-refresh-bundle.json" > /dev/null; then
             test -z "$(git -C "$RULESPEC_CHECKOUT" status --porcelain)"
           else
             "${workflow_python[@]}" \
@@ -2548,12 +2806,15 @@ jobs:
             axiom-encode/scripts/prepare_signed_backfill.py branch-name \
             "$COUNTRY" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT")"
           source_bundle="$(tr -d '\n' < "$RUNNER_TEMP/source-bundle.json")"
+          canonical_refresh_bundle="$(tr -d '\n' \
+            < "$RUNNER_TEMP/canonical-refresh-bundle.json")"
           existing_signed_imports="$(tr -d '\n' \
             < "$RUNNER_TEMP/existing-signed-imports.json")"
           body="$(printf '%s\n' \
             '## Signed apply manifest' \
             '' \
             "Citation: \`${CITATION}\`" \
+            "Independent canonical refresh bundle: \`${canonical_refresh_bundle}\`" \
             "Atomic source bundle: \`${source_bundle}\`" \
             "Existing signed imports: \`${existing_signed_imports}\`" \
             "Direct dependent: \`${DEPENDENT_CITATION:-n/a}\`" \
@@ -2623,6 +2884,7 @@ jobs:
         id: package_failed_reencode_diagnostics
         if: ${{ failure() && !cancelled() }}
         env:
+          CANONICAL_REFRESH_BUNDLE_JSON: ${{ inputs.canonical_refresh_bundle_json }}
           CITATION: ${{ inputs.citation }}
           CORPUS_REF: ${{ inputs.corpus_ref }}
           COUNTRY: ${{ inputs.country }}
@@ -3023,6 +3285,9 @@ jobs:
               )
               or None,
               "source_bundle_input": os.environ.get("SOURCE_BUNDLE_JSON", "[]"),
+              "canonical_refresh_bundle_input": os.environ.get(
+                  "CANONICAL_REFRESH_BUNDLE_JSON", "[]"
+              ),
               "step_outcomes": step_outcomes,
               "workflow_run_attempt": int(os.environ["GITHUB_RUN_ATTEMPT"]),
               "workflow_run_id": os.environ["GITHUB_RUN_ID"],

--- a/changelog.d/canonical-refresh-bundle.fixed.md
+++ b/changelog.d/canonical-refresh-bundle.fixed.md
@@ -1,0 +1,1 @@
+Allow one signed targeted workflow run to freshly re-encode a bounded set of independent canonical RuleSpec modules, while preserving full-checkout validation and exact per-lane provenance and publication inventory checks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1539"
+version = "0.2.1540"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -44,6 +44,7 @@ RULESPEC_ATOMIC_ROOTS = frozenset(
 )
 MAX_SOURCE_BUNDLE_CITATIONS = 16
 MAX_SOURCE_BUNDLE_JSON_BYTES = 512 * 1024
+MAX_CANONICAL_REFRESH_BUNDLE_CITATIONS = MAX_SOURCE_BUNDLE_CITATIONS - 1
 REVIEWED_RULESPEC_REFS = frozenset(
     {
         (
@@ -336,6 +337,347 @@ def parse_source_bundle(
         seen_citations.add(citation)
         seen_paths.add(path)
     return tuple(citations)
+
+
+def parse_canonical_refresh_bundle(
+    repo: Path,
+    refresh_bundle_json: str,
+    *,
+    primary_citation: str,
+    primary_rulespec_path: str,
+) -> tuple[dict[str, str | None], ...]:
+    """Validate independent existing canonical modules for atomic fresh encoding."""
+
+    from axiom_encode.corpus_resolver import (
+        require_canonical_corpus_citation_path,
+    )
+
+    if not isinstance(refresh_bundle_json, str):
+        raise ValueError("canonical refresh bundle JSON must be a string")
+    if len(refresh_bundle_json.encode("utf-8")) > MAX_SOURCE_BUNDLE_JSON_BYTES:
+        raise ValueError("canonical refresh bundle JSON exceeds the maximum input size")
+    payload = json.loads(refresh_bundle_json)
+    if not isinstance(payload, list):
+        raise ValueError("canonical refresh bundle JSON must be an array")
+    if len(payload) > MAX_CANONICAL_REFRESH_BUNDLE_CITATIONS:
+        raise ValueError(
+            "canonical refresh bundle and its primary contain more than "
+            f"{MAX_SOURCE_BUNDLE_CITATIONS} modules"
+        )
+    if not payload:
+        return ()
+
+    repo = repo.resolve(strict=True)
+    try:
+        primary_citation = require_canonical_corpus_citation_path(primary_citation)
+    except ValueError as exc:
+        raise ValueError(
+            "canonical refresh primary citation must be an exact canonical "
+            "corpus citation path"
+        ) from exc
+    primary_jurisdiction, _primary_relative = _citation_rulespec_path(primary_citation)
+    expected_repo_name = f"rulespec-{primary_jurisdiction.partition('-')[0]}"
+    if repo.name != expected_repo_name:
+        raise ValueError(
+            "repository directory must match the primary citation country: "
+            f"{expected_repo_name}"
+        )
+
+    primary_path = _safe_relative_path(
+        primary_rulespec_path,
+        label="canonical refresh primary RuleSpec",
+    )
+    expected_primary_path = citation_rulespec_path(primary_citation)
+    if primary_path != expected_primary_path:
+        raise ValueError(
+            "canonical refresh primary path must equal the citation's canonical "
+            "RuleSpec path"
+        )
+
+    requested: list[tuple[str, PurePosixPath]] = [(primary_citation, primary_path)]
+    seen_citations = {primary_citation}
+    seen_paths = {primary_path}
+    for index, value in enumerate(payload):
+        label = f"canonical refresh addition #{index + 1}"
+        if not isinstance(value, dict) or set(value) != {
+            "citation",
+            "replace_rulespec_path",
+        }:
+            raise ValueError(
+                f"{label} must contain exactly citation and replace_rulespec_path"
+            )
+        citation = value["citation"]
+        raw_path = value["replace_rulespec_path"]
+        if (
+            not isinstance(citation, str)
+            or not citation
+            or citation != citation.strip()
+            or any(ord(character) < 32 or ord(character) == 127 for character in citation)
+            or not isinstance(raw_path, str)
+            or not raw_path
+            or any(ord(character) < 32 or ord(character) == 127 for character in raw_path)
+        ):
+            raise ValueError(f"{label} fields must be nonempty canonical strings")
+        try:
+            citation = require_canonical_corpus_citation_path(citation)
+        except ValueError as exc:
+            raise ValueError(
+                f"{label} citation must be an exact canonical corpus citation path"
+            ) from exc
+        jurisdiction, _relative = _citation_rulespec_path(citation)
+        if jurisdiction != primary_jurisdiction:
+            raise ValueError(
+                "canonical refresh targets must use the primary citation "
+                "jurisdiction and country"
+            )
+        path = _safe_relative_path(raw_path, label=f"{label} RuleSpec path")
+        expected_path = citation_rulespec_path(citation)
+        if path != expected_path:
+            raise ValueError(
+                f"{label} path must equal the citation's canonical RuleSpec path"
+            )
+        if citation in seen_citations or path in seen_paths:
+            raise ValueError("canonical refresh citations and paths must be unique")
+        requested.append((citation, path))
+        seen_citations.add(citation)
+        seen_paths.add(path)
+
+    return tuple(
+        _canonical_refresh_target_inventory(repo, citation=citation, path=path)
+        for citation, path in requested
+    )
+
+
+def _canonical_refresh_target_inventory(
+    repo: Path,
+    *,
+    citation: str,
+    path: PurePosixPath,
+) -> dict[str, str | None]:
+    """Bind one refresh target and its untrusted predecessor manifest to HEAD."""
+
+    manifest_path = _existing_import_manifest_path(path)
+    companion_path = path.with_name(f"{path.stem}.test.yaml")
+    raw_by_path: dict[PurePosixPath, bytes] = {}
+    for tracked_path, label, max_bytes in (
+        (path, f"canonical refresh RuleSpec for {citation}", 10 * 1024 * 1024),
+        (manifest_path, f"canonical refresh manifest for {citation}", 1024 * 1024),
+    ):
+        try:
+            stage = _git(
+                repo,
+                "ls-files",
+                "--stage",
+                "--",
+                tracked_path.as_posix(),
+            ).decode("utf-8")
+        except (subprocess.CalledProcessError, UnicodeDecodeError) as exc:
+            raise ValueError(f"{label} must be exactly tracked 100644") from exc
+        lines = stage.splitlines()
+        if (
+            len(lines) != 1
+            or not lines[0].startswith("100644 ")
+            or lines[0].split("\t", 1)[-1] != tracked_path.as_posix()
+        ):
+            raise ValueError(f"{label} must be exactly tracked 100644")
+        raw = _read_bounded_regular(
+            repo,
+            tracked_path,
+            label=label,
+            max_bytes=max_bytes,
+        )
+        try:
+            base_raw = _git(repo, "show", f"HEAD:{tracked_path.as_posix()}")
+        except subprocess.CalledProcessError as exc:
+            raise ValueError(f"{label} is absent from HEAD") from exc
+        if raw != base_raw:
+            raise ValueError(f"{label} differs from HEAD")
+        raw_by_path[tracked_path] = raw
+
+    companion_label = f"canonical refresh companion for {citation}"
+    try:
+        companion_stage = _git(
+            repo,
+            "ls-files",
+            "--stage",
+            "--",
+            companion_path.as_posix(),
+        ).decode("utf-8")
+    except (subprocess.CalledProcessError, UnicodeDecodeError) as exc:
+        raise ValueError(
+            f"{companion_label} tracked state cannot be determined"
+        ) from exc
+    companion_lines = companion_stage.splitlines()
+    if companion_lines:
+        if (
+            len(companion_lines) != 1
+            or not companion_lines[0].startswith("100644 ")
+            or companion_lines[0].split("\t", 1)[-1]
+            != companion_path.as_posix()
+        ):
+            raise ValueError(f"{companion_label} must be exactly tracked 100644")
+        companion_raw = _read_bounded_regular(
+            repo,
+            companion_path,
+            label=companion_label,
+            max_bytes=10 * 1024 * 1024,
+        )
+        try:
+            companion_base_raw = _git(
+                repo,
+                "show",
+                f"HEAD:{companion_path.as_posix()}",
+            )
+        except subprocess.CalledProcessError as exc:
+            raise ValueError(f"{companion_label} is absent from HEAD") from exc
+        if companion_raw != companion_base_raw:
+            raise ValueError(f"{companion_label} differs from HEAD")
+        companion_sha256: str | None = hashlib.sha256(companion_raw).hexdigest()
+    else:
+        companion = repo.joinpath(*companion_path.parts)
+        if companion.exists() or companion.is_symlink():
+            raise ValueError(f"{companion_label} is untracked")
+        if _git(
+            repo,
+            "ls-tree",
+            "--full-tree",
+            "-z",
+            "HEAD",
+            "--",
+            companion_path.as_posix(),
+        ):
+            raise ValueError(f"{companion_label} differs from HEAD")
+        companion_sha256 = None
+
+    try:
+        manifest = json.loads(raw_by_path[manifest_path].decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
+        raise ValueError(
+            f"canonical refresh manifest for {citation} is invalid JSON"
+        ) from exc
+    target_sha256 = hashlib.sha256(raw_by_path[path]).hexdigest()
+    applied_files = manifest.get("applied_files") if isinstance(manifest, dict) else None
+    target_entries = [
+        item
+        for item in applied_files or []
+        if isinstance(item, dict) and item.get("path") == path.as_posix()
+    ]
+    if (
+        not isinstance(manifest, dict)
+        or manifest.get("schema_version") != "axiom-encode/applied-rulespec/v5"
+        or manifest.get("tool") != MODEL_APPLY_TOOL
+        or manifest.get("citation") != citation
+        or not isinstance(applied_files, list)
+        or len(target_entries) != 1
+        or target_entries[0].get("sha256") != target_sha256
+    ):
+        raise ValueError(
+            f"canonical refresh manifest for {citation} does not structurally "
+            "cover the requested target"
+        )
+    return {
+        "citation": citation,
+        "rulespec_path": path.as_posix(),
+        "rulespec_sha256": target_sha256,
+        "companion_path": companion_path.as_posix(),
+        "companion_sha256": companion_sha256,
+        "manifest_path": manifest_path.as_posix(),
+        "manifest_sha256": hashlib.sha256(raw_by_path[manifest_path]).hexdigest(),
+    }
+
+
+def verify_canonical_refresh_target(
+    repo: Path,
+    target_json: str,
+) -> dict[str, str | None]:
+    """Require one normalized target to remain byte-identical before its lane."""
+
+    try:
+        target = json.loads(target_json)
+    except (json.JSONDecodeError, RecursionError) as exc:
+        raise ValueError("canonical refresh target is invalid JSON") from exc
+    expected_fields = {
+        "citation",
+        "rulespec_path",
+        "rulespec_sha256",
+        "companion_path",
+        "companion_sha256",
+        "manifest_path",
+        "manifest_sha256",
+    }
+    if (
+        not isinstance(target, dict)
+        or set(target) != expected_fields
+        or not all(
+            isinstance(target[field], str) and target[field]
+            for field in expected_fields - {"companion_sha256"}
+        )
+        or (
+            target["companion_sha256"] is not None
+            and (
+                not isinstance(target["companion_sha256"], str)
+                or DIGEST_PATTERN.fullmatch(target["companion_sha256"]) is None
+            )
+        )
+        or DIGEST_PATTERN.fullmatch(target["rulespec_sha256"]) is None
+        or DIGEST_PATTERN.fullmatch(target["manifest_sha256"]) is None
+    ):
+        raise ValueError("canonical refresh target inventory is malformed")
+    repo = repo.resolve(strict=True)
+    rulespec_path = _safe_relative_path(
+        target["rulespec_path"], label="canonical refresh target RuleSpec"
+    )
+    manifest_path = _safe_relative_path(
+        target["manifest_path"], label="canonical refresh target manifest"
+    )
+    companion_path = _safe_relative_path(
+        target["companion_path"], label="canonical refresh target companion"
+    )
+    if (
+        citation_rulespec_path(target["citation"]) != rulespec_path
+        or _existing_import_manifest_path(rulespec_path) != manifest_path
+        or rulespec_path.with_name(f"{rulespec_path.stem}.test.yaml")
+        != companion_path
+    ):
+        raise ValueError("canonical refresh target inventory paths are inconsistent")
+    for path, digest, label, max_bytes in (
+        (
+            rulespec_path,
+            target["rulespec_sha256"],
+            "canonical refresh target RuleSpec",
+            10 * 1024 * 1024,
+        ),
+        (
+            manifest_path,
+            target["manifest_sha256"],
+            "canonical refresh target manifest",
+            1024 * 1024,
+        ),
+    ):
+        raw = _read_bounded_regular(repo, path, label=label, max_bytes=max_bytes)
+        if hashlib.sha256(raw).hexdigest() != digest:
+            raise ValueError(f"{label} changed before its signed refresh lane")
+    companion_sha256 = target["companion_sha256"]
+    if companion_sha256 is None:
+        companion = repo.joinpath(*companion_path.parts)
+        if companion.exists() or companion.is_symlink():
+            raise ValueError(
+                "canonical refresh target companion changed before its signed "
+                "refresh lane"
+            )
+    else:
+        companion_raw = _read_bounded_regular(
+            repo,
+            companion_path,
+            label="canonical refresh target companion",
+            max_bytes=10 * 1024 * 1024,
+        )
+        if hashlib.sha256(companion_raw).hexdigest() != companion_sha256:
+            raise ValueError(
+                "canonical refresh target companion changed before its signed "
+                "refresh lane"
+            )
+    return target
 
 
 def _existing_import_manifest_path(path: PurePosixPath) -> PurePosixPath:
@@ -1964,6 +2306,26 @@ def main() -> None:
         default=[],
         help="additional forbidden canonical citation; may be repeated",
     )
+    canonical_refresh_parser = subparsers.add_parser(
+        "parse-canonical-refresh-bundle",
+        help=(
+            "validate existing independent canonical modules for one atomic fresh "
+            "signed refresh and emit normalized JSON"
+        ),
+    )
+    canonical_refresh_parser.add_argument("repo", type=Path)
+    canonical_refresh_parser.add_argument(
+        "refresh_bundle_json",
+        help="JSON array containing at most 15 additional canonical citations",
+    )
+    canonical_refresh_parser.add_argument("--primary-citation", required=True)
+    canonical_refresh_parser.add_argument("--primary-rulespec-path", required=True)
+    canonical_refresh_target_parser = subparsers.add_parser(
+        "verify-canonical-refresh-target",
+        help="verify one normalized canonical refresh target remains unchanged",
+    )
+    canonical_refresh_target_parser.add_argument("repo", type=Path)
+    canonical_refresh_target_parser.add_argument("target_json")
     existing_imports_parser = subparsers.add_parser(
         "parse-existing-signed-imports",
         help=(
@@ -2040,6 +2402,26 @@ def main() -> None:
                         excluded_citations=tuple(args.exclude_citation),
                     ),
                     separators=(",", ":"),
+                )
+            )
+        elif args.command == "parse-canonical-refresh-bundle":
+            print(
+                json.dumps(
+                    parse_canonical_refresh_bundle(
+                        args.repo,
+                        args.refresh_bundle_json,
+                        primary_citation=args.primary_citation,
+                        primary_rulespec_path=args.primary_rulespec_path,
+                    ),
+                    separators=(",", ":"),
+                )
+            )
+        elif args.command == "verify-canonical-refresh-target":
+            print(
+                json.dumps(
+                    verify_canonical_refresh_target(args.repo, args.target_json),
+                    separators=(",", ":"),
+                    sort_keys=True,
                 )
             )
         elif args.command == "parse-existing-signed-imports":

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1539"
+__version__ = "0.2.1540"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -334,6 +334,9 @@ from .legacy_replacement_overlay import (
     LegacyReplacementOverlayError as _LegacyReplacementOverlayError,
 )
 from .legacy_replacement_overlay import (
+    scope_canonical_replacement_overlay as _scope_canonical_replacement_overlay,
+)
+from .legacy_replacement_overlay import (
     scope_replacement_overlay as _scope_replacement_overlay,
 )
 from .legacy_replacement_overlay import (
@@ -51343,10 +51346,16 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
         )
         if legacy_replacement is not None or replacement_overlay_scope:
             try:
-                _scope_replacement_overlay(
-                    overlay_repo,
-                    active_jurisdiction=policy_content_root.name,
-                )
+                if legacy_replacement is not None:
+                    _scope_replacement_overlay(
+                        overlay_repo,
+                        active_jurisdiction=policy_content_root.name,
+                    )
+                else:
+                    _scope_canonical_replacement_overlay(
+                        overlay_repo,
+                        active_jurisdiction=policy_content_root.name,
+                    )
             except _LegacyReplacementOverlayError as exc:
                 return False, [str(exc)], {}
         overlay_content_root = overlay_repo / policy_content_root.name

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -48,6 +48,7 @@ from axiom_encode.legacy_replacement import LegacyReplacementContract
 from axiom_encode.legacy_replacement_overlay import (
     LegacyReplacementOverlayError,
     replacement_excluded_jurisdictions,
+    scope_canonical_replacement_overlay,
     stage_legacy_replacement_overlay,
 )
 from axiom_encode.prompts.encoder import SOURCE_SCOPE_PROTOCOL
@@ -7812,6 +7813,16 @@ def _rulespec_validation_target(
             overlay_repo,
             ignore=overlay_ignore,
         )
+        if replacement_overlay_scope and legacy_replacement is None:
+            try:
+                scope_canonical_replacement_overlay(
+                    overlay_repo,
+                    active_jurisdiction=policy_root.name,
+                )
+            except LegacyReplacementOverlayError as exc:
+                raise UnsafeRulespecContextPath(
+                    f"Canonical replacement validation source is invalid: {exc}"
+                ) from exc
         validation_content_root = overlay_repo / policy_root.name
         if canonical_rulespec_root_identity(validation_content_root) != identity:
             raise UnsafeRulespecContextPath(

--- a/src/axiom_encode/legacy_replacement_overlay.py
+++ b/src/axiom_encode/legacy_replacement_overlay.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import hashlib
+import os
 import re
 import shutil
+import stat
 from pathlib import Path
 
+from .constants import RULESPEC_ATOMIC_MODULE_ROOTS
 from .legacy_replacement import (
     DESTINATION_PREDECESSOR_ABSENT,
     DESTINATION_PREDECESSOR_CANONICALIZED_UNOWNED_DUPLICATE,
@@ -16,6 +19,7 @@ from .legacy_replacement import (
     LegacyReplacementRewrite,
 )
 from .repo_routing import jurisdiction_subdir_names
+from .rulespec_path_migration import PathMigrationPlanError, canonical_destination
 
 
 class LegacyReplacementOverlayError(ValueError):
@@ -117,6 +121,95 @@ def scope_replacement_overlay(
                     f"Replacement overlay jurisdiction is unsafe: {candidate}"
                 )
             shutil.rmtree(candidate)
+
+
+def scope_canonical_replacement_overlay(
+    overlay_checkout: Path,
+    *,
+    active_jurisdiction: str,
+) -> tuple[Path, ...]:
+    """Scope one canonical replacement around frozen colon-path predecessors.
+
+    The hard-cut engine rejects every path with a colon-bearing component. A
+    canonical fresh replacement must therefore validate in an isolated view
+    that excludes those pre-hard-cut entries while retaining every canonical
+    path and all canonical validation debt. The caller binds the complete live
+    pre-apply tree identity separately; this function never mutates that tree.
+    """
+
+    scope_replacement_overlay(
+        overlay_checkout,
+        active_jurisdiction=active_jurisdiction,
+    )
+    active_root = overlay_checkout / active_jurisdiction
+    if active_root.is_symlink() or not active_root.is_dir():
+        raise LegacyReplacementOverlayError(
+            f"Canonical replacement jurisdiction is unsafe: {active_root}"
+        )
+
+    omitted: list[Path] = []
+
+    def visit(directory: Path) -> None:
+        try:
+            entries = sorted(os.scandir(directory), key=lambda entry: entry.name)
+        except OSError as exc:
+            raise LegacyReplacementOverlayError(
+                f"Cannot inspect canonical replacement overlay: {directory}"
+            ) from exc
+        for entry in entries:
+            candidate = Path(entry.path)
+            relative = candidate.relative_to(active_root)
+            try:
+                metadata = entry.stat(follow_symlinks=False)
+            except OSError as exc:
+                raise LegacyReplacementOverlayError(
+                    f"Cannot inspect canonical replacement overlay entry: {candidate}"
+                ) from exc
+            if stat.S_ISLNK(metadata.st_mode):
+                raise LegacyReplacementOverlayError(
+                    f"Canonical replacement overlay contains a symlink: {candidate}"
+                )
+            is_directory = stat.S_ISDIR(metadata.st_mode)
+            is_file = stat.S_ISREG(metadata.st_mode)
+            if not is_directory and not is_file:
+                raise LegacyReplacementOverlayError(
+                    "Canonical replacement overlay contains a special file: "
+                    f"{candidate}"
+                )
+
+            if any(":" in part for part in relative.parts):
+                checkout_relative = Path(active_jurisdiction) / relative
+                try:
+                    destination = canonical_destination(checkout_relative)
+                except PathMigrationPlanError as exc:
+                    raise LegacyReplacementOverlayError(
+                        "Colon-path replacement predecessor has no canonical "
+                        f"destination: {checkout_relative}"
+                    ) from exc
+                if destination == checkout_relative:
+                    raise LegacyReplacementOverlayError(
+                        "Colon-path replacement predecessor did not canonicalize: "
+                        f"{checkout_relative}"
+                    )
+                if is_directory:
+                    shutil.rmtree(candidate)
+                else:
+                    candidate.unlink()
+                omitted.append(checkout_relative)
+                continue
+            if is_directory:
+                visit(candidate)
+
+    for name in sorted(RULESPEC_ATOMIC_MODULE_ROOTS):
+        root = active_root / name
+        if not root.exists() and not root.is_symlink():
+            continue
+        if root.is_symlink() or not root.is_dir():
+            raise LegacyReplacementOverlayError(
+                f"Canonical replacement content root is unsafe: {root}"
+            )
+        visit(root)
+    return tuple(omitted)
 
 
 def scope_legacy_replacement_overlay(

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1539"
+ENCODER_VERSION = "0.2.1540"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -4556,6 +4556,29 @@ def test_canonical_replacement_validation_excludes_unrelated_jurisdictions(tmp_p
         assert not (overlay_checkout / ".axiom/encoding-manifests/us-nj").exists()
 
 
+def test_canonical_replacement_validation_omits_active_colon_paths_only(tmp_path):
+    policy_repo = _canonical_rulespec_content_root(tmp_path, "us-la")
+    colon_path = policy_repo / "statutes/47:32.yaml"
+    canonical_debt = policy_repo / "statutes/47/BROKEN.yaml"
+    target = policy_repo / "statutes/47/294.yaml"
+    for path in (colon_path, canonical_debt, target):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("format: rulespec/v1\nrules: []\n")
+    generated = tmp_path / "out/openai/statutes/47/294.yaml"
+    generated.parent.mkdir(parents=True)
+    generated.write_text("format: rulespec/v1\nrules: []\n")
+
+    with _rulespec_validation_target(
+        generated,
+        policy_repo,
+        replacement_overlay_scope=True,
+    ) as validation_file:
+        overlay_policy = validation_file.parents[3] / "us-la"
+        assert not (overlay_policy / "statutes/47:32.yaml").exists()
+        assert (overlay_policy / "statutes/47/BROKEN.yaml").is_file()
+        assert validation_file.is_file()
+
+
 def test_fresh_encode_validation_preserves_unrelated_jurisdictions(tmp_path):
     policy_repo = _canonical_rulespec_content_root(tmp_path, "us")
     checkout = policy_repo.parent

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1539"
+ENCODER_VERSION = "0.2.1540"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1539"
+ENCODER_VERSION = "0.2.1540"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_legacy_replacement.py
+++ b/tests/test_legacy_replacement.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import hashlib
 import json
+import os
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -33,9 +34,88 @@ from axiom_encode.legacy_replacement import (
 )
 from axiom_encode.legacy_replacement_overlay import (
     LegacyReplacementOverlayError,
+    scope_canonical_replacement_overlay,
     stage_legacy_replacement_overlay,
 )
 from axiom_encode.rulespec_path_migration import PlannedMove
+
+
+def test_canonical_replacement_overlay_omits_only_active_colon_paths(tmp_path) -> None:
+    checkout = tmp_path / "rulespec-us"
+    legacy_file = checkout / "us-la/statutes/47:32.yaml"
+    legacy_nested = checkout / "us-la/statutes/47:297/4.yaml"
+    legacy_legislation = checkout / "us-la/legislation/act:1.yaml"
+    canonical_file = checkout / "us-la/statutes/47/294.yaml"
+    canonical_debt = checkout / "us-la/statutes/47/BROKEN.yaml"
+    non_atomic_form = checkout / "us-la/forms/r-540:2026.yaml"
+    sibling = checkout / "us-nj/statutes/54a:4-7.yaml"
+    for path in (
+        legacy_file,
+        legacy_nested,
+        legacy_legislation,
+        canonical_file,
+        canonical_debt,
+        non_atomic_form,
+        sibling,
+    ):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("format: rulespec/v1\nrules: []\n")
+
+    omitted = scope_canonical_replacement_overlay(
+        checkout,
+        active_jurisdiction="us-la",
+    )
+
+    assert omitted == (
+        Path("us-la/legislation/act:1.yaml"),
+        Path("us-la/statutes/47:297"),
+        Path("us-la/statutes/47:32.yaml"),
+    )
+    assert not legacy_file.exists()
+    assert not legacy_nested.exists()
+    assert not legacy_legislation.exists()
+    assert canonical_file.is_file()
+    assert canonical_debt.is_file()
+    assert non_atomic_form.is_file()
+    assert not (checkout / "us-nj").exists()
+
+
+def test_canonical_replacement_overlay_rejects_symlink(tmp_path) -> None:
+    checkout = tmp_path / "rulespec-us"
+    statutes = checkout / "us-la/statutes"
+    statutes.mkdir(parents=True)
+    outside = tmp_path / "outside.yaml"
+    outside.write_text("format: rulespec/v1\nrules: []\n")
+    (statutes / "47:32.yaml").symlink_to(outside)
+
+    with pytest.raises(
+        LegacyReplacementOverlayError,
+        match="contains a symlink",
+    ):
+        scope_canonical_replacement_overlay(
+            checkout,
+            active_jurisdiction="us-la",
+        )
+
+
+def test_canonical_replacement_overlay_rejects_special_file(tmp_path) -> None:
+    checkout = tmp_path / "rulespec-us"
+    statutes = checkout / "us-la/statutes"
+    statutes.mkdir(parents=True)
+    fifo = statutes / "47:32.yaml"
+    fifo.parent.mkdir(parents=True, exist_ok=True)
+    fifo.touch()
+    fifo.unlink()
+    os.mkfifo(fifo)
+
+    with pytest.raises(
+        LegacyReplacementOverlayError,
+        match="contains a special file",
+    ):
+        scope_canonical_replacement_overlay(
+            checkout,
+            active_jurisdiction="us-la",
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1539"
+ENCODER_VERSION = "0.2.1540"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1539"
+ENCODER_VERSION = "0.2.1540"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1539"
+ENCODER_VERSION = "0.2.1540"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1539"
+ENCODER_VERSION = "0.2.1540"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -15,11 +15,13 @@ from axiom_encode.legacy_replacement import (
     receipt_identity_sha256,
 )
 from scripts.prepare_signed_backfill import (
+    MAX_CANONICAL_REFRESH_BUNDLE_CITATIONS,
     MAX_SOURCE_BUNDLE_JSON_BYTES,
     REVIEWED_RULESPEC_PR_BASE_BRANCHES,
     REVIEWED_RULESPEC_REFS,
     authorized_changed_paths,
     branch_name,
+    parse_canonical_refresh_bundle,
     parse_existing_signed_imports,
     parse_source_bundle,
     stage_authorized_changes,
@@ -27,6 +29,7 @@ from scripts.prepare_signed_backfill import (
     validate_dependent_cascade,
     validate_queue_tracking,
     validate_rulespec_base,
+    verify_canonical_refresh_target,
 )
 from scripts.prepare_signed_backfill import (
     main as prepare_signed_backfill_main,
@@ -189,6 +192,240 @@ def test_parse_source_bundle_cli_emits_normalized_json_array(
     prepare_signed_backfill_main()
 
     assert capsys.readouterr().out == '["us-ri/statute/44-30-1"]\n'
+
+
+def _canonical_refresh_repo(tmp_path: Path) -> Path:
+    repo = _repo(tmp_path)
+    for relative in (
+        "us-la/statutes/47/294.yaml",
+        "us-la/statutes/47/295.yaml",
+        "us-la/statutes/47/297/4.yaml",
+    ):
+        target = repo / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("format: rulespec/v1\nrules: []\n", encoding="utf-8")
+        if relative == "us-la/statutes/47/294.yaml":
+            target.with_name(f"{target.stem}.test.yaml").write_text(
+                "[]\n",
+                encoding="utf-8",
+            )
+        relative_path = target.relative_to(repo).as_posix()
+        manifest = (
+            repo
+            / ".axiom/encoding-manifests"
+            / target.relative_to(repo).with_suffix(".json")
+        )
+        manifest.parent.mkdir(parents=True, exist_ok=True)
+        manifest.write_text(
+            json.dumps(
+                {
+                    "schema_version": "axiom-encode/applied-rulespec/v5",
+                    "tool": "axiom-encode encode --apply",
+                    "citation": {
+                        "us-la/statutes/47/294.yaml": "us-la/statute/47:294",
+                        "us-la/statutes/47/295.yaml": "us-la/statute/47:295",
+                        "us-la/statutes/47/297/4.yaml": ("us-la/statute/47:297.4"),
+                    }[relative_path],
+                    "applied_files": [
+                        {
+                            "path": relative_path,
+                            "sha256": hashlib.sha256(target.read_bytes()).hexdigest(),
+                        }
+                    ],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+    _git(repo, "add", "us-la", ".axiom")
+    _git(repo, "commit", "-m", "add canonical refresh targets")
+    return repo
+
+
+def test_parse_canonical_refresh_bundle_accepts_tracked_canonical_targets(
+    tmp_path: Path,
+) -> None:
+    repo = _canonical_refresh_repo(tmp_path)
+
+    inventory = parse_canonical_refresh_bundle(
+        repo,
+        json.dumps(
+            [
+                {
+                    "citation": "us-la/statute/47:295",
+                    "replace_rulespec_path": "us-la/statutes/47/295.yaml",
+                },
+                {
+                    "citation": "us-la/statute/47:297.4",
+                    "replace_rulespec_path": "us-la/statutes/47/297/4.yaml",
+                },
+            ]
+        ),
+        primary_citation="us-la/statute/47:294",
+        primary_rulespec_path="us-la/statutes/47/294.yaml",
+    )
+    assert [item["citation"] for item in inventory] == [
+        "us-la/statute/47:294",
+        "us-la/statute/47:295",
+        "us-la/statute/47:297.4",
+    ]
+    assert [item["rulespec_path"] for item in inventory] == [
+        "us-la/statutes/47/294.yaml",
+        "us-la/statutes/47/295.yaml",
+        "us-la/statutes/47/297/4.yaml",
+    ]
+    assert all(
+        set(item)
+        == {
+            "citation",
+            "rulespec_path",
+            "rulespec_sha256",
+            "companion_path",
+            "companion_sha256",
+            "manifest_path",
+            "manifest_sha256",
+        }
+        for item in inventory
+    )
+    assert inventory[0]["companion_path"] == ("us-la/statutes/47/294.test.yaml")
+    assert inventory[0]["companion_sha256"] == hashlib.sha256(b"[]\n").hexdigest()
+    assert inventory[1]["companion_sha256"] is None
+
+
+def test_parse_canonical_refresh_bundle_accepts_empty_default(tmp_path: Path) -> None:
+    assert (
+        parse_canonical_refresh_bundle(
+            tmp_path / "not-created",
+            "[]",
+            primary_citation="us-la/statute/47:294",
+            primary_rulespec_path="",
+        )
+        == ()
+    )
+
+
+def test_parse_canonical_refresh_bundle_bounds_total_modules(tmp_path: Path) -> None:
+    raw = json.dumps(
+        [
+            {
+                "citation": f"us-la/statute/47:{index}",
+                "replace_rulespec_path": f"us-la/statutes/47/{index}.yaml",
+            }
+            for index in range(MAX_CANONICAL_REFRESH_BUNDLE_CITATIONS + 1)
+        ]
+    )
+
+    with pytest.raises(ValueError, match="and its primary contain more than 16"):
+        parse_canonical_refresh_bundle(
+            tmp_path / "not-created",
+            raw,
+            primary_citation="us-la/statute/47:294",
+            primary_rulespec_path="us-la/statutes/47/294.yaml",
+        )
+
+
+def test_parse_canonical_refresh_bundle_requires_exact_primary_path(
+    tmp_path: Path,
+) -> None:
+    repo = _canonical_refresh_repo(tmp_path)
+
+    with pytest.raises(ValueError, match="primary path must equal"):
+        parse_canonical_refresh_bundle(
+            repo,
+            '[{"citation":"us-la/statute/47:295",'
+            '"replace_rulespec_path":"us-la/statutes/47/295.yaml"}]',
+            primary_citation="us-la/statute/47:294",
+            primary_rulespec_path="us-la/statutes/47/295.yaml",
+        )
+
+
+def test_parse_canonical_refresh_bundle_rejects_untracked_target(
+    tmp_path: Path,
+) -> None:
+    repo = _canonical_refresh_repo(tmp_path)
+    target = repo / "us-la/statutes/47/297/8.yaml"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("format: rulespec/v1\nrules: []\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must be exactly tracked"):
+        parse_canonical_refresh_bundle(
+            repo,
+            '[{"citation":"us-la/statute/47:297.8",'
+            '"replace_rulespec_path":"us-la/statutes/47/297/8.yaml"}]',
+            primary_citation="us-la/statute/47:294",
+            primary_rulespec_path="us-la/statutes/47/294.yaml",
+        )
+
+
+def test_parse_canonical_refresh_bundle_cli_emits_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _canonical_refresh_repo(tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "prepare_signed_backfill.py",
+            "parse-canonical-refresh-bundle",
+            str(repo),
+            '[{"citation":"us-la/statute/47:295",'
+            '"replace_rulespec_path":"us-la/statutes/47/295.yaml"}]',
+            "--primary-citation",
+            "us-la/statute/47:294",
+            "--primary-rulespec-path",
+            "us-la/statutes/47/294.yaml",
+        ],
+    )
+
+    prepare_signed_backfill_main()
+
+    output = json.loads(capsys.readouterr().out)
+    assert [item["citation"] for item in output] == [
+        "us-la/statute/47:294",
+        "us-la/statute/47:295",
+    ]
+
+
+def test_verify_canonical_refresh_target_rejects_drift(tmp_path: Path) -> None:
+    repo = _canonical_refresh_repo(tmp_path)
+    inventory = parse_canonical_refresh_bundle(
+        repo,
+        '[{"citation":"us-la/statute/47:295",'
+        '"replace_rulespec_path":"us-la/statutes/47/295.yaml"}]',
+        primary_citation="us-la/statute/47:294",
+        primary_rulespec_path="us-la/statutes/47/294.yaml",
+    )
+    target = inventory[1]
+    verify_canonical_refresh_target(repo, json.dumps(target))
+    (repo / target["rulespec_path"]).write_text(
+        "format: rulespec/v1\nrules:\n  - name: drift\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="changed before its signed refresh lane"):
+        verify_canonical_refresh_target(repo, json.dumps(target))
+
+
+def test_verify_canonical_refresh_target_rejects_absent_companion_creation(
+    tmp_path: Path,
+) -> None:
+    repo = _canonical_refresh_repo(tmp_path)
+    inventory = parse_canonical_refresh_bundle(
+        repo,
+        '[{"citation":"us-la/statute/47:295",'
+        '"replace_rulespec_path":"us-la/statutes/47/295.yaml"}]',
+        primary_citation="us-la/statute/47:294",
+        primary_rulespec_path="us-la/statutes/47/294.yaml",
+    )
+    target = inventory[1]
+    assert target["companion_sha256"] is None
+    companion = repo / str(target["companion_path"])
+    companion.write_text("[]\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="companion changed before"):
+        verify_canonical_refresh_target(repo, json.dumps(target))
 
 
 def _add_existing_signed_import(repo: Path, path: str) -> None:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1539"')
+        .startswith('__version__ = "0.2.1540"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1539"
+    assert encoder_package["version"] == "0.2.1540"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1539"
+    assert project["project"]["version"] == "0.2.1540"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1539"')
+        .startswith('__version__ = "0.2.1540"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1539"
+    assert encoder_package["version"] == "0.2.1540"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1539"
+    assert project["project"]["version"] == "0.2.1540"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1539"')
+        .startswith('__version__ = "0.2.1540"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1539"
+ENCODER_VERSION = "0.2.1540"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -33,6 +33,7 @@ from axiom_encode.cli import (
 )
 from axiom_encode.harness.dependency_stubs import validate_explicit_context_file
 from axiom_encode.harness.evals import resolve_corpus_source_unit
+from scripts.prepare_signed_backfill import parse_canonical_refresh_bundle
 from tests.release_object_fixtures import bind_test_corpus_release
 from tests.signing_broker_fixtures import SigningBrokerFixture
 
@@ -1899,6 +1900,15 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         "default": "[]",
         "type": "string",
     }
+    assert inputs["canonical_refresh_bundle_json"] == {
+        "description": (
+            "JSON array of {citation,replace_rulespec_path} additions to "
+            "fresh-encode independently with the primary in one signed transaction"
+        ),
+        "required": False,
+        "default": "[]",
+        "type": "string",
+    }
     assert inputs["existing_signed_imports_json"] == {
         "description": (
             "JSON array of tracked same-jurisdiction signed-v5 modules to reuse "
@@ -1976,6 +1986,9 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     source_bundle_command = source_bundle_step["run"]
     assert source_bundle_step["env"]["SOURCE_BUNDLE_JSON"] == (
         "${{ inputs.source_bundle_json }}"
+    )
+    assert source_bundle_step["env"]["CANONICAL_REFRESH_BUNDLE_JSON"] == (
+        "${{ inputs.canonical_refresh_bundle_json }}"
     )
     assert source_bundle_step["env"]["EXISTING_SIGNED_IMPORTS_JSON"] == (
         "${{ inputs.existing_signed_imports_json }}"
@@ -2241,6 +2254,9 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "dependent review finding is required with dependent citation" in command
     assert "parse-source-bundle" in command
     assert "parse-existing-signed-imports" in command
+    assert "parse-canonical-refresh-bundle" in command
+    assert "verify-canonical-refresh-target" in command
+    assert '"$refresh_citation" "$refresh_finding" false "$refresh_lane"' in command
     assert '"$RUNNER_TEMP/existing-signed-import-paths.txt"' in command
     assert "source_bundle_count + existing_import_count" in command
     assert '> "$RUNNER_TEMP/source-bundle.json"' in command
@@ -2283,6 +2299,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     ) + 1 == steps.index(failure_package_step)
     assert failure_package_step["if"] == "${{ failure() && !cancelled() }}"
     assert set(failure_package_step["env"]) == {
+        "CANONICAL_REFRESH_BUNDLE_JSON",
         "CITATION",
         "CORPUS_REF",
         "COUNTRY",
@@ -2446,6 +2463,10 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert 'cp "$RUNNER_TEMP/source-bundle.json" "$artifact/source-bundle.json"' in (
         package_command
     )
+    assert (
+        'cp "$RUNNER_TEMP/canonical-refresh-bundle.json" \\\n'
+        '  "$artifact/canonical-refresh-bundle.json"'
+    ) in package_command
     assert '"$artifact/existing-signed-imports.json"' in package_command
     assert '"$artifact/signed-import-inventory.json"' in package_command
     assert '"$artifact/context-manifest.json"' in package_command
@@ -2910,7 +2931,7 @@ def test_targeted_signed_reencode_preserves_checkpoint_guard_failure(
         if step.get("name") == "Encode, review, validate, and apply"
     )
     checkpoint = command.split("checkpoint_signed_changes() {", 1)[1].split(
-        '\n}\n\nif [ "$source_bundle_enabled"',
+        '\n}\n\nif [ "$canonical_refresh_enabled"',
         1,
     )[0]
     guard_stub = tmp_path / "guard-stub"
@@ -3295,8 +3316,224 @@ def test_snap_queue_activation_checks_and_merge_revalidate_live_state() -> None:
 
 
 def _prepare_empty_signed_import_inputs(runner_temp: Path) -> None:
+    (runner_temp / "canonical-refresh-bundle.json").write_text("[]\n")
     (runner_temp / "existing-signed-imports.json").write_text("[]\n")
     (runner_temp / "existing-signed-import-paths.txt").write_text("")
+
+
+def _prepare_canonical_refresh_inputs(
+    tmp_path: Path,
+) -> tuple[Path, str, str, list[dict[str, str]]]:
+    repo = tmp_path / "rulespec-us"
+    repo.mkdir()
+    subprocess.run(["git", "-C", str(repo), "init", "-q"], check=True)
+    targets = [
+        ("us-la/statute/47:294", "us-la/statutes/47/294.yaml"),
+        ("us-la/statute/47:295", "us-la/statutes/47/295.yaml"),
+        ("us-la/statute/47:297.4", "us-la/statutes/47/297/4.yaml"),
+        ("us-la/statute/47:297.8", "us-la/statutes/47/297/8.yaml"),
+    ]
+    for citation, relative in targets:
+        rule = repo / relative
+        rule.parent.mkdir(parents=True, exist_ok=True)
+        rule.write_text("format: rulespec/v1\nrules: []\n", encoding="utf-8")
+        manifest = (
+            repo / ".axiom/encoding-manifests" / Path(relative).with_suffix(".json")
+        )
+        manifest.parent.mkdir(parents=True, exist_ok=True)
+        manifest.write_text(
+            json.dumps(
+                {
+                    "schema_version": "axiom-encode/applied-rulespec/v5",
+                    "tool": "axiom-encode encode --apply",
+                    "citation": citation,
+                    "applied_files": [
+                        {
+                            "path": relative,
+                            "sha256": hashlib.sha256(rule.read_bytes()).hexdigest(),
+                        }
+                    ],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-qm",
+            "add canonical refresh fixtures",
+        ],
+        check=True,
+    )
+    primary_citation, primary_path = targets[0]
+    additions = [
+        {"citation": citation, "replace_rulespec_path": relative}
+        for citation, relative in targets[1:]
+    ]
+    return repo, primary_citation, primary_path, additions
+
+
+def test_targeted_signed_reencode_runs_canonical_refresh_bundle_in_order(
+    tmp_path: Path,
+) -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
+    )
+    command = next(
+        step["run"]
+        for step in workflow["jobs"]["encode"]["steps"]
+        if step.get("name") == "Encode, review, validate, and apply"
+    ).replace(
+        "/opt/axiom-verification/axiom-encode-apply-signer run",
+        '"$SIGNER_STUB"',
+    )
+    before_checkpoint, checkpoint_and_after = command.split(
+        "checkpoint_signed_changes() {",
+        1,
+    )
+    _checkpoint_body, after_checkpoint = checkpoint_and_after.split(
+        '\n}\n\nif [ "$canonical_refresh_enabled"',
+        1,
+    )
+    command = (
+        before_checkpoint
+        + "checkpoint_signed_changes() {\n"
+        + '  printf \'%s\\n\' "$1" >> "$CHECKPOINTS_PATH"\n'
+        + '  : > "$RUNNER_TEMP/checkpoint-guard-generated.json"\n'
+        + '}\n\nif [ "$canonical_refresh_enabled"'
+        + after_checkpoint
+    )
+
+    repo, primary_citation, primary_path, additions = _prepare_canonical_refresh_inputs(
+        tmp_path
+    )
+    normalized = parse_canonical_refresh_bundle(
+        repo,
+        json.dumps(additions),
+        primary_citation=primary_citation,
+        primary_rulespec_path=primary_path,
+    )
+    runner_temp = tmp_path / "runner-temp"
+    runner_temp.mkdir()
+    (runner_temp / "canonical-refresh-bundle.json").write_text(
+        json.dumps(normalized, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    (runner_temp / "existing-signed-imports.json").write_text("[]\n")
+    (runner_temp / "existing-signed-import-paths.txt").write_text("")
+
+    calls_path = tmp_path / "calls.jsonl"
+    checkpoints_path = tmp_path / "checkpoints.txt"
+    signer_stub = tmp_path / "signer-stub"
+    signer_stub.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+calls_path = Path(os.environ["CALLS_PATH"])
+with calls_path.open("a", encoding="utf-8") as stream:
+    stream.write(json.dumps(sys.argv[1:]) + "\\n")
+mutation_path = os.environ.get("MUTATE_AFTER_FIRST_PATH")
+if mutation_path and len(calls_path.read_text(encoding="utf-8").splitlines()) == 1:
+    Path(mutation_path).write_text("[]\\n", encoding="utf-8")
+""",
+        encoding="utf-8",
+    )
+    signer_stub.chmod(0o700)
+
+    environment = {
+        **os.environ,
+        "AXIOM_ENCODE_APPLY_SIGNING_KEY": "test-key",
+        "AXIOM_TEST_PYTHON": sys.executable,
+        "CALLS_PATH": str(calls_path),
+        "CANONICAL_REFRESH_BUNDLE_JSON": json.dumps(additions),
+        "CHECKPOINTS_PATH": str(checkpoints_path),
+        "CITATION": primary_citation,
+        "DEPENDENT_CITATION": "",
+        "DEPENDENT_REVIEW_FINDING": "",
+        "EXISTING_SIGNED_IMPORTS_JSON": "[]",
+        "GITHUB_WORKSPACE": str(tmp_path),
+        "REPLACE_RULESPEC_PATH": primary_path,
+        "REVIEW_FINDING": "Refresh the independent Louisiana modules.",
+        "RULESPEC_CHECKOUT": str(repo),
+        "RULESPEC_REF": "a" * 40,
+        "RUNNER_TEMP": str(runner_temp),
+        "SECOND_DEPENDENT_CITATION": "",
+        "SECOND_DEPENDENT_REVIEW_FINDING": "",
+        "SIGNER_STUB": str(signer_stub),
+        "SOURCE_BUNDLE_JSON": "[]",
+    }
+    subprocess.run(
+        ["bash", "-c", command],
+        cwd=ROOT,
+        check=True,
+        env=environment,
+    )
+
+    calls = [
+        json.loads(line) for line in calls_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert len(calls) == 4
+    encode_args = [call[call.index("--") + 1 :] for call in calls]
+    expected_citations = [item["citation"] for item in normalized]
+    expected_paths = [item["rulespec_path"] for item in normalized]
+    assert [args[-1] for args in encode_args] == expected_citations
+    assert [
+        args[args.index("--replace-rulespec-path") + 1] for args in encode_args
+    ] == expected_paths
+    assert [Path(args[args.index("--output") + 1]).name for args in encode_args] == [
+        "target",
+        "canonical-refresh-01",
+        "canonical-refresh-02",
+        "canonical-refresh-03",
+    ]
+    assert "--review-findings" in encode_args[0]
+    assert all("--review-findings" not in args for args in encode_args[1:])
+    forbidden = {
+        "--apply-target-only",
+        "--required-import-rulespec-path",
+        "--replace-legacy-rulespec-path",
+        "--legacy-dependent-rulespec-path",
+        "--legacy-exact-dependent-rulespec-path",
+        "--legacy-retained-successor-rulespec-path",
+    }
+    assert all(not forbidden.intersection(args) for args in encode_args)
+    assert checkpoints_path.read_text(encoding="utf-8").splitlines() == [
+        f"Refresh signed canonical module for {citation}"
+        for citation in expected_citations
+    ]
+
+    calls_path.unlink()
+    checkpoints_path.unlink()
+    future_companion = repo / str(normalized[1]["companion_path"])
+    blocked = subprocess.run(
+        ["bash", "-c", command],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **environment,
+            "MUTATE_AFTER_FIRST_PATH": str(future_companion),
+        },
+    )
+    assert blocked.returncode != 0
+    assert "companion changed before its signed refresh lane" in blocked.stderr
+    assert len(calls_path.read_text(encoding="utf-8").splitlines()) == 1
+    assert checkpoints_path.read_text(encoding="utf-8").splitlines() == [
+        f"Refresh signed canonical module for {expected_citations[0]}"
+    ]
 
 
 @pytest.mark.parametrize("dependent_count", [0, 1, 2])
@@ -3431,7 +3668,7 @@ def test_targeted_signed_reencode_composes_nonempty_source_bundle(
         1,
     )
     _checkpoint_body, after_checkpoint = checkpoint_and_after.split(
-        '\n}\n\nif [ "$source_bundle_enabled"',
+        '\n}\n\nif [ "$canonical_refresh_enabled"',
         1,
     )
     command = (
@@ -3439,7 +3676,7 @@ def test_targeted_signed_reencode_composes_nonempty_source_bundle(
         + "checkpoint_signed_changes() {\n"
         + '  printf \'%s\\n\' "$1" >> "$CHECKPOINTS_PATH"\n'
         + '  : > "$RUNNER_TEMP/checkpoint-guard-generated.json"\n'
-        + '}\n\nif [ "$source_bundle_enabled"'
+        + '}\n\nif [ "$canonical_refresh_enabled"'
         + after_checkpoint
     )
 
@@ -3572,10 +3809,20 @@ def test_targeted_signed_reencode_rejects_nonatomic_source_bundle_replacements_e
     workflow = yaml.safe_load(
         (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
     )
-    command = next(
-        step["run"]
-        for step in workflow["jobs"]["encode"]["steps"]
-        if step.get("name") == "Validate atomic source inputs"
+    command = (
+        next(
+            step["run"]
+            for step in workflow["jobs"]["encode"]["steps"]
+            if step.get("name") == "Validate atomic source inputs"
+        )
+        .replace(
+            "axiom-encode/.venv/bin/python",
+            sys.executable,
+        )
+        .replace(
+            "axiom-encode/scripts/prepare_signed_backfill.py",
+            str(ROOT / "scripts/prepare_signed_backfill.py"),
+        )
     )
     checkout = tmp_path / "rulespec-us"
     checkout.mkdir()
@@ -3660,6 +3907,7 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
         normalized_existing + "\n"
     )
     (runner_temp / "existing-signed-import-paths.txt").write_text(existing_path + "\n")
+    (runner_temp / "canonical-refresh-bundle.json").write_text("[]\n")
 
     subprocess.run(
         ["bash", "-c", command],
@@ -4048,6 +4296,7 @@ def test_targeted_artifact_packages_signed_review_context(tmp_path: Path) -> Non
         ["git", "rev-parse", "HEAD"], cwd=rulespec, text=True
     ).strip()
     (tmp_path / "source-bundle.json").write_text("[]\n", encoding="utf-8")
+    (tmp_path / "canonical-refresh-bundle.json").write_text("[]\n", encoding="utf-8")
 
     citation = "us-la/statute/47:294"
     review_content = "Preserve every supported provision.\n"
@@ -4144,6 +4393,200 @@ def _targeted_metadata_script() -> str:
     )[0]
 
 
+@pytest.mark.parametrize(
+    ("mutation", "expected_error"),
+    [
+        (None, None),
+        (
+            "swapped-manifests",
+            "canonical refresh apply manifest does not match its exact requested target",
+        ),
+        (
+            "missing-manifest",
+            "canonical refresh changed manifest inventory differs from its exact requested targets",
+        ),
+        (
+            "extra-manifest",
+            "canonical refresh changed manifest inventory differs from its exact requested targets",
+        ),
+        (
+            "unrelated-companion",
+            "canonical refresh apply manifest does not match its exact requested target",
+        ),
+    ],
+)
+def test_targeted_artifact_enforces_exact_canonical_refresh_inventory(
+    tmp_path: Path,
+    mutation: str | None,
+    expected_error: str | None,
+) -> None:
+    script = _targeted_package_script()
+    rulespec = tmp_path / "rulespec-us"
+    rulespec.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=rulespec, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=rulespec,
+        check=True,
+    )
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=rulespec, check=True)
+    (rulespec / "README.md").write_text("fixture\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=rulespec, check=True)
+    subprocess.run(["git", "commit", "-qm", "fixture"], cwd=rulespec, check=True)
+    rulespec_ref = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=rulespec, text=True
+    ).strip()
+
+    target_rows = [
+        (
+            "us-la/statute/47:294",
+            "us-la/statutes/47/294.yaml",
+            ".axiom/encoding-manifests/us-la/statutes/47/294.json",
+            "target",
+        ),
+        (
+            "us-la/statute/47:295",
+            "us-la/statutes/47/295.yaml",
+            ".axiom/encoding-manifests/us-la/statutes/47/295.json",
+            "canonical-refresh-01",
+        ),
+    ]
+    inventory: list[dict[str, str | None]] = []
+    manifests: list[tuple[Path, dict[str, object]]] = []
+    expected_contexts: dict[str, bytes] = {}
+    for index, (citation, rulespec_path, manifest_path, lane) in enumerate(target_rows):
+        rule = rulespec / rulespec_path
+        rule.parent.mkdir(parents=True, exist_ok=True)
+        rule.write_text(f"format: rulespec/v1\nrules: [{index}]\n", encoding="utf-8")
+        finding = "Preserve the primary semantics.\n" if index == 0 else ""
+        context = {
+            "citation": citation,
+            "review_findings_files": (
+                [
+                    {
+                        "content": finding,
+                        "sha256": hashlib.sha256(finding.encode()).hexdigest(),
+                    }
+                ]
+                if finding
+                else []
+            ),
+        }
+        context_bytes = json.dumps(context, sort_keys=True).encode()
+        context_path = tmp_path / "generated" / lane / "context-manifest.json"
+        context_path.parent.mkdir(parents=True, exist_ok=True)
+        context_path.write_bytes(context_bytes)
+        expected_contexts[lane] = context_bytes
+        payload: dict[str, object] = {
+            "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+            "tool": "axiom-encode encode --apply",
+            "citation": citation,
+            "context_manifest_file": str(context_path),
+            "context_manifest_sha256": hashlib.sha256(context_bytes).hexdigest(),
+            "applied_files": [
+                {
+                    "path": rulespec_path,
+                    "sha256": hashlib.sha256(rule.read_bytes()).hexdigest(),
+                }
+            ],
+        }
+        manifests.append((rulespec / manifest_path, payload))
+        inventory.append(
+            {
+                "citation": citation,
+                "rulespec_path": rulespec_path,
+                "rulespec_sha256": "a" * 64,
+                "companion_path": str(
+                    Path(rulespec_path).with_name(
+                        f"{Path(rulespec_path).stem}.test.yaml"
+                    )
+                ),
+                "companion_sha256": None,
+                "manifest_path": manifest_path,
+                "manifest_sha256": "b" * 64,
+            }
+        )
+
+    if mutation == "swapped-manifests":
+        first_payload = manifests[0][1]
+        second_payload = manifests[1][1]
+        manifests[0] = (manifests[0][0], second_payload)
+        manifests[1] = (manifests[1][0], first_payload)
+    if mutation == "missing-manifest":
+        manifests.pop()
+    if mutation == "unrelated-companion":
+        applied_files = manifests[0][1]["applied_files"]
+        assert isinstance(applied_files, list)
+        applied_files.append(
+            {
+                "path": "us-la/statutes/47/295.test.yaml",
+                "sha256": "c" * 64,
+            }
+        )
+    for path, payload in manifests:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+    if mutation == "extra-manifest":
+        extra = (
+            rulespec / ".axiom/encoding-manifests/us-la/statutes/47/unrequested.json"
+        )
+        extra.parent.mkdir(parents=True, exist_ok=True)
+        extra.write_text(
+            json.dumps(
+                {
+                    "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+                    "tool": "axiom-encode encode --apply",
+                    "citation": "us-la/statute/47:999",
+                    "applied_files": [],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    (tmp_path / "source-bundle.json").write_text("[]\n", encoding="utf-8")
+    (tmp_path / "canonical-refresh-bundle.json").write_text(
+        json.dumps(inventory) + "\n",
+        encoding="utf-8",
+    )
+    artifact = tmp_path / "artifact"
+    artifact.mkdir()
+    packaged_context = artifact / "context-manifest.json"
+    packaged_inventory = artifact / "apply-manifests.json"
+    completed = subprocess.run(
+        [sys.executable, "-", str(packaged_context), str(packaged_inventory)],
+        cwd=tmp_path,
+        input=script,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "CITATION": target_rows[0][0],
+            "PYTHONPATH": str(ROOT / "src"),
+            "REVIEW_FINDING_PRESENT": "true",
+            "RUNNER_TEMP": str(tmp_path),
+            "RULESPEC_CHECKOUT": "rulespec-us",
+            "RULESPEC_REF": rulespec_ref,
+            "REPLACE_RULESPEC_PATH": target_rows[0][1],
+        },
+    )
+
+    if expected_error is not None:
+        assert completed.returncode != 0
+        assert expected_error in completed.stderr
+        return
+    assert completed.returncode == 0, completed.stderr
+    assert packaged_context.read_bytes() == expected_contexts["target"]
+    assert (
+        artifact / "canonical-refresh-01-context-manifest.json"
+    ).read_bytes() == expected_contexts["canonical-refresh-01"]
+    packaged = json.loads(packaged_inventory.read_text())
+    assert [item["citation"] for item in packaged["items"]] == [
+        row[0] for row in target_rows
+    ]
+
+
 def test_targeted_metadata_uses_consumed_repair_identity_after_evidence_mutation(
     tmp_path: Path,
 ) -> None:
@@ -4173,6 +4616,7 @@ def test_targeted_metadata_uses_consumed_repair_identity_after_evidence_mutation
     runner_temp = tmp_path / "runner-temp"
     runner_temp.mkdir()
     (runner_temp / "source-bundle.json").write_text("[]\n", encoding="utf-8")
+    (runner_temp / "canonical-refresh-bundle.json").write_text("[]\n", encoding="utf-8")
     (runner_temp / "existing-signed-imports.json").write_text("[]\n", encoding="utf-8")
     (runner_temp / "existing-signed-import-inventory.json").write_text(
         "{}\n", encoding="utf-8"
@@ -4416,6 +4860,7 @@ def test_targeted_artifact_packages_v4_retained_successor_closure(
         (json.dumps(outer, sort_keys=True) + "\n").encode(),
     )
     (tmp_path / "source-bundle.json").write_text("[]\n")
+    (tmp_path / "canonical-refresh-bundle.json").write_text("[]\n")
     selected_inputs = list(retained_sources)
     if mutation == "missing-input":
         selected_inputs.pop()
@@ -4543,6 +4988,7 @@ def test_targeted_artifact_preserves_pre_v4_replacement_receipts(
     outer_path.parent.mkdir(parents=True, exist_ok=True)
     outer_path.write_text(json.dumps(outer) + "\n")
     (tmp_path / "source-bundle.json").write_text("[]\n")
+    (tmp_path / "canonical-refresh-bundle.json").write_text("[]\n")
     artifact = tmp_path / "artifact"
     artifact.mkdir()
     completed = subprocess.run(
@@ -4638,6 +5084,7 @@ def test_targeted_artifact_enforces_target_and_dependent_context_lanes(
         ["git", "rev-parse", "HEAD"], cwd=rulespec, text=True
     ).strip()
     (tmp_path / "source-bundle.json").write_text("[]\n", encoding="utf-8")
+    (tmp_path / "canonical-refresh-bundle.json").write_text("[]\n", encoding="utf-8")
 
     target_citation = "us/regulation/42/435/555"
     dependent_citation = "us/regulation/42/435/559"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1539"
+version = "0.2.1540"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- add a bounded independent canonical-refresh transaction to the targeted signed workflow
- validate each existing canonical primary, companion present-or-absent state, and predecessor manifest against exact HEAD bytes before every pending lane
- validate replacements in an isolated full-jurisdiction overlay that omits only noncanonical colon-path predecessors across the shared atomic RuleSpec roots
- checkpoint and provenance-guard every signed lane, publish only at the end, and require exact requested manifest paths plus per-lane primary/companion closure
- bump axiom-encode to 0.2.1540

## Why

Louisiana canonical successors were signed by a retired apply key. Recovering or trusting that key is not acceptable. These independent modules must be freshly encoded under the current root before the separate legacy 47:32 migration can consume them.

## Validation

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- affected parser and signing workflow suites: 172 passed, 51 skipped
- affected overlay and eval suites: 813 passed
- packaged version and oracle-pin checks: 27 passed
- canonical focused parser, shell lane, drift, and packaging checks: 14 passed
- workflow YAML load and `git diff --check`

One earlier combined local run exhausted the shared volume after 424 passes and produced only temp-file and coverage SQLite errors. It is not treated as code evidence; the suites above were rerun separately and passed.

## Independent review cycle

The review found two actionable issues and both were fixed:

1. replace a duplicated root tuple with the shared atomic-module root constant, covering legislation and excluding forms
2. bind companion presence/absence per pending lane and reject every applied path outside that lane primary/companion closure

The post-fix independent review found no remaining actionable issues.