### PR TITLE
Fix state statute deferral path binding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1618"
+version = "0.2.1619"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1618"
+__version__ = "0.2.1619"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1682,8 +1682,8 @@ _SOURCE_BOUND_RUNTIME_GAP_LANGUAGE = re.compile(
 _ADMINISTRATIVE_SOURCE_ARTIFACT_LANGUAGE = re.compile(
     r"\b(?:"
     r"amendment|approval|audit|certification|comment|complaint|consultation|"
-    r"document|filing|hearing|inspection|notice|plan|procedure|recommendation|"
-    r"record|report|submission|waiver"
+    r"copy|document|filing|hearing|inspection|notice|plan|procedure|"
+    r"recommendation|record|report|return|submission|waiver"
     r")[a-z-]*\b",
     flags=re.IGNORECASE,
 )
@@ -1756,6 +1756,19 @@ def _imprecise_deferral_retry_shape(
                 "\nFor this rejected current-source branch, the literal citation "
                 f"required in `reason` is `{citation.title} U.S.C. "
                 f"{section}{fragments}`."
+            )
+    elif path:
+        citation_parts = [
+            part for part in corpus_citation_path.strip("/").split("/") if part
+        ]
+        if len(citation_parts) >= 3 and citation_parts[1] == "statute":
+            fragments = "".join(
+                f"({normalize_rulespec_path_segment(part)})" for part in path
+            )
+            branch_hint = (
+                "\nFor this rejected current-source branch, the literal canonical "
+                f"citation required in `reason` is "
+                f"`{corpus_citation_path.rstrip('/')}{fragments}`."
             )
     return f"{_IMPRECISE_DEFERRAL_RETRY_SHAPE}{branch_hint}"
 
@@ -5839,7 +5852,7 @@ def _reason_names_source_bound_runtime_gap(
     path: tuple[str, ...],
     corpus_citation_path: str,
 ) -> bool:
-    """Accept a concrete runtime gap anchored to the exact current USC branch."""
+    """Accept a concrete runtime gap anchored to the exact current statute branch."""
 
     if (
         not path
@@ -5849,32 +5862,18 @@ def _reason_names_source_bound_runtime_gap(
         or not _ADMINISTRATIVE_SOURCE_ARTIFACT_LANGUAGE.search(source_scope_text)
         or not _ADMINISTRATIVE_SOURCE_ACTION_LANGUAGE.search(source_scope_text)
         or source_states_explicit_computation(source_scope_text)
-        or not corpus_citation_path.startswith("us/statute/")
     ):
         return False
-    try:
-        citation = parse_usc_citation(corpus_citation_path)
-    except ValueError:
+    citation_parts = [
+        part for part in corpus_citation_path.strip("/").split("/") if part
+    ]
+    if len(citation_parts) < 3 or citation_parts[1] != "statute":
         return False
-
-    dash_pattern = (
-        "[-\\u2010\\u2011\\u2012\\u2013\\u2014\\u2015\\u2212\\ufe58\\ufe63\\uff0d]"
-    )
-    section_pattern = re.escape(
-        normalize_rulespec_path_segment(citation.section)
-    ).replace(r"\-", dash_pattern)
-    complete_branch = (*citation.fragments, *path)
-    branch_pattern = r"\s*".join(
-        rf"\(\s*{re.escape(normalize_rulespec_path_segment(part))}\s*\)"
-        for part in complete_branch
-    )
-    descendant_guard = r"(?!\s*\()" if len(complete_branch) > 1 else ""
-    exact_branch_citation = re.compile(
-        rf"\b{re.escape(citation.title)}\s+U\.?\s*S\.?\s*C\.?\s*"
-        rf"(?:§{{1,2}}\s*)?{section_pattern}\s*{branch_pattern}{descendant_guard}",
-        flags=re.IGNORECASE,
-    )
-    if not exact_branch_citation.search(reason):
+    if not _reason_cites_exact_current_statute_branch(
+        reason,
+        corpus_citation_path=corpus_citation_path,
+        path=path,
+    ):
         return False
 
     def substantive_tokens(text: str) -> set[str]:
@@ -5887,6 +5886,98 @@ def _reason_names_source_bound_runtime_gap(
     # Two shared source terms keep an exact self-citation from laundering a vague
     # or invented capability assertion into complete-source coverage.
     return len(substantive_tokens(reason) & substantive_tokens(source_scope_text)) >= 2
+
+
+def _reason_cites_exact_current_statute_branch(
+    reason: str,
+    *,
+    corpus_citation_path: str,
+    path: tuple[str, ...],
+) -> bool:
+    """Bind a runtime-gap reason to one complete current-source branch."""
+
+    dash_pattern = (
+        "[-\\u2010\\u2011\\u2012\\u2013\\u2014\\u2015\\u2212\\ufe58\\ufe63\\uff0d]"
+    )
+
+    def literal_pattern(value: str) -> str:
+        normalized = re.sub(
+            r"[-\u2010\u2011\u2012\u2013\u2014\u2015\u2212\ufe58\ufe63\uff0d]",
+            "-",
+            value,
+        )
+        return re.escape(normalized).replace(r"\-", dash_pattern)
+
+    complete_branch = path
+    branch_pattern = r"\s*".join(
+        rf"\(\s*{re.escape(normalize_rulespec_path_segment(part))}\s*\)"
+        for part in complete_branch
+    )
+    state_branch_terminal_guard = r"(?!\s*\()(?![A-Za-z0-9_])"
+
+    if corpus_citation_path.startswith("us/statute/"):
+        try:
+            citation = parse_usc_citation(corpus_citation_path)
+        except ValueError:
+            return False
+        complete_usc_branch = (*citation.fragments, *path)
+        usc_branch_pattern = r"\s*".join(
+            rf"\(\s*{re.escape(normalize_rulespec_path_segment(part))}\s*\)"
+            for part in complete_usc_branch
+        )
+        usc_descendant_guard = r"(?!\s*\()" if len(complete_usc_branch) > 1 else ""
+        section_pattern = literal_pattern(
+            normalize_rulespec_path_segment(citation.section)
+        )
+        return bool(
+            re.search(
+                rf"\b{re.escape(citation.title)}\s+U\.?\s*S\.?\s*C\.?\s*"
+                rf"(?:§{{1,2}}\s*)?{section_pattern}\s*{usc_branch_pattern}"
+                rf"{usc_descendant_guard}",
+                reason,
+                flags=re.IGNORECASE,
+            )
+        )
+
+    canonical_pattern = re.compile(
+        rf"(?<![A-Za-z0-9_.-]){literal_pattern(corpus_citation_path.rstrip('/'))}"
+        rf"\s*{branch_pattern}{state_branch_terminal_guard}",
+        flags=re.IGNORECASE,
+    )
+    if canonical_pattern.search(reason):
+        return True
+
+    citation_parts = [
+        part for part in corpus_citation_path.strip("/").split("/") if part
+    ]
+    if len(citation_parts) < 3 or citation_parts[0].lower() != "us-la":
+        return False
+    statute_tail = citation_parts[2:]
+    if not statute_tail:
+        return False
+    if ":" in statute_tail[0]:
+        title_section = statute_tail[0].split(":")
+        if len(title_section) != 2 or not all(title_section):
+            return False
+        title, section = title_section
+        existing_scope = statute_tail[1:]
+    else:
+        if len(statute_tail) < 2:
+            return False
+        title, section, *existing_scope = statute_tail
+    complete_louisiana_branch = (*existing_scope, *path)
+    louisiana_branch_pattern = r"\s*".join(
+        rf"\(\s*{re.escape(normalize_rulespec_path_segment(part))}\s*\)"
+        for part in complete_louisiana_branch
+    )
+    louisiana_rs_pattern = re.compile(
+        rf"(?<![A-Za-z0-9])(?:La\.?\s+)?R\.?\s*S\.?\s*"
+        rf"{literal_pattern(title)}\s*:\s*{literal_pattern(section)}\s*"
+        rf"{louisiana_branch_pattern}"
+        rf"{state_branch_terminal_guard}",
+        flags=re.IGNORECASE,
+    )
+    return bool(louisiana_rs_pattern.search(reason))
 
 
 def _rulespec_target_base(corpus_citation_path: str) -> str:
@@ -5906,7 +5997,42 @@ def _rulespec_target_base(corpus_citation_path: str) -> str:
         "policy": "policies",
         "form": "forms",
     }.get(document_class, f"{document_class}s")
+    if jurisdiction == "us-la" and plural == "statutes" and tail:
+        title_section = tail[0].split(":")
+        if len(title_section) == 2 and all(title_section):
+            tail = [*title_section, *tail[1:]]
+    if (
+        plural == "statutes"
+        and tail
+        and not _preserve_state_statute_dotted_target_leaf(
+            jurisdiction,
+            plural,
+            tail,
+        )
+    ):
+        leaf_segments = [part for part in tail[-1].split(".") if part]
+        if leaf_segments:
+            tail = [*tail[:-1], *leaf_segments]
     return f"{jurisdiction}:{plural}/{'/'.join(tail)}"
+
+
+def _preserve_state_statute_dotted_target_leaf(
+    jurisdiction: str,
+    root: str,
+    tail: list[str],
+) -> bool:
+    """Mirror canonical state-statute leaves that intentionally retain dots."""
+
+    if jurisdiction != "us-co" or root != "statutes" or len(tail) < 2:
+        return False
+    if len(tail) == 2 and tail[0].isdigit():
+        crs_segments = tail[-1].split("-")
+        return len(crs_segments) == 3 and all(
+            re.fullmatch(r"\d+(?:\.\d+)*", segment) for segment in crs_segments
+        )
+    if not re.fullmatch(r"\d+(?:\.\d+)+", tail[-1]):
+        return False
+    return bool(re.fullmatch(r"\d+(?:-\d+)+(?:\.\d+)?", tail[-2]))
 
 
 def _is_marker_only_container(

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1618"
+ENCODER_VERSION = "0.2.1619"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1618"
+ENCODER_VERSION = "0.2.1619"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1618"
+ENCODER_VERSION = "0.2.1619"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1618"
+ENCODER_VERSION = "0.2.1619"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1618"
+ENCODER_VERSION = "0.2.1619"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1618"
+ENCODER_VERSION = "0.2.1619"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1618"
+ENCODER_VERSION = "0.2.1619"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1618"')
+        .startswith('__version__ = "0.2.1619"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1618"
+    assert encoder_package["version"] == "0.2.1619"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1618"
+    assert project["project"]["version"] == "0.2.1619"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1618"')
+        .startswith('__version__ = "0.2.1619"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1618"
+    assert encoder_package["version"] == "0.2.1619"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1618"
+    assert project["project"]["version"] == "0.2.1619"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1618"')
+        .startswith('__version__ = "0.2.1619"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1618"
+ENCODER_VERSION = "0.2.1619"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -5955,6 +5955,186 @@ rules: []
     assert not result.issues
 
 
+def _louisiana_state_runtime_gap_fixture(citation: str) -> tuple[str, str]:
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-la/statute/47:295
+  deferred_outputs:
+    - output: us-la:statutes/47/295/c#federal_return_copy_becomes_part_of_state_return
+      reason: >-
+        {citation} cannot be encoded because the runtime lacks a
+        document-filing and document-incorporation capability for a filed
+        federal income tax return becoming part of the required state return.
+rules:
+  - name: annual_report_filing_record
+    kind: derived
+    dtype: Judgment
+    period: Day
+    source: us-la/statute/47:295(A)
+    versions:
+      - formula: 'true'
+  - name: audit_record_retention
+    kind: derived
+    dtype: Judgment
+    period: Day
+    source: us-la/statute/47:295(B)
+    versions:
+      - formula: 'true'
+"""
+    source = """\
+A. The secretary shall file an annual administration report.
+
+B. The secretary shall retain the audit record.
+
+C. The secretary may require that a complete copy of the taxpayer's federal income
+tax return, or any part thereof, be filed. When the return is filed, the federal
+income tax return, or part thereof, shall constitute and become part of the return
+required to be filed under this Part.
+"""
+    return content, source
+
+
+@pytest.mark.parametrize(
+    ("citation", "target"),
+    (
+        ("us-la/statute/47:295", "us-la:statutes/47/295"),
+        ("us-la/statute/47:297.4", "us-la:statutes/47/297/4"),
+        ("us-az/statute/43-1072.01", "us-az:statutes/43-1072/01"),
+        ("us-co/statute/39/39-22-123.5", "us-co:statutes/39/39-22-123.5"),
+        (
+            "us-co/regulation/10-ccr-2506-1/4.207.2",
+            "us-co:regulations/10-ccr-2506-1/4.207.2",
+        ),
+        ("us/regulation/26/1.36B-2", "us:regulations/26/1.36B-2"),
+        ("us-dc/statute/47/47-1803.02", "us-dc:statutes/47/47-1803/02"),
+        ("us-nj/statute/54a:8-6", "us-nj:statutes/54a:8-6"),
+    ),
+)
+def test_state_source_deferral_target_uses_canonical_rulespec_path(
+    citation: str,
+    target: str,
+):
+    assert completeness_module._rulespec_target_base(citation) == target
+
+
+def test_exact_louisiana_rs_branch_can_name_source_bound_runtime_gap():
+    content, source = _louisiana_state_runtime_gap_fixture("R.S. 47:295(C)")
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+        test_cases=[],
+    )
+
+    assert not _has_issue(result, "(c)", "deferral")
+    assert not _has_issue(result, "source branch c", "neither encoded")
+
+
+def test_exact_canonical_state_branch_can_name_source_bound_runtime_gap():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-nj/statute/54a:8-6
+  deferred_outputs:
+    - output: us-nj:statutes/54a:8-6/c#federal_return_copy_submission
+      reason: >-
+        us-nj/statute/54a:8-6(c) cannot be encoded until the runtime has a
+        document-submission capability for the required federal return copy.
+rules: []
+"""
+    source = (
+        "(c) The director may require the taxpayer to submit a copy of the "
+        "taxpayer's federal return."
+    )
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us-nj/statute/54a:8-6",
+        test_cases=[],
+    )
+
+    assert not result.issues
+
+
+@pytest.mark.parametrize(
+    "citation",
+    (
+        "R.S. 47:295",
+        "R.S. 47:295(B)",
+        "R.S. 47:296(C)",
+        "R.S. 47:295(C)(1)",
+        "R.S. 47:295(C)junk",
+        "us-la/statute/47:295",
+        "us-la/statute/47:295(b)",
+        "us-la/statute/47:296(c)",
+        "us-la/statute/47:295(c)(1)",
+        "us-la/statute/47:295(c)junk",
+    ),
+)
+def test_state_runtime_gap_requires_exact_current_branch(citation: str):
+    content, source = _louisiana_state_runtime_gap_fixture(citation)
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+        test_cases=[],
+    )
+
+    assert _has_issue(result, "(c)", "deferral", "runtime capability")
+
+
+def test_state_runtime_gap_retry_names_exact_canonical_branch():
+    content, source = _louisiana_state_runtime_gap_fixture("This current source branch")
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+        test_cases=[],
+    )
+
+    issue = next(
+        issue
+        for issue in result.issues
+        if issue.startswith("[complete-source-unit:deferral]")
+    )
+    assert "`us-la/statute/47:295(c)`" in issue
+
+
+@pytest.mark.parametrize(
+    ("corpus_citation_path", "path", "reason", "expected"),
+    (
+        ("us-la/statute/47/32", ("c",), "R.S. 47:32(C)", True),
+        ("us-la/statute/47/32", ("c",), "La. R.S. 47:32(C)", True),
+        ("us-la/statute/47:295/c", ("1",), "R.S. 47:295(C)(1)", True),
+        ("us-la/statute/47/295/c", ("1",), "R.S. 47:295(C)(1)", True),
+        ("us-la/statute/47:295/c", ("1",), "R.S. 47:295(1)", False),
+        ("us-la/statute/47:295/c", ("1",), "R.S. 47:295(C)(2)", False),
+        ("us-la/statute/47/32", ("c",), "R.S. 47:32(C)(1)", False),
+    ),
+)
+def test_louisiana_rs_branch_reconstructs_full_statute_tail(
+    corpus_citation_path: str,
+    path: tuple[str, ...],
+    reason: str,
+    expected: bool,
+):
+    assert (
+        completeness_module._reason_cites_exact_current_statute_branch(
+            reason,
+            corpus_citation_path=corpus_citation_path,
+            path=path,
+        )
+        is expected
+    )
+
+
 @pytest.mark.parametrize(
     "reason",
     [

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1618"
+version = "0.2.1619"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- bind completeness deferrals to the encoder's canonical RuleSpec target path for state statutes, including Louisiana title/section and dotted-leaf layouts
- permit source-bound administrative runtime gaps only when the reason cites the exact current state-statute branch; preserve the existing federal U.S.C. behavior and safeguards
- support compact, slash-form, and scoped Louisiana corpus IDs when matching official `R.S. title:section(...)` citations
- add exact-positive and adversarial-negative coverage and bump the encoder atomically to 0.2.1619

## Root cause

The completeness validator built Louisiana deferral targets as `us-la:statutes/47:295`, while the canonical encoder output is `us-la:statutes/47/295`. It also recognized exact runtime-gap citations only for federal U.S.C. sources. A complete Louisiana 47:295 branch C deferral therefore could not bind to its source branch even though it named the concrete missing document-filing/incorporation capability.

This fixes the shared path-binding and source-branch validation layers. It is not a Louisiana campaign workaround: the target mapper was compared with the encoder's canonical source-path mapper across all 362 unique state-income-tax statute citations in the campaign plan with zero mismatches.

## Review-fix cycle

The independent review cycle found and fixed:

- stale package and packaged-registry version pins
- dotted-leaf normalization that was initially broader than statutes and would have changed Colorado/federal regulation behavior
- missing state citation terminal guards that could accept descendants or attached suffixes
- incomplete official Louisiana matching for slash-form and already-scoped corpus identifiers

Two independent reviewers re-audited the final exact head after those changes and reported no actionable findings.

## Validation

- [x] exact archived Louisiana 47:295 replay: the prior branch C deferral failure is cleared (the artifact retains one independent paired-case coverage issue for branch B)
- [x] all 362 campaign statute citations match canonical encoder RuleSpec paths
- [x] `tests/test_source_completeness.py`: 2,743 passed
- [x] `tests/test_rulespec_validation.py`: 1,433 passed, 31 skipped
- [x] exact adversarial state citation/path matrix: 40 passed
- [x] full local suite: 8,893 passed, 119 skipped
- [x] version provenance reports 0.2.1619 at exact head `6676ec8f7278c0c9b28a5b97f16ca5d43504e340`
- [x] Ruff, compileall, and diff checks
- [x] independent review-fix cycle: two clean final reviews
- [x] exact-head hosted CI `31103110319`: green
- [x] exact-head signing supervisor `31103107402`: Ubuntu and macOS green

All required exact-head gates are green.
