### PR TITLE
Keep cross-run repair candidate as retry floor

### DIFF
--- a/changelog.d/immutable-repair-candidate-floor.fixed.md
+++ b/changelog.d/immutable-repair-candidate-floor.fixed.md
@@ -1,0 +1,1 @@
+Keep a checksum-bound cross-run repair candidate as the immutable retry baseline and render it next to the final output contract.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1541"
+version = "0.2.1542"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1541"
+__version__ = "0.2.1542"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -27465,9 +27465,9 @@ def _run_encode_attempt(
         ),
         validation_retry_feedback=_encode_validation_retry_feedback(prior_attempts),
         validation_retry_candidate=(
-            _latest_validation_retry_candidate(prior_attempts)
-            if prior_attempts
-            else initial_retry_candidate
+            initial_retry_candidate
+            if initial_retry_candidate is not None
+            else _latest_validation_retry_candidate(prior_attempts)
         ),
         required_import_targets=required_import_targets,
         legacy_replacement=(

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -9847,7 +9847,7 @@ Primary legal authority:
 {legal_authority_instruction}
 {corpus_source_section.rstrip()}
 {inline_source}
-{source_metadata_section}{provision_metadata_section}{amendment_section}{context_section}{missing_cited_source_section}{mandatory_review_findings_section}{validation_retry_feedback_section}{validation_retry_candidate_section}{required_import_section}
+{source_metadata_section}{provision_metadata_section}{amendment_section}{context_section}{missing_cited_source_section}{mandatory_review_findings_section}{validation_retry_feedback_section}{required_import_section}
 {backend_section}
 {canonical_concept_section}{complete_source_unit_section}
 RuleSpec requirements:
@@ -10645,6 +10645,7 @@ rules:
         formula: snap_member_eligible
 ```
 
+{validation_retry_candidate_section}
 {output_rules}
 Do not respond with summaries, markdown prose, or file-write confirmations.
 """

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1541"
+ENCODER_VERSION = "0.2.1542"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13141,6 +13141,48 @@ class TestCmdEncode:
         assert candidate.tests is not None
         assert "preserved-companion" in candidate.tests
 
+    def test_encode_keeps_cross_run_repair_candidate_as_retry_floor(self, tmp_path):
+        candidate_root = tmp_path / "preserved-candidate"
+        candidate_path = Path("statutes/26/1/j/2.yaml")
+        output_file = candidate_root / candidate_path
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            "format: rulespec/v1\n# preserved-cross-run-rule\nrules: []\n"
+        )
+        test_file = output_file.with_suffix(".test.yaml")
+        test_file.write_text("# preserved-cross-run-companion\n[]\n")
+        args = self._make_args(
+            tmp_path,
+            model=None,
+            apply=True,
+            sync=False,
+            escalation_enabled=True,
+            repair_candidate_root=candidate_root,
+            repair_candidate_path=candidate_path,
+            repair_candidate_rulespec_sha256=hashlib.sha256(
+                output_file.read_bytes()
+            ).hexdigest(),
+            repair_candidate_tests_sha256=hashlib.sha256(
+                test_file.read_bytes()
+            ).hexdigest(),
+        )
+
+        _exit_code, _generated, _validated, mock_run, _mock_validate, _mock_apply = (
+            self._run_validator_escalation_case(
+                args,
+                [(False, ["first candidate regressed"]), (True, [])],
+            )
+        )
+
+        retry_candidates = [
+            call.kwargs["validation_retry_candidate"]
+            for call in mock_run.call_args_list
+        ]
+        assert len(retry_candidates) == 2
+        assert retry_candidates[0] == retry_candidates[1]
+        assert "preserved-cross-run-rule" in retry_candidates[1].rulespec
+        assert "rejected-attempt-1" not in retry_candidates[1].rulespec
+
     @pytest.mark.parametrize(
         ("root", "relative_path", "message"),
         [

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -756,6 +756,12 @@ def test_workspace_prompt_embeds_latest_retry_candidate_as_untrusted_edit_contex
     assert "TY2000 historical branch case" in prompt
     assert "TY2026 current branch case" in prompt
     assert candidate.rulespec_sha256 in prompt or candidate.rulespec in prompt
+    assert prompt.index("RuleSpec requirements:") < prompt.index(
+        "UNTRUSTED REJECTED CANDIDATE RULESPEC"
+    )
+    assert prompt.index("UNTRUSTED REJECTED CANDIDATE RULESPEC") < prompt.index(
+        "Return exactly this two-file bundle"
+    )
     assert str(tmp_path) not in prompt
 
 

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1541"
+ENCODER_VERSION = "0.2.1542"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1541"
+ENCODER_VERSION = "0.2.1542"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1541"
+ENCODER_VERSION = "0.2.1542"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1541"
+ENCODER_VERSION = "0.2.1542"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1541"
+ENCODER_VERSION = "0.2.1542"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1541"
+ENCODER_VERSION = "0.2.1542"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1541"')
+        .startswith('__version__ = "0.2.1542"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1541"
+    assert encoder_package["version"] == "0.2.1542"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1541"
+    assert project["project"]["version"] == "0.2.1542"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1541"')
+        .startswith('__version__ = "0.2.1542"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1541"
+    assert encoder_package["version"] == "0.2.1542"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1541"
+    assert project["project"]["version"] == "0.2.1542"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1541"')
+        .startswith('__version__ = "0.2.1542"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1541"
+ENCODER_VERSION = "0.2.1542"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1541"
+version = "0.2.1542"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- retain a checksum-bound cross-run repair candidate as the baseline for every validator retry
- render retry candidate context immediately before the final output contract
- cover retry continuity and prompt ordering with regression tests

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- focused repair-candidate, prompt-ordering, version-provenance, and registry-pin tests
- `uv run pytest`: 7157 passed, 119 skipped

## Cycle
Independent review completed at exact head `3a4d5e20cb97c581a567f4477aa0318238eac272`: CLEAN, no actionable findings. Reviewer ran 16 targeted CLI tests and 4 targeted prompt/candidate tests.