### PR TITLE
Fix complete-source conjoined income intervals

### DIFF
--- a/changelog.d/complete-source-conjoined-income-interval.fixed.md
+++ b/changelog.d/complete-source-conjoined-income-interval.fixed.md
@@ -1,0 +1,1 @@
+Recognize conjoined lower and upper income limits as one bounded formula interval so complete-source tests do not misclassify the upper threshold as a computation operand.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1588"
+version = "0.2.1589"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1588"
+__version__ = "0.2.1589"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -9501,6 +9501,32 @@ def _formula_interval_from_text(
         r"exceeds?|exceeding|above)\b",
         lowered_range,
     ):
+        if len(occurrences) >= 2:
+            upper_gap = text[occurrences[0].end : occurrences[1].start]
+            normalized_upper_gap = " ".join(upper_gap.replace(",", " , ").split())
+            upper_match = re.fullmatch(
+                r"(?:(?:dollars?|usd|euros?|eur) )?(?:, )?"
+                r"(?:and|und) "
+                r"(?P<comparison>"
+                r"less than or equal to|less than|below|at most|"
+                r"weniger als oder gleich|weniger als|höchstens"
+                r")",
+                normalized_upper_gap,
+                flags=re.IGNORECASE,
+            )
+            if upper_match is not None:
+                inclusive = upper_match.group("comparison").lower() in {
+                    "less than or equal to",
+                    "at most",
+                    "weniger als oder gleich",
+                    "höchstens",
+                }
+                return _NumericInterval(
+                    occurrences[0],
+                    False,
+                    occurrences[1],
+                    inclusive,
+                )
         return _NumericInterval(occurrences[0], False, None, False)
     if re.match(
         r"(?:von|ab|from|at\s+least|mindestens)\b",

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1588"
+ENCODER_VERSION = "0.2.1589"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1588"
+ENCODER_VERSION = "0.2.1589"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1588"
+ENCODER_VERSION = "0.2.1589"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1588"
+ENCODER_VERSION = "0.2.1589"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1588"
+ENCODER_VERSION = "0.2.1589"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1588"
+ENCODER_VERSION = "0.2.1589"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1588"
+ENCODER_VERSION = "0.2.1589"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1588"')
+        .startswith('__version__ = "0.2.1589"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1588"
+    assert encoder_package["version"] == "0.2.1589"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1588"
+    assert project["project"]["version"] == "0.2.1589"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1588"')
+        .startswith('__version__ = "0.2.1589"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1588"
+    assert encoder_package["version"] == "0.2.1589"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1588"
+    assert project["project"]["version"] == "0.2.1589"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1588"')
+        .startswith('__version__ = "0.2.1589"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1588"
+ENCODER_VERSION = "0.2.1589"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -1757,6 +1757,148 @@ B.(1) If the credit against Louisiana income tax for resident individuals whose 
 
 
 @pytest.mark.parametrize(
+    ("comparison", "upper_inclusive"),
+    (
+        ("less than or equal to", True),
+        ("less than", False),
+    ),
+)
+def test_formula_interval_recognizes_conjoined_upper_bound(
+    comparison: str,
+    upper_inclusive: bool,
+):
+    source = (
+        "(2) If income is greater than twenty-five thousand dollars and "
+        f"{comparison} thirty-five thousand dollars, the credit equals "
+        "thirty percent of the federal credit."
+    )
+    branch = recognize_source_structure(source)[0]
+
+    interval = completeness_module._formula_branch_interval(
+        branch,
+        extract_numeric_occurrences=EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR,
+    )
+
+    assert interval is not None
+    assert interval.lower is not None
+    assert interval.lower.value == 25000
+    assert not interval.lower_inclusive
+    assert interval.upper is not None
+    assert interval.upper.value == 35000
+    assert interval.upper_inclusive is upper_inclusive
+
+
+def test_formula_interval_rejects_long_nonmatching_upper_gap_with_bounded_runtime():
+    source = "income greater than 1" + (" " * 10_000) + "x 2"
+
+    started = time.perf_counter()
+    interval = completeness_module._formula_interval_from_text(
+        source,
+        extract_numeric_occurrences=EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR,
+    )
+    elapsed = time.perf_counter() - started
+
+    assert interval is not None
+    assert interval.lower is not None
+    assert interval.lower.value == 1
+    assert interval.upper is None
+    assert elapsed < 0.5
+
+
+def test_conjoined_income_range_formula_has_executed_companion_witness():
+    source = """\
+(2) If the resident individual's federal adjusted gross income is greater than twenty-five thousand dollars and less than or equal to thirty-five thousand dollars, the credit shall be equal to thirty percent of the federal credit for child care expenses claimed on the resident individual's federal tax return.
+"""
+    content = yaml.safe_dump(
+        {
+            "format": "rulespec/v1",
+            "module": {
+                "source_verification": {
+                    "corpus_citation_path": "us-la/statute/47:297.4"
+                }
+            },
+            "rules": [
+                {
+                    "name": "middle_income_lower_bound",
+                    "kind": "parameter",
+                    "versions": [{"formula": "25000"}],
+                },
+                {
+                    "name": "middle_income_limit",
+                    "kind": "parameter",
+                    "versions": [{"formula": "35000"}],
+                },
+                {
+                    "name": "middle_income_rate",
+                    "kind": "parameter",
+                    "versions": [{"formula": "0.30"}],
+                },
+                {
+                    "name": "middle_income_credit",
+                    "kind": "derived",
+                    "source": "us-la/statute/47:297.4(2)",
+                    "metadata": {
+                        "proof": {
+                            "atoms": [
+                                {
+                                    "path": "versions[0].formula",
+                                    "kind": "formula",
+                                    "source": {
+                                        "corpus_citation_path": (
+                                            "us-la/statute/47:297.4"
+                                        ),
+                                        "excerpt": source.strip(),
+                                    },
+                                }
+                            ]
+                        }
+                    },
+                    "versions": [
+                        {
+                            "formula": (
+                                "if federal_adjusted_gross_income > "
+                                "middle_income_lower_bound and "
+                                "federal_adjusted_gross_income <= "
+                                "middle_income_limit: middle_income_rate * "
+                                "federal_credit else: 0"
+                            )
+                        }
+                    ],
+                },
+            ],
+        }
+    )
+    cases = [
+        {
+            "name": "inside_middle_income_range",
+            "period": "2024",
+            "input": {
+                "federal_adjusted_gross_income": 25001,
+                "federal_credit": 600,
+            },
+            "output": {
+                "us-la:statutes/47/297/4#middle_income_credit": 180,
+            },
+        }
+    ]
+
+    analysis = analyze_complete_source_unit(
+        content,
+        source,
+        corpus_citation_path="us-la/statute/47:297.4",
+        test_cases=cases,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        extract_numeric_grounding_occurrences=(
+            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
+        ),
+        extract_named_scalars=extract_named_scalar_occurrences,
+        numeric_value_is_grounded=numeric_value_is_grounded,
+    )
+
+    assert not _has_issue(analysis, "formula branch (2)")
+
+
+@pytest.mark.parametrize(
     "source",
     (
         "A. The tax equals income * 2:\n(1) This rule applies to residents.\nB. End.",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1588"
+version = "0.2.1589"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary\n- recognize conjoined upper bounds after a greater-than lower bound in complete-source formula intervals\n- preserve inclusive/exclusive upper-bound semantics for the Louisiana child-care credit bands\n- normalize the numeric gap before fixed-token matching to keep malformed inputs linear-time\n- bump encoder runtime and registry pins to 0.2.1589\n\n## Production evidence\nProtected repair run 31068350653 produced a valid executable witness for Louisiana R.S. 47:297.4(A)(2): AGI 25,001, federal credit 600, output 180. The validator parsed only the lower bound and therefore rejected that witness. Under this change the exact source clause parses as (25,000, 35,000], and the production-shaped completeness test accepts the executed 180 output.\n\n## Checks\n- independent review cycle: CLEAN at b4818ba95afd04c5755fa08123c9b15e0b79bd69\n- full source-completeness module: 1,522 passed\n- prior broad local run before the resource hardening: 2,978 passed, 31 skipped\n- changed oracle registry suites: 24 passed\n- focused version/lock tests: 40 passed\n- Ruff: passed\n- compileall: passed\n- git diff --check: passed\n- adversarial nonmatching gap: linear through 1,000,000 whitespace characters\n\n## Review cycle\nThe first independent review found cubic backtracking in the initial optional-whitespace regex. The implementation was amended to normalize the bounded grammar and use fixed-token matching, an adversarial regression was added, and the post-fix independent review returned CLEAN.