### PR TITLE
Fix Louisiana session-law numeric recall

### DIFF
--- a/changelog.d/la-session-law-numeric-recall.fixed.md
+++ b/changelog.d/la-session-law-numeric-recall.fixed.md
@@ -1,0 +1,1 @@
+Exclude Louisiana session-law citation numbers from substantive numeric-recall obligations while preserving nearby operative values.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1552"
+version = "0.2.1553"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1553"
+version = "0.2.1554"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1552"
+__version__ = "0.2.1553"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1553"
+__version__ = "0.2.1554"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1128,8 +1128,10 @@ _LOUISIANA_SESSION_LAW_CITATION = re.compile(
     r"Ex\.?\s*Sess\.?\s*,?\s*"
     r")?"
     r"No\.?\s*\d+(?:-\d+)?\b"
-    r"(?:\s*,?\s*§{1,2}\s*\d+"
-    r"(?:\s*(?:,|and|through|to|[-–—])\s*\d+)*)?",
+    r"(?:\s*,?\s*(?:"
+    r"§§\s*\d+(?:\s*(?:,|and|through|to|[-–—])\s*\d+)*"
+    r"|§\s*\d+"
+    r"))?",
     flags=re.IGNORECASE,
 )
 _STRUCTURAL_REFERENCE = re.compile(

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1121,6 +1121,13 @@ _TITLE_SUFFIX_LEGAL_CITATION = re.compile(
     r"\s*\d+[a-z]?)*\s+of\s+this\s+title\b",
     flags=re.IGNORECASE,
 )
+_LOUISIANA_SESSION_LAW_CITATION = re.compile(
+    r"\bActs?\s+\d{4}\s*,\s*"
+    r"(?:\d{1,2}(?:st|nd|rd|th)\s+Ex\.\s+Sess\.\s*,\s*)?"
+    r"No\.\s*\d+"
+    r"(?:\s*,\s*§+\s*\d+)?",
+    flags=re.IGNORECASE,
+)
 _STRUCTURAL_REFERENCE = re.compile(
     r"\b(?:"
     r"Artikel(?:s|n)?|Art\.|"
@@ -3874,6 +3881,7 @@ def authoritative_numeric_recall_text(source_text: str) -> str:
     cleaned = _strip_terminal_session_law_history(source_text)
     cleaned = _GERMAN_LEGAL_CITATION.sub("", cleaned)
     cleaned = _TITLE_SUFFIX_LEGAL_CITATION.sub("", cleaned)
+    cleaned = _LOUISIANA_SESSION_LAW_CITATION.sub("", cleaned)
     cleaned = _ENGLISH_LEGAL_CITATION.sub("", cleaned)
     cleaned = _STRUCTURAL_REFERENCE.sub("", cleaned)
     cleaned = re.sub(

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1122,10 +1122,14 @@ _TITLE_SUFFIX_LEGAL_CITATION = re.compile(
     flags=re.IGNORECASE,
 )
 _LOUISIANA_SESSION_LAW_CITATION = re.compile(
-    r"\bActs?\s+\d{4}\s*,\s*"
-    r"(?:\d{1,2}(?:st|nd|rd|th)\s+Ex\.\s+Sess\.\s*,\s*)?"
-    r"No\.\s*\d+"
-    r"(?:\s*,\s*§+\s*\d+)?",
+    r"\bActs?\s+\d{4}\s*,?\s*"
+    r"(?:"
+    r"(?:(?:\d+\s*(?:st|nd|rd|th|d)|first|second|third|fourth)\s+)?"
+    r"Ex\.?\s*Sess\.?\s*,?\s*"
+    r")?"
+    r"No\.?\s*\d+(?:-\d+)?\b"
+    r"(?:\s*,?\s*§{1,2}\s*\d+"
+    r"(?:\s*(?:,|and|through|to|[-–—])\s*\d+)*)?",
     flags=re.IGNORECASE,
 )
 _STRUCTURAL_REFERENCE = re.compile(
@@ -3879,9 +3883,9 @@ def authoritative_numeric_recall_text(source_text: str) -> str:
     """Remove structural/citation ordinals, never substantive source values."""
 
     cleaned = _strip_terminal_session_law_history(source_text)
+    cleaned = _LOUISIANA_SESSION_LAW_CITATION.sub("", cleaned)
     cleaned = _GERMAN_LEGAL_CITATION.sub("", cleaned)
     cleaned = _TITLE_SUFFIX_LEGAL_CITATION.sub("", cleaned)
-    cleaned = _LOUISIANA_SESSION_LAW_CITATION.sub("", cleaned)
     cleaned = _ENGLISH_LEGAL_CITATION.sub("", cleaned)
     cleaned = _STRUCTURAL_REFERENCE.sub("", cleaned)
     cleaned = re.sub(

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1553"
+ENCODER_VERSION = "0.2.1554"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1552"
+ENCODER_VERSION = "0.2.1553"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1553"
+ENCODER_VERSION = "0.2.1554"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1552"
+ENCODER_VERSION = "0.2.1553"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1552"
+ENCODER_VERSION = "0.2.1553"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1553"
+ENCODER_VERSION = "0.2.1554"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1553"
+ENCODER_VERSION = "0.2.1554"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1552"
+ENCODER_VERSION = "0.2.1553"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1553"
+ENCODER_VERSION = "0.2.1554"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1552"
+ENCODER_VERSION = "0.2.1553"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1552"
+ENCODER_VERSION = "0.2.1553"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1553"
+ENCODER_VERSION = "0.2.1554"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1552"
+ENCODER_VERSION = "0.2.1553"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1553"
+ENCODER_VERSION = "0.2.1554"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1553"')
+        .startswith('__version__ = "0.2.1554"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1553"
+    assert encoder_package["version"] == "0.2.1554"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1553"
+    assert project["project"]["version"] == "0.2.1554"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1553"')
+        .startswith('__version__ = "0.2.1554"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1553"
+    assert encoder_package["version"] == "0.2.1554"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1553"
+    assert project["project"]["version"] == "0.2.1554"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1553"')
+        .startswith('__version__ = "0.2.1554"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1552"')
+        .startswith('__version__ = "0.2.1553"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1552"
+    assert encoder_package["version"] == "0.2.1553"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1552"
+    assert project["project"]["version"] == "0.2.1553"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1552"')
+        .startswith('__version__ = "0.2.1553"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1552"
+    assert encoder_package["version"] == "0.2.1553"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1552"
+    assert project["project"]["version"] == "0.2.1553"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1552"')
+        .startswith('__version__ = "0.2.1553"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1553"
+ENCODER_VERSION = "0.2.1554"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1552"
+ENCODER_VERSION = "0.2.1553"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -5572,6 +5572,59 @@ def test_terminal_session_law_history_is_not_numeric_recall(history_tail):
     assert cleaned == operative
 
 
+def test_louisiana_session_law_citations_are_not_numeric_recall_values():
+    source = """\
+A. A standard deduction shall be allowed in determining a taxpayer's tax liability
+pursuant to this Part. Taxpayers are required to use the same filing status on their return
+required to be filed under this Part as they used on their federal income tax return. For tax
+year 2025, the amount of the standard deduction shall be as follows:
+
+(1) Single Individual and Married-Separate $12,500.00
+
+(2) Married-Joint Return, a Qualified Surviving 200% of the dollar amount
+
+Spouse, and Head of Household provided for Single Individuals
+
+B. Beginning January 1, 2026, and thereafter, the amount of the standard deduction
+provided in Subsection A of this Section shall be adjusted annually by an amount calculated
+by multiplying the amount of the prior year's standard deduction by the percentage increase
+in the Consumer Price Index United States city average for all urban consumers (CPI-U), as
+reported by the United States Department of Labor, Bureau of Labor Statistics, or its
+successor, for the previous calendar year.
+
+Acts 1980, No. 316, §1. Acts 1983, 2nd Ex. Sess., No. 1, §1, eff. Dec. 19,
+1983; Acts 2024, 3rd Ex. Sess., No. 11, §2, eff. Dec. 4, 2024.
+
+{{NOTE: SECTION 4 OF ACTS 1983, 2ND EX. SESS., NO. 1,
+PROVIDES AS FOLLOWS: "THE PROVISIONS OF THIS ACT SHALL
+BE APPLICABLE TO TAXABLE YEARS BEGINNING AFTER
+DECEMBER 31, 1982. FOR TAXABLE YEARS BEGINNING PRIOR TO
+JANUARY 1, 1983, THE TAX SHALL BE AS REQUIRED BY LAW
+PRIOR TO THE EFFECTIVE DATE OF THIS ACT."}}
+"""
+
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        authoritative_numeric_recall_text(source),
+        profile="en-US",
+    )
+
+    assert [(item.value, item.raw) for item in inventory] == [
+        (12500.0, "12,500.00"),
+        (200.0, "200"),
+    ]
+
+
+def test_louisiana_session_law_citation_filter_preserves_operative_value():
+    source = "Acts 2024, 3rd Ex. Sess., No. 11, §2 establishes an 11 dollar fee."
+
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        authoritative_numeric_recall_text(source),
+        profile="en-US",
+    )
+
+    assert [(item.value, item.raw) for item in inventory] == [(11.0, "11")]
+
+
 @pytest.mark.parametrize(
     "references",
     (

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -5643,6 +5643,20 @@ def test_louisiana_session_law_citation_filter_preserves_operative_value(
     assert [(item.value, item.raw) for item in inventory] == [(11.0, "11")]
 
 
+@pytest.mark.parametrize("connector", ("and", "through", "to", "-"))
+def test_louisiana_singular_section_citation_preserves_adjacent_amount(
+    connector: str,
+):
+    source = f"Under Acts 2024, No. 11, §2 {connector} 50 dollars shall be paid."
+
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        authoritative_numeric_recall_text(source),
+        profile="en-US",
+    )
+
+    assert [(item.value, item.raw) for item in inventory] == [(50.0, "50")]
+
+
 @pytest.mark.parametrize(
     "references",
     (

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -5614,8 +5614,26 @@ PRIOR TO THE EFFECTIVE DATE OF THIS ACT."}}
     ]
 
 
-def test_louisiana_session_law_citation_filter_preserves_operative_value():
-    source = "Acts 2024, 3rd Ex. Sess., No. 11, §2 establishes an 11 dollar fee."
+@pytest.mark.parametrize(
+    "citation",
+    (
+        "Acts 2024, 3rd Ex. Sess., No. 11, §2",
+        "Acts 1983, 2d Ex. Sess., No. 1, §1",
+        "Acts 2000, 2d Ex.Sess., No. 21, §1",
+        "Acts 1950, 2nd Ex.Sess., No. 11, §2",
+        "Acts 1973, Ex.Sess., No. 8, §1",
+        "Acts 2016, 1 st Ex. Sess., No.\n29, §2",
+        "Acts 1977, 1st Ex. Sess. No. 2, §1",
+        "Acts 2024, Third Ex. Sess., No. 11, §§2, 4",
+        "Acts 2002, No. 51, §§1 and 2",
+        "Acts 1997, No.\n129, §1",
+        "Acts 1995, No. 95-255, §1",
+    ),
+)
+def test_louisiana_session_law_citation_filter_preserves_operative_value(
+    citation: str,
+):
+    source = f"{citation} establishes an 11 dollar fee."
 
     inventory = extract_typed_numeric_inventory_occurrences_from_text(
         authoritative_numeric_recall_text(source),

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1552"
+version = "0.2.1553"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1553"
+version = "0.2.1554"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- treat Louisiana Acts and session-law citation numbers as structural numeric context
- cover the citation variants present in the immutable Louisiana Title 47 corpus
- preserve operative values adjacent to singular section citations
- regress the exact La. R.S. 47:294 history and trailing applicability-note shape
- bump the encoder to 0.2.1554

## Production evidence
Run 31021708823 failed closed with zero signatures because all four compiling candidates were incorrectly required to name Act No. 1. The exact retained source now exposes only the operative 12,500 and 200% numeric-recall values.

## Review cycle
- independent review found incomplete Louisiana citation variant coverage; fixed and retested
- independent re-review found a singular section adjacent-value false negative; fixed and retested
- final independent re-review at 1b86e678001413d5b05d6c6dcb904cddb38bf511: CLEAN, no actionable findings

## Checks
- full prescribed suite: 7198 passed, 119 skipped
- full source-completeness module: 1117 passed
- focused version and oracle checks: 1454 passed, 31 skipped
- Ruff, format, compileall, and diff check: passed
- hosted CI Python and lint: passed
- hosted signing supervisor Ubuntu and macOS: passed