### PR TITLE
Reject existing RuleSpec source-add targets

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -577,6 +577,13 @@ jobs:
             source_bundle_args+=(--exclude-citation "$SECOND_DEPENDENT_CITATION")
           fi
           normalized_source_bundle="$("${source_bundle_args[@]}")"
+          axiom-encode/.venv/bin/python \
+            axiom-encode/scripts/prepare_signed_backfill.py \
+            validate-source-add-targets "$RULESPEC_CHECKOUT" \
+            "$normalized_source_bundle" \
+            --primary-citation "$CITATION" \
+            --primary-rulespec-path "$REPLACE_RULESPEC_PATH" \
+            > /dev/null
           normalized_canonical_refresh_bundle="$(
             axiom-encode/.venv/bin/python \
               axiom-encode/scripts/prepare_signed_backfill.py \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to Axiom Encode will be documented here.
 
+- Reject source-add dispatches when the primary or bundled canonical RuleSpec
+  destination already exists in the pinned checkout. Existing modules must use
+  the authenticated canonical-refresh contract, so mode mistakes fail before
+  model execution or signing instead of reaching an invalid full-tree compile.
+
 - Classify affirmative duties introduced by a `notwithstanding` exemption as
   enabling exception effects, so complete-source companion tests can prove
   obligations that remain operative despite a separate filing exemption.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1557"
+version = "0.2.1558"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1558"
+version = "0.2.1559"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -7,6 +7,7 @@ import argparse
 import hashlib
 import json
 import re
+import stat
 import subprocess
 from pathlib import Path, PurePosixPath
 
@@ -366,6 +367,95 @@ def parse_source_bundle(
         seen_citations.add(citation)
         seen_paths.add(path)
     return tuple(citations)
+
+
+def _checkout_path_exists_without_indirection(
+    repo: Path,
+    relative: PurePosixPath,
+    *,
+    label: str,
+) -> bool:
+    """Return whether a checkout path exists, rejecting parent indirection."""
+
+    cursor = repo
+    for index, component in enumerate(relative.parts):
+        cursor /= component
+        try:
+            metadata = cursor.lstat()
+        except FileNotFoundError:
+            return False
+        except OSError as exc:
+            raise ValueError(f"cannot inspect {label}: {relative}") from exc
+        if stat.S_ISLNK(metadata.st_mode):
+            raise ValueError(f"{label} contains a symlink: {relative}")
+        if index < len(relative.parts) - 1 and not stat.S_ISDIR(metadata.st_mode):
+            raise ValueError(f"{label} parent is not a directory: {relative}")
+        if index == len(relative.parts) - 1:
+            return True
+    return False
+
+
+def validate_source_add_targets(
+    repo: Path,
+    source_bundle_json: str,
+    *,
+    primary_citation: str,
+    primary_rulespec_path: str = "",
+) -> tuple[str, ...]:
+    """Require source-add destinations to be absent in the pinned checkout.
+
+    Existing canonical modules belong to the canonical-refresh protocol.  A
+    primary replacement may still compose genuinely new source modules, but
+    those additions must not collide with a primary, companion, or ownership
+    manifest already present in the immutable RuleSpec base.
+    """
+
+    sources = parse_source_bundle(
+        source_bundle_json,
+        primary_citation=primary_citation,
+    )
+    primary_jurisdiction = primary_citation.partition("/")[0]
+    expected_repo_name = f"rulespec-{primary_jurisdiction.partition('-')[0]}"
+    repo = Path(repo).resolve(strict=True)
+    if not repo.is_dir() or repo.name != expected_repo_name:
+        raise ValueError(
+            "repository directory must match the primary citation country: "
+            f"{expected_repo_name}"
+        )
+
+    if primary_rulespec_path:
+        _safe_relative_path(
+            primary_rulespec_path,
+            label="source-add primary replacement",
+        )
+        additions = sources
+    else:
+        additions = (primary_citation, *sources)
+
+    conflicts: list[str] = []
+    for citation in additions:
+        rulespec_path = citation_rulespec_path(citation)
+        companion_path = rulespec_path.with_name(f"{rulespec_path.stem}.test.yaml")
+        manifest_path = MANIFEST_ROOT / rulespec_path.with_suffix(".json")
+        for label, path in (
+            ("RuleSpec primary", rulespec_path),
+            ("RuleSpec companion", companion_path),
+            ("RuleSpec ownership manifest", manifest_path),
+        ):
+            if _checkout_path_exists_without_indirection(
+                repo,
+                path,
+                label=label,
+            ):
+                conflicts.append(path.as_posix())
+
+    if conflicts:
+        raise ValueError(
+            "source-add destination already exists in the pinned RuleSpec "
+            "checkout; existing modules must use canonical_refresh_bundle: "
+            + ", ".join(sorted(conflicts))
+        )
+    return sources
 
 
 def parse_canonical_refresh_bundle(
@@ -2488,6 +2578,17 @@ def main() -> None:
         default=[],
         help="additional forbidden canonical citation; may be repeated",
     )
+    source_add_parser = subparsers.add_parser(
+        "validate-source-add-targets",
+        help=(
+            "reject source-add destinations already present in the pinned "
+            "RuleSpec checkout"
+        ),
+    )
+    source_add_parser.add_argument("repo", type=Path)
+    source_add_parser.add_argument("source_bundle_json")
+    source_add_parser.add_argument("--primary-citation", required=True)
+    source_add_parser.add_argument("--primary-rulespec-path", default="")
     atomic_source_parser = subparsers.add_parser(
         "split-atomic-source-input",
         help=(
@@ -2615,6 +2716,18 @@ def main() -> None:
                     split_atomic_source_input(args.atomic_source_json),
                     separators=(",", ":"),
                     sort_keys=True,
+                )
+            )
+        elif args.command == "validate-source-add-targets":
+            print(
+                json.dumps(
+                    validate_source_add_targets(
+                        args.repo,
+                        args.source_bundle_json,
+                        primary_citation=args.primary_citation,
+                        primary_rulespec_path=args.primary_rulespec_path,
+                    ),
+                    separators=(",", ":"),
                 )
             )
         elif args.command == "parse-canonical-refresh-bundle":

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1558"
+__version__ = "0.2.1559"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1557"
+__version__ = "0.2.1558"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1557"
+ENCODER_VERSION = "0.2.1558"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1558"
+ENCODER_VERSION = "0.2.1559"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1557"
+ENCODER_VERSION = "0.2.1558"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1558"
+ENCODER_VERSION = "0.2.1559"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1558"
+ENCODER_VERSION = "0.2.1559"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1557"
+ENCODER_VERSION = "0.2.1558"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1557"
+ENCODER_VERSION = "0.2.1558"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1558"
+ENCODER_VERSION = "0.2.1559"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1557"
+ENCODER_VERSION = "0.2.1558"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1558"
+ENCODER_VERSION = "0.2.1559"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1558"
+ENCODER_VERSION = "0.2.1559"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1557"
+ENCODER_VERSION = "0.2.1558"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1558"
+ENCODER_VERSION = "0.2.1559"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1557"
+ENCODER_VERSION = "0.2.1558"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -31,6 +31,7 @@ from scripts.prepare_signed_backfill import (
     validate_dependent_cascade,
     validate_queue_tracking,
     validate_rulespec_base,
+    validate_source_add_targets,
     verify_canonical_refresh_target,
 )
 from scripts.prepare_signed_backfill import (
@@ -389,6 +390,87 @@ def test_parse_source_bundle_cli_emits_normalized_json_array(
     prepare_signed_backfill_main()
 
     assert capsys.readouterr().out == '["us-ri/statute/44-30-1"]\n'
+
+
+def test_validate_source_add_targets_accepts_absent_primary_and_bundle(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "rulespec-us"
+    repo.mkdir()
+
+    assert validate_source_add_targets(
+        repo,
+        '["us-la/statute/47:295"]',
+        primary_citation="us-la/statute/47:294",
+    ) == ("us-la/statute/47:295",)
+
+
+@pytest.mark.parametrize(
+    "existing",
+    [
+        "us-la/statutes/47/294.yaml",
+        "us-la/statutes/47/295.test.yaml",
+        ".axiom/encoding-manifests/us-la/statutes/47/295.json",
+    ],
+)
+def test_validate_source_add_targets_rejects_existing_destinations(
+    tmp_path: Path,
+    existing: str,
+) -> None:
+    repo = tmp_path / "rulespec-us"
+    target = repo / existing
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("existing\n", encoding="utf-8")
+
+    with pytest.raises(
+        ValueError,
+        match="existing modules must use canonical_refresh_bundle",
+    ):
+        validate_source_add_targets(
+            repo,
+            '["us-la/statute/47:295"]',
+            primary_citation="us-la/statute/47:294",
+        )
+
+
+def test_validate_source_add_targets_allows_existing_replacement_primary(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "rulespec-us"
+    primary = repo / "us-la/statutes/47/294.yaml"
+    primary.parent.mkdir(parents=True)
+    primary.write_text("format: rulespec/v1\nrules: []\n", encoding="utf-8")
+
+    assert validate_source_add_targets(
+        repo,
+        '["us-la/statute/47:295"]',
+        primary_citation="us-la/statute/47:294",
+        primary_rulespec_path="us-la/statutes/47/294.yaml",
+    ) == ("us-la/statute/47:295",)
+
+
+def test_validate_source_add_targets_rejects_existing_bundle_with_replacement_primary(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "rulespec-us"
+    for relative in (
+        "us-la/statutes/47/294.yaml",
+        "us-la/statutes/47/295.yaml",
+    ):
+        target = repo / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("format: rulespec/v1\nrules: []\n", encoding="utf-8")
+
+    with pytest.raises(
+        ValueError,
+        match="existing modules must use canonical_refresh_bundle",
+    ):
+        validate_source_add_targets(
+            repo,
+            '["us-la/statute/47:295"]',
+            primary_citation="us-la/statute/47:294",
+            primary_rulespec_path="us-la/statutes/47/294.yaml",
+        )
 
 
 def _canonical_refresh_repo(tmp_path: Path) -> Path:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1558"')
+        .startswith('__version__ = "0.2.1559"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1558"
+    assert encoder_package["version"] == "0.2.1559"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1558"
+    assert project["project"]["version"] == "0.2.1559"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1558"')
+        .startswith('__version__ = "0.2.1559"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1558"
+    assert encoder_package["version"] == "0.2.1559"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1558"
+    assert project["project"]["version"] == "0.2.1559"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1558"')
+        .startswith('__version__ = "0.2.1559"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1557"')
+        .startswith('__version__ = "0.2.1558"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1557"
+    assert encoder_package["version"] == "0.2.1558"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1557"
+    assert project["project"]["version"] == "0.2.1558"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1557"')
+        .startswith('__version__ = "0.2.1558"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1557"
+    assert encoder_package["version"] == "0.2.1558"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1557"
+    assert project["project"]["version"] == "0.2.1558"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1557"')
+        .startswith('__version__ = "0.2.1558"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1557"
+ENCODER_VERSION = "0.2.1558"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1558"
+ENCODER_VERSION = "0.2.1559"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2003,6 +2003,8 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     )
     assert "split-atomic-source-input" in source_bundle_command
     assert 'parse-source-bundle "$source_bundle_json"' in source_bundle_command
+    assert "validate-source-add-targets" in source_bundle_command
+    assert 'validate-source-add-targets "$RULESPEC_CHECKOUT"' in (source_bundle_command)
     assert 'parse-existing-signed-imports "$RULESPEC_CHECKOUT"' in (
         source_bundle_command
     )
@@ -4114,6 +4116,65 @@ def test_targeted_signed_reencode_rejects_nonatomic_source_bundle_replacements_e
 
     assert completed.returncode != 0
     assert expected_error in completed.stderr
+
+
+def test_targeted_signed_reencode_rejects_existing_source_add_targets_early(
+    tmp_path: Path,
+) -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/targeted-signed-reencode.yml").read_text()
+    )
+    command = (
+        next(
+            step["run"]
+            for step in workflow["jobs"]["encode"]["steps"]
+            if step.get("name") == "Validate atomic source inputs"
+        )
+        .replace("axiom-encode/.venv/bin/python", sys.executable)
+        .replace(
+            "axiom-encode/scripts/prepare_signed_backfill.py",
+            str(ROOT / "scripts/prepare_signed_backfill.py"),
+        )
+    )
+    checkout = tmp_path / "rulespec-us"
+    for relative in (
+        "us-la/statutes/47/294.yaml",
+        "us-la/statutes/47/295.yaml",
+        "us-la/statutes/47/32.yaml",
+        "us-la/statutes/47:32.yaml",
+    ):
+        target = checkout / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("format: rulespec/v1\nrules: []\n", encoding="utf-8")
+
+    completed = subprocess.run(
+        ["bash", "-c", command],
+        cwd=ROOT.parent,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "ATOMIC_SOURCE_JSON": '["us-la/statute/47:295"]',
+            "CITATION": "us-la/statute/47:294",
+            "DEPENDENT_CITATION": "",
+            "EXISTING_SIGNED_IMPORTS_JSON": "[]",
+            "LEGACY_EXACT_DEPENDENT_RULESPEC_PATH": "",
+            "LEGACY_RETAINED_SUCCESSOR_RULESPEC_PATHS_JSON": "[]",
+            "QUEUE_ID": "",
+            "REPAIR_RUN_ID": "",
+            "REPLACE_LEGACY_RULESPEC_PATH": "",
+            "REPLACE_RULESPEC_PATH": "",
+            "RULESPEC_CHECKOUT": str(checkout),
+            "SECOND_DEPENDENT_CITATION": "",
+            "SECOND_LEGACY_EXACT_DEPENDENT_RULESPEC_PATH": "",
+        },
+    )
+
+    assert completed.returncode != 0
+    assert "existing modules must use canonical_refresh_bundle" in completed.stderr
+    assert "us-la/statutes/47/294.yaml" in completed.stderr
+    assert "us-la/statutes/47/295.yaml" in completed.stderr
 
 
 def test_targeted_signed_reencode_reuses_verified_existing_import(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1558"
+version = "0.2.1559"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1557"
+version = "0.2.1558"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- reject source-add primary, companion, or ownership-manifest destinations already present in the pinned RuleSpec checkout
- require existing modules to use the authenticated canonical-refresh inventory
- preserve source-add composition when the primary is an explicit replacement and every added source is genuinely absent

## Failure addressed
Protected run 31030319982 used source-add mode for existing Louisiana modules. The immutable RuleSpec cut retained both canonical and legacy path forms, so the engine correctly rejected the full source-add validation tree. The canonical context was not renamed. This change closes the mode-selection contract hole before model execution or signing and does not weaken canonical path validation.

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`: passed
- `python -m compileall -q src/axiom_encode scripts`: passed
- focused backfill/signing-supervisor suite: 201 passed, 51 skipped
- full prescribed pytest: 7,222 passed, 119 skipped
- exact protected Louisiana source-add payload: rejected with all occupied destinations
- exact protected Louisiana canonical-refresh inventory: accepted with four canonical paths

## Review cycle
Independent review: CLEAN on exact final head `1e9b3b0c1d8f704768f4f0b0e67af50561546403`; no actionable findings. Focused provenance invariant passed. All hosted checks are green.
