### PR TITLE
Bind retry diagnostics to rejected candidates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1617"
+version = "0.2.1618"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1617"
+__version__ = "0.2.1618"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -25128,6 +25128,7 @@ class _FailedEncodeAttempt(NamedTuple):
     result: Any
     error: str
     candidate: ValidationRetryCandidate | None = None
+    validation_issues: Sequence[str] = ()
 
 
 def _capture_validation_retry_candidate(
@@ -25278,70 +25279,100 @@ def _latest_validation_retry_candidate(
     return prior_attempts[-1].candidate if prior_attempts else None
 
 
+def _validation_retry_issue_snapshot(
+    *issue_groups: object,
+) -> tuple[str, ...]:
+    """Snapshot bounded validator issues that match one captured candidate."""
+
+    issues: list[str] = []
+    seen: set[str] = set()
+    inspection_limit = VALIDATION_RETRY_FEEDBACK_MAX_ITEMS * 4
+    for issue_group in issue_groups:
+        if not isinstance(issue_group, Sequence) or isinstance(
+            issue_group, (str, bytes)
+        ):
+            continue
+        inspected = 0
+        issue_iterator = iter(issue_group)
+        while (
+            len(issues) < VALIDATION_RETRY_FEEDBACK_MAX_ITEMS
+            and inspected < inspection_limit
+        ):
+            try:
+                issue = next(issue_iterator)
+            except StopIteration:
+                break
+            inspected += 1
+            if not isinstance(issue, str):
+                continue
+            item = bounded_validation_retry_feedback_item(issue)
+            if not item or item in seen:
+                continue
+            seen.add(item)
+            issues.append(item)
+        if len(issues) >= VALIDATION_RETRY_FEEDBACK_MAX_ITEMS:
+            break
+    return tuple(issues)
+
+
 def _encode_validation_retry_feedback(
     prior_attempts: Sequence[_FailedEncodeAttempt],
 ) -> tuple[str, ...]:
-    """Interleave bounded validator guidance across recent failed attempts."""
+    """Return bounded validator guidance for the immediately preceding candidate."""
+
+    if not prior_attempts:
+        return ()
 
     feedback_limit = VALIDATION_RETRY_FEEDBACK_MAX_ITEMS
-    attempt_feedback: list[list[str]] = []
-
-    for failed_attempt in reversed(prior_attempts[-feedback_limit:]):
-        items: list[str] = []
-        seen_in_attempt: set[str] = set()
-
-        def add_attempt_item(raw_item: object) -> None:
-            if len(items) >= feedback_limit or not isinstance(raw_item, str):
-                return
-            item = bounded_validation_retry_feedback_item(raw_item)
-            if not item or item in seen_in_attempt:
-                return
-            seen_in_attempt.add(item)
-            items.append(item)
-
-        add_attempt_item(failed_attempt.error)
-        metrics = getattr(failed_attempt.result, "metrics", None)
-        inspected_issues = 0
-        for attribute in ("compile_issues", "ci_issues"):
-            issues = getattr(metrics, attribute, ())
-            if isinstance(issues, Sequence) and not isinstance(issues, (str, bytes)):
-                issue_iterator = iter(issues)
-                for _ in range(feedback_limit - inspected_issues):
-                    try:
-                        issue = next(issue_iterator)
-                    except StopIteration:
-                        break
-                    inspected_issues += 1
-                    add_attempt_item(issue)
-            if inspected_issues >= feedback_limit:
-                break
-        if items:
-            attempt_feedback.append(items)
-
     feedback: list[str] = []
     feedback_chars = 0
     seen: set[str] = set()
 
-    def add(raw_item: str) -> None:
+    def add(raw_item: object) -> None:
         nonlocal feedback_chars
+        if not isinstance(raw_item, str):
+            return
+        item = bounded_validation_retry_feedback_item(raw_item)
         if (
             len(feedback) >= feedback_limit
-            or raw_item in seen
-            or feedback_chars + len(raw_item)
-            > VALIDATION_RETRY_FEEDBACK_MAX_TOTAL_CHARS
+            or not item
+            or item in seen
+            or feedback_chars + len(item) > VALIDATION_RETRY_FEEDBACK_MAX_TOTAL_CHARS
         ):
             return
-        seen.add(raw_item)
-        feedback.append(raw_item)
-        feedback_chars += len(raw_item)
+        seen.add(item)
+        feedback.append(item)
+        feedback_chars += len(item)
 
-    for item_index in range(max((len(items) for items in attempt_feedback), default=0)):
-        for items in attempt_feedback:
-            if item_index < len(items):
-                add(items[item_index])
-        if len(feedback) >= feedback_limit:
-            break
+    failed_attempt = prior_attempts[-1]
+    add(failed_attempt.error)
+    issues = failed_attempt.validation_issues
+    if isinstance(issues, Sequence) and not isinstance(issues, (str, bytes)):
+        issue_iterator = iter(issues)
+        for _ in range(feedback_limit):
+            try:
+                issue = next(issue_iterator)
+            except StopIteration:
+                break
+            add(issue)
     return tuple(feedback)
+
+
+def _encode_validation_retry_context(
+    prior_attempts: Sequence[_FailedEncodeAttempt],
+    *,
+    initial_retry_candidate: ValidationRetryCandidate | None,
+) -> tuple[tuple[str, ...], ValidationRetryCandidate | None]:
+    """Bind validator feedback to the exact candidate that produced it."""
+
+    if not prior_attempts:
+        return (), initial_retry_candidate
+    candidate = _latest_validation_retry_candidate(prior_attempts)
+    if candidate is None:
+        raise RuntimeError(
+            "Immediately preceding validator-rejected candidate is unavailable"
+        )
+    return _encode_validation_retry_feedback(prior_attempts), candidate
 
 
 class _EncodeAttemptExecution(NamedTuple):
@@ -25349,6 +25380,7 @@ class _EncodeAttemptExecution(NamedTuple):
     outcome: dict[str, Any]
     apply_passed: bool
     logged_run: EncodingRun | None
+    validation_issues: tuple[str, ...]
 
 
 class _EncodeReplacementTarget(NamedTuple):
@@ -27264,6 +27296,7 @@ def _run_encode_attempts_with_retries(
                     result=execution.result,
                     error=retry_error,
                     candidate=candidate,
+                    validation_issues=execution.validation_issues,
                 )
         if next_model is not None:
             action = "retrying" if next_model == current_model else "escalating"
@@ -27475,6 +27508,12 @@ def _run_encode_attempt(
     if replacement_target is not None:
         extra_context_paths.extend(replacement_target.context_paths)
     extra_context_paths.extend(required_import_paths)
+    validation_retry_feedback, validation_retry_candidate = (
+        _encode_validation_retry_context(
+            prior_attempts,
+            initial_retry_candidate=initial_retry_candidate,
+        )
+    )
     results = run_model_eval(
         citations=[args.citation],
         runner_specs=[runner],
@@ -27497,12 +27536,8 @@ def _run_encode_attempt(
             if replacement_target is not None
             else None
         ),
-        validation_retry_feedback=_encode_validation_retry_feedback(prior_attempts),
-        validation_retry_candidate=(
-            initial_retry_candidate
-            if initial_retry_candidate is not None
-            else _latest_validation_retry_candidate(prior_attempts)
-        ),
+        validation_retry_feedback=validation_retry_feedback,
+        validation_retry_candidate=validation_retry_candidate,
         required_import_targets=required_import_targets,
         legacy_replacement=(
             replacement_target.legacy_replacement
@@ -27592,6 +27627,13 @@ def _run_encode_attempt(
 
     outcome = _initial_encode_outcome(result, apply_requested=apply_requested)
     apply_passed = False
+    retry_validation_issues: tuple[str, ...] = ()
+    metrics = getattr(result, "metrics", None)
+    if metrics is not None:
+        retry_validation_issues = _validation_retry_issue_snapshot(
+            getattr(metrics, "compile_issues", ()),
+            getattr(metrics, "ci_issues", ()),
+        )
     if apply_requested:
         if not _can_attempt_apply(result):
             detail = str(getattr(result, "error", None) or "generation failed")
@@ -30212,6 +30254,7 @@ def _run_encode_attempt(
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
+                retry_validation_issues = _validation_retry_issue_snapshot(apply_issues)
                 detail = (
                     apply_issues[0]
                     if apply_issues
@@ -30302,6 +30345,9 @@ def _run_encode_attempt(
                         apply_issues = required_import_issues
                         outcome["overlay_validation_success"] = False
                 if not can_apply:
+                    retry_validation_issues = _validation_retry_issue_snapshot(
+                        apply_issues
+                    )
                     detail = (
                         apply_issues[0]
                         if apply_issues
@@ -30343,6 +30389,7 @@ def _run_encode_attempt(
         outcome=outcome,
         apply_passed=apply_passed,
         logged_run=logged_run,
+        validation_issues=retry_validation_issues,
     )
 
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -9117,11 +9117,11 @@ def _format_validation_retry_feedback(feedback: Sequence[str]) -> str:
     if not rendered_items:
         return ""
     return f"""
-Deterministic validation feedback from prior generation attempts:
+Deterministic validation feedback for the rejected candidate below:
 - This is repair guidance from the validator, not legal authority. Keep the
   authoritative source and release-bound corpus evidence as the sole basis for
   legal facts and values.
-- Correct every listed issue in this attempt. Do not repeat the rejected
+- Correct every listed issue in this candidate. Do not repeat the rejected
   pattern.
 
 === BEGIN PRIOR VALIDATION FEEDBACK ===
@@ -9197,6 +9197,10 @@ def _build_rulespec_eval_prompt(
     required_import_targets: Sequence[str] = (),
 ) -> str:
     """Build the RuleSpec authoring prompt used by current evals."""
+    if validation_retry_feedback and validation_retry_candidate is None:
+        raise ValueError(
+            "Validation retry feedback requires its matching rejected candidate"
+        )
     source_text = workspace.source_text_file.read_text()
     corpus_citation_path = _workspace_corpus_citation_path(workspace)
     backend_section = ""

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1617"
+ENCODER_VERSION = "0.2.1618"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12878,8 +12878,8 @@ class TestCmdEncode:
         ] == [
             (),
             ("terra-1",),
-            ("terra-2", "terra-1"),
-            ("sol-1", "terra-2", "terra-1"),
+            ("terra-2",),
+            ("sol-1",),
         ]
         retry_candidates = [
             call.kwargs["validation_retry_candidate"]
@@ -12935,10 +12935,11 @@ class TestCmdEncode:
             result=SimpleNamespace(
                 metrics=SimpleNamespace(
                     compile_issues=[],
-                    ci_issues=[hint],
+                    ci_issues=["stale pre-repair diagnostic"],
                 )
             ),
             error="Generated RuleSpec failed CI validation",
+            validation_issues=(hint,),
         )
 
         assert cli_module._encode_validation_retry_feedback([failed_attempt]) == (
@@ -12946,7 +12947,7 @@ class TestCmdEncode:
             hint,
         )
 
-    def test_encode_retry_feedback_round_robins_across_failed_attempts(self):
+    def test_encode_retry_feedback_matches_only_latest_candidate(self):
         import axiom_encode.cli as cli_module
 
         generic_error = "Generated RuleSpec failed CI validation"
@@ -12956,13 +12957,14 @@ class TestCmdEncode:
                 result=SimpleNamespace(
                     metrics=SimpleNamespace(
                         compile_issues=[],
-                        ci_issues=list(issues),
+                        ci_issues=["stale pre-repair diagnostic"],
                     )
                 ),
                 error=generic_error,
+                validation_issues=issues,
             )
 
-        formula_output = (
+        stale_formula_output = (
             "[complete-source-unit:formula-output] parameter-only representation "
             "is invalid; bind the computation to a principal derived output"
         )
@@ -12971,20 +12973,20 @@ class TestCmdEncode:
         )
         feedback = cli_module._encode_validation_retry_feedback(
             [
-                failed_attempt(formula_output),
+                failed_attempt(stale_formula_output),
                 failed_attempt("middle companion-test failure"),
                 failed_attempt("latest branch-test failure", *latest_flood),
             ]
         )
 
         assert len(feedback) == 12
-        assert feedback[:4] == (
+        assert feedback[:2] == (
             generic_error,
             "latest branch-test failure",
-            "middle companion-test failure",
-            formula_output,
         )
-        assert feedback.index(formula_output) < feedback.index(latest_flood[0])
+        assert "middle companion-test failure" not in feedback
+        assert stale_formula_output not in feedback
+        assert latest_flood[0] in feedback
 
     def test_encode_retry_feedback_bounds_diagnostic_flood_inspection(self):
         import axiom_encode.cli as cli_module
@@ -13004,10 +13006,11 @@ class TestCmdEncode:
             result=SimpleNamespace(
                 metrics=SimpleNamespace(
                     compile_issues=[],
-                    ci_issues=issues,
+                    ci_issues=["stale pre-repair diagnostic"],
                 )
             ),
             error="Generated RuleSpec failed CI validation",
+            validation_issues=issues,
         )
 
         feedback = cli_module._encode_validation_retry_feedback([failed_attempt])
@@ -13017,6 +13020,43 @@ class TestCmdEncode:
         assert feedback[0] == "Generated RuleSpec failed CI validation"
         assert all(len(item) <= 16_000 for item in feedback)
         assert sum(map(len, feedback)) <= 64_000
+
+    def test_encode_retry_issue_snapshot_deduplicates_before_output_cap(self):
+        import axiom_encode.cli as cli_module
+
+        snapshot = cli_module._validation_retry_issue_snapshot(
+            ["repeated current issue"] * 12 + ["distinct current issue"]
+        )
+
+        assert snapshot == ("repeated current issue", "distinct current issue")
+
+    def test_encode_retry_issue_snapshot_bounds_invalid_iterator_inspection(self):
+        import axiom_encode.cli as cli_module
+
+        class EndlessInvalidIssues(list):
+            inspected = 0
+
+            def __iter__(self):
+                while True:
+                    self.inspected += 1
+                    yield None
+
+        issues = EndlessInvalidIssues()
+
+        assert cli_module._validation_retry_issue_snapshot(issues) == ()
+        assert issues.inspected == 48
+
+    def test_encode_retry_issue_snapshot_bounds_each_issue_group_independently(self):
+        import axiom_encode.cli as cli_module
+
+        assert cli_module._validation_retry_issue_snapshot(
+            [None] * 48,
+            ["current CI issue"],
+        ) == ("current CI issue",)
+        assert cli_module._validation_retry_issue_snapshot(
+            ["duplicate compile issue"] * 48,
+            ["current CI issue"],
+        ) == ("duplicate compile issue", "current CI issue")
 
     def test_encode_retry_feedback_retains_compound_diagnostic_tail(self):
         import axiom_encode.cli as cli_module
@@ -13031,10 +13071,11 @@ class TestCmdEncode:
             result=SimpleNamespace(
                 metrics=SimpleNamespace(
                     compile_issues=[],
-                    ci_issues=[diagnostic],
+                    ci_issues=["stale pre-repair diagnostic"],
                 )
             ),
             error="Generated RuleSpec failed CI validation",
+            validation_issues=(diagnostic,),
         )
 
         feedback = cli_module._encode_validation_retry_feedback([failed_attempt])
@@ -13141,7 +13182,7 @@ class TestCmdEncode:
         assert candidate.tests is not None
         assert "preserved-companion" in candidate.tests
 
-    def test_encode_keeps_cross_run_repair_candidate_as_retry_floor(self, tmp_path):
+    def test_encode_replaces_cross_run_candidate_after_in_run_rejection(self, tmp_path):
         candidate_root = tmp_path / "preserved-candidate"
         candidate_path = Path("statutes/26/1/j/2.yaml")
         output_file = candidate_root / candidate_path
@@ -13179,9 +13220,36 @@ class TestCmdEncode:
             for call in mock_run.call_args_list
         ]
         assert len(retry_candidates) == 2
-        assert retry_candidates[0] == retry_candidates[1]
-        assert "preserved-cross-run-rule" in retry_candidates[1].rulespec
-        assert "rejected-attempt-1" not in retry_candidates[1].rulespec
+        assert "preserved-cross-run-rule" in retry_candidates[0].rulespec
+        assert "rejected-attempt-1" in retry_candidates[1].rulespec
+        assert "preserved-cross-run-rule" not in retry_candidates[1].rulespec
+        assert mock_run.call_args_list[1].kwargs["validation_retry_feedback"] == (
+            "first candidate regressed",
+        )
+
+    def test_encode_retry_context_rejects_feedback_without_matching_candidate(self):
+        import axiom_encode.cli as cli_module
+
+        failed_attempt = cli_module._FailedEncodeAttempt(
+            result=SimpleNamespace(
+                metrics=SimpleNamespace(compile_issues=[], ci_issues=["fix me"])
+            ),
+            error="Generated RuleSpec failed CI validation",
+            candidate=None,
+            validation_issues=("fix me",),
+        )
+
+        with pytest.raises(
+            RuntimeError,
+            match="Immediately preceding validator-rejected candidate is unavailable",
+        ):
+            cli_module._encode_validation_retry_context(
+                [failed_attempt],
+                initial_retry_candidate=cli_module.ValidationRetryCandidate(
+                    rulespec="format: rulespec/v1\nrules: []\n",
+                    tests="[]\n",
+                ),
+            )
 
     @pytest.mark.parametrize(
         ("root", "relative_path", "message"),

--- a/tests/test_complete_source_mode_plumbing.py
+++ b/tests/test_complete_source_mode_plumbing.py
@@ -288,16 +288,22 @@ def test_eval_prompt_adds_prior_validation_feedback_only_when_supplied(tmp_path)
         "substantive numeric value in the source text. Complete-source "
         "stated-conversion hint: encode separate grounded parameters.",
     )
+    candidate = evals.ValidationRetryCandidate(
+        rulespec="format: rulespec/v1\nrules: []\n",
+        tests="[]\n",
+    )
 
     default_prompt = evals._build_eval_prompt(**kwargs)
     retry_prompt = evals._build_eval_prompt(
         **kwargs,
         validation_retry_feedback=feedback,
+        validation_retry_candidate=candidate,
     )
 
     assert "PRIOR VALIDATION FEEDBACK" not in default_prompt
     assert "PRIOR VALIDATION FEEDBACK" in retry_prompt
     assert "repair guidance from the validator, not legal authority" in retry_prompt
+    assert "feedback for the rejected candidate below" in retry_prompt
     assert feedback[0] in retry_prompt
 
 
@@ -311,6 +317,10 @@ def test_eval_prompt_preserves_compound_validation_feedback_tail(tmp_path):
     )
     final_control = "FINAL_REQUIRED_CONTROL_PAIR_MUST_REACH_MODEL"
     feedback = ("missing controls: " + "x" * 5_000 + final_control,)
+    candidate = evals.ValidationRetryCandidate(
+        rulespec="format: rulespec/v1\nrules: []\n",
+        tests="[]\n",
+    )
 
     prompt = evals._build_eval_prompt(
         citation="de/regulation/example/1",
@@ -321,10 +331,36 @@ def test_eval_prompt_preserves_compound_validation_feedback_tail(tmp_path):
         include_tests=True,
         runner_backend="openai",
         validation_retry_feedback=feedback,
+        validation_retry_candidate=candidate,
     )
 
     assert feedback[0] in prompt
     assert final_control in prompt
+
+
+def test_eval_prompt_rejects_retry_feedback_without_matching_candidate(tmp_path):
+    source_file = tmp_path / "source.txt"
+    source_file.write_text("The annual amount is 73 800.")
+    workspace = EvalWorkspace(
+        root=tmp_path,
+        source_text_file=source_file,
+        manifest_file=tmp_path / "context-manifest.json",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Validation retry feedback requires its matching rejected candidate",
+    ):
+        evals._build_eval_prompt(
+            citation="de/regulation/example/1",
+            mode="cold",
+            workspace=workspace,
+            context_files=[],
+            target_file_name="1.yaml",
+            include_tests=True,
+            runner_backend="openai",
+            validation_retry_feedback=("candidate-specific issue",),
+        )
 
 
 def test_run_model_eval_forces_tests_and_forwards_complete_mode(tmp_path):

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1617"
+ENCODER_VERSION = "0.2.1618"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1617"
+ENCODER_VERSION = "0.2.1618"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1617"
+ENCODER_VERSION = "0.2.1618"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1617"
+ENCODER_VERSION = "0.2.1618"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1617"
+ENCODER_VERSION = "0.2.1618"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1617"
+ENCODER_VERSION = "0.2.1618"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1617"')
+        .startswith('__version__ = "0.2.1618"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1617"
+    assert encoder_package["version"] == "0.2.1618"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1617"
+    assert project["project"]["version"] == "0.2.1618"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1617"')
+        .startswith('__version__ = "0.2.1618"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1617"
+    assert encoder_package["version"] == "0.2.1618"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1617"
+    assert project["project"]["version"] == "0.2.1618"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1617"')
+        .startswith('__version__ = "0.2.1618"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1617"
+ENCODER_VERSION = "0.2.1618"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1617"
+version = "0.2.1618"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- bind retry validation feedback to the exact immediately preceding rejected RuleSpec and tests candidate
- snapshot final post-auto-repair overlay issues instead of rereading stale standalone metrics
- bound and deduplicate issue inspection independently per validator group
- use a cross-run repair candidate only for the first in-run attempt and fail closed when a rejected candidate cannot be captured
- bump axiom-encode to 0.2.1618 in the same atomic commit as every encoder-affecting change

## Checks

- prescribed full suite: 8865 passed, 119 skipped
- full CLI regression before the atomic equivalent-tree rebuild: 1162 passed, 10 skipped
- eval and prompt regressions: 748 passed
- complete-source prompt plumbing: 17 passed
- final review focused retry, escalation, and cross-run suite: 39 passed
- version provenance: passed on final atomic head
- Ruff format check: passed
- Ruff check: passed
- compileall: passed
- diff check: passed
- exact-head hosted CI lint and tests: passed
- exact-head signing supervisor on Ubuntu and macOS: passed

## Review cycle

The independent review-fix-repeat cycle is clean on exact atomic head 164c327d728605c0de820502924be7693214e78d.

The first review found that a shared inspection budget could let malformed or duplicate compile diagnostics starve a valid CI diagnostic. The fix uses an independent bounded budget per validator group and adds direct starvation regressions.

A hosted formatting failure was fixed with Ruff. A second reviewer then identified that the formatter-only follow-up commit violated the encoder version provenance boundary. The branch was rebuilt as one atomic commit directly over main so the version bump and every encoder-affecting change share the same commit. Both reviewers independently verified that the final tree is byte-for-byte identical to the behaviorally reviewed formatted tree, that version provenance resolves to exact HEAD, and that no actionable findings remain.

No new concept or acronym token is introduced.