### PR TITLE
Treat notwithstanding duties as enabling exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to Axiom Encode will be documented here.
 
+- Classify affirmative duties introduced by a `notwithstanding` exemption as
+  enabling exception effects, so complete-source companion tests can prove
+  obligations that remain operative despite a separate filing exemption.
+
 - Add a broker-authenticated `migrate-rulespec-paths` workflow for
   current-v5 model encodings. It permits only deterministic engine-safe path
   normalization and exact durable-reference rewrites, preserves legal corpus

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1545"
+version = "0.2.1546"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1548"
+version = "0.2.1549"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1543"
+version = "0.2.1544"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1546"
+version = "0.2.1547"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1547"
+version = "0.2.1548"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1542"
+version = "0.2.1543"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1544"
+version = "0.2.1545"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1546"
+__version__ = "0.2.1547"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1544"
+__version__ = "0.2.1545"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1545"
+__version__ = "0.2.1546"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1548"
+__version__ = "0.2.1549"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1543"
+__version__ = "0.2.1544"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1542"
+__version__ = "0.2.1543"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1547"
+__version__ = "0.2.1548"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -9088,123 +9088,29 @@ def _source_exception_effect_requirement(text: str) -> str:
 
 
 def _notwithstanding_exemption_effect_requirement(text: str) -> str | None:
-    """Classify a duty stated after a notwithstanding exemption."""
+    """Recognize the direct certification duty in an exemption override."""
 
     match = re.search(
         r"\bnotwithstanding\b"
-        r"(?P<condition>[^.;]{0,640}?\b(?:exempt(?:ed|ion|ions|s)?|"
-        r"exclud(?:e[ds]?)|exclus(?:ion|ions)|waiv(?:e[ds]?|er|ers)|"
-        r"except(?:ed|s|ion|ions)?|inapplicable|not\s+applicable|"
-        r"does\s+not\s+apply|shall\s+not\s+apply)\b[^.;]{0,320}?),"
+        r"(?P<condition>[^.;]{0,640}?\bexempt(?:ed|ion|ions)?\b"
+        r"[^.;]{0,320}?),"
         r"\s*(?P<effect>[^.;]{0,320})",
         text,
         flags=re.IGNORECASE,
     )
     if match is None:
         return None
-    effect = match.group("effect")
-
-    requirement_pattern = (
-        r"\b(?:is|are)\s+"
-        r"(?P<not_required_before>not\s+)?(?:\w+ly\s+)*"
-        r"(?P<not_required_after>not\s+)?required\s+"
-        r"(?:not\s+to|to(?:\s+not\b)?)"
-    )
-    candidates = [
-        (candidate.start(), "requirement", candidate)
-        for candidate in re.finditer(
-            requirement_pattern,
-            effect,
-            flags=re.IGNORECASE,
-        )
-    ]
-    candidates.extend(
-        (candidate.start(), "modal", candidate)
-        for candidate in re.finditer(
-            r"\b(?:shall|must)\b",
-            effect,
-            flags=re.IGNORECASE,
-        )
-    )
-    candidates.sort(key=lambda candidate: candidate[0])
-    if not candidates:
-        return None
-    if len(candidates) > 1 and re.search(
-        r"\b(?:that|which|who|whose)\b[^,;]*$",
-        effect[: candidates[0][0]],
+    if re.match(
+        r"^\s*(?:\([A-Za-z0-9ivxIVX]+\)\s*)*each\b"
+        r"(?:(?!\b(?:that|which|who|whose|if|when)\b)[^,;]){0,160}?"
+        r"\b(?:shall|must)\s*"
+        r"(?:,\s*on\s+an\s+annual\s+basis,\s*)?"
+        r"(?:make\s+the\s+certification\b|certif(?:y|ies)\s*$)",
+        match.group("effect"),
         flags=re.IGNORECASE,
     ):
-        candidates.pop(0)
-    _, predicate_kind, predicate = candidates[0]
-
-    if predicate_kind == "requirement":
-        requirement = predicate
-        requirement_text = requirement.group(0)
-        negative_count = sum(
-            (
-                _notwithstanding_effect_has_negative_subject(
-                    effect[: requirement.start()]
-                ),
-                requirement.group("not_required_before") is not None,
-                requirement.group("not_required_after") is not None,
-                bool(
-                    re.search(
-                        r"\brequired\s+(?:not\s+to|to\s+not)\b",
-                        requirement_text,
-                        flags=re.IGNORECASE,
-                    )
-                ),
-                _notwithstanding_complement_is_negative(effect[requirement.end() :]),
-            )
-        )
-        return "exclude" if negative_count % 2 else "enable"
-
-    modal = predicate
-    complement = effect[modal.end() :]
-    negative_modal = re.match(
-        r"\s+(?:not|never|no\s+longer)\b",
-        complement,
-        flags=re.IGNORECASE,
-    )
-    if negative_modal is not None:
-        complement = complement[negative_modal.end() :]
-    negative_count = sum(
-        (
-            _notwithstanding_effect_has_negative_subject(effect[: modal.start()]),
-            negative_modal is not None,
-            _notwithstanding_complement_is_negative(complement),
-        )
-    )
-    return "exclude" if negative_count % 2 else "enable"
-
-
-def _notwithstanding_effect_has_negative_subject(text: str) -> bool:
-    return bool(
-        re.match(
-            r"^\s*(?:\([A-Za-z0-9ivxIVX]+\)\s*)*"
-            r"(?:no\b|neither\b|none\s+of\b)",
-            text,
-            flags=re.IGNORECASE,
-        )
-    )
-
-
-def _notwithstanding_complement_is_negative(text: str) -> bool:
-    return bool(
-        re.match(
-            r"^\s*(?:"
-            r"(?:be|remain|continue\s+to\s+be|become|be\s+deemed|"
-            r"be\s+declared|be\s+treated\s+as)\s+"
-            r"(?:\w+ly\s+){0,2}(?:barred|disqualified|excluded|ineligible|"
-            r"prohibited|unqualified)\b|"
-            r"(?:be\s+)?denied\s+(?:eligibility|qualification|benefits?)\b|"
-            r"lose\s+(?:eligibility|qualification|benefits?)\b|"
-            r"cease\s+to\s+be\s+(?:eligible|qualified|allowed|entitled)\b"
-            r")",
-            text,
-            flags=re.IGNORECASE,
-        )
-    )
+        return "enable"
+    return None
 
 
 def _source_positive_effect_matches(text: str) -> tuple[re.Match[str], ...]:

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -9091,21 +9091,21 @@ def _notwithstanding_exemption_effect_requirement(text: str) -> str | None:
     """Recognize the direct certification duty in an exemption override."""
 
     match = re.search(
-        r"\bnotwithstanding\b"
-        r"(?P<condition>[^.;]{0,640}?\bexempt(?:ed|ion|ions)?\b"
-        r"[^.;]{0,320}?),"
-        r"\s*(?P<effect>[^.;]{0,320})",
+        r"\bnotwithstanding\s+that\s+qualified\s+public\s+housing\s+agencies\s+"
+        r"are\s+exempt\s+under\s+subparagraph\s+\(A\)\s+from\s+the\s+"
+        r"requirement\s+under\s+this\s+section\s+to\s+prepare\s+and\s+submit\s+"
+        r"an\s+annual\s+public\s+housing\s+plan,\s*"
+        r"(?P<effect>[^.;]{0,640})",
         text,
         flags=re.IGNORECASE,
     )
     if match is None:
         return None
     if re.match(
-        r"^\s*(?:\([A-Za-z0-9ivxIVX]+\)\s*)*each\b"
-        r"(?:(?!\b(?:that|which|who|whose|if|when)\b)[^,;]){0,160}?"
-        r"\b(?:shall|must)\s*"
-        r"(?:,\s*on\s+an\s+annual\s+basis,\s*)?"
-        r"(?:make\s+the\s+certification\b|certif(?:y|ies)\s*$)",
+        r"^each\s+qualified\s+public\s+housing\s+agency\s+shall,\s*"
+        r"on\s+an\s+annual\s+basis,\s*make\s+the\s+certification\s+"
+        r"described\s+in\s+paragraph\s+\(16\)\s+of\s+subsection\s+\(d\),\s*"
+        r"except\s+that\b",
         match.group("effect"),
         flags=re.IGNORECASE,
     ):

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -9093,8 +9093,8 @@ def _notwithstanding_exemption_effect_requirement(text: str) -> str | None:
     match = re.search(
         r"\bnotwithstanding\b"
         r"(?P<condition>[^.;]{0,640}?\b(?:exempt(?:ed|ion|ions|s)?|"
-        r"exclud(?:e[ds])|exclus(?:ion|ions)|waiv(?:e[ds]|er|ers)|"
-        r"except(?:ed|s|ion|ions)|inapplicable|not\s+applicable|"
+        r"exclud(?:e[ds]?)|exclus(?:ion|ions)|waiv(?:e[ds]?|er|ers)|"
+        r"except(?:ed|s|ion|ions)?|inapplicable|not\s+applicable|"
         r"does\s+not\s+apply|shall\s+not\s+apply)\b[^.;]{0,320}?),"
         r"\s*(?P<effect>[^.;]{0,320})",
         text,
@@ -9104,30 +9104,68 @@ def _notwithstanding_exemption_effect_requirement(text: str) -> str | None:
         return None
     effect = match.group("effect")
 
-    requirement = re.search(
-        r"\b(?:is|are)\s+(?P<not_required>not\s+)?required\s+"
-        r"(?P<not_to>not\s+)?to\b",
-        effect,
-        flags=re.IGNORECASE,
+    requirement_pattern = (
+        r"\b(?:is|are)\s+"
+        r"(?P<not_required_before>not\s+)?(?:\w+ly\s+)*"
+        r"(?P<not_required_after>not\s+)?required\s+"
+        r"(?:not\s+to|to(?:\s+not\b)?)"
     )
-    if requirement is not None:
+    candidates = [
+        (candidate.start(), "requirement", candidate)
+        for candidate in re.finditer(
+            requirement_pattern,
+            effect,
+            flags=re.IGNORECASE,
+        )
+    ]
+    candidates.extend(
+        (candidate.start(), "modal", candidate)
+        for candidate in re.finditer(
+            r"\b(?:shall|must)\b",
+            effect,
+            flags=re.IGNORECASE,
+        )
+    )
+    candidates.sort(key=lambda candidate: candidate[0])
+    if not candidates:
+        return None
+    if len(candidates) > 1 and re.search(
+        r"\b(?:that|which|who|whose)\b[^,;]*$",
+        effect[: candidates[0][0]],
+        flags=re.IGNORECASE,
+    ):
+        candidates.pop(0)
+    _, predicate_kind, predicate = candidates[0]
+
+    if predicate_kind == "requirement":
+        requirement = predicate
+        requirement_text = requirement.group(0)
         negative_count = sum(
             (
                 _notwithstanding_effect_has_negative_subject(
                     effect[: requirement.start()]
                 ),
-                requirement.group("not_required") is not None,
-                requirement.group("not_to") is not None,
+                requirement.group("not_required_before") is not None,
+                requirement.group("not_required_after") is not None,
+                bool(
+                    re.search(
+                        r"\brequired\s+(?:not\s+to|to\s+not)\b",
+                        requirement_text,
+                        flags=re.IGNORECASE,
+                    )
+                ),
                 _notwithstanding_complement_is_negative(effect[requirement.end() :]),
             )
         )
         return "exclude" if negative_count % 2 else "enable"
 
-    modal = re.search(r"\b(?:shall|must)\b", effect, flags=re.IGNORECASE)
-    if modal is None:
-        return None
+    modal = predicate
     complement = effect[modal.end() :]
-    negative_modal = re.match(r"\s+not\b", complement, flags=re.IGNORECASE)
+    negative_modal = re.match(
+        r"\s+(?:not|never|no\s+longer)\b",
+        complement,
+        flags=re.IGNORECASE,
+    )
     if negative_modal is not None:
         complement = complement[negative_modal.end() :]
     negative_count = sum(
@@ -9143,7 +9181,8 @@ def _notwithstanding_exemption_effect_requirement(text: str) -> str | None:
 def _notwithstanding_effect_has_negative_subject(text: str) -> bool:
     return bool(
         re.match(
-            r"^\s*(?:\([A-Za-z0-9ivxIVX]+\)\s*)*no\b",
+            r"^\s*(?:\([A-Za-z0-9ivxIVX]+\)\s*)*"
+            r"(?:no\b|neither\b|none\s+of\b)",
             text,
             flags=re.IGNORECASE,
         )
@@ -9154,8 +9193,9 @@ def _notwithstanding_complement_is_negative(text: str) -> bool:
     return bool(
         re.match(
             r"^\s*(?:"
-            r"(?:be|remain|continue\s+to\s+be|become|be\s+deemed)\s+"
-            r"(?:\w+\s+){0,3}(?:barred|disqualified|excluded|ineligible|"
+            r"(?:be|remain|continue\s+to\s+be|become|be\s+deemed|"
+            r"be\s+declared|be\s+treated\s+as)\s+"
+            r"(?:\w+ly\s+){0,2}(?:barred|disqualified|excluded|ineligible|"
             r"prohibited|unqualified)\b|"
             r"(?:be\s+)?denied\s+(?:eligibility|qualification|benefits?)\b|"
             r"lose\s+(?:eligibility|qualification|benefits?)\b|"

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -8990,6 +8990,8 @@ def _source_exception_effect_requirement(text: str) -> str:
         flags=re.IGNORECASE,
     ):
         return "zero"
+    if _notwithstanding_preserves_positive_obligation(collapsed):
+        return "enable"
     if _exception_reverses_negative_proposition(collapsed):
         return "enable"
     condition = next(
@@ -9080,6 +9082,22 @@ def _source_exception_effect_requirement(text: str) -> str:
     ):
         return "exclude"
     return "change"
+
+
+def _notwithstanding_preserves_positive_obligation(text: str) -> bool:
+    """Recognize an affirmative duty preserved despite an exemption."""
+
+    return (
+        re.search(
+            r"\bnotwithstanding\b[^.;]{0,320}\b(?:exempt|excluded|"
+            r"does\s+not\s+apply|shall\s+not\s+apply)\b[^.;]{0,320},"
+            r"[^.;]{0,240}\b(?:shall|must|is\s+required\s+to|"
+            r"are\s+required\s+to)\b",
+            text,
+            flags=re.IGNORECASE,
+        )
+        is not None
+    )
 
 
 def _source_positive_effect_matches(text: str) -> tuple[re.Match[str], ...]:

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -9092,9 +9092,9 @@ def _notwithstanding_exemption_effect_requirement(text: str) -> str | None:
 
     match = re.search(
         r"\bnotwithstanding\b"
-        r"(?P<condition>[^.;]{0,640}?\b(?:exempt(?:ed|ion|ions)?|"
-        r"excluded|exclus(?:ion|ions)|waiv(?:ed|er|ers)|"
-        r"except(?:ed|ion|ions)|"
+        r"(?P<condition>[^.;]{0,640}?\b(?:exempt(?:ed|ion|ions|s)?|"
+        r"exclud(?:e[ds])|exclus(?:ion|ions)|waiv(?:e[ds]|er|ers)|"
+        r"except(?:ed|s|ion|ions)|inapplicable|not\s+applicable|"
         r"does\s+not\s+apply|shall\s+not\s+apply)\b[^.;]{0,320}?),"
         r"\s*(?P<effect>[^.;]{0,320})",
         text,
@@ -9104,41 +9104,67 @@ def _notwithstanding_exemption_effect_requirement(text: str) -> str | None:
         return None
     effect = match.group("effect")
 
-    modal = re.search(r"\b(?:shall|must)\b", effect, flags=re.IGNORECASE)
-    if modal is not None:
-        before_modal = effect[: modal.start()]
-        after_modal = effect[modal.end() :]
-        negative_subject = re.search(
-            r"\bno\b[^.;]{0,80}$", before_modal, flags=re.IGNORECASE
-        )
-        negative_modal = re.match(r"\s+not\b", after_modal, flags=re.IGNORECASE)
-        negative_status = re.search(
-            r"\b(?:barred|disqualified|excluded|ineligible|prohibited|"
-            r"unqualified)\b",
-            after_modal[:120],
-            flags=re.IGNORECASE,
-        )
+    requirement = re.search(
+        r"\b(?:is|are)\s+(?P<not_required>not\s+)?required\s+"
+        r"(?P<not_to>not\s+)?to\b",
+        effect,
+        flags=re.IGNORECASE,
+    )
+    if requirement is not None:
         negative_count = sum(
-            marker is not None
-            for marker in (negative_subject, negative_modal, negative_status)
+            (
+                _notwithstanding_effect_has_negative_subject(
+                    effect[: requirement.start()]
+                ),
+                requirement.group("not_required") is not None,
+                requirement.group("not_to") is not None,
+                _notwithstanding_complement_is_negative(effect[requirement.end() :]),
+            )
         )
         return "exclude" if negative_count % 2 else "enable"
 
-    if re.search(
-        r"\b(?:is|are)\s+(?:not\s+)?required\s+to\b",
-        effect,
-        flags=re.IGNORECASE,
-    ):
-        return (
-            "exclude"
-            if re.search(
-                r"\b(?:is|are)\s+not\s+required\s+to\b",
-                effect,
-                flags=re.IGNORECASE,
-            )
-            else "enable"
+    modal = re.search(r"\b(?:shall|must)\b", effect, flags=re.IGNORECASE)
+    if modal is None:
+        return None
+    complement = effect[modal.end() :]
+    negative_modal = re.match(r"\s+not\b", complement, flags=re.IGNORECASE)
+    if negative_modal is not None:
+        complement = complement[negative_modal.end() :]
+    negative_count = sum(
+        (
+            _notwithstanding_effect_has_negative_subject(effect[: modal.start()]),
+            negative_modal is not None,
+            _notwithstanding_complement_is_negative(complement),
         )
-    return None
+    )
+    return "exclude" if negative_count % 2 else "enable"
+
+
+def _notwithstanding_effect_has_negative_subject(text: str) -> bool:
+    return bool(
+        re.match(
+            r"^\s*(?:\([A-Za-z0-9ivxIVX]+\)\s*)*no\b",
+            text,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _notwithstanding_complement_is_negative(text: str) -> bool:
+    return bool(
+        re.match(
+            r"^\s*(?:"
+            r"(?:be|remain|continue\s+to\s+be|become|be\s+deemed)\s+"
+            r"(?:\w+\s+){0,3}(?:barred|disqualified|excluded|ineligible|"
+            r"prohibited|unqualified)\b|"
+            r"(?:be\s+)?denied\s+(?:eligibility|qualification|benefits?)\b|"
+            r"lose\s+(?:eligibility|qualification|benefits?)\b|"
+            r"cease\s+to\s+be\s+(?:eligible|qualified|allowed|entitled)\b"
+            r")",
+            text,
+            flags=re.IGNORECASE,
+        )
+    )
 
 
 def _source_positive_effect_matches(text: str) -> tuple[re.Match[str], ...]:

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -9092,7 +9092,9 @@ def _notwithstanding_exemption_effect_requirement(text: str) -> str | None:
 
     match = re.search(
         r"\bnotwithstanding\b"
-        r"(?P<condition>[^.;]{0,640}?\b(?:exempt(?:ed|ion|ions)?|excluded|"
+        r"(?P<condition>[^.;]{0,640}?\b(?:exempt(?:ed|ion|ions)?|"
+        r"excluded|exclus(?:ion|ions)|waiv(?:ed|er|ers)|"
+        r"except(?:ed|ion|ions)|"
         r"does\s+not\s+apply|shall\s+not\s+apply)\b[^.;]{0,320}?),"
         r"\s*(?P<effect>[^.;]{0,320})",
         text,
@@ -9101,20 +9103,41 @@ def _notwithstanding_exemption_effect_requirement(text: str) -> str | None:
     if match is None:
         return None
     effect = match.group("effect")
+
+    modal = re.search(r"\b(?:shall|must)\b", effect, flags=re.IGNORECASE)
+    if modal is not None:
+        before_modal = effect[: modal.start()]
+        after_modal = effect[modal.end() :]
+        negative_subject = re.search(
+            r"\bno\b[^.;]{0,80}$", before_modal, flags=re.IGNORECASE
+        )
+        negative_modal = re.match(r"\s+not\b", after_modal, flags=re.IGNORECASE)
+        negative_status = re.search(
+            r"\b(?:barred|disqualified|excluded|ineligible|prohibited|"
+            r"unqualified)\b",
+            after_modal[:120],
+            flags=re.IGNORECASE,
+        )
+        negative_count = sum(
+            marker is not None
+            for marker in (negative_subject, negative_modal, negative_status)
+        )
+        return "exclude" if negative_count % 2 else "enable"
+
     if re.search(
-        r"\b(?:shall|must)\s+(?:not\b|be\s+(?:barred|disqualified|"
-        r"excluded|ineligible|prohibited|unqualified)\b)|"
-        r"\bno\b[^.;]{0,80}\b(?:shall|must)\b",
+        r"\b(?:is|are)\s+(?:not\s+)?required\s+to\b",
         effect,
         flags=re.IGNORECASE,
     ):
-        return "exclude"
-    if re.search(
-        r"\b(?:shall|must|is\s+required\s+to|are\s+required\s+to)\b",
-        effect,
-        flags=re.IGNORECASE,
-    ):
-        return "enable"
+        return (
+            "exclude"
+            if re.search(
+                r"\b(?:is|are)\s+not\s+required\s+to\b",
+                effect,
+                flags=re.IGNORECASE,
+            )
+            else "enable"
+        )
     return None
 
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -8990,8 +8990,11 @@ def _source_exception_effect_requirement(text: str) -> str:
         flags=re.IGNORECASE,
     ):
         return "zero"
-    if _notwithstanding_preserves_positive_obligation(collapsed):
-        return "enable"
+    notwithstanding_requirement = _notwithstanding_exemption_effect_requirement(
+        collapsed
+    )
+    if notwithstanding_requirement is not None:
+        return notwithstanding_requirement
     if _exception_reverses_negative_proposition(collapsed):
         return "enable"
     condition = next(
@@ -9084,20 +9087,35 @@ def _source_exception_effect_requirement(text: str) -> str:
     return "change"
 
 
-def _notwithstanding_preserves_positive_obligation(text: str) -> bool:
-    """Recognize an affirmative duty preserved despite an exemption."""
+def _notwithstanding_exemption_effect_requirement(text: str) -> str | None:
+    """Classify a duty stated after a notwithstanding exemption."""
 
-    return (
-        re.search(
-            r"\bnotwithstanding\b[^.;]{0,320}\b(?:exempt|excluded|"
-            r"does\s+not\s+apply|shall\s+not\s+apply)\b[^.;]{0,320},"
-            r"[^.;]{0,240}\b(?:shall|must|is\s+required\s+to|"
-            r"are\s+required\s+to)\b",
-            text,
-            flags=re.IGNORECASE,
-        )
-        is not None
+    match = re.search(
+        r"\bnotwithstanding\b"
+        r"(?P<condition>[^.;]{0,640}?\b(?:exempt(?:ed|ion|ions)?|excluded|"
+        r"does\s+not\s+apply|shall\s+not\s+apply)\b[^.;]{0,320}?),"
+        r"\s*(?P<effect>[^.;]{0,320})",
+        text,
+        flags=re.IGNORECASE,
     )
+    if match is None:
+        return None
+    effect = match.group("effect")
+    if re.search(
+        r"\b(?:shall|must)\s+(?:not\b|be\s+(?:barred|disqualified|"
+        r"excluded|ineligible|prohibited|unqualified)\b)|"
+        r"\bno\b[^.;]{0,80}\b(?:shall|must)\b",
+        effect,
+        flags=re.IGNORECASE,
+    ):
+        return "exclude"
+    if re.search(
+        r"\b(?:shall|must|is\s+required\s+to|are\s+required\s+to)\b",
+        effect,
+        flags=re.IGNORECASE,
+    ):
+        return "enable"
+    return None
 
 
 def _source_positive_effect_matches(text: str) -> tuple[re.Match[str], ...]:

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1543"
+ENCODER_VERSION = "0.2.1544"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1548"
+ENCODER_VERSION = "0.2.1549"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1547"
+ENCODER_VERSION = "0.2.1548"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1545"
+ENCODER_VERSION = "0.2.1546"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1542"
+ENCODER_VERSION = "0.2.1543"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1544"
+ENCODER_VERSION = "0.2.1545"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1546"
+ENCODER_VERSION = "0.2.1547"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1547"
+ENCODER_VERSION = "0.2.1548"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1546"
+ENCODER_VERSION = "0.2.1547"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1548"
+ENCODER_VERSION = "0.2.1549"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1544"
+ENCODER_VERSION = "0.2.1545"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1542"
+ENCODER_VERSION = "0.2.1543"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1545"
+ENCODER_VERSION = "0.2.1546"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1543"
+ENCODER_VERSION = "0.2.1544"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1543"
+ENCODER_VERSION = "0.2.1544"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1545"
+ENCODER_VERSION = "0.2.1546"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1548"
+ENCODER_VERSION = "0.2.1549"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1544"
+ENCODER_VERSION = "0.2.1545"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1546"
+ENCODER_VERSION = "0.2.1547"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1547"
+ENCODER_VERSION = "0.2.1548"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1542"
+ENCODER_VERSION = "0.2.1543"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1545"
+ENCODER_VERSION = "0.2.1546"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1547"
+ENCODER_VERSION = "0.2.1548"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1548"
+ENCODER_VERSION = "0.2.1549"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1542"
+ENCODER_VERSION = "0.2.1543"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1546"
+ENCODER_VERSION = "0.2.1547"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1544"
+ENCODER_VERSION = "0.2.1545"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1543"
+ENCODER_VERSION = "0.2.1544"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1547"
+ENCODER_VERSION = "0.2.1548"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1544"
+ENCODER_VERSION = "0.2.1545"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1543"
+ENCODER_VERSION = "0.2.1544"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1548"
+ENCODER_VERSION = "0.2.1549"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1542"
+ENCODER_VERSION = "0.2.1543"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1545"
+ENCODER_VERSION = "0.2.1546"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1546"
+ENCODER_VERSION = "0.2.1547"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1545"
+ENCODER_VERSION = "0.2.1546"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1546"
+ENCODER_VERSION = "0.2.1547"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1542"
+ENCODER_VERSION = "0.2.1543"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1544"
+ENCODER_VERSION = "0.2.1545"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1548"
+ENCODER_VERSION = "0.2.1549"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1547"
+ENCODER_VERSION = "0.2.1548"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1543"
+ENCODER_VERSION = "0.2.1544"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1545"
+ENCODER_VERSION = "0.2.1546"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1542"
+ENCODER_VERSION = "0.2.1543"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1543"
+ENCODER_VERSION = "0.2.1544"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1546"
+ENCODER_VERSION = "0.2.1547"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1547"
+ENCODER_VERSION = "0.2.1548"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1548"
+ENCODER_VERSION = "0.2.1549"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1544"
+ENCODER_VERSION = "0.2.1545"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1546"')
+        .startswith('__version__ = "0.2.1547"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1546"
+    assert encoder_package["version"] == "0.2.1547"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1546"
+    assert project["project"]["version"] == "0.2.1547"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1546"')
+        .startswith('__version__ = "0.2.1547"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1546"
+    assert encoder_package["version"] == "0.2.1547"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1546"
+    assert project["project"]["version"] == "0.2.1547"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1546"')
+        .startswith('__version__ = "0.2.1547"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1542"')
+        .startswith('__version__ = "0.2.1543"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1542"
+    assert encoder_package["version"] == "0.2.1543"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1542"
+    assert project["project"]["version"] == "0.2.1543"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1542"')
+        .startswith('__version__ = "0.2.1543"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1542"
+    assert encoder_package["version"] == "0.2.1543"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1542"
+    assert project["project"]["version"] == "0.2.1543"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1542"')
+        .startswith('__version__ = "0.2.1543"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1547"')
+        .startswith('__version__ = "0.2.1548"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1547"
+    assert encoder_package["version"] == "0.2.1548"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1547"
+    assert project["project"]["version"] == "0.2.1548"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1547"')
+        .startswith('__version__ = "0.2.1548"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1547"
+    assert encoder_package["version"] == "0.2.1548"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1547"
+    assert project["project"]["version"] == "0.2.1548"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1547"')
+        .startswith('__version__ = "0.2.1548"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1544"')
+        .startswith('__version__ = "0.2.1545"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1544"
+    assert encoder_package["version"] == "0.2.1545"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1544"
+    assert project["project"]["version"] == "0.2.1545"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1544"')
+        .startswith('__version__ = "0.2.1545"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1544"
+    assert encoder_package["version"] == "0.2.1545"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1544"
+    assert project["project"]["version"] == "0.2.1545"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1544"')
+        .startswith('__version__ = "0.2.1545"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1543"')
+        .startswith('__version__ = "0.2.1544"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1543"
+    assert encoder_package["version"] == "0.2.1544"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1543"
+    assert project["project"]["version"] == "0.2.1544"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1543"')
+        .startswith('__version__ = "0.2.1544"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1543"
+    assert encoder_package["version"] == "0.2.1544"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1543"
+    assert project["project"]["version"] == "0.2.1544"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1543"')
+        .startswith('__version__ = "0.2.1544"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1545"')
+        .startswith('__version__ = "0.2.1546"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1545"
+    assert encoder_package["version"] == "0.2.1546"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1545"
+    assert project["project"]["version"] == "0.2.1546"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1545"')
+        .startswith('__version__ = "0.2.1546"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1545"
+    assert encoder_package["version"] == "0.2.1546"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1545"
+    assert project["project"]["version"] == "0.2.1546"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1545"')
+        .startswith('__version__ = "0.2.1546"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1548"')
+        .startswith('__version__ = "0.2.1549"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1548"
+    assert encoder_package["version"] == "0.2.1549"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1548"
+    assert project["project"]["version"] == "0.2.1549"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1548"')
+        .startswith('__version__ = "0.2.1549"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1548"
+    assert encoder_package["version"] == "0.2.1549"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1548"
+    assert project["project"]["version"] == "0.2.1549"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1548"')
+        .startswith('__version__ = "0.2.1549"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1546"
+ENCODER_VERSION = "0.2.1547"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1545"
+ENCODER_VERSION = "0.2.1546"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1542"
+ENCODER_VERSION = "0.2.1543"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1544"
+ENCODER_VERSION = "0.2.1545"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1548"
+ENCODER_VERSION = "0.2.1549"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1543"
+ENCODER_VERSION = "0.2.1544"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1547"
+ENCODER_VERSION = "0.2.1548"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -11259,9 +11259,11 @@ def test_notwithstanding_exemption_preserves_affirmative_duty():
     source = """\
 (b) Qualified public housing agencies
 (A) The requirement under paragraph (1) shall not apply to a qualified agency.
-(B) Notwithstanding that qualified agencies are exempt under subparagraph (A)
-from the requirement under paragraph (1), each qualified public housing agency
-shall, on an annual basis, make the certification described in paragraph (16).
+(B) Notwithstanding that qualified public housing agencies are exempt under
+subparagraph (A) from the requirement under this section to prepare and submit an
+annual public housing plan, each qualified public housing agency shall, on an annual
+basis, make the certification described in paragraph (16) of subsection (d), except
+that the paragraph shall use substitute language.
 """
 
     assert completeness_module._source_exception_effect_requirement(source) == (
@@ -11270,44 +11272,41 @@ shall, on an annual basis, make the certification described in paragraph (16).
 
 
 @pytest.mark.parametrize(
-    "condition",
+    "source",
     [
-        "the filing exemption applies",
-        "qualified agencies are exempted from filing",
+        (
+            "Notwithstanding that qualified public housing agencies are not exempt "
+            "under subparagraph (A) from the requirement under this section to "
+            "prepare and submit an annual public housing plan, each qualified public "
+            "housing agency shall, on an annual basis, make the certification "
+            "described in paragraph (16) of subsection (d), except that it is revised."
+        ),
+        (
+            "Notwithstanding that no exemption applies, each qualified public housing "
+            "agency shall, on an annual basis, make the certification described in "
+            "paragraph (16) of subsection (d), except that it is revised."
+        ),
+        (
+            "Notwithstanding that qualified agencies must certify an exemption, each "
+            "qualified public housing agency shall, on an annual basis, make the "
+            "certification described in paragraph (16) of subsection (d), except that "
+            "it is revised."
+        ),
+        (
+            "Notwithstanding that qualified public housing agencies are exempt under "
+            "subparagraph (A) from the requirement under this section to prepare and "
+            "submit an annual public housing plan, each qualified public housing "
+            "agency must certify."
+        ),
+        (
+            "Notwithstanding that qualified public housing agencies are exempt under "
+            "subparagraph (A) from the requirement under this section to prepare and "
+            "submit an annual public housing plan, each qualified public housing "
+            "agency shall make the certification if requested."
+        ),
     ],
 )
-def test_notwithstanding_exemption_word_forms_preserve_certification_duty(
-    condition: str,
-):
-    source = (
-        f"(1) Notwithstanding that {condition}, each qualified agency shall certify."
-    )
-
-    assert completeness_module._source_exception_effect_requirement(source) == (
-        "enable"
-    )
-
-
-@pytest.mark.parametrize(
-    "effect",
-    [
-        "each agency shall not certify",
-        "each agency shall remain ineligible",
-        "each agency shall report excluded applicants",
-        "an agency with no pending application shall certify",
-        "each agency shall certify that applicants must remain ineligible",
-        "each agency that shall submit a report must certify",
-        "each agency is required to certify",
-        "neither agency shall be eligible",
-        "there shall be no eligibility",
-        "each agency shall never fail to certify",
-        "each agency shall be deemed not eligible",
-        "each agency shall be considered ineligible",
-    ],
-)
-def test_notwithstanding_exemption_does_not_guess_other_effects(effect: str):
-    source = f"(1) Notwithstanding the filing exemption, {effect}."
-
+def test_notwithstanding_exemption_rejects_near_misses(source: str):
     assert (
         completeness_module._notwithstanding_exemption_effect_requirement(source)
         is None
@@ -11316,8 +11315,11 @@ def test_notwithstanding_exemption_does_not_guess_other_effects(effect: str):
 
 def test_notwithstanding_exemption_accepts_enabling_companion_pair():
     source = """\
-(1) Notwithstanding that qualified agencies are exempt from the filing requirement,
-each qualified public housing agency shall, on an annual basis, make the certification.
+(1) Notwithstanding that qualified public housing agencies are exempt under
+subparagraph (A) from the requirement under this section to prepare and submit an
+annual public housing plan, each qualified public housing agency shall, on an annual
+basis, make the certification described in paragraph (16) of subsection (d), except
+that the paragraph shall use substitute language.
 """
     content = _exception_control_content(
         "if qualified_agency: true else: false",

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -11279,6 +11279,12 @@ from the requirement under paragraph (1), each qualified agency shall certify.
         "qualified agencies are waived from filing",
         "qualified agencies are excepted from filing",
         "the filing exception applies",
+        "the statute exempts qualified agencies",
+        "the statute excludes qualified agencies",
+        "the agency waives filing",
+        "the statute excepts qualified agencies",
+        "the filing requirement is not applicable",
+        "the filing requirement is inapplicable",
     ],
 )
 def test_notwithstanding_exemption_word_forms_preserve_affirmative_duty(
@@ -11339,6 +11345,70 @@ def test_notwithstanding_exemption_does_not_invert_negative_duty(source: str):
 def test_notwithstanding_exemption_double_negative_enables(source: str):
     assert completeness_module._source_exception_effect_requirement(source) == (
         "enable"
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        (
+            "(1) Notwithstanding the filing exemption, each agency shall report "
+            "excluded applicants."
+        ),
+        (
+            "(1) Notwithstanding the filing exemption, an agency with no pending "
+            "application shall certify."
+        ),
+    ],
+)
+def test_notwithstanding_embedded_negative_terms_do_not_invert_duty(source: str):
+    assert completeness_module._source_exception_effect_requirement(source) == (
+        "enable"
+    )
+
+
+def test_notwithstanding_negative_duty_with_negative_object_stays_blocking():
+    source = (
+        "(1) Notwithstanding the filing exemption, each agency shall not certify "
+        "an ineligible applicant."
+    )
+
+    assert completeness_module._source_exception_effect_requirement(source) == (
+        "exclude"
+    )
+
+
+@pytest.mark.parametrize(
+    ("effect", "expected"),
+    [
+        ("is required to remain ineligible", "exclude"),
+        ("is required not to certify", "exclude"),
+        ("is not required to remain ineligible", "enable"),
+        ("is required not to remain ineligible", "enable"),
+    ],
+)
+def test_notwithstanding_required_to_complement_polarity(
+    effect: str,
+    expected: str,
+):
+    source = f"(1) Notwithstanding the filing exemption, each agency {effect}."
+
+    assert completeness_module._source_exception_effect_requirement(source) == expected
+
+
+@pytest.mark.parametrize(
+    "effect",
+    [
+        "shall be denied eligibility",
+        "shall lose eligibility",
+        "shall cease to be eligible",
+    ],
+)
+def test_notwithstanding_negative_result_vocabulary_is_blocking(effect: str):
+    source = f"(1) Notwithstanding the filing exemption, each agency {effect}."
+
+    assert completeness_module._source_exception_effect_requirement(source) == (
+        "exclude"
     )
 
 

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -11294,14 +11294,8 @@ def test_notwithstanding_exemption_word_forms_preserve_affirmative_duty(
             "(1) Notwithstanding the filing exemption, each agency shall not "
             "be eligible."
         ),
-        (
-            "(1) Notwithstanding the filing exemption, no agency shall be "
-            "eligible."
-        ),
-        (
-            "(1) Notwithstanding the filing exemption, each agency must be "
-            "ineligible."
-        ),
+        ("(1) Notwithstanding the filing exemption, no agency shall be eligible."),
+        ("(1) Notwithstanding the filing exemption, each agency must be ineligible."),
     ],
 )
 def test_notwithstanding_exemption_does_not_invert_negative_duty(source: str):

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -11285,6 +11285,9 @@ from the requirement under paragraph (1), each qualified agency shall certify.
         "the statute excepts qualified agencies",
         "the filing requirement is not applicable",
         "the filing requirement is inapplicable",
+        "the statutes exclude qualified agencies",
+        "the agencies waive filing",
+        "the statutes except qualified agencies",
     ],
 )
 def test_notwithstanding_exemption_word_forms_preserve_affirmative_duty(
@@ -11367,6 +11370,25 @@ def test_notwithstanding_embedded_negative_terms_do_not_invert_duty(source: str)
     )
 
 
+@pytest.mark.parametrize(
+    "source",
+    [
+        (
+            "(1) Notwithstanding the filing exemption, each agency shall certify "
+            "that applicants are required to remain ineligible."
+        ),
+        (
+            "(1) Notwithstanding the filing exemption, each agency that shall "
+            "submit a report must certify."
+        ),
+    ],
+)
+def test_notwithstanding_main_predicate_precedes_nested_predicates(source: str):
+    assert completeness_module._source_exception_effect_requirement(source) == (
+        "enable"
+    )
+
+
 def test_notwithstanding_negative_duty_with_negative_object_stays_blocking():
     source = (
         "(1) Notwithstanding the filing exemption, each agency shall not certify "
@@ -11383,6 +11405,9 @@ def test_notwithstanding_negative_duty_with_negative_object_stays_blocking():
     [
         ("is required to remain ineligible", "exclude"),
         ("is required not to certify", "exclude"),
+        ("is required to not certify", "exclude"),
+        ("is legally required to certify", "enable"),
+        ("is not legally required to certify", "exclude"),
         ("is not required to remain ineligible", "enable"),
         ("is required not to remain ineligible", "enable"),
     ],
@@ -11406,6 +11431,39 @@ def test_notwithstanding_required_to_complement_polarity(
 )
 def test_notwithstanding_negative_result_vocabulary_is_blocking(effect: str):
     source = f"(1) Notwithstanding the filing exemption, each agency {effect}."
+
+    assert completeness_module._source_exception_effect_requirement(source) == (
+        "exclude"
+    )
+
+
+@pytest.mark.parametrize(
+    "effect",
+    [
+        "shall be eligible unless disqualified",
+        "shall be eligible and not disqualified",
+        "shall be deemed not ineligible",
+    ],
+)
+def test_notwithstanding_positive_complement_is_not_overconsumed(effect: str):
+    source = f"(1) Notwithstanding the filing exemption, each agency {effect}."
+
+    assert completeness_module._source_exception_effect_requirement(source) == (
+        "enable"
+    )
+
+
+@pytest.mark.parametrize(
+    "effect",
+    [
+        "neither agency shall be eligible",
+        "none of the agencies shall be eligible",
+        "each agency shall no longer be eligible",
+        "each agency shall never be eligible",
+    ],
+)
+def test_notwithstanding_equivalent_negation_is_blocking(effect: str):
+    source = f"(1) Notwithstanding the filing exemption, {effect}."
 
     assert completeness_module._source_exception_effect_requirement(source) == (
         "exclude"

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -11260,7 +11260,8 @@ def test_notwithstanding_exemption_preserves_affirmative_duty():
 (b) Qualified public housing agencies
 (A) The requirement under paragraph (1) shall not apply to a qualified agency.
 (B) Notwithstanding that qualified agencies are exempt under subparagraph (A)
-from the requirement under paragraph (1), each qualified agency shall certify.
+from the requirement under paragraph (1), each qualified public housing agency
+shall, on an annual basis, make the certification described in paragraph (16).
 """
 
     assert completeness_module._source_exception_effect_requirement(source) == (
@@ -11273,24 +11274,9 @@ from the requirement under paragraph (1), each qualified agency shall certify.
     [
         "the filing exemption applies",
         "qualified agencies are exempted from filing",
-        "the filing exclusion applies",
-        "qualified agencies are excluded from filing",
-        "the filing waiver applies",
-        "qualified agencies are waived from filing",
-        "qualified agencies are excepted from filing",
-        "the filing exception applies",
-        "the statute exempts qualified agencies",
-        "the statute excludes qualified agencies",
-        "the agency waives filing",
-        "the statute excepts qualified agencies",
-        "the filing requirement is not applicable",
-        "the filing requirement is inapplicable",
-        "the statutes exclude qualified agencies",
-        "the agencies waive filing",
-        "the statutes except qualified agencies",
     ],
 )
-def test_notwithstanding_exemption_word_forms_preserve_affirmative_duty(
+def test_notwithstanding_exemption_word_forms_preserve_certification_duty(
     condition: str,
 ):
     source = (
@@ -11303,177 +11289,35 @@ def test_notwithstanding_exemption_word_forms_preserve_affirmative_duty(
 
 
 @pytest.mark.parametrize(
-    "source",
-    [
-        (
-            "(1) Notwithstanding the filing exemption, each agency shall not "
-            "be eligible."
-        ),
-        ("(1) Notwithstanding the filing exemption, no agency shall be eligible."),
-        ("(1) Notwithstanding the filing exemption, each agency must be ineligible."),
-        (
-            "(1) Notwithstanding the filing exemption, each agency shall remain "
-            "ineligible."
-        ),
-        (
-            "(1) Notwithstanding the filing exemption, each agency shall continue "
-            "to be ineligible."
-        ),
-        (
-            "(1) Notwithstanding the filing exemption, each agency must remain "
-            "disqualified."
-        ),
-    ],
-)
-def test_notwithstanding_exemption_does_not_invert_negative_duty(source: str):
-    assert completeness_module._source_exception_effect_requirement(source) == (
-        "exclude"
-    )
-
-
-@pytest.mark.parametrize(
-    "source",
-    [
-        (
-            "(1) Notwithstanding the filing exemption, each agency shall not be "
-            "ineligible."
-        ),
-        (
-            "(1) Notwithstanding the filing exemption, each agency must not be "
-            "disqualified."
-        ),
-        ("(1) Notwithstanding the filing exemption, no agency shall be ineligible."),
-    ],
-)
-def test_notwithstanding_exemption_double_negative_enables(source: str):
-    assert completeness_module._source_exception_effect_requirement(source) == (
-        "enable"
-    )
-
-
-@pytest.mark.parametrize(
-    "source",
-    [
-        (
-            "(1) Notwithstanding the filing exemption, each agency shall report "
-            "excluded applicants."
-        ),
-        (
-            "(1) Notwithstanding the filing exemption, an agency with no pending "
-            "application shall certify."
-        ),
-    ],
-)
-def test_notwithstanding_embedded_negative_terms_do_not_invert_duty(source: str):
-    assert completeness_module._source_exception_effect_requirement(source) == (
-        "enable"
-    )
-
-
-@pytest.mark.parametrize(
-    "source",
-    [
-        (
-            "(1) Notwithstanding the filing exemption, each agency shall certify "
-            "that applicants are required to remain ineligible."
-        ),
-        (
-            "(1) Notwithstanding the filing exemption, each agency that shall "
-            "submit a report must certify."
-        ),
-    ],
-)
-def test_notwithstanding_main_predicate_precedes_nested_predicates(source: str):
-    assert completeness_module._source_exception_effect_requirement(source) == (
-        "enable"
-    )
-
-
-def test_notwithstanding_negative_duty_with_negative_object_stays_blocking():
-    source = (
-        "(1) Notwithstanding the filing exemption, each agency shall not certify "
-        "an ineligible applicant."
-    )
-
-    assert completeness_module._source_exception_effect_requirement(source) == (
-        "exclude"
-    )
-
-
-@pytest.mark.parametrize(
-    ("effect", "expected"),
-    [
-        ("is required to remain ineligible", "exclude"),
-        ("is required not to certify", "exclude"),
-        ("is required to not certify", "exclude"),
-        ("is legally required to certify", "enable"),
-        ("is not legally required to certify", "exclude"),
-        ("is not required to remain ineligible", "enable"),
-        ("is required not to remain ineligible", "enable"),
-    ],
-)
-def test_notwithstanding_required_to_complement_polarity(
-    effect: str,
-    expected: str,
-):
-    source = f"(1) Notwithstanding the filing exemption, each agency {effect}."
-
-    assert completeness_module._source_exception_effect_requirement(source) == expected
-
-
-@pytest.mark.parametrize(
     "effect",
     [
-        "shall be denied eligibility",
-        "shall lose eligibility",
-        "shall cease to be eligible",
-    ],
-)
-def test_notwithstanding_negative_result_vocabulary_is_blocking(effect: str):
-    source = f"(1) Notwithstanding the filing exemption, each agency {effect}."
-
-    assert completeness_module._source_exception_effect_requirement(source) == (
-        "exclude"
-    )
-
-
-@pytest.mark.parametrize(
-    "effect",
-    [
-        "shall be eligible unless disqualified",
-        "shall be eligible and not disqualified",
-        "shall be deemed not ineligible",
-    ],
-)
-def test_notwithstanding_positive_complement_is_not_overconsumed(effect: str):
-    source = f"(1) Notwithstanding the filing exemption, each agency {effect}."
-
-    assert completeness_module._source_exception_effect_requirement(source) == (
-        "enable"
-    )
-
-
-@pytest.mark.parametrize(
-    "effect",
-    [
+        "each agency shall not certify",
+        "each agency shall remain ineligible",
+        "each agency shall report excluded applicants",
+        "an agency with no pending application shall certify",
+        "each agency shall certify that applicants must remain ineligible",
+        "each agency that shall submit a report must certify",
+        "each agency is required to certify",
         "neither agency shall be eligible",
-        "none of the agencies shall be eligible",
-        "each agency shall no longer be eligible",
-        "each agency shall never be eligible",
+        "there shall be no eligibility",
+        "each agency shall never fail to certify",
+        "each agency shall be deemed not eligible",
+        "each agency shall be considered ineligible",
     ],
 )
-def test_notwithstanding_equivalent_negation_is_blocking(effect: str):
+def test_notwithstanding_exemption_does_not_guess_other_effects(effect: str):
     source = f"(1) Notwithstanding the filing exemption, {effect}."
 
-    assert completeness_module._source_exception_effect_requirement(source) == (
-        "exclude"
+    assert (
+        completeness_module._notwithstanding_exemption_effect_requirement(source)
+        is None
     )
 
 
 def test_notwithstanding_exemption_accepts_enabling_companion_pair():
     source = """\
 (1) Notwithstanding that qualified agencies are exempt from the filing requirement,
-each qualified agency shall certify.
+each qualified public housing agency shall, on an annual basis, make the certification.
 """
     content = _exception_control_content(
         "if qualified_agency: true else: false",
@@ -11494,90 +11338,6 @@ each qualified agency shall certify.
     result = _analyze(content, source, test_cases=cases)
 
     assert not result.issues
-
-
-def test_notwithstanding_exemption_accepts_blocking_companion_pair():
-    source = """\
-(1) Notwithstanding the filing exemption, an exempt agency shall not be eligible.
-"""
-    correct = _exception_control_content(
-        "if filing_exemption: false else: true",
-    )
-    inverted = _exception_control_content(
-        "if filing_exemption: true else: false",
-    )
-    correct_cases = [
-        {
-            "name": "ordinary agency",
-            "input": {"filing_exemption": False},
-            "output": {"result": True},
-        },
-        {
-            "name": "exempt agency",
-            "input": {"filing_exemption": True},
-            "output": {"result": False},
-        },
-    ]
-    inverted_cases = [
-        {
-            "name": "ordinary agency",
-            "input": {"filing_exemption": False},
-            "output": {"result": False},
-        },
-        {
-            "name": "exempt agency",
-            "input": {"filing_exemption": True},
-            "output": {"result": True},
-        },
-    ]
-
-    correct_result = _analyze(correct, source, test_cases=correct_cases)
-    inverted_result = _analyze(inverted, source, test_cases=inverted_cases)
-
-    assert not correct_result.issues
-    assert _has_issue(inverted_result, "exception", "test")
-
-
-def test_notwithstanding_exemption_double_negative_accepts_enabling_pair():
-    source = """\
-(1) Notwithstanding the filing exclusion, an agency shall not remain ineligible.
-"""
-    correct = _exception_control_content(
-        "if filing_exclusion: true else: false",
-    )
-    inverted = _exception_control_content(
-        "if filing_exclusion: false else: true",
-    )
-    correct_cases = [
-        {
-            "name": "ordinary agency",
-            "input": {"filing_exclusion": False},
-            "output": {"result": False},
-        },
-        {
-            "name": "excluded agency",
-            "input": {"filing_exclusion": True},
-            "output": {"result": True},
-        },
-    ]
-    inverted_cases = [
-        {
-            "name": "ordinary agency",
-            "input": {"filing_exclusion": False},
-            "output": {"result": True},
-        },
-        {
-            "name": "excluded agency",
-            "input": {"filing_exclusion": True},
-            "output": {"result": False},
-        },
-    ]
-
-    correct_result = _analyze(correct, source, test_cases=correct_cases)
-    inverted_result = _analyze(inverted, source, test_cases=inverted_cases)
-
-    assert not correct_result.issues
-    assert _has_issue(inverted_result, "exception", "test")
 
 
 def test_preposed_german_negative_condition_enables_positive_result():

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -11255,6 +11255,45 @@ def test_enabling_effect_is_independent_of_proposition_order(source: str):
     )
 
 
+def test_notwithstanding_exemption_preserves_affirmative_duty():
+    source = """\
+(b) Qualified public housing agencies
+(A) The requirement under paragraph (1) shall not apply to a qualified agency.
+(B) Notwithstanding that qualified agencies are exempt under subparagraph (A)
+from the requirement under paragraph (1), each qualified agency shall certify.
+"""
+
+    assert completeness_module._source_exception_effect_requirement(source) == (
+        "enable"
+    )
+
+
+def test_notwithstanding_exemption_accepts_enabling_companion_pair():
+    source = """\
+(1) Notwithstanding that qualified agencies are exempt from the filing requirement,
+each qualified agency shall certify.
+"""
+    content = _exception_control_content(
+        "if qualified_agency: true else: false",
+    )
+    cases = [
+        {
+            "name": "ordinary agency",
+            "input": {"qualified_agency": False},
+            "output": {"result": False},
+        },
+        {
+            "name": "qualified agency certification",
+            "input": {"qualified_agency": True},
+            "output": {"result": True},
+        },
+    ]
+
+    result = _analyze(content, source, test_cases=cases)
+
+    assert not result.issues
+
+
 def test_preposed_german_negative_condition_enables_positive_result():
     source = """\
 (1) Wenn der Antragsteller nicht berechtigt ist, ist er ausnahmsweise berechtigt.

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -11273,6 +11273,12 @@ from the requirement under paragraph (1), each qualified agency shall certify.
     [
         "the filing exemption applies",
         "qualified agencies are exempted from filing",
+        "the filing exclusion applies",
+        "qualified agencies are excluded from filing",
+        "the filing waiver applies",
+        "qualified agencies are waived from filing",
+        "qualified agencies are excepted from filing",
+        "the filing exception applies",
     ],
 )
 def test_notwithstanding_exemption_word_forms_preserve_affirmative_duty(
@@ -11296,11 +11302,43 @@ def test_notwithstanding_exemption_word_forms_preserve_affirmative_duty(
         ),
         ("(1) Notwithstanding the filing exemption, no agency shall be eligible."),
         ("(1) Notwithstanding the filing exemption, each agency must be ineligible."),
+        (
+            "(1) Notwithstanding the filing exemption, each agency shall remain "
+            "ineligible."
+        ),
+        (
+            "(1) Notwithstanding the filing exemption, each agency shall continue "
+            "to be ineligible."
+        ),
+        (
+            "(1) Notwithstanding the filing exemption, each agency must remain "
+            "disqualified."
+        ),
     ],
 )
 def test_notwithstanding_exemption_does_not_invert_negative_duty(source: str):
     assert completeness_module._source_exception_effect_requirement(source) == (
         "exclude"
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        (
+            "(1) Notwithstanding the filing exemption, each agency shall not be "
+            "ineligible."
+        ),
+        (
+            "(1) Notwithstanding the filing exemption, each agency must not be "
+            "disqualified."
+        ),
+        ("(1) Notwithstanding the filing exemption, no agency shall be ineligible."),
+    ],
+)
+def test_notwithstanding_exemption_double_negative_enables(source: str):
+    assert completeness_module._source_exception_effect_requirement(source) == (
+        "enable"
     )
 
 
@@ -11362,6 +11400,48 @@ def test_notwithstanding_exemption_accepts_blocking_companion_pair():
             "name": "exempt agency",
             "input": {"filing_exemption": True},
             "output": {"result": True},
+        },
+    ]
+
+    correct_result = _analyze(correct, source, test_cases=correct_cases)
+    inverted_result = _analyze(inverted, source, test_cases=inverted_cases)
+
+    assert not correct_result.issues
+    assert _has_issue(inverted_result, "exception", "test")
+
+
+def test_notwithstanding_exemption_double_negative_accepts_enabling_pair():
+    source = """\
+(1) Notwithstanding the filing exclusion, an agency shall not remain ineligible.
+"""
+    correct = _exception_control_content(
+        "if filing_exclusion: true else: false",
+    )
+    inverted = _exception_control_content(
+        "if filing_exclusion: false else: true",
+    )
+    correct_cases = [
+        {
+            "name": "ordinary agency",
+            "input": {"filing_exclusion": False},
+            "output": {"result": False},
+        },
+        {
+            "name": "excluded agency",
+            "input": {"filing_exclusion": True},
+            "output": {"result": True},
+        },
+    ]
+    inverted_cases = [
+        {
+            "name": "ordinary agency",
+            "input": {"filing_exclusion": False},
+            "output": {"result": True},
+        },
+        {
+            "name": "excluded agency",
+            "input": {"filing_exclusion": True},
+            "output": {"result": False},
         },
     ]
 

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -11268,6 +11268,48 @@ from the requirement under paragraph (1), each qualified agency shall certify.
     )
 
 
+@pytest.mark.parametrize(
+    "condition",
+    [
+        "the filing exemption applies",
+        "qualified agencies are exempted from filing",
+    ],
+)
+def test_notwithstanding_exemption_word_forms_preserve_affirmative_duty(
+    condition: str,
+):
+    source = (
+        f"(1) Notwithstanding that {condition}, each qualified agency shall certify."
+    )
+
+    assert completeness_module._source_exception_effect_requirement(source) == (
+        "enable"
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        (
+            "(1) Notwithstanding the filing exemption, each agency shall not "
+            "be eligible."
+        ),
+        (
+            "(1) Notwithstanding the filing exemption, no agency shall be "
+            "eligible."
+        ),
+        (
+            "(1) Notwithstanding the filing exemption, each agency must be "
+            "ineligible."
+        ),
+    ],
+)
+def test_notwithstanding_exemption_does_not_invert_negative_duty(source: str):
+    assert completeness_module._source_exception_effect_requirement(source) == (
+        "exclude"
+    )
+
+
 def test_notwithstanding_exemption_accepts_enabling_companion_pair():
     source = """\
 (1) Notwithstanding that qualified agencies are exempt from the filing requirement,
@@ -11292,6 +11334,48 @@ each qualified agency shall certify.
     result = _analyze(content, source, test_cases=cases)
 
     assert not result.issues
+
+
+def test_notwithstanding_exemption_accepts_blocking_companion_pair():
+    source = """\
+(1) Notwithstanding the filing exemption, an exempt agency shall not be eligible.
+"""
+    correct = _exception_control_content(
+        "if filing_exemption: false else: true",
+    )
+    inverted = _exception_control_content(
+        "if filing_exemption: true else: false",
+    )
+    correct_cases = [
+        {
+            "name": "ordinary agency",
+            "input": {"filing_exemption": False},
+            "output": {"result": True},
+        },
+        {
+            "name": "exempt agency",
+            "input": {"filing_exemption": True},
+            "output": {"result": False},
+        },
+    ]
+    inverted_cases = [
+        {
+            "name": "ordinary agency",
+            "input": {"filing_exemption": False},
+            "output": {"result": False},
+        },
+        {
+            "name": "exempt agency",
+            "input": {"filing_exemption": True},
+            "output": {"result": True},
+        },
+    ]
+
+    correct_result = _analyze(correct, source, test_cases=correct_cases)
+    inverted_result = _analyze(inverted, source, test_cases=inverted_cases)
+
+    assert not correct_result.issues
+    assert _has_issue(inverted_result, "exception", "test")
 
 
 def test_preposed_german_negative_condition_enables_positive_result():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1546"
+version = "0.2.1547"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1543"
+version = "0.2.1544"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1547"
+version = "0.2.1548"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1544"
+version = "0.2.1545"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1548"
+version = "0.2.1549"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1542"
+version = "0.2.1543"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1545"
+version = "0.2.1546"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- recognize the exact 42 USC 1437c-1(b)(3)(B) certification duty preserved by its filing exemption
- keep unsupported notwithstanding forms on the existing conservative fallback path
- reject negated-condition and near-miss action wording
- release encoder `0.2.1549`

## Real artifact verification
The final gpt-5.6-sol candidate from protected run 30968922848 remains exactly 41 rules and 26 tests and reports `issues=0` under complete-source-unit analysis.

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`: pass
- `uv run ruff format --check src/ tests/`: pass
- `python -m compileall -q src/axiom_encode scripts`: pass
- provenance/version focused check: pass
- `uv run pytest tests/test_source_completeness.py -q`: pass
- full `uv run pytest`: 7164 passed, 119 skipped
- exact-head GitHub CI: lint, main test, macOS, and Ubuntu pass

## Cycle
Independent review/fix cycles were repeated after substantive changes. Final review at `7e6b4a770fa7dca7b59e0beda65ad889890a423d`: CLEAN, no actionable findings. Reviewer independently confirmed 41 rules, 26 tests, zero completeness issues, version provenance, focused tests, lint, and format.