### PR TITLE
Make root deferral feedback candidate-bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1619"
+version = "0.2.1620"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1619"
+__version__ = "0.2.1620"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -4281,38 +4281,158 @@ def _deferred_coverage(
             source_text=source_text,
             branches=branches,
         )
-        if "blocked_by" in record:
-            precise = (
-                exact_blockers
-                and bool(_MISSING_DEPENDENCY_LANGUAGE.search(reason))
-                and all(
-                    _reason_identifies_blocker(
-                        reason,
-                        blocker,
-                        corpus_citation_path=corpus_citation_path,
+
+        def reason_is_precise_for(
+            candidate_scope_text: str,
+            candidate_path: tuple[str, ...],
+        ) -> bool:
+            if "blocked_by" in record:
+                return (
+                    exact_blockers
+                    and bool(_MISSING_DEPENDENCY_LANGUAGE.search(reason))
+                    and all(
+                        _reason_identifies_blocker(
+                            reason,
+                            blocker,
+                            corpus_citation_path=corpus_citation_path,
+                        )
+                        for blocker in blocker_targets
                     )
-                    for blocker in blocker_targets
-                )
-                and all(
-                    _source_scope_identifies_blocker(
-                        source_scope_text,
-                        blocker,
-                        corpus_citation_path=corpus_citation_path,
+                    and all(
+                        _source_scope_identifies_blocker(
+                            candidate_scope_text,
+                            blocker,
+                            corpus_citation_path=corpus_citation_path,
+                        )
+                        for blocker in blocker_targets
                     )
-                    for blocker in blocker_targets
                 )
-            )
-        else:
-            precise = _reason_dependency_is_source_bound(
+            return _reason_dependency_is_source_bound(
                 reason,
-                source_scope_text,
+                candidate_scope_text,
                 corpus_citation_path=corpus_citation_path,
             ) or _reason_names_source_bound_runtime_gap(
                 reason,
-                source_scope_text,
-                path=path,
+                candidate_scope_text,
+                path=candidate_path,
                 corpus_citation_path=corpus_citation_path,
             )
+
+        valid_root_symbol = (
+            not path
+            and output.count("#") == 1
+            and bool(re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", output.partition("#")[2]))
+        )
+        if valid_root_symbol:
+            cited_branches = {
+                branch.path
+                for branch in branches
+                if branch.path
+                and _reason_cites_exact_current_statute_branch(
+                    reason,
+                    corpus_citation_path=corpus_citation_path,
+                    path=branch.path,
+                    strict_terminal=True,
+                )
+            }
+            most_specific_cited_branches = {
+                candidate
+                for candidate in cited_branches
+                if not any(
+                    len(other) > len(candidate) and other[: len(candidate)] == candidate
+                    for other in cited_branches
+                )
+            }
+            most_specific_source_scopes = {
+                candidate: _deferred_source_scope_text(
+                    candidate,
+                    source_text=source_text,
+                    branches=branches,
+                )
+                for candidate in most_specific_cited_branches
+            }
+            attempted_runtime_gap = bool(
+                _MISSING_DEPENDENCY_LANGUAGE.search(reason)
+                and _SOURCE_BOUND_RUNTIME_GAP_LANGUAGE.search(reason)
+            )
+            common_cited_branches = {
+                candidate
+                for candidate in cited_branches
+                if all(other[: len(candidate)] == candidate for other in cited_branches)
+            }
+            precise_external_dependency = any(
+                (
+                    "blocked_by" in record
+                    and reason_is_precise_for(candidate_scope_text, candidate)
+                )
+                or _reason_dependency_is_source_bound(
+                    reason,
+                    candidate_scope_text,
+                    corpus_citation_path=corpus_citation_path,
+                )
+                for candidate, candidate_scope_text in most_specific_source_scopes.items()
+            )
+            cited_scope_states_explicit_computation = any(
+                source_states_explicit_computation(candidate_scope_text)
+                for candidate_scope_text in most_specific_source_scopes.values()
+            )
+            if (
+                attempted_runtime_gap
+                and not precise_external_dependency
+                and cited_scope_states_explicit_computation
+                and common_cited_branches
+            ):
+                explicit_computation_branch = max(common_cited_branches, key=len)
+                rendered_branch = "/".join(
+                    _deferred_branch_display_path(
+                        explicit_computation_branch,
+                        corpus_citation_path=corpus_citation_path,
+                        branches=branches,
+                    )
+                )
+                issues.append(
+                    "[complete-source-unit:deferral] "
+                    f"`module.deferred_outputs[{index}]` cites exact source branch "
+                    f"(`{rendered_branch}`), but that branch states an explicit "
+                    "computation and cannot be deferred as a runtime gap. Declare "
+                    "the source-stated operative facts as local RuleSpec inputs and "
+                    "encode the principal derived output."
+                )
+                continue
+            cited_branch = (
+                next(iter(most_specific_cited_branches))
+                if len(most_specific_cited_branches) == 1
+                else None
+            )
+            if cited_branch is not None:
+                cited_source_scope_text = _deferred_source_scope_text(
+                    cited_branch,
+                    source_text=source_text,
+                    branches=branches,
+                )
+                display_cited_branch = _deferred_branch_display_path(
+                    cited_branch,
+                    corpus_citation_path=corpus_citation_path,
+                    branches=branches,
+                )
+                rendered_branch = "/".join(display_cited_branch)
+                if reason_is_precise_for(cited_source_scope_text, cited_branch):
+                    fragment = output.partition("#")[2]
+                    corrected_output = f"{base_target}/{rendered_branch}#{fragment}"
+                    retry_shape = _imprecise_deferral_retry_shape(
+                        corpus_citation_path=corpus_citation_path,
+                        path=display_cited_branch,
+                    )
+                    issues.append(
+                        "[complete-source-unit:deferral] "
+                        f"`module.deferred_outputs[{index}].output` is rooted at the "
+                        f"source unit (`{output}`), but its otherwise precise reason "
+                        f"cites exact source branch (`{rendered_branch}`). Preserve "
+                        f"that branch in the output path, for example "
+                        f"`{corrected_output}`.\n{retry_shape}"
+                    )
+                    continue
+        precise = reason_is_precise_for(source_scope_text, path)
         if precise:
             covered.add(path)
         else:
@@ -4342,6 +4462,43 @@ def _deferred_source_scope_text(
         return source_text
     candidates = [branch.text for branch in branches if branch.path == path]
     return max(candidates, key=len, default="")
+
+
+def _deferred_branch_display_path(
+    path: tuple[str, ...],
+    *,
+    corpus_citation_path: str,
+    branches: Sequence[SourceStructureBranch],
+) -> tuple[str, ...]:
+    """Restore source-marker case for federal branch-path retry advice."""
+
+    if not corpus_citation_path.startswith("us/statute/"):
+        return path
+    display_path: list[str] = []
+    for depth, segment in enumerate(path, start=1):
+        prefix = path[:depth]
+        candidate_texts = (branch.text for branch in branches if branch.path == prefix)
+        source_scope_text = max(candidate_texts, key=len, default="")
+        marker_match = re.match(
+            r"\s*(?P<markers>(?:\(\s*[A-Za-z0-9]+\s*\)\s*)+)",
+            source_scope_text,
+        )
+        if marker_match is None:
+            display_path.append(segment)
+            continue
+        marker_labels = re.findall(
+            r"\(\s*([A-Za-z0-9]+)\s*\)",
+            marker_match.group("markers"),
+        )
+        display_segment = segment
+        for width in range(min(len(prefix), len(marker_labels)), 0, -1):
+            if tuple(label.lower() for label in marker_labels[:width]) == tuple(
+                part.lower() for part in prefix[-width:]
+            ):
+                display_segment = marker_labels[width - 1]
+                break
+        display_path.append(display_segment)
+    return tuple(display_path)
 
 
 def _reason_identifies_blocker(
@@ -5893,6 +6050,7 @@ def _reason_cites_exact_current_statute_branch(
     *,
     corpus_citation_path: str,
     path: tuple[str, ...],
+    strict_terminal: bool = False,
 ) -> bool:
     """Bind a runtime-gap reason to one complete current-source branch."""
 
@@ -5925,7 +6083,11 @@ def _reason_cites_exact_current_statute_branch(
             rf"\(\s*{re.escape(normalize_rulespec_path_segment(part))}\s*\)"
             for part in complete_usc_branch
         )
-        usc_descendant_guard = r"(?!\s*\()" if len(complete_usc_branch) > 1 else ""
+        usc_terminal_guard = (
+            state_branch_terminal_guard
+            if strict_terminal
+            else (r"(?!\s*\()" if len(complete_usc_branch) > 1 else "")
+        )
         section_pattern = literal_pattern(
             normalize_rulespec_path_segment(citation.section)
         )
@@ -5933,7 +6095,7 @@ def _reason_cites_exact_current_statute_branch(
             re.search(
                 rf"\b{re.escape(citation.title)}\s+U\.?\s*S\.?\s*C\.?\s*"
                 rf"(?:§{{1,2}}\s*)?{section_pattern}\s*{usc_branch_pattern}"
-                rf"{usc_descendant_guard}",
+                rf"{usc_terminal_guard}",
                 reason,
                 flags=re.IGNORECASE,
             )

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1619"
+ENCODER_VERSION = "0.2.1620"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1619"
+ENCODER_VERSION = "0.2.1620"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1619"
+ENCODER_VERSION = "0.2.1620"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1619"
+ENCODER_VERSION = "0.2.1620"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1619"
+ENCODER_VERSION = "0.2.1620"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1619"
+ENCODER_VERSION = "0.2.1620"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1619"
+ENCODER_VERSION = "0.2.1620"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1619"')
+        .startswith('__version__ = "0.2.1620"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1619"
+    assert encoder_package["version"] == "0.2.1620"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1619"
+    assert project["project"]["version"] == "0.2.1620"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1619"')
+        .startswith('__version__ = "0.2.1620"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1619"
+    assert encoder_package["version"] == "0.2.1620"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1619"
+    assert project["project"]["version"] == "0.2.1620"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1619"')
+        .startswith('__version__ = "0.2.1620"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1619"
+ENCODER_VERSION = "0.2.1620"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -6107,6 +6107,393 @@ def test_state_runtime_gap_retry_names_exact_canonical_branch():
     assert "`us-la/statute/47:295(c)`" in issue
 
 
+def test_root_state_deferral_retry_rejects_explicit_computation_runtime_gap():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-la/statute/47:294
+  deferred_outputs:
+    - output: us-la:statutes/47/294#standard_deduction_under_subsection_a
+      reason: >-
+        La. R.S. 47:294(A), specifically the taxpayer-specific standard deduction
+        determined by the filing-status amounts in La. R.S. 47:294(A)(1) and the
+        joint-return rule in La. R.S. 47:294(A)(2), cannot be encoded because the
+        runtime lacks an executable federal filing-status classification.
+rules:
+  - name: annual_adjustment
+    kind: derived
+    dtype: Money
+    unit: USD
+    period: Year
+    source: La. R.S. 47:294(B)
+    versions:
+      - formula: prior_year_standard_deduction * cpi_u_percentage_increase
+"""
+    source = """\
+A. A standard deduction shall be allowed based on the filing status used on the
+taxpayer's federal income tax return. The single amount is $12,500, and the joint
+amount is twice the single amount.
+
+B. The prior year's standard deduction shall be multiplied by the CPI-U percentage
+increase.
+"""
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us-la/statute/47:294",
+        test_cases=[],
+    )
+
+    issue = next(
+        issue
+        for issue in result.issues
+        if "module.deferred_outputs[0]" in issue and "explicit computation" in issue
+    )
+    assert "cannot be deferred as a runtime gap" in issue
+    assert "local RuleSpec inputs" in issue
+    assert "principal derived output" in issue
+    assert "us-la:statutes/47/294/a#" not in issue
+
+
+def test_precise_root_state_deferral_retry_preserves_branch_in_output_path():
+    content, source = _louisiana_state_runtime_gap_fixture("R.S. 47:295(C)")
+    content = content.replace(
+        "us-la:statutes/47/295/c#federal_return_copy_becomes_part_of_state_return",
+        "us-la:statutes/47/295#federal_return_copy_becomes_part_of_state_return",
+    )
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+        test_cases=[],
+    )
+
+    issue = next(
+        issue for issue in result.issues if "module.deferred_outputs[0].output" in issue
+    )
+    assert "otherwise precise reason" in issue
+    assert (
+        "`us-la:statutes/47/295/c#federal_return_copy_becomes_part_of_state_return`"
+        in issue
+    )
+    assert "`us-la/statute/47:295(c)`" in issue
+
+
+def test_root_deferral_retry_preserves_uppercase_federal_subparagraph():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/42/1396a/a/10
+  deferred_outputs:
+    - output: us:statutes/42/1396a/a/10#hearing_process
+      reason: >-
+        42 U.S.C. 1396a(a)(10)(A) cannot be encoded because the runtime lacks
+        hearing-event and notice-record capabilities.
+rules: []
+"""
+    source = "(A) The State agency shall conduct a hearing and provide notice."
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us/statute/42/1396a/a/10",
+        test_cases=[],
+    )
+
+    issue = next(
+        issue for issue in result.issues if "module.deferred_outputs[0].output" in issue
+    )
+    assert "`us:statutes/42/1396a/a/10/A#hearing_process`" in issue
+    assert "`42 U.S.C. 1396a(a)(10)(A)`" in issue
+    assert "us:statutes/42/1396a/a/10/a#hearing_process" not in issue
+
+
+def test_root_explicit_computation_feedback_preserves_exact_external_blocker():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/42/1234
+  deferred_outputs:
+    - output: us:statutes/42/1234#benefit
+      blocked_by:
+        - us:statutes/26#taxable_income
+      reason: >-
+        42 USC 1234(a) cannot be computed because the runtime input taxable
+        income under section 26 is missing.
+rules: []
+"""
+    source = (
+        "(a) The benefit shall equal taxable income under section 26 plus 5 dollars."
+    )
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us/statute/42/1234",
+        test_cases=[],
+    )
+
+    issue = next(
+        issue for issue in result.issues if "module.deferred_outputs[0].output" in issue
+    )
+    assert "`us:statutes/42/1234/a#benefit`" in issue
+    assert "explicit computation" not in issue
+
+
+def test_root_explicit_computation_feedback_ignores_uncited_sibling_formula():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/42/1234
+  deferred_outputs:
+    - output: us:statutes/42/1234#filing_record
+      reason: >-
+        42 USC 1234(a), specifically 42 USC 1234(a)(1), cannot be encoded because
+        the runtime lacks an agency annual filing-record capability.
+rules: []
+"""
+    source = "(a) General requirements with filing and benefit branches."
+    payload = yaml.safe_load(content)
+    branch_specs = (
+        (
+            ("a",),
+            "(a) General requirements. (1) The agency shall file an annual "
+            "record. (2) The benefit equals twice the base amount.",
+        ),
+        (("a", "1"), "(1) The agency shall file an annual record."),
+        (("a", "2"), "(2) The benefit equals twice the base amount."),
+    )
+    branches = tuple(
+        completeness_module.SourceStructureBranch(
+            path=branch_path,
+            kind="outline",
+            label=branch_path[-1],
+            text=branch_text,
+            start=index,
+            end=index + 1,
+        )
+        for index, (branch_path, branch_text) in enumerate(branch_specs)
+    )
+
+    _covered, issues = completeness_module._deferred_coverage(
+        payload,
+        corpus_citation_path="us/statute/42/1234",
+        source_text=source,
+        branches=branches,
+    )
+
+    issue = next(
+        issue for issue in issues if "module.deferred_outputs[0].output" in issue
+    )
+    assert "`us:statutes/42/1234/a/1#filing_record`" in issue
+    assert "explicit computation" not in issue
+
+
+def test_nested_federal_root_deferral_retry_uses_exact_deep_branch():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/42/1437c-1
+  deferred_outputs:
+    - output: us:statutes/42/1437c-1#agency_report_submission
+      reason: >-
+        42 USC 1437c-1(a)(2) cannot be encoded because the runtime lacks an
+        agency report document-submission capability.
+rules: []
+"""
+    source = "The agency plan shall contain a statement and submit a report copy."
+    payload = yaml.safe_load(content)
+    branch_specs = (
+        (("a",), "The agency plan shall contain:"),
+        (("a", "1"), "A statement of needs."),
+        (("a", "2"), "The agency shall submit a copy of the report."),
+    )
+    branches = tuple(
+        completeness_module.SourceStructureBranch(
+            path=path,
+            kind="outline",
+            label=path[-1],
+            text=text,
+            start=index,
+            end=index + 1,
+        )
+        for index, (path, text) in enumerate(branch_specs)
+    )
+
+    _covered, issues = completeness_module._deferred_coverage(
+        payload,
+        corpus_citation_path="us/statute/42/1437c-1",
+        source_text=source,
+        branches=branches,
+    )
+
+    issue = next(
+        issue for issue in issues if "module.deferred_outputs[0].output" in issue
+    )
+    assert "`us:statutes/42/1437c-1/a/2#agency_report_submission`" in issue
+    assert "`42 U.S.C. 1437c-1(a)(2)`" in issue
+    assert "`us:statutes/42/1437c-1/a#agency_report_submission`" not in issue
+
+
+@pytest.mark.parametrize(
+    ("path", "reason"),
+    (
+        (("a",), "42 USC 1234(a)junk"),
+        (("a",), "42 USC 1234(a)_junk"),
+        (("a", "1"), "42 USC 1234(a)(1)junk"),
+        (("a", "1"), "42 USC 1234(a)(1)_junk"),
+    ),
+)
+def test_strict_federal_branch_match_rejects_attached_token_junk(
+    path: tuple[str, ...],
+    reason: str,
+):
+    assert not completeness_module._reason_cites_exact_current_statute_branch(
+        reason,
+        corpus_citation_path="us/statute/42/1234",
+        path=path,
+        strict_terminal=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("source", "reason"),
+    (
+        (
+            "(a) The agency shall file an annual report.",
+            "42 USC 1234(a)junk cannot be encoded because the runtime lacks an "
+            "annual-report filing capability.",
+        ),
+        (
+            "(a)(1) The agency shall file an annual report.",
+            "42 USC 1234(a)(1)_junk cannot be encoded because the runtime lacks an "
+            "annual-report filing capability.",
+        ),
+    ),
+)
+def test_root_branch_retry_rejects_federal_citation_token_junk(
+    source: str,
+    reason: str,
+):
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/42/1234
+  deferred_outputs:
+    - output: us:statutes/42/1234#annual_report
+      reason: >-
+        {reason}
+rules: []
+"""
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us/statute/42/1234",
+        test_cases=[],
+    )
+
+    assert not any(
+        "Preserve that branch in the output path" in issue for issue in result.issues
+    )
+    assert _has_issue(result, "deferral", "missing dependency", "runtime capability")
+
+
+def test_root_branch_citation_without_precise_reason_keeps_reason_diagnostic():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-la/statute/47:295
+  deferred_outputs:
+    - output: us-la:statutes/47/295#federal_return_copy
+      reason: See R.S. 47:295(C).
+rules: []
+"""
+    source = """\
+A. The secretary shall file an annual administration report.
+C. The secretary may require a copy of the federal return to be filed.
+"""
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+        test_cases=[],
+    )
+
+    assert not any(
+        "Preserve that branch in the output path" in issue for issue in result.issues
+    )
+    assert _has_issue(result, "deferral", "missing dependency", "runtime capability")
+
+
+def test_root_deferral_retry_does_not_choose_between_incomparable_branches():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-la/statute/47:295
+  deferred_outputs:
+    - output: us-la:statutes/47/295#administrative_documents
+      reason: >-
+        R.S. 47:295(A) and R.S. 47:295(C) cannot be encoded because the runtime
+        lacks annual-report filing and federal-return attachment capabilities.
+rules: []
+"""
+    source = """\
+A. The secretary shall file an annual administration report.
+C. The secretary may require a copy of the federal return to be filed.
+"""
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+        test_cases=[],
+    )
+
+    assert not any(
+        "Preserve that branch in the output path" in issue for issue in result.issues
+    )
+
+
+@pytest.mark.parametrize(
+    "output",
+    (
+        "us-la:statutes/47/295",
+        "us-la:statutes/47/295#",
+        "us-la:statutes/47/295#federal_return_copy#junk",
+        "us-la:statutes/47/295#not-a-symbol",
+    ),
+)
+def test_root_branch_retry_does_not_suggest_invalid_output_fragment(output: str):
+    content, source = _louisiana_state_runtime_gap_fixture("R.S. 47:295(C)")
+    content = content.replace(
+        "us-la:statutes/47/295/c#federal_return_copy_becomes_part_of_state_return",
+        output,
+    )
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+        test_cases=[],
+    )
+
+    assert not any(
+        "Preserve that branch in the output path" in issue for issue in result.issues
+    )
+
+
 @pytest.mark.parametrize(
     ("corpus_citation_path", "path", "reason", "expected"),
     (

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1619"
+version = "0.2.1620"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- reject root-scoped runtime-gap deferrals when the most-specific exact cited scope already states an explicit computation
- direct retries to declare source-stated operative facts as local RuleSpec inputs and encode the principal derived output
- preserve exact external blockers and isolate cited scopes from uncited sibling computations
- suggest a branch-preserving output path only for a valid symbol, an otherwise precise reason, and one unique most-specific exact branch
- preserve case-sensitive federal source markers and require strict terminal citation boundaries
- keep validation fail-closed: no candidate rewrite, acceptance, or artifact-specific exception
- bump the encoder to 0.2.1620

## Production evidence

Full atomic Louisiana run 31104802697 attempt 1 failed before provenance, packaging, commit, push, or PR publication. Its rejected 47:294 candidate cited La. R.S. 47:294(A), (A)(1), and (A)(2), then deferred the taxpayer-specific standard deduction because an executable federal filing-status classification was absent.

The statute itself states the operative filing-status facts and deduction computation. Under the encoder contract those facts must become local inputs and the principal output must be encoded; moving the same deferral from the source root to /a would only preserve the underlying defect. Exact replay of the archived Sol candidate returns the explicit-computation diagnostic.

This is a general validator-feedback correction, not a Louisiana artifact workaround. The terminal run must never be rerun or reapproved.

## Checks on exact head ca4902090e335b3aebe47d9ec4ac48e9695eae92

- full repository suite: 8,911 passed, 119 skipped
- source completeness: 2,761 passed
- RuleSpec validation and version-pinned state registries: 1,457 passed, 31 skipped
- focused root-deferral adversarial coverage: 18 passed
- exact archived 47:294 Sol candidate replay: explicit-computation feedback at branch a
- package/version provenance regressions: 2 passed
- ruff check pyproject.toml src/axiom_encode scripts tests
- ruff format --check src/axiom_encode scripts tests
- python -m compileall -q src/axiom_encode scripts
- git diff --check
- hosted CI 31108040412: passed
- hosted signing supervisor 31108040302: Ubuntu and macOS passed

## Review cycle

Three independent review-fix cycles completed. Cycle one fixed unsafe parent matching and over-eager correction of malformed/imprecise candidates. Cycle two fixed precise external-blocker precedence, uncited sibling-formula contamination, uppercase federal path rendering, and attached citation-token junk. Both independent reviewers rechecked every finding on exact head ca4902090e335b3aebe47d9ec4ac48e9695eae92 and reported no actionable findings.