### PR TITLE
Authorize stale legacy index manifest replacement

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -1073,6 +1073,24 @@ jobs:
             if [ -n "$replacement_path" ]; then
               args+=(--replace-rulespec-path "$replacement_path")
             fi
+            if [ -n "$replacement_path" ] && [ -z "$legacy_source_path" ]; then
+              shrink_authorized="$(
+                "$workflow_python" "$backfill_helper" \
+                  authorize-legacy-index-manifest-shrink \
+                  "$RULESPEC_CHECKOUT" "$replacement_path"
+              )"
+              case "$shrink_authorized" in
+                true)
+                  args+=(--allow-shrink)
+                  ;;
+                false)
+                  ;;
+                *)
+                  echo "manifest shrink authorization returned malformed output" >&2
+                  exit 1
+                  ;;
+              esac
+            fi
             if [ -n "$legacy_source_path" ]; then
               args+=(--replace-legacy-rulespec-path "$legacy_source_path")
               if [ -n "$dependent_rulespec_path" ]; then

--- a/changelog.d/targeted-legacy-index-manifest-shrink.fixed.md
+++ b/changelog.d/targeted-legacy-index-manifest-shrink.fixed.md
@@ -1,0 +1,1 @@
+Allow protected canonical re-encodes to replace an exact legacy migration manifest whose only stale extra ownership claim is the provisions-to-rules index.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1549"
+version = "0.2.1550"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -17,6 +17,8 @@ QUEUE_TRACKING_PATTERN = re.compile(r"[a-z0-9][a-z0-9-]{0,63}")
 MANIFEST_ROOT = PurePosixPath(".axiom/encoding-manifests")
 LEGACY_REPLACEMENT_RECEIPT_ROOT = PurePosixPath(".axiom/legacy-replacements")
 LEGACY_REPLACEMENT_TOOL = "axiom-encode encode --apply --replace-legacy-rulespec-path"
+APPLIED_MANIFEST_SCHEMA_V5 = "axiom-encode/applied-rulespec/v5"
+PROVISIONS_TO_RULES_INDEX = PurePosixPath(".axiom/index/provisions_to_rules.json")
 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V1 = "axiom-encode/legacy-fresh-reencode-receipt/v1"
 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2 = "axiom-encode/legacy-fresh-reencode-receipt/v2"
 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3 = "axiom-encode/legacy-fresh-reencode-receipt/v3"
@@ -1022,6 +1024,142 @@ def _validate_rulespec_path(repo: Path, path: PurePosixPath, *, label: str) -> N
 
 def _rulespec_companion_path(primary: PurePosixPath) -> PurePosixPath:
     return primary.with_name(f"{primary.stem}.test.yaml")
+
+
+def authorize_legacy_index_manifest_shrink(
+    repo: Path,
+    target_rulespec_path: str,
+) -> bool:
+    """Authorize replacing one migration manifest that has a stale index claim."""
+
+    target = _safe_relative_path(
+        target_rulespec_path,
+        label="target RuleSpec path",
+    )
+    _validate_rulespec_path(repo, target, label="target RuleSpec path")
+    companion = _rulespec_companion_path(target)
+    manifest_relative = MANIFEST_ROOT / target.with_suffix(".json")
+    manifest_path = repo / manifest_relative
+    try:
+        manifest_path.lstat()
+    except FileNotFoundError:
+        return False
+    payload = json.loads(
+        _read_bounded_regular(
+            repo,
+            manifest_relative,
+            label="existing target apply manifest",
+            max_bytes=8 * 1024 * 1024,
+        ).decode("utf-8")
+    )
+    if not isinstance(payload, dict) or payload.get("tool") != LEGACY_REPLACEMENT_TOOL:
+        return False
+    if payload.get("schema_version") != APPLIED_MANIFEST_SCHEMA_V5:
+        raise ValueError("legacy replacement manifest is not current v5")
+
+    entries = payload.get("applied_files")
+    if not isinstance(entries, list):
+        raise ValueError("legacy replacement manifest has malformed applied_files")
+    live: dict[PurePosixPath, str] = {}
+    deleted: list[PurePosixPath] = []
+    for index, item in enumerate(entries):
+        if not isinstance(item, dict):
+            raise ValueError(f"applied_files[{index}] is not an object")
+        path = _safe_relative_path(
+            item.get("path"),
+            label=f"applied_files[{index}].path",
+        )
+        if item.get("deleted") is True:
+            if set(item) != {"path", "deleted"}:
+                raise ValueError(f"applied_files[{index}] deletion is malformed")
+            deleted.append(path)
+            continue
+        digest = item.get("sha256")
+        if set(item) != {"path", "sha256"} or not isinstance(digest, str):
+            raise ValueError(f"applied_files[{index}] live entry is malformed")
+        if DIGEST_PATTERN.fullmatch(digest) is None or path in live:
+            raise ValueError(f"applied_files[{index}] digest or path is malformed")
+        live[path] = digest
+
+    expected_live = {target, companion, PROVISIONS_TO_RULES_INDEX}
+    if set(live) != expected_live or len(deleted) != 2:
+        return False
+    deleted_primary = next(
+        (path for path in deleted if not path.name.endswith(".test.yaml")),
+        None,
+    )
+    if (
+        deleted_primary is None
+        or deleted_primary == target
+        or set(deleted) != {deleted_primary, _rulespec_companion_path(deleted_primary)}
+    ):
+        return False
+
+    replacement = payload.get("replacement")
+    if not isinstance(replacement, dict):
+        raise ValueError("legacy replacement manifest has no replacement receipt")
+    expected_legacy_manifest = MANIFEST_ROOT / deleted_primary.with_suffix(".json")
+    if replacement.get("legacy_manifest_path") != expected_legacy_manifest.as_posix():
+        return False
+    receipt_path = _safe_relative_path(
+        replacement.get("receipt_path"),
+        label="replacement receipt path",
+    )
+    receipt_digest = replacement.get("receipt_sha256")
+    if (
+        not receipt_path.is_relative_to(LEGACY_REPLACEMENT_RECEIPT_ROOT)
+        or not isinstance(receipt_digest, str)
+        or DIGEST_PATTERN.fullmatch(receipt_digest) is None
+    ):
+        raise ValueError("legacy replacement receipt binding is malformed")
+    receipt_raw = _read_bounded_regular(
+        repo,
+        receipt_path,
+        label="legacy replacement receipt",
+        max_bytes=8 * 1024 * 1024,
+    )
+    if hashlib.sha256(receipt_raw).hexdigest() != receipt_digest:
+        raise ValueError("legacy replacement receipt digest does not match")
+
+    embedded = payload.get("replacement_manifest")
+    if (
+        not isinstance(embedded, dict)
+        or embedded.get("schema_version") != APPLIED_MANIFEST_SCHEMA_V5
+        or embedded.get("tool") != MODEL_APPLY_TOOL
+        or embedded.get("backend") not in MODEL_APPLY_BACKENDS
+    ):
+        raise ValueError("embedded model apply manifest is malformed")
+    embedded_entries = embedded.get("applied_files")
+    if not isinstance(embedded_entries, list):
+        raise ValueError("embedded model apply manifest has malformed applied_files")
+    embedded_live = {
+        PurePosixPath(item["path"]): item["sha256"]
+        for item in embedded_entries
+        if isinstance(item, dict)
+        and set(item) == {"path", "sha256"}
+        and isinstance(item.get("path"), str)
+        and isinstance(item.get("sha256"), str)
+    }
+    expected_model_live = {target: live[target], companion: live[companion]}
+    if embedded_live != expected_model_live or len(embedded_live) != len(embedded_entries):
+        return False
+
+    for path in (target, companion):
+        raw = _read_bounded_regular(
+            repo,
+            path,
+            label=f"legacy replacement live file {path}",
+            max_bytes=32 * 1024 * 1024,
+        )
+        if hashlib.sha256(raw).hexdigest() != live[path]:
+            raise ValueError(f"legacy replacement live file is stale: {path}")
+    current_index = _read_bounded_regular(
+        repo,
+        PROVISIONS_TO_RULES_INDEX,
+        label="provisions-to-rules index",
+        max_bytes=64 * 1024 * 1024,
+    )
+    return hashlib.sha256(current_index).hexdigest() != live[PROVISIONS_TO_RULES_INDEX]
 
 
 def _base_regular_blob(
@@ -2318,6 +2456,9 @@ def main() -> None:
     cascade_parser.add_argument("dependent_citations", nargs="+")
     citation_path_parser = subparsers.add_parser("citation-rulespec-path")
     citation_path_parser.add_argument("citation")
+    shrink_parser = subparsers.add_parser("authorize-legacy-index-manifest-shrink")
+    shrink_parser.add_argument("repo", type=Path)
+    shrink_parser.add_argument("target_rulespec_path")
     source_bundle_parser = subparsers.add_parser(
         "parse-source-bundle",
         help="validate a bounded source bundle and emit one normalized JSON array",
@@ -2438,6 +2579,15 @@ def main() -> None:
             )
         elif args.command == "citation-rulespec-path":
             print(citation_rulespec_path(args.citation))
+        elif args.command == "authorize-legacy-index-manifest-shrink":
+            print(
+                "true"
+                if authorize_legacy_index_manifest_shrink(
+                    args.repo,
+                    args.target_rulespec_path,
+                )
+                else "false"
+            )
         elif args.command == "parse-source-bundle":
             print(
                 json.dumps(

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -1132,16 +1132,26 @@ def authorize_legacy_index_manifest_shrink(
     embedded_entries = embedded.get("applied_files")
     if not isinstance(embedded_entries, list):
         raise ValueError("embedded model apply manifest has malformed applied_files")
-    embedded_live = {
-        PurePosixPath(item["path"]): item["sha256"]
-        for item in embedded_entries
-        if isinstance(item, dict)
-        and set(item) == {"path", "sha256"}
-        and isinstance(item.get("path"), str)
-        and isinstance(item.get("sha256"), str)
-    }
+    embedded_live: dict[PurePosixPath, str] = {}
+    for index, item in enumerate(embedded_entries):
+        if not isinstance(item, dict) or set(item) != {"path", "sha256"}:
+            raise ValueError(f"embedded applied_files[{index}] is malformed")
+        path = _safe_relative_path(
+            item.get("path"),
+            label=f"embedded applied_files[{index}].path",
+        )
+        digest = item.get("sha256")
+        if (
+            not isinstance(digest, str)
+            or DIGEST_PATTERN.fullmatch(digest) is None
+            or path in embedded_live
+        ):
+            raise ValueError(
+                f"embedded applied_files[{index}] digest or path is malformed"
+            )
+        embedded_live[path] = digest
     expected_model_live = {target: live[target], companion: live[companion]}
-    if embedded_live != expected_model_live or len(embedded_live) != len(embedded_entries):
+    if embedded_live != expected_model_live:
         return False
 
     for path in (target, companion):

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1549"
+__version__ = "0.2.1550"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1549"
+ENCODER_VERSION = "0.2.1550"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1549"
+ENCODER_VERSION = "0.2.1550"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1549"
+ENCODER_VERSION = "0.2.1550"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1549"
+ENCODER_VERSION = "0.2.1550"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1549"
+ENCODER_VERSION = "0.2.1550"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1549"
+ENCODER_VERSION = "0.2.1550"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1549"
+ENCODER_VERSION = "0.2.1550"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -153,6 +153,29 @@ def test_authorize_legacy_index_manifest_shrink_rejects_stale_target(
         )
 
 
+@pytest.mark.parametrize(
+    "malformed_path",
+    [
+        "us//statutes/42/1437c-1.yaml",
+        "us/statutes/42/./1437c-1.yaml",
+    ],
+)
+def test_authorize_legacy_index_manifest_shrink_rejects_malformed_embedded_path(
+    tmp_path: Path,
+    malformed_path: str,
+) -> None:
+    repo, target, manifest = _legacy_index_shrink_repo(tmp_path)
+    payload = json.loads(manifest.read_text())
+    payload["replacement_manifest"]["applied_files"][0]["path"] = malformed_path
+    manifest.write_text(json.dumps(payload) + "\n")
+
+    with pytest.raises(ValueError, match="not a safe repository-relative path"):
+        authorize_legacy_index_manifest_shrink(
+            repo,
+            target.relative_to(repo).as_posix(),
+        )
+
+
 def test_split_atomic_source_input_preserves_legacy_source_array() -> None:
     assert split_atomic_source_input('["us-ri/statute/44-30-1"]') == {
         "canonical_refresh_bundle": [],

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -19,6 +19,7 @@ from scripts.prepare_signed_backfill import (
     MAX_SOURCE_BUNDLE_JSON_BYTES,
     REVIEWED_RULESPEC_PR_BASE_BRANCHES,
     REVIEWED_RULESPEC_REFS,
+    authorize_legacy_index_manifest_shrink,
     authorized_changed_paths,
     branch_name,
     parse_canonical_refresh_bundle,
@@ -35,6 +36,121 @@ from scripts.prepare_signed_backfill import (
 from scripts.prepare_signed_backfill import (
     main as prepare_signed_backfill_main,
 )
+
+
+def _legacy_index_shrink_repo(tmp_path: Path) -> tuple[Path, Path, Path]:
+    repo = tmp_path / "rulespec-us"
+    target = repo / "us/statutes/42/1437c-1.yaml"
+    companion = target.with_name("1437c-1.test.yaml")
+    index = repo / ".axiom/index/provisions_to_rules.json"
+    target.parent.mkdir(parents=True)
+    index.parent.mkdir(parents=True)
+    target.write_text("format: rulespec/v1\nrules: []\n")
+    companion.write_text("[]\n")
+    index.write_text('{"generation":2}\n')
+    receipt = repo / ".axiom/legacy-replacements/receipt.json"
+    receipt.parent.mkdir(parents=True)
+    receipt.write_text('{"schema":"receipt"}\n')
+
+    target_relative = target.relative_to(repo).as_posix()
+    companion_relative = companion.relative_to(repo).as_posix()
+    target_digest = hashlib.sha256(target.read_bytes()).hexdigest()
+    companion_digest = hashlib.sha256(companion.read_bytes()).hexdigest()
+    model_manifest = {
+        "schema_version": "axiom-encode/applied-rulespec/v5",
+        "tool": "axiom-encode encode --apply",
+        "backend": "openai",
+        "applied_files": [
+            {"path": target_relative, "sha256": target_digest},
+            {"path": companion_relative, "sha256": companion_digest},
+        ],
+    }
+    manifest = repo / ".axiom/encoding-manifests/us/statutes/42/1437c-1.json"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": "axiom-encode/applied-rulespec/v5",
+                "tool": (
+                    "axiom-encode encode --apply "
+                    "--replace-legacy-rulespec-path"
+                ),
+                "replacement": {
+                    "legacy_manifest_path": (
+                        ".axiom/encoding-manifests/us/statutes/42/1437c–1.json"
+                    ),
+                    "receipt_path": receipt.relative_to(repo).as_posix(),
+                    "receipt_sha256": hashlib.sha256(receipt.read_bytes()).hexdigest(),
+                },
+                "replacement_manifest": model_manifest,
+                "applied_files": [
+                    {"path": target_relative, "sha256": target_digest},
+                    {"path": companion_relative, "sha256": companion_digest},
+                    {
+                        "path": ".axiom/index/provisions_to_rules.json",
+                        "sha256": hashlib.sha256(b'{"generation":1}\n').hexdigest(),
+                    },
+                    {"path": "us/statutes/42/1437c–1.yaml", "deleted": True},
+                    {
+                        "path": "us/statutes/42/1437c–1.test.yaml",
+                        "deleted": True,
+                    },
+                ],
+            }
+        )
+        + "\n"
+    )
+    return repo, target, manifest
+
+
+def test_authorize_legacy_index_manifest_shrink_accepts_exact_stale_index_claim(
+    tmp_path: Path,
+) -> None:
+    repo, target, _manifest = _legacy_index_shrink_repo(tmp_path)
+
+    assert authorize_legacy_index_manifest_shrink(
+        repo,
+        target.relative_to(repo).as_posix(),
+    )
+
+
+@pytest.mark.parametrize("mutation", ["tool", "extra-live", "current-index"])
+def test_authorize_legacy_index_manifest_shrink_denies_other_manifest_shapes(
+    tmp_path: Path,
+    mutation: str,
+) -> None:
+    repo, target, manifest = _legacy_index_shrink_repo(tmp_path)
+    payload = json.loads(manifest.read_text())
+    if mutation == "tool":
+        payload["tool"] = "axiom-encode encode --apply"
+    elif mutation == "extra-live":
+        payload["applied_files"].append(
+            {"path": "us/extra.yaml", "sha256": "a" * 64}
+        )
+    else:
+        index = repo / ".axiom/index/provisions_to_rules.json"
+        payload["applied_files"][2]["sha256"] = hashlib.sha256(
+            index.read_bytes()
+        ).hexdigest()
+    manifest.write_text(json.dumps(payload) + "\n")
+
+    assert not authorize_legacy_index_manifest_shrink(
+        repo,
+        target.relative_to(repo).as_posix(),
+    )
+
+
+def test_authorize_legacy_index_manifest_shrink_rejects_stale_target(
+    tmp_path: Path,
+) -> None:
+    repo, target, _manifest = _legacy_index_shrink_repo(tmp_path)
+    target.write_text("format: rulespec/v1\nrules:\n- changed\n")
+
+    with pytest.raises(ValueError, match="live file is stale"):
+        authorize_legacy_index_manifest_shrink(
+            repo,
+            target.relative_to(repo).as_posix(),
+        )
 
 
 def test_split_atomic_source_input_preserves_legacy_source_array() -> None:

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -71,10 +71,7 @@ def _legacy_index_shrink_repo(tmp_path: Path) -> tuple[Path, Path, Path]:
         json.dumps(
             {
                 "schema_version": "axiom-encode/applied-rulespec/v5",
-                "tool": (
-                    "axiom-encode encode --apply "
-                    "--replace-legacy-rulespec-path"
-                ),
+                "tool": ("axiom-encode encode --apply --replace-legacy-rulespec-path"),
                 "replacement": {
                     "legacy_manifest_path": (
                         ".axiom/encoding-manifests/us/statutes/42/1437c–1.json"
@@ -124,9 +121,7 @@ def test_authorize_legacy_index_manifest_shrink_denies_other_manifest_shapes(
     if mutation == "tool":
         payload["tool"] = "axiom-encode encode --apply"
     elif mutation == "extra-live":
-        payload["applied_files"].append(
-            {"path": "us/extra.yaml", "sha256": "a" * 64}
-        )
+        payload["applied_files"].append({"path": "us/extra.yaml", "sha256": "a" * 64})
     else:
         index = repo / ".axiom/index/provisions_to_rules.json"
         payload["applied_files"][2]["sha256"] = hashlib.sha256(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1549"')
+        .startswith('__version__ = "0.2.1550"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1549"
+    assert encoder_package["version"] == "0.2.1550"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1549"
+    assert project["project"]["version"] == "0.2.1550"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1549"')
+        .startswith('__version__ = "0.2.1550"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1549"
+    assert encoder_package["version"] == "0.2.1550"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1549"
+    assert project["project"]["version"] == "0.2.1550"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1549"')
+        .startswith('__version__ = "0.2.1550"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1549"
+ENCODER_VERSION = "0.2.1550"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1847,7 +1847,7 @@ def test_targeted_signed_reencode_only_allows_audited_legacy_index_shrink() -> N
     command = step["run"]
 
     assert "authorize-legacy-index-manifest-shrink" in command
-    assert 'args+=(--allow-shrink)' in command
+    assert "args+=(--allow-shrink)" in command
     assert command.count("--allow-shrink") == 1
     assert '[ -n "$replacement_path" ] && [ -z "$legacy_source_path" ]' in command
 

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1835,6 +1835,23 @@ def test_targeted_signed_reencode_shell_steps_have_valid_syntax(tmp_path: Path) 
             subprocess.run(["bash", "-n", str(script)], check=True)
 
 
+def test_targeted_signed_reencode_only_allows_audited_legacy_index_shrink() -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
+    )
+    step = next(
+        item
+        for item in workflow["jobs"]["encode"]["steps"]
+        if item.get("name") == "Encode, review, validate, and apply"
+    )
+    command = step["run"]
+
+    assert "authorize-legacy-index-manifest-shrink" in command
+    assert 'args+=(--allow-shrink)' in command
+    assert command.count("--allow-shrink") == 1
+    assert '[ -n "$replacement_path" ] && [ -z "$legacy_source_path" ]' in command
+
+
 def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     workflow = yaml.safe_load(
         (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1549"
+version = "0.2.1550"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- authorize `--allow-shrink` only for an exact legacy path-migration manifest whose sole extra live claim is a stale provisions-to-rules index
- bind authorization to matching target/test bytes, embedded model manifest, deleted predecessor pair, and replacement receipt
- keep queue target overrides and every other manifest shrink default-denied
- bump encoder to 0.2.1550 and advance exact version pin fixtures

## Validation
- exact hardcut probe at `6535019ce780d9e78f10509f2fe7a2607fb2bdc4`: `true`
- focused helper/workflow suite: 188 passed, 51 skipped
- version registry suites and exact validation pin tests: passed
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`: passed
- `python -m compileall -q src/axiom_encode scripts`: passed
- full `uv run pytest`: running

## Review cycle
Independent review is in progress. This PR remains draft until actionable findings are resolved and exact-head checks are green.