### PR TITLE
Keep canonical refresh dispatch within GitHub input limit

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -39,12 +39,7 @@ on:
         required: false
         type: string
       source_bundle_json:
-        description: JSON array of additional same-jurisdiction citations to encode as signed atomic imports
-        required: false
-        default: "[]"
-        type: string
-      canonical_refresh_bundle_json:
-        description: JSON array of {citation,replace_rulespec_path} additions to fresh-encode independently with the primary in one signed transaction
+        description: JSON citation array for atomic imports, or {"canonical_refresh_bundle":[{citation,replace_rulespec_path}]} for an independent refresh transaction
         required: false
         default: "[]"
         type: string
@@ -358,7 +353,7 @@ jobs:
         id: repair_candidate
         if: ${{ inputs.repair_run_id != '' }}
         env:
-          CANONICAL_REFRESH_BUNDLE_JSON: ${{ inputs.canonical_refresh_bundle_json }}
+          ATOMIC_SOURCE_JSON: ${{ inputs.source_bundle_json }}
           CITATION: ${{ inputs.citation }}
           CORPUS_REF: ${{ inputs.corpus_ref }}
           COUNTRY: ${{ inputs.country }}
@@ -376,9 +371,17 @@ jobs:
           RULESPEC_REF: ${{ inputs.rulespec_ref }}
           SECOND_DEPENDENT_CITATION: ${{ inputs.second_dependent_citation }}
           SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.second_legacy_exact_dependent_rulespec_path }}
-          SOURCE_BUNDLE_JSON: ${{ inputs.source_bundle_json }}
         run: |
           set -euo pipefail
+          atomic_source_payload="$(
+            python \
+              axiom-encode/scripts/prepare_signed_backfill.py \
+              split-atomic-source-input "${ATOMIC_SOURCE_JSON:-[]}"
+          )"
+          source_bundle_json="$(jq -cer '.source_bundle' \
+            <<< "$atomic_source_payload")"
+          canonical_refresh_bundle_json="$(jq -cer '.canonical_refresh_bundle' \
+            <<< "$atomic_source_payload")"
           if [[ ! "$REPAIR_RUN_ID" =~ ^[0-9]+$ ]] || \
              [ "$REPAIR_RUN_ID" = "$GITHUB_RUN_ID" ]; then
             echo "repair_run_id must identify a different decimal workflow run" >&2
@@ -392,9 +395,9 @@ jobs:
              [ -n "$SECOND_DEPENDENT_CITATION" ] || \
              [ -n "$QUEUE_ID" ] || \
              ! jq -e 'type == "array" and length == 0' \
-               <<< "${CANONICAL_REFRESH_BUNDLE_JSON:-[]}" > /dev/null || \
+               <<< "$canonical_refresh_bundle_json" > /dev/null || \
              ! jq -e 'type == "array" and length == 0' \
-               <<< "${SOURCE_BUNDLE_JSON:-[]}" > /dev/null || \
+               <<< "$source_bundle_json" > /dev/null || \
              ! jq -e 'type == "array" and length == 0' \
                <<< "${EXISTING_SIGNED_IMPORTS_JSON:-[]}" > /dev/null || \
              ! jq -e 'type == "array" and length == 0' \
@@ -537,7 +540,7 @@ jobs:
 
       - name: Validate atomic source inputs
         env:
-          CANONICAL_REFRESH_BUNDLE_JSON: ${{ inputs.canonical_refresh_bundle_json }}
+          ATOMIC_SOURCE_JSON: ${{ inputs.source_bundle_json }}
           CITATION: ${{ inputs.citation }}
           DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
           EXISTING_SIGNED_IMPORTS_JSON: ${{ inputs.existing_signed_imports_json }}
@@ -550,13 +553,21 @@ jobs:
           RULESPEC_CHECKOUT: rulespec-${{ inputs.country }}
           SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.second_legacy_exact_dependent_rulespec_path }}
           SECOND_DEPENDENT_CITATION: ${{ inputs.second_dependent_citation }}
-          SOURCE_BUNDLE_JSON: ${{ inputs.source_bundle_json }}
         run: |
           set -euo pipefail
+          atomic_source_payload="$(
+            axiom-encode/.venv/bin/python \
+              axiom-encode/scripts/prepare_signed_backfill.py \
+              split-atomic-source-input "${ATOMIC_SOURCE_JSON:-[]}"
+          )"
+          source_bundle_json="$(jq -cer '.source_bundle' \
+            <<< "$atomic_source_payload")"
+          canonical_refresh_bundle_json="$(jq -cer '.canonical_refresh_bundle' \
+            <<< "$atomic_source_payload")"
           source_bundle_args=(
             axiom-encode/.venv/bin/python
             axiom-encode/scripts/prepare_signed_backfill.py
-            parse-source-bundle "${SOURCE_BUNDLE_JSON:-[]}"
+            parse-source-bundle "$source_bundle_json"
             --primary-citation "$CITATION"
           )
           if [ -n "$DEPENDENT_CITATION" ]; then
@@ -570,7 +581,7 @@ jobs:
             axiom-encode/.venv/bin/python \
               axiom-encode/scripts/prepare_signed_backfill.py \
               parse-canonical-refresh-bundle "$RULESPEC_CHECKOUT" \
-              "${CANONICAL_REFRESH_BUNDLE_JSON:-[]}" \
+              "$canonical_refresh_bundle_json" \
               --primary-citation "$CITATION" \
               --primary-rulespec-path "$REPLACE_RULESPEC_PATH"
           )"
@@ -846,7 +857,7 @@ jobs:
 
       - name: Verify existing signed imports
         env:
-          CANONICAL_REFRESH_BUNDLE_JSON: ${{ inputs.canonical_refresh_bundle_json }}
+          ATOMIC_SOURCE_JSON: ${{ inputs.source_bundle_json }}
           CITATION: ${{ inputs.citation }}
           DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
           EXISTING_SIGNED_IMPORTS_JSON: ${{ inputs.existing_signed_imports_json }}
@@ -858,14 +869,21 @@ jobs:
           RULESPEC_REF: ${{ inputs.rulespec_ref }}
           SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.second_legacy_exact_dependent_rulespec_path }}
           SECOND_DEPENDENT_CITATION: ${{ inputs.second_dependent_citation }}
-          SOURCE_BUNDLE_JSON: ${{ inputs.source_bundle_json }}
         run: |
           set -euo pipefail
           workflow_python=/opt/axiom-verification/python/bin/python
           backfill_helper=axiom-encode/scripts/prepare_signed_backfill.py
+          atomic_source_payload="$(
+            "$workflow_python" -I "$backfill_helper" \
+              split-atomic-source-input "${ATOMIC_SOURCE_JSON:-[]}"
+          )"
+          source_bundle_json="$(jq -cer '.source_bundle' \
+            <<< "$atomic_source_payload")"
+          canonical_refresh_bundle_json="$(jq -cer '.canonical_refresh_bundle' \
+            <<< "$atomic_source_payload")"
           source_bundle_args=(
             "$workflow_python" -I "$backfill_helper" parse-source-bundle
-            "${SOURCE_BUNDLE_JSON:-[]}" --primary-citation "$CITATION"
+            "$source_bundle_json" --primary-citation "$CITATION"
           )
           if [ -n "$DEPENDENT_CITATION" ]; then
             source_bundle_args+=(--exclude-citation "$DEPENDENT_CITATION")
@@ -879,7 +897,7 @@ jobs:
           normalized_canonical_refresh_bundle="$(
             "$workflow_python" -I "$backfill_helper" \
               parse-canonical-refresh-bundle "$RULESPEC_CHECKOUT" \
-              "${CANONICAL_REFRESH_BUNDLE_JSON:-[]}" \
+              "$canonical_refresh_bundle_json" \
               --primary-citation "$CITATION" \
               --primary-rulespec-path "$REPLACE_RULESPEC_PATH"
           )"
@@ -978,7 +996,7 @@ jobs:
         id: encode_apply
         env:
           AXIOM_ENCODE_APPLY_SIGNING_KEY: ${{ secrets.AXIOM_ENCODE_APPLY_SIGNING_KEY }}
-          CANONICAL_REFRESH_BUNDLE_JSON: ${{ inputs.canonical_refresh_bundle_json }}
+          ATOMIC_SOURCE_JSON: ${{ inputs.source_bundle_json }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CITATION: ${{ inputs.citation }}
           REVIEW_FINDING: ${{ inputs.review_finding }}
@@ -997,7 +1015,6 @@ jobs:
           SECOND_DEPENDENT_CITATION: ${{ inputs.second_dependent_citation }}
           SECOND_DEPENDENT_REVIEW_FINDING: ${{ inputs.second_dependent_review_finding }}
           EXISTING_SIGNED_IMPORTS_JSON: ${{ inputs.existing_signed_imports_json }}
-          SOURCE_BUNDLE_JSON: ${{ inputs.source_bundle_json }}
           RULESPEC_CHECKOUT: ${{ github.workspace }}/rulespec-${{ inputs.country }}
           RULESPEC_REF: ${{ inputs.rulespec_ref }}
         run: |
@@ -1230,9 +1247,17 @@ jobs:
               citation-rulespec-path "$SECOND_DEPENDENT_CITATION")"
           fi
 
+          atomic_source_payload="$(
+            "$workflow_python" "$backfill_helper" split-atomic-source-input \
+              "${ATOMIC_SOURCE_JSON:-[]}"
+          )"
+          source_bundle_json="$(jq -cer '.source_bundle' \
+            <<< "$atomic_source_payload")"
+          canonical_refresh_bundle_json="$(jq -cer '.canonical_refresh_bundle' \
+            <<< "$atomic_source_payload")"
           source_bundle_args=(
             "$workflow_python" "$backfill_helper" parse-source-bundle
-            "${SOURCE_BUNDLE_JSON:-[]}" --primary-citation "$CITATION"
+            "$source_bundle_json" --primary-citation "$CITATION"
           )
           if [ -n "$DEPENDENT_CITATION" ]; then
             source_bundle_args+=(--exclude-citation "$DEPENDENT_CITATION")
@@ -1244,7 +1269,7 @@ jobs:
           normalized_canonical_refresh_bundle="$(
             "$workflow_python" "$backfill_helper" \
               parse-canonical-refresh-bundle "$RULESPEC_CHECKOUT" \
-              "${CANONICAL_REFRESH_BUNDLE_JSON:-[]}" \
+              "$canonical_refresh_bundle_json" \
               --primary-citation "$CITATION" \
               --primary-rulespec-path "$REPLACE_RULESPEC_PATH"
           )"
@@ -2884,7 +2909,7 @@ jobs:
         id: package_failed_reencode_diagnostics
         if: ${{ failure() && !cancelled() }}
         env:
-          CANONICAL_REFRESH_BUNDLE_JSON: ${{ inputs.canonical_refresh_bundle_json }}
+          ATOMIC_SOURCE_JSON: ${{ inputs.source_bundle_json }}
           CITATION: ${{ inputs.citation }}
           CORPUS_REF: ${{ inputs.corpus_ref }}
           COUNTRY: ${{ inputs.country }}
@@ -2924,7 +2949,6 @@ jobs:
           RULESPEC_REF: ${{ inputs.rulespec_ref }}
           SECOND_DEPENDENT_CITATION: ${{ inputs.second_dependent_citation }}
           SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH: ${{ inputs.second_legacy_exact_dependent_rulespec_path }}
-          SOURCE_BUNDLE_JSON: ${{ inputs.source_bundle_json }}
           UPLOAD_SIGNED_REENCODE_ARTIFACT_CONCLUSION: ${{ steps.upload_signed_reencode_artifact.conclusion }}
           UPLOAD_SIGNED_REENCODE_ARTIFACT_OUTCOME: ${{ steps.upload_signed_reencode_artifact.outcome }}
           VERIFY_EXISTING_SIGNED_IMPORT_INTEGRITY_CONCLUSION: ${{ steps.verify_existing_signed_import_integrity.conclusion }}
@@ -3284,10 +3308,7 @@ jobs:
                   "SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH"
               )
               or None,
-              "source_bundle_input": os.environ.get("SOURCE_BUNDLE_JSON", "[]"),
-              "canonical_refresh_bundle_input": os.environ.get(
-                  "CANONICAL_REFRESH_BUNDLE_JSON", "[]"
-              ),
+              "atomic_source_input": os.environ.get("ATOMIC_SOURCE_JSON", "[]"),
               "step_outcomes": step_outcomes,
               "workflow_run_attempt": int(os.environ["GITHUB_RUN_ATTEMPT"]),
               "workflow_run_id": os.environ["GITHUB_RUN_ID"],

--- a/changelog.d/canonical-refresh-dispatch-limit.fixed.md
+++ b/changelog.d/canonical-refresh-dispatch-limit.fixed.md
@@ -1,0 +1,1 @@
+Keep the targeted signed re-encode workflow within GitHub's 25-input dispatch limit by using one bounded, mutually exclusive atomic-source input for source composition and canonical refresh transactions, while preserving legacy and new repair-artifact compatibility.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1540"
+version = "0.2.1541"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/extract_repair_candidate.py
+++ b/scripts/extract_repair_candidate.py
@@ -24,6 +24,10 @@ RUNNER_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
 CONTRACT = runpy.run_path(
     Path(__file__).parents[1] / "src/axiom_encode/repair_candidate_contract.py"
 )
+BACKFILL_CONTRACT = runpy.run_path(
+    Path(__file__).with_name("prepare_signed_backfill.py")
+)
+SPLIT_ATOMIC_SOURCE_INPUT = BACKFILL_CONTRACT["split_atomic_source_input"]
 MAX_CANDIDATE_BYTES = CONTRACT["VALIDATION_RETRY_CANDIDATE_MAX_FILE_BYTES"]
 SINGLE_TARGET_MODE_FIELDS = {
     "dependent_citation": None,
@@ -38,7 +42,6 @@ SINGLE_TARGET_MODE_FIELDS = {
     "replace_legacy_rulespec_path": None,
     "second_dependent_citation": None,
     "second_legacy_exact_dependent_rulespec_path": None,
-    "source_bundle_input": "[]",
 }
 
 
@@ -156,6 +159,41 @@ def _expected_module_path(country: str, replace_rulespec_path: str) -> str:
     return PurePosixPath(*path.parts[1:]).as_posix()
 
 
+def _require_empty_atomic_source(metadata: dict[str, object]) -> None:
+    has_atomic = "atomic_source_input" in metadata
+    has_legacy_source = "source_bundle_input" in metadata
+    has_legacy_refresh = "canonical_refresh_bundle_input" in metadata
+    if has_atomic:
+        if has_legacy_source or has_legacy_refresh:
+            raise ValueError(
+                "repair artifact is not a compatible single-target run: "
+                "atomic_source_input"
+            )
+        raw_atomic = metadata["atomic_source_input"]
+        try:
+            split = SPLIT_ATOMIC_SOURCE_INPUT(raw_atomic)
+        except (TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise ValueError(
+                "repair artifact is not a compatible single-target run: "
+                "atomic_source_input"
+            ) from exc
+        if split != {"canonical_refresh_bundle": [], "source_bundle": []}:
+            raise ValueError(
+                "repair artifact is not a compatible single-target run: "
+                "atomic_source_input"
+            )
+        return
+    if not has_legacy_source or metadata["source_bundle_input"] != "[]":
+        raise ValueError(
+            "repair artifact is not a compatible single-target run: source_bundle_input"
+        )
+    if has_legacy_refresh and metadata["canonical_refresh_bundle_input"] != "[]":
+        raise ValueError(
+            "repair artifact is not a compatible single-target run: "
+            "canonical_refresh_bundle_input"
+        )
+
+
 def extract_candidate(args: argparse.Namespace) -> dict[str, str]:
     destination = Path(args.destination).resolve()
     destination.mkdir(parents=True, exist_ok=False)
@@ -204,6 +242,7 @@ def extract_candidate(args: argparse.Namespace) -> dict[str, str]:
                 raise ValueError(
                     f"repair artifact is not a compatible single-target run: {field}"
                 )
+        _require_empty_atomic_source(metadata)
         if metadata.get("workflow_run_attempt") != 1:
             raise ValueError("repair artifact must come from workflow attempt 1")
         if metadata.get("failed_steps") != ["encode_apply"]:

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -249,6 +249,33 @@ def citation_rulespec_path(citation: str) -> PurePosixPath:
     return PurePosixPath(jurisdiction) / relative
 
 
+def split_atomic_source_input(atomic_source_json: str) -> dict[str, object]:
+    """Split the bounded dispatch input into exactly one atomic source mode."""
+
+    if not isinstance(atomic_source_json, str):
+        raise ValueError("atomic source JSON must be a string")
+    if len(atomic_source_json.encode("utf-8")) > MAX_SOURCE_BUNDLE_JSON_BYTES:
+        raise ValueError("atomic source JSON exceeds the maximum input size")
+    payload = json.loads(atomic_source_json)
+    if isinstance(payload, list):
+        return {
+            "canonical_refresh_bundle": [],
+            "source_bundle": payload,
+        }
+    if not isinstance(payload, dict) or set(payload) != {"canonical_refresh_bundle"}:
+        raise ValueError(
+            "atomic source JSON must be a source citation array or an exact "
+            "canonical_refresh_bundle object"
+        )
+    refresh_bundle = payload["canonical_refresh_bundle"]
+    if not isinstance(refresh_bundle, list):
+        raise ValueError("canonical_refresh_bundle must be an array")
+    return {
+        "canonical_refresh_bundle": refresh_bundle,
+        "source_bundle": [],
+    }
+
+
 def parse_source_bundle(
     source_bundle_json: str,
     *,
@@ -412,10 +439,14 @@ def parse_canonical_refresh_bundle(
             not isinstance(citation, str)
             or not citation
             or citation != citation.strip()
-            or any(ord(character) < 32 or ord(character) == 127 for character in citation)
+            or any(
+                ord(character) < 32 or ord(character) == 127 for character in citation
+            )
             or not isinstance(raw_path, str)
             or not raw_path
-            or any(ord(character) < 32 or ord(character) == 127 for character in raw_path)
+            or any(
+                ord(character) < 32 or ord(character) == 127 for character in raw_path
+            )
         ):
             raise ValueError(f"{label} fields must be nonempty canonical strings")
         try:
@@ -512,8 +543,7 @@ def _canonical_refresh_target_inventory(
         if (
             len(companion_lines) != 1
             or not companion_lines[0].startswith("100644 ")
-            or companion_lines[0].split("\t", 1)[-1]
-            != companion_path.as_posix()
+            or companion_lines[0].split("\t", 1)[-1] != companion_path.as_posix()
         ):
             raise ValueError(f"{companion_label} must be exactly tracked 100644")
         companion_raw = _read_bounded_regular(
@@ -556,7 +586,9 @@ def _canonical_refresh_target_inventory(
             f"canonical refresh manifest for {citation} is invalid JSON"
         ) from exc
     target_sha256 = hashlib.sha256(raw_by_path[path]).hexdigest()
-    applied_files = manifest.get("applied_files") if isinstance(manifest, dict) else None
+    applied_files = (
+        manifest.get("applied_files") if isinstance(manifest, dict) else None
+    )
     target_entries = [
         item
         for item in applied_files or []
@@ -636,8 +668,7 @@ def verify_canonical_refresh_target(
     if (
         citation_rulespec_path(target["citation"]) != rulespec_path
         or _existing_import_manifest_path(rulespec_path) != manifest_path
-        or rulespec_path.with_name(f"{rulespec_path.stem}.test.yaml")
-        != companion_path
+        or rulespec_path.with_name(f"{rulespec_path.stem}.test.yaml") != companion_path
     ):
         raise ValueError("canonical refresh target inventory paths are inconsistent")
     for path, digest, label, max_bytes in (
@@ -2306,6 +2337,20 @@ def main() -> None:
         default=[],
         help="additional forbidden canonical citation; may be repeated",
     )
+    atomic_source_parser = subparsers.add_parser(
+        "split-atomic-source-input",
+        help=(
+            "split the bounded source input into mutually exclusive source "
+            "composition and canonical refresh payloads"
+        ),
+    )
+    atomic_source_parser.add_argument(
+        "atomic_source_json",
+        help=(
+            "legacy source citation array or exact "
+            '{"canonical_refresh_bundle":[...]} object'
+        ),
+    )
     canonical_refresh_parser = subparsers.add_parser(
         "parse-canonical-refresh-bundle",
         help=(
@@ -2402,6 +2447,14 @@ def main() -> None:
                         excluded_citations=tuple(args.exclude_citation),
                     ),
                     separators=(",", ":"),
+                )
+            )
+        elif args.command == "split-atomic-source-input":
+            print(
+                json.dumps(
+                    split_atomic_source_input(args.atomic_source_json),
+                    separators=(",", ":"),
+                    sort_keys=True,
                 )
             )
         elif args.command == "parse-canonical-refresh-bundle":

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1540"
+__version__ = "0.2.1541"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1540"
+ENCODER_VERSION = "0.2.1541"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_extract_repair_candidate.py
+++ b/tests/test_extract_repair_candidate.py
@@ -46,6 +46,7 @@ def _archive(tmp_path: Path, *, candidate: bytes | None = None) -> tuple[Path, d
         "failed_steps": ["encode_apply"],
         "generated_lanes": ["target"],
         **SINGLE_TARGET_MODE_FIELDS,
+        "source_bundle_input": "[]",
         "files": [
             {
                 "path": path,
@@ -114,6 +115,25 @@ def test_extracts_checksum_bound_final_candidate(tmp_path):
     assert result["source_rulespec_ref"] == "d" * 40
     assert (root / result["path"]).read_text() == "format: rulespec/v1\nrules: []\n"
     assert (root / "statutes/42/1437c-1.test.yaml").read_text() == "[]\n"
+
+
+@pytest.mark.parametrize(
+    "atomic_source_input",
+    ["[]", '{"canonical_refresh_bundle":[]}'],
+)
+def test_extracts_new_atomic_source_metadata(tmp_path, atomic_source_input):
+    archive, metadata = _archive(tmp_path)
+    del metadata["source_bundle_input"]
+    metadata["atomic_source_input"] = atomic_source_input
+    replacement = _rewrite_metadata(
+        archive,
+        tmp_path / "new-atomic-source.tar",
+        metadata,
+    )
+
+    result = extract_candidate(_args(tmp_path, replacement))
+
+    assert result["source_rulespec_ref"] == "d" * 40
 
 
 def test_rejects_metadata_identity_mismatch(tmp_path):
@@ -217,7 +237,6 @@ def test_rejects_archive_member_flood(tmp_path):
             "second_legacy_exact_dependent_rulespec_path",
             "us/statutes/second.yaml",
         ),
-        ("source_bundle_input", '["us/statute/42/source"]'),
     ],
 )
 def test_rejects_incompatible_prior_run_mode(tmp_path, field, value):
@@ -230,6 +249,46 @@ def test_rejects_incompatible_prior_run_mode(tmp_path, field, value):
     )
 
     with pytest.raises(ValueError, match=f"single-target run: {field}"):
+        extract_candidate(_args(tmp_path, replacement))
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("source_bundle_input", '["us/statute/42/source"]'),
+        ("canonical_refresh_bundle_input", '[{"citation":"x"}]'),
+        ("atomic_source_input", '["us/statute/42/source"]'),
+        (
+            "atomic_source_input",
+            '{"canonical_refresh_bundle":[{"citation":"x"}]}',
+        ),
+    ],
+)
+def test_rejects_nonempty_atomic_source_metadata(tmp_path, field, value):
+    archive, metadata = _archive(tmp_path)
+    if field == "atomic_source_input":
+        del metadata["source_bundle_input"]
+    metadata[field] = value
+    replacement = _rewrite_metadata(
+        archive,
+        tmp_path / "nonempty-atomic-source.tar",
+        metadata,
+    )
+
+    with pytest.raises(ValueError, match=f"single-target run: {field}"):
+        extract_candidate(_args(tmp_path, replacement))
+
+
+def test_rejects_missing_legacy_and_atomic_source_metadata(tmp_path):
+    archive, metadata = _archive(tmp_path)
+    del metadata["source_bundle_input"]
+    replacement = _rewrite_metadata(
+        archive,
+        tmp_path / "missing-source-mode.tar",
+        metadata,
+    )
+
+    with pytest.raises(ValueError, match="single-target run: source_bundle_input"):
         extract_candidate(_args(tmp_path, replacement))
 
 

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1540"
+ENCODER_VERSION = "0.2.1541"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1540"
+ENCODER_VERSION = "0.2.1541"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1540"
+ENCODER_VERSION = "0.2.1541"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1540"
+ENCODER_VERSION = "0.2.1541"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1540"
+ENCODER_VERSION = "0.2.1541"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1540"
+ENCODER_VERSION = "0.2.1541"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -24,6 +24,7 @@ from scripts.prepare_signed_backfill import (
     parse_canonical_refresh_bundle,
     parse_existing_signed_imports,
     parse_source_bundle,
+    split_atomic_source_input,
     stage_authorized_changes,
     validate_country,
     validate_dependent_cascade,
@@ -34,6 +35,68 @@ from scripts.prepare_signed_backfill import (
 from scripts.prepare_signed_backfill import (
     main as prepare_signed_backfill_main,
 )
+
+
+def test_split_atomic_source_input_preserves_legacy_source_array() -> None:
+    assert split_atomic_source_input('["us-ri/statute/44-30-1"]') == {
+        "canonical_refresh_bundle": [],
+        "source_bundle": ["us-ri/statute/44-30-1"],
+    }
+
+
+def test_split_atomic_source_input_selects_canonical_refresh_mode() -> None:
+    addition = {
+        "citation": "us-la/statute/47:295",
+        "replace_rulespec_path": "us-la/statutes/47/295.yaml",
+    }
+
+    assert split_atomic_source_input(
+        json.dumps({"canonical_refresh_bundle": [addition]})
+    ) == {
+        "canonical_refresh_bundle": [addition],
+        "source_bundle": [],
+    }
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "null",
+        '"citation"',
+        "{}",
+        '{"canonical_refresh_bundle":[],"source_bundle":[]}',
+        '{"canonical_refresh_bundle":"invalid"}',
+    ],
+)
+def test_split_atomic_source_input_rejects_ambiguous_or_invalid_modes(raw: str) -> None:
+    with pytest.raises(ValueError, match="atomic source|canonical_refresh_bundle"):
+        split_atomic_source_input(raw)
+
+
+def test_split_atomic_source_input_rejects_oversized_json_before_parsing() -> None:
+    with pytest.raises(ValueError, match="maximum input size"):
+        split_atomic_source_input(" " * (MAX_SOURCE_BUNDLE_JSON_BYTES + 1))
+
+
+def test_split_atomic_source_input_cli_emits_normalized_object(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "prepare_signed_backfill.py",
+            "split-atomic-source-input",
+            '["us-ri/statute/44-30-1"]',
+        ],
+    )
+
+    prepare_signed_backfill_main()
+
+    assert capsys.readouterr().out == (
+        '{"canonical_refresh_bundle":[],"source_bundle":["us-ri/statute/44-30-1"]}\n'
+    )
 
 
 def test_parse_source_bundle_accepts_ordered_same_jurisdiction_citations() -> None:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1540"')
+        .startswith('__version__ = "0.2.1541"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1540"
+    assert encoder_package["version"] == "0.2.1541"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1540"
+    assert project["project"]["version"] == "0.2.1541"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1540"')
+        .startswith('__version__ = "0.2.1541"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1540"
+    assert encoder_package["version"] == "0.2.1541"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1540"
+    assert project["project"]["version"] == "0.2.1541"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1540"')
+        .startswith('__version__ = "0.2.1541"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1540"
+ENCODER_VERSION = "0.2.1541"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1871,6 +1871,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert concurrency_suffix("manual-user", "", "queue-generation", "run-3") == "run-3"
     assert concurrency_suffix("github-actions[bot]", "snap", "", "run-4") == "run-4"
     inputs = trigger["workflow_dispatch"]["inputs"]
+    assert len(inputs) == 25
     assert "allowlisted reviewed SHA" in inputs["rulespec_ref"]["description"]
     assert "artifact-only" in inputs["rulespec_ref"]["description"]
     assert inputs["country"] == {
@@ -1893,22 +1894,15 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert inputs["pr_base_branch"]["default"] == "main"
     assert inputs["source_bundle_json"] == {
         "description": (
-            "JSON array of additional same-jurisdiction citations to encode as "
-            "signed atomic imports"
+            "JSON citation array for atomic imports, or "
+            '{"canonical_refresh_bundle":[{citation,replace_rulespec_path}]} '
+            "for an independent refresh transaction"
         ),
         "required": False,
         "default": "[]",
         "type": "string",
     }
-    assert inputs["canonical_refresh_bundle_json"] == {
-        "description": (
-            "JSON array of {citation,replace_rulespec_path} additions to "
-            "fresh-encode independently with the primary in one signed transaction"
-        ),
-        "required": False,
-        "default": "[]",
-        "type": "string",
-    }
+    assert "canonical_refresh_bundle_json" not in inputs
     assert inputs["existing_signed_imports_json"] == {
         "description": (
             "JSON array of tracked same-jurisdiction signed-v5 modules to reuse "
@@ -1984,16 +1978,14 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         step for step in steps if step.get("name") == "Validate atomic source inputs"
     )
     source_bundle_command = source_bundle_step["run"]
-    assert source_bundle_step["env"]["SOURCE_BUNDLE_JSON"] == (
+    assert source_bundle_step["env"]["ATOMIC_SOURCE_JSON"] == (
         "${{ inputs.source_bundle_json }}"
-    )
-    assert source_bundle_step["env"]["CANONICAL_REFRESH_BUNDLE_JSON"] == (
-        "${{ inputs.canonical_refresh_bundle_json }}"
     )
     assert source_bundle_step["env"]["EXISTING_SIGNED_IMPORTS_JSON"] == (
         "${{ inputs.existing_signed_imports_json }}"
     )
-    assert 'parse-source-bundle "${SOURCE_BUNDLE_JSON:-[]}"' in (source_bundle_command)
+    assert "split-atomic-source-input" in source_bundle_command
+    assert 'parse-source-bundle "$source_bundle_json"' in source_bundle_command
     assert 'parse-existing-signed-imports "$RULESPEC_CHECKOUT"' in (
         source_bundle_command
     )
@@ -2025,6 +2017,14 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         if step.get("name") == "Install encoder"
     )
 
+    repair_step = next(
+        step
+        for step in steps
+        if step.get("name") == "Resolve trusted prior-run repair candidate"
+    )
+    repair_preflight = repair_step["run"].split('api_version="', 1)[0]
+    assert "split-atomic-source-input" in repair_preflight
+    assert ".venv/bin/python" not in repair_preflight
     identity_step = next(
         step
         for step in steps
@@ -2299,7 +2299,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     ) + 1 == steps.index(failure_package_step)
     assert failure_package_step["if"] == "${{ failure() && !cancelled() }}"
     assert set(failure_package_step["env"]) == {
-        "CANONICAL_REFRESH_BUNDLE_JSON",
+        "ATOMIC_SOURCE_JSON",
         "CITATION",
         "CORPUS_REF",
         "COUNTRY",
@@ -2339,7 +2339,6 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         "RULESPEC_REF",
         "SECOND_DEPENDENT_CITATION",
         "SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH",
-        "SOURCE_BUNDLE_JSON",
         "UPLOAD_SIGNED_REENCODE_ARTIFACT_CONCLUSION",
         "UPLOAD_SIGNED_REENCODE_ARTIFACT_OUTCOME",
         "VERIFY_EXISTING_SIGNED_IMPORT_INTEGRITY_CONCLUSION",
@@ -2600,6 +2599,45 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     )
     assert steps.index(checksum_step) + 1 == steps.index(upload_step)
     assert steps.index(failure_upload_step) == len(steps) - 1
+
+
+def test_repair_preflight_splits_atomic_source_before_encoder_install() -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
+    )
+    command = next(
+        step["run"]
+        for step in workflow["jobs"]["encode"]["steps"]
+        if step.get("name") == "Resolve trusted prior-run repair candidate"
+    ).split('api_version="', 1)[0]
+    command = command.replace(
+        "axiom-encode/scripts/prepare_signed_backfill.py",
+        str(ROOT / "scripts/prepare_signed_backfill.py"),
+    )
+
+    completed = subprocess.run(
+        ["bash", "-c", command],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "ATOMIC_SOURCE_JSON": "[]",
+            "DEPENDENT_CITATION": "",
+            "EXISTING_SIGNED_IMPORTS_JSON": "[]",
+            "GITHUB_RUN_ID": "200",
+            "LEGACY_EXACT_DEPENDENT_RULESPEC_PATH": "",
+            "LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON": "[]",
+            "QUEUE_ID": "",
+            "REPAIR_RUN_ID": "100",
+            "REPLACE_LEGACY_RULESPEC_PATH": "",
+            "REPLACE_RULESPEC_PATH": "us-ri/statutes/44-30-2.6.yaml",
+            "SECOND_DEPENDENT_CITATION": "",
+            "SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH": "",
+        },
+    )
+
+    assert completed.returncode == 0, completed.stderr
 
 
 @pytest.mark.parametrize(
@@ -3457,7 +3495,7 @@ if mutation_path and len(calls_path.read_text(encoding="utf-8").splitlines()) ==
         "AXIOM_ENCODE_APPLY_SIGNING_KEY": "test-key",
         "AXIOM_TEST_PYTHON": sys.executable,
         "CALLS_PATH": str(calls_path),
-        "CANONICAL_REFRESH_BUNDLE_JSON": json.dumps(additions),
+        "ATOMIC_SOURCE_JSON": json.dumps({"canonical_refresh_bundle": additions}),
         "CHECKPOINTS_PATH": str(checkpoints_path),
         "CITATION": primary_citation,
         "DEPENDENT_CITATION": "",
@@ -3472,7 +3510,6 @@ if mutation_path and len(calls_path.read_text(encoding="utf-8").splitlines()) ==
         "SECOND_DEPENDENT_CITATION": "",
         "SECOND_DEPENDENT_REVIEW_FINDING": "",
         "SIGNER_STUB": str(signer_stub),
-        "SOURCE_BUNDLE_JSON": "[]",
     }
     subprocess.run(
         ["bash", "-c", command],
@@ -3588,7 +3625,7 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
         "SECOND_DEPENDENT_CITATION": "",
         "SECOND_DEPENDENT_REVIEW_FINDING": "",
         "SIGNER_STUB": str(signer_stub),
-        "SOURCE_BUNDLE_JSON": "[]",
+        "ATOMIC_SOURCE_JSON": '{"canonical_refresh_bundle":[]}',
     }
     if dependent_count >= 1:
         environment.update(
@@ -3740,7 +3777,7 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
             "SECOND_DEPENDENT_CITATION": "",
             "SECOND_DEPENDENT_REVIEW_FINDING": "",
             "SIGNER_STUB": str(signer_stub),
-            "SOURCE_BUNDLE_JSON": json.dumps(sources),
+            "ATOMIC_SOURCE_JSON": json.dumps(sources),
         },
     )
 
@@ -3846,7 +3883,7 @@ def test_targeted_signed_reencode_rejects_nonatomic_source_bundle_replacements_e
             "RULESPEC_CHECKOUT": str(checkout),
             "SECOND_DEPENDENT_CITATION": "",
             "SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH": "",
-            "SOURCE_BUNDLE_JSON": '["us-ri/statute/44-30-1"]',
+            "ATOMIC_SOURCE_JSON": '["us-ri/statute/44-30-1"]',
         },
     )
 
@@ -3929,7 +3966,7 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
             "SECOND_DEPENDENT_CITATION": "",
             "SECOND_DEPENDENT_REVIEW_FINDING": "",
             "SIGNER_STUB": str(signer_stub),
-            "SOURCE_BUNDLE_JSON": "[]",
+            "ATOMIC_SOURCE_JSON": "[]",
         },
     )
 
@@ -4004,7 +4041,7 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
         "SECOND_DEPENDENT_CITATION": "",
         "SECOND_DEPENDENT_REVIEW_FINDING": "",
         "SIGNER_STUB": str(signer_stub),
-        "SOURCE_BUNDLE_JSON": "[]",
+        "ATOMIC_SOURCE_JSON": "[]",
     }
     subprocess.run(
         ["bash", "-c", command],
@@ -4109,7 +4146,7 @@ with Path(os.environ["CALLS_PATH"]).open("a", encoding="utf-8") as stream:
         "SECOND_DEPENDENT_REVIEW_FINDING": "",
         "SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH": exact_dependents[1],
         "SIGNER_STUB": str(signer_stub),
-        "SOURCE_BUNDLE_JSON": "[]",
+        "ATOMIC_SOURCE_JSON": "[]",
     }
 
     subprocess.run(["bash", "-c", command], check=True, env=environment)
@@ -4218,7 +4255,7 @@ def test_targeted_signed_reencode_rejects_invalid_second_dependent_inputs(
         "RUNNER_TEMP": str(runner_temp),
         "SECOND_DEPENDENT_CITATION": "",
         "SECOND_DEPENDENT_REVIEW_FINDING": "",
-        "SOURCE_BUNDLE_JSON": "[]",
+        "ATOMIC_SOURCE_JSON": "[]",
         **overrides,
     }
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1540"
+version = "0.2.1541"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- restore the targeted signed re-encode workflow to GitHub’s 25-input limit
- preserve legacy source citation arrays while adding an exact tagged canonical-refresh transaction shape
- split and revalidate the bounded atomic-source input at repair, preflight, verification, apply, and diagnostics boundaries
- preserve repair replay for both legacy failure metadata and the new mutually exclusive atomic-source metadata

## Review cycle
Independent review found two actionable blockers at the first head: the repair preflight used a not-yet-installed virtualenv, and the repair extractor did not understand new failure metadata. Both were fixed. Independent re-review is CLEAN at exact head `a6f1f9e8aae9cac77d7e2e3ef960d41243ae443a`, with no remaining actionable findings.

## Checks
- final affected parser/workflow/repair suite: `222 passed, 51 skipped`
- `24 passed` (affected oracle-version registries)
- Ruff check and format check passed
- compileall, YAML load, exact 25-input assertion, diff check passed
- actionlint v1.7.12 passed after verified checksum
