### PR TITLE
Recognize bounded tax-year formula prefaces

### DIFF
--- a/changelog.d/complete-source-tax-year-range-preface.fixed.md
+++ b/changelog.d/complete-source-tax-year-range-preface.fixed.md
@@ -1,0 +1,3 @@
+Recognize bounded tax-year applicability prefaces when matching complete-source
+formula computations, so their date endpoints are not treated as arithmetic
+operands.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1587"
+version = "0.2.1588"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1587"
+__version__ = "0.2.1588"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -702,6 +702,11 @@ _FORMULA_APPLICABILITY_DATE = (
 )
 _FORMULA_APPLICABILITY_PREFACE = re.compile(
     rf"^\s*(?:(?:\([^)]+\)|[A-Z]\.)\s*)?(?:"
+    rf"(?:for|during)\s+(?:the\s+)?"
+    rf"(?:tax(?:able)?|calendar|fiscal|assessment)\s+years?\s+"
+    rf"beginning\s+(?:after|on)\s+{_FORMULA_APPLICABILITY_DATE}"
+    rf"(?:\s+and\s+ending\s+(?:before|on)\s+"
+    rf"{_FORMULA_APPLICABILITY_DATE})?\s*,?|(?:"
     rf"beginning\s+(?:on\s+)?{_FORMULA_APPLICABILITY_DATE}"
     rf"(?:,?\s+and\s+thereafter)?|"
     rf"(?:for|during)\s+(?:the\s+)?"
@@ -709,7 +714,7 @@ _FORMULA_APPLICABILITY_PREFACE = re.compile(
     rf"{_FORMULA_APPLICABILITY_YEAR}|"
     rf"(?:effective(?:\s+(?:on|from))?|starting(?:\s+(?:on|from))?|"
     rf"as\s+of|on\s+or\s+after)\s+{_FORMULA_APPLICABILITY_DATE}"
-    rf")\s*,",
+    rf")\s*,)",
     flags=re.IGNORECASE,
 )
 _STATED_CONVERSION_CUE = re.compile(

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1587"
+ENCODER_VERSION = "0.2.1588"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1587"
+ENCODER_VERSION = "0.2.1588"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1587"
+ENCODER_VERSION = "0.2.1588"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1587"
+ENCODER_VERSION = "0.2.1588"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1587"
+ENCODER_VERSION = "0.2.1588"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1587"
+ENCODER_VERSION = "0.2.1588"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1587"
+ENCODER_VERSION = "0.2.1588"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1587"')
+        .startswith('__version__ = "0.2.1588"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1587"
+    assert encoder_package["version"] == "0.2.1588"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1587"
+    assert project["project"]["version"] == "0.2.1588"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1587"')
+        .startswith('__version__ = "0.2.1588"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1587"
+    assert encoder_package["version"] == "0.2.1588"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1587"
+    assert project["project"]["version"] == "0.2.1588"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1587"')
+        .startswith('__version__ = "0.2.1588"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1587"
+ENCODER_VERSION = "0.2.1588"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -10974,6 +10974,7 @@ rules:
     (
         "Effective January 1, 2026, the amount is calculated by multiplying income by the rate.",
         "Beginning January 1, 2026 and thereafter, the amount is calculated by multiplying income by the rate.",
+        "For tax years beginning after December 31, 2005 and ending before January 1, 2007, the amount is calculated by multiplying income by the rate.",
     ),
 )
 def test_common_formula_applicability_prefaces_are_not_coefficients(source):
@@ -11021,6 +11022,108 @@ rules:
     )
 
     assert not result.issues
+
+
+def test_tax_year_range_preface_does_not_hide_following_percentage():
+    source = (
+        "(i) For tax years beginning after December 31, 2005 and ending before "
+        "January 1, 2007, twenty-five percent of the unreduced federal credit."
+    )
+    occurrences = EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR(source)
+
+    temporal = [item for item in occurrences if item.has_temporal_context]
+    substantive = [item for item in occurrences if not item.has_temporal_context]
+
+    assert temporal
+    assert all(
+        completeness_module._temporal_occurrence_is_formula_applicability_preface(
+            item, source
+        )
+        for item in temporal
+    )
+    assert any(item.value == 25 for item in substantive)
+    assert all(
+        not completeness_module._temporal_occurrence_is_formula_applicability_preface(
+            item, source
+        )
+        for item in substantive
+    )
+
+
+def test_tax_year_range_prefaces_allow_distinct_temporal_rate_witnesses():
+    source = """\
+(i) For tax years beginning after December 31, 2005 and ending before January 1, 2007, twenty-five percent of the unreduced federal credit.
+(ii) For tax years beginning after December 31, 2006 fifty percent of the unreduced federal credit.
+"""
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-la/statute/47:297.4
+rules:
+  - name: credit_percentage
+    kind: parameter
+    dtype: Rate
+    source: La. R.S. 47:297.4(A)(1)(a)(i)-(ii)
+    versions:
+      - effective_from: '2006-01-01'
+        formula: 0.25
+      - effective_from: '2007-01-01'
+        formula: 0.50
+  - name: child_care_expense_credit
+    kind: derived
+    dtype: Money
+    source: La. R.S. 47:297.4(A)(1)(a)(i)-(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-la/statute/47:297.4
+              excerpt: >-
+                (i) For tax years beginning after December 31, 2005 and ending before January 1, 2007, twenty-five percent of the unreduced federal credit.
+          - path: versions[1].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-la/statute/47:297.4
+              excerpt: >-
+                (ii) For tax years beginning after December 31, 2006 fifty percent of the unreduced federal credit.
+    versions:
+      - effective_from: '2006-01-01'
+        formula: credit_percentage * unreduced_federal_credit
+      - effective_from: '2007-01-01'
+        formula: credit_percentage * unreduced_federal_credit
+"""
+    cases = [
+        {
+            "name": "subparagraph i",
+            "period": "2006",
+            "input": {"unreduced_federal_credit": 1000},
+            "output": {"child_care_expense_credit": 250},
+        },
+        {
+            "name": "subparagraph ii",
+            "period": "2007",
+            "input": {"unreduced_federal_credit": 1000},
+            "output": {"child_care_expense_credit": 500},
+        },
+    ]
+
+    result = analyze_complete_source_unit(
+        content,
+        source,
+        corpus_citation_path="us-la/statute/47:297.4",
+        test_cases=cases,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+        extract_named_scalars=extract_named_scalar_occurrences,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
+
+    assert not _has_issue(result, "formula branch")
 
 
 def test_temporal_formula_filter_keeps_substantive_multiplier_grounding():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1587"
+version = "0.2.1588"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- recognize source formula applicability phrased as tax years beginning after a date and optionally ending before a date
- keep applicability dates out of complete-source arithmetic matching while preserving the following percentage operand
- add the exact Louisiana 25%/50% temporal branch regression

## Checks
- `pytest -q tests/test_source_completeness.py -k "common_formula_applicability_prefaces or tax_year_range_preface or temporal_formula_operand_remains"` (10 passed)
- `pytest -q tests/test_source_completeness.py tests/test_rulespec_validation.py -k "complete_source or formula_applicability or temporal_formula or version or registry"` (83 passed)
- `ruff check pyproject.toml src/axiom_encode/harness/source_completeness.py tests/test_source_completeness.py`
- `ruff format --check src/axiom_encode/harness/source_completeness.py tests/test_source_completeness.py`
- `python -m compileall -q src/axiom_encode`

## Review cycle
Pending independent review.