### PR TITLE
Fix post-sign provenance key isolation

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -1423,14 +1423,18 @@ jobs:
             else
               rm "$guard_stderr"
             fi
-            if ! jq -e '
+            if ! jq -e -s '
               select(
-                type == "object"
-                and keys == ["issues", "passed", "repo"]
-                and (.repo | type == "string")
-                and (.passed | type == "boolean")
-                and (.issues | type == "array" and all(.[]; type == "string"))
+                length == 1
+                and (
+                  .[0] | type == "object"
+                  and keys == ["issues", "passed", "repo"]
+                  and (.repo | type == "string")
+                  and (.passed | type == "boolean")
+                  and (.issues | type == "array" and all(.[]; type == "string"))
+                )
               )
+              | .[0]
             ' "$guard_json" >&2; then
               mv "$guard_json" \
                 "$RUNNER_TEMP/checkpoint-guard-generated.stdout.log"

--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -1400,21 +1400,33 @@ jobs:
 
           checkpoint_signed_changes() {
             local message="$1"
+            local guard_json="$RUNNER_TEMP/checkpoint-guard-generated.json"
+            local guard_stderr="$RUNNER_TEMP/checkpoint-guard-generated.stderr.log"
             set +e
-            /opt/axiom-verification/axiom-encode-signing-supervisor \
-              --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
-              --trusted-python-runtime-root /opt/axiom-verification/python \
-              --trusted-python-import-root /opt/axiom-verification/python/lib/python3.13/site-packages \
-              --trusted-python-package-root /opt/axiom-verification/python/lib/python3.13/site-packages/axiom_encode \
-              -- /opt/axiom-verification/axiom-encode guard-generated \
-              --repo "$RULESPEC_CHECKOUT" \
-              --corpus-path "$GITHUB_WORKSPACE/axiom-corpus" \
-              --expected-encoder-checkout "$GITHUB_WORKSPACE/axiom-encode" \
-              --json > "$RUNNER_TEMP/checkpoint-guard-generated.json"
+            (
+              unset AXIOM_ENCODE_APPLY_SIGNING_KEY
+              /opt/axiom-verification/axiom-encode-signing-supervisor \
+                --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
+                --trusted-python-runtime-root /opt/axiom-verification/python \
+                --trusted-python-import-root /opt/axiom-verification/python/lib/python3.13/site-packages \
+                --trusted-python-package-root /opt/axiom-verification/python/lib/python3.13/site-packages/axiom_encode \
+                -- /opt/axiom-verification/axiom-encode guard-generated \
+                --repo "$RULESPEC_CHECKOUT" \
+                --corpus-path "$GITHUB_WORKSPACE/axiom-corpus" \
+                --expected-encoder-checkout "$GITHUB_WORKSPACE/axiom-encode" \
+                --json
+            ) > "$guard_json" 2> "$guard_stderr"
             local guard_status="$?"
             set -e
+            if [ -s "$guard_stderr" ]; then
+              cat "$guard_stderr" >&2
+            else
+              rm "$guard_stderr"
+            fi
             if [ "$guard_status" -ne 0 ]; then
-              if ! jq . "$RUNNER_TEMP/checkpoint-guard-generated.json" >&2; then
+              if ! jq . "$guard_json" >&2; then
+                mv "$guard_json" \
+                  "$RUNNER_TEMP/checkpoint-guard-generated.stdout.log"
                 echo "checkpoint provenance guard returned malformed diagnostics" >&2
               fi
               return "$guard_status"
@@ -3189,6 +3201,33 @@ jobs:
               guard_inventory.append(
                   {
                       "path": f"guards/{guard_generated.name}",
+                      "sha256": hashlib.sha256(guard_payload).hexdigest(),
+                      "size": len(guard_payload),
+                  }
+              )
+
+          guard_log_candidates = [
+              guard_root / "checkpoint-guard-generated.stderr.log",
+              guard_root / "checkpoint-guard-generated.stdout.log",
+          ]
+          for guard_log in guard_log_candidates:
+              if not guard_log.exists() and not guard_log.is_symlink():
+                  continue
+              try:
+                  guard_payload = read_bounded_regular_file(
+                      guard_root,
+                      guard_log,
+                      label="generated provenance guard raw diagnostics",
+                      max_bytes=1024 * 1024,
+                  )
+              except UnsafeDiagnosticPathError as exc:
+                  raise SystemExit(str(exc)) from exc
+              guard_destination = artifact / "guards" / guard_log.name
+              guard_destination.parent.mkdir(parents=True, exist_ok=True)
+              guard_destination.write_bytes(guard_payload)
+              guard_inventory.append(
+                  {
+                      "path": f"guards/{guard_log.name}",
                       "sha256": hashlib.sha256(guard_payload).hexdigest(),
                       "size": len(guard_payload),
                   }

--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -1423,12 +1423,23 @@ jobs:
             else
               rm "$guard_stderr"
             fi
-            if [ "$guard_status" -ne 0 ]; then
-              if ! jq . "$guard_json" >&2; then
-                mv "$guard_json" \
-                  "$RUNNER_TEMP/checkpoint-guard-generated.stdout.log"
-                echo "checkpoint provenance guard returned malformed diagnostics" >&2
+            if ! jq -e '
+              select(
+                type == "object"
+                and keys == ["issues", "passed", "repo"]
+                and (.repo | type == "string")
+                and (.passed | type == "boolean")
+                and (.issues | type == "array" and all(.[]; type == "string"))
+              )
+            ' "$guard_json" >&2; then
+              mv "$guard_json" \
+                "$RUNNER_TEMP/checkpoint-guard-generated.stdout.log"
+              echo "checkpoint provenance guard returned malformed diagnostics" >&2
+              if [ "$guard_status" -eq 0 ]; then
+                guard_status=1
               fi
+            fi
+            if [ "$guard_status" -ne 0 ]; then
               return "$guard_status"
             fi
             git -C "$RULESPEC_CHECKOUT" diff --check

--- a/changelog.d/post-sign-checkpoint-key-isolation.fixed.md
+++ b/changelog.d/post-sign-checkpoint-key-isolation.fixed.md
@@ -1,0 +1,1 @@
+Keep post-signing provenance checkpoints outside the private-key environment and preserve bounded raw supervisor diagnostics without relaxing strict JSON guard validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1551"
+version = "0.2.1552"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1551"
+__version__ = "0.2.1552"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1551"
+ENCODER_VERSION = "0.2.1552"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1551"
+ENCODER_VERSION = "0.2.1552"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1551"
+ENCODER_VERSION = "0.2.1552"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1551"
+ENCODER_VERSION = "0.2.1552"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1551"
+ENCODER_VERSION = "0.2.1552"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1551"
+ENCODER_VERSION = "0.2.1552"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1551"
+ENCODER_VERSION = "0.2.1552"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1551"')
+        .startswith('__version__ = "0.2.1552"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1551"
+    assert encoder_package["version"] == "0.2.1552"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1551"
+    assert project["project"]["version"] == "0.2.1552"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1551"')
+        .startswith('__version__ = "0.2.1552"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1551"
+    assert encoder_package["version"] == "0.2.1552"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1551"
+    assert project["project"]["version"] == "0.2.1552"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1551"')
+        .startswith('__version__ = "0.2.1552"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1551"
+ENCODER_VERSION = "0.2.1552"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2289,7 +2289,9 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "unset AXIOM_ENCODE_APPLY_SIGNING_KEY" in command
     assert ') > "$guard_json" 2> "$guard_stderr"' in command
     assert 'local guard_status="$?"' in command
-    assert 'jq . "$guard_json" >&2' in command
+    assert 'and keys == ["issues", "passed", "repo"]' in command
+    assert 'and (.issues | type == "array"' in command
+    assert 'if [ "$guard_status" -eq 0 ]; then' in command
     assert 'checkpoint-guard-generated.stdout.log"' in command
     assert '"$workflow_python" "$backfill_helper" stage "$RULESPEC_CHECKOUT"' in (
         command
@@ -3108,6 +3110,115 @@ def test_targeted_signed_reencode_preserves_checkpoint_guard_failure(
         "passed": False,
         "issues": ["checkpoint manifest mismatch"],
     }
+
+
+def test_targeted_signed_reencode_packages_stderr_only_checkpoint_failure(
+    tmp_path: Path,
+) -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
+    )
+    steps = workflow["jobs"]["encode"]["steps"]
+    apply_command = next(
+        step["run"]
+        for step in steps
+        if step.get("name") == "Encode, review, validate, and apply"
+    )
+    checkpoint = apply_command.split("checkpoint_signed_changes() {", 1)[1].split(
+        '\n}\n\nif [ "$canonical_refresh_enabled"',
+        1,
+    )[0]
+    guard_stub = tmp_path / "guard-stub"
+    guard_stub.write_text(
+        "#!/bin/sh\n"
+        'if [ -n "${AXIOM_ENCODE_APPLY_SIGNING_KEY:-}" ]; then\n'
+        "  echo 'signing key reached direct supervisor invocation' >&2\n"
+        "  exit 91\n"
+        "fi\n"
+        "echo 'private keys are forbidden in the signing supervisor' >&2\n"
+        "exit 7\n"
+    )
+    guard_stub.chmod(0o700)
+    checkpoint_script = (
+        "set -euo pipefail\n"
+        "checkpoint_signed_changes() {"
+        + checkpoint.replace(
+            "/opt/axiom-verification/axiom-encode-signing-supervisor",
+            '"$GUARD_STUB"',
+        )
+        + "\n}\ncheckpoint_signed_changes test\n"
+    )
+    checkpoint_result = subprocess.run(
+        ["bash", "-c", checkpoint_script],
+        env={
+            **os.environ,
+            "AXIOM_ENCODE_APPLY_SIGNING_KEY": "test-key",
+            "GITHUB_WORKSPACE": str(tmp_path),
+            "GUARD_STUB": str(guard_stub),
+            "RULESPEC_CHECKOUT": str(tmp_path / "rulespec-us"),
+            "RUNNER_TEMP": str(tmp_path),
+        },
+        capture_output=True,
+        text=True,
+    )
+
+    assert checkpoint_result.returncode == 7
+    assert "private keys are forbidden" in checkpoint_result.stderr
+    assert not (tmp_path / "checkpoint-guard-generated.json").exists()
+    assert (tmp_path / "checkpoint-guard-generated.stdout.log").read_bytes() == b""
+    assert (
+        tmp_path / "checkpoint-guard-generated.stderr.log"
+    ).read_text() == "private keys are forbidden in the signing supervisor\n"
+
+    (tmp_path / "generated").mkdir()
+    package_command = next(
+        step["run"]
+        for step in steps
+        if step.get("name") == "Package failed re-encode diagnostics"
+    ).replace(
+        "/opt/axiom-verification/python/bin/python",
+        sys.executable,
+    )
+    package_result = subprocess.run(
+        ["bash", "-c", package_command],
+        env={
+            **os.environ,
+            "CITATION": "us-la/statute/47:294",
+            "CORPUS_REF": "corpus-ref",
+            "COUNTRY": "us",
+            "ENCODE_APPLY_CONCLUSION": "failure",
+            "ENCODE_APPLY_OUTCOME": "failure",
+            "GITHUB_RUN_ATTEMPT": "1",
+            "GITHUB_RUN_ID": "31017990537",
+            "GITHUB_SHA": "encoder-ref",
+            "PROVISION_SIGNING_SUPERVISOR_CONCLUSION": "success",
+            "RULES_ENGINE_REF": "rules-engine-ref",
+            "RULESPEC_REF": "rulespec-ref",
+            "RUNNER_TEMP": str(tmp_path),
+        },
+        capture_output=True,
+        text=True,
+    )
+
+    assert package_result.returncode == 0, package_result.stderr
+    with tarfile.open(tmp_path / "targeted-reencode-failure.tar", mode="r") as bundle:
+        file_member_names = {
+            member.name.removeprefix("./")
+            for member in bundle.getmembers()
+            if member.isfile()
+        }
+        assert file_member_names == {
+            "guards/checkpoint-guard-generated.stderr.log",
+            "guards/checkpoint-guard-generated.stdout.log",
+            "metadata.json",
+        }
+        metadata_file = bundle.extractfile("./metadata.json")
+        assert metadata_file is not None
+        metadata = json.loads(metadata_file.read())
+    assert [item["path"] for item in metadata["guards"]] == [
+        "guards/checkpoint-guard-generated.stderr.log",
+        "guards/checkpoint-guard-generated.stdout.log",
+    ]
 
 
 def test_targeted_signed_reencode_rejects_symlinked_failure_diagnostics(

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2289,6 +2289,8 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "unset AXIOM_ENCODE_APPLY_SIGNING_KEY" in command
     assert ') > "$guard_json" 2> "$guard_stderr"' in command
     assert 'local guard_status="$?"' in command
+    assert "if ! jq -e -s" in command
+    assert "length == 1" in command
     assert 'and keys == ["issues", "passed", "repo"]' in command
     assert 'and (.issues | type == "array"' in command
     assert 'if [ "$guard_status" -eq 0 ]; then' in command
@@ -3112,8 +3114,19 @@ def test_targeted_signed_reencode_preserves_checkpoint_guard_failure(
     }
 
 
-def test_targeted_signed_reencode_packages_stderr_only_checkpoint_failure(
+@pytest.mark.parametrize(
+    "guard_stdout",
+    [
+        pytest.param("", id="empty"),
+        pytest.param(
+            '{"repo":"/runner/rulespec-us","passed":false,"issues":[]}\n{}\n',
+            id="multiple-json-roots",
+        ),
+    ],
+)
+def test_targeted_signed_reencode_packages_noncontract_checkpoint_failure(
     tmp_path: Path,
+    guard_stdout: str,
 ) -> None:
     workflow = yaml.safe_load(
         (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
@@ -3135,6 +3148,7 @@ def test_targeted_signed_reencode_packages_stderr_only_checkpoint_failure(
         "  echo 'signing key reached direct supervisor invocation' >&2\n"
         "  exit 91\n"
         "fi\n"
+        "printf '%s' \"${GUARD_STDOUT:-}\"\n"
         "echo 'private keys are forbidden in the signing supervisor' >&2\n"
         "exit 7\n"
     )
@@ -3154,6 +3168,7 @@ def test_targeted_signed_reencode_packages_stderr_only_checkpoint_failure(
             **os.environ,
             "AXIOM_ENCODE_APPLY_SIGNING_KEY": "test-key",
             "GITHUB_WORKSPACE": str(tmp_path),
+            "GUARD_STDOUT": guard_stdout,
             "GUARD_STUB": str(guard_stub),
             "RULESPEC_CHECKOUT": str(tmp_path / "rulespec-us"),
             "RUNNER_TEMP": str(tmp_path),
@@ -3165,7 +3180,9 @@ def test_targeted_signed_reencode_packages_stderr_only_checkpoint_failure(
     assert checkpoint_result.returncode == 7
     assert "private keys are forbidden" in checkpoint_result.stderr
     assert not (tmp_path / "checkpoint-guard-generated.json").exists()
-    assert (tmp_path / "checkpoint-guard-generated.stdout.log").read_bytes() == b""
+    assert (
+        tmp_path / "checkpoint-guard-generated.stdout.log"
+    ).read_text() == guard_stdout
     assert (
         tmp_path / "checkpoint-guard-generated.stderr.log"
     ).read_text() == "private keys are forbidden in the signing supervisor\n"

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2286,8 +2286,11 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert "source-bundle replacements cannot include dependent migrations" in command
     assert "Canonicalize signed replacement target before source bundle" in command
     assert "checkpoint_signed_changes()" in command
+    assert "unset AXIOM_ENCODE_APPLY_SIGNING_KEY" in command
+    assert ') > "$guard_json" 2> "$guard_stderr"' in command
     assert 'local guard_status="$?"' in command
-    assert 'jq . "$RUNNER_TEMP/checkpoint-guard-generated.json" >&2' in command
+    assert 'jq . "$guard_json" >&2' in command
+    assert 'checkpoint-guard-generated.stdout.log"' in command
     assert '"$workflow_python" "$backfill_helper" stage "$RULESPEC_CHECKOUT"' in (
         command
     )
@@ -2717,6 +2720,10 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
     }
     preflight_guard_raw = json.dumps(preflight_guard_payload) + "\n"
     (tmp_path / "target-preflight-guard-generated.json").write_text(preflight_guard_raw)
+    checkpoint_stderr_raw = "checkpoint supervisor rejected the invocation\n"
+    (tmp_path / "checkpoint-guard-generated.stderr.log").write_text(
+        checkpoint_stderr_raw
+    )
     # A failed resolver can leave the shell redirection target empty. Failure
     # packaging must preserve that resolver failure without parsing partial evidence.
     (tmp_path / "repair-candidate.json").write_text("")
@@ -2758,6 +2765,7 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
             "generated/target/model/statutes/54a:4-7.test.yaml",
             "generated/target/model/target.repair.json",
             "guards/guard-generated.json",
+            "guards/checkpoint-guard-generated.stderr.log",
             "guards/target-preflight-guard-generated.json",
             "metadata.json",
         }
@@ -2767,6 +2775,9 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
         )
         repair = bundle.extractfile("./generated/target/model/target.repair.json")
         guard = bundle.extractfile("./guards/guard-generated.json")
+        checkpoint_stderr = bundle.extractfile(
+            "./guards/checkpoint-guard-generated.stderr.log"
+        )
         preflight_guard = bundle.extractfile(
             "./guards/target-preflight-guard-generated.json"
         )
@@ -2774,6 +2785,7 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
         assert target is not None
         assert repair is not None
         assert guard is not None
+        assert checkpoint_stderr is not None
         assert preflight_guard is not None
         assert metadata_file is not None
         assert target.read() == b"format: rulespec/v1\n"
@@ -2783,6 +2795,7 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
             "passed": False,
             "issues": ["waiver transition requires protected base"],
         }
+        assert checkpoint_stderr.read() == checkpoint_stderr_raw.encode()
         assert json.loads(preflight_guard.read()) == preflight_guard_payload
         metadata = json.loads(metadata_file.read())
     assert metadata["schema"] == "axiom-encode/failed-reencode-diagnostics/v1"
@@ -2792,6 +2805,7 @@ def test_targeted_signed_reencode_packages_bounded_failure_diagnostics(
     guards_by_path = {item["path"]: item for item in metadata["guards"]}
     assert set(guards_by_path) == {
         "guards/guard-generated.json",
+        "guards/checkpoint-guard-generated.stderr.log",
         "guards/target-preflight-guard-generated.json",
     }
     preflight_inventory = guards_by_path["guards/target-preflight-guard-generated.json"]
@@ -2974,6 +2988,62 @@ def test_targeted_signed_reencode_rejects_unsafe_guard_diagnostics(
     assert not (tmp_path / "targeted-reencode-failure.tar").exists()
 
 
+@pytest.mark.parametrize(
+    ("mutation", "expected_error"),
+    [
+        ("symlink", "Could not safely open"),
+        ("oversize", "safety limit"),
+    ],
+)
+def test_targeted_signed_reencode_rejects_unsafe_raw_guard_diagnostics(
+    tmp_path: Path,
+    mutation: str,
+    expected_error: str,
+) -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
+    )
+    step = next(
+        item
+        for item in workflow["jobs"]["encode"]["steps"]
+        if item.get("name") == "Package failed re-encode diagnostics"
+    )
+    command = step["run"].replace(
+        "/opt/axiom-verification/python/bin/python",
+        sys.executable,
+    )
+    (tmp_path / "generated").mkdir()
+    guard_log = tmp_path / "checkpoint-guard-generated.stderr.log"
+    if mutation == "symlink":
+        outside = tmp_path / "outside.log"
+        outside.write_text("outside diagnostic\n")
+        guard_log.symlink_to(outside)
+    else:
+        guard_log.write_bytes(b"x" * (1024 * 1024 + 1))
+
+    completed = subprocess.run(
+        ["bash", "-c", command],
+        env={
+            **os.environ,
+            "CITATION": "us/statute/42/1437c-1",
+            "CORPUS_REF": "corpus-ref",
+            "COUNTRY": "us",
+            "GITHUB_RUN_ATTEMPT": "1",
+            "GITHUB_RUN_ID": "1234",
+            "GITHUB_SHA": "encoder-ref",
+            "RULES_ENGINE_REF": "rules-engine-ref",
+            "RULESPEC_REF": "rulespec-ref",
+            "RUNNER_TEMP": str(tmp_path),
+        },
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert expected_error in completed.stderr
+    assert not (tmp_path / "targeted-reencode-failure.tar").exists()
+
+
 def test_targeted_signed_reencode_preserves_checkpoint_guard_failure(
     tmp_path: Path,
 ) -> None:
@@ -2992,9 +3062,14 @@ def test_targeted_signed_reencode_preserves_checkpoint_guard_failure(
     guard_stub = tmp_path / "guard-stub"
     guard_stub.write_text(
         "#!/bin/sh\n"
+        'if [ -n "${AXIOM_ENCODE_APPLY_SIGNING_KEY:-}" ]; then\n'
+        "  echo 'signing key reached direct supervisor invocation' >&2\n"
+        "  exit 91\n"
+        "fi\n"
         "printf '%s\\n' "
         '\'{"repo":"/runner/rulespec-us","passed":false,'
         '"issues":["checkpoint manifest mismatch"]}\'\n'
+        "echo 'bounded checkpoint failure detail' >&2\n"
         "exit 7\n"
     )
     guard_stub.chmod(0o700)
@@ -3012,6 +3087,7 @@ def test_targeted_signed_reencode_preserves_checkpoint_guard_failure(
         ["bash", "-c", script],
         env={
             **os.environ,
+            "AXIOM_ENCODE_APPLY_SIGNING_KEY": "test-key",
             "GITHUB_WORKSPACE": str(tmp_path),
             "GUARD_STUB": str(guard_stub),
             "RULESPEC_CHECKOUT": str(tmp_path / "rulespec-us"),
@@ -3023,6 +3099,10 @@ def test_targeted_signed_reencode_preserves_checkpoint_guard_failure(
 
     assert completed.returncode == 7
     assert "checkpoint manifest mismatch" in completed.stderr
+    assert "bounded checkpoint failure detail" in completed.stderr
+    assert (
+        tmp_path / "checkpoint-guard-generated.stderr.log"
+    ).read_text() == "bounded checkpoint failure detail\n"
     assert json.loads((tmp_path / "checkpoint-guard-generated.json").read_text()) == {
         "repo": "/runner/rulespec-us",
         "passed": False,

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1551"
+version = "0.2.1552"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- remove the apply signing key from direct post-signing provenance supervisor invocations while preserving the external signer path
- require exactly one complete {repo, passed, issues} JSON guard document before checkpointing
- retain fixed-path, no-follow, 1 MiB-bounded raw checkpoint diagnostics separately from strict JSON evidence
- add key-bearing empty-output and multi-document checkpoint-to-packager regressions
- bump axiom-encode to 0.2.1552

## Validation

- Ruff across pyproject.toml, src/axiom_encode, scripts, and tests
- compileall across src/axiom_encode and scripts
- exact-head full local suite: 7,182 passed, 119 skipped, 12 dependency warnings
- focused version/oracle validation: 33 passed
- hosted lint and both signing-supervisor platforms are green; hosted full Python is pending

## Cycle

Independent review found and resolved two diagnostics-contract issues: empty guard stdout and multiple JSON roots. Exact-head re-review of 236afefd583c3562decd5bbf634f5639febd2587 is CLEAN with no remaining actionable findings. The PR remains draft until all exact-head hosted checks are green.