### PR TITLE
Fix temporal and rate formula grounding

### DIFF
--- a/changelog.d/formula-temporal-rate-grounding.fixed.md
+++ b/changelog.d/formula-temporal-rate-grounding.fixed.md
@@ -1,0 +1,1 @@
+Keep effective-date numbers out of formula coefficient matching, recognize source-stated `multiplying`, and ground percentages above 100% as decimal factors only when the source occurrence has local rate context.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1560"
+version = "0.2.1561"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1562"
+version = "0.2.1563"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1559"
+version = "0.2.1560"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1563"
+version = "0.2.1564"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1561"
+version = "0.2.1562"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1559"
+__version__ = "0.2.1560"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1560"
+__version__ = "0.2.1561"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1562"
+__version__ = "0.2.1563"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1561"
+__version__ = "0.2.1562"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1563"
+__version__ = "0.2.1564"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -5600,7 +5600,10 @@ def _formula_execution_matches_source_branch(
     computation_occurrences = tuple(
         occurrence
         for occurrence in source_occurrences
-        if not occurrence.has_temporal_context
+        if not _temporal_occurrence_is_formula_applicability_preface(
+            occurrence,
+            branch.text,
+        )
         and not any(
             _numeric_occurrences_are_equivalent(occurrence, boundary)
             for boundary in boundaries
@@ -5635,6 +5638,26 @@ def _formula_execution_matches_source_branch(
         )
         for source_occurrence in computation_occurrences
     )
+
+
+def _temporal_occurrence_is_formula_applicability_preface(
+    occurrence: NumericOccurrenceLike,
+    source_text: str,
+) -> bool:
+    """Separate leading temporal applicability from arithmetic operands."""
+
+    if not occurrence.has_temporal_context:
+        return False
+    computation_starts = [
+        match.start()
+        for pattern in (
+            _COMPUTATION_LANGUAGE,
+            _ARITHMETIC_EXPRESSION,
+            _WORDED_ARITHMETIC_EXPRESSION,
+        )
+        if (match := pattern.search(source_text)) is not None
+    ]
+    return bool(computation_starts) and occurrence.end <= min(computation_starts)
 
 
 def _formula_operation_kinds(text: str) -> set[str]:

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -310,12 +310,12 @@ _COMPUTATION_LANGUAGE = re.compile(
 _FORMULA_APPLICABILITY_PREFACE = re.compile(
     r"^\s*(?:(?:\([^)]+\)|[A-Z]\.)\s*)?(?:"
     r"beginning\b[^.;]{0,80}?\b(?:18|19|20)\d{2}\b"
-    r"(?:,\s*and\s+thereafter)?|"
-    r"(?:for|during)\b[^,.;]{0,80}?\b"
+    r"(?:,?\s+and\s+thereafter)?|"
+    r"(?:for|during)\b[^.;]{0,80}?\b"
     r"(?:tax(?:able)?|calendar|fiscal|assessment)\s+years?\b"
-    r"[^,.;]{0,40}?\b(?:18|19|20)\d{2}\b|"
+    r"[^.;]{0,40}?\b(?:18|19|20)\d{2}\b|"
     r"(?:effective(?:\s+(?:on|from))?|starting|as\s+of|on\s+or\s+after)\b"
-    r"[^,.;]{0,80}?\b(?:18|19|20)\d{2}\b"
+    r"[^.;]{0,80}?\b(?:18|19|20)\d{2}\b"
     r")\s*,",
     flags=re.IGNORECASE,
 )

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -5600,7 +5600,8 @@ def _formula_execution_matches_source_branch(
     computation_occurrences = tuple(
         occurrence
         for occurrence in source_occurrences
-        if not any(
+        if not occurrence.has_temporal_context
+        and not any(
             _numeric_occurrences_are_equivalent(occurrence, boundary)
             for boundary in boundaries
         )
@@ -5664,7 +5665,7 @@ def _formula_operation_kinds(text: str) -> set[str]:
         "multiply": (
             r"(?:[*×·•∗∙]|\d+(?:[.,]\d+)?\s*%\s+(?:des|der|von|of)\b|"
             r"\bprodukt\b|\bproduct\s+of\b|"
-            r"\b(?:multiplied|multiply|multiplication|multipliziert|"
+            r"\b(?:multiplied|multiply|multiplying|multiplication|multipliziert|"
             r"multiplizieren|multiplikation)\b|\bvervielfach\w*\b|\bmal\b|"
             r"\b(?:verfünf|versechs|versieben|veracht|verneun|verzehn)"
             r"fach\w*\b|"

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -307,6 +307,18 @@ _COMPUTATION_LANGUAGE = re.compile(
     r")\b",
     flags=re.IGNORECASE,
 )
+_FORMULA_APPLICABILITY_PREFACE = re.compile(
+    r"^\s*(?:(?:\([^)]+\)|[A-Z]\.)\s*)?(?:"
+    r"beginning\b[^.;]{0,80}?\b(?:18|19|20)\d{2}\b"
+    r"(?:,\s*and\s+thereafter)?|"
+    r"(?:for|during)\b[^,.;]{0,80}?\b"
+    r"(?:tax(?:able)?|calendar|fiscal|assessment)\s+years?\b"
+    r"[^,.;]{0,40}?\b(?:18|19|20)\d{2}\b|"
+    r"(?:effective(?:\s+(?:on|from))?|starting|as\s+of|on\s+or\s+after)\b"
+    r"[^,.;]{0,80}?\b(?:18|19|20)\d{2}\b"
+    r")\s*,",
+    flags=re.IGNORECASE,
+)
 _STATED_CONVERSION_CUE = re.compile(
     r"\b(?:umgerechnet|converted)\b",
     flags=re.IGNORECASE,
@@ -5648,16 +5660,12 @@ def _temporal_occurrence_is_formula_applicability_preface(
 
     if not occurrence.has_temporal_context:
         return False
-    computation_starts = [
-        match.start()
-        for pattern in (
-            _COMPUTATION_LANGUAGE,
-            _ARITHMETIC_EXPRESSION,
-            _WORDED_ARITHMETIC_EXPRESSION,
-        )
-        if (match := pattern.search(source_text)) is not None
-    ]
-    return bool(computation_starts) and occurrence.end <= min(computation_starts)
+    preface = _FORMULA_APPLICABILITY_PREFACE.match(source_text)
+    return bool(
+        preface is not None
+        and occurrence.start >= preface.start()
+        and occurrence.end <= preface.end()
+    )
 
 
 def _formula_operation_kinds(text: str) -> set[str]:

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -307,16 +307,28 @@ _COMPUTATION_LANGUAGE = re.compile(
     r")\b",
     flags=re.IGNORECASE,
 )
+_FORMULA_APPLICABILITY_YEAR = r"(?:18|19|20)\d{2}"
+_FORMULA_APPLICABILITY_MONTH = (
+    r"(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|"
+    r"jul(?:y)?|aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|"
+    r"nov(?:ember)?|dec(?:ember)?)\.?"
+)
+_FORMULA_APPLICABILITY_DAY = r"(?:0?[1-9]|[12]\d|3[01])(?:st|nd|rd|th)?"
+_FORMULA_APPLICABILITY_DATE = (
+    rf"(?:{_FORMULA_APPLICABILITY_MONTH}\s+"
+    rf"(?:{_FORMULA_APPLICABILITY_DAY}\s*,?\s*)?"
+    rf"{_FORMULA_APPLICABILITY_YEAR}|{_FORMULA_APPLICABILITY_YEAR})"
+)
 _FORMULA_APPLICABILITY_PREFACE = re.compile(
-    r"^\s*(?:(?:\([^)]+\)|[A-Z]\.)\s*)?(?:"
-    r"beginning\b[^.;]{0,80}?\b(?:18|19|20)\d{2}\b"
-    r"(?:,?\s+and\s+thereafter)?|"
-    r"(?:for|during)\b[^.;]{0,80}?\b"
-    r"(?:tax(?:able)?|calendar|fiscal|assessment)\s+years?\b"
-    r"[^.;]{0,40}?\b(?:18|19|20)\d{2}\b|"
-    r"(?:effective(?:\s+(?:on|from))?|starting|as\s+of|on\s+or\s+after)\b"
-    r"[^.;]{0,80}?\b(?:18|19|20)\d{2}\b"
-    r")\s*,",
+    rf"^\s*(?:(?:\([^)]+\)|[A-Z]\.)\s*)?(?:"
+    rf"beginning\s+(?:on\s+)?{_FORMULA_APPLICABILITY_DATE}"
+    rf"(?:,?\s+and\s+thereafter)?|"
+    rf"(?:for|during)\s+(?:the\s+)?"
+    rf"(?:tax(?:able)?|calendar|fiscal|assessment)\s+years?\s+"
+    rf"{_FORMULA_APPLICABILITY_YEAR}|"
+    rf"(?:effective(?:\s+(?:on|from))?|starting(?:\s+(?:on|from))?|"
+    rf"as\s+of|on\s+or\s+after)\s+{_FORMULA_APPLICABILITY_DATE}"
+    rf")\s*,",
     flags=re.IGNORECASE,
 )
 _STATED_CONVERSION_CUE = re.compile(

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -23686,7 +23686,7 @@ def numeric_value_is_grounded(
             return True
         if (
             occurrence.has_rate_context
-            and 0 < abs(value) <= 1
+            and 0 < abs(value)
             and math.isclose(
                 value * 100,
                 occurrence.source_value

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1560"
+ENCODER_VERSION = "0.2.1561"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1563"
+ENCODER_VERSION = "0.2.1564"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1561"
+ENCODER_VERSION = "0.2.1562"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1562"
+ENCODER_VERSION = "0.2.1563"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1559"
+ENCODER_VERSION = "0.2.1560"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1562"
+ENCODER_VERSION = "0.2.1563"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1561"
+ENCODER_VERSION = "0.2.1562"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1560"
+ENCODER_VERSION = "0.2.1561"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1559"
+ENCODER_VERSION = "0.2.1560"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1563"
+ENCODER_VERSION = "0.2.1564"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1560"
+ENCODER_VERSION = "0.2.1561"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1559"
+ENCODER_VERSION = "0.2.1560"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1562"
+ENCODER_VERSION = "0.2.1563"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1563"
+ENCODER_VERSION = "0.2.1564"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1561"
+ENCODER_VERSION = "0.2.1562"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1560"
+ENCODER_VERSION = "0.2.1561"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1559"
+ENCODER_VERSION = "0.2.1560"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1561"
+ENCODER_VERSION = "0.2.1562"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1563"
+ENCODER_VERSION = "0.2.1564"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1562"
+ENCODER_VERSION = "0.2.1563"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1563"
+ENCODER_VERSION = "0.2.1564"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1559"
+ENCODER_VERSION = "0.2.1560"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1560"
+ENCODER_VERSION = "0.2.1561"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1562"
+ENCODER_VERSION = "0.2.1563"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1561"
+ENCODER_VERSION = "0.2.1562"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1559"
+ENCODER_VERSION = "0.2.1560"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1561"
+ENCODER_VERSION = "0.2.1562"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1562"
+ENCODER_VERSION = "0.2.1563"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1560"
+ENCODER_VERSION = "0.2.1561"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1563"
+ENCODER_VERSION = "0.2.1564"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1560"
+ENCODER_VERSION = "0.2.1561"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1563"
+ENCODER_VERSION = "0.2.1564"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1559"
+ENCODER_VERSION = "0.2.1560"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1561"
+ENCODER_VERSION = "0.2.1562"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1562"
+ENCODER_VERSION = "0.2.1563"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1560"')
+        .startswith('__version__ = "0.2.1561"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1560"
+    assert encoder_package["version"] == "0.2.1561"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1560"
+    assert project["project"]["version"] == "0.2.1561"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1560"')
+        .startswith('__version__ = "0.2.1561"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1560"
+    assert encoder_package["version"] == "0.2.1561"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1560"
+    assert project["project"]["version"] == "0.2.1561"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1560"')
+        .startswith('__version__ = "0.2.1561"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1559"')
+        .startswith('__version__ = "0.2.1560"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1559"
+    assert encoder_package["version"] == "0.2.1560"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1559"
+    assert project["project"]["version"] == "0.2.1560"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1559"')
+        .startswith('__version__ = "0.2.1560"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1559"
+    assert encoder_package["version"] == "0.2.1560"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1559"
+    assert project["project"]["version"] == "0.2.1560"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1559"')
+        .startswith('__version__ = "0.2.1560"')
     )
 
 
@@ -9193,6 +9193,27 @@ rules:
 """
 
     assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+
+
+@pytest.mark.parametrize(
+    ("source_text", "expected"),
+    (
+        ("The multiplier is 200% of the amount.", True),
+        ("The multiplier is 200 percent of the amount.", True),
+        ("The amount is 200 dollars.", False),
+        ("The amount is $200.", False),
+    ),
+)
+def test_numeric_grounding_scales_rates_above_one_only_with_local_rate_context(
+    source_text,
+    expected,
+):
+    occurrences = extract_typed_numeric_occurrences_from_text(
+        source_text,
+        profile="en-US",
+    )
+
+    assert numeric_value_is_grounded(2.0, occurrences) is expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1561"')
+        .startswith('__version__ = "0.2.1562"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1561"
+    assert encoder_package["version"] == "0.2.1562"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1561"
+    assert project["project"]["version"] == "0.2.1562"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1561"')
+        .startswith('__version__ = "0.2.1562"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1561"
+    assert encoder_package["version"] == "0.2.1562"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1561"
+    assert project["project"]["version"] == "0.2.1562"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1561"')
+        .startswith('__version__ = "0.2.1562"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1563"')
+        .startswith('__version__ = "0.2.1564"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1563"
+    assert encoder_package["version"] == "0.2.1564"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1563"
+    assert project["project"]["version"] == "0.2.1564"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1563"')
+        .startswith('__version__ = "0.2.1564"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1563"
+    assert encoder_package["version"] == "0.2.1564"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1563"
+    assert project["project"]["version"] == "0.2.1564"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1563"')
+        .startswith('__version__ = "0.2.1564"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1562"')
+        .startswith('__version__ = "0.2.1563"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1562"
+    assert encoder_package["version"] == "0.2.1563"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1562"
+    assert project["project"]["version"] == "0.2.1563"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1562"')
+        .startswith('__version__ = "0.2.1563"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1562"
+    assert encoder_package["version"] == "0.2.1563"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1562"
+    assert project["project"]["version"] == "0.2.1563"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1562"')
+        .startswith('__version__ = "0.2.1563"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1561"
+ENCODER_VERSION = "0.2.1562"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1559"
+ENCODER_VERSION = "0.2.1560"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1563"
+ENCODER_VERSION = "0.2.1564"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1560"
+ENCODER_VERSION = "0.2.1561"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1562"
+ENCODER_VERSION = "0.2.1563"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -9565,6 +9565,9 @@ rules:
     (
         "The amount is calculated by subtracting tax year 2020 from the current tax year.",
         "Tax year 2020 is subtracted from the current tax year, and the amount is calculated.",
+        "Effective rate is calculated by subtracting tax year 2020, from the current tax year.",
+        "For purposes of this section, the base is tax year 2020, and the amount is calculated as the current tax year minus the base.",
+        "For tax year calculations, the amount is calculated by subtracting tax year 2020 from the current tax year.",
     ),
 )
 def test_temporal_formula_operand_remains_required_outside_applicability_preface(

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -9506,12 +9506,17 @@ rules:
     assert _has_issue(result, "formula branch")
 
 
-def test_temporal_formula_operand_remains_required_after_computation_cue():
-    source = (
-        "The amount is calculated by subtracting tax year 2020 from "
-        "the current tax year."
-    )
-    content = """\
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The amount is calculated by subtracting tax year 2020 from the current tax year.",
+        "Tax year 2020 is subtracted from the current tax year, and the amount is calculated.",
+    ),
+)
+def test_temporal_formula_operand_remains_required_outside_applicability_preface(
+    source,
+):
+    content = f"""\
 format: rulespec/v1
 module:
   source_verification:
@@ -9535,8 +9540,7 @@ rules:
             source:
               corpus_citation_path: us-la/statute/47:294
               excerpt: >-
-                The amount is calculated by subtracting tax year 2020 from the
-                current tax year.
+                {source}
     versions:
       - formula: tax_year - base_tax_year
 """

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -9457,6 +9457,60 @@ rules:
     assert _has_issue(pre_effective, "formula branch")
 
 
+@pytest.mark.parametrize(
+    "source",
+    (
+        "Effective January 1, 2026, the amount is calculated by multiplying income by the rate.",
+        "Beginning January 1, 2026 and thereafter, the amount is calculated by multiplying income by the rate.",
+    ),
+)
+def test_common_formula_applicability_prefaces_are_not_coefficients(source):
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-la/statute/47:294
+rules:
+  - name: adjusted_amount
+    kind: derived
+    dtype: Money
+    source: us-la/statute/47:294
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-la/statute/47:294
+              excerpt: >-
+                {source}
+    versions:
+      - effective_from: '2026-01-01'
+        formula: income * rate
+"""
+    case = {
+        "name": "effective formula",
+        "period": "2026",
+        "input": {"income": 100, "rate": 0.05},
+        "output": {"adjusted_amount": 5},
+    }
+
+    result = analyze_complete_source_unit(
+        content,
+        source,
+        corpus_citation_path="us-la/statute/47:294",
+        test_cases=[case],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+        extract_named_scalars=extract_named_scalar_occurrences,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
+
+    assert not result.issues
+
+
 def test_temporal_formula_filter_keeps_substantive_multiplier_grounding():
     source = (
         "For tax year 2026, the amount is calculated by multiplying "

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -9370,6 +9370,218 @@ rules:
     assert not correct.issues
 
 
+def test_louisiana_cpi_formula_separates_effective_year_from_computation():
+    source = """\
+Beginning January 1, 2026, and thereafter, the amount of the standard deduction
+provided in Subsection A of this Section shall be adjusted annually by an amount calculated
+by multiplying the amount of the prior year's standard deduction by the percentage increase
+in the Consumer Price Index United States city average for all urban consumers (CPI-U), as
+reported by the United States Department of Labor, Bureau of Labor Statistics, or its
+successor, for the previous calendar year.
+"""
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-la/statute/47:294
+rules:
+  - name: annual_standard_deduction_adjustment
+    kind: derived
+    dtype: Money
+    source: La. R.S. 47:294(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-la/statute/47:294
+              excerpt: |-
+                Beginning January 1, 2026, and thereafter, the amount of the standard deduction
+                provided in Subsection A of this Section shall be adjusted annually by an amount calculated
+                by multiplying the amount of the prior year's standard deduction by the percentage increase
+                in the Consumer Price Index United States city average for all urban consumers (CPI-U), as
+                reported by the United States Department of Labor, Bureau of Labor Statistics, or its
+                successor, for the previous calendar year.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: prior_year_standard_deduction * consumer_price_index_u_percentage_increase_for_previous_calendar_year
+"""
+    case = {
+        "name": "2026 CPI-U adjustment",
+        "period": {
+            "period_kind": "tax_year",
+            "start": "2026-01-01",
+            "end": "2026-12-31",
+        },
+        "input": {
+            "prior_year_standard_deduction": 20000,
+            "consumer_price_index_u_percentage_increase_for_previous_calendar_year": 0.05,
+        },
+        "output": {"annual_standard_deduction_adjustment": 1000},
+    }
+
+    def analyze(candidate_content, candidate_case):
+        return analyze_complete_source_unit(
+            candidate_content,
+            source,
+            corpus_citation_path="us-la/statute/47:294",
+            test_cases=[candidate_case],
+            extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+            extract_numeric_grounding_occurrences=(
+                EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+            ),
+            extract_named_scalars=extract_named_scalar_occurrences,
+            numeric_value_is_grounded=numeric_value_is_grounded,
+        )
+
+    correct = analyze(content, case)
+    wrong_operation_content = content.replace(
+        "prior_year_standard_deduction * consumer_price_index_u_percentage_increase_for_previous_calendar_year",
+        "prior_year_standard_deduction + consumer_price_index_u_percentage_increase_for_previous_calendar_year",
+    )
+    wrong_operation_case = yaml.safe_load(yaml.safe_dump(case))
+    wrong_operation_case["output"]["annual_standard_deduction_adjustment"] = 20000.05
+    wrong_operation = analyze(wrong_operation_content, wrong_operation_case)
+    pre_effective_case = yaml.safe_load(yaml.safe_dump(case))
+    pre_effective_case["name"] = "pre-effective CPI-U adjustment"
+    pre_effective_case["period"] = {
+        "period_kind": "tax_year",
+        "start": "2025-01-01",
+        "end": "2025-12-31",
+    }
+    pre_effective = analyze(content, pre_effective_case)
+
+    assert not correct.issues
+    assert _has_issue(wrong_operation, "formula branch")
+    assert _has_issue(pre_effective, "formula branch")
+
+
+def test_temporal_formula_filter_keeps_substantive_multiplier_grounding():
+    source = (
+        "For tax year 2026, the amount is calculated by multiplying "
+        "the prior amount by 3."
+    )
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-la/statute/47:294
+rules:
+  - name: multiplier
+    kind: parameter
+    dtype: Decimal
+    source: us-la/statute/47:294(B)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2
+  - name: adjusted_amount
+    kind: derived
+    dtype: Money
+    source: us-la/statute/47:294(B)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: prior_amount * multiplier
+"""
+    case = {
+        "name": "wrong substantive multiplier",
+        "period": "2026",
+        "input": {"prior_amount": 10},
+        "output": {"adjusted_amount": 20},
+    }
+
+    result = analyze_complete_source_unit(
+        content,
+        source,
+        corpus_citation_path="us-la/statute/47:294",
+        test_cases=[case],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+        extract_named_scalars=extract_named_scalar_occurrences,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
+
+    assert _has_issue(result, "formula branch")
+
+
+def test_louisiana_line_wrapped_two_hundred_percent_formula_grounds_factor_two():
+    source = """\
+(2) Married-Joint Return, a Qualified Surviving 200% of the dollar amount
+
+Spouse, and Head of Household provided for Single Individuals
+"""
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-la/statute/47:294
+rules:
+  - name: joint_standard_deduction_multiplier
+    kind: parameter
+    dtype: Rate
+    source: La. R.S. 47:294(A)(2)
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 2.0
+  - name: joint_standard_deduction
+    kind: derived
+    dtype: Money
+    source: La. R.S. 47:294(A)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-la/statute/47:294
+              excerpt: |-
+                Married-Joint Return, a Qualified Surviving 200% of the dollar amount
+
+                Spouse, and Head of Household provided for Single Individuals
+    versions:
+      - effective_from: '2025-01-01'
+        formula: single_standard_deduction * joint_standard_deduction_multiplier
+"""
+    case = {
+        "name": "joint deduction is twice the single amount",
+        "period": "2025",
+        "input": {"single_standard_deduction": 12500},
+        "output": {"joint_standard_deduction": 25000},
+    }
+
+    result = analyze_complete_source_unit(
+        content,
+        source,
+        corpus_citation_path="us-la/statute/47:294",
+        test_cases=[case],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+        extract_named_scalars=extract_named_scalar_occurrences,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
+    wrong_multiplier_case = yaml.safe_load(yaml.safe_dump(case))
+    wrong_multiplier_case["output"]["joint_standard_deduction"] = 37500
+    wrong_multiplier = analyze_complete_source_unit(
+        content.replace("formula: 2.0", "formula: 3.0"),
+        source,
+        corpus_citation_path="us-la/statute/47:294",
+        test_cases=[wrong_multiplier_case],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+        extract_named_scalars=extract_named_scalar_occurrences,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
+
+    assert not result.issues
+    assert _has_issue(wrong_multiplier, "formula branch")
+
+
 def test_formula_witness_preserves_source_operation_topology():
     source = "(1) Der Betrag wird als Einkommen * 2 + 3 berechnet."
     content = """\

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -9506,6 +9506,75 @@ rules:
     assert _has_issue(result, "formula branch")
 
 
+def test_temporal_formula_operand_remains_required_after_computation_cue():
+    source = (
+        "The amount is calculated by subtracting tax year 2020 from "
+        "the current tax year."
+    )
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-la/statute/47:294
+rules:
+  - name: base_tax_year
+    kind: parameter
+    dtype: Decimal
+    source: us-la/statute/47:294
+    versions:
+      - formula: 2020
+  - name: elapsed_tax_years
+    kind: derived
+    dtype: Decimal
+    source: us-la/statute/47:294
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-la/statute/47:294
+              excerpt: >-
+                The amount is calculated by subtracting tax year 2020 from the
+                current tax year.
+    versions:
+      - formula: tax_year - base_tax_year
+"""
+    case = {
+        "name": "elapsed years from the statutory base year",
+        "period": "2026",
+        "input": {"tax_year": 2026},
+        "output": {"elapsed_tax_years": 6},
+    }
+
+    def analyze(candidate_content, candidate_case):
+        return analyze_complete_source_unit(
+            candidate_content,
+            source,
+            corpus_citation_path="us-la/statute/47:294",
+            test_cases=[candidate_case],
+            extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+            extract_numeric_grounding_occurrences=(
+                EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+            ),
+            extract_named_scalars=extract_named_scalar_occurrences,
+            numeric_value_is_grounded=numeric_value_is_grounded,
+        )
+
+    correct = analyze(content, case)
+    wrong_content = content.replace(
+        "tax_year - base_tax_year",
+        "tax_year - unrelated_year",
+    )
+    wrong_case = yaml.safe_load(yaml.safe_dump(case))
+    wrong_case["input"]["unrelated_year"] = 2000
+    wrong_case["output"]["elapsed_tax_years"] = 26
+    wrong = analyze(wrong_content, wrong_case)
+
+    assert not correct.issues
+    assert _has_issue(wrong, "formula branch")
+
+
 def test_louisiana_line_wrapped_two_hundred_percent_formula_grounds_factor_two():
     source = """\
 (2) Married-Joint Return, a Qualified Surviving 200% of the dollar amount

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1561"
+version = "0.2.1562"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1563"
+version = "0.2.1564"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1559"
+version = "0.2.1560"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1560"
+version = "0.2.1561"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1562"
+version = "0.2.1563"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- stop treating temporal source values such as an effective year as arithmetic coefficients during formula witness matching
- recognize the exact English operation token `multiplying`
- allow locally rate-typed percentages above 100% to ground their decimal multiplier while preserving non-rate isolation
- add artifact-shaped Louisiana positive and fail-closed negative regressions
- bump the encoder atomically to `0.2.1564`

## Production evidence

Protected run `31034805346` failed closed with zero signatures and no publication. Its retained artifact reproduces the validator false negative on encoder `0.2.1559`; replaying the exact Sol candidate with this change yields zero complete-source-unit issues for both the line-wrapped A(2) 200% formula and the 2026 CPI-U formula. The failed run will not be rerun or reapproved.

## Checks

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run ruff format --check src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest -q --no-cov tests/test_source_completeness.py` (1,144 passed)
- `uv run pytest -q --no-cov tests/test_source_completeness.py tests/test_rulespec_validation.py` before review hardening (2,570 passed, 31 skipped)
- full `uv run pytest -q` before the atomic commit: 7,228 passed, 119 skipped; sole expected provenance failure because the version-changing commit did not yet exist
- post-commit provenance and exact temporal/rate regressions: 15 passed

## Cycle

Two independent reviewers completed the review-fix loop on exact head
`3757bc75cfb511671c16f855e94894895c44e969` with no actionable findings.
The cycle added the changelog fragment, narrowed temporal exclusion to explicit
anchored date/year applicability prefaces, and added fail-closed regressions for
temporal operands before and after computation cues and for misleading
`Effective rate`, `For purposes`, and `For tax year calculations` prefixes.
