### PR TITLE
Support state paths in authenticated repair replay

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -493,7 +493,8 @@ jobs:
             --country "$COUNTRY" \
             --source-ref "$repair_source_rulespec_ref" \
             --current-ref "$RULESPEC_REF" \
-            --candidate-path "$repair_candidate_path"
+            --candidate-path "$repair_candidate_path" \
+            --rulespec-path "$REPLACE_RULESPEC_PATH"
           echo "root=$(jq -r '.root' "$RUNNER_TEMP/repair-candidate.json")" \
             >> "$GITHUB_OUTPUT"
           echo "path=$(jq -r '.path' "$RUNNER_TEMP/repair-candidate.json")" \

--- a/changelog.d/state-repair-path.fixed.md
+++ b/changelog.d/state-repair-path.fixed.md
@@ -1,0 +1,1 @@
+Allow authenticated repair replay for state RuleSpec paths such as `us-la/statutes/...` while keeping generated candidate paths lane-relative and binding base-advance checks to the exact repository-relative target, companion test, and manifest paths.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1585"
+version = "0.2.1586"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/extract_repair_candidate.py
+++ b/scripts/extract_repair_candidate.py
@@ -21,6 +21,7 @@ MAX_ARCHIVE_MEMBERS = 8192
 SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
 COMMIT_PATTERN = re.compile(r"[0-9a-f]{40}")
 RUNNER_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+JURISDICTION_PATTERN = re.compile(r"[a-z]{2,3}(?:-[a-z0-9]+)*")
 CONTRACT = runpy.run_path(
     Path(__file__).parents[1] / "src/axiom_encode/repair_candidate_contract.py"
 )
@@ -146,10 +147,13 @@ def _verified_generated_file(
 
 def _expected_module_path(country: str, replace_rulespec_path: str) -> str:
     path = PurePosixPath(replace_rulespec_path)
+    jurisdiction = path.parts[0] if path.parts else ""
     if (
         path.is_absolute()
+        or path.as_posix() != replace_rulespec_path
         or len(path.parts) < 3
-        or path.parts[0] != country
+        or JURISDICTION_PATTERN.fullmatch(jurisdiction) is None
+        or (jurisdiction != country and not jurisdiction.startswith(f"{country}-"))
         or path.parts[1] not in ATOMIC_ROOTS
         or path.suffix != ".yaml"
         or path.name.endswith(".test.yaml")

--- a/scripts/verify_repair_base_advance.py
+++ b/scripts/verify_repair_base_advance.py
@@ -12,6 +12,7 @@ ATOMIC_ROOTS = frozenset(
     {"guidance", "manuals", "policies", "programs", "regulations", "statutes"}
 )
 COMMIT_PATTERN = re.compile(r"[0-9a-f]{40}")
+JURISDICTION_PATTERN = re.compile(r"[a-z]{2,3}(?:-[a-z0-9]+)*")
 
 
 def _git(
@@ -32,12 +33,14 @@ def verify_base_advance(
     source_ref: str,
     current_ref: str,
     candidate_path: str,
+    rulespec_path: str | None = None,
 ) -> None:
     repository = repository.resolve()
     path = PurePosixPath(candidate_path)
     if (
         re.fullmatch(r"[a-z][a-z0-9-]*", country) is None
         or path.is_absolute()
+        or path.as_posix() != candidate_path
         or len(path.parts) < 2
         or path.parts[0] not in ATOMIC_ROOTS
         or path.suffix != ".yaml"
@@ -71,16 +74,47 @@ def verify_base_advance(
     if ancestor.returncode != 0:
         raise ValueError("repair source RuleSpec ref is not an ancestor of current")
 
-    rulespec_path = PurePosixPath(country, path)
+    repository_path = (
+        PurePosixPath(rulespec_path)
+        if rulespec_path is not None
+        else PurePosixPath(country, path)
+    )
+    jurisdiction = repository_path.parts[0] if repository_path.parts else ""
+    if (
+        repository_path.is_absolute()
+        or (rulespec_path is not None and repository_path.as_posix() != rulespec_path)
+        or len(repository_path.parts) < 3
+        or JURISDICTION_PATTERN.fullmatch(jurisdiction) is None
+        or (jurisdiction != country and not jurisdiction.startswith(f"{country}-"))
+        or repository_path.parts[1] not in ATOMIC_ROOTS
+        or repository_path.suffix != ".yaml"
+        or repository_path.name.endswith(".test.yaml")
+        or any(part in {"", ".", ".."} for part in repository_path.parts)
+        or PurePosixPath(*repository_path.parts[1:]) != path
+    ):
+        raise ValueError("repair repository RuleSpec path is not canonical")
     test_path = path.with_suffix(".test.yaml")
     manifest_path = (
-        PurePosixPath(".axiom", "encoding-manifests") / rulespec_path
+        PurePosixPath(".axiom", "encoding-manifests") / repository_path
     ).with_suffix(".json")
     tracked_paths = (
-        rulespec_path.as_posix(),
-        PurePosixPath(country, test_path).as_posix(),
+        repository_path.as_posix(),
+        PurePosixPath(repository_path.parts[0], test_path).as_posix(),
         manifest_path.as_posix(),
     )
+    for tracked_path in tracked_paths:
+        exists_at_source = _git(
+            repository,
+            "cat-file",
+            "-e",
+            f"{source_ref}:{tracked_path}",
+            check=False,
+        )
+        if exists_at_source.returncode != 0:
+            raise ValueError(
+                "repair replay target identity is missing at its source RuleSpec "
+                f"base: {tracked_path}"
+            )
     unchanged = _git(
         repository,
         "diff",
@@ -106,6 +140,7 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--source-ref", required=True)
     parser.add_argument("--current-ref", required=True)
     parser.add_argument("--candidate-path", required=True)
+    parser.add_argument("--rulespec-path")
     return parser
 
 
@@ -117,6 +152,7 @@ def main() -> int:
         source_ref=args.source_ref,
         current_ref=args.current_ref,
         candidate_path=args.candidate_path,
+        rulespec_path=args.rulespec_path,
     )
     return 0
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1585"
+__version__ = "0.2.1586"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1585"
+ENCODER_VERSION = "0.2.1586"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_extract_repair_candidate.py
+++ b/tests/test_extract_repair_candidate.py
@@ -13,6 +13,7 @@ from scripts.extract_repair_candidate import (
     MAX_ARCHIVE_MEMBERS,
     MAX_CANDIDATE_BYTES,
     SINGLE_TARGET_MODE_FIELDS,
+    _expected_module_path,
     extract_candidate,
 )
 
@@ -115,6 +116,34 @@ def test_extracts_checksum_bound_final_candidate(tmp_path):
     assert result["source_rulespec_ref"] == "d" * 40
     assert (root / result["path"]).read_text() == "format: rulespec/v1\nrules: []\n"
     assert (root / "statutes/42/1437c-1.test.yaml").read_text() == "[]\n"
+
+
+def test_state_rulespec_path_maps_to_lane_relative_candidate_path():
+    assert (
+        _expected_module_path("us", "us-la/statutes/47/297/4.yaml")
+        == "statutes/47/297/4.yaml"
+    )
+
+
+@pytest.mark.parametrize(
+    "replace_rulespec_path",
+    (
+        "ca-la/statutes/47/297/4.yaml",
+        "us-/statutes/47/297/4.yaml",
+        "us-_/statutes/47/297/4.yaml",
+        "us-LA/statutes/47/297/4.yaml",
+        "us-la_foo/statutes/47/297/4.yaml",
+        "us-la//statutes/47/297/4.yaml",
+        "us-la/./statutes/47/297/4.yaml",
+        "us-la/other/47/297/4.yaml",
+        "us-la/statutes/47/297/4.test.yaml",
+        "us-la/statutes/../297/4.yaml",
+        "/us-la/statutes/47/297/4.yaml",
+    ),
+)
+def test_rejects_noncanonical_state_rulespec_path(replace_rulespec_path):
+    with pytest.raises(ValueError, match="not canonical"):
+        _expected_module_path("us", replace_rulespec_path)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1585"
+ENCODER_VERSION = "0.2.1586"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1585"
+ENCODER_VERSION = "0.2.1586"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1585"
+ENCODER_VERSION = "0.2.1586"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1585"
+ENCODER_VERSION = "0.2.1586"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1585"
+ENCODER_VERSION = "0.2.1586"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1585"
+ENCODER_VERSION = "0.2.1586"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1585"')
+        .startswith('__version__ = "0.2.1586"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1585"
+    assert encoder_package["version"] == "0.2.1586"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1585"
+    assert project["project"]["version"] == "0.2.1586"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1585"')
+        .startswith('__version__ = "0.2.1586"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1585"
+    assert encoder_package["version"] == "0.2.1586"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1585"
+    assert project["project"]["version"] == "0.2.1586"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1585"')
+        .startswith('__version__ = "0.2.1586"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1585"
+ENCODER_VERSION = "0.2.1586"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2128,6 +2128,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert '--source-ref "$repair_source_rulespec_ref"' in repair_command
     assert '--current-ref "$RULESPEC_REF"' in repair_command
     assert '--candidate-path "$repair_candidate_path"' in repair_command
+    assert '--rulespec-path "$REPLACE_RULESPEC_PATH"' in repair_command
     assert 'echo "runner=$(jq -r' in repair_command
     assert 'echo "source_rulespec_ref=$repair_source_rulespec_ref"' in repair_command
 

--- a/tests/test_verify_repair_base_advance.py
+++ b/tests/test_verify_repair_base_advance.py
@@ -24,13 +24,14 @@ def _repository(
     tmp_path: Path,
     *,
     candidate_path: str = "statutes/42/1437c-1.yaml",
+    jurisdiction: str = "us",
 ) -> tuple[Path, str]:
     repository = tmp_path / "rulespec-us"
     repository.mkdir()
     subprocess.run(["git", "-C", str(repository), "init", "-q"], check=True)
     _git(repository, "config", "user.email", "test@example.com")
     _git(repository, "config", "user.name", "Test")
-    rulespec_path = Path("us") / candidate_path
+    rulespec_path = Path(jurisdiction) / candidate_path
     payloads = {
         rulespec_path: "format: rulespec/v1\n",
         rulespec_path.with_suffix(".test.yaml"): "tests: []\n",
@@ -57,6 +58,114 @@ def test_accepts_ancestor_base_when_repair_target_identity_is_unchanged(
         current_ref=current_ref,
         candidate_path="statutes/42/1437c-1.yaml",
     )
+
+
+def test_accepts_state_jurisdiction_repository_path(tmp_path: Path) -> None:
+    candidate_path = "statutes/47/297/4.yaml"
+    repository, source_ref = _repository(
+        tmp_path,
+        candidate_path=candidate_path,
+        jurisdiction="us-la",
+    )
+    (repository / "unrelated.txt").write_text("advance\n", encoding="utf-8")
+    current_ref = _commit(repository, "unrelated advance")
+
+    verify_base_advance(
+        repository,
+        country="us",
+        source_ref=source_ref,
+        current_ref=current_ref,
+        candidate_path=candidate_path,
+        rulespec_path="us-la/statutes/47/297/4.yaml",
+    )
+
+
+def test_rejects_mismatched_state_candidate_repository_path(
+    tmp_path: Path,
+) -> None:
+    candidate_path = "statutes/47/297/4.yaml"
+    repository, source_ref = _repository(
+        tmp_path,
+        candidate_path=candidate_path,
+        jurisdiction="us-la",
+    )
+
+    with pytest.raises(ValueError, match="repository RuleSpec path"):
+        verify_base_advance(
+            repository,
+            country="us",
+            source_ref=source_ref,
+            current_ref=source_ref,
+            candidate_path=candidate_path,
+            rulespec_path="us-la/statutes/47/297/8.yaml",
+        )
+
+
+@pytest.mark.parametrize(
+    "rulespec_path",
+    [
+        "ca-la/statutes/47/297/4.yaml",
+        "us-/statutes/47/297/4.yaml",
+        "us-_/statutes/47/297/4.yaml",
+        "us-LA/statutes/47/297/4.yaml",
+        "us-la_foo/statutes/47/297/4.yaml",
+        "us-la//statutes/47/297/4.yaml",
+        "us-la/./statutes/47/297/4.yaml",
+        "us-la/other/47/297/4.yaml",
+        "us-la/statutes/47/297/4.test.yaml",
+        "us-la/statutes/../297/4.yaml",
+        "/us-la/statutes/47/297/4.yaml",
+    ],
+)
+def test_rejects_noncanonical_state_repository_path(
+    tmp_path: Path,
+    rulespec_path: str,
+) -> None:
+    candidate_path = "statutes/47/297/4.yaml"
+    repository, source_ref = _repository(
+        tmp_path,
+        candidate_path=candidate_path,
+        jurisdiction="us-la",
+    )
+
+    with pytest.raises(ValueError, match="repository RuleSpec path"):
+        verify_base_advance(
+            repository,
+            country="us",
+            source_ref=source_ref,
+            current_ref=source_ref,
+            candidate_path=candidate_path,
+            rulespec_path=rulespec_path,
+        )
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "us/statutes/42/1437c-1.yaml",
+        "us/statutes/42/1437c-1.test.yaml",
+        ".axiom/encoding-manifests/us/statutes/42/1437c-1.json",
+    ],
+)
+def test_rejects_target_identity_missing_at_source_base(
+    tmp_path: Path,
+    relative_path: str,
+) -> None:
+    repository, _ = _repository(tmp_path)
+    subprocess.run(
+        ["git", "-C", str(repository), "rm", "-q", "--", relative_path],
+        check=True,
+    )
+    source_ref = _commit(repository, "source without identity path")
+
+    with pytest.raises(ValueError, match="missing at its source RuleSpec base"):
+        verify_base_advance(
+            repository,
+            country="us",
+            source_ref=source_ref,
+            current_ref=source_ref,
+            candidate_path="statutes/42/1437c-1.yaml",
+        )
 
 
 @pytest.mark.parametrize(
@@ -149,6 +258,8 @@ def test_rejects_current_ref_that_is_not_checkout_head(tmp_path: Path) -> None:
         ("../us", "statutes/42/1437c-1.yaml"),
         ("us", "../statutes/42/1437c-1.yaml"),
         ("us", "/statutes/42/1437c-1.yaml"),
+        ("us", "statutes//42/1437c-1.yaml"),
+        ("us", "statutes/./42/1437c-1.yaml"),
         ("us", "statutes/42/1437c-1.test.yaml"),
     ],
 )

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1585"
+version = "0.2.1586"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary\n\n- accept state-jurisdiction replacement paths such as us-la/statutes/... when extracting an authenticated repair candidate for the rulespec-us repository\n- keep the generated repair candidate lane-relative while passing the exact repository-relative path separately to base-advance verification\n- bind unchanged checks to the exact state module, companion test, and descriptor-relative manifest\n- bump encoder to 0.2.1586\n\n## Production failure\n\nProtected run 31060963371 rejected the authenticated repair artifact for run 31060219683 before model execution because extract_repair_candidate compared us-la to country us. The original run and repair both failed closed and created no RuleSpec PR or signed apply.\n\n## Validation\n\n- 1,583 passed, 82 skipped across repair extraction, base advance, signing supervisor, version, and registry suites\n- Ruff check and format clean\n- compileall and git diff check clean\n\n## Review cycle\n\nIndependent review pending. Keep draft until the cycle is CLEAN and hosted checks pass.