### PR TITLE
Fix English ordinal source-structure false positives

### DIFF
--- a/changelog.d/english-ordinal-source-structure.fixed.md
+++ b/changelog.d/english-ordinal-source-structure.fixed.md
@@ -1,0 +1,1 @@
+Exclude English ordinal suffixes from glued German sentence-marker recognition.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1550"
+version = "0.2.1551"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1550"
+__version__ = "0.2.1551"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -193,7 +193,11 @@ _LETTER_MARKER = re.compile(
     r"(?m)^[ \t]*(?P<marker>(?P<label>[a-z]{1,2})\))[ \t]+",
     flags=re.IGNORECASE,
 )
-_GLUED_SENTENCE_MARKER = re.compile(r"(?<![\w])(?P<label>[1-9]\d?)(?=[A-ZÄÖÜ](?!:))")
+_GLUED_SENTENCE_MARKER = re.compile(
+    r"(?<![\w])(?P<label>[1-9]\d?)"
+    r"(?!(?i:st|nd|rd|th)\b)"
+    r"(?=[A-ZÄÖÜ](?!:))"
+)
 _EXPLICIT_SENTENCE_MARKER = re.compile(
     r"(?:(?<=^)|(?<=[.;])|(?<=\)))[ \t]*Satz[ \t]+"
     r"(?P<label>[1-9]\d?)(?:[ \t]*:[ \t]*|[ \t]+)(?=[A-ZÄÖÜ])",

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1550"
+ENCODER_VERSION = "0.2.1551"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1550"
+ENCODER_VERSION = "0.2.1551"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1550"
+ENCODER_VERSION = "0.2.1551"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1550"
+ENCODER_VERSION = "0.2.1551"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1550"
+ENCODER_VERSION = "0.2.1551"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1550"
+ENCODER_VERSION = "0.2.1551"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1550"
+ENCODER_VERSION = "0.2.1551"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1550"')
+        .startswith('__version__ = "0.2.1551"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1550"
+    assert encoder_package["version"] == "0.2.1551"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1550"
+    assert project["project"]["version"] == "0.2.1551"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1550"')
+        .startswith('__version__ = "0.2.1551"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1550"
+    assert encoder_package["version"] == "0.2.1551"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1550"
+    assert project["project"]["version"] == "0.2.1551"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1550"')
+        .startswith('__version__ = "0.2.1551"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1550"
+ENCODER_VERSION = "0.2.1551"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -1141,7 +1141,7 @@ def test_nj_title_54a_citations_are_not_glued_german_sentence_markers():
 @pytest.mark.parametrize("ordinal", ["1ST", "2ND", "3RD", "4TH", "21st"])
 def test_english_ordinals_are_not_glued_german_sentence_markers(ordinal: str):
     branches = recognize_source_structure(
-        f'(2) The amount applies. Acts 1983, {ordinal} EX. SESS., No. 1.'
+        f"(2) The amount applies. Acts 1983, {ordinal} EX. SESS., No. 1."
     )
 
     assert [branch.label for branch in branches if branch.kind == "sentence"] == []

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -1138,6 +1138,34 @@ def test_nj_title_54a_citations_are_not_glued_german_sentence_markers():
     ]
 
 
+@pytest.mark.parametrize("ordinal", ["1ST", "2ND", "3RD", "4TH", "21st"])
+def test_english_ordinals_are_not_glued_german_sentence_markers(ordinal: str):
+    branches = recognize_source_structure(
+        f'(2) The amount applies. Acts 1983, {ordinal} EX. SESS., No. 1.'
+    )
+
+    assert [branch.label for branch in branches if branch.kind == "sentence"] == []
+
+
+def test_louisiana_session_law_ordinal_does_not_invent_source_branch():
+    source = """\
+(1) Single Individual and Married-Separate $12,500.00
+
+(2) Married-Joint Return, a Qualified Surviving 200% of the dollar amount
+
+Spouse, and Head of Household provided for Single Individuals
+
+Acts 1983, 2ND EX. SESS., NO. 1, §1.
+"""
+
+    branches = recognize_source_structure(source)
+
+    assert [(branch.path, branch.kind) for branch in branches] == [
+        (("1",), "paragraph"),
+        (("2",), "paragraph"),
+    ]
+
+
 def test_nj_historical_rate_remains_a_source_unit_formula_obligation():
     source = (
         "54A:4-7 New Jersey credit. (2) For the purposes of the calculation of "

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1550"
+version = "0.2.1551"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- exclude English ordinal suffixes from glued German sentence-marker recognition
- preserve real glued and explicit German Satz recognition
- add exact Louisiana session-law regression coverage
- bump encoder to 0.2.1551

## Why

Louisiana canonical-refresh run 31013880262 failed closed because the completeness parser interpreted the session-law token 2ND as a glued German Satz 2 marker. This changes the source-structure recognizer itself; it does not waive completeness, relax validation, change signer trust, or alter oracle behavior. The failed targeted run will not be rerun or reused.

## Checks

- full local suite: 7,178 passed, 119 skipped
- source-completeness suite: 1,101 passed
- version/oracle-pin checks: 27 passed
- exact Louisiana failure artifact reproduction no longer produces the fabricated Satz 2 branch
- formatter-descendant focused tests: 13 passed
- Ruff check and format check passed
- compileall passed
- lock integrity and git diff --check passed

## Cycle

Independent review of behavioral head 485a2494fe2f732115ccfc44924571a3ddafc974 completed CLEAN with no actionable findings. Hosted lint then found one Ruff quote-format issue in a new test. Exact current head fbf113e74805d9066d74fbc200ececdb761908b0 differs only by that f-string delimiter, with identical contents, and a lightweight independent exact-head re-review completed CLEAN. This PR remains draft until fresh hosted CI is fully green.