### PR TITLE
Authenticate all-state SNAP queue release repins

### DIFF
--- a/.github/workflows/prepare-all-state-snap-queue.yml
+++ b/.github/workflows/prepare-all-state-snap-queue.yml
@@ -22,11 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      CORPUS_REF: 0fd35bfbda98836c406ec539a492c4e661c6695d
-      RELEASE_NAME: us-rulespec-2026-07-24-snap-cms-pit-union
-      RELEASE_SHA: cb275c76c4f07f8ad37470a32296bb1763e5db853d152697524ab07021b6d544
-      RULES_ENGINE_REF: 05eac9d2f89dabe5c6673176260762cef3a58f47
-      RULESPEC_REF: b61918da93fe8a1a29b35b9330aef2085291a5d0
+      CORPUS_REF: d9d6fba0b9069c7e0f0ed4255817b3e78c00dd64
+      RELEASE_NAME: us-rulespec-2026-08-03-ecps-pit-tariff-union
+      RELEASE_SHA: aa034219ef1519a31c0f354149bfd4b873fb5d8f2804b5cfe78c2813ee8af4e5
+      RULES_ENGINE_REF: 4658144031f8ef1b39a971eb7002997fa0880b5a
+      RULESPEC_REF: 38ddc92d4160a0d39af13bfe232a446b554a15c5
       SUPABASE_URL: https://swocpijqqahhuwtuahwc.supabase.co
     steps:
       - name: Checkout immutable encoder main

--- a/.github/workflows/validate-snap-queue-activation.yml
+++ b/.github/workflows/validate-snap-queue-activation.yml
@@ -53,7 +53,7 @@ jobs:
           echo "queue_path=$queue" >> "$GITHUB_OUTPUT"
           python3 scripts/prepare_signed_queue.py validate "$queue"
           previous_queue="$RUNNER_TEMP/previous-snap-queue.json"
-          initial=false
+          authenticate_queue=false
           if git cat-file -e "$BASE_SHA:$queue" 2> /dev/null; then
             git show "$BASE_SHA:$queue" > "$previous_queue"
           elif [ "$(jq -r '.state' "$queue")" != "paused" ] || ! jq -e '
@@ -62,7 +62,7 @@ jobs:
             echo "new queue must start paused with untouched pending items" >&2
             exit 1
           else
-            initial=true
+            authenticate_queue=true
           fi
           queue_id="$(jq -r '.queue_id' "$queue")"
           if [ "$(jq -r '.state' "$queue")" = "active" ]; then
@@ -78,8 +78,20 @@ jobs:
               exit 1
             fi
           fi
-          echo "initial=$initial" >> "$GITHUB_OUTPUT"
-          if [ "$initial" = "true" ]; then
+          if [ "$(jq -r '.state' "$queue")" = "paused" ]; then
+            if [ -f "$previous_queue" ]; then
+              python3 scripts/prepare_signed_queue.py verify-paused-transition \
+                "$queue" --previous-queue "$previous_queue"
+              if jq -e --slurpfile previous "$previous_queue" '
+                .dispatch != $previous[0].dispatch
+                or .release != $previous[0].release
+              ' "$queue" > /dev/null; then
+                authenticate_queue=true
+              fi
+            fi
+          fi
+          echo "initial=$authenticate_queue" >> "$GITHUB_OUTPUT"
+          if [ "$authenticate_queue" = "true" ]; then
             printf 'queue_id=%s\n' "$queue_id" >> "$GITHUB_OUTPUT"
             for field in corpus_ref rules_engine_ref rulespec_ref; do
               printf '%s=%s\n' "$field" \
@@ -92,11 +104,7 @@ jobs:
               "$(jq -r '.release.content_sha256' "$queue")" >> "$GITHUB_OUTPUT"
           fi
           if [ "$(jq -r '.state' "$queue")" = "paused" ]; then
-            if [ -f "$previous_queue" ]; then
-              python3 scripts/prepare_signed_queue.py verify-paused-transition \
-                "$queue" --previous-queue "$previous_queue"
-            fi
-            echo "Queue is paused; no activation evidence is required."
+            echo "Queue is paused; authenticated regeneration runs when required."
             exit 0
           fi
 
@@ -204,6 +212,7 @@ jobs:
         if: ${{ steps.transition.outputs.initial == 'true' }}
         env:
           CORPUS_RELEASE_PUBLIC_KEY: ${{ vars.AXIOM_CORPUS_RELEASE_PUBLIC_KEY }}
+          GH_TOKEN: ${{ github.token }}
           QUEUE_PATH: ${{ steps.transition.outputs.queue_path }}
           RELEASE_NAME: ${{ steps.transition.outputs.release_name }}
           RELEASE_SHA: ${{ steps.transition.outputs.release_sha }}
@@ -219,6 +228,29 @@ jobs:
             "${{ steps.transition.outputs.rulespec_ref }}"
           test "$(git -C initial-axiom-rules-engine rev-parse HEAD)" = \
             "${{ steps.transition.outputs.rules_engine_ref }}"
+          api_version="2026-03-10"
+          test "$(gh api \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: $api_version" \
+            repos/TheAxiomFoundation/rulespec-us/git/ref/heads/hard-cut/canonical-layout-us \
+            --jq '.object.sha')" = "${{ steps.transition.outputs.rulespec_ref }}"
+          git -C initial-axiom-rules-engine merge-base --is-ancestor \
+            "${{ steps.transition.outputs.rules_engine_ref }}" \
+            refs/remotes/origin/main
+          gh api --paginate --slurp \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: $api_version" \
+            "repos/TheAxiomFoundation/axiom-rules-engine/commits/${{ steps.transition.outputs.rules_engine_ref }}/check-runs?per_page=100" \
+            > "$RUNNER_TEMP/rules-engine-check-runs.json"
+          jq -e '
+            [.[].check_runs[]] as $checks
+            | ($checks | length) > 0
+            and all(
+              $checks[];
+              .status == "completed"
+              and (.conclusion | IN("success", "neutral", "skipped"))
+            )
+          ' "$RUNNER_TEMP/rules-engine-check-runs.json" > /dev/null
 
           response="$RUNNER_TEMP/corpus-release-response.json"
           release_object="$RUNNER_TEMP/corpus-release-object.json"

--- a/changelog.d/snap-queue-signed-release-repin.fixed.md
+++ b/changelog.d/snap-queue-signed-release-repin.fixed.md
@@ -1,0 +1,1 @@
+Allow a pristine paused SNAP queue to move to a newer signed corpus release, reviewed RuleSpec tip, and rules engine only when CI regenerates the complete queue from exact authenticated inputs.

--- a/data/encoding-queues/us-snap-all-states-2026-07.json
+++ b/data/encoding-queues/us-snap-all-states-2026-07.json
@@ -1,13 +1,13 @@
 {
   "description": "All-state SNAP logical source-unit inventory for the 50 states and District of Columbia. Every item requires an encoder disposition.",
   "dispatch": {
-    "corpus_ref": "0fd35bfbda98836c406ec539a492c4e661c6695d",
+    "corpus_ref": "d9d6fba0b9069c7e0f0ed4255817b3e78c00dd64",
     "country": "us",
     "max_batch_size": 4,
     "open_pr": true,
     "pr_base_branch": "hard-cut/canonical-layout-us",
-    "rules_engine_ref": "05eac9d2f89dabe5c6673176260762cef3a58f47",
-    "rulespec_ref": "8f224620540f9e285428ec839d094835396f7d99"
+    "rules_engine_ref": "4658144031f8ef1b39a971eb7002997fa0880b5a",
+    "rulespec_ref": "38ddc92d4160a0d39af13bfe232a446b554a15c5"
   },
   "expected_counts": {
     "total": 17784,
@@ -177914,9 +177914,9 @@
   "pause_reason": "Awaiting a green, independently reviewed exact RuleSpec protected-branch tip.",
   "queue_id": "us-snap-all-states-2026-07",
   "release": {
-    "content_sha256": "cb275c76c4f07f8ad37470a32296bb1763e5db853d152697524ab07021b6d544",
-    "manifest_sha256": "be18ff3f1557f4e30a1520e519e4d14b31c01122534ca1690294729bb7029691",
-    "name": "us-rulespec-2026-07-24-snap-cms-pit-union"
+    "content_sha256": "aa034219ef1519a31c0f354149bfd4b873fb5d8f2804b5cfe78c2813ee8af4e5",
+    "manifest_sha256": "13678b8a4fd05e2d026d9531346f2344bd157bc0f146810244ad9a8a620f7d5a",
+    "name": "us-rulespec-2026-08-03-ecps-pit-tariff-union"
   },
   "schema": "axiom-encode/signed-encoding-queue/v1",
   "state": "paused",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1565"
+version = "0.2.1566"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -72,6 +72,10 @@ REVIEWED_RULESPEC_REFS = frozenset(
         ),
         (
             "us",
+            "38ddc92d4160a0d39af13bfe232a446b554a15c5",
+        ),
+        (
+            "us",
             "6535019ce780d9e78f10509f2fe7a2607fb2bdc4",
         ),
         (

--- a/scripts/prepare_signed_queue.py
+++ b/scripts/prepare_signed_queue.py
@@ -1480,15 +1480,51 @@ def verify_paused_transition(
         raise ValueError("paused transition verification requires a paused queue")
     for field in (
         "description",
-        "dispatch",
         "expected_counts",
         "issue",
         "queue_id",
-        "release",
         "schema",
     ):
         if queue[field] != previous[field]:
             raise ValueError(f"paused queue transition changed trusted field {field}")
+    toolchain_repin = (
+        queue["dispatch"] != previous["dispatch"]
+        or queue["release"] != previous["release"]
+    )
+    if toolchain_repin:
+        if previous["state"] != "paused":
+            raise ValueError("paused queue toolchain repin requires a paused base")
+        unchanged_dispatch_fields = set(queue["dispatch"]) - {
+            "corpus_ref",
+            "rules_engine_ref",
+            "rulespec_ref",
+        }
+        if any(
+            queue["dispatch"][field] != previous["dispatch"][field]
+            for field in unchanged_dispatch_fields
+        ):
+            raise ValueError("paused queue toolchain repin changed dispatch policy")
+        if any(
+            queue["dispatch"][field] == previous["dispatch"][field]
+            for field in ("corpus_ref", "rules_engine_ref", "rulespec_ref")
+        ):
+            raise ValueError(
+                "paused queue toolchain repin must replace every source pin"
+            )
+        if queue["release"] == previous["release"]:
+            raise ValueError(
+                "paused queue toolchain repin must replace the signed release"
+            )
+        if (
+            queue.get("suspension") is not None
+            or previous.get("suspension") is not None
+        ):
+            raise ValueError("suspended queue cannot use a pristine toolchain repin")
+        if queue["items"] != previous["items"] or not all(
+            item["status"] == "pending" and item["attempt"] == 1
+            for item in queue["items"]
+        ):
+            raise ValueError("paused queue toolchain repin requires pristine items")
     if previous["state"] == "paused" and queue.get("suspension") != previous.get(
         "suspension"
     ):

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1565"
+__version__ = "0.2.1566"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_all_state_snap_queue.py
+++ b/tests/test_all_state_snap_queue.py
@@ -462,3 +462,45 @@ def test_all_state_preparation_uses_authenticated_release_builder() -> None:
     assert "AXIOM_CORPUS_RELEASE_PUBLIC_KEY" in workflow
     assert "NEXT_PUBLIC_SUPABASE_ANON_KEY" in workflow
     assert "--state paused" in workflow
+    assert "d9d6fba0b9069c7e0f0ed4255817b3e78c00dd64" in workflow
+    assert "4658144031f8ef1b39a971eb7002997fa0880b5a" in workflow
+    assert "38ddc92d4160a0d39af13bfe232a446b554a15c5" in workflow
+
+
+def test_all_state_queue_repin_is_regenerated_from_authenticated_inputs() -> None:
+    queue = json.loads(
+        (ROOT / "data/encoding-queues/us-snap-all-states-2026-07.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    workflow = (
+        ROOT / ".github/workflows/validate-snap-queue-activation.yml"
+    ).read_text(encoding="utf-8")
+
+    assert queue["dispatch"] == {
+        "corpus_ref": "d9d6fba0b9069c7e0f0ed4255817b3e78c00dd64",
+        "country": "us",
+        "max_batch_size": 4,
+        "open_pr": True,
+        "pr_base_branch": "hard-cut/canonical-layout-us",
+        "rules_engine_ref": "4658144031f8ef1b39a971eb7002997fa0880b5a",
+        "rulespec_ref": "38ddc92d4160a0d39af13bfe232a446b554a15c5",
+    }
+    assert queue["release"] == {
+        "content_sha256": (
+            "aa034219ef1519a31c0f354149bfd4b873fb5d8f2804b5cfe78c2813ee8af4e5"
+        ),
+        "manifest_sha256": (
+            "13678b8a4fd05e2d026d9531346f2344bd157bc0f146810244ad9a8a620f7d5a"
+        ),
+        "name": "us-rulespec-2026-08-03-ecps-pit-tariff-union",
+    }
+    assert "authenticate_queue=true" in workflow
+    assert ".dispatch != $previous[0].dispatch" in workflow
+    assert ".release != $previous[0].release" in workflow
+    assert "cmp --silent" in workflow
+    assert '"$QUEUE_PATH" "$generated_queue"' in workflow
+    assert "rulespec-us/git/ref/heads/hard-cut/canonical-layout-us" in workflow
+    assert "initial-axiom-rules-engine merge-base --is-ancestor" in workflow
+    assert "rules-engine-check-runs.json" in workflow
+    assert "($checks | length) > 0" in workflow

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1565"
+ENCODER_VERSION = "0.2.1566"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1565"
+ENCODER_VERSION = "0.2.1566"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1565"
+ENCODER_VERSION = "0.2.1566"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1565"
+ENCODER_VERSION = "0.2.1566"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1565"
+ENCODER_VERSION = "0.2.1566"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1565"
+ENCODER_VERSION = "0.2.1566"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1565"
+ENCODER_VERSION = "0.2.1566"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -2626,6 +2626,7 @@ def test_validate_rulespec_base_rejects_stale_main_pr_base(
         ("us", "68cca4a6fa806b63f95277c129575d88d2ac07f1"),
         ("us", "1e04e456ab404860050586c34eef51321eea95e9"),
         ("us", "b1a6e07af093d62f613f83afe26fcb4dd87de491"),
+        ("us", "38ddc92d4160a0d39af13bfe232a446b554a15c5"),
         ("us", "6535019ce780d9e78f10509f2fe7a2607fb2bdc4"),
         ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
     ],
@@ -2644,6 +2645,7 @@ def test_validate_rulespec_base_accepts_exact_reviewed_head_artifact_only(
             ("us", "68cca4a6fa806b63f95277c129575d88d2ac07f1"),
             ("us", "1e04e456ab404860050586c34eef51321eea95e9"),
             ("us", "b1a6e07af093d62f613f83afe26fcb4dd87de491"),
+            ("us", "38ddc92d4160a0d39af13bfe232a446b554a15c5"),
             ("us", "6535019ce780d9e78f10509f2fe7a2607fb2bdc4"),
             ("ca", "f60f7a84c30e38c7d4961d70647eb0457e7d76c2"),
         }

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1565"')
+        .startswith('__version__ = "0.2.1566"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1565"
+    assert encoder_package["version"] == "0.2.1566"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1565"
+    assert project["project"]["version"] == "0.2.1566"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1565"')
+        .startswith('__version__ = "0.2.1566"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1565"
+    assert encoder_package["version"] == "0.2.1566"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1565"
+    assert project["project"]["version"] == "0.2.1566"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1565"')
+        .startswith('__version__ = "0.2.1566"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1565"
+ENCODER_VERSION = "0.2.1566"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signed_snap_queue.py
+++ b/tests/test_signed_snap_queue.py
@@ -179,6 +179,54 @@ def test_paused_transition_rejects_manual_completion(tmp_path: Path) -> None:
         verify_paused_transition(current, previous_queue_path=previous)
 
 
+def test_paused_transition_accepts_only_pristine_complete_toolchain_repin(
+    tmp_path: Path,
+) -> None:
+    previous_payload = _queue(active=False)
+    current_payload = copy.deepcopy(previous_payload)
+    current_payload["dispatch"].update(
+        {
+            "corpus_ref": "1" * 40,
+            "rules_engine_ref": "2" * 40,
+            "rulespec_ref": "3" * 40,
+        }
+    )
+    current_payload["release"] = {
+        "content_sha256": "4" * 64,
+        "manifest_sha256": "5" * 64,
+        "name": "replacement-signed-release",
+    }
+    previous = tmp_path / "previous.json"
+    current = tmp_path / "current.json"
+    previous.write_text(json.dumps(previous_payload), encoding="utf-8")
+    current.write_text(json.dumps(current_payload), encoding="utf-8")
+
+    verify_paused_transition(current, previous_queue_path=previous)
+
+    current_payload["items"][0]["attempt"] = 2
+    current.write_text(json.dumps(current_payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="requires pristine items"):
+        verify_paused_transition(current, previous_queue_path=previous)
+
+
+def test_paused_transition_rejects_partial_toolchain_repin(tmp_path: Path) -> None:
+    previous_payload = _queue(active=False)
+    current_payload = copy.deepcopy(previous_payload)
+    current_payload["dispatch"]["rules_engine_ref"] = "2" * 40
+    current_payload["release"] = {
+        "content_sha256": "4" * 64,
+        "manifest_sha256": "5" * 64,
+        "name": "replacement-signed-release",
+    }
+    previous = tmp_path / "previous.json"
+    current = tmp_path / "current.json"
+    previous.write_text(json.dumps(previous_payload), encoding="utf-8")
+    current.write_text(json.dumps(current_payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must replace every source pin"):
+        verify_paused_transition(current, previous_queue_path=previous)
+
+
 def test_selectable_snap_queue_returns_history_scan_pool() -> None:
     candidates = selectable_items(_queue())
 

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -3493,7 +3493,9 @@ def test_snap_queue_activation_checks_and_merge_revalidate_live_state() -> None:
     assert '--finalizer-jobs "$RUNNER_TEMP/finalizer-jobs.json"' in validate_command
     assert "snap-queue-finalization-$run_id" in validate_command
     assert "git/ref/heads/hard-cut/canonical-layout-us" in validate_command
-    assert 'echo "initial=$initial" >> "$GITHUB_OUTPUT"' in validate_command
+    assert 'echo "initial=$authenticate_queue" >> "$GITHUB_OUTPUT"' in validate_command
+    assert ".dispatch != $previous[0].dispatch" in validate_command
+    assert ".release != $previous[0].release" in validate_command
 
     steps = validate["jobs"]["validate"]["steps"]
     initial_checkouts = [
@@ -3530,6 +3532,11 @@ def test_snap_queue_activation_checks_and_merge_revalidate_live_state() -> None:
     assert "unsupported initial SNAP queue" in provenance_command
     assert "--state paused" in provenance_command
     assert "cmp --silent" in provenance_command
+    assert "rulespec-us/git/ref/heads/hard-cut/canonical-layout-us" in (
+        provenance_command
+    )
+    assert "initial-axiom-rules-engine merge-base --is-ancestor" in (provenance_command)
+    assert "rules-engine-check-runs.json" in provenance_command
 
     merge = yaml.safe_load(
         (ROOT / ".github/workflows/merge-snap-queue-activation.yml").read_text()

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1565"
+version = "0.2.1566"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- permit a toolchain repin only for a pristine paused SNAP queue with byte-identical item inventory
- regenerate the complete queue in CI from the signed corpus release and exact corpus, live protected RuleSpec, and merged green rules-engine refs
- repin all 17,784 SNAP source units to the August signed release and temporal-fix engine without changing any item identity
- admit the independently reviewed RuleSpec hard-cut tip and bump axiom-encode to 0.2.1566

## Provenance
- signed corpus release: `us-rulespec-2026-08-03-ecps-pit-tariff-union` / `aa034219...`
- corpus commit: `d9d6fba0b9069c7e0f0ed4255817b3e78c00dd64`
- RuleSpec hard-cut tip: `38ddc92d4160a0d39af13bfe232a446b554a15c5`
- rules engine: `4658144031f8ef1b39a971eb7002997fa0880b5a`
- queue item SHA-256 before and after: `dbf52b9558daf0a4b56d5d76f6f218a105cb35cad044373e3e558fb9c68c4c93`

## Checks
- authenticated local full regeneration is byte-identical to the committed queue
- 1,650 passed, 31 skipped across signed queue, backfill, RuleSpec validation, and version/oracle registry suites
- full Ruff check and format check
- Python compileall
- workflow YAML parse
- exact transition validation against the current main queue

## Review cycle
Independent cloud multi-agent review is running on exact head `a4d130ab0`. Keep draft until it returns clean, hosted checks are green, and any main advance is rebased and re-reviewed.