### PR TITLE
Allow hash-bound unchanged signed apply files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1616"
+version = "0.2.1617"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -1345,8 +1345,8 @@ def _validate_legacy_exact_dependents(
     live_manifests: set[PurePosixPath],
     manifest_payloads: dict[PurePosixPath, dict[str, object]],
     changed: set[PurePosixPath],
-) -> set[PurePosixPath]:
-    """Verify every v2 exact dependent and return unchanged authorized files."""
+) -> set[tuple[PurePosixPath, PurePosixPath]]:
+    """Verify v2 exact dependents and return manifest-bound unchanged claims."""
 
     from axiom_encode.cli import (
         _legacy_primary_source_citations,
@@ -1364,7 +1364,7 @@ def _validate_legacy_exact_dependents(
         raise ValueError(
             f"legacy replacement exact_dependents are malformed: {root_manifest}"
         )
-    unchanged_authorized: set[PurePosixPath] = set()
+    unchanged_authorized: set[tuple[PurePosixPath, PurePosixPath]] = set()
     seen_primaries: set[PurePosixPath] = set()
     seen_group_paths: set[PurePosixPath] = set()
     seen_manifests: set[PurePosixPath] = set()
@@ -1561,7 +1561,7 @@ def _validate_legacy_exact_dependents(
                 continue
             if base_by_path[path] != live_by_path[path] or path in changed:
                 raise ValueError(f"{label} unrewritten file differs: {path}")
-            unchanged_authorized.add(path)
+            unchanged_authorized.add((expected_manifest, path))
 
         if expected_manifest not in live_manifests or expected_manifest not in changed:
             raise ValueError(f"{label} lacks a changed exact dependent manifest")
@@ -1663,10 +1663,21 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
 
     authorized = set(live_manifests)
     authorized_unchanged: set[PurePosixPath] = set()
+    authenticated_unchanged_claims: set[tuple[PurePosixPath, PurePosixPath]] = set()
+    unchanged_claims: set[tuple[PurePosixPath, PurePosixPath]] = set()
     for relative, payload in manifest_payloads.items():
+        tool = payload.get("tool")
+        backend = payload.get("backend")
+        if tool == MODEL_APPLY_TOOL and (
+            not isinstance(backend, str) or backend not in MODEL_APPLY_BACKENDS
+        ):
+            raise ValueError(
+                f"model apply manifest has an unsupported backend: {relative}"
+            )
+        is_model_apply = tool == MODEL_APPLY_TOOL
         replacement = payload.get("replacement")
         receipt_rewrites: set[PurePosixPath] = set()
-        if payload.get("tool") == LEGACY_REPLACEMENT_TOOL:
+        if tool == LEGACY_REPLACEMENT_TOOL:
             if not isinstance(replacement, dict):
                 raise ValueError(f"legacy replacement binding is malformed: {relative}")
             receipt_relative = _safe_relative_path(
@@ -2229,6 +2240,9 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                         )
                     if live_path not in changed:
                         authorized_unchanged.add(live_path)
+                        authenticated_unchanged_claims.add(
+                            (retained_manifest, live_path)
+                        )
                 authorized.add(retained_old_manifest)
             expected_applied_files = [
                 *live_files,
@@ -2447,20 +2461,22 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
             }:
+                exact_unchanged_claims = _validate_legacy_exact_dependents(
+                    repo,
+                    root_manifest=relative,
+                    receipt_relative=receipt_relative,
+                    receipt_sha256=hashlib.sha256(receipt_raw).hexdigest(),
+                    receipt=receipt,
+                    receipt_replacement=receipt_replacement,
+                    base_commit=str(base_commit or ""),
+                    authoritative_replacements=authoritative_replacements,
+                    live_manifests=live_manifests,
+                    manifest_payloads=manifest_payloads,
+                    changed=changed,
+                )
+                authenticated_unchanged_claims.update(exact_unchanged_claims)
                 authorized_unchanged.update(
-                    _validate_legacy_exact_dependents(
-                        repo,
-                        root_manifest=relative,
-                        receipt_relative=receipt_relative,
-                        receipt_sha256=hashlib.sha256(receipt_raw).hexdigest(),
-                        receipt=receipt,
-                        receipt_replacement=receipt_replacement,
-                        base_commit=str(base_commit or ""),
-                        authoritative_replacements=authoritative_replacements,
-                        live_manifests=live_manifests,
-                        manifest_payloads=manifest_payloads,
-                        changed=changed,
-                    )
+                    path for _manifest, path in exact_unchanged_claims
                 )
             authorized.update({receipt_relative, old_manifest_path, *receipt_rewrites})
 
@@ -2477,6 +2493,52 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
             if applied_path not in receipt_rewrites:
                 _validate_rulespec_path(repo, applied_path, label=label)
             authorized.add(applied_path)
+            if is_model_apply:
+                digest = entry.get("sha256")
+                if (
+                    set(entry) != {"path", "sha256"}
+                    or not isinstance(digest, str)
+                    or DIGEST_PATTERN.fullmatch(digest) is None
+                ):
+                    raise ValueError(
+                        f"{relative} applied_files[{index}] must bind an exact sha256"
+                    )
+                live_raw = _read_bounded_regular(
+                    repo,
+                    applied_path,
+                    label="model-applied file",
+                    max_bytes=16 * 1024 * 1024,
+                )
+                if hashlib.sha256(live_raw).hexdigest() != digest:
+                    raise ValueError(
+                        f"{relative} applied_files[{index}] differs from its signed "
+                        "sha256"
+                    )
+                if applied_path not in changed:
+                    try:
+                        base_raw = _git(
+                            repo,
+                            "show",
+                            f"HEAD:{applied_path.as_posix()}",
+                        )
+                    except subprocess.CalledProcessError as exc:
+                        raise ValueError(
+                            f"{relative} unchanged applied_files[{index}] is not an "
+                            "existing clean-HEAD file"
+                        ) from exc
+                    if hashlib.sha256(base_raw).hexdigest() != digest:
+                        raise ValueError(
+                            f"{relative} unchanged applied_files[{index}] differs "
+                            "from its signed sha256"
+                        )
+                    authorized_unchanged.add(applied_path)
+                    authenticated_unchanged_claims.add((relative, applied_path))
+            elif (
+                tool == LEGACY_REPLACEMENT_TOOL and applied_path in authorized_unchanged
+            ):
+                authenticated_unchanged_claims.add((relative, applied_path))
+            if applied_path not in changed:
+                unchanged_claims.add((relative, applied_path))
 
     if deleted_manifests - authorized:
         raise ValueError(
@@ -2484,6 +2546,11 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
             + ", ".join(map(str, sorted(deleted_manifests - authorized)))
         )
 
+    authorized_unchanged.difference_update(
+        path
+        for manifest, path in unchanged_claims
+        if (manifest, path) not in authenticated_unchanged_claims
+    )
     authorized.difference_update(authorized_unchanged)
     unexpected = changed - authorized
     missing = authorized - changed

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1616"
+__version__ = "0.2.1617"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1616"
+ENCODER_VERSION = "0.2.1617"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1616"
+ENCODER_VERSION = "0.2.1617"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1616"
+ENCODER_VERSION = "0.2.1617"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1616"
+ENCODER_VERSION = "0.2.1617"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1616"
+ENCODER_VERSION = "0.2.1617"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1616"
+ENCODER_VERSION = "0.2.1617"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1616"
+ENCODER_VERSION = "0.2.1617"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -1778,6 +1778,192 @@ def test_stage_authorized_changes_stages_only_manifest_and_applied_files(
     )
 
 
+def _write_model_change_with_unchanged_companion(
+    repo: Path,
+    *,
+    companion_sha256: str | None = None,
+) -> tuple[Path, Path, Path]:
+    companion = repo / "us/regulations/example.test.yaml"
+    companion.parent.mkdir(parents=True)
+    companion.write_text("- name: existing\n", encoding="utf-8")
+    _git(repo, "add", companion.relative_to(repo).as_posix())
+    _git(repo, "commit", "-m", "add existing companion")
+
+    rule = repo / "us/regulations/example.yaml"
+    rule.write_text("rules: []\n", encoding="utf-8")
+    manifest = repo / ".axiom/encoding-manifests/us/regulations/example.json"
+    manifest.parent.mkdir(parents=True)
+    companion_entry: dict[str, str] = {"path": companion.relative_to(repo).as_posix()}
+    if companion_sha256 is not None:
+        companion_entry["sha256"] = companion_sha256
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": "axiom-encode/applied-rulespec/v5",
+                "tool": "axiom-encode encode --apply",
+                "backend": "openai",
+                "applied_files": [
+                    {
+                        "path": rule.relative_to(repo).as_posix(),
+                        "sha256": hashlib.sha256(rule.read_bytes()).hexdigest(),
+                    },
+                    companion_entry,
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return rule, companion, manifest
+
+
+def test_stage_accepts_hash_bound_unchanged_model_applied_file(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    companion_sha256 = hashlib.sha256(b"- name: existing\n").hexdigest()
+    rule, companion, manifest = _write_model_change_with_unchanged_companion(
+        repo,
+        companion_sha256=companion_sha256,
+    )
+
+    stage_authorized_changes(repo)
+
+    assert _git(repo, "diff", "--cached", "--name-only").splitlines() == sorted(
+        [str(manifest.relative_to(repo)), str(rule.relative_to(repo))]
+    )
+    assert (
+        companion.relative_to(repo).as_posix()
+        not in _git(repo, "diff", "--cached", "--name-only").splitlines()
+    )
+
+
+def test_stage_rejects_unbound_unchanged_model_applied_file(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    _write_model_change_with_unchanged_companion(repo)
+
+    with pytest.raises(ValueError, match="must bind an exact sha256"):
+        stage_authorized_changes(repo)
+
+
+def test_stage_rejects_wrong_hash_for_unchanged_model_applied_file(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    _write_model_change_with_unchanged_companion(repo, companion_sha256="a" * 64)
+
+    with pytest.raises(ValueError, match="differs from its signed sha256"):
+        stage_authorized_changes(repo)
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        {"path": "us/regulations/example.yaml"},
+        {
+            "path": "us/regulations/example.yaml",
+            "sha256": False,
+            "extra": [],
+        },
+    ],
+)
+def test_stage_rejects_malformed_changed_model_applied_file(
+    tmp_path: Path,
+    entry: dict[str, object],
+) -> None:
+    repo = _repo(tmp_path)
+    _rule, _companion, manifest = _write_model_change_with_unchanged_companion(
+        repo,
+        companion_sha256=hashlib.sha256(b"- name: existing\n").hexdigest(),
+    )
+    payload = json.loads(manifest.read_text(encoding="utf-8"))
+    payload["applied_files"][0] = entry
+    manifest.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must bind an exact sha256"):
+        stage_authorized_changes(repo)
+
+
+def test_stage_rejects_wrong_hash_for_changed_model_applied_file(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    _rule, _companion, manifest = _write_model_change_with_unchanged_companion(
+        repo,
+        companion_sha256=hashlib.sha256(b"- name: existing\n").hexdigest(),
+    )
+    payload = json.loads(manifest.read_text(encoding="utf-8"))
+    payload["applied_files"][0]["sha256"] = "a" * 64
+    manifest.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="differs from its signed sha256"):
+        stage_authorized_changes(repo)
+
+
+def test_stage_rejects_unsupported_model_backend(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    _rule, _companion, manifest = _write_model_change_with_unchanged_companion(
+        repo,
+        companion_sha256=hashlib.sha256(b"- name: existing\n").hexdigest(),
+    )
+    payload = json.loads(manifest.read_text(encoding="utf-8"))
+    payload["backend"] = "unsupported"
+    manifest.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unsupported backend"):
+        stage_authorized_changes(repo)
+
+
+@pytest.mark.parametrize("mutation", ["delete", "symlink", "executable"])
+def test_stage_rejects_noncanonical_changed_model_applied_file(
+    tmp_path: Path,
+    mutation: str,
+) -> None:
+    repo = _repo(tmp_path)
+    _rule, companion, _manifest = _write_model_change_with_unchanged_companion(
+        repo,
+        companion_sha256=hashlib.sha256(b"- name: existing\n").hexdigest(),
+    )
+    if mutation == "delete":
+        companion.unlink()
+    elif mutation == "symlink":
+        companion.unlink()
+        companion.symlink_to("example.yaml")
+    else:
+        companion.chmod(0o755)
+
+    with pytest.raises(ValueError, match="model-applied file"):
+        stage_authorized_changes(repo)
+
+
+def test_stage_rejects_borrowed_unchanged_exemption_across_manifests(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    _rule, companion, _manifest = _write_model_change_with_unchanged_companion(
+        repo,
+        companion_sha256=hashlib.sha256(b"- name: existing\n").hexdigest(),
+    )
+    second_rule = repo / "us/regulations/second.yaml"
+    second_rule.write_text("rules: []\n", encoding="utf-8")
+    second_manifest = repo / ".axiom/encoding-manifests/us/regulations/second.json"
+    second_manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": "axiom-encode/applied-rulespec/v5",
+                "tool": "unsupported",
+                "applied_files": [
+                    {"path": second_rule.relative_to(repo).as_posix()},
+                    {"path": companion.relative_to(repo).as_posix()},
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="authorizes paths that are not changed"):
+        stage_authorized_changes(repo)
+
+
 def test_stage_authorized_changes_rejects_unexpected_file(tmp_path: Path) -> None:
     repo = _repo(tmp_path)
     _write_signed_change(repo)

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1616"')
+        .startswith('__version__ = "0.2.1617"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1616"
+    assert encoder_package["version"] == "0.2.1617"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1616"
+    assert project["project"]["version"] == "0.2.1617"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1616"')
+        .startswith('__version__ = "0.2.1617"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1616"
+    assert encoder_package["version"] == "0.2.1617"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1616"
+    assert project["project"]["version"] == "0.2.1617"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1616"')
+        .startswith('__version__ = "0.2.1617"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1616"
+ENCODER_VERSION = "0.2.1617"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1616"
+version = "0.2.1617"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- allow a fresh supported model apply manifest to retain an applied file already byte-identical to clean HEAD
- validate every supported model entry as exact `{path, sha256}` evidence against bounded regular `0644` live bytes, whether changed or unchanged
- additionally bind unchanged entries to the exact HEAD bytes and stage only actual changes
- bind unchanged exemptions to individual authenticated manifest/path claims so overlapping manifests cannot borrow authorization
- reject unsupported model backends, malformed or wrong hashes, live-file deletions, symlinks, and mode-only executable changes
- preserve authenticated legacy exact-dependent and retained-successor behavior
- bump encoder release identity to `0.2.1617`

## Incident

Fresh Louisiana run `31092291242` generated and signed a changed `47:294` rule plus a test companion already identical to protected RuleSpec tip `38ddc92d4160a0d39af13bfe232a446b554a15c5`. The generated checkpoint passed, but publication staging rejected the manifest because the unchanged companion was authorized but absent from the Git delta. No canonical refresh lane or durable publication ran. The failed run will never be rerun or reapproved. This PR repairs the general signed-manifest/delta contract before a new atomic dispatch.

## Validation

- prescribed Ruff check: green
- focused Ruff format check: green
- `python -m compileall -q src/axiom_encode scripts`: green
- `tests/test_prepare_signed_backfill.py`: `144 passed`
- RuleSpec validation plus eight oracle registries and backfill tests: `1,593 passed, 31 skipped`
- post-commit encoder version provenance guard: green
- exact-head full repository suite: `8,860 passed, 119 skipped` in 8m47s
- hosted CI `31094244466`: green
- hosted signing supervisor `31094244532`: green

## Review cycle

The first exact-head review found two actionable integrity gaps in the initial patch: changed model entries bypassed strict evidence validation, and a path-global unchanged exemption could leak across manifests. Both were fixed and regression-tested. Two independent repeat reviews of exact head `1eaea30f9e4cd2268501407c44c1063db4de4495` are CLEAN. Reviewers replayed missing/false/extra/wrong hash cases, deletion, symlink, `0755`, bad backend, valid Louisiana staging, conflicting and overlapping manifest claims across multiple hash seeds, and real legacy exact/retained flows. One reviewer also completed an independent full suite with `8,860 passed, 119 skipped`. No actionable findings remain.