### PR TITLE
Fix Louisiana Revised Statutes cross-reference validation

### DIFF
--- a/changelog.d/la-revised-statutes-crossref-completeness.fixed.md
+++ b/changelog.d/la-revised-statutes-crossref-completeness.fixed.md
@@ -1,1 +1,1 @@
-Treat Louisiana Revised Statutes cross-references as structural citations during numeric recall, and keep line-wrapped `R.S. 47:...` references in one source clause so they do not create synthetic applicability-test obligations.
+Treat Louisiana Revised Statutes cross-references as structural citations during numeric recall, keep line-wrapped `R.S. 47:...` references in one source clause, and preserve real numeric or runtime conditions that follow the citation for paired-case validation.

--- a/changelog.d/la-revised-statutes-crossref-completeness.fixed.md
+++ b/changelog.d/la-revised-statutes-crossref-completeness.fixed.md
@@ -1,0 +1,1 @@
+Treat Louisiana Revised Statutes cross-references as structural citations during numeric recall, and keep line-wrapped `R.S. 47:...` references in one source clause so they do not create synthetic applicability-test obligations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1555"
+version = "0.2.1556"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1556"
+version = "0.2.1557"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1554"
+version = "0.2.1555"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1554"
+__version__ = "0.2.1555"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1555"
+__version__ = "0.2.1556"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1556"
+__version__ = "0.2.1557"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1134,6 +1134,13 @@ _LOUISIANA_SESSION_LAW_CITATION = re.compile(
     r"))?",
     flags=re.IGNORECASE,
 )
+_LOUISIANA_NOTWITHSTANDING_RS_REFERENCE_PREFIX = re.compile(
+    r"^\s*notwithstanding\s+(?:the\s+)?provisions?\s+of\s+"
+    r"R\.S\.\s*\d+[A-Za-z]?:\d+[A-Za-z]?"
+    r"(?:-\d+[A-Za-z]?(?:\.\d+)*)?\s*[,;]\s*"
+    r"(?P<tail>.+)$",
+    flags=re.IGNORECASE,
+)
 _STRUCTURAL_REFERENCE = re.compile(
     r"\b(?:"
     r"Artikel(?:s|n)?|Art\.|"
@@ -1463,6 +1470,7 @@ def analyze_complete_source_unit(
     corpus_citation_path: str,
     test_cases: Sequence[object] | None,
     extract_numeric_occurrences: NumericOccurrenceExtractor,
+    extract_numeric_grounding_occurrences: NumericOccurrenceExtractor | None = None,
     extract_named_scalars: NamedScalarExtractor,
     numeric_value_is_grounded: NumericGroundingPredicate,
     artifact_numeric_values: Sequence[float] | None = None,
@@ -1489,6 +1497,9 @@ def analyze_complete_source_unit(
                 corpus_citation_path=corpus_citation_path,
                 test_cases=test_cases,
                 extract_numeric_occurrences=extract_numeric_occurrences,
+                extract_numeric_grounding_occurrences=(
+                    extract_numeric_grounding_occurrences or extract_numeric_occurrences
+                ),
                 extract_named_scalars=extract_named_scalars,
                 numeric_value_is_grounded=numeric_value_is_grounded,
                 artifact_numeric_values=artifact_numeric_values,
@@ -1506,6 +1517,7 @@ def _analyze_rulespec_payload(
     corpus_citation_path: str,
     test_cases: Sequence[object] | None,
     extract_numeric_occurrences: NumericOccurrenceExtractor,
+    extract_numeric_grounding_occurrences: NumericOccurrenceExtractor,
     extract_named_scalars: NamedScalarExtractor,
     numeric_value_is_grounded: NumericGroundingPredicate,
     artifact_numeric_values: Sequence[float] | None,
@@ -1673,7 +1685,7 @@ def _analyze_rulespec_payload(
                 corpus_citation_path=corpus_citation_path,
                 deferred_paths=deferred_paths,
                 test_cases=test_cases,
-                extract_numeric_occurrences=extract_numeric_occurrences,
+                extract_numeric_occurrences=extract_numeric_grounding_occurrences,
                 numeric_value_is_grounded=numeric_value_is_grounded,
                 formula_environment=formula_environment,
             )
@@ -8102,7 +8114,8 @@ def _formula_interval_from_text(
         r"nicht\s+mehr\s+als|über|unter))|"
         r"from|unter|less\s+than|below|"
         r"bis|up\s+to|höchstens|nicht\s+mehr\s+als|"
-        r"at\s+most|über|more\s+than|above|ab|at\s+least|mindestens)\b",
+        r"at\s+most|über|more\s+than|greater\s+than|"
+        r"exceeds?|exceeding|above|ab|at\s+least|mindestens)\b",
         lowered,
     )
     if keyword is None:
@@ -8160,7 +8173,8 @@ def _formula_interval_from_text(
     ):
         return _NumericInterval(None, False, occurrences[0], True)
     if re.match(
-        r"(?:(?:von\s+)?mehr\s+als|über|more\s+than|above)\b",
+        r"(?:(?:von\s+)?mehr\s+als|über|more\s+than|greater\s+than|"
+        r"exceeds?|exceeding|above)\b",
         lowered_range,
     ):
         return _NumericInterval(occurrences[0], False, None, False)
@@ -8471,12 +8485,11 @@ def _source_exception_requires_paired_witness(text: str) -> bool:
     """
 
     collapsed = _collapse_text(text)
-    if re.search(
-        r"\bnotwithstanding\b",
-        collapsed,
-        flags=re.IGNORECASE,
-    ) and _source_reference_reservation_is_only_references(collapsed):
-        return False
+    notwithstanding_tail = _louisiana_notwithstanding_reference_tail(collapsed)
+    if notwithstanding_tail is not None:
+        return _notwithstanding_reference_tail_requires_paired_witness(
+            notwithstanding_tail
+        )
     if re.search(
         r"\bexcept\s+as\s+[^.;]{0,100}\bprovided\b",
         collapsed,
@@ -8492,6 +8505,56 @@ def _source_exception_requires_paired_witness(text: str) -> bool:
     ) and _source_reference_reservation_is_only_references(collapsed):
         return False
     return True
+
+
+def _louisiana_notwithstanding_reference_tail(text: str) -> str | None:
+    """Return the rule tail after a leading Louisiana R.S. override reference."""
+
+    match = _LOUISIANA_NOTWITHSTANDING_RS_REFERENCE_PREFIX.match(
+        _strip_source_clause_marker(_collapse_text(text))
+    )
+    return match.group("tail").strip() if match is not None else None
+
+
+def _notwithstanding_reference_tail_requires_paired_witness(text: str) -> bool:
+    """Keep locally testable conditions after a non-toggleable override citation."""
+
+    for match in _source_exception_or_applicability_matches(text):
+        if _subject_to_is_administrative_effect(text, match):
+            continue
+        return True
+    return bool(
+        re.search(
+            r"\b(?:exceeds?|exceeding|greater\s+than|less\s+than|more\s+than|"
+            r"at\s+least|at\s+most|above|below)\b|[<>]=?",
+            text,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _subject_to_is_administrative_effect(
+    text: str,
+    match: re.Match[str],
+) -> bool:
+    """Distinguish an oversight result from a ``subject to`` condition."""
+
+    if match.group(0).strip().lower() != "subject to":
+        return False
+    prefix = text[max(0, match.start() - 32) : match.start()]
+    suffix = text[match.end() : match.end() + 32]
+    return bool(
+        re.search(
+            r"\b(?:(?:shall|must|will|may)\s+be|is|are|was|were)\s+$",
+            prefix,
+            flags=re.IGNORECASE,
+        )
+        and re.match(
+            r"\s+(?:oversight|review|approval|audit|reporting)\b",
+            suffix,
+            flags=re.IGNORECASE,
+        )
+    )
 
 
 def _source_has_formal_cross_reference(text: str) -> bool:
@@ -8568,7 +8631,7 @@ def _source_is_simple_main_proposition(text: str) -> bool:
 def _source_reference_reservation_is_only_references(text: str) -> bool:
     clause = _strip_source_clause_marker(_collapse_text(text)).strip()
     marker = re.search(
-        r"\b(?P<marker>subject\s+to|vorbehaltlich|except\s+as|notwithstanding)\b",
+        r"\b(?P<marker>subject\s+to|vorbehaltlich|except\s+as)\b",
         clause,
         flags=re.IGNORECASE,
     )
@@ -8578,12 +8641,7 @@ def _source_reference_reservation_is_only_references(text: str) -> bool:
     if marker.start() == 0:
         tail = clause[marker.end() :]
         delimiter = re.search(r"[,;]", tail)
-        if (
-            marker.group("marker").lower() == "notwithstanding"
-            and delimiter is not None
-        ):
-            complement = tail[: delimiter.start()].strip(" \t,;:.")
-        elif delimiter is not None and _source_is_simple_main_proposition(
+        if delimiter is not None and _source_is_simple_main_proposition(
             tail[delimiter.end() :]
         ):
             complement = tail[: delimiter.start()].strip(" \t,;:.")
@@ -8940,6 +8998,10 @@ def _exception_witnesses_for_branch(
     }
     requirement = _source_exception_effect_requirement(branch.text)
     condition_text = _source_exception_condition_text(branch.text)
+    numeric_interval = _formula_interval_from_text(
+        authoritative_numeric_recall_text(branch.text),
+        extract_numeric_occurrences=extract_numeric_occurrences,
+    )
     return {
         witness
         for witness in toggled_exception_selectors
@@ -8952,7 +9014,8 @@ def _exception_witnesses_for_branch(
             )
             if witness.numeric_transition is not None
             else (
-                witness.active_value
+                numeric_interval is None
+                and witness.active_value
                 == _source_exception_selector_active_value(
                     condition_text,
                     witness.selector_name,
@@ -8971,6 +9034,9 @@ def _source_exception_condition_text(text: str) -> str:
     """Return the condition region without the ordinary claim subject."""
 
     clause = _strip_source_clause_marker(text)
+    notwithstanding_tail = _louisiana_notwithstanding_reference_tail(clause)
+    if notwithstanding_tail is not None:
+        return notwithstanding_tail
     marker = next(iter(_source_exception_or_applicability_matches(clause)), None)
     if marker is None:
         return clause
@@ -9283,6 +9349,7 @@ def _source_selector_concept_matches(
         "condition": r"\b(?:condition|voraussetzung)\w*",
         "eligible": r"\b(?:eligible|berechtig|anspruch)\w*",
         "income": r"\b(?:income|einkommen)\w*",
+        "penalty": r"\b(?:penalt(?:y|ies))\b",
         "qualified": r"\b(?:qualified|berechtig|anspruch)\w*",
         "exempt": r"\b(?:exempt|befrei)\w*",
         "exception": r"\b(?:exception|ausnahme|abweich|befrei)\w*",

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -4536,10 +4536,15 @@ def _source_clause_spans(
         r";|[.!?](?=(?:[ \t]+[A-ZÄÖÜ(]|\s*$))",
         flags=re.MULTILINE,
     )
+    boundary_matches = (
+        match
+        for match in boundary.finditer(source_text)
+        if not _source_clause_boundary_splits_state_code_citation(source_text, match)
+    )
     split_points = {
         0,
         len(source_text),
-        *(match.end() for match in boundary.finditer(source_text)),
+        *(match.end() for match in boundary_matches),
         *(branch.start for branch in branches),
     }
     for start, end in zip(sorted(split_points), sorted(split_points)[1:]):
@@ -4552,6 +4557,22 @@ def _source_clause_spans(
                 start + right_trimmed,
                 raw[left_trimmed:right_trimmed],
             )
+
+
+def _source_clause_boundary_splits_state_code_citation(
+    source_text: str,
+    boundary: re.Match[str],
+) -> bool:
+    """Keep a line-wrapped ``R.S. 47:...`` citation in one legal clause."""
+
+    return bool(
+        boundary.group(0) == "."
+        and re.search(r"\bR\.S\.$", source_text[: boundary.end()], re.IGNORECASE)
+        and re.match(
+            r"\s*\d+[A-Za-z]?:\d+[A-Za-z]?",
+            source_text[boundary.end() :],
+        )
+    )
 
 
 def _span_is_deferred(
@@ -8451,6 +8472,12 @@ def _source_exception_requires_paired_witness(text: str) -> bool:
 
     collapsed = _collapse_text(text)
     if re.search(
+        r"\bnotwithstanding\b",
+        collapsed,
+        flags=re.IGNORECASE,
+    ) and _source_reference_reservation_is_only_references(collapsed):
+        return False
+    if re.search(
         r"\bexcept\s+as\s+[^.;]{0,100}\bprovided\b",
         collapsed,
         flags=re.IGNORECASE,
@@ -8541,7 +8568,7 @@ def _source_is_simple_main_proposition(text: str) -> bool:
 def _source_reference_reservation_is_only_references(text: str) -> bool:
     clause = _strip_source_clause_marker(_collapse_text(text)).strip()
     marker = re.search(
-        r"\b(?P<marker>subject\s+to|vorbehaltlich|except\s+as)\b",
+        r"\b(?P<marker>subject\s+to|vorbehaltlich|except\s+as|notwithstanding)\b",
         clause,
         flags=re.IGNORECASE,
     )
@@ -8551,7 +8578,12 @@ def _source_reference_reservation_is_only_references(text: str) -> bool:
     if marker.start() == 0:
         tail = clause[marker.end() :]
         delimiter = re.search(r"[,;]", tail)
-        if delimiter is not None and _source_is_simple_main_proposition(
+        if (
+            marker.group("marker").lower() == "notwithstanding"
+            and delimiter is not None
+        ):
+            complement = tail[: delimiter.start()].strip(" \t,;:.")
+        elif delimiter is not None and _source_is_simple_main_proposition(
             tail[delimiter.end() :]
         ):
             complement = tail[: delimiter.start()].strip(" \t,;:.")

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1135,7 +1135,8 @@ _LOUISIANA_SESSION_LAW_CITATION = re.compile(
     flags=re.IGNORECASE,
 )
 _LOUISIANA_NOTWITHSTANDING_RS_REFERENCE_PREFIX = re.compile(
-    r"^\s*notwithstanding\s+(?:the\s+)?provisions?\s+of\s+"
+    r"^\s*notwithstanding\s+"
+    r"(?:(?:the\s+)?provisions?\s+of\s+)?"
     r"R\.S\.\s*\d+[A-Za-z]?:\d+[A-Za-z]?"
     r"(?:-\d+[A-Za-z]?(?:\.\d+)*)?\s*[,;]\s*"
     r"(?P<tail>.+)$",

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -1191,7 +1191,7 @@ _STRUCTURAL_SOURCE_LEGAL_EDITION_PATTERN = re.compile(
     r")\s+of\s+(?:18|19|20)\d{2}\b"
 )
 _STRUCTURAL_SOURCE_STATE_CODE_CITATION_TARGET = (
-    r"\d+[A-Za-z]?:\d+[A-Za-z]?-\d+[A-Za-z]?(?:\.\d+)*"
+    r"\d+[A-Za-z]?:\d+[A-Za-z]?(?:-\d+[A-Za-z]?(?:\.\d+)*)?"
     r"(?:\([A-Za-z0-9]+\)[A-Za-z0-9]*)*"
 )
 _STRUCTURAL_SOURCE_STATE_CODE_CITATION_PATTERN = re.compile(

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -6582,6 +6582,28 @@ def _german_word_number_occurrences(
     return grounding, inventory
 
 
+def _english_word_number_occurrences(
+    cleaned: str,
+    *,
+    view: _NumericTextView,
+    collector: _LegacyNumericCollector,
+) -> list[NumericOccurrence]:
+    """Extract unambiguous compound English cardinal grounding candidates."""
+
+    return [
+        collector.occurrence(
+            view,
+            span,
+            value,
+            is_word_number=True,
+        )
+        for span, value in _iter_cardinal_word_number_matches(
+            cleaned,
+            compound_only=True,
+        )
+    ]
+
+
 def _scalar_recall_numeric_inventory(
     occurrences: Iterable[NumericOccurrence],
 ) -> tuple[NumericOccurrence, ...]:
@@ -6683,6 +6705,14 @@ def _tokenize_profiled_numeric_occurrences(
         )
         grounding_occurrences.extend(word_grounding)
         inventory_occurrences.extend(word_inventory)
+    elif profile in {"en-US", "en-GB"}:
+        grounding_occurrences.extend(
+            _english_word_number_occurrences(
+                cleaned,
+                view=view,
+                collector=collector,
+            )
+        )
 
     grounding_occurrences = list(
         _complete_typed_year_occurrences(collector, grounding_occurrences)
@@ -24550,9 +24580,14 @@ class ValidatorPipeline:
         artifact_numeric_values = tuple(
             value for _name, value in artifact_numeric_bindings
         )
+        numeric_profile = _numeric_profile_for_citation_path(corpus_citation_path)
         numeric_occurrence_extractor = functools.partial(
             extract_typed_numeric_inventory_occurrences_from_text,
-            profile=_numeric_profile_for_citation_path(corpus_citation_path),
+            profile=numeric_profile,
+        )
+        numeric_grounding_occurrence_extractor = functools.partial(
+            extract_typed_numeric_occurrences_from_text,
+            profile=numeric_profile,
         )
         completeness = analyze_complete_source_unit(
             content,
@@ -24560,6 +24595,9 @@ class ValidatorPipeline:
             corpus_citation_path=corpus_citation_path,
             test_cases=test_cases,
             extract_numeric_occurrences=numeric_occurrence_extractor,
+            extract_numeric_grounding_occurrences=(
+                numeric_grounding_occurrence_extractor
+            ),
             extract_named_scalars=extract_named_scalar_occurrences,
             numeric_value_is_grounded=numeric_value_is_grounded,
             artifact_numeric_values=artifact_numeric_values,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -6590,18 +6590,23 @@ def _english_word_number_occurrences(
 ) -> list[NumericOccurrence]:
     """Extract unambiguous compound English cardinal grounding candidates."""
 
-    return [
-        collector.occurrence(
-            view,
-            span,
-            value,
-            is_word_number=True,
+    occurrences: list[NumericOccurrence] = []
+    for span, value in _iter_cardinal_word_number_matches(
+        cleaned,
+        compound_only=True,
+    ):
+        strict_value = _parse_strict_cardinal_number_words(cleaned[slice(*span)])
+        if strict_value is None or not math.isclose(strict_value, value):
+            continue
+        occurrences.append(
+            collector.occurrence(
+                view,
+                span,
+                strict_value,
+                is_word_number=True,
+            )
         )
-        for span, value in _iter_cardinal_word_number_matches(
-            cleaned,
-            compound_only=True,
-        )
-    ]
+    return occurrences
 
 
 def _scalar_recall_numeric_inventory(

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1555"
+ENCODER_VERSION = "0.2.1556"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1556"
+ENCODER_VERSION = "0.2.1557"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1554"
+ENCODER_VERSION = "0.2.1555"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1554"
+ENCODER_VERSION = "0.2.1555"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1556"
+ENCODER_VERSION = "0.2.1557"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1555"
+ENCODER_VERSION = "0.2.1556"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1555"
+ENCODER_VERSION = "0.2.1556"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1554"
+ENCODER_VERSION = "0.2.1555"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1556"
+ENCODER_VERSION = "0.2.1557"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1555"
+ENCODER_VERSION = "0.2.1556"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1554"
+ENCODER_VERSION = "0.2.1555"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1556"
+ENCODER_VERSION = "0.2.1557"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1556"
+ENCODER_VERSION = "0.2.1557"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1555"
+ENCODER_VERSION = "0.2.1556"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1554"
+ENCODER_VERSION = "0.2.1555"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1554"
+ENCODER_VERSION = "0.2.1555"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1556"
+ENCODER_VERSION = "0.2.1557"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1555"
+ENCODER_VERSION = "0.2.1556"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1554"
+ENCODER_VERSION = "0.2.1555"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1556"
+ENCODER_VERSION = "0.2.1557"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1555"
+ENCODER_VERSION = "0.2.1556"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1555"')
+        .startswith('__version__ = "0.2.1556"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1555"
+    assert encoder_package["version"] == "0.2.1556"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1555"
+    assert project["project"]["version"] == "0.2.1556"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1555"')
+        .startswith('__version__ = "0.2.1556"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1555"
+    assert encoder_package["version"] == "0.2.1556"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1555"
+    assert project["project"]["version"] == "0.2.1556"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1555"')
+        .startswith('__version__ = "0.2.1556"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1556"')
+        .startswith('__version__ = "0.2.1557"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1556"
+    assert encoder_package["version"] == "0.2.1557"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1556"
+    assert project["project"]["version"] == "0.2.1557"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1556"')
+        .startswith('__version__ = "0.2.1557"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1556"
+    assert encoder_package["version"] == "0.2.1557"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1556"
+    assert project["project"]["version"] == "0.2.1557"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1556"')
+        .startswith('__version__ = "0.2.1557"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1554"')
+        .startswith('__version__ = "0.2.1555"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1554"
+    assert encoder_package["version"] == "0.2.1555"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1554"
+    assert project["project"]["version"] == "0.2.1555"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1554"')
+        .startswith('__version__ = "0.2.1555"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1554"
+    assert encoder_package["version"] == "0.2.1555"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1554"
+    assert project["project"]["version"] == "0.2.1555"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1554"')
+        .startswith('__version__ = "0.2.1555"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1555"
+ENCODER_VERSION = "0.2.1556"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1556"
+ENCODER_VERSION = "0.2.1557"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1554"
+ENCODER_VERSION = "0.2.1555"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -37,6 +37,10 @@ EN_NUMERIC_OCCURRENCE_EXTRACTOR = functools.partial(
     extract_typed_numeric_inventory_occurrences_from_text,
     profile="en-US",
 )
+EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR = functools.partial(
+    extract_typed_numeric_occurrences_from_text,
+    profile="en-US",
+)
 
 
 def _analyze(
@@ -5475,7 +5479,36 @@ penalty waived under the voluntary disclosure program.
     assert [
         completeness_module._source_exception_requires_paired_witness(branch.text)
         for branch in exception_branches
-    ] == [False, True]
+    ] == [True, True]
+    assert [
+        (occurrence.raw, occurrence.value)
+        for occurrence in EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR(source)
+        if occurrence.is_word_number
+    ] == [("twenty-five\nthousand", 25000.0)]
+
+
+def test_pure_louisiana_notwithstanding_reference_is_not_toggleable():
+    source = (
+        "Notwithstanding the provisions of R.S. 47:1508, the reporting rule applies."
+    )
+
+    assert not completeness_module._source_exception_requires_paired_witness(source)
+
+
+@pytest.mark.parametrize(
+    "tail",
+    (
+        "if income exceeds 25000 dollars, the credit applies",
+        "when voluntary disclosure is false, oversight applies",
+        "subject to an income limit, the credit applies",
+    ),
+)
+def test_louisiana_notwithstanding_reference_preserves_runtime_condition(
+    tail: str,
+):
+    source = f"Notwithstanding R.S. 47:1508, {tail}."
+
+    assert completeness_module._source_exception_requires_paired_witness(source)
 
 
 def test_louisiana_cross_reference_does_not_require_synthetic_case_pair():
@@ -5540,12 +5573,33 @@ rules:
         corpus_citation_path="us-la/statute/47:295",
         test_cases=cases,
         extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
         extract_named_scalars=extract_named_scalar_occurrences,
         numeric_value_is_grounded=numeric_value_is_grounded,
     )
 
     assert not _has_issue(result, "exception", "test")
     assert not _has_issue(result, "numeric-recall")
+
+    missing_threshold_pair = analyze_complete_source_unit(
+        content,
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+        test_cases=(cases[0], cases[2]),
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+        extract_named_scalars=extract_named_scalar_occurrences,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
+
+    assert _has_issue(missing_threshold_pair, "exception", "test")
+    assert any(
+        "exceeding twenty-five" in issue for issue in missing_threshold_pair.issues
+    )
 
 
 def test_en_us_state_code_citation_filter_preserves_real_unit_and_ratio_values():

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -5487,14 +5487,26 @@ penalty waived under the voluntary disclosure program.
     ] == [("twenty-five\nthousand", 25000.0)]
 
 
-def test_pure_louisiana_notwithstanding_reference_is_not_toggleable():
-    source = (
-        "Notwithstanding the provisions of R.S. 47:1508, the reporting rule applies."
-    )
+@pytest.mark.parametrize(
+    "reference",
+    (
+        "R.S. 47:1508",
+        "provision of R.S. 47:1508",
+        "the provisions of R.S. 47:1508",
+    ),
+)
+def test_pure_louisiana_notwithstanding_reference_is_not_toggleable(
+    reference: str,
+):
+    source = f"Notwithstanding {reference}, the reporting rule applies."
 
     assert not completeness_module._source_exception_requires_paired_witness(source)
 
 
+@pytest.mark.parametrize(
+    "reference",
+    ("R.S. 47:1508", "the provisions of R.S. 47:1508"),
+)
 @pytest.mark.parametrize(
     "tail",
     (
@@ -5504,11 +5516,38 @@ def test_pure_louisiana_notwithstanding_reference_is_not_toggleable():
     ),
 )
 def test_louisiana_notwithstanding_reference_preserves_runtime_condition(
+    reference: str,
     tail: str,
 ):
-    source = f"Notwithstanding R.S. 47:1508, {tail}."
+    source = f"Notwithstanding {reference}, {tail}."
 
     assert completeness_module._source_exception_requires_paired_witness(source)
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "twenty thirty dollars",
+        "one one dollars",
+        "five thousand hundred dollars",
+        "one million thousand dollars",
+    ),
+)
+def test_en_us_compound_word_grounding_rejects_malformed_order(source: str):
+    assert not any(
+        occurrence.is_word_number
+        for occurrence in EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR(source)
+    )
+
+
+def test_en_us_compound_word_grounding_preserves_coordinated_values():
+    assert [
+        (occurrence.raw, occurrence.value)
+        for occurrence in EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR(
+            "between five and ten years"
+        )
+        if occurrence.is_word_number
+    ] == [("five", 5.0), ("ten", 10.0)]
 
 
 def test_louisiana_cross_reference_does_not_require_synthetic_case_pair():

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -5433,6 +5433,121 @@ def test_en_us_state_code_citations_are_structural_for_numeric_recall():
     assert inventory == []
 
 
+def test_louisiana_revised_statutes_citations_are_structural_for_numeric_recall():
+    source = (
+        "The amount is determined under R.S. 47:32. Notwithstanding R.S.\n"
+        "47:1508, a 25,000 dollar threshold applies, with a separate 2:1 ratio."
+    )
+
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        source,
+        profile="en-US",
+    )
+
+    assert [(item.value, item.raw) for item in inventory] == [
+        (25000.0, "25,000"),
+        (2.0, "2"),
+        (1.0, "1"),
+    ]
+
+
+def test_line_wrapped_louisiana_cross_reference_stays_in_one_clause():
+    source = """\
+Notwithstanding the provisions of R.S.
+47:1508, beginning January 1, 2016, waivers of all penalties exceeding twenty-five
+thousand dollars shall be subject to oversight. This provision shall not apply to a
+penalty waived under the voluntary disclosure program.
+"""
+
+    clauses = tuple(completeness_module._source_clause_spans(source, branches=()))
+    exception_branches = completeness_module._source_exception_branches(
+        source,
+        branches=(),
+        active_branches=(),
+        deferred_paths=set(),
+        formula_branches=(),
+    )
+
+    assert any(
+        "R.S.\n47:1508" in clause and "subject to oversight" in clause
+        for _start, _end, clause in clauses
+    )
+    assert [
+        completeness_module._source_exception_requires_paired_witness(branch.text)
+        for branch in exception_branches
+    ] == [False, True]
+
+
+def test_louisiana_cross_reference_does_not_require_synthetic_case_pair():
+    source = """\
+Notwithstanding the provisions of R.S.
+47:1508, beginning January 1, 2016, waivers of all penalties exceeding twenty-five
+thousand dollars shall be subject to oversight. This provision shall not apply to a
+penalty waived under the voluntary disclosure program.
+"""
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-la/statute/47:295
+rules:
+  - name: penalty_waiver_oversight_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Day
+    source: us-la/statute/47:295
+    versions:
+      - formula: 25000
+  - name: penalty_waiver_subject_to_oversight
+    kind: derived
+    dtype: Judgment
+    period: Day
+    source: us-la/statute/47:295
+    versions:
+      - formula: penalty_amount > penalty_waiver_oversight_threshold and not voluntary_disclosure_program
+"""
+    cases = [
+        {
+            "name": "above threshold",
+            "input": {
+                "penalty_amount": 26000,
+                "voluntary_disclosure_program": False,
+            },
+            "output": {"penalty_waiver_subject_to_oversight": True},
+        },
+        {
+            "name": "at threshold",
+            "input": {
+                "penalty_amount": 25000,
+                "voluntary_disclosure_program": False,
+            },
+            "output": {"penalty_waiver_subject_to_oversight": False},
+        },
+        {
+            "name": "voluntary disclosure exception",
+            "input": {
+                "penalty_amount": 26000,
+                "voluntary_disclosure_program": True,
+            },
+            "output": {"penalty_waiver_subject_to_oversight": False},
+        },
+    ]
+
+    result = analyze_complete_source_unit(
+        content,
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+        test_cases=cases,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_named_scalars=extract_named_scalar_occurrences,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
+
+    assert not _has_issue(result, "exception", "test")
+    assert not _has_issue(result, "numeric-recall")
+
+
 def test_en_us_state_code_citation_filter_preserves_real_unit_and_ratio_values():
     source = (
         "Under N.J.S.54A:1-1, the amount is 1 dollar, the required ratio is 2:1, "

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1556"
+version = "0.2.1557"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1555"
+version = "0.2.1556"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1554"
+version = "0.2.1555"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- recognize Louisiana R.S. title and section references without a hyphenated tail as structural numeric context
- keep a line-wrapped R.S. 47:... citation in one legal source clause
- distinguish numeric grounding evidence from named-scalar recall inventory, including strictly parsed compound English word numbers
- ignore pure short- and full-form notwithstanding cross-reference reservations while preserving real numeric and runtime conditions after the citation
- require numeric condition clauses to be covered by numeric case transitions, not unrelated boolean pairs
- bump the encoder to 0.2.1557

## Production evidence
Run 31025494601 failed closed in canonical refresh 47:295. The primary 47:294 lane succeeded only inside the disposable runner; atomic publication skipped provenance, durable commit, push, and PR creation. The retained source shows R.S. 47:32 and line-wrapped R.S. 47:1508 surviving numeric recall, while the line wrap and cross-reference classification distorted applicability obligations.

At exact head a17fffe30e9f285421998558f732e5e972304795, the retained Sol 47:295 artifact has zero completeness issues with all companion cases. Removing only its at-threshold case reports only the exceeding twenty-five thousand branch; removing only its voluntary-disclosure case reports only that exclusion.

## Checks
- production-shaped Louisiana focused regressions, including malformed word-order controls: 17 passed
- exact retained Sol artifact: zero issues; both single-case negative controls identify the correct branch
- full source-completeness module: 1134 passed
- focused version and oracle checks: 1453 passed, 31 skipped
- full prescribed suite: 7215 passed, 119 skipped
- Ruff, format, compileall, and diff check: passed
- hosted CI and signing checks: all passed on exact head
- independent review/fix cycle: CLEAN on exact head