### PR TITLE
fix: validate Louisiana external statute deferrals

### DIFF
--- a/changelog.d/louisiana-external-statute-deferrals.fixed.md
+++ b/changelog.d/louisiana-external-statute-deferrals.fixed.md
@@ -1,0 +1,5 @@
+Validate Louisiana `R.S. title:section` deferrals as exact external legal
+dependencies when the same citation is operative in the source clause. This
+keeps delegated tax computations with their owning statute while rejecting
+self-citations, contextual references, citation-prefix matches, negated links,
+and missingness borrowed from another citation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1621"
+version = "0.2.1622"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1621"
+__version__ = "0.2.1622"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1151,6 +1151,36 @@ _RELATIVE_USC_DEFERRAL_DEPENDENCY = re.compile(
     r"(?P<tail>(?:\s*\(\s*[A-Za-z0-9]+\s*\))*)",
     flags=re.IGNORECASE,
 )
+_LOUISIANA_RS_DEFERRAL_DEPENDENCY = re.compile(
+    r"(?<![A-Za-z0-9_])(?:(?:La\.?\s*)|(?:LSA\s*[-\u2010-\u2015]?\s*))?"
+    r"R\.?\s*S\.?\s*(?:§{1,2}\s*)?"
+    r"(?P<title>\d+[A-Za-z]?)\s*:\s*"
+    r"(?P<section>\d+[A-Za-z]?(?:(?:[-\u2010\u2011\u2012\u2013\u2014\u2015"
+    r"\u2212\ufe58\ufe63\uff0d][A-Za-z0-9]+)|(?:\.\d+[A-Za-z]?))*)"
+    r"(?P<tail>(?:\s*\(\s*[A-Za-z0-9]+\s*\))*"
+    r"(?:\s*(?:"
+    r",\s*(?:and\s+)?(?:(?:clauses?|divisions?|items?|lines?|paragraphs?|parts?|"
+    r"schedules?|subclauses?|subdivisions?|subitems?|subparagraphs?|subparts?|"
+    r"subsections?)\s+)?|"
+    r"(?:and/or|and|or|plus|&|as\s+well\s+as|together\s+with|along\s+with|"
+    r"in\s+(?:conjunction|combination|tandem)\s+with|in\s+relation\s+(?:to|with)|"
+    r"as\s+supplemented\s+by|"
+    r"combined\s+with|in\s+addition\s+to|as\s+amended\s+by|including|through|to|"
+    r"followed\s+by|as\s+provided\s+in|read\s+with|read\s+together\s+with|"
+    r"subject\s+to|except\s+as\s+provided\s+in|as\s+(?:modified|qualified)\s+by|"
+    r"[-\u2013\u2014])\s*"
+    r"(?:(?:clauses?|divisions?|items?|lines?|paragraphs?|parts?|schedules?|"
+    r"subclauses?|subdivisions?|subitems?|subparagraphs?|subparts?|subsections?)\s+)?"
+    r"|(?:clauses?|divisions?|items?|lines?|paragraphs?|parts?|schedules?|"
+    r"subclauses?|subdivisions?|subitems?|subparagraphs?|subparts?|subsections?)\s+"
+    r")\(\s*[A-Za-z0-9]+(?:[-\u2013][A-Za-z0-9]+)*\s*\)"
+    r"(?!\s+(?:filers?\b|of\s+(?:the\s+)?(?:calculation|explanatory\s+report|"
+    r"form|report|return|tax\s+return|worksheet)\b)))*)"
+    r"(?!\s*\()(?![A-Za-z0-9_])(?![./:]\s*(?:[A-Za-z0-9]|\())"
+    r"(?![-\u2010\u2011\u2012\u2013\u2014\u2015\u2212\ufe58\ufe63\uff0d]"
+    r"\s*(?:[A-Za-z0-9]|\())",
+    flags=re.IGNORECASE,
+)
 _MISSING_DEPENDENCY_LANGUAGE = re.compile(
     r"\b(?:"
     r"requires?|depends?\s+on|missing|not\s+yet\s+encoded|unavailable|"
@@ -1305,6 +1335,7 @@ _DEPENDENCY_OBJECT_MODIFIER_TERMS = frozenset(
         "described",
         "determined",
         "eligible",
+        "senior",
         "established",
         "furnished",
         "issued",
@@ -1815,12 +1846,15 @@ _TITLE_SUFFIX_LEGAL_CITATION = re.compile(
     flags=re.IGNORECASE,
 )
 _LOUISIANA_SESSION_LAW_CITATION = re.compile(
-    r"\bActs?\s+\d{4}\s*,?\s*"
+    r"\bActs?(?:\s+of)?\s+\d{4}\s*,?\s*"
     r"(?:"
-    r"(?:(?:\d+\s*(?:st|nd|rd|th|d)|first|second|third|fourth)\s+)?"
-    r"Ex\.?\s*Sess\.?\s*,?\s*"
+    r"(?:(?:\d+\s*(?:st|nd|rd|th|d)|"
+    r"[A-Za-z]+(?:[-\s]+[A-Za-z]+){0,3})\s+)?"
+    r"(?:E\.?\s*S\.?|Ex\.?|Extra\.?|Extraordinary)\s*"
+    r"(?:Sess\.?|Session)?\s*,?\s*"
     r")?"
-    r"No\.?\s*\d+(?:-\d+)?\b"
+    r"Nos?\.?\s*\d+(?:-\d+)?\b"
+    r"(?:\s*(?:,|and)\s*(?:Nos?\.?\s*)?\d+(?:-\d+)?\b)*"
     r"(?:\s*,?\s*(?:"
     r"§§\s*\d+(?:\s*(?:,|and|through|to|[-–—])\s*\d+)*"
     r"|§\s*\d+"
@@ -4627,15 +4661,30 @@ def _source_clause_links_dependency(
 
     before = clause[:reference_start]
     after = clause[reference_end:]
-    if re.search(
+    dependency_link = re.search(
         r"\b(?:"
         r"nach|gemäß|laut|entsprechend|under|according\s+to|pursuant\s+to|"
+        r"in\s+accordance\s+with(?:\s+the\s+provisions?\s+of)?|"
         r"abhängig\s+von|depends?\s+on|setzt|requires?|benötigt"
         r")\s*$",
         before,
         flags=re.IGNORECASE,
-    ):
-        return True
+    )
+    if dependency_link:
+        preceding_link = before[: dependency_link.start()]
+        is_in_accordance_link = bool(
+            re.fullmatch(
+                r"in\s+accordance\s+with(?:\s+the\s+provisions?\s+of)?",
+                dependency_link.group(0).strip(),
+                flags=re.IGNORECASE,
+            )
+        )
+        negated_in_accordance_link = (
+            is_in_accordance_link
+            and _source_link_scope_has_unreset_negation(preceding_link)
+        )
+        if not negated_in_accordance_link:
+            return True
     if re.search(
         r"\b(?:voraussetzung\w*|bedingung\w*|conditions?)"
         r"[^.;]{0,100}\b(?:des|der|nach|under)\s*$",
@@ -4717,14 +4766,1707 @@ def _source_scope_cites_usc_dependency(
     return False
 
 
+def _source_scope_cites_louisiana_rs_dependency(
+    source_scope_text: str,
+    *,
+    title: str,
+    section: str,
+    fragments: tuple[str, ...],
+    tail_identity: str,
+) -> bool:
+    """Return whether an operative Louisiana clause cites one exact R.S. dependency."""
+
+    normalized_section = normalize_rulespec_path_segment(section.lower())
+    references = tuple(
+        reference
+        for reference in _qualified_louisiana_rs_dependencies(source_scope_text)
+        if not _louisiana_rs_match_has_detached_structural_subject(
+            source_scope_text, reference
+        )
+    )
+    for reference in references:
+        if (
+            reference.group("title").lower() != title.lower()
+            or normalize_rulespec_path_segment(reference.group("section").lower())
+            != normalized_section
+            or _usc_dependency_fragments(reference) != fragments
+            or _louisiana_rs_tail_identity(reference) != tail_identity
+        ):
+            continue
+        clause_start, clause_end = _reason_clause_bounds(source_scope_text, reference)
+        clause = source_scope_text[clause_start:clause_end]
+        clause_references = tuple(
+            candidate
+            for candidate in references
+            if clause_start <= candidate.start() and candidate.end() <= clause_end
+        )
+        syntax_reference = reference
+        reference_index = clause_references.index(reference)
+        starts_finite_clause = _louisiana_reference_starts_finite_clause(
+            source_scope_text[reference.end() : clause_end]
+        )
+        outer_predicate_follows_citation_list = (
+            starts_finite_clause
+            and _louisiana_citation_list_completes_outer_subject(
+                source_scope_text[clause_start : clause_references[0].start()]
+            )
+        )
+        detached_coordinated_relative = bool(
+            starts_finite_clause
+            and re.match(
+                r"\s*,?\s*(?:along|together)\s+with\b[^,.;]{0,120}"
+                r"\b(?:that|which|who)\b",
+                source_scope_text[reference.end() : clause_end],
+                flags=re.IGNORECASE,
+            )
+        )
+        if detached_coordinated_relative and not outer_predicate_follows_citation_list:
+            continue
+        while reference_index > 0:
+            previous_reference = clause_references[reference_index - 1]
+            bridge = source_scope_text[
+                previous_reference.end() : syntax_reference.start()
+            ]
+            if not re.fullmatch(
+                r"\s*(?:,\s*(?:(?:and/or|and|or)\s*)?|"
+                r"(?:and/or|and|or|as\s+well\s+as|together\s+with|along\s+with|"
+                r"combined\s+with|plus|&)\s*)",
+                bridge,
+                re.IGNORECASE,
+            ):
+                break
+            # Finite-clause evidence wins over optional comma punctuation.  The
+            # exception is a citation list completing a reduced-passive outer
+            # subject (``the amount determined under A, B, and C is rounded``).
+            if starts_finite_clause and not outer_predicate_follows_citation_list:
+                break
+            syntax_reference = previous_reference
+            reference_index -= 1
+        previous_reference_end = max(
+            (
+                candidate.end()
+                for candidate in references
+                if clause_start <= candidate.start()
+                and candidate.end() <= syntax_reference.start()
+            ),
+            default=clause_start,
+        )
+        local_before = source_scope_text[
+            previous_reference_end : syntax_reference.start()
+        ]
+        if _louisiana_disclaimer_governs_reference(local_before):
+            continue
+        reference_start = syntax_reference.start() - clause_start
+        if not _louisiana_source_link_is_operative(
+            clause,
+            reference_start=reference_start,
+            reference_end=reference.end() - clause_start,
+        ):
+            continue
+        return True
+    return False
+
+
+_LOUISIANA_CITATION_FINITE_PREDICATE = re.compile(
+    r"\s*(?:,\s*)?(?:(?:however|merely|only),?\s+)*(?:"
+    r"(?:(?:and|together\s+with)\s+(?:its|the)\s+"
+    r"[A-Za-z][A-Za-z-]*(?:\s+[A-Za-z][A-Za-z-]*){0,3},?\s+)?"
+    r"(?!(?:along|as|by|combined|for|from|if|in|of|or|plus|through|to|"
+    r"together|under|when|where|with)\b)(?![A-Za-z][A-Za-z-]*ly\b)"
+    r"[A-Za-z][A-Za-z-]*\b)",
+    flags=re.IGNORECASE,
+)
+
+
+def _louisiana_reference_starts_finite_clause(after_reference: str) -> bool:
+    """Reject citation-list inheritance when the citation is a new clause subject."""
+
+    suffix = re.sub(
+        r"^\s*,?\s*(?:(?:however|merely|only),?\s+)*",
+        "",
+        after_reference,
+        flags=re.IGNORECASE,
+    )
+    bounded_modifier = re.match(
+        r"(?:in\s+its\s+(?:current|amended|revised)\s+form|"
+        r"as\s+(?:currently|further|subsequently)\s+amended),?\s*",
+        suffix,
+        flags=re.IGNORECASE,
+    )
+    if bounded_modifier:
+        return _louisiana_reference_starts_finite_clause(
+            suffix[bounded_modifier.end() :]
+        )
+    modal_predicate = re.match(
+        r"(?:along|together)\s+with\s+(?P<premodal>[^,.;]{1,80}?),?\s+"
+        r"(?:(?:[A-Za-z][A-Za-z-]*ly)\s+)?"
+        r"(?:shall|should|must|will|would|can|could|may|might|does?|did)\s+"
+        r"(?:not\s+)?[A-Za-z][A-Za-z-]*\b",
+        suffix,
+        flags=re.IGNORECASE,
+    )
+    if modal_predicate and not re.search(
+        r"\b(?:that|which|who)\b",
+        modal_predicate.group("premodal"),
+        flags=re.IGNORECASE,
+    ):
+        return True
+    coordinated_body = re.match(
+        r"(?:along|together)\s+with\s+(?P<body>[^,.;]{1,120})",
+        suffix,
+        flags=re.IGNORECASE,
+    )
+    if coordinated_body:
+        body = coordinated_body.group("body")
+        relative = re.search(r"\b(?:that|which|who)\b", body, flags=re.IGNORECASE)
+        if relative is not None:
+            relative_tail = body[relative.end() :]
+            relative_nouns = {
+                "agencies",
+                "analysis",
+                "authors",
+                "codes",
+                "guidelines",
+                "instructions",
+                "irs",
+                "ordinances",
+                "policies",
+                "process",
+                "standards",
+                "forms",
+                "provisions",
+                "regulations",
+                "rules",
+                "sections",
+                "series",
+                "statutes",
+                "taxpayers",
+                "terms",
+            }
+            relative_predicate = next(
+                (
+                    token
+                    for token in re.finditer(r"[A-Za-z][A-Za-z-]*", relative_tail)
+                    if token.group(0).lower() in {"was", "were"}
+                    or token.group(0).lower()
+                    in {
+                        "administer",
+                        "address",
+                        "apply",
+                        "cover",
+                        "consult",
+                        "enforce",
+                        "follow",
+                        "govern",
+                        "issues",
+                        "made",
+                        "obey",
+                        "publishes",
+                        "rely",
+                        "review",
+                        "retain",
+                        "use",
+                        "wrote",
+                    }
+                    or token.group(0).lower().endswith("ed")
+                    or (
+                        token.group(0).lower().endswith("s")
+                        and not token.group(0).isupper()
+                        and not token.group(0).lower().endswith(("is", "ss", "us"))
+                        and token.group(0).lower() not in relative_nouns
+                    )
+                ),
+                None,
+            )
+            body = (
+                relative_tail[relative_predicate.end() :] if relative_predicate else ""
+            )
+        if re.search(
+            r"\b(?:(?:already|currently|now|presently|still)\s+"
+            r"(?:effective|in\s+(?:effect|force))|"
+            r"effective\s+(?:today|on\s+[A-Za-z]+\s+\d{1,2}))\s*$",
+            body,
+            flags=re.IGNORECASE,
+        ):
+            return False
+        words = re.findall(r"[A-Za-z][A-Za-z-]*", body)
+        if relative is not None and re.search(
+            r"\b(?:can|could|may|might|must|shall|should|will|would)\s+"
+            r"[A-Za-z][A-Za-z-]*\b|\b[A-Za-z][A-Za-z-]*ed\b",
+            body,
+            flags=re.IGNORECASE,
+        ):
+            return True
+        for index, word in enumerate(words):
+            if (
+                (index > 0 or relative is not None)
+                and word.lower().endswith("s")
+                and word.lower()
+                not in {
+                    "codes",
+                    "cases",
+                    "guidelines",
+                    "instructions",
+                    "irs",
+                    "notices",
+                    "ordinances",
+                    "policies",
+                    "requirements",
+                    "schedules",
+                    "standards",
+                    "forms",
+                    "provisions",
+                    "regulations",
+                    "rules",
+                    "sections",
+                    "statutes",
+                    "tables",
+                    "taxpayers",
+                    "terms",
+                    "this",
+                    "those",
+                    "directives",
+                }
+                and (
+                    relative is not None
+                    or any(
+                        previous.lower() not in {"a", "an", "its", "the"}
+                        for previous in words[:index]
+                    )
+                )
+            ):
+                return True
+        if relative is not None and not body.strip():
+            return False
+    if re.match(
+        r"(?:along|together)\s+with\s+[^,.;]{1,80}?,?\s+"
+        r"(?:(?:[A-Za-z][A-Za-z-]*ly)\s+)?"
+        r"(?:is|are|was|were|became|becomes?|remained|remains?|"
+        r"applies?|controls?|governs?|"
+        r"sets?|determines?|calculates?|computes?|establishes?|imposes?)\b",
+        suffix,
+        flags=re.IGNORECASE,
+    ):
+        return True
+    if re.match(
+        r"(?:along|together)\s+with\s+"
+        r"(?:[A-Za-z][A-Za-z-]*\s+){1,6}?"
+        r"(?:adopt(?:s|ed)|amend(?:s|ed)|chang(?:es|ed)|creat(?:es|ed)|"
+        r"enact(?:s|ed)|fil(?:es|ed)|gives?|gave|has|have|had|holds?|held|"
+        r"issu(?:es|ed)|makes?|made|puts?|put|requir(?:es|ed)|seeks?|sought|"
+        r"takes?|took|writes?|wrote|brought|built|bought|caught|chose|drew|"
+        r"found|got|heard|hid|kept|laid|left|lost|met|paid|ran|read|saw|sent|"
+        r"set|sold|taught|told|won)\b"
+        r"\s+(?:a\s+(?!(?:(?:calendar|fiscal|taxable)\s+)?"
+        r"(?:century|day|decade|generation|month|period|quarter|time|week|year)\b)|"
+        r"an|no|"
+        r"the\s+(?!(?:(?:current|following|last|next|prior|"
+        r"previous|same)\s+)?(?:day|month|quarter|week|year)\b)|filing|tax|effect\b|"
+        r"(?:this|that)\s+(?!(?:day|month|quarter|week|year)\b))",
+        suffix,
+        flags=re.IGNORECASE,
+    ):
+        return True
+    list_modifier = re.match(
+        r"(?:(?:taken|read|considered)\s+together|together|along)"
+        r"(?:\s+with\s+(?:its|the|two|three|multiple)\s+"
+        r"[A-Za-z][A-Za-z-]*(?:\s+[A-Za-z][A-Za-z-]*){0,3})?|"
+        r"(?:alone|both|collectively|equally|jointly|respectively)\b|"
+        r"(?:if|when|whenever|where)\s+(?:applicable|required)\b",
+        suffix,
+        flags=re.IGNORECASE,
+    )
+    if list_modifier:
+        remainder = suffix[list_modifier.end() :].lstrip(" ,")
+        return bool(remainder) and _louisiana_reference_starts_finite_clause(remainder)
+    suffix = re.sub(
+        r"^(?:as\s+amended|where\s+applicable),?\s*",
+        "",
+        suffix,
+        flags=re.IGNORECASE,
+    )
+    return bool(
+        re.match(
+            r"(?:(?:and|together\s+with)\s+(?:its|the)\s+"
+            r"[A-Za-z][A-Za-z-]*(?:\s+[A-Za-z][A-Za-z-]*){0,3},?\s+)?"
+            r"(?:[A-Za-z][A-Za-z-]*ly\s+)?"
+            r"(?!(?:along|as|by|combined|for|from|if|in|of|or|plus|through|to|"
+            r"together|under|when|whenever|where|with)\b)"
+            r"[A-Za-z][A-Za-z-]*\b",
+            suffix,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _louisiana_citation_list_completes_outer_subject(
+    before_first_reference: str,
+) -> bool:
+    """Recognize a citation list embedded in a reduced-passive subject."""
+
+    reduced = re.search(
+        r"(?P<subject>\b[^,.;]{1,100}?)\s+"
+        r"(?:(?:[A-Za-z][A-Za-z-]*ly|hereby|then)\s+)*"
+        r"(?:allowed|assessed|calculated|computed|derived|determined|established|"
+        r"fixed|imposed|levied|prescribed|set|specified)\s+"
+        r"(?:according\s+to|pursuant\s+to|under|in\s+accordance\s+with)\s*$",
+        before_first_reference,
+        flags=re.IGNORECASE,
+    )
+    if reduced is None:
+        return False
+    return not re.search(
+        r"\b(?:am|are|be|been|being|becomes?|is|remains?|was|were)\s*$",
+        reduced.group("subject"),
+        flags=re.IGNORECASE,
+    )
+
+
+_LOUISIANA_POSITIVE_OPERATIVE_PREDICATE = re.compile(
+    r"\b(?:"
+    r"(?:is|are|was|were|becomes?|remains?)\s+"
+    r"(?:(?:[A-Za-z][A-Za-z-]*ly|hereby|then)\s+)*"
+    r"(?:allowed|assessed|available|calculated|computed|derived|determined|rounded|"
+    r"established|fixed|imposed|levied|prescribed|set|specified)|"
+    r"(?:shall|may|must|will|would|can|could)\s+be\s+"
+    r"(?:(?:[A-Za-z][A-Za-z-]*ly|hereby|then)\s+)*"
+    r"(?:allowed|assessed|available|calculated|computed|derived|determined|rounded|"
+    r"established|fixed|imposed|levied|prescribed|set|specified)|"
+    r"(?:shall|may|must|will|would|can|could|does|do|did)\s+"
+    r"(?:(?:[A-Za-z][A-Za-z-]*ly|hereby|then)\s+)*"
+    r"(?:appl(?:y|ies)|arise[sd]?|calculates?|computes?|derives?|determines?|"
+    r"establishes?|imposes?)|"
+    r"(?:is|are|was|were)\s+to\s+be\s+(?:allowed|assessed|available|calculated|"
+    r"computed|derived|determined|established|fixed|imposed|levied|prescribed|rounded|set|specified)|"
+    r"except\s+as\s+(?:(?:[A-Za-z][A-Za-z-]*ly|hereby|then)\s+)*"
+    r"(?:allowed|assessed|available|calculated|computed|derived|determined|"
+    r"established|fixed|imposed|levied|prescribed|set|specified)|"
+    r"(?:amount|base|calculation|computation|credit|deduction|formula|income|liability|"
+    r"percentage|rate|result|rule|schedule|statute|table|tax|threshold)\s+"
+    r"(?:(?:[A-Za-z][A-Za-z-]*ly|hereby|then)\s+)*"
+    r"(?:allowed|assessed|available|calculated|computed|derived|determined|"
+    r"established|fixed|imposed|levied|prescribed|set|specified)|"
+    r"(?:agency|commission|commissioner|court|department|employer|rule|secretary|"
+    r"statute|taxpayer)\s+"
+    r"(?:(?:[A-Za-z][A-Za-z-]*ly|hereby|then)\s+)*"
+    r"(?:allows?|assesses?|calculates?|computes?|derives?|determines?|"
+    r"establishes?|fixes?|imposes?|levies?|prescribes?|sets?|specifies?)\s+"
+    r"(?:the\s+)?(?:[A-Za-z][A-Za-z-]*\s+){0,3}(?:amount|base|calculation|computation|credit|deduction|formula|"
+    r"liability|rate|rule|tax)|"
+    r"(?:but|yet)\s+(?:allowed|assessed|available|calculated|computed|derived|"
+    r"determined|established|fixed|imposed|levied|prescribed|rounded|set|specified)|"
+    r"(?:amount|base|calculation|computation|credit|deduction|income|liability|rate|"
+    r"rule|statute|tax)\s+"
+    r"(?:(?:[A-Za-z][A-Za-z-]*ly|hereby|then)\s+)*"
+    r"(?:appl(?:y|ies)|arise[sd]?|calculates?|computes?|derives?|determines?|"
+    r"establishes?|imposes?)"
+    r")\b",
+    flags=re.IGNORECASE,
+)
+
+
+_LOUISIANA_REPORTING_PREDICATE = re.compile(
+    r"\b(?:alleg\w*|answer\w*|assert\w*|aver(?:s|red|ring)?|believ\w*|"
+    r"claim\w*|conclud\w*|"
+    r"conjectur\w*|contend\w*|declar\w*|estimat\w*|infer\w*|maintain\w*|"
+    r"explain\w*|not(?:e|es|ed|ing)|observ\w*|opin\w*|posit\w*|postulat\w*|"
+    r"acknowledg\w*|confirm\w*|conclusion|predict\w*|presum\w*|purport\w*|"
+    r"recall\w*|recit\w*|recount\w*|remark\w*|report\w*|"
+    r"said|say\w*|speculat\w*|tell(?:s|ing)?|told|writ(?:e|es|ing|ten)|wrote|"
+    r"(?<!-)stat(?:e|es|ed|ing)|surmis\w*|"
+    r"testif\w*|underst(?:and|ands|anding|ood))\b",
+    flags=re.IGNORECASE,
+)
+
+_LOUISIANA_NONOPERATIVE_LANGUAGE = re.compile(
+    r"\b(?:alleged(?:ly)?|apparently|assumed|candidate|conceivable|conceivably|"
+    r"assumption|conditionally|conceptual|contrived|demonstration|draft|dubious|"
+    r"example|fictional(?:ly)?|"
+    r"hypothetical(?:ly)?|"
+    r"illustration|illustrative|imagined|mock|nonbinding|notional|ostensibly|perhaps|"
+    r"nominally|possibly|potentially|proposed|prototype|purported(?:ly)?|"
+    r"putative(?:ly)?|questionable|"
+    r"questionably|reportedly|sample|scenario|seemingly|specimen|supposedly|"
+    r"theoretical(?:ly)?|"
+    r"unlikely|unproven|unsupported|unverified)\b",
+    flags=re.IGNORECASE,
+)
+
+
+def _louisiana_text_has_nonoperative_framing(text: str) -> bool:
+    """Classify bounded hypothetical, evidential, or reported language."""
+
+    if _LOUISIANA_NONOPERATIVE_LANGUAGE.search(text):
+        return True
+    if re.search(
+        r"\b(?:affidavit|testimony)\b[^.;]{0,80}\b"
+        r"(?:provides?(?:\s*,?\s*in\s+(?:relevant|pertinent)\s+part\s*,?)?\s+that|"
+        r"reads?(?:\s*,?\s*in\s+(?:relevant|pertinent)\s+part\s*,?)?\s+"
+        r"(?:substantially\s+|in\s+substance\s+)?as\s+follows|"
+        r"sets?\s+forth(?:\s*,?\s*in\s+(?:relevant|pertinent)\s+part\s*,?)?"
+        r"\s+that)\b",
+        text,
+        flags=re.IGNORECASE,
+    ):
+        return True
+    if re.search(
+        r"\bit\s+(?:(?:has|had)\s+been|is|was)\s+provided\s+in\s+(?:the\s+)?"
+        r"(?:affidavit|testimony)\s+that\b",
+        text,
+        flags=re.IGNORECASE,
+    ):
+        return True
+    if re.search(
+        r"\b(?:affidavit|agency|analysis|analyst|article|author|commentator|"
+        r"document|expert|narrative|professor|report|source|statement|testimony|"
+        r"witness)\b[^.;]{0,120}" + _LOUISIANA_REPORTING_PREDICATE.pattern,
+        text,
+        flags=re.IGNORECASE,
+    ):
+        return True
+    for reporting in _LOUISIANA_REPORTING_PREDICATE.finditer(text):
+        report_tail = text[reporting.end() :]
+        preceding_state = text[: reporting.start()]
+        state_tail_is_executable = bool(
+            re.match(
+                r"(?:-|\s)+(?:[A-Za-z][A-Za-z-]*\s+){0,4}"
+                r"(?:amount|base|calculation|computation|credit|deduction|formula|"
+                r"income|liability|percentage|rate|result|rule|schedule|table|tax|"
+                r"threshold)\b",
+                report_tail,
+                flags=re.IGNORECASE,
+            )
+        )
+        preceding_word = re.search(r"([A-Za-z][A-Za-z-]*)\s*$", preceding_state)
+        state_descriptors = {
+            "adjusted",
+            "applicable",
+            "excess",
+            "federal",
+            "final",
+            "gross",
+            "louisiana",
+            "local",
+            "net",
+            "taxable",
+            "various",
+        }
+        if reporting.group(0).lower() == "state" and (
+            not preceding_state.strip()
+            or re.search(
+                r"\b(?:a|an|in|the|this|that)\s*$",
+                preceding_state,
+                flags=re.IGNORECASE,
+            )
+            or (
+                state_tail_is_executable
+                and preceding_word is not None
+                and preceding_word.group(1).lower() in state_descriptors
+            )
+        ):
+            continue
+        if (
+            reporting.group(0).lower() == "said"
+            and (
+                not preceding_state.strip()
+                or re.search(
+                    r"\b(?:the|this|that)\s*$",
+                    preceding_state,
+                    flags=re.IGNORECASE,
+                )
+            )
+            and re.match(
+                r"\s+(?:[A-Za-z][A-Za-z-]*\s+){0,4}"
+                r"(?:amount|base|calculation|computation|credit|deduction|formula|"
+                r"income|liability|percentage|rate|result|rule|schedule|table|tax|"
+                r"threshold)\b",
+                report_tail,
+                flags=re.IGNORECASE,
+            )
+        ):
+            continue
+        if (
+            reporting.group(0).lower() == "understood"
+            and re.search(
+                r"(?:^|[.;])\s*(?:(?:a|an|the|this|that)\s+)?"
+                r"(?:[A-Za-z][A-Za-z-]*ly\s+)?$",
+                preceding_state,
+                flags=re.IGNORECASE,
+            )
+            and re.match(
+                r"\s+(?:[A-Za-z][A-Za-z-]*\s+){0,4}"
+                r"(?:amount|base|calculation|computation|credit|deduction|formula|"
+                r"income|liability|percentage|rate|result|rule|schedule|table|tax|"
+                r"threshold)\b",
+                report_tail,
+                flags=re.IGNORECASE,
+            )
+        ):
+            continue
+        preceding_compound_head = (
+            preceding_word.group(1).lower() if preceding_word is not None else ""
+        )
+        if (
+            preceding_compound_head
+            in {
+                "amount",
+                "base",
+                "calculation",
+                "computation",
+                "credit",
+                "deduction",
+                "formula",
+                "income",
+                "liability",
+                "rate",
+                "rule",
+                "tax",
+            }
+            and reporting.group(0).lower().endswith("ing")
+            and re.match(
+                r"\s+(?:[A-Za-z][A-Za-z-]*\s+){0,2}"
+                r"(?:amount|base|calculation|computation|credit|deduction|formula|"
+                r"income|liability|rate|rule|tax)\s+"
+                r"(?:(?:depends?|requires?|relies?)\b|$)|"
+                r"\s+(?:calculation|computation|formula)\s*$",
+                report_tail,
+                flags=re.IGNORECASE,
+            )
+        ):
+            continue
+        report_tail = re.sub(
+            r"^\s*(?:(?:[:,;]|\(|\[|[—–])\s*){0,2}"
+            r"in\s+(?:(?:relevant|pertinent)\s+)?(?:parts?|portions?)\s*"
+            r"(?:(?:[,;]|\)|\]|[—–])\s*){0,2}"
+            r"(?:as\s+follows)?",
+            " as follows",
+            report_tail,
+            flags=re.IGNORECASE,
+        )
+        has_complement = (
+            re.match(
+                r"\s*(?:(?:(?:in\s+(?:(?:relevant|pertinent)\s+)?"
+                r"(?:parts?|portions?)"
+                r"(?:\s+as\s+follows)?|(?:substantially\s+|in\s+substance\s+)?"
+                r"as\s+follows)|"
+                r"the\s+following"
+                r"(?:\s+[A-Za-z][A-Za-z-]*){0,2})\s*)?"
+                r"(?:[:,]|[—–-])?\s*[\"'“”‘’]?\s*"
+                r"(?:(?:[A-Za-z][A-Za-z-]*ly)\s+)*"
+                r"(?:,?\s*(?:with|without)\s+"
+                r"(?:[A-Za-z][A-Za-z-]*\s+){0,3}[A-Za-z][A-Za-z-]*,?\s*)?"
+                r"(?:(?:it|this|that)\s+"
+                r"(?:is|are|was|were|shall|may|must|will|would|can|could)\b|"
+                r"(?:that\s+)?(?:the\s+)?(?:[A-Za-z][A-Za-z-]*\s+){0,3}"
+                r"(?:amount|base|calculation|computation|credit|deduction|formula|"
+                r"income|liability|rate|rule|tax)\b)",
+                report_tail,
+                flags=re.IGNORECASE,
+            )
+            or re.match(
+                r"\s*,\s*[^,.;]{1,60},\s*that\s+(?:the\s+)?"
+                r"(?:[A-Za-z][A-Za-z-]*\s+){0,3}"
+                r"(?:amount|base|calculation|computation|credit|deduction|formula|"
+                r"income|liability|rate|rule|tax)\b",
+                report_tail,
+                flags=re.IGNORECASE,
+            )
+            or re.match(
+                r"\s*,?\s*(?:[A-Za-z][A-Za-z-]*\s+){1,5}"
+                r"that\s+(?:the\s+)?(?:[A-Za-z][A-Za-z-]*\s+){0,3}"
+                r"(?:amount|base|calculation|computation|credit|deduction|formula|"
+                r"income|liability|rate|rule|tax)\b",
+                report_tail,
+                flags=re.IGNORECASE,
+            )
+        )
+        if not has_complement:
+            continue
+        local_subject = re.split(r"[,.;]", text[: reporting.start()])[-1]
+        subject_core = re.split(
+            r"\bof\b", local_subject, maxsplit=1, flags=re.IGNORECASE
+        )[0]
+        subject_tokens = re.findall(r"[A-Za-z]+", subject_core.lower())
+        legal_speaker = bool(
+            subject_tokens
+            and subject_tokens[-1]
+            in {
+                "act",
+                "code",
+                "court",
+                "department",
+                "law",
+                "legislature",
+                "ordinance",
+                "provision",
+                "regulation",
+                "rule",
+                "section",
+                "statute",
+            }
+        )
+        authoritative_speech = re.fullmatch(
+            r"(?:assert\w*|conclud\w*|declar\w*|presum\w*|report\w*|say\w*|"
+            r"stat(?:e|es|ed|ing))",
+            reporting.group(0),
+            flags=re.IGNORECASE,
+        )
+        if legal_speaker and authoritative_speech:
+            continue
+        return True
+    return False
+
+
+def _louisiana_source_link_is_operative(
+    clause: str,
+    *,
+    reference_start: int,
+    reference_end: int,
+) -> bool:
+    """Require a local positive executable predicate governing the R.S. link."""
+
+    before = clause[:reference_start]
+    if _louisiana_reference_has_nonoperative_postfix(clause[reference_end:]):
+        return False
+    dependency_link = re.search(
+        r"\b(?:under(?:\s+(?:both|either))?|according\s+to|pursuant\s+to|"
+        r"in\s+accordance\s+with(?:\s+the\s+provisions?\s+of)?|"
+        r"depends?(?:\s*,?\s*(?:directly|entirely|necessarily|primarily|solely|"
+        r"ultimately|in\s+part)\s*,?)*\s+(?:on|upon)|"
+        r"is\s+(?:(?:directly|entirely|necessarily|primarily|solely|ultimately)\s+)*"
+        r"dependent(?:\s*,?\s*(?:directly|entirely|necessarily|primarily|solely|"
+        r"ultimately|in\s+part)\s*,?)*\s+(?:on|upon)|"
+        r"relies?(?:\s*,?\s*(?:directly|entirely|necessarily|primarily|solely|"
+        r"ultimately|in\s+part)\s*,?)*\s+"
+        r"(?:on|upon)|requires?)\s*$",
+        before,
+        flags=re.IGNORECASE,
+    )
+    if dependency_link is None:
+        return False
+    linker_text = dependency_link.group(0).strip().lower()
+    governing_scope = before[: dependency_link.start()]
+    if _louisiana_scope_has_nonoperative_framing(governing_scope):
+        return False
+    if re.fullmatch(
+        r"(?:depends?(?:\s*,?\s*(?:directly|entirely|necessarily|primarily|solely|"
+        r"ultimately|in\s+part)\s*,?)*\s+(?:on|upon)|"
+        r"is\s+(?:(?:directly|entirely|necessarily|primarily|solely|ultimately)\s+)*"
+        r"dependent(?:\s*,?\s*(?:directly|entirely|necessarily|primarily|solely|"
+        r"ultimately|in\s+part)\s*,?)*\s+(?:on|upon)|"
+        r"relies?(?:\s*,?\s*(?:directly|entirely|necessarily|primarily|solely|"
+        r"ultimately|in\s+part)\s*,?)*\s+"
+        r"(?:on|upon)|requires?)",
+        linker_text,
+    ):
+        return _louisiana_direct_dependency_subject_is_executable(governing_scope)
+
+    governing_scope = _louisiana_strip_inline_context_preamble(governing_scope)
+    operative_predicates = tuple(
+        _LOUISIANA_POSITIVE_OPERATIVE_PREDICATE.finditer(governing_scope)
+    )
+    if not operative_predicates:
+        return False
+    operative = operative_predicates[-1]
+    if _louisiana_text_has_nonoperative_framing(operative.group(0)):
+        return False
+    # The operative predicate must be the expression immediately attached to
+    # the dependency linker.  This prevents an earlier computation from lending
+    # operativeness to later metadata, commentary, examples, or uncertainty.
+    if not _louisiana_operative_suffix_is_bounded(governing_scope[operative.end() :]):
+        return False
+    local_before_operative = _louisiana_local_finite_clause(
+        governing_scope[: operative.start()]
+    )
+    if re.search(
+        r"\b(?:appendix|audit|background|chart|commentary|comparison|description|"
+        r"documentation|example|exhibit|explanation|illustration|label|memo|"
+        r"memorandum|metadata|nonbinding|note|record|report|sample|scenario|summary)\b|"
+        r"\b(?:alleg\w*|assum\w*|believ\w*|claim\w*|describ\w*|discuss\w*|"
+        r"indicat\w*|illustrat\w*|list\w*|mention\w*|purport\w*|quot\w*|"
+        r"report\w*|say\w*|show\w*|suggest\w*|suppos\w*|testif\w*|"
+        r"summariz\w*|treat\w*)\b",
+        local_before_operative,
+        flags=re.IGNORECASE,
+    ):
+        return False
+    local_clause = local_before_operative + operative.group(0)
+    if re.match(r"\s*no\b", local_clause, flags=re.IGNORECASE):
+        return False
+    return not _louisiana_predicate_is_in_negative_complement(
+        governing_scope, predicate_start=operative.start()
+    )
+
+
+def _louisiana_reference_has_nonoperative_postfix(after_reference: str) -> bool:
+    """Reject a qualifier after the citation that retracts its operative use."""
+
+    suffix = after_reference.strip()
+    legal_authority = (
+        r"(?:act|code|court|department|language|law|legislature|ordinance|"
+        r"provisions?|regulation|rule|section|statute|table|terms?|text)"
+    )
+    if re.match(
+        r"^,?\s*(?:in|for|during|using|under)\b",
+        suffix,
+        flags=re.IGNORECASE,
+    ):
+        return _louisiana_text_has_nonoperative_framing(suffix)
+    if re.match(
+        r"^,?\s*(?:but\s+)?(?:this|that|the\s+(?:statement|proposition))\b"
+        r"[^.;]{0,80}\b(?:contrived|draft|dubious|fictional|hypothetical|"
+        r"illustrative|questionable|unproven)\b",
+        suffix,
+        flags=re.IGNORECASE,
+    ):
+        return True
+    independent = re.match(
+        r"^,?\s*(?:although|and|but|though|while|whereas|yet)\s+"
+        r"(?:the\s+|a\s+|an\s+)?(?:[A-Za-z][A-Za-z-]*\s+){0,5}"
+        r"(?:is|are|was|were|has|have|had|can|could|may|might|must|shall|"
+        r"should|will|would|alleges?|asserts?|believes?|claims?|declares?|"
+        r"discusses?|reports?|says?|states?|speculates?)\b",
+        suffix,
+        flags=re.IGNORECASE,
+    )
+    if independent:
+        return False
+    attribution = re.match(
+        r"^,?\s*(?:at\s+least\s+)?(?:purportedly\s+)?according\s+to\s+"
+        r"(?P<object>[^.;]{1,100})",
+        suffix,
+        flags=re.IGNORECASE,
+    )
+    if attribution:
+        return not _louisiana_speaker_is_legal_authority(attribution.group("object"))
+    conditional = re.match(
+        r"^,?\s*if\s+(?P<condition>[^.;]{1,100})",
+        suffix,
+        flags=re.IGNORECASE,
+    )
+    if conditional:
+        condition_core = re.split(
+            r"\b(?:under|according\s+to|pursuant\s+to)\b",
+            conditional.group("condition"),
+            maxsplit=1,
+            flags=re.IGNORECASE,
+        )[0]
+        return not re.search(
+            rf"\b(?:statutory|legal|applicable|{legal_authority})\b",
+            condition_core,
+            flags=re.IGNORECASE,
+        )
+    speech = re.match(
+        r"^,?\s*(?:(?:as|or\s+so)\s+)?(?:the\s+)?"
+        r"(?P<speaker>[A-Za-z][A-Za-z-]*(?:\s+[A-Za-z][A-Za-z-]*){0,9}?)\s+"
+        r"(?:(?:[A-Za-z][A-Za-z-]*ly)\s+)*"
+        r"(?:alleges?|asserts?|believes?|claims?|concludes?|contends?|declares?|"
+        r"maintains?|opines?|reports?|says?|states?|testif(?:y|ies|ied))\b",
+        suffix,
+        flags=re.IGNORECASE,
+    )
+    if speech:
+        return not _louisiana_speaker_is_legal_authority(speech.group("speaker"))
+    return bool(
+        re.match(
+            r"^,?\s*(?:"
+            r"(?:but\s+)?(?:merely|only)\b[^.;]{0,100}\b(?:contrived|example|"
+            r"fictional|hypothetical|illustrati\w*|sample|scenario)\b|"
+            r"though\s+(?:allegedly|apparently|hypothetically|purportedly|"
+            r"reportedly|supposedly|theoretically)\b|"
+            r"(?:but\s+)?(?:this|that|which|the\s+(?:statement|proposition))\b"
+            r"[^.;]{0,80}\b(?:contrived|draft|dubious|fictional|hypothetical|"
+            r"illustrative|questionable|unproven)\b"
+            r")",
+            suffix,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _louisiana_speaker_is_legal_authority(speaker: str) -> bool:
+    """Resolve the grammatical authority head and any required complement."""
+
+    intrinsic_heads = {
+        "act",
+        "code",
+        "constitution",
+        "court",
+        "department",
+        "law",
+        "legislature",
+        "ordinance",
+        "regulation",
+        "rule",
+        "section",
+        "statute",
+        "table",
+    }
+    derivative_heads = {
+        "article",
+        "decision",
+        "language",
+        "opinion",
+        "order",
+        "provision",
+        "provisions",
+        "term",
+        "terms",
+        "text",
+    }
+    relation = re.search(r"\b(?:for|of)\b", speaker, flags=re.IGNORECASE)
+    head_scope = speaker[: relation.start()] if relation else speaker
+    head_tokens = re.findall(r"[A-Za-z]+", head_scope.lower())
+    if not head_tokens:
+        return False
+    head = (
+        "article"
+        if re.fullmatch(
+            r"articles?\s+(?:\d+|[ivxlcdm]+)(?:-[a-z0-9]+|\([a-z0-9]+\))?"
+            r"(?:\s+and\s+(?:\d+|[ivxlcdm]+))?"
+            r"(?:\s*,\s*(?:(?:§+|sections?)\s*\d+(?:[.-]\d+)*"
+            r"(?:\([a-z0-9]+\))*(?:\s*(?:-|–)\s*\([a-z0-9]+\)|"
+            r"\s+and\s+(?:\d+(?:\([a-z0-9]+\))*|\([a-z0-9]+\)))?"
+            r"(?:\s*,\s*paragraph\s+(?:[a-z0-9]+|\([a-z0-9]+\)))?|"
+            r"paragraphs?\s+(?:[a-z0-9]+|\([a-z0-9]+\))"
+            r"(?:\s+and\s+(?:[a-z0-9]+|\([a-z0-9]+\)))?))?",
+            head_scope.strip(),
+            flags=re.IGNORECASE,
+        )
+        else head_tokens[-1]
+    )
+    governmental_department_modifiers = {
+        "federal",
+        "health",
+        "justice",
+        "labor",
+        "louisiana",
+        "revenue",
+        "state",
+        "tax",
+        "taxation",
+        "treasury",
+    }
+    if (
+        head == "department"
+        and len(head_tokens) > 1
+        and not any(
+            token in governmental_department_modifiers for token in head_tokens[:-1]
+        )
+    ):
+        return False
+    if head in intrinsic_heads:
+        return True
+    if head == "order" and re.search(
+        r"\b(?:administrative|court|executive|judicial|restraining)\s+order\s*$|"
+        r"\bcease-and-desist\s+order\s*$",
+        head_scope.strip(),
+        flags=re.IGNORECASE,
+    ):
+        return True
+    if head not in derivative_heads:
+        return False
+    if re.search(r"\b(?:legal|statutory)\b", head_scope, flags=re.IGNORECASE):
+        return True
+    if relation is None:
+        return head in {"provision", "provisions", "term", "terms"}
+    complement_source = speaker[relation.end() :]
+    documentary_person = re.search(
+        r"\b(?:analyst|author|commentator|consultant|expert|researcher|witness)\b",
+        complement_source,
+        flags=re.IGNORECASE,
+    )
+    preceding_authority = (
+        re.search(
+            r"\b(?:act|code|constitution|court|department|law|legislature|"
+            r"ordinance|order|regulation|rule|section|statute|table)\b",
+            complement_source[: documentary_person.start()],
+            flags=re.IGNORECASE,
+        )
+        if documentary_person is not None
+        else None
+    )
+    if documentary_person is not None and preceding_authority is None:
+        return False
+    participle = re.search(
+        r"\b[A-Za-z][A-Za-z-]*ing\b", complement_source, flags=re.IGNORECASE
+    )
+    authority_modifiers = {
+        "administrative",
+        "agency",
+        "federal",
+        "governing",
+        "implementing",
+        "local",
+        "louisiana",
+        "outside",
+        "reviewing",
+        "state",
+        "tax",
+    }
+    prefix_tokens = (
+        tuple(
+            token
+            for token in re.findall(
+                r"[A-Za-z]+", complement_source[: participle.start()].lower()
+            )
+            if token not in {"a", "an", "the"}
+        )
+        if participle is not None
+        else ()
+    )
+    if participle is not None and any(
+        token not in authority_modifiers for token in prefix_tokens
+    ):
+        complement_source = complement_source[: participle.start()]
+    complement_scope = re.split(
+        r"\b(?:about|concerning|in|on|regarding|under|with)\b",
+        complement_source,
+        maxsplit=1,
+        flags=re.IGNORECASE,
+    )[0]
+    complement_tokens = re.findall(r"[A-Za-z]+", complement_scope.lower())
+    if (
+        complement_tokens
+        and complement_tokens[-1] == "department"
+        and len(complement_tokens) > 1
+        and not any(
+            token in governmental_department_modifiers
+            for token in complement_tokens[:-1]
+        )
+    ):
+        return False
+    return bool(complement_tokens and complement_tokens[-1] in intrinsic_heads)
+
+
+def _louisiana_scope_has_nonoperative_framing(scope: str) -> bool:
+    """Reject hypothetical or documentary embeddings before syntax branches."""
+
+    if re.match(
+        r"\s*(?:\(|\[)?\s*in\s+(?:(?:relevant|pertinent)\s+)?"
+        r"(?:parts?|portions?)\s*"
+        r"(?:\)|\])?\s*,?\s*(?:as\s+follows\b)?",
+        scope,
+        flags=re.IGNORECASE,
+    ):
+        return True
+    if re.match(
+        r"\s*in\s+(?:(?:the\s+)?(?:author|commentator|expert|witness)"
+        r"(?:'s|’s)?\s+(?:own\s+)?words|the\s+words\s+of\s+(?:the\s+)?"
+        r"(?:author|commentator|expert|witness))\s*,|"
+        r"\s*as\s+(?:the\s+)?(?:affidavit|testimony)\s+puts?\s+it\s*,",
+        scope,
+        flags=re.IGNORECASE,
+    ):
+        return True
+    if re.match(
+        r"\s*as\s+set\s+forth\s+in\s+(?:the\s+)?(?:affidavit|testimony)\s*,",
+        scope,
+        flags=re.IGNORECASE,
+    ):
+        return True
+
+    prefix_attribution = re.match(
+        r"\s*according\s+to\s+(?:the\s+)?(?P<speaker>[^.;]{1,80})\s*,",
+        scope,
+        flags=re.IGNORECASE,
+    )
+    if prefix_attribution:
+        if not _louisiana_speaker_is_legal_authority(
+            prefix_attribution.group("speaker")
+        ):
+            return True
+
+    # A fronted subordinate supplies context for, but does not grammatically
+    # govern, the comma-delimited main clause that carries the dependency.
+    if (
+        re.match(
+            r"\s*(?:although|because|since|when|while|whereas)\b",
+            scope,
+            flags=re.IGNORECASE,
+        )
+        and (fronted_end := scope.find(",")) >= 0
+        and re.match(
+            r"\s*(?:the|a|an|this|final|applicable)\s+[A-Za-z]",
+            scope[fronted_end + 1 :],
+            flags=re.IGNORECASE,
+        )
+    ):
+        scope = scope[fronted_end + 1 :]
+
+    independent_resets = tuple(
+        re.finditer(
+            r"(?:\b(?:although|and|because|but|or|while|whereas)\s+|"
+            r"\byet\s+(?=(?:the|a|an|this|that|final|applicable)\b))"
+            r"(?=(?:(?:the|a|an|this|that|final|applicable)\s+)?"
+            r"(?:(?:[A-Za-z][A-Za-z-]*\s+){1,7}"
+            r"(?:is|are|was|were|shall|may|must|will|would|can|could|does|do|did|"
+            r"depends?|requires?|relies?|determines?|calculates?|computes?|"
+            r"establishes?|applies?|imposes?|allows?|arises?)\b|"
+            r"(?:[A-Za-z][A-Za-z-]*\s*){1,5}$))",
+            scope,
+            flags=re.IGNORECASE,
+        )
+    )
+    if independent_resets:
+        reset = independent_resets[-1]
+        embedding_prefix = scope[: reset.start()]
+        if not re.search(
+            r"\b(?:alleges?|asserts?|avers?|claims?|contends?|declares?|imagines?|"
+            r"maintains?|reports?|states?|suppose[sd]?|testif(?:y|ies|ied))\s+"
+            r"(?:that\s+)?[^.;]{0,120}$",
+            embedding_prefix,
+            flags=re.IGNORECASE,
+        ):
+            scope = scope[reset.end() :]
+    return _louisiana_text_has_nonoperative_framing(scope) or bool(
+        re.search(
+            r"\b(?:assumed|candidate|conceivable|conceivably|conceptual|draft|"
+            r"example|fictional|fictionally|hypothetical(?:ly)?|illustrative|"
+            r"imagined|mock|nonbinding|notional|perhaps|possibly|proposed|prototype|"
+            r"purported|putative|sample|scenario|specimen|suppose[sd]?|theoretical)\b|"
+            r"\b(?:for\s+purposes\s+of\s+argument|in\s+theory)\b|"
+            r"\b(?:chance|could\s+be|might\s+be|possibility)\b[^.;]{0,40}\bthat\b|"
+            r"^\s*if\s+(?:the\s+)?(?:account|description|narrative|report|source)\s+"
+            r"is\s+(?:accurate|correct|true)\b|"
+            r"\b(?:agency|analysis|analyst|article|commentator|document|narrative|"
+            r"requirement|source|table|witness)\b[^.;]{0,100}"
+            r"\b(?:alleges?|asserts?|avers?|believes?|cannot\s+confirm|concludes?|"
+            r"contends?|declares?|estimates?|has\s+yet\s+to\s+confirm|indicates?|"
+            r"infers?|maintains?|observes?|opines?|predicts?|recites?|surmises?|"
+            r"testif(?:y|ies|ied))\b",
+            scope,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _louisiana_direct_dependency_subject_is_executable(scope: str) -> bool:
+    """Bind ``depends on`` and ``requires`` to the direct grammatical subject."""
+
+    scope = re.sub(
+        r"\b(directly|entirely|necessarily|ordinarily|solely|ultimately)\s+and\s+"
+        r"(?=(?:directly|entirely|necessarily|ordinarily|solely|ultimately)\b)",
+        r"\1 ",
+        scope,
+        flags=re.IGNORECASE,
+    )
+    local_clause = _louisiana_local_finite_clause(scope).strip(" ,")
+    if re.search(
+        r"\b(?:after|before)\s+(?:the|a|an)\s+"
+        r"[A-Za-z][A-Za-z-]*(?:\s+[A-Za-z][A-Za-z-]*){0,4}\s*$",
+        scope,
+        flags=re.IGNORECASE,
+    ):
+        local_clause = scope.strip(" ,")
+    if re.search(
+        r"\b(?:line|paragraph|part|schedule)\s+[A-Za-z0-9]+\s+of\s+(?:the\s+)?"
+        r"(?:calculation|report|return|tax\s+return|worksheet)\b",
+        local_clause,
+        flags=re.IGNORECASE,
+    ):
+        return False
+    if _LOUISIANA_DOCUMENTARY_HEAD.search(local_clause) or re.search(
+        r"^\s*(?:no|neither|nothing)\b|"
+        r"\b(?:can|could|did|does|do|is|are|was|were|will|would)\s+"
+        r"(?:never|not)\b|n['’]t\b|"
+        r"\b(?:uncertain|unknown|whether)\b|"
+        r"\b(?:assertion|availability|citation|claim|date|discussion|email|filing|"
+        r"footnote|guide|historical|hypothetical|identifier|outline|proposal|"
+        r"reference|rumor|status|title|website)\b",
+        local_clause,
+        flags=re.IGNORECASE,
+    ):
+        return False
+    if re.search(
+        r"\b(?:ceases?|fails?|refuses?)\s+to\s*$",
+        local_clause,
+        flags=re.IGNORECASE,
+    ):
+        return False
+    subject = local_clause
+    while True:
+        stripped = re.sub(
+            r"\s*,?\s*\b(?:directly|entirely|necessarily|ordinarily|solely|"
+            r"ultimately)\b(?:\s+and\s+\b(?:directly|entirely|necessarily|"
+            r"ordinarily|solely|ultimately)\b)*\s*$",
+            "",
+            subject,
+            flags=re.IGNORECASE,
+        ).strip(" ,")
+        if stripped == subject:
+            break
+        subject = stripped
+    if re.match(
+        r"which\s+(?:amount|base|calculation|computation|rate|tax)\s+applies$",
+        subject,
+        re.IGNORECASE,
+    ):
+        return True
+    if re.match(
+        r"(?:application|determination)\s+of\s+(?:the\s+)?(?:amount|base|rate|tax)$",
+        subject,
+        re.IGNORECASE,
+    ):
+        return True
+    if re.match(
+        r"(?:the\s+)?(?:lesser|greater)\s+of\s+(?:the\s+)?(?:two|multiple)?\s*rates?$",
+        subject,
+        re.IGNORECASE,
+    ):
+        return True
+    executable_heads = {
+        "amount",
+        "base",
+        "calculation",
+        "computation",
+        "credit",
+        "deduction",
+        "formula",
+        "income",
+        "liability",
+        "percentage",
+        "rate",
+        "result",
+        "rule",
+        "schedule",
+        "statute",
+        "table",
+        "tax",
+        "taxes",
+        "threshold",
+    }
+    relation = re.search(
+        r",|(?<!-)\b(?:about|accompanying|as|beneath|beside|by|concerning|"
+        r"after|against|before|containing|covering|describing|displaying|during|"
+        r"comprising|excluding|for|in|including|incorporating|listing|of|on|"
+        r"outside|under|using|"
+        r"presenting|reciting|"
+        r"regarding|setting\s+out|matching|reflecting|to|with|without|that|which|who|"
+        r"(?:arising|derived|emerging|flowing|resulting|stemming)\s+from|"
+        r"(?:based|dependent|predicated|reliant)\s+(?:on|upon)|"
+        r"(?:linked|related|tied)\s+to)\b(?!-)",
+        subject,
+        flags=re.IGNORECASE,
+    )
+    relation_start = relation.start() if relation else None
+    if relation is None:
+        for candidate in re.finditer(
+            r"\b(?P<head>[A-Za-z][A-Za-z-]*)\s+"
+            r"(?P<relation>(?:[A-Za-z]+ed|drawn|taken)\s+from)\b",
+            subject,
+            flags=re.IGNORECASE,
+        ):
+            if candidate.group("head").lower() in {"a", "an", "the"}:
+                continue
+            relation_start = candidate.start("relation")
+            break
+    if relation_start is None:
+        participial_clause = re.search(
+            r"\b[A-Za-z][A-Za-z-]*ing\s+(?=(?:a|an|the)\s+"
+            r"(?:[A-Za-z][A-Za-z-]*\s+){0,3}"
+            r"(?:amount|base|calculation|computation|credit|deduction|formula|"
+            r"income|liability|rate|rule|tax)\b)",
+            subject,
+            flags=re.IGNORECASE,
+        )
+        if participial_clause is not None:
+            relation_start = participial_clause.start()
+    grammatical_head_scope = (
+        subject[:relation_start] if relation_start is not None else subject
+    )
+    tokens = re.findall(r"[A-Za-z]+", grammatical_head_scope.lower())
+    if not tokens:
+        return False
+    if tokens[-1] in executable_heads:
+        return True
+    executable_positions = [
+        index for index, token in enumerate(tokens) if token in executable_heads
+    ]
+    if not executable_positions:
+        return False
+    modifiers = {
+        "allowed",
+        "alone",
+        "applicable",
+        "adopted",
+        "attached",
+        "allowable",
+        "calculated",
+        "computed",
+        "determined",
+        "due",
+        "final",
+        "imposed",
+        "itself",
+        "named",
+        "owed",
+        "otherwise",
+        "outstanding",
+        "owing",
+        "payable",
+        "prescribed",
+        "remaining",
+        "required",
+        "selected",
+        "shown",
+        "specified",
+    }
+    return all(
+        token in modifiers or token.endswith(("able", "ible", "ly"))
+        for token in tokens[executable_positions[-1] + 1 :]
+    )
+
+
+def _louisiana_operative_suffix_is_bounded(suffix: str) -> bool:
+    """Allow statutory modifiers without admitting documentary framing."""
+
+    suffix = re.sub(
+        r"\b(and|or|but)\s*,\s*where\s+applicable\s*,\s*",
+        r"\1 ",
+        suffix,
+        flags=re.IGNORECASE,
+    )
+    positive_participle = (
+        r"(?:allowed|assessed|available|calculated|computed|derived|determined|"
+        r"established|fixed|imposed|levied|prescribed|rounded|set|specified)"
+    )
+    bounded_modifier = (
+        r"(?:annually|directly|entirely|exclusively|finally|separately|solely|"
+        r"statutorily|provisionally|annually|monthly|quarterly|"
+        r"for\s+(?:each|every)\s+(?:taxpayer|return|filing\s+unit)|each\s+year|"
+        r"for\s+(?:the\s+)?taxable\s+year|per\s+taxpayer|on\s+(?:the\s+)?return|"
+        r"on\s+an\s+annual\s+basis|at\s+the\s+taxpayer\s+level|"
+        r"for\s+the\s+applicable\s+taxable\s+year|to\s+the\s+nearest\s+dollar|"
+        r"for\s+each\s+(?:taxable\s+year|filing\s+period)|"
+        r"to\s+the\s+nearest\s+whole\s+dollar|"
+        r"as\s+of\s+the\s+close\s+of\s+the\s+taxable\s+year|"
+        r"in\s+all\s+cases|where\s+applicable|"
+        r"for\s+purposes\s+of\s+(?:this|the)\s+(?:section|subsection)|"
+        r"as\s+applicable|with\s+no\s+(?:adjustment|cap))"
+    )
+    return bool(
+        re.fullmatch(
+            rf"[\s,]*(?:(?:(?:and(?:\s+then)?|or|but|then)\s+)?"
+            rf"(?:(?:provisionally|finally|directly)\s+)*"
+            rf"{positive_participle}[\s,]*)*(?:{bounded_modifier}[\s,]*)*",
+            suffix,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _louisiana_local_finite_clause(scope: str) -> str:
+    """Return text after the last structural clause connector."""
+
+    connectors = tuple(
+        re.finditer(
+            r"\b(?:and|although|because|before|but|if|once|or|since|then|"
+            r"unless|when|whenever|where|whereas|while|yet)\b",
+            scope,
+            flags=re.IGNORECASE,
+        )
+    )
+    boundary = connectors[-1].end() if connectors else 0
+    # A comma after a fronted subordinate clause starts a fresh finite main
+    # clause; its negation must not contaminate the later operative predicate.
+    comma_boundaries = tuple(
+        match.end()
+        for match in re.finditer(r",", scope)
+        if re.match(
+            r"\s*(?:(?:the|a|an|this|that|final|applicable)\s+)?"
+            r"(?:[A-Za-z][A-Za-z-]*\s+){1,6}"
+            r"(?:is|are|was|were|shall|may|must|will|would|can|could|does|do|did)\b",
+            scope[match.end() :],
+            flags=re.IGNORECASE,
+        )
+    )
+    if (
+        re.match(
+            r"\s*(?:although|because|since|when|while)\b",
+            scope,
+            flags=re.IGNORECASE,
+        )
+        and "," in scope
+    ):
+        comma_boundaries += (scope.rfind(",") + 1,)
+    if comma_boundaries:
+        boundary = max(boundary, comma_boundaries[-1])
+    return scope[boundary:]
+
+
+def _louisiana_predicate_is_in_negative_complement(
+    scope: str,
+    *,
+    predicate_start: int,
+) -> bool:
+    """Reject a positive-looking predicate inside a negated ``that`` complement."""
+
+    prefix = scope[:predicate_start]
+    complement_markers = tuple(
+        re.finditer(r"\b(?:if|that|whether)\b", prefix, re.IGNORECASE)
+    )
+    if not complement_markers:
+        return bool(
+            re.search(
+                r"\b(?:uncertain|unknown|unclear|undetermined)\b",
+                _louisiana_local_finite_clause(prefix),
+                flags=re.IGNORECASE,
+            )
+        )
+    complement = complement_markers[-1]
+    marker = complement.group(0).lower()
+    introducer = prefix[: complement.start()]
+    if marker == "whether":
+        return True
+    if marker == "if":
+        return bool(
+            re.search(
+                r"\b(?:possible|uncertain|unclear|unknown|undetermined|questions?|"
+                r"asks?|doubts?)\b",
+                _louisiana_local_finite_clause(introducer),
+                flags=re.IGNORECASE,
+            )
+        )
+    preceding_word = re.search(r"([A-Za-z]+)\s*$", introducer)
+    if preceding_word and preceding_word.group(1).lower() in {
+        "except",
+        "provided",
+        "so",
+    }:
+        return False
+    local_introducer = _louisiana_local_finite_clause(introducer)
+    return bool(
+        re.search(
+            r"\b(?:no|not|nothing|never|cannot|denies?|rejects?|disclaims?|fails?|"
+            r"refuses?)\b|"
+            r"\b(?:assumes?|claims?|reports?|says?|purports?|suggests?)\b|"
+            r"\b(?:doubtful|evidence|false|untrue|impossible|possible|uncertain|"
+            r"unclear|unknown)\b|"
+            r"\bby\s+no\s+means\b|n['’]t\b",
+            local_introducer,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _source_link_scope_has_unreset_negation(governing_scope: str) -> bool:
+    """Bind negation to a linker unless a later finite predicate resets it."""
+
+    negative_markers = tuple(
+        re.finditer(
+            r"\b(?:not|never|neither|nor|cannot|nowhere|prohibit\w*|barred|"
+            r"forbidden|precluded|prevented|excluded|denied|except)\b|"
+            r"\b(?:denies?|rejects?|disclaims?)\b|"
+            r"\b(?:false|untrue|impossible)\s+that\b|"
+            r"(?:^|[,;:]\s*|\b(?:and|but|or|that|while|whereas)\s+)"
+            r"no\s+(?:amount|tax|liability|computation|calculation|"
+            r"determination|rate|base|statute|rule|provision|requirement)\b"
+            r"(?:\s+[A-Za-z-]+){0,3}\s+(?:is|are|was|were|shall|may|must|will|"
+            r"would|can|could|does|do|did|states?|provides?|requires?|"
+            r"determines?|calculates?|computes?|applies?|arises?)\b|"
+            r"\b(?:ca|do|does|did|is|are|was|were|"
+            r"shall|will|would|could|should|must|need)n['’]t\b|"
+            r"\b(?:fails?|refuses?|unable)\s+to\b|"
+            r"\bwithout\s+(?:being\s+)?(?:determin\w*|comput\w*|calculat\w*|"
+            r"appl\w*|impos\w*|aris\w*)\b|"
+            r"\b(?:in\s+no\s+(?:case|event)|under\s+no\s+circumstances|"
+            r"at\s+no\s+time|by\s+no\s+means|in\s+no\s+way|"
+            r"on\s+no\s+account|under\s+no\s+conditions?|"
+            r"in\s+no\s+(?:manner|respect))\b|"
+            r"\b(?:rather|other)\s+than\b",
+            governing_scope,
+            flags=re.IGNORECASE,
+        )
+    )
+    if not negative_markers:
+        return False
+
+    last_negative = negative_markers[-1]
+    after_last_negative = governing_scope[last_negative.end() :]
+
+    # A finite predicate inside an expressly negated complement does not escape
+    # merely because the complement coordinates another subject and verb.
+    if re.search(
+        r"(?:\bnot\s+the\s+case|\b(?:does?|did|is|are|was|were|has|have|had)"
+        r"\s+not\s+(?:provide|state|say|specify|indicate|require|establish|"
+        r"declare|permit|allow|assert|show)|\bnever\s+(?:provides?|states?|"
+        r"says?|specifies?|indicates?|requires?|establishes?|declares?|permits?|"
+        r"allows?|asserts?|shows?)|\b(?:denies?|rejects?|disclaims?)|"
+        r"\b(?:false|untrue|impossible))\s+that\b",
+        governing_scope,
+        flags=re.IGNORECASE,
+    ) and not re.search(
+        r"\b(?:but|yet|however|nevertheless|nonetheless)\b",
+        after_last_negative,
+        flags=re.IGNORECASE,
+    ):
+        return True
+
+    reset = re.search(
+        r"(?:\b(?:provided\s+that|even\s+though|so\s+long\s+as|and|but|yet|"
+        r"while|whereas|or|then|because|since|if|when|whenever|although|unless|"
+        r"once|after|before|where|as)\b|,)\s+"
+        r"(?:instead\s+)?(?:"
+        # A repeated auxiliary/copula makes a coordinated predicate finite.
+        r"(?:is|are|was|were|shall|may|must|will|would|can|could|does|do|did|"
+        r"becomes?|remains?)\b|"
+        # Otherwise require an explicit subject before the finite predicate;
+        # this keeps shared-negation forms such as "not apply or arise" bound.
+        r"(?:(?:the|a|an|this|that|final|preliminary|separate)\s+)?"
+        r"(?:[A-Za-z][A-Za-z-]*\s+){1,7}?"
+        r"(?:is|are|was|were|shall|may|must|will|would|can|could|does|do|did|"
+        r"becomes?|remains?|depends?|requires?|determines?|calculates?|computes?|"
+        r"establishes?|applies?|imposes?|allows?|arises?|supplies?|provides?)\b"
+        r")",
+        after_last_negative,
+        flags=re.IGNORECASE,
+    )
+    if reset is None:
+        return True
+    reset_scope = after_last_negative[reset.start() :]
+    # A new negative construction after the reset governs the dependency.
+    return bool(
+        re.search(
+            r"\b(?:not|never|neither|nor|cannot|nowhere|prohibit\w*|barred|"
+            r"forbidden|precluded|prevented|excluded|denied|except)\b|"
+            r"\b(?:denies?|rejects?|disclaims?)\b|"
+            r"\b(?:false|untrue|impossible)\s+that\b|"
+            r"\b(?:fails?|refuses?|unable)\s+to\b|"
+            r"\bwithout\s+(?:being\s+)?(?:determin\w*|comput\w*|calculat\w*|"
+            r"appl\w*|impos\w*|aris\w*)\b",
+            reset_scope,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _louisiana_disclaimer_governs_reference(local_before: str) -> bool:
+    """Bind a contextual disclaimer to its citation, not an earlier preamble."""
+
+    disclaimers = tuple(
+        re.finditer(
+            r"\b(?:without\s+prejudice\s+to|remain\w*\s+unaffected|"
+            r"unaffected\s+by|does\s+not\s+affect|notwithstanding)\b",
+            local_before,
+            flags=re.IGNORECASE,
+        )
+    )
+    if not disclaimers:
+        return False
+    disclaimer = disclaimers[-1]
+    after_disclaimer = local_before[disclaimer.end() :]
+    separator = re.search(r"(?:,|:|[-\u2013\u2014])", after_disclaimer)
+    if separator is None:
+        return True
+    disclaimer_object = after_disclaimer[: separator.start()]
+    reset_scope = after_disclaimer[separator.end() :]
+    disclaimer_is_context_preamble = _louisiana_disclaimer_object_is_context_preamble(
+        disclaimer_object
+    )
+    relative_reset = re.match(
+        r"\s*(?:(?:by|to|through|under|pursuant\s+to|in|according\s+to)\s+which|"
+        r"which|who|whom|whose|where|whereby|wherein|that)\b",
+        reset_scope,
+        flags=re.IGNORECASE,
+    )
+    if relative_reset:
+        independent_boundaries = []
+        for boundary in re.finditer(
+            r"\b(?:although|and|because|but|or|while|whereas|yet)\b|,",
+            reset_scope,
+            re.IGNORECASE,
+        ):
+            candidate = reset_scope[boundary.end() :]
+            if not _louisiana_scope_starts_independent_finite_clause(candidate):
+                continue
+            if boundary.group(0) == "," and not _louisiana_relative_prefix_is_closed(
+                reset_scope[: boundary.start()]
+            ):
+                continue
+            independent_boundaries.append(boundary)
+        if not independent_boundaries:
+            return True
+        reset_candidates = [
+            reset_scope[boundary.end() :] for boundary in independent_boundaries
+        ]
+    else:
+        reset_candidates = [reset_scope]
+        reset_candidates.extend(
+            after_disclaimer[boundary.end() :]
+            for boundary in re.finditer(r"(?:,|:|[-\u2013\u2014])", after_disclaimer)
+            if boundary.end() > separator.end()
+        )
+    for candidate in reversed(reset_candidates):
+        if re.match(
+            r"\s*(?:(?:although|and|because|but|or|since|when|while|whereas|yet)\s+)?"
+            r"(?:under\s+which|in\s+which|which|who|whom|whose|where|that)\b",
+            candidate,
+            flags=re.IGNORECASE,
+        ):
+            continue
+        operative = _LOUISIANA_POSITIVE_OPERATIVE_PREDICATE.search(candidate)
+        if operative is None:
+            continue
+        has_independent_connector = bool(
+            re.match(
+                r"\s*(?:although|and|because|but|or|since|when|while|whereas|yet)\b",
+                candidate,
+                flags=re.IGNORECASE,
+            )
+        )
+        if not disclaimer_is_context_preamble and not has_independent_connector:
+            continue
+        introduction = candidate[: operative.start()]
+        if re.search(
+            r"\b(?:alleges?|asserts?|claims?|declares?|indicates?|notes?|observes?|"
+            r"opines?|proclaims?|recites?|reports?|says?|states?|stipulates?|"
+            r"testifies?)"
+            r"\b",
+            introduction,
+            flags=re.IGNORECASE,
+        ):
+            continue
+        if re.match(
+            r"\s*(?:(?:although|and|because|but|or|since|when|while|whereas|yet)\s+)?"
+            r"(?:(?:the|a|an|this|that|final|applicable)\s+)?"
+            r"(?:[A-Za-z][A-Za-z-]*\s+){0,7}"
+            r"(?:is|are|was|were|shall|may|must|will|would|can|could|does|do|did|"
+            r"becomes?|remains?|allows?|assesses?|calculates?|computes?|derives?|"
+            r"determines?|establishes?|fixes?|imposes?|levies?|prescribes?|sets?|"
+            r"specifies?)\b",
+            candidate,
+            flags=re.IGNORECASE,
+        ):
+            return False
+    if not disclaimer_is_context_preamble:
+        return True
+    before_disclaimer = local_before[: disclaimer.start()]
+    reset_is_relative = bool(
+        re.match(
+            r"\s*(?:(?:although|and|because|but|or|since|when|while|whereas|yet)\s+)?"
+            r"(?:(?:by|to|through|under|pursuant\s+to|in|according\s+to)\s+which|"
+            r"which|who|whom|whose|where|whereby|wherein|that)\b",
+            reset_scope,
+            flags=re.IGNORECASE,
+        )
+    )
+    if reset_is_relative:
+        return True
+    return not bool(
+        (
+            not reset_is_relative
+            and _LOUISIANA_POSITIVE_OPERATIVE_PREDICATE.search(reset_scope)
+        )
+        or _LOUISIANA_POSITIVE_OPERATIVE_PREDICATE.search(before_disclaimer)
+    )
+
+
+def _louisiana_scope_starts_independent_finite_clause(scope: str) -> bool:
+    """Require an explicit subject before a disclaimer reset predicate."""
+
+    return bool(
+        re.match(
+            r"\s*(?:(?:the|a|an|this|that|final|applicable)\s+)?"
+            r"(?:[A-Za-z][A-Za-z-]*\s+){1,7}"
+            r"(?:is|are|was|were|shall|may|must|will|would|can|could|does|do|did|"
+            r"becomes?|remains?|allows?|assesses?|calculates?|computes?|derives?|"
+            r"determines?|establishes?|fixes?|imposes?|levies?|prescribes?|sets?|"
+            r"specifies?)\b",
+            scope,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _louisiana_relative_prefix_is_closed(prefix: str) -> bool:
+    """Return whether a relative clause has a finite predicate before a comma."""
+
+    relative = re.match(
+        r"\s*(?:(?:by|to|through|under|pursuant\s+to|in|according\s+to)\s+which|"
+        r"which|who|whom|whose|where|whereby|wherein|that)\b",
+        prefix,
+        flags=re.IGNORECASE,
+    )
+    if relative is None:
+        return False
+    return bool(
+        re.search(
+            r"\b(?:is|are|was|were|has|have|had|does|do|did|applies?|continues?|"
+            r"exists?|remains?|governs?|controls?|requires?|provides?|states?)\b",
+            prefix[relative.end() :],
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _louisiana_disclaimer_object_is_context_preamble(disclaimer_object: str) -> bool:
+    """Recognize a self-contained external-law preamble object."""
+
+    return bool(
+        re.search(
+            r"(?:\b(?:applicable|federal|louisiana|other|state)\s+"
+            r"(?:law|rights?|return\s+rule|statute)|"
+            r"\bthe\s+law\s+of\s+this\s+state|"
+            r"\bany\s+law\s+(?:to\s+the\s+)?contrary|"
+            r"\bany\s+other\s+provision\s+of\s+law|"
+            r"\b\d+\s+U\.?\s*S\.?\s*C\.?\s+\d+[A-Za-z0-9.\-]*|"
+            r"\bR\.?\s*S\.?\s*\d+[A-Za-z]?\s*:\s*\d+[A-Za-z0-9.\-]*)\s*$",
+            disclaimer_object,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _louisiana_strip_inline_context_preamble(scope: str) -> str:
+    """Remove a bounded inline external-law preamble before attachment checks."""
+
+    return re.sub(
+        r"(?:,\s*|[-\u2013\u2014]\s*)"
+        r"(?:notwithstanding|without\s+prejudice\s+to)\s+"
+        r"(?:(?:applicable|federal|other|state)\s+"
+        r"(?:law|rights?|return\s+rule|statute)|"
+        r"any\s+other\s+provision\s+of\s+law|"
+        r"\d+\s+U\.?\s*S\.?\s*C\.?\s+\d+[A-Za-z0-9.\-]*|"
+        r"R\.?\s*S\.?\s*\d+[A-Za-z]?\s*:\s*\d+[A-Za-z0-9.\-]*)\s*"
+        r"(?:,|[-\u2013\u2014])\s*",
+        " ",
+        scope,
+        flags=re.IGNORECASE,
+    )
+
+
 def _usc_dependency_fragments(match: re.Match[str]) -> tuple[str, ...]:
     return tuple(
         fragment.lower()
         for fragment in re.findall(
-            r"\(\s*([A-Za-z0-9]+)\s*\)",
+            r"\(\s*([A-Za-z0-9]+(?:[-\u2013][A-Za-z0-9]+)*)\s*\)",
             match.group("tail") or "",
         )
     )
+
+
+def _louisiana_rs_tail_identity(match: re.Match[str]) -> str:
+    """Preserve connector and legal-label semantics in an R.S. citation tail."""
+
+    tail = (match.group("tail") or "").lower()
+    tail = re.sub(r"[\u2010-\u2015\u2212\ufe58\ufe63\uff0d]", "-", tail)
+    tail = re.sub(r"\s+", " ", tail)
+    tail = re.sub(r",\s*(?:and\s+)?(?=\()", " and ", tail)
+    tail = re.sub(r"&", " and ", tail)
+    tail = re.sub(
+        r"\b(?:clauses?|divisions?|items?|lines?|paragraphs?|parts?|"
+        r"schedules?|subclauses?|subdivisions?|subitems?|subparagraphs?|"
+        r"subparts?)\b",
+        lambda item: item.group(0).removesuffix("s"),
+        tail,
+    )
+    tail = re.sub(r"\bsubsections?\s+(?=\()", "", tail)
+    tail = re.sub(r"\bread\s+together\s+with\b", "read with", tail)
+    tail = re.sub(r"\b(?:through|to)\b|-(?=\s*\()", " range ", tail)
+    tail = re.sub(r"\s*([(),])\s*", r"\1", tail)
+    tail = re.sub(r"\s+", " ", tail)
+    return tail.strip()
 
 
 def _qualified_usc_dependencies(text: str) -> tuple[re.Match[str], ...]:
@@ -4738,6 +6480,79 @@ def _qualified_usc_dependencies(text: str) -> tuple[re.Match[str], ...]:
             key=lambda match: (match.start(), match.end()),
         )
     )
+
+
+def _qualified_louisiana_rs_dependencies(text: str) -> tuple[re.Match[str], ...]:
+    """Return exact R.S. citations, excluding natural fragment continuations."""
+
+    return tuple(
+        match
+        for match in _LOUISIANA_RS_DEFERRAL_DEPENDENCY.finditer(text)
+        if not _louisiana_rs_match_has_unsupported_fragment_tail(text, match)
+    )
+
+
+def _louisiana_rs_match_has_detached_structural_subject(
+    text: str,
+    match: re.Match[str],
+) -> bool:
+    """Reject a labeled parenthetical that is the subject of following prose."""
+
+    tail = match.group("tail") or ""
+    if not re.search(
+        r"\b(?:clause|division|item|line|paragraph|part|schedule|subsection)s?\s+"
+        r"\(",
+        tail,
+        flags=re.IGNORECASE,
+    ):
+        return False
+    if _louisiana_citation_list_completes_outer_subject(text[: match.start()]):
+        return False
+    return _louisiana_reference_starts_finite_clause(text[match.end() :])
+
+
+def _louisiana_rs_match_has_unsupported_fragment_tail(
+    text: str,
+    match: re.Match[str],
+) -> bool:
+    """Reject only parenthetical fragments structurally continuing a citation."""
+
+    same_clause_tail = re.split(r"[.;\n]", text[match.end() :], maxsplit=1)[0]
+    previous_end = 0
+    for parenthetical in re.finditer(
+        r"\(\s*[A-Za-z0-9]+(?:[-\u2013][A-Za-z0-9]+)*\s*\)",
+        same_clause_tail,
+        flags=re.IGNORECASE,
+    ):
+        prefix = same_clause_tail[previous_end : parenthetical.start()]
+        following = same_clause_tail[parenthetical.end() :]
+        previous_end = parenthetical.end()
+        if re.match(
+            r"\s+(?:filers?\b|of\s+(?:the\s+)?(?:calculation|explanatory\s+report|"
+            r"form|report|return|tax\s+return|worksheet)\b)",
+            following,
+            flags=re.IGNORECASE,
+        ):
+            continue
+        if re.fullmatch(
+            r"\s*,?\s*(?:"
+            r"(?:and|or|plus|as\s+well\s+as|together\s+with|as\s+supplemented\s+by|"
+            r"combined\s+with|in\s+addition\s+to|as\s+amended\s+by|including|"
+            r"through|to|&|[-\u2013\u2014])|"
+            r"followed\s+by(?:\s+(?:clause|division|item|line|paragraph|schedule|"
+            r"subclause|subdivision|subitem|subparagraph|subpart|subsection))?|"
+            r"as\s+enumerated\s+in|as\s+also\s+set\s+forth\s+at|alongside|"
+            r"as\s+extended\s+from|"
+            r"(?:as\s+[^,.;]{0,100}|together\s+with\s+[^,.;]{0,100})|"
+            r"(?:clause|division|item|paragraph|schedule|subclause|subdivision|"
+            r"subitem|subparagraph|subpart|subsection))\s*",
+            prefix,
+            flags=re.IGNORECASE,
+        ):
+            return True
+        if re.fullmatch(r"\s*,\s*", prefix):
+            return True
+    return False
 
 
 def _citation_instrument_identity(
@@ -4796,7 +6611,11 @@ def _reason_dependency_is_source_bound(
 ) -> bool:
     """Require one external dependency citation to bind to the deferred source."""
 
-    if not _MISSING_DEPENDENCY_LANGUAGE.search(reason):
+    louisiana_dependencies = _qualified_louisiana_rs_dependencies(reason)
+    if not _MISSING_DEPENDENCY_LANGUAGE.search(reason) and not any(
+        _reason_match_has_bounded_insufficiency(reason, dependency)
+        for dependency in louisiana_dependencies
+    ):
         return False
     try:
         current_citation = parse_usc_citation(corpus_citation_path)
@@ -4824,6 +6643,27 @@ def _reason_dependency_is_source_bound(
                 current_citation is not None
                 and current_citation.title.lower() == match.group("title").lower()
             ),
+        ):
+            return True
+
+    for match in louisiana_dependencies:
+        if not _reason_match_names_missing_dependency(
+            reason,
+            match,
+            source_scope_text=source_scope_text,
+            current_usc_title=None,
+            allow_bounded_insufficiency=True,
+        ) or not _louisiana_rs_dependency_is_external(
+            match,
+            corpus_citation_path=corpus_citation_path,
+        ):
+            continue
+        if _source_scope_cites_louisiana_rs_dependency(
+            source_scope_text,
+            title=match.group("title"),
+            section=match.group("section"),
+            fragments=_usc_dependency_fragments(match),
+            tail_identity=_louisiana_rs_tail_identity(match),
         ):
             return True
 
@@ -4886,6 +6726,7 @@ def _reason_match_names_missing_dependency(
     *,
     source_scope_text: str,
     current_usc_title: str | None,
+    allow_bounded_insufficiency: bool = False,
 ) -> bool:
     clause_start, clause_end = _reason_clause_bounds(reason, match)
     clause = reason[clause_start:clause_end]
@@ -4914,6 +6755,10 @@ def _reason_match_names_missing_dependency(
         after,
         flags=re.IGNORECASE,
     )
+    if allow_bounded_insufficiency and _reason_match_has_bounded_insufficiency(
+        reason, match
+    ):
+        return True
     direct_signals = list(_MISSING_DEPENDENCY_LANGUAGE.finditer(before))
     direct_signal_text = direct_signals[-1].group(0) if direct_signals else ""
     if (
@@ -5008,6 +6853,1751 @@ def _reason_match_names_missing_dependency(
     return True
 
 
+def _reason_match_has_bounded_insufficiency(
+    reason: str,
+    match: re.Match[str],
+) -> bool:
+    """Recognize one citation-local statement that a supplied dependency is incomplete."""
+
+    _clause_start, clause_end = _reason_clause_bounds(reason, match)
+    if clause_end < len(reason) and clause_end - match.end() <= 240:
+        later_stop = re.search(r"[.;\n]", reason[clause_end + 1 :])
+        clause_end = (
+            min(len(reason), clause_end + 1 + later_stop.end())
+            if later_stop is not None
+            else len(reason)
+        )
+    after = reason[match.end() : clause_end]
+    insufficiency = re.match(
+        r"\s*(?:(?:dependency|context|module|output|provision|rulespec)\s+)?"
+        r"(?:(?:provides?|exports?)\s+only\b(?P<limited>[^.;\n]{1,200}?)"
+        r"\s+and\s+)?(?P<verb>lacks?|does\s+not\s+provide)\s+",
+        after,
+        flags=re.IGNORECASE,
+    )
+    if insufficiency is None:
+        return False
+    limited = insufficiency.group("limited") or ""
+    if _has_adversative_language(limited):
+        return False
+    dependencies_after = tuple(
+        dependency
+        for dependency in _reason_dependencies(after)
+        if not (
+            re.search(
+                r"\b(?:both|those)\s*$",
+                after[: dependency.start()],
+                flags=re.IGNORECASE,
+            )
+            and re.match(
+                r"\s+[A-Za-z][A-Za-z-]*\b",
+                after[dependency.end() :],
+            )
+        )
+    )
+    if any(
+        dependency.start() < insufficiency.end() for dependency in dependencies_after
+    ):
+        return False
+    missing_tail = after[insufficiency.end() :]
+    if re.match(r"\s*(?:no|not|none|without)\b", missing_tail, flags=re.IGNORECASE):
+        return False
+    current_family = _dependency_citation_family(match)
+    current_identity = (
+        match.groupdict().get("title", "").lower(),
+        normalize_rulespec_path_segment(match.group("section").lower()),
+        _usc_dependency_fragments(match),
+    )
+    foreign_dependency_starts = []
+    for dependency in dependencies_after:
+        dependency_groups = dependency.groupdict()
+        if not dependency_groups.get("section"):
+            foreign_dependency_starts.append(dependency.start())
+            continue
+        dependency_identity = (
+            (dependency_groups.get("title") or "").lower(),
+            normalize_rulespec_path_segment(dependency_groups["section"].lower()),
+            _usc_dependency_fragments(dependency),
+        )
+        if (
+            _dependency_citation_family(dependency) != current_family
+            or dependency_identity != current_identity
+        ):
+            foreign_dependency_starts.append(dependency.start())
+    missing_end = min(foreign_dependency_starts, default=len(after))
+    missing_scope = after[insufficiency.end() : missing_end]
+    missing_scope = _louisiana_normalize_parenthetical_aspect(missing_scope)
+    missing_scope = re.sub(
+        r"\b(?:(?:although|even\s+though|though|while)\s+"
+        r"(?:it|this|that)\s+(?:is|was)\s+(?:[A-Za-z][A-Za-z-]*ly\s+)?|"
+        r"(?:despite|notwithstanding)\s+(?:the\s+fact\s+)?that\s+"
+        r"(?:it|this|that)\s+(?:is|was)\s+|despite\s+(?:itself\s+)?)"
+        r"not\s+(?:being\s+)?(?=(?:merely\s+)?(?:an?\s+)?"
+        r"(?:hypothetical|proposed)\b)",
+        "not ",
+        missing_scope,
+        flags=re.IGNORECASE,
+    )
+    missing_scope = re.sub(
+        r"\b(?:although|even\s+though|though|while)\s+"
+        r"(?:[A-Za-z][A-Za-z-]*ly\s+)?"
+        r"(?=not\s+(?:merely\s+)?(?:an?\s+)?"
+        r"(?:hypothetical|proposed)\b)",
+        "",
+        missing_scope,
+        flags=re.IGNORECASE,
+    )
+    return bool(
+        len(missing_scope) <= 240
+        and _missing_scope_starts_with_executable_object(missing_scope)
+        and not _missing_scope_reverses_insufficiency(missing_scope)
+    )
+
+
+_LOUISIANA_DOCUMENTARY_HEAD = re.compile(
+    r"\b(?:abstracts?|annotations?|appendices|appendix|articles?|audits?|background|"
+    r"bibliograph(?:y|ies)|briefs?|catalogs?|charts?|commentary|comparisons?|"
+    r"descriptions?|digests?|documents?|documentation|examples?|exhibits?|"
+    r"explanations?|guidance|illustrations?|index(?:es)?|indices|labels?|legends?|manuals?|"
+    r"materials?|memos?|memoranda|memorandums?|metadata|narratives?|notes?|overviews?|"
+    r"reports?|summaries|summary|synopses|synopsis|transcripts?|worksheets?)\b",
+    flags=re.IGNORECASE,
+)
+
+_LOUISIANA_SUPPLY_VERB_PATTERN = (
+    r"(?:suppl(?:y|ies|ied|ying)|provid(?:e[sd]?|ing)|export(?:s|ed|ing)?|"
+    r"contain(?:s|ed|ing)?|includ(?:e[sd]?|ing)|furnish(?:es|ed|ing)?|"
+    r"implement(?:s|ed|ing)?|deliver(?:s|ed|ing)?|return(?:s|ed|ing)?|"
+    r"produc(?:e[sd]?|ing)|yield(?:s|ed|ing)?|deriv(?:e[sd]?|ing)|"
+    r"expos(?:e[sd]?|ing)|generat(?:e[sd]?|ing)|possess(?:es|ed|ing)?|"
+    r"retain(?:s|ed|ing)?|offers?|lists?|reproduces?|computes?|calculates?|"
+    r"determines?|defines?|encodes?|publishes?|gives?|"
+    r"outputs(?=\s+(?:(?:a|an|the|this|that)\s+)?[A-Za-z])|stores?|holds?|"
+    r"specifies?|displays?|emits?|retrieves?|access(?:es|ed|ing)?|uses?|reads?|"
+    r"loads?|imports?|keeps?|ship(?:s|ped|ping)?|has|have|makes?|renders?|"
+    r"gave|sent|made|kept|had)"
+)
+
+
+def _louisiana_supply_verb_is_completed(verb: str) -> bool:
+    """Recognize regular and common irregular completed supply predicates."""
+
+    normalized = verb.lower()
+    return normalized.endswith("ed") or normalized in {
+        "gave",
+        "had",
+        "kept",
+        "made",
+        "sent",
+    }
+
+
+def _missing_scope_starts_with_executable_object(missing_scope: str) -> bool:
+    """Require the direct missing object's semantic head to be executable."""
+
+    primary_object_scope = re.split(
+        r"\b(?:and|but|while|yet)\b", missing_scope, maxsplit=1, flags=re.IGNORECASE
+    )[0]
+    if _LOUISIANA_DOCUMENTARY_HEAD.search(primary_object_scope) or re.search(
+        r"\b(?:candidate|conceptual|draft|fictional|hypothetical|illustrative|mock|"
+        r"notional|placeholder|proposed|prototype|purported|sample|specimen|suggested)\b|"
+        r"\b(?:provisional|tentative)\s+(?:amount|calculation|computation|formula|"
+        r"method)\b",
+        primary_object_scope,
+        flags=re.IGNORECASE,
+    ):
+        return False
+    if re.search(
+        r"\brecords?\b[^.;\n]{0,100}\b(?:containing|detailing|discussing|"
+        r"documenting|that|which|whose)\b",
+        primary_object_scope,
+        flags=re.IGNORECASE,
+    ):
+        return False
+    direct_object = re.split(
+        r"\b(?:and|but|while|yet|that|which|who|whose|about|against|among|around|at|"
+        r"before|behind|below|beneath|beside|between|beyond|by|concerning|"
+        r"considering|covering|despite|down|during|except|following|for|from|in|inside|"
+        r"into|like|near|of|off|on|onto|opposite|outside|over|past|regarding|"
+        r"round|since|through|throughout|to|toward|under|underneath|unlike|"
+        r"until|up|upon|via|with|within|without|contain\w*|detail\w*|describ\w*|"
+        r"discuss\w*|document\w*|explain\w*|illustrat\w*|outline\w*|"
+        r"demonstrat\w*|summariz\w*|"
+        r"includ\w*|support\w*|needed|used|intended|required\s+to|"
+        r"necessary\s+to)\b|,",
+        missing_scope,
+        maxsplit=1,
+        flags=re.IGNORECASE,
+    )[0]
+    direct_object = _LOUISIANA_RS_DEFERRAL_DEPENDENCY.sub(" ", direct_object)
+    tokens = re.findall(r"[A-Za-z]+", direct_object.lower())
+    while tokens and tokens[0] in {"a", "an", "the"}:
+        tokens.pop(0)
+    if not tokens:
+        return False
+    if _louisiana_object_signature(tokens[-1]) is not None:
+        return True
+    return bool(
+        tokens[-1] in {"set", "sets"}
+        and len(tokens) > 1
+        and _louisiana_object_signature(tokens[-2]) is not None
+    )
+
+
+def _missing_scope_reverses_insufficiency(missing_scope: str) -> bool:
+    """Reject a positive coordinated assertion supplying the missing object."""
+
+    missing_scope = re.sub(
+        r",\s*which\s*,\s*(?:"
+        r"(?:although|even\s+though|though|while)\s+"
+        r"(?:(?:[A-Za-z][A-Za-z-]*ly)(?:\s+and\s+"
+        r"[A-Za-z][A-Za-z-]*ly)*\s+)?not\s+(?:merely\s+)?(?:an?\s+)?"
+        r"(?:hypothetical|proposed)|"
+        r"despite\s+[^,.;]{0,80}\bnot\s+being\s+(?:merely\s+)?(?:an?\s+)?"
+        r"(?:hypothetical|proposed)|"
+        r"(?:far\s+from|nowhere\s+near|anything\s+but|the\s+opposite\s+of)\s+"
+        r"(?:merely\s+)?"
+        r"(?:hypothetical|proposed)|"
+        r"being\s+(?:actual|real)\s+rather\s+than\s+"
+        r"(?:hypothetical|proposed))\s*,\s*",
+        " ",
+        missing_scope,
+        flags=re.IGNORECASE,
+    )
+    missing_scope = re.sub(
+        r"(?P<relative>\b(?:that|which)\b[^,.;]{1,100}),\s*"
+        r"(?:if|unless|provided\s+that|so\s+long\s+as)\b[^,.;]{1,80},"
+        r"(?=\s*(?:and|as\s+well\s+as|but|or|yet)\s+"
+        r"[A-Za-z][A-Za-z-]*\b)",
+        r"\g<relative>",
+        missing_scope,
+        flags=re.IGNORECASE,
+    )
+
+    coordinators = tuple(
+        re.finditer(
+            r"\b(?:although|and|despite|however|notwithstanding|since|then|while)\b|"
+            r"(?<!anything )(?<!nothing )\bbut\b|"
+            r"(?<!not )\byet\b|"
+            r"\bin\s+spite\s+of\b|\beven\s+though\b|[.;]\s*|"
+            rf",(?!\s*(?:because|so)\b)\s*(?=(?:then\s+)?[^,.;]{{0,80}}\b"
+            rf"(?:(?:(?:can|could|does|may|might|must|shall|should|will|would)\s+)?"
+            rf"{_LOUISIANA_SUPPLY_VERB_PATTERN}|"
+            r"(?:is|are|was|were|becomes?|remains?)\s+(?:available|complete|present|"
+            r"supplied|provided|implemented|accessible))\b)",
+            missing_scope,
+            re.IGNORECASE,
+        )
+    )
+    if not coordinators:
+        return False
+    missing_head = _missing_scope_semantic_head(
+        missing_scope[: coordinators[0].start()]
+    )
+    if missing_head is None:
+        return False
+    missing_object = missing_scope[: coordinators[0].start()]
+    coordinated_list_supplies_missing = _louisiana_coordinated_list_supplies_object(
+        missing_scope, missing_object=missing_object
+    )
+    last_supply_assertion = False
+    last_explicit_signature: tuple[str, frozenset[str]] | None = None
+    numbered_explicit_signatures: dict[str, tuple[str, frozenset[str]]] = {}
+    pending_conditional_context = False
+    for index, coordinator in enumerate(coordinators):
+        segment_end = (
+            coordinators[index + 1].start()
+            if index + 1 < len(coordinators)
+            else len(missing_scope)
+        )
+        segment = missing_scope[coordinator.end() : segment_end]
+        assertions = tuple(
+            assertion
+            for assertion in re.finditer(
+                rf"\b(?P<verb>{_LOUISIANA_SUPPLY_VERB_PATTERN})\b",
+                segment,
+                flags=re.IGNORECASE,
+            )
+            if not (
+                assertion.group("verb").lower().startswith("return")
+                and re.search(
+                    r"\b(?:for|of)\s*$",
+                    segment[: assertion.start()],
+                    flags=re.IGNORECASE,
+                )
+            )
+            and not (
+                assertion.group("verb").lower() == "provided"
+                and not segment[: assertion.start()].strip()
+                and re.match(
+                    r"\s+that\b",
+                    segment[assertion.end() :],
+                    flags=re.IGNORECASE,
+                )
+            )
+            and not (
+                _louisiana_supply_verb_is_completed(assertion.group("verb"))
+                and (
+                    re.search(
+                        r"\b(?:is|are|was|were|be|been|being)\s*$",
+                        segment[: assertion.start()],
+                        flags=re.IGNORECASE,
+                    )
+                    or not segment[assertion.end() :].strip()
+                    or (
+                        not re.search(
+                            r",\s*(?:because|so)\b",
+                            segment[assertion.end() :],
+                            flags=re.IGNORECASE,
+                        )
+                        and re.match(
+                            rf"\s+[A-Za-z][A-Za-z-]*\s+[^,.;]{{0,40}}\b"
+                            rf"{_LOUISIANA_SUPPLY_VERB_PATTERN}\b",
+                            segment[assertion.end() :],
+                            flags=re.IGNORECASE,
+                        )
+                    )
+                )
+            )
+            and not (
+                assertion.group("verb").lower().startswith(("contain", "includ"))
+                and re.search(
+                    r"\b[A-Za-z][A-Za-z-]*(?:s|ed)\s+(?:a|an|the)\s+"
+                    r"[^,.;]{1,60}\s+$",
+                    segment[: assertion.start()],
+                    flags=re.IGNORECASE,
+                )
+            )
+        )
+        if not assertions and last_supply_assertion:
+            shared_object = re.sub(r"^\s*(?:then\s+)?", "", segment)
+            demonstrative = re.match(
+                r"\s*(?:this|that|those|it|them|both|the\s+same|same)\b",
+                shared_object,
+                flags=re.IGNORECASE,
+            )
+            antecedent_signature = _louisiana_demonstrative_antecedent_signature(
+                shared_object,
+                last_explicit_signature=last_explicit_signature,
+                numbered_signatures=numbered_explicit_signatures,
+            )
+            if not (
+                demonstrative
+                and antecedent_signature is not None
+                and not _louisiana_signatures_corefer(
+                    antecedent_signature,
+                    _louisiana_object_signature(missing_object),
+                )
+            ) and _louisiana_assertion_object_corefers(
+                shared_object,
+                missing_head=missing_head,
+                missing_object=missing_object,
+            ):
+                return True
+        if not assertions and re.match(
+            r"\s*(?:if|unless|provided(?:\s+that)?|so\s+long\s+as|in\s+case|"
+            r"subject\s+to|dependent\s+on|contingent\s+(?:on|upon)|"
+            r"conditioned\s+(?:on|upon)|pending(?:\s+receipt)?|"
+            r"(?:on|upon|following)\s+(?:approval|receipt))\b",
+            segment,
+            flags=re.IGNORECASE,
+        ):
+            pending_conditional_context = True
+        for assertion_index, assertion in enumerate(assertions):
+            prefix_signature = _louisiana_pre_supply_antecedent_signature(
+                segment[: assertion.start()]
+            )
+            if prefix_signature is not None:
+                last_explicit_signature = prefix_signature
+                prefix_number = _louisiana_object_number(segment[: assertion.start()])
+                if prefix_number is not None:
+                    numbered_explicit_signatures[prefix_number] = prefix_signature
+            assertion_end = (
+                assertions[assertion_index + 1].start()
+                if assertion_index + 1 < len(assertions)
+                else len(segment)
+            )
+            object_scope = segment[assertion.end() : assertion_end]
+            if re.match(
+                r"\s*(?:this|that|those|it|them|both|the\s+same|same)\b",
+                object_scope,
+                flags=re.IGNORECASE,
+            ):
+                direct_object = object_scope
+            else:
+                direct_object = re.split(
+                    r",\s*(?:then\s+)?|\b(?:after|and|because|before|but|"
+                    r"concerning|describing|once|that|then|to|used|when|which|"
+                    r"while|whose|yet)\b",
+                    object_scope,
+                    maxsplit=1,
+                    flags=re.IGNORECASE,
+                )[0]
+            if _louisiana_supply_assertion_has_nonoperative_framing(
+                segment, assertion
+            ) or _louisiana_assertion_is_negative(segment, assertion.start()):
+                last_supply_assertion = False
+                continue
+            if pending_conditional_context and not _louisiana_supply_verb_is_completed(
+                assertion.group("verb")
+            ):
+                pending_conditional_context = False
+                last_supply_assertion = False
+                continue
+            pending_conditional_context = False
+            if re.match(
+                r"\s*(?:absolutely\s+)?(?:(?:no|none|not)\b|an?\s+incomplete\b|"
+                r"only\s+(?:part\s+of|an?\s+(?:draft|incomplete|partial))|"
+                r"(?:hardly|barely|scarcely)\s+any|almost\s+no|"
+                r"(?:(?:merely\s+)?(?:some|half(?:\s+of)?)|"
+                r"an?\s+(?:draft|fragment|partial|subset|fraction)|"
+                r"(?:an?\s+few|merely)?\s*(?:pieces?|portions?|fragments?|excerpt)\s+of|"
+                r"less\s+than\s+all(?:\s+of)?|most\b))",
+                direct_object,
+                flags=re.IGNORECASE,
+            ):
+                last_supply_assertion = False
+                continue
+            direct_signature = _louisiana_nearest_object_signature(
+                direct_object, allow_opaque=True
+            )
+            demonstrative = bool(
+                re.match(
+                    r"\s*(?:this|that|those|it|them|both|the\s+same|same)\b",
+                    direct_object,
+                    flags=re.IGNORECASE,
+                )
+            )
+            antecedent_signature = _louisiana_demonstrative_antecedent_signature(
+                direct_object,
+                last_explicit_signature=last_explicit_signature,
+                numbered_signatures=numbered_explicit_signatures,
+            )
+            if (
+                demonstrative
+                and re.match(
+                    r"\s*(?:them|those|both)\b",
+                    direct_object,
+                    flags=re.IGNORECASE,
+                )
+                and coordinated_list_supplies_missing
+            ):
+                return True
+            if (
+                demonstrative
+                and antecedent_signature is not None
+                and not _louisiana_signatures_corefer(
+                    antecedent_signature,
+                    _louisiana_object_signature(missing_object),
+                )
+            ):
+                last_supply_assertion = True
+                continue
+            if _louisiana_assertion_object_corefers(
+                direct_object,
+                missing_head=missing_head,
+                missing_object=missing_object,
+            ):
+                return True
+            if direct_signature is not None:
+                if not re.search(
+                    r"\b(?:choice|alternative|option)\b",
+                    direct_object,
+                    flags=re.IGNORECASE,
+                ):
+                    last_explicit_signature = direct_signature
+                    direct_number = _louisiana_object_number(direct_object)
+                    if direct_number is not None:
+                        numbered_explicit_signatures[direct_number] = direct_signature
+            last_supply_assertion = True
+            if (
+                assertion.group("verb").lower().startswith("return")
+                and missing_head in {"calculation", "computation", "formula"}
+                and re.search(r"\bamount\b", direct_object, flags=re.IGNORECASE)
+            ):
+                return True
+
+        precontrast_states = re.finditer(
+            r"\b(?P<object>(?:the\s+)?[A-Za-z][A-Za-z -]{0,60}?)\s*"
+            r"(?:,\s*(?:which|that)\s*)?"
+            r"(?:,\s*|\(\s*|[—–]\s*)"
+            r"(?:(?:although|even\s+though|though|while)\s+)?not\s+"
+            r"(?:merely\s+)?(?:an?\s+)?"
+            r"(?:hypothetical|proposed)(?:\s+[A-Za-z-]+)?"
+            r"(?:,\s*|\)\s*|[—–]\s*)"
+            r"(?:is|are|was|were|became|becomes?|remains?)\s+"
+            r"(?:available|present|complete|accessible|usable|ready|extant|installed|"
+            r"released|posted|deployed|in\s+place|on\s+file|on\s+hand|at\s+hand)\b",
+            segment,
+            flags=re.IGNORECASE,
+        )
+        for assertion in precontrast_states:
+            if _louisiana_assertion_object_corefers(
+                assertion.group("object"),
+                missing_head=missing_head,
+                missing_object=missing_object,
+            ):
+                return True
+
+        state_assertions = tuple(
+            re.finditer(
+                r"\b(?P<object>this|that|those|it|them|both|the\s+same|"
+                r"(?:the\s+)?[A-Za-z][A-Za-z -]{0,60}?)\s*"
+                r"(?:(?:,\s*|\(\s*|[—–]\s*)"
+                r"(?:(?:although|even\s+though|though|while)\s+)?not\s+"
+                r"(?:merely\s+)?"
+                r"(?:an?\s+)?(?:hypothetical|proposed)(?:\s+[A-Za-z-]+)?"
+                r"(?:,\s*|\)\s*|[—–]\s*))?"
+                r"(?P<state>exists?|(?:(?:can|could|may|might|must|shall|should|will|would)\s+"
+                r"(?:(?:[A-Za-z][A-Za-z-]*ly|already|always|just|now|still)\s+)*be|"
+                r"(?:has|have|had)\s+"
+                r"(?:(?:[A-Za-z][A-Za-z-]*ly|already|always|just|now|still)\s+)*been|"
+                r"(?:has|have|had)\s+become|came\s+to\s+be|"
+                r"(?:is|are|was|were)\s+(?:being|made)|"
+                r"(?:is|are|was|were|became|becomes?|remains?))\s+"
+                r"(?:(?:not\s+(?:just|merely)|[A-Za-z][A-Za-z-]*ly|already|always|"
+                r"just|now|still)\s+)*"
+                r"(?:available|present|supplied|provided|implemented|"
+                r"computed|calculated|determined|encoded|defined|accessible|accessed|"
+                r"displayed|emitted|retrieved|complete|obtainable|retained|included|"
+                r"loaded|imported|stored|obtained|furnished|delivered|published|"
+                r"returned|produced|generated|exported|held|given|"
+                r"made\s+(?:available|obtainable)|rendered\s+(?:available|accessible)|"
+                r"put\s+on\s+hand|ready\s+for\s+use|retrievable|downloadable|"
+                r"recoverable|operational|usable|ready|extant|installed|released|posted|"
+                r"deployed|downloaded|recovered|found|in\s+place|on\s+file|"
+                r"at\s+the\s+ready|on\s+hand|at\s+hand))\b",
+                segment,
+                flags=re.IGNORECASE,
+            )
+        )
+        for assertion in state_assertions:
+            if (
+                _louisiana_assertion_is_negative(segment, assertion.start("state"))
+                or re.match(
+                    r"(?:may|might|should|could|would)\b",
+                    assertion.group("state"),
+                    flags=re.IGNORECASE,
+                )
+                or _louisiana_state_assertion_has_nonoperative_framing(
+                    segment, assertion
+                )
+                or pending_conditional_context
+                or re.match(
+                    r"\s*(?:if|unless|provided\s+that|so\s+long\s+as|in\s+case|"
+                    r"subject\s+to|dependent\s+on|contingent\s+(?:on|upon)|"
+                    r"conditioned\s+(?:on|upon)|pending(?:\s+receipt)?|"
+                    r"(?:on|upon|following)\s+(?:approval|receipt))\b",
+                    segment[: assertion.start()],
+                    flags=re.IGNORECASE,
+                )
+                or _louisiana_suffix_has_clause_level_condition(
+                    segment[assertion.end() :], include_temporal=False
+                )
+                or (
+                    not re.match(
+                        r"(?:was|were|became|has|have|had|came)\b",
+                        assertion.group("state"),
+                        flags=re.IGNORECASE,
+                    )
+                    and re.search(
+                        r"\bwhenever\b|\bas\s+soon\s+as\b|"
+                        r"\bonly\s+(?:after|when)\b|\bafter\b",
+                        segment[assertion.end() :],
+                        flags=re.IGNORECASE,
+                    )
+                )
+            ):
+                continue
+            state_object = assertion.group("object")
+            if state_object.lower() in {"that", "which"}:
+                relative_antecedent = re.search(
+                    r"(?P<object>(?:the\s+)?[A-Za-z][A-Za-z -]{0,60}?)\s*,\s*$",
+                    segment[: assertion.start()],
+                    flags=re.IGNORECASE,
+                )
+                if relative_antecedent is not None:
+                    state_object = relative_antecedent.group("object")
+            antecedent_signature = _louisiana_demonstrative_antecedent_signature(
+                state_object,
+                last_explicit_signature=last_explicit_signature,
+                numbered_signatures=numbered_explicit_signatures,
+            )
+            if (
+                re.fullmatch(
+                    r"(?:this|that|those|it|them|both|the\s+same)",
+                    state_object.strip(),
+                    flags=re.IGNORECASE,
+                )
+                and antecedent_signature is not None
+                and not _louisiana_signatures_corefer(
+                    antecedent_signature,
+                    _louisiana_object_signature(missing_object),
+                )
+            ):
+                continue
+            if _louisiana_assertion_object_corefers(
+                state_object,
+                missing_head=missing_head,
+                missing_object=missing_object,
+            ):
+                return True
+        if state_assertions:
+            pending_conditional_context = False
+
+        actual_presence = re.finditer(
+            r"\b(?P<object>this|that|those|it|them|the\s+same|"
+            r"(?:the\s+)?[A-Za-z][A-Za-z -]{0,60}?)\s+"
+            r"(?:has|have|had)\s+arrived\b|"
+            r"\b(?P<located_object>this|that|those|it|them|the\s+same|"
+            r"(?:the\s+)?[A-Za-z][A-Za-z -]{0,60}?)\s+resides?\s+in\s+"
+            r"(?:the\s+)?repository\b",
+            segment,
+            flags=re.IGNORECASE,
+        )
+        for assertion in actual_presence:
+            state_object = assertion.group("object") or assertion.group(
+                "located_object"
+            )
+            if _louisiana_assertion_object_corefers(
+                state_object,
+                missing_head=missing_head,
+                missing_object=missing_object,
+            ):
+                return True
+
+        if not assertions:
+            explicit_signature = _louisiana_coordinated_antecedent_signature(segment)
+            if (
+                explicit_signature is None
+                and re.match(
+                    r"\s*(?:a|an|the|this|that)\s+[A-Za-z]",
+                    segment,
+                    flags=re.IGNORECASE,
+                )
+                and not re.match(
+                    r"\s*(?:the|this|that)?\s*(?:encoder|implementation|module|"
+                    r"package|runtime|service|source|system)\b",
+                    segment,
+                    flags=re.IGNORECASE,
+                )
+            ):
+                explicit_signature = _louisiana_nearest_object_signature(
+                    segment, allow_opaque=True
+                )
+            if explicit_signature is not None and not re.fullmatch(
+                r"\s*(?:the|this|that)?\s*(?:encoder|implementation|module|"
+                r"package|runtime|service|source|system)\s*",
+                segment,
+                flags=re.IGNORECASE,
+            ):
+                previous_signature = last_explicit_signature
+                last_explicit_signature = explicit_signature
+                explicit_number = _louisiana_object_number(segment)
+                if explicit_number is not None:
+                    numbered_explicit_signatures[explicit_number] = explicit_signature
+                if (
+                    coordinator.group(0).strip().lower() == "and"
+                    and previous_signature is not None
+                    and explicit_number == "singular"
+                    and "plural" not in numbered_explicit_signatures
+                ):
+                    missing_signature = _louisiana_object_signature(missing_object)
+                    if _louisiana_signatures_corefer(
+                        previous_signature, missing_signature
+                    ) or _louisiana_signatures_corefer(
+                        explicit_signature, missing_signature
+                    ):
+                        numbered_explicit_signatures["plural"] = missing_signature
+
+        existential = re.finditer(
+            r"\bthere\s+(?:is|are|was|were)\s+(?P<object>[^,.;]{1,80})",
+            segment,
+            flags=re.IGNORECASE,
+        )
+        for assertion in existential:
+            if _louisiana_assertion_is_negative(segment, assertion.start()):
+                continue
+            if _louisiana_assertion_object_corefers(
+                assertion.group("object"),
+                missing_head=missing_head,
+                missing_object=missing_object,
+            ):
+                return True
+
+        capability = re.search(
+            r"\b(?:is|are)\s+(?:able\s+to|capable\s+of)\s+"
+            r"(?:provid\w*|suppl\w*|comput\w*|calculat\w*|determin\w*)"
+            r"(?P<object>[^,.;]{0,80})",
+            segment,
+            flags=re.IGNORECASE,
+        )
+        if capability and _louisiana_assertion_object_corefers(
+            capability.group("object"),
+            missing_head=missing_head,
+            missing_object=missing_object,
+        ):
+            return True
+    return False
+
+
+def _louisiana_coordinated_list_supplies_object(
+    missing_scope: str, *, missing_object: str
+) -> bool:
+    """Recognize a plural pronoun that supplies every member of an object list."""
+
+    missing_scope = re.sub(
+        r"\b(?P<pronoun>both|those)\s*[\(\[]\s*(?:"
+        r"[A-Za-z][A-Za-z-]*ly|in\s+fact|as\s+expected|with\s+success)\s*[\)\]]",
+        r"\g<pronoun>",
+        missing_scope,
+        flags=re.IGNORECASE,
+    )
+    missing_scope = re.sub(
+        r"\b(?P<pronoun>both|those)\s+in\s+fact(?=\s*[,.;])",
+        r"\g<pronoun>",
+        missing_scope,
+        flags=re.IGNORECASE,
+    )
+    listed = re.search(
+        r"\b(?:identif(?:y|ies|ied)|lists?|finds?|creates?|records?|selects?)\s+"
+        r"(?P<objects>(?:not\s+only\s+[^.;]{1,100}\bbut\s+also\b[^.;]{1,100}|"
+        r"[^:.;]{1,40}:\s*[^.;]{1,160},[^.;]{1,100}?|"
+        r"[^.;]{1,80}\b(?:along\s+with|as\s+well\s+as|in\s+addition\s+to|"
+        r"plus|together\s+with)\b"
+        r"[^.;]{1,80}?(?:\band\b[^.;]{1,80}?)?|"
+        r"(?:[^,.;]{1,80},){2}[^.;]{1,100}?))"
+        r",?\s*(?:then\s+)?(?:provid(?:e[sd]?|ing)|suppl(?:y|ies|ied|ying)|"
+        r"giv(?:e[sd]?|ing)|gave)\s+"
+        r"(?P<pronoun>them|"
+        r"those(?!\s*(?:[^\w\s,.;:!?—–]\s*)?[A-Za-z0-9])|"
+        r"both(?!\s*(?:[^\w\s,.;:!?—–]\s*)?[A-Za-z0-9]))\b",
+        missing_scope,
+        flags=re.IGNORECASE,
+    )
+    if listed is None:
+        return False
+    objects = re.sub(
+        r"^\s*(?:not\s+only\s+|[^:]{1,40}:\s*)",
+        "",
+        listed.group("objects"),
+        flags=re.IGNORECASE,
+    )
+    additive_coordination = bool(
+        re.search(
+            r"\b(?:along\s+with|as\s+well\s+as|but\s+also|"
+            r"in\s+addition\s+to|plus|together\s+with)\b",
+            objects,
+            flags=re.IGNORECASE,
+        )
+    )
+    objects = re.sub(r",?\s*then\s*$", "", objects, flags=re.IGNORECASE)
+    objects = re.sub(
+        r"\bprofit\s+and\s+loss\b", "profit-and-loss", objects, flags=re.IGNORECASE
+    )
+    objects = re.sub(
+        r"\b(?:along\s+with|as\s+well\s+as|but\s+also|in\s+addition\s+to|"
+        r"plus|together\s+with)\b",
+        ",",
+        objects,
+        flags=re.IGNORECASE,
+    )
+    missing_signature = _louisiana_object_signature(missing_object)
+    member_separator = r"\s*,\s*" if additive_coordination else r"\s*,\s*|\s+and\s+"
+    members = tuple(
+        member for member in re.split(member_separator, objects) if member.strip()
+    )
+    if listed.group("pronoun").lower() == "both" and len(members) != 2:
+        return False
+    return any(
+        _louisiana_signatures_corefer(
+            _louisiana_object_signature(member), missing_signature
+        )
+        for member in members
+    )
+
+
+def _louisiana_supply_assertion_has_nonoperative_framing(
+    segment: str, assertion: re.Match[str]
+) -> bool:
+    """Bind evidential framing to the supply clause it actually governs."""
+
+    prefix = _louisiana_normalize_parenthetical_aspect(segment[: assertion.end()])
+    prefix = re.sub(
+        r"\bno\s+(?:fewer|less)\s+than\b", "at least", prefix, flags=re.IGNORECASE
+    )
+    local_prefix = re.split(r"[,.;]", prefix)[-1]
+    main_subjects = tuple(
+        re.finditer(
+            r"\b(?:the|this|that)\s+(?:encoder|implementation|module|package|"
+            r"runtime|service|source|system)\b",
+            local_prefix,
+            flags=re.IGNORECASE,
+        )
+    )
+    if main_subjects:
+        local_prefix = local_prefix[main_subjects[-1].start() :]
+    if _louisiana_text_has_nonoperative_framing(local_prefix):
+        return True
+    verb = assertion.group(0).lower()
+    habitual = bool(
+        re.search(
+            r"\b(?:always|regularly|routinely|usually)\b",
+            local_prefix[: -len(assertion.group(0))],
+            flags=re.IGNORECASE,
+        )
+    )
+    zero_duration = bool(
+        re.search(
+            r"\bfor\s+(?:(?:an?\s+)?(?:[A-Za-z][A-Za-z-]*\s+){0,3}"
+            r"(?:duration|period|total)\s+"
+            r"(?:of|totaling|equal\s+to|amounting\s+to)\s+)?"
+            r"(?:exactly\s+|precisely\s+)?"
+            r"(?:0|nil|no(?!\s+(?:fewer|less)\s+than\b)|none\s+of|zero)\b"
+            r"\s+(?:the\s+)?(?:(?:aggregate|calendar|cumulative|elapsed|filing|"
+            r"fiscal|taxable|total)\s+){0,2}"
+            r"(?:centur(?:y|ies)|days?|decades?|durations?|generations?|hours?|"
+            r"minutes?|months?|periods?|quarters?|seconds?|time|weeks?|years?)\b",
+            local_prefix[: -len(assertion.group(0))],
+            flags=re.IGNORECASE,
+        )
+    )
+    actual_progressive = bool(
+        verb.endswith("ing")
+        and not zero_duration
+        and re.search(
+            r"\b(?:"
+            r"(?:am|is|are|was|were|will)\s+"
+            r"(?:(?:[A-Za-z][A-Za-z-]*ly|already|always|just|now|still|"
+            r"in\s+fact|at\s+the\s+time|for\s+(?!(?:0|no|zero)\b)"
+            r"[A-Za-z0-9-]+(?:\s+[A-Za-z0-9-]+)*)\s+)*"
+            r"(?:be\s+)?|"
+            r"(?:has|have|had)\s+"
+            r"(?:(?:[A-Za-z][A-Za-z-]*ly|already|always|just|now|still|"
+            r"in\s+fact|at\s+the\s+time|for\s+(?!(?:0|no|zero)\b)"
+            r"[A-Za-z0-9-]+(?:\s+[A-Za-z0-9-]+)*)\s+)*"
+            r"been\s+"
+            r"(?:(?:[A-Za-z][A-Za-z-]*ly|already|always|just|now|still|"
+            r"in\s+fact|at\s+the\s+time|for\s+(?!(?:0|no|zero)\b)"
+            r"[A-Za-z0-9-]+(?:\s+[A-Za-z0-9-]+)*)\s+)*"
+            r")$",
+            local_prefix[: -len(assertion.group(0))],
+            flags=re.IGNORECASE,
+        )
+    )
+    if (
+        not _louisiana_supply_verb_is_completed(verb)
+        and not habitual
+        and not actual_progressive
+    ):
+        suffix = segment[assertion.end() :]
+        if _louisiana_suffix_has_clause_level_condition(suffix):
+            return True
+    return bool(
+        re.search(
+            r"\b(?:appears?|appeared|seems?|seemed)\s+to(?:\s+have)?\s+$|"
+            r"\b(?:is|was)\s+(?:believed|expected|likely|projected|reported|"
+            r"said|scheduled|supposed)\s+to(?:\s+have)?\s+$|"
+            r"\b(?:aims?|aimed|attempts?|attempted|claims?|claimed|declines?|"
+            r"declined|endeavors?|endeavored|expects?|expected|forgets?|forgot|"
+            r"hopes?|hoped|intends?|intended|neglects?|neglected|plans?|planned|"
+            r"pretends?|pretended|promises?|promised|seeks?|sought|struggles?|"
+            r"struggled|threatens?|threatened|tries?|tried)\s+"
+            r"(?:(?:[A-Za-z][A-Za-z-]*ly|in\s+vain|without\s+success)\s+)*"
+            r"to(?:\s+have)?\s+$|"
+            r"\b(?:(?:am|is|are|was|were|will)\s+"
+            r"(?:(?:[A-Za-z][A-Za-z-]*ly)\s+)*(?:be\s+)?|"
+            r"(?:has|have|had)\s+(?:(?:[A-Za-z][A-Za-z-]*ly)\s+)*been\s+)"
+            r"(?:(?:[A-Za-z][A-Za-z-]*ly)\s+)*(?:aiming|attempting|claiming|declining|"
+            r"endeavoring|expecting|forgetting|hoping|intending|neglecting|planning|"
+            r"pretending|promising|seeking|struggling|threatening|trying)\s+"
+            r"(?:(?:[A-Za-z][A-Za-z-]*ly|in\s+vain|without\s+success)\s+)*to"
+            r"(?:\s+have)?\s+$|"
+            r"\b(?:has|have|had)\s+(?:aimed|attempted|claimed|declined|endeavored|"
+            r"expected|forgotten|hoped|intended|neglected|planned|pretended|"
+            r"promised|sought|struggled|threatened|tried)\s+to(?:\s+have)?\s+$|"
+            r"\bwould\s+prefer\s+to\s+$|"
+            r"\b(?:is|was)\s+(?:about|preparing)\s+to\s+$|"
+            r"\b(?:is|was)\s+hardly\s+able\s+to\s+$",
+            local_prefix[: -len(assertion.group(0))],
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _louisiana_state_assertion_has_nonoperative_framing(
+    segment: str, assertion: re.Match[str]
+) -> bool:
+    """Keep an entailed availability state across explicit contrast."""
+
+    scope = segment[assertion.start() :]
+    if re.search(
+        r"\b(?:actually\s+)?(?:available|present|supplied|provided|implemented|"
+        r"computed|calculated|determined|encoded|defined|accessible|complete|"
+        r"obtainable|retained|included|loaded|imported|stored|furnished|delivered|"
+        r"published|returned|produced|generated|exported|held|given|retrievable|"
+        r"downloadable|recoverable|operational|usable|ready|extant|installed|"
+        r"released|posted|deployed|downloaded|recovered|found|in\s+place|"
+        r"on\s+file|at\s+the\s+ready|on\s+hand|at\s+hand|ready\s+for\s+use|"
+        r"made\s+(?:available|obtainable)|rendered\s+(?:available|accessible)|"
+        r"put\s+on\s+hand)\b[^.;]{0,80}"
+        r"(?:(?:,\s*|\(\s*|[—–]\s*)"
+        r"(?:(?:although|even\s+though|though|while)\s+)?not\s+"
+        r"(?:merely\s+)?(?:an?\s+)?"
+        r"(?:hypothetical|proposed)"
+        r"(?:\s+[A-Za-z][A-Za-z-]*)?|rather\s+than\s+"
+        r"(?:merely\s+)?(?:hypothetical|proposed))\b",
+        scope,
+        flags=re.IGNORECASE,
+    ):
+        return False
+    if re.search(
+        r"(?:(?:,\s*|\(\s*|[—–]\s*)"
+        r"(?:(?:although|even\s+though|though|while)\s+)?not\s+"
+        r"(?:merely\s+)?(?:an?\s+)?"
+        r"(?:hypothetical|proposed)(?:\s+[A-Za-z-]+)?"
+        r"(?:,\s*|\)\s*|[—–]\s*))[^.;]{0,40}\b"
+        r"(?:is|are|was|were|became|becomes?|remains?)\s+"
+        r"(?:available|present|complete|accessible|usable|ready|extant|installed|"
+        r"released|posted|deployed|in\s+place|on\s+file|on\s+hand|at\s+hand)\b",
+        scope,
+        flags=re.IGNORECASE,
+    ):
+        return False
+    return _louisiana_text_has_nonoperative_framing(scope)
+
+
+def _louisiana_normalize_parenthetical_aspect(text: str) -> str:
+    """Remove delimiters around bounded aspect and attempt adjuncts."""
+
+    def normalized(match: re.Match[str]) -> str:
+        content = match.group("content")
+        if re.search(
+            r"\b(?:anything\s+but|in\s+no\s+(?:respect|sense)|no\s+longer|"
+            r"not(?:\s+(?:at\s+all|ever))?)\s+"
+            r"in\s+vain\b",
+            content,
+            flags=re.IGNORECASE,
+        ):
+            return " with success "
+        if re.search(
+            r"\b(?:at\s+no\s+point\s+|by\s+no\s+means\s*,?\s+|"
+            r"in\s+no\s+way\s*,?\s+|under\s+no\s+circumstances\s+|"
+            r"never\s*,?\s+|no\s+longer\s*,?\s+|"
+            r"not\s+(?:at\s+all|[A-Za-z][A-Za-z-]*ly)\s+)"
+            r"in\s+fact\b",
+            content,
+            flags=re.IGNORECASE,
+        ):
+            return " never "
+        if re.search(r"\bno\s+longer\s+in\s+vain\b", content, flags=re.IGNORECASE):
+            return " with success "
+        if re.search(
+            r"\b(?:never\s*,?\s+|no\s+longer\s+)in\s+fact\b",
+            content,
+            flags=re.IGNORECASE,
+        ):
+            return " never "
+        if re.search(r"\bnever\s+in\s+vain\b", content, flags=re.IGNORECASE):
+            return " with success "
+        if re.search(r"\bnot\s+without\s+success\b", content, flags=re.IGNORECASE):
+            return " with success "
+        if re.search(r"\bnot\s+in\s+vain\b", content, flags=re.IGNORECASE):
+            return " with success "
+        if re.search(r"\bnot\s*,?\s+in\s+fact\b", content, flags=re.IGNORECASE):
+            return " not "
+        if re.search(r"\bin\s+vain\b", content, flags=re.IGNORECASE):
+            return " in vain "
+        if re.search(r"\bwithout\s+success\b", content, flags=re.IGNORECASE):
+            return " without success "
+        if re.search(r"\bin\s+fact\b", content, flags=re.IGNORECASE):
+            return " in fact "
+        if re.search(r"\bfor\s+", content, flags=re.IGNORECASE):
+            return " " + re.sub(r"\s*[:,;—–]\s*", " ", content) + " "
+        return f" {content} "
+
+    text = re.sub(
+        r"\(\s*without\s+interruption\s*\)",
+        " without interruption ",
+        text,
+        flags=re.IGNORECASE,
+    )
+    text = re.sub(
+        r"\(\s*(?P<content>[^()]{0,120}(?:in\s+vain|without\s+success|"
+        r"in\s+fact|at\s+the\s+time|for\s+[^()]{1,100})[^()]{0,60})\s*\)",
+        normalized,
+        text,
+        flags=re.IGNORECASE,
+    )
+    return re.sub(
+        r"(?:,|\(|\[|[—–])\s*(?P<content>[^()\[\]—–]{0,60}"
+        r"(?:in\s+vain|without\s+success|in\s+fact|at\s+the\s+time|"
+        r"for\s+[^()\[\]—–,]{1,100})[^()\[\]—–]{0,60})\s*"
+        r"(?:,|\)|\]|[—–])",
+        normalized,
+        text,
+        flags=re.IGNORECASE,
+    )
+
+
+def _louisiana_suffix_has_clause_level_condition(
+    suffix: str, *, include_temporal: bool = True
+) -> bool:
+    """Recognize a condition on the assertion, not one inside its object NP."""
+
+    temporal = (
+        r"when|after|whenever|as\s+soon\s+as|"
+        r"once(?!\s+(?:each|every|per)\b)|"
+        if include_temporal
+        else ""
+    )
+    condition = re.search(
+        rf"\b(?:{temporal}unless|if|provided\s+that|"
+        r"so\s+long\s+as|in\s+case|"
+        r"(?:on|upon|pending|following)\s+(?:approval|receipt)|"
+        r"subject\s+to|dependent\s+on|contingent\s+(?:on|upon)|"
+        r"conditioned\s+(?:on|upon)|to\s+the\s+extent|on\s+paper)\b",
+        suffix,
+        flags=re.IGNORECASE,
+    )
+    if condition is None:
+        return False
+    object_prefix = suffix[: condition.start()]
+    relative_before_comma = re.search(
+        r"\b(?:that|which)\b(?P<body>[^,]*)[,]\s*$",
+        object_prefix,
+        flags=re.IGNORECASE,
+    )
+    relative_is_completed = bool(
+        relative_before_comma
+        and re.search(
+            r"(?:\b(?:am|are|is|was|were|be|been|being)\s+"
+            r"[A-Za-z][A-Za-z-]*(?:ed|en)|\b[A-Za-z][A-Za-z-]*ed|"
+            r"\b(?:began|bought|brought|built|caught|chose|came|did|drew|felt|"
+            r"found|gave|got|had|heard|held|kept|knew|left|lost|made|met|paid|"
+            r"ran|read|said|saw|sent|set|sold|spoke|taught|told|took|understood|"
+            r"went|won|wrote))"
+            r"(?:\s+(?:at|by|for|from|in|on|to|under|with)\s+"
+            r"(?:(?:a|an|the)\s+)?(?:[A-Za-z][A-Za-z-]*\s+){0,4}"
+            r"[A-Za-z][A-Za-z-]*)?"
+            r"(?:\s+(?:earlier|last\s+(?:day|month|week|year)|today|yesterday))?\s*$",
+            relative_before_comma.group("body"),
+            flags=re.IGNORECASE,
+        )
+    )
+    if (
+        relative_before_comma
+        and not relative_is_completed
+        and not re.search(
+            r"\b(?:am|are|is|was|were|becomes?|remains?|applies?|uses?|"
+            r"requested|completed|selected|specified)\b",
+            relative_before_comma.group("body"),
+            flags=re.IGNORECASE,
+        )
+    ):
+        return False
+    if relative_before_comma and re.search(
+        r"^[^.;]{0,80},\s*(?:and|as\s+well\s+as|both|but|or|yet)\s+"
+        r"[A-Za-z][A-Za-z-]*\b",
+        suffix[condition.end() :],
+        flags=re.IGNORECASE,
+    ):
+        return False
+    if relative_before_comma and re.search(
+        r"^[^.;]{0,80},\s*(?:after|at|before|by|during|for|in|on|"
+        r"pursuant\s+to|"
+        r"through|throughout|under|until|using|via|while|with|without)\b",
+        suffix[condition.end() :],
+        flags=re.IGNORECASE,
+    ):
+        return False
+    if (
+        relative_before_comma
+        and not relative_is_completed
+        and re.search(
+            r"^[^.;]{0,80},\s*(?:because|so)\b",
+            suffix[condition.end() :],
+            flags=re.IGNORECASE,
+        )
+    ):
+        return False
+    if re.search(r",\s*$", object_prefix):
+        return True
+    return not re.search(
+        r"\b(?:for\s+use|note\b[^,.;]{0,50}\b(?:saying|stating)|that|which)\b",
+        object_prefix,
+        flags=re.IGNORECASE,
+    )
+
+
+def _louisiana_pre_supply_antecedent_signature(
+    prefix: str,
+) -> tuple[str, frozenset[str]] | None:
+    """Return an object introduced by a finite predicate before a supply verb."""
+
+    return _louisiana_explicit_transitive_object_signature(
+        prefix, terminal=r"(?:before|prior\s+to)"
+    )
+
+
+def _louisiana_coordinated_antecedent_signature(
+    segment: str,
+) -> tuple[str, frozenset[str]] | None:
+    """Track an explicit object introduced in an ordinary coordinated clause."""
+
+    return _louisiana_explicit_transitive_object_signature(segment, terminal=None)
+
+
+def _louisiana_explicit_transitive_object_signature(
+    text: str,
+    *,
+    terminal: str | None,
+) -> tuple[str, frozenset[str]] | None:
+    """Extract the direct object of a bounded finite transitive predicate."""
+
+    ending = rf"\s+{terminal}\s*$" if terminal is not None else r"\s*$"
+    antecedent = re.search(
+        r"\b(?:(?:can|could|may|might|must|shall|should|will|would)\s+)?"
+        r"[A-Za-z][A-Za-z-]*\s+"
+        r"(?P<object>(?:a|an|the|this|that)\s+[^,.;]{1,60}?)" + ending,
+        text,
+        flags=re.IGNORECASE,
+    )
+    if antecedent is None:
+        antecedent = re.search(
+            r"\b(?:(?:can|could|may|might|must|shall|should|will|would)\s+"
+            r"[A-Za-z][A-Za-z-]*|[A-Za-z][A-Za-z-]*(?:s|ed)|brought|built|"
+            r"bought|caught|chose|drew|found|gave|got|heard|held|hid|kept|laid|"
+            r"left|lost|made|met|paid|put|ran|read|saw|sent|set|sold|taught|told|"
+            r"took|won|wrote)\s+"
+            r"(?P<object>(?:[A-Za-z][A-Za-z-]*\s+){0,5}[A-Za-z][A-Za-z-]*?)" + ending,
+            text,
+            flags=re.IGNORECASE,
+        )
+    if antecedent is None:
+        return None
+    object_text = re.sub(
+        r"\s+(?:aside|later)\s*$", "", antecedent.group("object"), flags=re.IGNORECASE
+    )
+    object_text = re.split(
+        r"\b(?:containing|covering|describing|displaying|including|with)\b",
+        object_text,
+        maxsplit=1,
+        flags=re.IGNORECASE,
+    )[0]
+    return _louisiana_nearest_object_signature(object_text, allow_opaque=True)
+
+
+def _louisiana_assertion_is_negative(segment: str, assertion_start: int) -> bool:
+    """Return the scoped polarity of one supply assertion."""
+
+    prefix = re.split(r"[,.;]", segment[:assertion_start])[-1]
+    prefix = re.sub(r"\bwithout\s+delay\b", " ", prefix, flags=re.IGNORECASE)
+    prefix = re.sub(
+        r"\bno\s+(?:fewer|less)\s+than\b", "at least", prefix, flags=re.IGNORECASE
+    )
+    prefix = re.sub(
+        r"\b(?:no\s+interruptions?|none\s+of\s+(?:the\s+)?"
+        r"(?:[A-Za-z][A-Za-z-]*\s+){0,3}interruptions?)\b",
+        " ",
+        prefix,
+        flags=re.IGNORECASE,
+    )
+    if re.search(r"\b(?:before|prior\s+to)\s*$", prefix, flags=re.IGNORECASE):
+        return False
+    if re.search(
+        r"\bnot\s+(?:surprisingly|unexpectedly)\s*$",
+        prefix,
+        flags=re.IGNORECASE,
+    ):
+        return False
+    if re.search(
+        r"\b(?:may|might|should|could|would)\s+"
+        r"(?:(?:[A-Za-z][A-Za-z-]*ly)\s+)*$",
+        prefix,
+        flags=re.IGNORECASE,
+    ):
+        return True
+    if re.search(
+        r"\b(?:unable|incapable)\b[^,.;]{0,40}\bnot\s+(?:to\s+)?$|"
+        r"\b(?:fails?|refuses?|unable|incapable|hesitates?)\b[^,.;]{0,40}\b"
+        r"(?:avoid|stop|refrain)\w*\s+(?:from\s+|to\s+)?$",
+        prefix,
+        flags=re.IGNORECASE,
+    ):
+        return False
+    if re.search(
+        r"\b(?:can|does?)\s+(?:do\s+)?nothing\s+(?:but|except)\s*$|"
+        r"\bcannot\s+do\s+otherwise\s+than\s*$|"
+        r"\b(?:is|are|was|were)\s+powerless\s+to\s+avoid\s*$|"
+        r"\b(?:has|have|had|is|are|was|were)\b[^,.;]{0,40}"
+        r"\bno\s+(?:alternative|option)\s+(?:except\s+to|other\s+than)\s*$|"
+        r"\b(?:has|have|had)\s+little\s+choice\s+other\s+than\s*$",
+        prefix,
+        flags=re.IGNORECASE,
+    ):
+        return False
+    if re.search(
+        r"\b(?:cannot|can['’]t)\s+help\s*$|"
+        r"\b(?:has|have|had)\s+no\s+(?:difficulty|trouble)\s*$|"
+        r"\bno\s+doubt\s*$",
+        prefix,
+        flags=re.IGNORECASE,
+    ):
+        return False
+
+    negative_complement = re.search(
+        r"\b(?:lacks?\s+(?:the\s+)?ability|fails?|refuses?|avoids?|delays?|"
+        r"hesitates?|ceases?|stops?|refrains?|unable|incapable)\b"
+        r"(?P<tail>[^,.;]{0,80}?)(?:to|before)?\s*$",
+        prefix,
+        flags=re.IGNORECASE,
+    )
+    if negative_complement:
+        if re.search(
+            r"\b(?:anything\s+but|far\s+from)\s*$",
+            prefix[: negative_complement.start()],
+            flags=re.IGNORECASE,
+        ):
+            return False
+        reversals = tuple(
+            re.finditer(
+                r"\b(?:cannot|never|nothing|neither|no|not)\b|n['’]t\b",
+                prefix[: negative_complement.start()],
+                flags=re.IGNORECASE,
+            )
+        )
+        if not reversals:
+            return True
+        if reversals[-1].group(0).lower() == "not" and re.search(
+            r"\b(?:may|might)\b[^,.;]*$",
+            prefix[: reversals[-1].start()],
+            flags=re.IGNORECASE,
+        ):
+            return True
+        between = prefix[reversals[-1].end() : negative_complement.start()]
+        if re.search(
+            r"\b(?:necessarily|always|ordinarily|inevitably|consistently|reliably)\b",
+            between,
+            flags=re.IGNORECASE,
+        ):
+            return True
+        return False
+
+    direct_negators = tuple(
+        re.finditer(
+            r"\b(?:cannot|never|nothing|neither|not|no(?!\s+later\b))\b|n['’]t\b",
+            prefix,
+            flags=re.IGNORECASE,
+        )
+    )
+    return len(direct_negators) % 2 == 1
+
+
+def _louisiana_assertion_object_corefers(
+    object_text: str,
+    *,
+    missing_head: str,
+    missing_object: str,
+) -> bool:
+    """Match a direct assertion object to the missing grammatical object."""
+
+    normalized = object_text.strip().lower()
+    if re.match(
+        r"(?:(?:it|them)\b|both\s*$|"
+        r"(?:this|that(?:\s+same)?|those|the\s+same|same)\s*$)",
+        normalized,
+    ):
+        if _louisiana_text_has_nonoperative_framing(normalized) or re.search(
+            r"\b(?:if|conditionally)\b|\bin\s+theory\b|"
+            r"\bnot\s+in\s+practice\b|\baccording\s+to\b|"
+            r"\bmerely\s+as\b|\b(?:only\s+)?in\s+the\s+event\b|"
+            r"\bonly\s+upon\b|\bsubject\s+to\b|\bassuming\b|"
+            r"\bon\s+(?:the\s+)?condition(?:\s+that)?\b|\bcontingently\b|"
+            r"\bwere\b[^.;]{0,40}\bsupplied\b|\bonly\s+after\b",
+            normalized,
+            flags=re.IGNORECASE,
+        ):
+            return False
+        return not re.search(
+            r"\b(?:different|draft|excerpt|fraction|fragment|incomplete|outline|"
+            r"part|partial|piece|portion|provisional|separate|subset|unrelated)\b|"
+            r"\b(?:barely|hardly|scarcely)\s+any\b|\balmost\s+no\b|"
+            r"\b(?:less\s+than\s+all|most\s+but\s+not\s+all)\b",
+            normalized,
+        )
+    if re.search(
+        r"\b(?:different|draft|excerpt|fraction|fragment|incomplete|outline|part|"
+        r"partial|piece|portion|provisional|separate|subset|unrelated)\b|"
+        r"\b(?:barely|hardly|scarcely)\s+any\b|\balmost\s+no\b|"
+        r"\b(?:less\s+than\s+all|most\s+but\s+not\s+all)\b|"
+        r"\b(?:a\s+few|merely)\s+(?:fragments?|pieces?|portions?)\b",
+        normalized,
+    ):
+        return False
+    object_signature = _louisiana_object_signature(normalized)
+    missing_signature = _louisiana_object_signature(missing_object)
+    if object_signature is None or missing_signature is None:
+        return False
+    object_family, object_modifiers = object_signature
+    missing_family, missing_modifiers = missing_signature
+    expected_family = _louisiana_object_family(missing_head)
+    if object_family != missing_family or missing_family != expected_family:
+        return False
+    return object_modifiers == missing_modifiers
+
+
+def _louisiana_object_number(text: str) -> str | None:
+    """Infer the grammatical number of the nearest explicit object head."""
+
+    outer_np = re.split(
+        r"\b(?:accompanied\s+by|containing|of|that|which|with)\b",
+        text,
+        maxsplit=1,
+        flags=re.IGNORECASE,
+    )[0]
+    determiners = tuple(
+        re.finditer(
+            r"\b(?P<determiner>a|an|one|each|every|this|that|these|those|"
+            r"many|several|two|three|four|five|six|seven|eight|nine|ten)\s+",
+            outer_np,
+            flags=re.IGNORECASE,
+        )
+    )
+    if determiners:
+        determiner = determiners[0].group("determiner").lower()
+        if determiner in {"a", "an", "one", "each", "every", "this", "that"}:
+            return "singular"
+        return "plural"
+    tokens = re.findall(r"[A-Za-z][A-Za-z-]*", outer_np.lower())
+    while tokens and tokens[-1] in {
+        "aside",
+        "later",
+        "same",
+        "successfully",
+    }:
+        tokens.pop()
+    if not tokens:
+        return None
+    head = tokens[-1]
+    if head in {"them", "those", "these"}:
+        return "plural"
+    if head in {"it", "this", "that"}:
+        return "singular"
+    if head in {"children", "data", "men", "people", "women"}:
+        return "plural"
+    if head in {"analysis", "basis", "means", "process", "series", "status"}:
+        return "singular"
+    if head.endswith("s") and not head.endswith(("ss", "us", "is")):
+        return "plural"
+    return "singular"
+
+
+def _louisiana_demonstrative_antecedent_signature(
+    text: str,
+    *,
+    last_explicit_signature: tuple[str, frozenset[str]] | None,
+    numbered_signatures: dict[str, tuple[str, frozenset[str]]],
+) -> tuple[str, frozenset[str]] | None:
+    """Resolve a demonstrative to the nearest antecedent of matching number."""
+
+    pronoun = re.match(
+        r"\s*(?P<pronoun>this|that|those|it|them|both|the\s+same|same)\b",
+        text,
+        flags=re.IGNORECASE,
+    )
+    if pronoun is None:
+        return last_explicit_signature
+    normalized = pronoun.group("pronoun").lower()
+    number = (
+        "plural"
+        if normalized in {"those", "them", "both"}
+        else "singular"
+        if normalized in {"this", "that", "it"}
+        else None
+    )
+    if number is not None and number in numbered_signatures:
+        return numbered_signatures[number]
+    return last_explicit_signature
+
+
+def _louisiana_object_family(head: str) -> str:
+    """Normalize synonymous executable object heads."""
+
+    signature = _louisiana_object_signature(head)
+    return signature[0] if signature is not None else head
+
+
+def _louisiana_object_signature(text: str) -> tuple[str, frozenset[str]] | None:
+    """Return an executable synonym family and its meaningful modifiers."""
+
+    text = re.split(
+        r"\bwith\s+(?:a|an|the)\s+(?:annotation|comment|description|note|report)\b|"
+        r"\baccompanied\s+by\s+(?:a|an|the)\s+"
+        r"(?:annotation|comment|description|note|report)\b|"
+        r"(?<=\w)\s+(?:that|which)\b|\bfor\s+use\s+if\b",
+        text,
+        maxsplit=1,
+        flags=re.IGNORECASE,
+    )[0]
+    text = re.sub(r"\btwice\s+per\s+year\b", "semiannual", text, flags=re.IGNORECASE)
+    text = re.sub(
+        r"\b(?:each|every)\s+two\s+weeks\b", "biweekly", text, flags=re.IGNORECASE
+    )
+    text = re.sub(
+        r"\b(?:(?:for\s+)?(?:each|every)|per)\s+year\b|\bper\s+annum\b",
+        "annual",
+        text,
+        flags=re.IGNORECASE,
+    )
+    text = re.sub(
+        r"\b(?:(?:for\s+)?(?:each|every)|per)\s+month\b",
+        "monthly",
+        text,
+        flags=re.IGNORECASE,
+    )
+    for period, normalized in (
+        ("quarter", "quarterly"),
+        ("week", "weekly"),
+        ("day", "daily"),
+    ):
+        text = re.sub(
+            rf"\b(?:(?:for\s+)?(?:each|every)|per)\s+{period}\b",
+            normalized,
+            text,
+            flags=re.IGNORECASE,
+        )
+    tokens = re.findall(r"[a-z0-9]+", text.lower().replace("’s", "").replace("'s", ""))
+    ignored = {
+        "a",
+        "an",
+        "available",
+        "complete",
+        "completely",
+        "directly",
+        "delay",
+        "fully",
+        "hand",
+        "immediately",
+        "on",
+        "only",
+        "same",
+        "successfully",
+        "with",
+        "that",
+        "the",
+        "this",
+        "those",
+    }
+    tokens = [token for token in tokens if token not in ignored]
+    if "resident" in tokens and "taxpayer" in tokens:
+        tokens.remove("taxpayer")
+    if "individual" in tokens and "income" in tokens:
+        tokens.remove("income")
+    modifier_normalization = {
+        "corporation": "corporate",
+        "corporations": "corporate",
+        "criteria": "criterion",
+        "data": "datum",
+        "individuals": "individual",
+        "annually": "annual",
+        "media": "medium",
+        "residents": "resident",
+        "spousal": "spouse",
+        "taxpayers": "taxpayer",
+        "yearly": "annual",
+    }
+    tokens = [modifier_normalization.get(token, token) for token in tokens]
+    family_members = {
+        "algorithm": "algorithm",
+        "algorithms": "algorithm",
+        "amount": "amount",
+        "amounts": "amount",
+        "base": "base",
+        "bases": "base",
+        "calculation": "calculation",
+        "calculations": "calculation",
+        "capability": "capability",
+        "capabilities": "capability",
+        "classification": "classification",
+        "classifications": "classification",
+        "computation": "calculation",
+        "computations": "calculation",
+        "condition": "condition",
+        "conditions": "condition",
+        "credit": "credit",
+        "credits": "credit",
+        "data": "data",
+        "datum": "data",
+        "deduction": "deduction",
+        "deductions": "deduction",
+        "definition": "definition",
+        "definitions": "definition",
+        "determination": "determination",
+        "determinations": "determination",
+        "document": "document",
+        "documents": "document",
+        "equation": "formula",
+        "equations": "formula",
+        "fact": "fact",
+        "facts": "fact",
+        "formula": "formula",
+        "formulas": "formula",
+        "implementation": "implementation",
+        "implementations": "implementation",
+        "input": "input",
+        "inputs": "input",
+        "instruction": "instruction",
+        "instructions": "instruction",
+        "liability": "liability",
+        "liabilities": "liability",
+        "logic": "logic",
+        "lookup": "lookup",
+        "lookups": "lookup",
+        "mapping": "mapping",
+        "mappings": "mapping",
+        "matrix": "matrix",
+        "matrices": "matrix",
+        "mechanics": "mechanics",
+        "mechanism": "mechanism",
+        "mechanisms": "mechanism",
+        "method": "method",
+        "methods": "method",
+        "output": "output",
+        "outputs": "output",
+        "parameter": "parameter",
+        "parameters": "parameter",
+        "percentage": "percentage",
+        "percentages": "percentage",
+        "procedure": "procedure",
+        "procedures": "procedure",
+        "process": "process",
+        "processes": "process",
+        "protocol": "protocol",
+        "protocols": "protocol",
+        "rate": "rate",
+        "rates": "rate",
+        "record": "record",
+        "records": "record",
+        "requirement": "requirement",
+        "requirements": "requirement",
+        "rule": "rule",
+        "rules": "rule",
+        "schedule": "rate",
+        "schedules": "rate",
+        "sequence": "sequence",
+        "sequences": "sequence",
+        "specification": "specification",
+        "specifications": "specification",
+        "standard": "standard",
+        "standards": "standard",
+        "status": "status",
+        "statuses": "status",
+        "step": "step",
+        "steps": "step",
+        "structure": "structure",
+        "structures": "structure",
+        "table": "rate",
+        "tables": "rate",
+        "tax": "tax",
+        "taxes": "tax",
+        "threshold": "threshold",
+        "thresholds": "threshold",
+        "workflow": "workflow",
+        "workflows": "workflow",
+    }
+    family_positions = [
+        (index, family_members[token])
+        for index, token in enumerate(tokens)
+        if token in family_members
+    ]
+    if not family_positions:
+        return None
+    relation_positions = [
+        index for index, token in enumerate(tokens) if token in {"for", "of"}
+    ]
+    if relation_positions:
+        before_relation = [
+            item for item in family_positions if item[0] < relation_positions[0]
+        ]
+        head_position, family = (before_relation or family_positions)[-1]
+    else:
+        head_position, family = family_positions[-1]
+    modifier_sequence = tuple(
+        _louisiana_normalize_modifier_token(token)
+        for index, token in enumerate(tokens)
+        if index != head_position
+        and token not in {"for", "of", "tax"}
+        and (token not in family_members or family_members[token] != family)
+    )
+    modifier_tokens = set(modifier_sequence)
+    relational_modifiers = {
+        "appeal",
+        "beneficiary",
+        "borrower",
+        "buyer",
+        "creditor",
+        "debtor",
+        "denial",
+        "destination",
+        "donee",
+        "donor",
+        "employee",
+        "employer",
+        "executor",
+        "grantee",
+        "grantor",
+        "guardian",
+        "heir",
+        "landlord",
+        "lender",
+        "lessee",
+        "lessor",
+        "licensee",
+        "licensor",
+        "owner",
+        "origin",
+        "parent",
+        "partner",
+        "partnership",
+        "payer",
+        "principal",
+        "recipient",
+        "renter",
+        "representative",
+        "seller",
+        "subsidiary",
+        "taxpayer",
+        "tenant",
+        "testator",
+        "trustee",
+        "ward",
+        "trust",
+        "decedent",
+    }
+
+    ordered_sequence = tuple(
+        token
+        for token in modifier_sequence
+        if not re.fullmatch(r"(?:19|20)\d{2}", token)
+    )
+    inverse_role_stems: dict[str, set[str]] = {}
+    for token in ordered_sequence:
+        suffix = next(
+            (ending for ending in ("ee", "or", "er", "ed") if token.endswith(ending)),
+            None,
+        )
+        if suffix is not None and len(token) > len(suffix) + 2:
+            inverse_role_stems.setdefault(token[: -len(suffix)], set()).add(suffix)
+    inverse_stems = {
+        stem
+        for stem, suffixes in inverse_role_stems.items()
+        if bool(suffixes & {"ee", "ed"}) and bool(suffixes & {"or", "er"})
+    }
+    relational_sequence = tuple(
+        token for token in ordered_sequence if token in relational_modifiers
+    )
+    person_descriptor_sequence = tuple(
+        token
+        for token in ordered_sequence
+        if token in relational_modifiers or token in {"dependent", "student", "widow"}
+    )
+    inverse_sequence = tuple(
+        token
+        for token in ordered_sequence
+        if any(
+            token.startswith(stem) and token[len(stem) :] in {"ee", "or", "er", "ed"}
+            for stem in inverse_stems
+        )
+    )
+    order_sensitive = set(inverse_sequence)
+    if relational_sequence and len(person_descriptor_sequence) >= 2:
+        order_sensitive.update(person_descriptor_sequence)
+    ordered_roles = tuple(
+        token for token in ordered_sequence if token in order_sensitive
+    )
+    if len(ordered_roles) >= 2:
+        modifier_tokens.add("order:" + ">".join(ordered_roles))
+    return family, frozenset(modifier_tokens)
+
+
+def _louisiana_normalize_modifier_token(token: str) -> str:
+    """Normalize ordinary singular/plural variation in object modifiers."""
+
+    irregular = {
+        "analyses": "analysis",
+        "bonuses": "bonus",
+        "children": "child",
+        "leaves": "leaf",
+        "matrices": "matrix",
+        "means": "means",
+        "monies": "money",
+        "people": "person",
+        "men": "man",
+        "wives": "wife",
+        "women": "woman",
+    }
+    if token in irregular:
+        return irregular[token]
+    if token.endswith("statuses"):
+        return token[:-2]
+    if token.endswith("ies") and len(token) > 3:
+        return token[:-3] + "y"
+    if token.endswith(("sses", "shes", "ches", "xes", "zes")):
+        return token[:-2]
+    if token.endswith("s") and not token.endswith(("ss", "us", "is")):
+        return token[:-1]
+    return token
+
+
+def _louisiana_nearest_object_signature(
+    text: str,
+    *,
+    allow_opaque: bool = False,
+) -> tuple[str, frozenset[str]] | None:
+    """Return the nearest executable or documentary antecedent signature."""
+
+    executable = _louisiana_object_signature(text)
+    documentary_heads = tuple(_LOUISIANA_DOCUMENTARY_HEAD.finditer(text))
+    if not documentary_heads:
+        if executable is not None or not allow_opaque:
+            return executable
+        opaque_tokens = re.findall(r"[A-Za-z][A-Za-z-]*", text.lower())
+        if not opaque_tokens:
+            return None
+        return (
+            f"other:{_louisiana_normalize_modifier_token(opaque_tokens[-1])}",
+            frozenset(),
+        )
+    executable_heads = tuple(
+        match
+        for match in re.finditer(r"\b[A-Za-z]+\b", text)
+        if _louisiana_object_signature(match.group(0)) is not None
+    )
+    if (
+        executable_heads
+        and executable_heads[-1].start() > documentary_heads[-1].start()
+    ):
+        return executable
+    return (f"other:{documentary_heads[-1].group(0).lower()}", frozenset())
+
+
+def _louisiana_signatures_corefer(
+    first: tuple[str, frozenset[str]] | None,
+    second: tuple[str, frozenset[str]] | None,
+) -> bool:
+    """Compare executable identity without discarding meaningful modifiers."""
+
+    return first is not None and second is not None and first == second
+
+
+def _missing_scope_semantic_head(scope: str) -> str | None:
+    """Return the final executable semantic head of a direct missing object."""
+
+    signature = _louisiana_object_signature(scope)
+    return signature[0] if signature is not None else None
+
+
 def _reason_dependency_occurrence_is_contextual(
     reason: str,
     match: re.Match[str],
@@ -5024,6 +8614,7 @@ def _reason_dependency_occurrence_is_contextual(
         candidates = (
             *_qualified_usc_dependencies(reason),
             *_RELATIVE_USC_DEFERRAL_DEPENDENCY.finditer(reason),
+            *_qualified_louisiana_rs_dependencies(reason),
         )
         for candidate in candidates:
             if _usc_dependency_occurrences_match(
@@ -5065,6 +8656,7 @@ def _reason_dependencies(reason: str) -> list[re.Match[str]]:
         (
             *_qualified_usc_dependencies(reason),
             *_RELATIVE_USC_DEFERRAL_DEPENDENCY.finditer(reason),
+            *_qualified_louisiana_rs_dependencies(reason),
             *_PRECISE_DEFERRAL_DEPENDENCY.finditer(reason),
         ),
         key=lambda dependency: (dependency.start(), -dependency.end()),
@@ -5105,11 +8697,18 @@ def _reason_dependency_local_context(
     return before + after
 
 
+def _dependency_citation_family(match: re.Match[str]) -> str:
+    if match.re is _LOUISIANA_RS_DEFERRAL_DEPENDENCY:
+        return "louisiana-rs"
+    return "usc"
+
+
 def _usc_dependencies_match(left: re.Match[str], right: re.Match[str]) -> bool:
     left_groups = left.groupdict()
     right_groups = right.groupdict()
     return bool(
-        left_groups.get("title")
+        _dependency_citation_family(left) == _dependency_citation_family(right)
+        and left_groups.get("title")
         and right_groups.get("title")
         and left_groups["title"].lower() == right_groups["title"].lower()
         and normalize_rulespec_path_segment(left_groups["section"])
@@ -5154,7 +8753,10 @@ def _reason_clause_bounds(
     match: re.Match[str],
 ) -> tuple[int, int]:
     masked = list(reason)
-    for dependency in _qualified_usc_dependencies(reason):
+    for dependency in (
+        *_qualified_usc_dependencies(reason),
+        *_qualified_louisiana_rs_dependencies(reason),
+    ):
         for position in range(dependency.start(), dependency.end()):
             if masked[position] in {".", ";"}:
                 masked[position] = " "
@@ -5972,6 +9574,39 @@ def _usc_dependency_is_external(
     ).lower() != current_citation.title.lower() or normalize_rulespec_path_segment(
         match.group("section").lower()
     ) != normalize_rulespec_path_segment(current_citation.section.lower())
+
+
+def _louisiana_rs_dependency_is_external(
+    match: re.Match[str],
+    *,
+    corpus_citation_path: str,
+) -> bool:
+    """Reject current-section Louisiana citations masquerading as dependencies."""
+
+    citation_parts = [
+        part for part in corpus_citation_path.strip("/").split("/") if part
+    ]
+    if (
+        len(citation_parts) < 3
+        or citation_parts[0].lower() != "us-la"
+        or citation_parts[1].lower() != "statute"
+    ):
+        return False
+    statute_tail = citation_parts[2:]
+    if ":" in statute_tail[0]:
+        title_section = statute_tail[0].split(":")
+        if len(title_section) != 2 or not all(title_section):
+            return False
+        current_title, current_section = title_section
+    elif len(statute_tail) >= 2:
+        current_title, current_section = statute_tail[:2]
+    else:
+        return False
+    return match.group(
+        "title"
+    ).lower() != current_title.lower() or normalize_rulespec_path_segment(
+        match.group("section").lower()
+    ) != normalize_rulespec_path_segment(current_section.lower())
 
 
 def _prose_dependency_is_external(

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1621"
+ENCODER_VERSION = "0.2.1622"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1621"
+ENCODER_VERSION = "0.2.1622"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1621"
+ENCODER_VERSION = "0.2.1622"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1621"
+ENCODER_VERSION = "0.2.1622"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1621"
+ENCODER_VERSION = "0.2.1622"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1621"
+ENCODER_VERSION = "0.2.1622"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1621"
+ENCODER_VERSION = "0.2.1622"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1621"')
+        .startswith('__version__ = "0.2.1622"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1621"
+    assert encoder_package["version"] == "0.2.1622"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1621"
+    assert project["project"]["version"] == "0.2.1622"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1621"')
+        .startswith('__version__ = "0.2.1622"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1621"
+    assert encoder_package["version"] == "0.2.1622"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1621"
+    assert project["project"]["version"] == "0.2.1622"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1621"')
+        .startswith('__version__ = "0.2.1622"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1621"
+ENCODER_VERSION = "0.2.1622"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -6756,6 +6756,1659 @@ rules: []
     assert not _has_issue(result, "(b)", "deferral")
 
 
+def _louisiana_external_dependency_deferral(
+    reason: str,
+    *,
+    source_reference: str = "R.S. 47:32",
+    source_link: str = "determined in accordance with the provisions of",
+):
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-la/statute/47:295
+  deferred_outputs:
+    - output: us-la:statutes/47/295/a#individual_louisiana_income_tax_amount
+      reason: >-
+        {reason}
+rules: []
+"""
+    source = (
+        "A. There is imposed an income tax for each taxable year upon the Louisiana "
+        "income of every individual. The amount of the tax shall be "
+        f"{source_link} {source_reference}.\n\nB. Reserved."
+    )
+    return _analyze(
+        content,
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+        test_cases=[],
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        (
+            "R.S. 47:295(A) imposes tax upon Louisiana income but directs that "
+            "the amount be determined in accordance with R.S. 47:32; the supplied "
+            "R.S. 47:32 context provides only an individual income tax rate and "
+            "lacks the complete R.S. 47:32 taxable-income-base computation needed "
+            "to calculate the tax amount."
+        ),
+        (
+            "Cannot compute the tax imposed by us-la/statute/47:295(a) because "
+            "the supplied R.S. 47:32 dependency exports only the individual income "
+            "tax rate and does not provide the complete tax-amount computation "
+            "that R.S. 47:295(A) directs determines the amount."
+        ),
+    ),
+)
+def test_source_bound_louisiana_rs_dependency_accepts_archived_reasons(reason: str):
+    result = _louisiana_external_dependency_deferral(reason)
+
+    assert not _has_issue(result, "(a)", "deferral")
+    assert not _has_issue(result, "source branch a", "neither encoded")
+
+
+def test_line_wrapped_source_bound_louisiana_rs_dependency_is_accepted():
+    result = _louisiana_external_dependency_deferral(
+        "Cannot compute the tax until the calculation required by La. R.S. "
+        "47:32 is available.",
+        source_reference="R.S.\n47:32",
+    )
+
+    assert not _has_issue(result, "(a)", "deferral")
+    assert not _has_issue(result, "source branch a", "neither encoded")
+
+
+def test_compact_source_bound_louisiana_rs_dependency_is_accepted():
+    result = _louisiana_external_dependency_deferral(
+        "Cannot compute the tax until the calculation required by RS 47:32 is "
+        "available.",
+        source_reference="La. R.S. 47:32",
+    )
+
+    assert not _has_issue(result, "(a)", "deferral")
+
+
+def test_dotted_source_bound_louisiana_rs_dependency_is_accepted():
+    result = _louisiana_external_dependency_deferral(
+        "Cannot compute the tax because R.S. 47:297.4 lacks the required tax "
+        "amount computation.",
+        source_reference="R.S. 47:297.4",
+    )
+
+    assert not _has_issue(result, "(a)", "deferral")
+
+
+@pytest.mark.parametrize(
+    ("reason", "source_reference", "source_link"),
+    (
+        (
+            "Cannot compute the tax because R.S. 47:33 lacks the required tax "
+            "amount computation.",
+            "R.S. 47:32",
+            "determined in accordance with the provisions of",
+        ),
+        (
+            "Cannot compute the tax because R.S. 47:32 lacks the required tax "
+            "amount computation.",
+            "R.S. 47:33",
+            "determined in accordance with the provisions of",
+        ),
+        (
+            "Cannot compute the tax because R.S. 47:295(A) lacks the required tax "
+            "amount computation.",
+            "R.S. 47:295(A)",
+            "determined in accordance with the provisions of",
+        ),
+        (
+            "Cannot compute the tax because R.S. 47:32 is supplied only as "
+            "historical context and lacks the required tax amount computation.",
+            "R.S. 47:32",
+            "determined in accordance with the provisions of",
+        ),
+        (
+            "Cannot compute the tax because R.S. 47:32 lacks the required tax "
+            "amount computation.",
+            "R.S. 47:32",
+            "stated notwithstanding",
+        ),
+        (
+            "Cannot compute the tax because R.S. 47:32 lacks the required tax "
+            "amount computation.",
+            "R.S. 47:32(A)",
+            "determined in accordance with the provisions of",
+        ),
+        (
+            "Cannot compute the tax because R.S. 48:32 lacks the required tax "
+            "amount computation.",
+            "R.S. 47:32",
+            "determined in accordance with the provisions of",
+        ),
+        (
+            "Cannot compute the tax because R.S. 47:32junk lacks the required tax "
+            "amount computation.",
+            "R.S. 47:32",
+            "determined in accordance with the provisions of",
+        ),
+        (
+            "Cannot compute the tax because R.S. 47:32(A)junk lacks the required "
+            "tax amount computation.",
+            "R.S. 47:32(A)",
+            "determined in accordance with the provisions of",
+        ),
+        (
+            "Cannot compute the tax because junk_R.S. 47:32 lacks the required tax "
+            "amount computation.",
+            "R.S. 47:32",
+            "determined in accordance with the provisions of",
+        ),
+        (
+            "Cannot compute the tax because R.S. 47:32 lacks the required tax "
+            "amount computation.",
+            "R.S. 47:32",
+            "is stated without prejudice to",
+        ),
+        (
+            "Cannot compute the tax because R.S. 47:32 lacks the required tax "
+            "amount computation.",
+            "R.S. 47:32",
+            "does not affect",
+        ),
+    ),
+)
+def test_louisiana_rs_dependency_requires_exact_operative_external_reference(
+    reason: str,
+    source_reference: str,
+    source_link: str,
+):
+    result = _louisiana_external_dependency_deferral(
+        reason,
+        source_reference=source_reference,
+        source_link=source_link,
+    )
+
+    assert _has_issue(result, "(a)", "deferral", "runtime capability")
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        (
+            "R.S. 47:33 lacks the required tax amount computation, but "
+            "R.S. 47:32 is available."
+        ),
+        (
+            "R.S. 47:32 is available, but R.S. 47:33 lacks the required tax "
+            "amount computation."
+        ),
+        (
+            "R.S. 47:33 lacks the required tax amount computation; "
+            "R.S. 47:32 is mentioned for context."
+        ),
+    ),
+)
+def test_louisiana_rs_dependencies_cannot_borrow_missingness(reason: str):
+    result = _louisiana_external_dependency_deferral(reason)
+
+    assert _has_issue(result, "(a)", "deferral", "runtime capability")
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        ("R.S. 47:32 lacks metadata and supplies the required tax amount computation."),
+        "R.S. 47:32 lacks no required tax amount computation.",
+        (
+            "R.S. 47:32 exports only the rate, but RS 47:33 lacks the required "
+            "computation."
+        ),
+        (
+            "R.S. 47:32 exports only the rate and RS 47:33 lacks the required "
+            "computation."
+        ),
+        (
+            "R.S. 47:32 exports only the rate, but the unrelated runtime lacks "
+            "the required computation."
+        ),
+        (
+            "R.S. 47:32 does not provide historical notes and provides the "
+            "required tax amount computation."
+        ),
+    ),
+)
+def test_louisiana_rs_insufficiency_must_govern_the_missing_object(reason: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined in accordance with R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        (
+            "R.S. 47:32 lacks metadata and is fully available with required tax "
+            "amount computation."
+        ),
+        "R.S. 47:32 lacks metadata and defines a complete tax formula.",
+        "R.S. 47:32 lacks historical notes about required tax amount computation.",
+        "R.S. 47:32 lacks metadata required to audit tax amount computation.",
+        ("R.S. 47:32 does not provide a commentary describing tax amount formula."),
+        "R.S. 47:32 lacks required tax computation examples.",
+        "R.S. 47:32 lacks the complete tax formula commentary.",
+        "R.S. 47:32 lacks the complete tax calculation notes.",
+        "R.S. 47:32 lacks metadata regarding the required tax computation.",
+        "R.S. 47:32 lacks commentary on the tax formula.",
+        "R.S. 47:32 lacks notes concerning the income calculation.",
+        "R.S. 47:32 lacks examples illustrating the required computation.",
+        "R.S. 47:32 lacks documentation supporting the tax formula.",
+        "R.S. 47:32 lacks metadata documenting the tax computation.",
+        "R.S. 47:32 lacks metadata explaining the tax formula.",
+        "R.S. 47:32 lacks notes outlining the tax computation.",
+        "R.S. 47:32 lacks examples demonstrating the required calculation.",
+        "R.S. 47:32 lacks commentary summarizing the tax formula.",
+        "R.S. 47:32 lacks metadata, including the required tax computation.",
+        "R.S. 47:32 lacks annotations detailing the tax computation.",
+        "R.S. 47:32 lacks guidance discussing the tax formula.",
+        "R.S. 47:32 lacks background covering the required computation.",
+        "R.S. 47:32 lacks explanatory material setting out the calculation.",
+        "R.S. 47:32 lacks a memo detailing the computation.",
+        "R.S. 47:32 lacks a summary covering the tax formula.",
+    ),
+)
+def test_louisiana_rs_insufficiency_requires_an_immediate_executable_object(
+    reason: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined in accordance with R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The amount shall be determined not in accordance with R.S. 47:32.",
+        "The amount need not be determined in accordance with R.S. 47:32.",
+        "The amount shall in no event be determined in accordance with R.S. 47:32.",
+        (
+            "The amount is determined independently of, not in accordance with "
+            "R.S. 47:32."
+        ),
+        (
+            "The amount is prohibited from being determined in accordance with "
+            "R.S. 47:32."
+        ),
+        "The amount shall not be determined under R.S. 47:32.",
+        "The amount is not calculated according to R.S. 47:32.",
+        "The amount need not be established pursuant to R.S. 47:32.",
+        "The amount does not depend on R.S. 47:32.",
+        "The amount must never be computed pursuant to R.S. 47:32.",
+        (
+            "The amount shall under no circumstances be determined in accordance "
+            "with R.S. 47:32."
+        ),
+        (
+            "The amount is expressly barred from being determined in accordance "
+            "with R.S. 47:32."
+        ),
+        "The amount is determined rather than in accordance with R.S. 47:32.",
+        "The amount is determined other than in accordance with R.S. 47:32.",
+        "The amount shall not, under R.S. 47:32, be assessed.",
+        "The amount must never, pursuant to R.S. 47:32, be computed.",
+        (
+            "The amount shall not, under any circumstances, be determined under "
+            "R.S. 47:32."
+        ),
+        "The amount shall not, however, be calculated according to R.S. 47:32.",
+        (
+            "The amount shall not under any circumstances be determined under "
+            "R.S. 47:32."
+        ),
+        "The amount shall not ever be determined under R.S. 47:32.",
+        "The amount may in no case be calculated according to R.S. 47:32.",
+        "The amount shall at no time be computed pursuant to R.S. 47:32.",
+        "The amount must by no means be determined under R.S. 47:32.",
+        "The tax shall not apply under R.S. 47:32.",
+        "The tax shall not be imposed under R.S. 47:32.",
+        "The amount is not allowed under R.S. 47:32.",
+        "The liability may not arise under R.S. 47:32.",
+        "The amount shall not then be determined under R.S. 47:32.",
+        ("The amount shall not be computed or determined under R.S. 47:32."),
+        "The tax shall not apply or arise under R.S. 47:32.",
+        "The amount does not depend on or arise under R.S. 47:32.",
+        "The amount shall neither be calculated nor determined under R.S. 47:32.",
+        "The amount cannot be determined under R.S. 47:32.",
+        "The amount fails to be determined under R.S. 47:32.",
+        "The amount is forbidden from being determined under R.S. 47:32.",
+        "The amount is precluded from being determined under R.S. 47:32.",
+        "The amount is fixed without being determined under R.S. 47:32.",
+        (
+            "It is not the case that the preliminary amount is fixed and the final "
+            "amount is determined under R.S. 47:32."
+        ),
+        (
+            "The statute does not provide that the preliminary amount is fixed and "
+            "the final amount is determined under R.S. 47:32."
+        ),
+        (
+            "The rule never states that the base is fixed or the amount is "
+            "determined under R.S. 47:32."
+        ),
+        (
+            "The preliminary amount is not fixed, but the final amount is neither "
+            "calculated nor determined under R.S. 47:32."
+        ),
+        (
+            "The preliminary amount is not fixed, but the final amount is fixed "
+            "without being determined under R.S. 47:32."
+        ),
+        "The amount isn't determined under R.S. 47:32.",
+        "The amount is unable to be determined under R.S. 47:32.",
+        "The amount is fixed without determination under R.S. 47:32.",
+        "The amount is in no way determined under R.S. 47:32.",
+        "No amount is determined under R.S. 47:32.",
+        "No tax is computed under R.S. 47:32.",
+        "The amount is prevented from being determined under R.S. 47:32.",
+        "The amount is excluded from being determined under R.S. 47:32.",
+        "The amount is determined except under R.S. 47:32.",
+        "The amount is determined in no manner under R.S. 47:32.",
+        "The law denies that the amount is determined under R.S. 47:32.",
+        "It is false that the amount is determined under R.S. 47:32.",
+        "The amount does not depend on or ordinarily arise under R.S. 47:32.",
+        "The amount shall not apply or otherwise arise under R.S. 47:32.",
+        ("The amount is not computed, and instead is described under R.S. 47:32."),
+        "The amount is not computed, but is merely discussed under R.S. 47:32.",
+        "The amount is not computed, but is only referenced under R.S. 47:32.",
+        "No credit is calculated under R.S. 47:32.",
+        "No deduction is determined under R.S. 47:32.",
+        "The amount won’t be determined under R.S. 47:32.",
+        "The amount hasn’t been determined under R.S. 47:32.",
+        "The amount is incapable of being determined under R.S. 47:32.",
+        "The amount is merely described as calculated under R.S. 47:32.",
+        "The amount is referenced as determined under R.S. 47:32.",
+        "The amount is discussed as computed under R.S. 47:32.",
+        "The amount is quoted as calculated under R.S. 47:32.",
+        (
+            "The amount is determined without regard to the requirements under "
+            "R.S. 47:32."
+        ),
+        (
+            "The statute does not mean that the base is fixed and the amount is "
+            "determined under R.S. 47:32."
+        ),
+        (
+            "The statute does not imply that the base is fixed and the amount is "
+            "determined under R.S. 47:32."
+        ),
+        (
+            "The statute does not provide evidence that the base is fixed and the "
+            "amount is determined under R.S. 47:32."
+        ),
+        (
+            "It is by no means true that the base is fixed and the amount is "
+            "determined under R.S. 47:32."
+        ),
+    ),
+)
+def test_louisiana_rs_source_link_rejects_natural_negation(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the required tax amount computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        (
+            "The amount shall not exceed the statutory cap and is determined "
+            "under R.S. 47:32."
+        ),
+        (
+            "The preliminary amount shall not be determined below zero and the "
+            "final amount is computed under R.S. 47:32."
+        ),
+        (
+            "The amount shall not be determined by estimate and instead is "
+            "calculated according to R.S. 47:32."
+        ),
+        (
+            "The amount must not be calculated provisionally and shall be "
+            "determined pursuant to R.S. 47:32."
+        ),
+        (
+            "The preliminary amount shall not be determined while the final amount "
+            "is computed under R.S. 47:32."
+        ),
+        (
+            "The preliminary amount shall not be determined whereas the final "
+            "amount is computed under R.S. 47:32."
+        ),
+        (
+            "The preliminary amount shall not be determined or the final amount is "
+            "computed under R.S. 47:32."
+        ),
+        (
+            "The preliminary amount shall not be determined then the final amount "
+            "is computed under R.S. 47:32."
+        ),
+        (
+            "The preliminary amount shall not be determined, but the final amount "
+            "is computed in accordance with R.S. 47:32."
+        ),
+        "The amount with no cap is determined under R.S. 47:32.",
+        "The amount is determined with no adjustment under R.S. 47:32.",
+        ("The amount, which shall not exceed the cap, is determined under R.S. 47:32."),
+        (
+            "The preliminary amount is not fixed and the final amount becomes "
+            "determined under R.S. 47:32."
+        ),
+        (
+            "The preliminary amount is not fixed and the final amount remains "
+            "determined under R.S. 47:32."
+        ),
+        (
+            "The preliminary amount is not fixed because the final amount is "
+            "determined under R.S. 47:32."
+        ),
+        (
+            "The preliminary amount is not fixed since the final amount is "
+            "determined under R.S. 47:32."
+        ),
+        (
+            "The preliminary amount is not fixed if the final amount is determined "
+            "under R.S. 47:32."
+        ),
+        (
+            "The preliminary amount is not fixed when the final amount is "
+            "determined under R.S. 47:32."
+        ),
+        (
+            "The preliminary amount is not fixed although the final amount is "
+            "determined under R.S. 47:32."
+        ),
+        (
+            "The preliminary amount is not fixed unless the final amount is "
+            "determined under R.S. 47:32."
+        ),
+        (
+            "The preliminary amount is not fixed as the final amount is determined "
+            "under R.S. 47:32."
+        ),
+        (
+            "The preliminary amount is not fixed provided that the final amount is "
+            "determined under R.S. 47:32."
+        ),
+        (
+            "The preliminary amount is not fixed even though the final amount is "
+            "determined under R.S. 47:32."
+        ),
+        "The amount is zero except as determined under R.S. 47:32.",
+        (
+            "The amount is calculated, except that the rate is determined under "
+            "R.S. 47:32."
+        ),
+    ),
+)
+def test_louisiana_rs_source_link_does_not_borrow_unrelated_negation(source: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the required tax amount computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reference",
+    (
+        "R.S. 47:295/1",
+        "R.S. 47:295:1",
+        "R.S. 47:295/1:2",
+    ),
+)
+def test_noncanonical_louisiana_suffix_cannot_turn_self_reference_external(
+    reference: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"{reference} lacks the required tax amount computation.",
+        f"The amount is determined in accordance with {reference}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("reason_reference", "source_reference"),
+    (
+        ("R.S. 47:32-1", "R.S. 47:32-2"),
+        ("R.S. 47:32–1", "R.S. 47:32–2"),
+        ("R.S. 47:32.1x", "R.S. 47:32.1y"),
+        ("R.S. 47:32/1", "R.S. 47:32/2"),
+        ("R.S. 47:32:1", "R.S. 47:32:2"),
+    ),
+)
+def test_louisiana_rs_dependency_requires_complete_section_suffix(
+    reason_reference: str,
+    source_reference: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"{reason_reference} lacks the required tax amount computation.",
+        f"The amount is determined in accordance with {source_reference}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("dash", ("-", "–"))
+def test_louisiana_rs_dependency_consumes_alphabetic_dash_suffix(dash: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the required tax amount computation.",
+        f"The amount is determined in accordance with R.S. 47:32{dash}foo.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("separator", ("-", "–", "/", ":"))
+def test_louisiana_rs_dependency_rejects_post_fragment_suffix_laundering(
+    separator: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"Missing tax computation under R.S. 47:32(A){separator}(B).",
+        (f"The amount is determined under R.S. 47:32(A){separator}(C)."),
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "connector",
+    (
+        "through",
+        "to",
+        "and",
+        "or",
+        ",",
+        "as well as",
+        "plus",
+        "&",
+        "together with",
+        "and subsection",
+        "through subsection",
+        "and paragraph",
+    ),
+)
+def test_louisiana_rs_dependency_rejects_post_fragment_list_laundering(
+    connector: str,
+):
+    separator = connector if connector == "," else f" {connector}"
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32(A){separator} (B) lacks the required tax computation.",
+        (f"The amount is determined under R.S. 47:32(A){separator} (C)."),
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "as additionally amended and further extended through subsection",
+        "as well as the newly enacted and renumbered subsection",
+        "together with the separately codified and recently amended paragraph",
+    ),
+)
+def test_louisiana_rs_dependency_rejects_long_fragment_tail_laundering(
+    continuation: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32(A) {continuation} (B) lacks the required computation.",
+        f"The amount is determined under R.S. 47:32(A) {continuation} (C).",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    (
+        "using table (1)",
+        "when condition (B) applies",
+        "and labeled output (X)",
+        "revised by Act (2026)",
+    ),
+)
+def test_louisiana_rs_dependency_allows_unrelated_labeled_parenthetical(
+    annotation: str,
+):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32(A) lacks the required computation.",
+        f"The amount is determined under R.S. 47:32(A), {annotation}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        (
+            "Notwithstanding R.S. 47:31, the amount is determined in accordance "
+            "with R.S. 47:32."
+        ),
+        (
+            "Without prejudice to R.S. 47:31, the amount is determined in "
+            "accordance with R.S. 47:32."
+        ),
+        (
+            "Notwithstanding any other provision of law, the amount is determined "
+            "in accordance with R.S. 47:32."
+        ),
+        (
+            "Without prejudice to any other right, the amount is determined under "
+            "R.S. 47:32."
+        ),
+        (
+            "Without prejudice to 42 USC 1234, the amount is determined in "
+            "accordance with R.S. 47:32."
+        ),
+        "Notwithstanding federal law, the amount is determined under R.S. 47:32.",
+        (
+            "Without prejudice to the federal return rule, the amount is calculated "
+            "pursuant to R.S. 47:32."
+        ),
+        (
+            "Without prejudice to federal law, the final amount becomes determined "
+            "under R.S. 47:32."
+        ),
+        (
+            "Without prejudice to federal law—the final amount remains determined "
+            "under R.S. 47:32."
+        ),
+        (
+            "Without prejudice to federal law: the final amount becomes determined "
+            "under R.S. 47:32."
+        ),
+    ),
+)
+def test_louisiana_context_disclaimer_is_bound_to_its_own_citation(source: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the required tax amount computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        (
+            "The amount is determined without prejudice to the requirements, if "
+            "any, under R.S. 47:32."
+        ),
+        (
+            "The amount is unaffected by the requirements, if applicable, under "
+            "R.S. 47:32."
+        ),
+        ("The rule does not affect the calculation, as described, under R.S. 47:32."),
+        (
+            "Notwithstanding the calculation requirements, as amended, under "
+            "R.S. 47:32, the separate rule applies."
+        ),
+        (
+            "Notwithstanding other law, the amount is determined without prejudice "
+            "to the requirements under R.S. 47:32."
+        ),
+        (
+            "Without prejudice to other rights, the amount is determined but "
+            "remains unaffected by the requirements under R.S. 47:32."
+        ),
+        (
+            "The amount is determined without prejudice to the requirement—that "
+            "the tax is calculated under R.S. 47:32."
+        ),
+        (
+            "The amount is determined without prejudice to the requirement: the "
+            "tax is calculated under R.S. 47:32."
+        ),
+        (
+            "The amount is unaffected by the requirement, which is determined "
+            "under R.S. 47:32."
+        ),
+    ),
+)
+def test_louisiana_context_disclaimer_with_interruption_is_not_operative(
+    source: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the required tax amount computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks the executable tax computation.",
+        "R.S. 47:32 lacks the taxpayer-specific tax amount computation.",
+        "R.S. 47:32 lacks the net income calculation.",
+        "R.S. 47:32 lacks the state individual income tax formula.",
+        "R.S. 47:32 lacks the upstream tax computation.",
+        "R.S. 47:32 lacks the adjusted gross income calculation.",
+        "R.S. 47:32 lacks the filing-status classification.",
+        "R.S. 47:32 lacks the taxpayer eligibility determination.",
+        "R.S. 47:32 lacks the executable computations.",
+        "R.S. 47:32 lacks the required calculations.",
+        "R.S. 47:32 lacks the tax formulas.",
+        "R.S. 47:32 lacks necessary inputs.",
+        "R.S. 47:32 lacks the tax calculation logic.",
+        "R.S. 47:32 lacks the tax formula implementation.",
+        "R.S. 47:32 lacks the calculation procedure.",
+        "R.S. 47:32 lacks the amount-computation rule set.",
+        "R.S. 47:32 lacks the taxable-income-base mechanics.",
+        "R.S. 47:32 lacks the tax calculation method.",
+        "R.S. 47:32 lacks the tax computation algorithm.",
+        "R.S. 47:32 lacks the rate schedule.",
+        "R.S. 47:32 lacks the data set.",
+        "R.S. 47:32 lacks the calculation steps.",
+        "R.S. 47:32 lacks the computation instructions.",
+        "R.S. 47:32 lacks the calculation mechanism.",
+        "R.S. 47:32 lacks the executable rule sequence.",
+        "R.S. 47:32 lacks the formula set.",
+        "R.S. 47:32 lacks the rate lookup.",
+        "R.S. 47:32 lacks the bracket threshold.",
+        "R.S. 47:32 lacks the data sets.",
+        "R.S. 47:32 lacks the rule sets.",
+        "R.S. 47:32 lacks the formula sets.",
+        "R.S. 47:32 lacks the calculation specification.",
+        "R.S. 47:32 lacks the computation protocol.",
+        "R.S. 47:32 lacks the formula definition.",
+        "R.S. 47:32 lacks the rate structure.",
+    ),
+)
+def test_louisiana_rs_insufficiency_accepts_precise_executable_object_heads(
+    reason: str,
+):
+    assert completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined in accordance with R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks the required tax computation and supplies it in full.",
+        "R.S. 47:32 does not provide the tax formula and then provides the formula.",
+        (
+            "R.S. 47:32 exports only the rate and lacks the computation and supplies "
+            "the complete computation."
+        ),
+        "R.S. 47:32 lacks the required computation and it is supplied in full.",
+        "R.S. 47:32 lacks the tax formula and the module does provide the formula.",
+        "R.S. 47:32 lacks the computation and the module can compute it.",
+        "R.S. 47:32 lacks the formula and the module makes it available.",
+        "R.S. 47:32 lacks the computation and the module is capable of computing it.",
+        "R.S. 47:32 lacks the formula and the module returns the amount.",
+        "R.S. 47:32 lacks the computation and the module already computes it.",
+        "R.S. 47:32 lacks the computation and the module successfully supplies it.",
+        "R.S. 47:32 lacks the computation and the supplied module computes it.",
+        "R.S. 47:32 lacks the computation and the context provides it.",
+        "R.S. 47:32 lacks the formula and the module has the formula.",
+        "R.S. 47:32 lacks the formula and the module exposes it.",
+        "R.S. 47:32 lacks the computation and the module generates it.",
+    ),
+)
+def test_louisiana_rs_insufficiency_rejects_coordinated_reversal(reason: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined in accordance with R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_rs_insufficiency_accepts_coordinated_missing_object_list():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation and the required table.",
+        "The amount is determined in accordance with R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The amount is determined, and metadata is recorded under R.S. 47:32.",
+        "The tax is computed, but commentary is published under R.S. 47:32.",
+        "The amount is calculated, while notes are maintained under R.S. 47:32.",
+        (
+            "The amount is determined for one purpose, while reporting is required "
+            "under R.S. 47:32."
+        ),
+        "The source shows the amount as determined under R.S. 47:32.",
+        "The amount is listed as calculated under R.S. 47:32.",
+        "An example treats the amount as calculated under R.S. 47:32.",
+        "The amount is determined not under R.S. 47:32.",
+        "The amount is determined other than under R.S. 47:32.",
+        "The amount is determined rather than under R.S. 47:32.",
+        "The historical note depends on R.S. 47:32.",
+        "The amount description depends on R.S. 47:32.",
+        "The amount ceases to depend on R.S. 47:32.",
+        "The documentation requires R.S. 47:32.",
+        "The amount ceases to require R.S. 47:32.",
+        "The note about the amount depends on R.S. 47:32.",
+        "The example shows the tax calculated under R.S. 47:32.",
+        "The amount is calculated only as an example under R.S. 47:32.",
+        "The amount is calculated for comparison under R.S. 47:32.",
+        "The amount is calculated solely for background under R.S. 47:32.",
+        (
+            "The statute fails to establish that the amount is determined under "
+            "R.S. 47:32."
+        ),
+        (
+            "The statute does not state whether the amount is determined under "
+            "R.S. 47:32."
+        ),
+        "It is uncertain whether the amount is determined under R.S. 47:32.",
+    ),
+)
+def test_louisiana_source_requires_immediately_attached_positive_predicate(
+    source: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The amount is fixed under R.S. 47:32.",
+        "The rate is prescribed under R.S. 47:32.",
+        "The amount is specified under R.S. 47:32.",
+        "The rate is set under R.S. 47:32.",
+        "The deduction is allowed under R.S. 47:32.",
+        "The credit is available under R.S. 47:32.",
+        "The amount is statutorily determined under R.S. 47:32.",
+        "The amount is equal to the tax calculated under R.S. 47:32.",
+        "The amount equals the amount determined under R.S. 47:32.",
+        "The amount shall equal the tax computed under R.S. 47:32.",
+        "The department computes the amount under R.S. 47:32.",
+        "The computation depends on R.S. 47:32.",
+        "The calculation requires R.S. 47:32.",
+    ),
+)
+def test_louisiana_source_accepts_common_attached_operative_predicates(source: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "subdivision",
+        "division",
+        "subpart",
+        "followed by subdivision",
+        "followed by",
+        "including",
+        "as enumerated in",
+        "as also set forth at",
+        "alongside",
+        "as extended from",
+    ),
+)
+def test_louisiana_citation_rejects_arbitrary_hidden_fragment_continuations(
+    continuation: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"Missing computation under R.S. 47:32(A) {continuation} (B).",
+        f"The amount is determined under R.S. 47:32(A) {continuation} (C).",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_citation_rejects_compound_hidden_fragment_continuation():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "Missing computation under R.S. 47:32(A) through (B-1).",
+        "The amount is determined under R.S. 47:32(A) through (C-1).",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_citation_rejects_uppercase_multiletter_fragment():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "Missing computation under R.S. 47:32(A) followed by (AA).",
+        "The amount is determined under R.S. 47:32(A) followed by (BB).",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    (
+        "and the calculation uses schedule (1)",
+        "and the worksheet reports line (2)",
+        "and is rounded (annually)",
+        "and is rounded (statewide)",
+        "and is rounded (otherwise)",
+    ),
+)
+def test_louisiana_citation_allows_nonfragment_parenthetical_prose(annotation: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32(A) lacks the computation.",
+        f"The amount is determined under R.S. 47:32(A), {annotation}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The amount, notwithstanding federal law, is determined under R.S. 47:32.",
+        ("The amount is determined, notwithstanding federal law, under R.S. 47:32."),
+        "The amount—notwithstanding federal law—is calculated under R.S. 47:32.",
+        ("The amount is determined, notwithstanding 42 USC 1234, under R.S. 47:32."),
+        (
+            "The preliminary amount remains unaffected by federal law, but the "
+            "final amount is determined under R.S. 47:32."
+        ),
+        (
+            "The prior calculation does not affect liability, while the final "
+            "amount is computed under R.S. 47:32."
+        ),
+    ),
+)
+def test_louisiana_context_disclaimer_allows_independent_operative_reset(source: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        (
+            "Without prejudice to the requirement—that the tax is calculated "
+            "under R.S. 47:32."
+        ),
+        (
+            "Without prejudice to the requirement: the tax is calculated under "
+            "R.S. 47:32."
+        ),
+    ),
+)
+def test_louisiana_clause_initial_disclaimer_keeps_finite_object(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks a memorandum whose subject is the tax computation.",
+        "R.S. 47:32 lacks an annotation whose subject is the formula.",
+    ),
+)
+def test_louisiana_missing_object_rejects_documentary_relative_possessor(reason: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks the corresponding tax calculation.",
+        "R.S. 47:32 lacks the governing tax computation.",
+        "R.S. 47:32 lacks the underlying tax formula.",
+        "R.S. 47:32 lacks the resulting amount calculation.",
+        "R.S. 47:32 lacks the remaining tax calculation.",
+        "R.S. 47:32 lacks the calculation parameters.",
+        "R.S. 47:32 lacks the tax equation.",
+        "R.S. 47:32 lacks the income averaging computation.",
+        "R.S. 47:32 lacks the capital gains netting calculation.",
+        "R.S. 47:32 lacks the tax credit ordering rules.",
+        "R.S. 47:32 lacks the bracket rounding method.",
+        "R.S. 47:32 lacks the tax benefit stacking algorithm.",
+    ),
+)
+def test_louisiana_missing_object_accepts_tax_compound_modifiers(reason: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks the tax computation and provides the tax rate.",
+        "R.S. 47:32 lacks the formula and has documentation.",
+        "R.S. 47:32 lacks the computation and calculates a separate fee.",
+        "R.S. 47:32 lacks the formula and the module provides no formula.",
+        "R.S. 47:32 lacks the formula and the module has no formula.",
+        "R.S. 47:32 lacks the computation and provides no formula.",
+        "R.S. 47:32 lacks the computation and supplies none of it.",
+        "R.S. 47:32 lacks the computation and has no calculation logic.",
+        "R.S. 47:32 lacks the computation and is not available.",
+        "R.S. 47:32 lacks the computation and makes no formula available.",
+        "R.S. 47:32 lacks the computation and never calculates it.",
+        "R.S. 47:32 lacks the computation and fails to provide it.",
+        "R.S. 47:32 lacks the formula and the formula is mentioned in a note.",
+        (
+            "R.S. 47:32 lacks the computation and provides the tax rate used to "
+            "calculate the formula."
+        ),
+    ),
+)
+def test_louisiana_reversal_requires_positive_coreferent_assertion(reason: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks the formula and the module possesses the formula.",
+        "R.S. 47:32 lacks the formula and the module retains it.",
+        "R.S. 47:32 lacks the formula and the formula exists.",
+        "R.S. 47:32 lacks the formula and it is fully available.",
+        ("R.S. 47:32 lacks the computation and without delay the module provides it."),
+        (
+            "R.S. 47:32 lacks the computation and the module, not previously "
+            "loaded, provides it."
+        ),
+        ("R.S. 47:32 lacks the computation and the module never fails to provide it."),
+    ),
+)
+def test_louisiana_reversal_rejects_positive_coreferent_variants(reason: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "For comparison, the amount is calculated under R.S. 47:32.",
+        "As an example, the amount is computed under R.S. 47:32.",
+        "For background, the tax is determined under R.S. 47:32.",
+        "In a nonbinding example, the tax is computed under R.S. 47:32.",
+        "The example has the amount calculated under R.S. 47:32.",
+        "The report says the amount is determined under R.S. 47:32.",
+        "The record assumes that the amount is determined under R.S. 47:32.",
+        "It is unclear if the amount is determined under R.S. 47:32.",
+        "It is possible that the amount is determined under R.S. 47:32.",
+        "The source purports to establish that the amount is determined under R.S. 47:32.",
+        "The narrative claims that the amount is determined under R.S. 47:32.",
+        "The source reportedly suggests the amount is determined under R.S. 47:32.",
+    ),
+)
+def test_louisiana_source_rejects_fronted_or_complementary_context(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The illustration of the tax depends on R.S. 47:32.",
+        "The explanation of the amount depends on R.S. 47:32.",
+        "The audit of the computation depends on R.S. 47:32.",
+        "A chart of the tax requires R.S. 47:32.",
+        "The comparison of the formula depends on R.S. 47:32.",
+        "The label for the tax depends on R.S. 47:32.",
+        "The historical discussion of the tax depends on R.S. 47:32.",
+        "The availability of the formula depends on R.S. 47:32.",
+    ),
+)
+def test_louisiana_direct_dependency_rejects_contextual_subject_head(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The final computation directly depends on R.S. 47:32.",
+        "The amount directly depends on R.S. 47:32.",
+        "Taxable income depends on R.S. 47:32.",
+        "The applicable percentage depends on R.S. 47:32.",
+        "The rate schedule depends on R.S. 47:32.",
+        "The bracket threshold depends on R.S. 47:32.",
+    ),
+)
+def test_louisiana_direct_dependency_accepts_executable_subject_head(source: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The amount is determined annually under R.S. 47:32.",
+        "The amount is computed separately under R.S. 47:32.",
+        "The amount is calculated for each taxpayer under R.S. 47:32.",
+        "The amount shall be computed exclusively under R.S. 47:32.",
+        "The tax is imposed each year under R.S. 47:32.",
+        "The amount is calculated and determined under R.S. 47:32.",
+        "The tax shall be assessed and imposed under R.S. 47:32.",
+        "The rate is established and prescribed under R.S. 47:32.",
+        "The amount is determined solely under R.S. 47:32.",
+        "The amount is determined, for purposes of this section, under R.S. 47:32.",
+        "The tax is determined, as applicable, under R.S. 47:32.",
+        "The commissioner calculates the amount under R.S. 47:32.",
+        "The court determines the tax under R.S. 47:32.",
+        "The taxpayer computes the amount under R.S. 47:32.",
+        "Although no preliminary amount is calculated, the final amount is determined under R.S. 47:32.",
+        "Because no estimate is used, the amount is determined under R.S. 47:32.",
+        "While no adjustment applies, the amount is calculated under R.S. 47:32.",
+        "Notwithstanding state law, the amount is determined under R.S. 47:32.",
+        "Without prejudice to the federal statute, the amount is fixed under R.S. 47:32.",
+        "Without prejudice to state rights, the amount is fixed under R.S. 47:32.",
+    ),
+)
+def test_louisiana_source_accepts_bounded_modifiers_and_legal_framing(source: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("connector", ("because", "although", "or", "when", "since"))
+def test_louisiana_disclaimer_allows_independent_connector_reset(connector: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        (
+            "The preliminary amount is unaffected by the cap, "
+            f"{connector} the final amount is determined under R.S. 47:32."
+        ),
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The amount is determined without prejudice to federal law, which is established under R.S. 47:32.",
+        "Without prejudice to federal law, which is established under R.S. 47:32, the amount is fixed.",
+        "Notwithstanding other law, which is determined under R.S. 47:32, the amount applies.",
+    ),
+)
+def test_louisiana_disclaimer_does_not_reset_into_relative_object(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("reason", "source"),
+    (
+        (
+            "Missing computation under R.S. 47:32(A) followed by (vi).",
+            "The amount is determined under R.S. 47:32(A) followed by (vii).",
+        ),
+        (
+            "Missing computation under R.S. 47:32(A) followed by (aa).",
+            "The amount is determined under R.S. 47:32(A) followed by (bb).",
+        ),
+        (
+            "Missing computation under R.S. 47:32(A) and line (B).",
+            "The amount is determined under R.S. 47:32(A) and line (C).",
+        ),
+        (
+            "Missing computation under R.S. 47:32(A) and schedule (B).",
+            "The amount is determined under R.S. 47:32(A) and schedule (C).",
+        ),
+        (
+            "Missing computation under R.S. 47:32(A)-(B).",
+            "The amount is determined under R.S. 47:32(A)-(C).",
+        ),
+    ),
+)
+def test_louisiana_citation_rejects_lowercase_and_labeled_fragment_tails(
+    reason: str, source: str
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    (
+        "for married filers (MFJ)",
+        "for qualifying widows (QW)",
+        "for Louisiana residents (LA)",
+        "in United States dollars (USD)",
+        "for category (B)",
+        "for group (C)",
+        "using Appendix (A)",
+        "under option (2)",
+        "in column (3)",
+        "during phase (B)",
+    ),
+)
+def test_louisiana_citation_allows_detached_tax_annotations(annotation: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32(A) lacks the computation.",
+        f"The amount is determined under R.S. 47:32(A), {annotation}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks a record whose subject is the formula.",
+        "R.S. 47:32 lacks a record which discusses the formula.",
+        "R.S. 47:32 lacks an exhibit containing the tax formula.",
+        "R.S. 47:32 lacks an appendix containing the computation.",
+        "R.S. 47:32 lacks a report detailing the calculation.",
+        "R.S. 47:32 lacks an audit record documenting the computation.",
+    ),
+)
+def test_louisiana_missing_object_rejects_documentary_head_synonyms(reason: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks the computation and the module provides this.",
+        "R.S. 47:32 lacks the formula and the module supplies that.",
+        "R.S. 47:32 lacks the calculations and the module provides those.",
+        "R.S. 47:32 lacks the formula and the module includes the same.",
+        "R.S. 47:32 lacks the formula and offers the formula.",
+        "R.S. 47:32 lacks the rate and lists the rate.",
+        "R.S. 47:32 lacks the formula and the formula is present.",
+        "R.S. 47:32 lacks the formula and reproduces it.",
+        "R.S. 47:32 lacks the formula and does not provide notes, then possesses the formula.",
+        "R.S. 47:32 lacks the formula and the module does not fail to provide it.",
+        "R.S. 47:32 lacks the formula and the module is not unable to provide it.",
+        "R.S. 47:32 lacks the formula and the module cannot fail to provide it.",
+        "R.S. 47:32 lacks the formula and the module doesn't fail to provide it.",
+        "R.S. 47:32 lacks the formula and the module provides only the formula.",
+    ),
+)
+def test_louisiana_reversal_rejects_demonstratives_and_composed_positives(reason: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks the formula and no module provides it.",
+        "R.S. 47:32 lacks the formula and nothing provides it.",
+        "R.S. 47:32 lacks the formula and neither module provides it.",
+        "R.S. 47:32 lacks the formula and the module lacks the ability to provide it.",
+        "R.S. 47:32 lacks the formula and the module is not capable of providing it.",
+        "R.S. 47:32 lacks the formula and provides the deduction computation.",
+        "R.S. 47:32 lacks the marginal rate and provides the average rate.",
+        "R.S. 47:32 lacks the formula and possesses only an incomplete formula.",
+        "R.S. 47:32 lacks the formula and provides a formula outline.",
+        "R.S. 47:32 lacks the formula and provides the rate because it is required.",
+    ),
+)
+def test_louisiana_reversal_accepts_negative_or_noncoreferent_assertions(reason: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "Hypothetically, the amount is calculated under R.S. 47:32.",
+        "In a hypothetical scenario, the amount is determined under R.S. 47:32.",
+        "The hypothetical amount is determined under R.S. 47:32.",
+        "The sample amount is calculated under R.S. 47:32.",
+        "Suppose the amount is determined under R.S. 47:32.",
+        "The statute indicates the possibility that the tax is determined under R.S. 47:32.",
+        "It is conceivable that the amount is computed under R.S. 47:32.",
+        "The table indicates the amount is calculated under R.S. 47:32.",
+        "The source alleges that the amount is calculated under R.S. 47:32.",
+        "The narrative indicates that the tax is determined under R.S. 47:32.",
+        "The witness testifies that the amount is computed under R.S. 47:32.",
+        "The analyst believes that the amount is determined under R.S. 47:32.",
+        "If the narrative is accurate, the amount is determined under R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle10_rejects_hypothetical_or_documentary_framing(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The hypothetical tax depends on R.S. 47:32.",
+        "The illustrative calculation depends on R.S. 47:32.",
+        "The comparison calculation depends on R.S. 47:32.",
+        "The audit on the formula depends on R.S. 47:32.",
+        "The description accompanying the tax depends on R.S. 47:32.",
+        "The report covering the formula depends on R.S. 47:32.",
+        "The label attached to the rate depends on R.S. 47:32.",
+        "The metadata entry named tax depends on R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle10_rejects_contextual_direct_dependency_subject(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The computation in this section depends on R.S. 47:32.",
+        "The amount necessarily and directly depends on R.S. 47:32.",
+        "The amount, as adjusted, depends on R.S. 47:32.",
+        "The amount depends directly on R.S. 47:32.",
+        "The computation is dependent on R.S. 47:32.",
+        "The formula relies on R.S. 47:32.",
+        "Which rate applies depends on R.S. 47:32.",
+        "Application of the rate depends on R.S. 47:32.",
+        "Determination of the amount depends on R.S. 47:32.",
+        "The lesser of two rates depends on R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle10_accepts_direct_dependency_grammar_variants(source: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The amount is determined for the taxable year under R.S. 47:32.",
+        "The amount is computed per taxpayer under R.S. 47:32.",
+        "The amount is calculated on the return under R.S. 47:32.",
+        "The amount is determined monthly under R.S. 47:32.",
+        "The amount is determined quarterly under R.S. 47:32.",
+        "The amount is determined in all cases under R.S. 47:32.",
+        "The amount is calculated and then determined under R.S. 47:32.",
+        "The amount is calculated or determined under R.S. 47:32.",
+        "The amount is computed, rounded, and determined under R.S. 47:32.",
+        "The tax is assessed, levied, and imposed under R.S. 47:32.",
+        "The amount shall not be calculated but determined under R.S. 47:32.",
+        "The commissioner determines the net amount under R.S. 47:32.",
+        "The employer computes the withholding tax under R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle10_accepts_operative_sequences_and_modifiers(source: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The amount is unaffected by federal law, which remains applicable, but the final amount is determined under R.S. 47:32.",
+        "The rule does not affect federal law, which applies independently, while the final amount is computed under R.S. 47:32.",
+        "Without prejudice to federal law, which applies independently, the amount is determined under R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle10_disclaimer_allows_later_independent_reset(source: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The amount is unaffected by the requirement, but the requirement states that the tax is determined under R.S. 47:32.",
+        "The amount is unaffected by the requirement, although the requirement indicates that the tax is determined under R.S. 47:32.",
+        "Without prejudice to federal law, under which the amount is determined under R.S. 47:32.",
+        "Without prejudice to federal law, in which the amount is determined under R.S. 47:32.",
+        "Without prejudice to federal law, where the amount is determined under R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle10_disclaimer_rejects_governed_relative_or_report(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks the sample calculation.",
+        "R.S. 47:32 lacks the hypothetical formula.",
+        "R.S. 47:32 lacks the draft computation.",
+        "R.S. 47:32 lacks the proposed formula.",
+        "R.S. 47:32 lacks an overview covering the tax formula.",
+    ),
+)
+def test_louisiana_cycle10_missing_object_rejects_nonoperative_artifacts(reason: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks the formula and the module does not not provide it.",
+        "R.S. 47:32 lacks the formula and the module did not refuse to provide it.",
+        "R.S. 47:32 lacks the formula and the module cannot refuse to provide it.",
+        "R.S. 47:32 lacks the formula and the module makes the formula available.",
+        "R.S. 47:32 lacks the formula and there is a formula.",
+        "R.S. 47:32 lacks the formula, the module provides the formula.",
+        "R.S. 47:32 lacks the formula and the module publishes the formula.",
+        "R.S. 47:32 lacks the computation and the module provides the calculation.",
+        "R.S. 47:32 lacks the formula and the module provides the equation.",
+        "R.S. 47:32 lacks the rate schedule and the module provides the rate table.",
+    ),
+)
+def test_louisiana_cycle10_reversal_rejects_composed_positive_synonyms(reason: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks the formula and the module can't provide it.",
+        "R.S. 47:32 lacks the formula and the module couldn't provide it.",
+        "R.S. 47:32 lacks the formula and the module won't provide it.",
+        "R.S. 47:32 lacks the formula and the module hasn't provided it.",
+        "R.S. 47:32 lacks the formula and the module isn't able to provide it.",
+        "R.S. 47:32 lacks the formula and the module provides only part of the formula.",
+        "R.S. 47:32 lacks the formula and the module provides hardly any formula.",
+        "R.S. 47:32 lacks the formula and the module provides a draft formula.",
+        "R.S. 47:32 lacks the resident calculation and the module provides the corporate calculation.",
+        "R.S. 47:32 lacks the income-tax formula and the module provides the payroll-tax formula.",
+        "R.S. 47:32 lacks the taxpayer's calculation and the module provides the employer's computation.",
+        "R.S. 47:32 lacks the 2025 calculation and the module provides the 2024 computation.",
+        "R.S. 47:32 lacks the marginal rate and the module provides this average rate.",
+    ),
+)
+def test_louisiana_cycle10_reversal_accepts_negative_partial_or_distinct(reason: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "and (B)",
+        "or (B)",
+        "plus (B)",
+        "as well as (B)",
+        "together with (B)",
+        "as supplemented by (B)",
+        "combined with (B)",
+        "in addition to (B)",
+        "as amended by (B)",
+        "through (ii)",
+        "followed by (vi)",
+        "and line (B)",
+        "and schedule (B)",
+        "-(B)",
+    ),
+)
+def test_louisiana_cycle10_citation_accepts_identical_natural_tail(continuation: str):
+    reference = (
+        f"R.S. 47:32(A) {continuation}"
+        if not continuation.startswith("-")
+        else f"R.S. 47:32(A){continuation}"
+    )
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"{reference} lacks the computation.",
+        f"The amount is determined under {reference}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "masked_tail",
+    (
+        "R.S. 47:32(A), for category (X), followed by (B)",
+        "R.S. 47:32(A), see table (1), followed by (B)",
+    ),
+)
+def test_louisiana_cycle10_citation_rejects_annotation_masked_tail(masked_tail: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"{masked_tail} lacks the computation.",
+        f"The amount is determined under {masked_tail.replace('(B)', '(C)')}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle10_citation_allows_detached_line_annotation():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32(A) lacks the computation.",
+        "The amount is determined under R.S. 47:32(A), line (B) of the worksheet is then used.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        (
+            "47 USC 32 is supplied only as historical context. R.S. 47:32 lacks "
+            "the required computation."
+        ),
+        (
+            "R.S. 47:32 lacks the required computation. 47 USC 32 is supplied "
+            "only as historical context."
+        ),
+    ),
+)
+def test_louisiana_rs_context_is_not_contaminated_by_usc(reason: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined in accordance with R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        ("47 USC 32 lacks the required computation. R.S. 47:32 is available."),
+        ("R.S. 47:32 is available. 47 USC 32 lacks the required computation."),
+    ),
+)
+def test_louisiana_rs_dependency_cannot_borrow_usc_missingness(reason: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined in accordance with R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "verb",
+    ("computed", "encoded", "resolved"),
+)
+def test_malformed_cannot_dependency_language_is_rejected(verb: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"Cannot {verb} the benefit under 42 USC 1437f(o).",
+        "The benefit is determined under 42 USC 1437f(o).",
+        corpus_citation_path="us/statute/42/1437c-1",
+    )
+
+
+def test_bare_rs_dependency_is_not_louisiana_outside_louisiana_source():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the required tax amount computation.",
+        "The amount is determined in accordance with R.S. 47:32.",
+        corpus_citation_path="us-nj/statute/54a:1-1",
+    )
+
+
 def test_unrelated_usc_dependency_cannot_defer_computable_source():
     content = """\
 format: rulespec/v1
@@ -18986,3 +20639,6172 @@ rules:
 
     assert not correct.issues
     assert _has_issue(cancelled, "rounding", "fractional")
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The sample tax calculation depends on R.S. 47:32.",
+        "The example tax calculation depends on R.S. 47:32.",
+        "The draft tax formula depends on R.S. 47:32.",
+        "The proposed tax formula depends on R.S. 47:32.",
+        "The fictional tax formula depends on R.S. 47:32.",
+        "The nonbinding tax formula depends on R.S. 47:32.",
+        "The witness asserts the tax depends on R.S. 47:32.",
+        "The regulation recites the tax depends on R.S. 47:32.",
+        "The requirement declares the tax depends on R.S. 47:32.",
+        "Fictionally, the tax depends on R.S. 47:32.",
+        "The document avers the amount is determined under R.S. 47:32.",
+        "The analysis predicts the amount is determined under R.S. 47:32.",
+        "The agency contends the amount is determined under R.S. 47:32.",
+        "There might be a chance that the amount is determined under R.S. 47:32.",
+        "The source cannot confirm if the amount is determined under R.S. 47:32.",
+        "The agency has yet to confirm if the amount is determined under R.S. 47:32.",
+        "The footnote to the tax depends on R.S. 47:32.",
+        "The commentary beside the tax depends on R.S. 47:32.",
+        "The annotation beneath the tax depends on R.S. 47:32.",
+        "The example illustrating the tax depends on R.S. 47:32.",
+        "The exhibit containing the tax depends on R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle11_rejects_documentary_and_hypothetical_links(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The tax depends solely on R.S. 47:32.",
+        "The tax depends entirely upon R.S. 47:32.",
+        "The tax ultimately depends on R.S. 47:32.",
+        "The tax depends in part on R.S. 47:32.",
+        "The tax is directly dependent on R.S. 47:32.",
+        "The tax relies directly upon R.S. 47:32.",
+        "The rate shown in the table depends on R.S. 47:32.",
+        "The amount specified in the subsection depends upon R.S. 47:32.",
+        "The calculation required for the return relies directly on R.S. 47:32.",
+        "The computation alone is directly dependent on R.S. 47:32.",
+        "The amount is hereby determined under R.S. 47:32.",
+        "The amount is to be determined under R.S. 47:32.",
+        "The amount is calculated and provisionally determined under R.S. 47:32.",
+        "The amount is calculated and, where applicable, determined under R.S. 47:32.",
+        "The amount is determined for every taxpayer under R.S. 47:32.",
+        "The amount is determined for each return under R.S. 47:32.",
+        "The amount is determined on an annual basis under R.S. 47:32.",
+        "The amount is determined at the taxpayer level under R.S. 47:32.",
+        "The amount is determined for the applicable taxable year under R.S. 47:32.",
+        "The amount is rounded to the nearest dollar under R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle11_accepts_operational_dependency_variants(source: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The amount is determined under R.S. 47:31 and R.S. 47:32.",
+        "The amount is determined pursuant to R.S. 47:31 or R.S. 47:32.",
+        "The tax depends on R.S. 47:31 and R.S. 47:32.",
+        "The calculation requires R.S. 47:31 or R.S. 47:32.",
+        "The amount is determined under both R.S. 47:31 and R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle11_accepts_coordinated_second_citation(source: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The report relies on 42 U.S.C. 1234.",
+        "The annotation is dependent on 42 U.S.C. 1234.",
+        "The description depends directly on 42 U.S.C. 1234.",
+    ),
+)
+def test_cycle11_louisiana_linkers_do_not_expand_generic_usc_syntax(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "42 U.S.C. 1234 lacks the computation.",
+        source,
+        corpus_citation_path="us/statute/1/1",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        (
+            "Without prejudice to federal law, which remains applicable, but the "
+            "final amount is determined under R.S. 47:32."
+        ),
+        (
+            "Without prejudice to federal law, which remains applicable, and the "
+            "final amount is determined under R.S. 47:32."
+        ),
+        (
+            "Without prejudice to federal law, which, despite the filing rule, "
+            "remains applicable, the final amount is determined under R.S. 47:32."
+        ),
+    ),
+)
+def test_louisiana_cycle11_disclaimer_allows_independent_main_reset(source: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        (
+            "Without prejudice to federal law, to which the amount is determined "
+            "under R.S. 47:32."
+        ),
+        (
+            "Without prejudice to federal law, pursuant to which the amount is "
+            "determined under R.S. 47:32."
+        ),
+        (
+            "Without prejudice to federal law, which, despite the filing rule, "
+            "remains applicable under R.S. 47:32."
+        ),
+        (
+            "Without prejudice to federal law, which remains applicable, and the "
+            "requirement asserts the final amount is determined under R.S. 47:32."
+        ),
+        (
+            "Without prejudice to federal law, which remains applicable, but the "
+            "requirement declares the final amount is determined under R.S. 47:32."
+        ),
+        (
+            "Without prejudice to federal law, which remains applicable, while "
+            "the requirement recites the final amount is determined under R.S. 47:32."
+        ),
+    ),
+)
+def test_louisiana_cycle11_disclaimer_rejects_relative_or_reported_reset(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("reason", "source"),
+    (
+        (
+            "R.S. 47:32(A), (B) lacks the computation.",
+            "The amount is determined under R.S. 47:32(A), (B).",
+        ),
+        (
+            "R.S. 47:32(A), and (B) lacks the computation.",
+            "The amount is determined under R.S. 47:32(A), and (B).",
+        ),
+        (
+            "R.S. 47:32(A) & (B) lacks the computation.",
+            "The amount is determined under R.S. 47:32(A) & (B).",
+        ),
+        (
+            "R.S. 47:32(A) as provided in (B) lacks the computation.",
+            "The amount is determined under R.S. 47:32(A) as provided in (B).",
+        ),
+        (
+            "R.S. 47:32(A) together with subsection (B) lacks the computation.",
+            (
+                "The amount is determined under R.S. 47:32(A) together with "
+                "subsection (B)."
+            ),
+        ),
+        (
+            "R.S. 47:32, subsections (A) and (B) lacks the computation.",
+            "The amount is determined under R.S. 47:32, subsections (A) and (B).",
+        ),
+        (
+            "R.S. 47:32(A) paragraphs (1) through (3) lacks the computation.",
+            (
+                "The amount is determined under R.S. 47:32(A) paragraphs (1) "
+                "through (3)."
+            ),
+        ),
+        (
+            "R.S. 47:32(A) subject to paragraph (B) lacks the computation.",
+            ("The amount is determined under R.S. 47:32(A) subject to paragraph (B)."),
+        ),
+        (
+            "R.S. 47:32(A) read together with paragraph (B) lacks the computation.",
+            (
+                "The amount is determined under R.S. 47:32(A) read together with "
+                "paragraph (B)."
+            ),
+        ),
+        (
+            "R.S. 47:32(A) except as provided in paragraph (B) lacks the computation.",
+            (
+                "The amount is determined under R.S. 47:32(A) except as provided "
+                "in paragraph (B)."
+            ),
+        ),
+    ),
+)
+def test_louisiana_cycle11_accepts_exact_structural_citation_tails(
+    reason: str, source: str
+):
+    assert completeness_module._reason_dependency_is_source_bound(
+        reason,
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("reason_tail", "source_tail"),
+    (
+        ("and (B)", "or (B)"),
+        ("and line (B)", "and schedule (B)"),
+        ("through (B)", "followed by (B)"),
+        ("plus (B)", "as amended by (B)"),
+        ("as supplemented by (B)", "combined with (B)"),
+        ("read with (B)", "read with (C)"),
+        ("and part (B)", "and part (C)"),
+    ),
+)
+def test_louisiana_cycle11_rejects_structural_citation_tail_mismatch(
+    reason_tail: str, source_tail: str
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32(A) {reason_tail} lacks the computation.",
+        f"The amount is determined under R.S. 47:32(A) {source_tail}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks a placeholder formula.",
+        "R.S. 47:32 lacks a mock calculation.",
+        "R.S. 47:32 lacks a fictional computation.",
+        "R.S. 47:32 lacks a notional method.",
+        "R.S. 47:32 lacks a tentative amount.",
+        "R.S. 47:32 lacks a purported deduction.",
+        "R.S. 47:32 lacks a suggested liability.",
+        "R.S. 47:32 lacks a digest of the formula.",
+        "R.S. 47:32 lacks a brief about the calculation.",
+        "R.S. 47:32 lacks a narrative of the computation.",
+        "R.S. 47:32 lacks a transcript of the formula.",
+    ),
+)
+def test_louisiana_cycle11_rejects_nonoperative_missing_objects(reason: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("head", ("deduction", "credit", "liability", "tax"))
+def test_louisiana_cycle11_accepts_executable_missing_object_heads(head: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the {head}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks the formula and the module provides it directly.",
+        "R.S. 47:32 lacks the formula and the module provides it completely.",
+        "R.S. 47:32 lacks the formula and the module provides notes and the formula.",
+        "R.S. 47:32 lacks the formula and the module provides notes, then the formula.",
+        "R.S. 47:32 lacks the formula and the module gives the formula.",
+        "R.S. 47:32 lacks the formula and the module outputs the formula.",
+        "R.S. 47:32 lacks the formula and the module stores the formula.",
+        "R.S. 47:32 lacks the formula and the module holds the formula.",
+        "R.S. 47:32 lacks the formula and the module specifies the formula.",
+        "R.S. 47:32 lacks the formula and the formula is encoded.",
+        "R.S. 47:32 lacks the formula and the formula is defined.",
+        "R.S. 47:32 lacks the formula and the formula is accessible.",
+        "R.S. 47:32 lacks the formula and the formula is complete.",
+        "R.S. 47:32 lacks the formula and the module provides that same.",
+        "R.S. 47:32 lacks the formula, the engine provides it.",
+        "R.S. 47:32 lacks the formula, a formula is present.",
+        "R.S. 47:32 lacks the formula. The module provides it.",
+        "R.S. 47:32 lacks the formula and no module fails to provide it.",
+        "R.S. 47:32 lacks the formula and the module should not fail to provide it.",
+        "R.S. 47:32 lacks the formula and the module can't not provide it.",
+        "R.S. 47:32 lacks the formula and the module won't fail to provide it.",
+        "R.S. 47:32 lacks the formula and the module couldn't refuse to provide it.",
+        "R.S. 47:32 lacks the threshold and the module provides the threshold.",
+        "R.S. 47:32 lacks the base and the module provides the base.",
+        "R.S. 47:32 lacks the algorithm and the module provides the algorithm.",
+        "R.S. 47:32 lacks the amount and the module provides the amount.",
+        "R.S. 47:32 lacks the method and the module provides the method.",
+        (
+            "R.S. 47:32 lacks the resident taxpayer formula and the module "
+            "provides the resident formula."
+        ),
+        (
+            "R.S. 47:32 lacks the individual-income formula and the module "
+            "provides the individual formula."
+        ),
+        (
+            "R.S. 47:32 lacks the annual formula and the module provides the "
+            "yearly formula."
+        ),
+        (
+            "R.S. 47:32 lacks the corporate formula and the module provides the "
+            "corporation formula."
+        ),
+    ),
+)
+def test_louisiana_cycle11_rejects_positive_coreferent_reversals(reason: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks the formula and the module shouldn't provide it.",
+        "R.S. 47:32 lacks the formula and the module mustn't provide it.",
+        "R.S. 47:32 lacks the formula and the module needn't provide it.",
+        "R.S. 47:32 lacks the formula and the module mightn't provide it.",
+        "R.S. 47:32 lacks the formula and the module provides a provisional formula.",
+        "R.S. 47:32 lacks the formula and scarcely any formula is present.",
+        (
+            "R.S. 47:32 lacks the formula and the module identifies the rate but "
+            "provides it."
+        ),
+        (
+            "R.S. 47:32 lacks the formula and the module lists the rate then "
+            "provides this."
+        ),
+        (
+            "R.S. 47:32 lacks the standard deduction formula and the module "
+            "provides the itemized deduction formula."
+        ),
+    ),
+)
+def test_louisiana_cycle11_accepts_negative_partial_or_noncoreferent_supply(
+    reason: str,
+):
+    assert completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The tax depends primarily on R.S. 47:32.",
+        "The tax depends, in part, on R.S. 47:32.",
+        "The tax is dependent, in part, on R.S. 47:32.",
+        "The tax relies in part on R.S. 47:32.",
+        "The amount is determined for each taxable year under R.S. 47:32.",
+        "The amount is determined for each filing period under R.S. 47:32.",
+        "The amount is rounded to the nearest whole dollar under R.S. 47:32.",
+        "The amount is determined as of the close of the taxable year under R.S. 47:32.",
+        "The witness discussed another issue, but the tax depends on R.S. 47:32.",
+        "The hypothetical amount is irrelevant, while the final tax depends on R.S. 47:32.",
+        "The fictional example is unrelated, yet the final amount is determined under R.S. 47:32.",
+        "The tax is not determined under R.S. 47:31 but is determined under R.S. 47:32.",
+        "The amount is determined under both R.S. 47:31 and R.S. 47:32.",
+        "The amount is determined under either R.S. 47:31 or R.S. 47:32.",
+        "The amount is determined under R.S. 47:30, R.S. 47:31, and R.S. 47:32.",
+        "The amount is determined under R.S. 47:30 as well as R.S. 47:31 together with R.S. 47:32.",
+        "Without prejudice to Louisiana law, the amount is determined under R.S. 47:32.",
+        "Without regard to the law of this state, the amount is determined under R.S. 47:32.",
+        "Notwithstanding any law contrary, the amount is determined under R.S. 47:32.",
+        "The amount is determined under La. R.S. § 47:32.",
+        "The amount is determined under La.R.S. §§ 47:32.",
+        "The amount is determined under R.S. § 47:32.",
+        "The amount is determined under LSA-R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle12_accepts_operative_source_variants(source: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "Perhaps the amount is determined under R.S. 47:32.",
+        "Possibly the amount is determined under R.S. 47:32.",
+        "Conceivably the amount is determined under R.S. 47:32.",
+        "It could be that the amount is determined under R.S. 47:32.",
+        "The putative tax depends on R.S. 47:32.",
+        "The assumed tax depends on R.S. 47:32.",
+        "The purported tax depends on R.S. 47:32.",
+        "For purposes of argument, the tax depends on R.S. 47:32.",
+        "In theory, the tax depends on R.S. 47:32.",
+        "The imagined tax depends on R.S. 47:32.",
+        "The theoretical tax depends on R.S. 47:32.",
+        "The analyst estimates the tax depends on R.S. 47:32.",
+        "The agency opines the tax depends on R.S. 47:32.",
+        "The commentator opines the tax depends on R.S. 47:32.",
+        "The article observes the tax depends on R.S. 47:32.",
+        "The filing for the tax depends on R.S. 47:32.",
+        "The title of the tax depends on R.S. 47:32.",
+        "The index entry for the tax depends on R.S. 47:32.",
+        "The appendix for the tax depends on R.S. 47:32.",
+        "The worksheet for the tax depends on R.S. 47:32.",
+        "The narrative for the tax depends on R.S. 47:32.",
+        "The manual for the tax depends on R.S. 47:32.",
+        "The guide for the tax depends on R.S. 47:32.",
+        "The amount is determined under R.S. 47:31, and R.S. 47:32 is discussed.",
+        "The amount is determined pursuant to R.S. 47:31, or R.S. 47:32 illustrates the rule.",
+        "The tax depends on R.S. 47:31, and R.S. 47:32 appears in a footnote.",
+        "The rule requires R.S. 47:31, or R.S. 47:32 is not required.",
+        "The schedule B of the return depends on R.S. 47:32.",
+        "The line B of the tax return depends on R.S. 47:32.",
+        "The part B of the calculation depends on R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle12_rejects_framed_or_documentary_source(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "Without prejudice to federal law, by which the amount is determined under R.S. 47:32.",
+        "Without prejudice to federal law, through which the amount is determined under R.S. 47:32.",
+        "Without prejudice to federal law, whereby the amount is determined under R.S. 47:32.",
+        "Without prejudice to federal law, wherein the amount is determined under R.S. 47:32.",
+        "Without prejudice to federal law, which, despite the filing rule, remains applicable under R.S. 47:32.",
+        "Without prejudice to federal law, which remains applicable, whereas the report stipulates the amount is determined under R.S. 47:32.",
+        "Without prejudice to federal law, which remains applicable, although the article observes the amount is determined under R.S. 47:32.",
+        "Without prejudice to federal law, which remains applicable, because the agency opines the amount is determined under R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle12_rejects_relative_or_reported_disclaimer(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("reason", "source"),
+    (
+        (
+            "R.S. 47:32(A) and (B) lacks the computation.",
+            "The amount is determined under R.S. 47:32(A) & (B).",
+        ),
+        (
+            "R.S. 47:32(A) and (B) lacks the computation.",
+            "The amount is determined under R.S. 47:32(A), and (B).",
+        ),
+        (
+            "R.S. 47:32(A) paragraphs (1) and (2) lacks the computation.",
+            "The amount is determined under R.S. 47:32(A) paragraph (1) and (2).",
+        ),
+        (
+            "R.S. 47:32(A) subsection (B) lacks the computation.",
+            "The amount is determined under R.S. 47:32(A) (B).",
+        ),
+        (
+            "R.S. 47:32(A) read with (B) lacks the computation.",
+            "The amount is determined under R.S. 47:32(A) read together with (B).",
+        ),
+        (
+            "R.S. 47:32(A) through (C) lacks the computation.",
+            "The amount is determined under R.S. 47:32(A) to (C).",
+        ),
+    ),
+)
+def test_louisiana_cycle12_accepts_semantic_citation_equivalence(
+    reason: str, source: str
+):
+    assert completeness_module._reason_dependency_is_source_bound(
+        reason,
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks a prototype formula.",
+        "R.S. 47:32 lacks a specimen formula.",
+        "R.S. 47:32 lacks a conceptual formula.",
+        "R.S. 47:32 lacks a candidate formula.",
+        "R.S. 47:32 lacks a synopsis of the formula.",
+        "R.S. 47:32 lacks an abstract of the formula.",
+        "R.S. 47:32 lacks an article about the formula.",
+        "R.S. 47:32 lacks an index of the formula.",
+        "R.S. 47:32 lacks a catalog of the formula.",
+    ),
+)
+def test_louisiana_cycle12_rejects_nonexecutable_missing_artifacts(reason: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks the tentative tax.",
+        "R.S. 47:32 lacks the provisional credit.",
+        "R.S. 47:32 lacks the applicable percentage.",
+    ),
+)
+def test_louisiana_cycle12_accepts_executable_missing_modifiers(reason: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "head",
+    (
+        "implementation",
+        "output",
+        "parameter",
+        "procedure",
+        "protocol",
+        "rule",
+        "specification",
+        "structure",
+        "data",
+        "input",
+        "logic",
+        "lookup",
+        "mapping",
+        "status",
+        "workflow",
+        "capability",
+        "condition",
+    ),
+)
+def test_louisiana_cycle12_rejects_generic_positive_reversal(head: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the {head} and the module provides the {head}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks the formula and the module displays the formula.",
+        "R.S. 47:32 lacks the formula and the module emits the formula.",
+        "R.S. 47:32 lacks the formula and the module retrieves the formula.",
+        "R.S. 47:32 lacks the formula, despite the module providing the formula.",
+        "R.S. 47:32 lacks the formula while the module is providing the formula.",
+        "R.S. 47:32 lacks the formula and the formula has been provided.",
+        "R.S. 47:32 lacks the formula and the formula was made available.",
+        "R.S. 47:32 lacks the formula and the formula can be accessed.",
+        "R.S. 47:32 lacks the formula and the module provides it successfully.",
+        "R.S. 47:32 lacks the formula and the module provides it immediately.",
+        "R.S. 47:32 lacks the formula and the module provides it without delay.",
+        "R.S. 47:32 lacks the formula. The module provides it",
+        "R.S. 47:32 lacks the formula and the module must not fail to provide it.",
+        "R.S. 47:32 lacks the formula and the module could not fail to provide it.",
+        "R.S. 47:32 lacks the formula and the module wouldn't refuse to provide it.",
+        "R.S. 47:32 lacks the formula and the module mightn't fail to provide it.",
+    ),
+)
+def test_louisiana_cycle12_rejects_positive_supply_forms(reason: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks the formula and the module does not currently provide it.",
+        "R.S. 47:32 lacks the formula and the module never actually provides it.",
+        "R.S. 47:32 lacks the formula and the module cannot readily provide it.",
+        "R.S. 47:32 lacks the formula and the module doesn't presently provide it.",
+        "R.S. 47:32 lacks the formula and the module isn't able to provide it.",
+        "R.S. 47:32 lacks the formula and the module shan't provide it.",
+        "R.S. 47:32 lacks the formula and the module oughtn't provide it.",
+        "R.S. 47:32 lacks the formula and the module daren't provide it.",
+        "R.S. 47:32 lacks the formula and the module provides some formula.",
+        "R.S. 47:32 lacks the formula and the module provides half of the formula.",
+        "R.S. 47:32 lacks the formula and the module provides a fragment of the formula.",
+        "R.S. 47:32 lacks the formula and the module provides portions of the formula.",
+        "R.S. 47:32 lacks the formula and the module provides most but not all of the formula.",
+        "R.S. 47:32 lacks the formula and the module provides pieces of the formula.",
+        "R.S. 47:32 lacks the formula and the module provides an excerpt of the formula.",
+        "R.S. 47:32 lacks the formula and barely any formula is available.",
+        "R.S. 47:32 lacks the formula and almost no formula is available.",
+        "R.S. 47:32 lacks the corporate formula and the module provides the individual formula.",
+        "R.S. 47:32 lacks the marginal rate and the module provides the average rate.",
+        "R.S. 47:32 lacks the formula and the module identifies the rate but the rate is available.",
+        "R.S. 47:32 lacks the formula and the guidance is available; it states the rate.",
+    ),
+)
+def test_louisiana_cycle12_accepts_negative_partial_or_distinct_supply(reason: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "predicate",
+    (
+        "governs a separate report",
+        "determines a filing date",
+        "controls metadata",
+        "establishes a filing date",
+        "sets the label",
+        "supplies commentary",
+        ", however, is discussed only in the report",
+        "merely appears in a footnote",
+        "only illustrates the comparison",
+    ),
+)
+def test_louisiana_cycle13_does_not_inherit_into_new_citation_clause(
+    predicate: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:31, and R.S. 47:32 {predicate}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "connector",
+    ("&", "plus", "along with", "combined with"),
+)
+def test_louisiana_cycle13_accepts_common_citation_list_connectors(connector: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:31 {connector} R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The witness asserts that the example is wrong but the tax is determined under R.S. 47:32.",
+        "Suppose the example is irrelevant, but the final tax is determined under R.S. 47:32.",
+        "The tax memorandum depends on R.S. 47:32.",
+        "The formula bibliography depends on R.S. 47:32.",
+        "The tax legend depends on R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle13_rejects_embedded_reset_or_documentary_head(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("reason", "source", "expected"),
+    (
+        (
+            "R.S. 47:32(A), schedule (B) lacks the computation.",
+            "The amount is determined under R.S. 47:32(A), schedule (B) applies separately.",
+            False,
+        ),
+        (
+            "R.S. 47:32(A) lacks the computation.",
+            "The amount is determined under R.S. 47:32(A), paragraph (B) of the explanatory report.",
+            True,
+        ),
+        (
+            "R.S. 47:32(A) lacks the computation.",
+            "The amount is determined under R.S. 47:32(A) and (MFJ) filers use the joint table.",
+            True,
+        ),
+        (
+            "R.S. 47:32(A) in relation to subsection (B) lacks the computation.",
+            "The amount is determined under R.S. 47:32(A) in relation to subsection (B).",
+            True,
+        ),
+    ),
+)
+def test_louisiana_cycle13_distinguishes_citation_tail_from_annotation(
+    reason: str, source: str, expected: bool
+):
+    assert (
+        completeness_module._reason_dependency_is_source_bound(
+            reason,
+            source,
+            corpus_citation_path="us-la/statute/47:295",
+        )
+        is expected
+    )
+
+
+@pytest.mark.parametrize(
+    "head",
+    (
+        "fact",
+        "instruction",
+        "mechanism",
+        "bases",
+        "facts",
+        "instructions",
+        "inputs",
+        "mechanisms",
+        "rates",
+        "records",
+        "requirements",
+        "outputs",
+    ),
+)
+def test_louisiana_cycle13_rejects_all_registry_head_reversals(head: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the {head} and the module provides the {head}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks the formula and the module provides a subset of the formula.",
+        "R.S. 47:32 lacks the formula and the module provides a fraction of the formula.",
+        "R.S. 47:32 lacks the formula and the module provides less than all of the formula.",
+        "R.S. 47:32 lacks the corporate formula and the module provides a formula.",
+        "R.S. 47:32 lacks the formula and the module provides merely pieces of the formula.",
+        "R.S. 47:32 lacks the formula and the module provides a few fragments of the formula.",
+        "R.S. 47:32 lacks the formula and the module does not yet provide it.",
+        "R.S. 47:32 lacks the formula and the module does not ordinarily provide it.",
+        "R.S. 47:32 lacks the formula and the module cannot reliably provide it.",
+        "R.S. 47:32 lacks the formula and the module never directly provides it.",
+        "R.S. 47:32 lacks the formula and the module isn't currently able to provide it.",
+        "R.S. 47:32 lacks the formula and the module is unable currently to provide it.",
+        "R.S. 47:32 lacks the formula and the module does not affirmatively provide it.",
+        "R.S. 47:32 lacks the formula and the module isn't presently able to provide it.",
+    ),
+)
+def test_louisiana_cycle13_accepts_partial_distinct_or_negative_supply(reason: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks the formula and the module does not lack the ability to provide it.",
+        "R.S. 47:32 lacks the formula and the module never lacks the ability to provide it.",
+        "R.S. 47:32 lacks the formula and the module is by no means unable to provide it.",
+        "R.S. 47:32 lacks the formula since the module provides it.",
+        "R.S. 47:32 lacks the formula and the module uses the formula.",
+        "R.S. 47:32 lacks the formula and the module accesses the formula.",
+        "R.S. 47:32 lacks the formula and the module can access the formula.",
+        "R.S. 47:32 lacks the formula and the module reads the formula.",
+        "R.S. 47:32 lacks the formula and the module loads the formula.",
+        "R.S. 47:32 lacks the formula and the module imports the formula.",
+        "R.S. 47:32 lacks the formula and the module ships with the formula.",
+        "R.S. 47:32 lacks the formula and the module keeps the formula on hand.",
+    ),
+)
+def test_louisiana_cycle13_rejects_composed_or_explicit_positive_supply(reason: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "actor",
+    (
+        "library",
+        "package",
+        "implementation",
+        "codebase",
+        "repository",
+        "runtime",
+        "service",
+        "system",
+    ),
+)
+def test_louisiana_cycle13_rejects_comma_splice_supply_by_any_actor(actor: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula, the {actor} provides it.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "object_text",
+    ("metadata", "an example", "a label", "background", "an appendix", "a catalog"),
+)
+def test_louisiana_cycle13_uses_nearest_nonexecutive_antecedent(object_text: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module provides {object_text} and it is complete.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "predicate",
+    (
+        "lacks the computation",
+        "defines a filing term",
+        "specifies a filing term",
+        "prescribes a filing rule",
+        "imposes a filing rule",
+        "authorizes a filing method",
+        "addresses a separate issue",
+        "covers a separate issue",
+        "lists a filing date",
+        "identifies a filing date",
+        "references a report",
+        "modifies a filing rule",
+        "amends a filing rule",
+        "creates a filing rule",
+    ),
+)
+def test_louisiana_cycle14_does_not_inherit_into_finite_citation_clause(
+    predicate: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:31, and R.S. 47:32 {predicate}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "predicate",
+    (
+        "defines a separate rule",
+        "is discussed in the report",
+        "does not govern the tax",
+        "merely appears in a note",
+    ),
+)
+def test_louisiana_cycle14_rejects_detached_labeled_tail_subject(predicate: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32(A), schedule (B) lacks the computation.",
+        f"The amount is determined under R.S. 47:32(A), schedule (B) {predicate}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The analyst concludes that the tax depends on R.S. 47:32.",
+        "The article concludes that the tax depends on R.S. 47:32.",
+        "The agency maintains that the tax depends on R.S. 47:32.",
+        "The witness surmises that the tax depends on R.S. 47:32.",
+        "The analysis infers that the tax depends on R.S. 47:32.",
+        "It is doubtful that the amount is determined under R.S. 47:32.",
+        "There is no evidence that the amount is determined under R.S. 47:32.",
+        "Nothing establishes that the amount is determined under R.S. 47:32.",
+        "The amount is determined under R.S. 47:32, but this is only a hypothetical example.",
+        "The amount is determined under R.S. 47:32 only in the discarded example.",
+        "The amount is determined under R.S. 47:32, or so the witness claims.",
+    ),
+)
+def test_louisiana_cycle14_rejects_nonoperative_dependency_framing(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "Although the example is illustrative, the amount is determined under R.S. 47:32.",
+        "While the background is hypothetical, the tax is calculated under R.S. 47:32.",
+        "Because the sample is merely illustrative, the final amount is computed under R.S. 47:32.",
+        "The amount itself depends on R.S. 47:32.",
+        "The tax due depends on R.S. 47:32.",
+        "The amount payable depends on R.S. 47:32.",
+        "The amount that applies depends on R.S. 47:32.",
+        "The tax that is due depends on R.S. 47:32.",
+        "The formula selected by the commissioner depends on R.S. 47:32.",
+        "The amount is legally determined under R.S. 47:32.",
+        "The amount is properly determined under R.S. 47:32.",
+        "The amount is generally determined under R.S. 47:32.",
+        "The amount is specifically determined under R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle14_accepts_structural_operative_variants(source: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks the formula and the module does not avoid providing the formula.",
+        "R.S. 47:32 lacks the formula and the module does not delay providing the formula.",
+        "R.S. 47:32 lacks the formula and the module does not hesitate before providing the formula.",
+        "R.S. 47:32 lacks the formula, software provides it.",
+        "R.S. 47:32 lacks the formula, Axiom provides it.",
+        "R.S. 47:32 lacks the formula, this module provides it.",
+        "R.S. 47:32 lacks the formula, our module provides it.",
+        "R.S. 47:32 lacks the tax calculation and the module provides the calculation of tax.",
+        "R.S. 47:32 lacks the rate table and the module provides the table of rates.",
+        "R.S. 47:32 lacks the credit formula and the module provides the formula for the credit.",
+        "R.S. 47:32 lacks the computation of liability and the module provides the liability computation.",
+        "R.S. 47:32 lacks the formula and the formula is on hand.",
+        "R.S. 47:32 lacks the formula and the formula is obtainable.",
+    ),
+)
+def test_louisiana_cycle14_rejects_structural_positive_supply(reason: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks the formula and the module identifies the rate before providing it.",
+        "R.S. 47:32 lacks the formula and the module does not at any point in practice provide it.",
+        "R.S. 47:32 lacks the formula and the module cannot as a practical matter reliably provide it.",
+    ),
+)
+def test_louisiana_cycle14_accepts_distinct_or_unbounded_negative_supply(reason: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "documentary_head",
+    (
+        "a chart",
+        "an exhibit",
+        "an illustration",
+        "a description",
+        "a comparison",
+        "a transcript",
+        "a synopsis",
+        "a digest",
+        "an index",
+        "a brief",
+        "an annotation",
+    ),
+)
+def test_louisiana_cycle14_uses_unified_documentary_antecedents(
+    documentary_head: str,
+):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module provides {documentary_head} and it is complete.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "predicate",
+    (
+        "repeals a filing rule",
+        "incorporates a filing rule",
+        "replaces a filing rule",
+        "exempts a filing rule",
+        "permits a filing method",
+        "prohibits a filing method",
+        "delegates a filing duty",
+        "regulates a filing method",
+    ),
+)
+def test_louisiana_cycle15_does_not_inherit_unlisted_finite_citation_clause(
+    predicate: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:31, and R.S. 47:32 {predicate}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "predicate",
+    (
+        "cannot govern the tax",
+        "ought not govern the tax",
+        "governed a filing rule",
+        "concerns a filing rule",
+        "pertains to a filing rule",
+    ),
+)
+def test_louisiana_cycle15_rejects_additional_detached_tail_predicates(
+    predicate: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32(A), schedule (B) lacks the computation.",
+        f"The amount is determined under R.S. 47:32(A), schedule (B) {predicate}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The amount determined under R.S. 47:31 and R.S. 47:32 is rounded.",
+        "The rate prescribed under R.S. 47:31 and R.S. 47:32 applies.",
+    ),
+)
+def test_louisiana_cycle15_inherits_citation_object_list_before_outer_predicate(
+    source: str,
+):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "It is questionable that the amount is determined under R.S. 47:32.",
+        "It is dubious that the amount is determined under R.S. 47:32.",
+        "It is unlikely that the amount is determined under R.S. 47:32.",
+        "It is unproven that the amount is determined under R.S. 47:32.",
+        "The analyst posits that the amount is determined under R.S. 47:32.",
+        "The analyst postulates that the amount is determined under R.S. 47:32.",
+        "The analyst speculates that the amount is determined under R.S. 47:32.",
+        "The analyst conjectures that the amount is determined under R.S. 47:32.",
+        "The analyst presumes that the amount is determined under R.S. 47:32.",
+        "The amount is allegedly determined under R.S. 47:32.",
+        "The amount is reportedly determined under R.S. 47:32.",
+        "The amount is supposedly determined under R.S. 47:32.",
+        "The amount is purportedly determined under R.S. 47:32.",
+        "The amount is ostensibly determined under R.S. 47:32.",
+        "The amount is apparently determined under R.S. 47:32.",
+        "The amount is putatively determined under R.S. 47:32.",
+        "The amount is theoretically determined under R.S. 47:32.",
+        "The amount is questionably determined under R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle15_rejects_expanded_nonoperative_framing(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "tail",
+    (
+        "but only as an illustration",
+        "as the witness claims",
+        "according to a draft report",
+        "only as a contrived example",
+        "though hypothetically",
+        "but the statement is hypothetical",
+    ),
+)
+def test_louisiana_cycle15_rejects_expanded_postfix_framing(tail: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:32, {tail}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "Although the report states, without evidence, that the amount is determined under R.S. 47:32.",
+        "While the witness claims, in passing, that the amount is determined under R.S. 47:32.",
+        "Because the analyst maintains, without support, that the amount is determined under R.S. 47:32.",
+        "Although the document reports, as background, that the amount is determined under R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle15_does_not_reset_inside_fronted_reporting_clause(
+    source: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "verb",
+    (
+        "documents",
+        "records",
+        "reports",
+        "discusses",
+        "explains",
+        "outlines",
+        "summarizes",
+        "catalogs",
+    ),
+)
+def test_louisiana_cycle15_uses_structural_pre_supply_antecedent(verb: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {verb} the rate before providing it.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks the formula and the module does not log metadata before providing the formula.",
+        "R.S. 47:32 lacks the formula and the module without hesitation provides the formula.",
+        "R.S. 47:32 lacks the formula and the module not surprisingly provides the formula.",
+        "R.S. 47:32 lacks the formula and the module no later than today provides the formula.",
+        "R.S. 47:32 lacks the formula, software returns it.",
+        "R.S. 47:32 lacks the formula, software delivers it.",
+        "R.S. 47:32 lacks the formula, software produces it.",
+        "R.S. 47:32 lacks the formula, software generates it.",
+        "R.S. 47:32 lacks the formula, software retains it.",
+        "R.S. 47:32 lacks the formula, software offers it.",
+        "R.S. 47:32 lacks the formula, software computes it.",
+        "R.S. 47:32 lacks the formula, software defines it.",
+        "R.S. 47:32 lacks the formula, software encodes it.",
+        "R.S. 47:32 lacks the formula, software publishes it.",
+        "R.S. 47:32 lacks the formula and the formula is readily available.",
+        "R.S. 47:32 lacks the formula and the formula is currently available.",
+        "R.S. 47:32 lacks the formula and the formula has been stored.",
+        "R.S. 47:32 lacks the formula and the formula is freely accessible.",
+        "R.S. 47:32 lacks the formula and the formula is retained.",
+        "R.S. 47:32 lacks the formula and the formula is included.",
+        "R.S. 47:32 lacks the formula and the formula is loaded.",
+        "R.S. 47:32 lacks the formula and the formula is imported.",
+        "R.S. 47:32 lacks the formula and the formula is at hand.",
+    ),
+)
+def test_louisiana_cycle15_rejects_structural_positive_supply(reason: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks the formula and the module does not necessarily fail to provide it.",
+        "R.S. 47:32 lacks the formula and the module does not always fail to provide it.",
+        "R.S. 47:32 lacks the formula without which the module cannot provide it.",
+        "R.S. 47:32 lacks the formula and the module fails without warning to provide it.",
+        "R.S. 47:32 lacks the formula and the module refuses without explanation to provide it.",
+    ),
+)
+def test_louisiana_cycle15_accepts_negative_or_uncertain_supply(reason: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "subject",
+    (
+        "The formula digest",
+        "The tax assertion",
+        "The tax rumor",
+        "The formula outline",
+        "The tax proposal",
+        "The tax abstract",
+        "The tax brief",
+        "The tax material",
+        "The tax overview",
+        "The tax summary",
+        "The tax transcript",
+        "The citation",
+        "The reference",
+        "The claim",
+        "The website",
+        "The email",
+    ),
+)
+def test_louisiana_cycle15_rejects_documentary_or_contextual_subject(subject: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"{subject} depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("missing", "provided"),
+    (
+        ("the corporate formula", "the formula for corporations"),
+        ("the resident calculation", "the calculation for residents"),
+        ("the individual rate", "the rate for individuals"),
+        ("the taxpayer calculation", "the calculation of taxpayers"),
+    ),
+)
+def test_louisiana_cycle15_normalizes_plural_object_modifiers(
+    missing: str, provided: str
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks {missing} and the module provides {provided}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The amount is determined under R.S. 47:31 and R.S. 47:32 governs a separate filing rule.",
+        "The amount is determined under R.S. 47:31 or R.S. 47:32 controls only metadata.",
+        "The tax depends on R.S. 47:31 and R.S. 47:32 sets a filing date.",
+        "The amount is determined under R.S. 47:31, and R.S. 47:32 set a deadline.",
+        "The amount is determined under R.S. 47:31, and R.S. 47:32 made no change.",
+        "The amount is determined under R.S. 47:31, and R.S. 47:32 held a hearing.",
+        "The amount is determined under R.S. 47:31, and R.S. 47:32 wrote a rule.",
+        "The amount is determined under R.S. 47:31, and R.S. 47:32 gave relief.",
+        "The amount is determined under R.S. 47:31, and R.S. 47:32 put a limit in place.",
+        "The amount is determined under R.S. 47:31, and R.S. 47:32 sought a report.",
+    ),
+)
+def test_louisiana_cycle16_finite_clause_evidence_overrides_punctuation(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The amount determined under R.S. 47:30, R.S. 47:31, and R.S. 47:32 is rounded.",
+        "The rate prescribed under R.S. 47:31 and R.S. 47:32 applies.",
+    ),
+)
+def test_louisiana_cycle16_preserves_outer_subject_citation_lists(source: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "predicate",
+    (
+        "set a separate filing date",
+        "said nothing about the tax",
+        "made no change",
+        "govern separate filings",
+    ),
+)
+def test_louisiana_cycle16_rejects_structural_detached_tail_predicates(
+    predicate: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32(A), schedule (B) lacks the computation.",
+        f"The amount is determined under R.S. 47:32(A), schedule (B) {predicate}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The amount is determined under R.S. 47:32, but the analyst speculates about a different issue.",
+        "The amount is determined under R.S. 47:32, but the witness reportedly disagrees.",
+        "The amount is determined under R.S. 47:32, and a hypothetical example follows.",
+        "The amount is determined under R.S. 47:32, while the report discusses a fictional scenario.",
+        "The amount is determined under R.S. 47:32, though the analyst claims the rate is wrong.",
+        "The statute declares that the amount is determined under R.S. 47:32.",
+        "The Act declares that the tax is calculated under R.S. 47:32.",
+        "The legislature declares that the amount is determined under R.S. 47:32.",
+        "The section presumes that the amount is determined under R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle16_preserves_independent_postfix_or_legal_speaker(
+    source: str,
+):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The amount remaining depends on R.S. 47:32.",
+        "The credit allowed depends on R.S. 47:32.",
+        "The liability imposed depends on R.S. 47:32.",
+        "The amount owed depends on R.S. 47:32.",
+        "The calculation adopted by the department depends on R.S. 47:32.",
+        "The tax legally due depends on R.S. 47:32.",
+        "The amount ultimately payable depends on R.S. 47:32.",
+        "The amount determined for this return depends on R.S. 47:32.",
+        "The amount with no adjustment depends on R.S. 47:32.",
+        "The amount without rounding depends on R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle16_accepts_executable_postpositive_subjects(source: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks the formula and the module cannot help providing the formula.",
+        "R.S. 47:32 lacks the formula and the module does not log metadata prior to providing the formula.",
+        "R.S. 47:32 lacks the formula and the module no doubt provides it.",
+        "R.S. 47:32 lacks the formula and the module never ceases to provide it.",
+        "R.S. 47:32 lacks the formula and the module has no difficulty providing it.",
+    ),
+)
+def test_louisiana_cycle16_rejects_scoped_positive_supply_idioms(reason: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle16_accepts_uncertain_modal_reversal():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module may not fail to provide it.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "adjunct",
+    (
+        "without qualification",
+        "unconditionally",
+        "in every case",
+        "for all filers",
+        "as needed",
+        "on request",
+        "at all times",
+        "in its entirety",
+        "today",
+    ),
+)
+def test_louisiana_cycle16_corefers_pronoun_with_bounded_adjunct(adjunct: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module provides it {adjunct}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "antecedent",
+    (
+        "a diagram",
+        "a certificate",
+        "an address",
+        "a message",
+        "a warning",
+        "an attachment",
+        "a receipt",
+    ),
+)
+def test_louisiana_cycle16_tracks_opaque_pre_supply_antecedent(antecedent: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module identifies {antecedent} before providing it.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks the formula and the formula is already available.",
+        "R.S. 47:32 lacks the formula and the formula is still available.",
+        "R.S. 47:32 lacks the formula and the formula is now available.",
+        "R.S. 47:32 lacks the formula and the formula is publicly accessible.",
+        "R.S. 47:32 lacks the formula and the formula has already been stored.",
+        "R.S. 47:32 lacks the formula and the formula can readily be obtained.",
+        "R.S. 47:32 lacks the formula and the formula is unquestionably available.",
+    ),
+)
+def test_louisiana_cycle16_rejects_generalized_availability_states(reason: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("missing", "provided"),
+    (
+        ("the annual formula", "the formula for each year"),
+        ("the monthly formula", "the formula for each month"),
+        ("the child formula", "the formula for children"),
+        ("the return formula", "the formula for returns"),
+        ("the household formula", "the formula for households"),
+    ),
+)
+def test_louisiana_cycle16_normalizes_temporal_and_generic_plural_modifiers(
+    missing: str, provided: str
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks {missing} and the module provides {provided}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "modifier",
+    (
+        "collectively",
+        "jointly",
+        "equally",
+        "respectively",
+        ", where applicable",
+        ", if applicable",
+        ", when required",
+    ),
+)
+def test_louisiana_cycle17_preserves_citation_list_modifiers(modifier: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:31 and R.S. 47:32 {modifier}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The amount is determined under R.S. 47:31, and R.S. 47:32 read as a filing rule.",
+        "The amount is determined under R.S. 47:31, and R.S. 47:32 and its regulations set a deadline.",
+        "The amount is determined under R.S. 47:31, and R.S. 47:32 together with its regulations, sets a deadline.",
+    ),
+)
+def test_louisiana_cycle17_rejects_modified_finite_citation_subject(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle17_accepts_generic_reduced_passive_citation_list():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the rule.",
+        "The statute prescribed under R.S. 47:31 and R.S. 47:32 applies.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle17_accepts_detached_label_in_outer_reduced_passive():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32(A), schedule (B) lacks the computation.",
+        "The amount determined under R.S. 47:32(A), schedule (B) is rounded.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle17_rejects_coordinated_detached_label_subject():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32(A), schedule (B) lacks the computation.",
+        "The amount is determined under R.S. 47:32(A), schedule (B) and its appendix set a deadline.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "tail",
+    (
+        "merely for illustrative purposes",
+        "only by way of example",
+        "if the witness is correct",
+        "according to the analyst",
+        "as the commentator alleges",
+        "or so the agency says",
+        "purportedly according to the report",
+        "which is only a hypothetical example",
+        "merely as an illustration",
+        "or so the commentator claims",
+    ),
+)
+def test_louisiana_cycle17_rejects_semantically_governing_postfix(tail: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:32, {tail}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The taxpayer claims that the tax depends on R.S. 47:32.",
+        "The applicant alleges that the amount depends on R.S. 47:32.",
+        "Counsel states that the formula depends on R.S. 47:32.",
+        "The petitioner contends that the amount depends on R.S. 47:32.",
+        "The auditor believes that the amount depends on R.S. 47:32.",
+        "The author states that the amount is determined under R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle17_rejects_reporter_agnostic_evidential_complement(
+    source: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "subject",
+    (
+        "The tax petition",
+        "The tax question",
+        "The tax sentence",
+        "The tax notice",
+        "The tax newsletter",
+        "The tax blog",
+        "The tax testimony",
+        "The tax affidavit",
+        "The tax advertisement",
+        "The tax press release",
+        "The eligibility for the tax credit",
+        "The accuracy of the formula",
+        "The timing of the calculation",
+    ),
+)
+def test_louisiana_cycle17_rejects_nonexecutive_grammatical_subject(subject: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"{subject} depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks the formula and the module does not stop providing it.",
+        "R.S. 47:32 lacks the formula and the module never stops providing it.",
+        "R.S. 47:32 lacks the formula and the module does not refrain from providing it.",
+        "R.S. 47:32 lacks the formula and the module is anything but unable to provide it.",
+        "R.S. 47:32 lacks the formula and the module is far from unable to provide it.",
+        "R.S. 47:32 lacks the formula and the module is not incapable of providing it.",
+    ),
+)
+def test_louisiana_cycle17_rejects_continuative_or_double_negative_supply(
+    reason: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("modal", ("may", "might", "should"))
+def test_louisiana_cycle17_accepts_non_guaranteed_modal_supply(modal: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {modal} provide the formula.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "adjunct",
+    (
+        "only hypothetically",
+        "in a fictional example",
+        "if the missing dependency were supplied",
+        "only conditionally",
+        "merely as a sample",
+        "according to an unverified report",
+        "in theory but not in practice",
+    ),
+)
+def test_louisiana_cycle17_accepts_nonoperative_pronoun_supply(adjunct: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module provides it {adjunct}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "identifies a diagram, then provides it",
+        "identifies a diagram and then provides it",
+        "selects a certificate; then provides it",
+        "mentions an address and later provides it",
+        "creates a message, and provides it",
+    ),
+)
+def test_louisiana_cycle17_tracks_opaque_antecedent_across_coordination(
+    continuation: str,
+):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "adverb",
+    (
+        "allegedly",
+        "reportedly",
+        "supposedly",
+        "purportedly",
+        "hypothetically",
+        "possibly",
+        "ostensibly",
+        "apparently",
+        "theoretically",
+        "questionably",
+    ),
+)
+def test_louisiana_cycle17_accepts_epistemic_availability(adverb: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the formula is {adverb} available.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "state",
+    (
+        "is furnished",
+        "was delivered",
+        "has just been stored",
+        "is published",
+    ),
+)
+def test_louisiana_cycle17_rejects_general_passive_supply(state: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the formula {state}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle17_corefers_natural_presupply_subject_object():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module identifies the formula before providing it.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "provided",
+    ("the formula annually", "the formula for every year"),
+)
+def test_louisiana_cycle17_normalizes_annual_modifier_forms(provided: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the annual formula and the module provides {provided}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("missing", "provided"),
+    (
+        ("the formula for classes", "the class formula"),
+        ("the calculation for businesses", "the business calculation"),
+        ("the formula for addresses", "the address formula"),
+        ("the calculation for filing statuses", "the filing status calculation"),
+    ),
+)
+def test_louisiana_cycle17_normalizes_stable_es_plural_modifiers(
+    missing: str, provided: str
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks {missing} and the module provides {provided}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "modifier",
+    (
+        "taken together",
+        "read together",
+        "considered together",
+        "alone",
+        "both",
+        "whenever applicable",
+    ),
+)
+def test_louisiana_cycle18_accepts_citation_list_modifiers(modifier: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:31 and R.S. 47:32, {modifier}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle18_accepts_taxable_income_reduced_passive_citation_list():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The taxable income calculated under R.S. 47:31 and R.S. 47:32 is rounded.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "tail",
+    (
+        "independently governs the filing deadline",
+        "separately sets the filing deadline",
+        "expressly governs the filing deadline",
+        "ordinarily sets the filing deadline",
+        "as amended, governs the filing deadline",
+        "becomes determined before the filing deadline",
+    ),
+)
+def test_louisiana_cycle18_rejects_finite_citation_subject_tail(tail: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:31, and R.S. 47:32 {tail}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "tail",
+    (
+        "according to its terms",
+        "according to the applicable table",
+        "as the statute states",
+        "as the department states",
+        "if the statutory condition is satisfied",
+    ),
+)
+def test_louisiana_cycle18_accepts_operative_legal_postfix(tail: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:32, {tail}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "tail",
+    (
+        "as the analyst claims",
+        "according to the analyst",
+        "at least according to the analyst",
+    ),
+)
+def test_louisiana_cycle18_rejects_nonlegal_postfix(tail: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:32, {tail}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "speaker",
+    ("law", "regulation", "rule", "Code", "ordinance", "provision"),
+)
+def test_louisiana_cycle18_accepts_operative_legal_speaker(speaker: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The {speaker} declares the amount depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("speaker", "verb"),
+    (
+        ("court", "speculates"),
+        ("department", "conjectures"),
+        ("statute", "predicts"),
+        ("section", "opines"),
+        ("legislature", "estimates"),
+        ("author of the statute", "states"),
+    ),
+)
+def test_louisiana_cycle18_rejects_speculative_or_nonlegal_speaker(
+    speaker: str, verb: str
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The {speaker} {verb} the amount depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "subject",
+    (
+        "The tax mailing",
+        "The tax warning",
+        "The tax posting",
+        "The tax briefing",
+        "The tax pleading",
+        "The tax recording",
+        "The formula wording",
+        "The tax advertising",
+        "The tax datafeed",
+    ),
+)
+def test_louisiana_cycle18_rejects_documentary_suffix_head(subject: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"{subject} depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "subject", ("The specified amount", "The amount otherwise allowable")
+)
+def test_louisiana_cycle18_accepts_executable_subject_modifier(subject: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"{subject} depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "is unable not to provide the formula",
+        "is incapable not to provide the formula",
+        "fails to avoid providing the formula",
+        "fails to stop providing the formula",
+        "refuses to stop providing the formula",
+        "is unable to stop providing the formula",
+        "hesitates to stop providing the formula",
+    ),
+)
+def test_louisiana_cycle18_rejects_nested_positive_supply(continuation: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "condition",
+    (
+        "only in the event it is requested",
+        "only upon receipt of authorization",
+        "subject to approval",
+        "assuming the dependency arrives",
+        "on condition that access is granted",
+        "contingently",
+        "were it ever supplied",
+        "only after the dependency arrives",
+    ),
+)
+def test_louisiana_cycle18_accepts_conditional_pronoun_supply(condition: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module provides it {condition}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "chose a diagram, then provided it",
+        "found a receipt, then provided it",
+        "made a message, then provided it",
+        "put an attachment aside, then provided it",
+        "will select a certificate, then provide it",
+        "gave a warning, then provided it",
+        "found a diagram and provided it",
+        "identifies a draft formula before providing it",
+    ),
+)
+def test_louisiana_cycle18_tracks_irregular_or_modal_opaque_antecedent(
+    continuation: str,
+):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "state",
+    (
+        "is available only hypothetically",
+        "is available according to an unverified report",
+        "may be available",
+    ),
+)
+def test_louisiana_cycle18_accepts_epistemic_or_modal_availability(state: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the formula {state}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "state",
+    (
+        "has been made available",
+        "has just been made available",
+        "has become available",
+        "was rendered available",
+        "came to be available",
+        "was exported",
+        "was held",
+        "was given",
+    ),
+)
+def test_louisiana_cycle18_rejects_actual_availability(state: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the formula {state}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "may readily provide the formula",
+        "allegedly provides the formula",
+        "possibly supplies the formula",
+    ),
+)
+def test_louisiana_cycle18_accepts_uncertain_direct_supply(continuation: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("missing", "provided"),
+    (
+        ("the bonus formula", "the bonuses formula"),
+        ("the matrix formula", "the matrices formula"),
+        ("the wife formula", "the wives formula"),
+        ("the leaf formula", "the leaves formula"),
+        ("the analysis formula", "the analyses formula"),
+        ("the annual formula", "the formula per year"),
+        ("the monthly formula", "the formula every month"),
+    ),
+)
+def test_louisiana_cycle18_normalizes_irregular_or_period_modifier(
+    missing: str, provided: str
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks {missing} and the module provides {provided}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "tail",
+    (
+        "alone sets a deadline",
+        "both sets a deadline and controls metadata",
+        "considered together with its regulations, sets a deadline",
+        "along with its regulations, sets a deadline",
+        "together with two regulations, sets a deadline",
+    ),
+)
+def test_louisiana_cycle19_rejects_modified_citation_finite_predicate(tail: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:31, and R.S. 47:32 {tail}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("head", ("result", "threshold"))
+def test_louisiana_cycle19_accepts_generic_reduced_passive_head(head: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The {head} determined under R.S. 47:31 and R.S. 47:32 is rounded.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "tail",
+    (
+        "according to the analyst’s interpretation of the statute",
+        "the court reporter claims",
+        "if the analyst is correct under applicable law",
+        "the analyst believes",
+    ),
+)
+def test_louisiana_cycle19_rejects_nonlegal_postfix_mentioning_law(tail: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:32, {tail}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The author states that the taxable amount is determined under R.S. 47:32.",
+        "The author states emphatically that the amount is determined under R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle19_rejects_modified_reporter_complement(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle19_rejects_relational_nonexecutive_subject():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The eligibility under the formula depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "subject", ("The liability enforceable", "The amount receivable")
+)
+def test_louisiana_cycle19_accepts_postpositive_executable_adjective(subject: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"{subject} depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "appears to provide it",
+        "seems to provide it",
+        "is expected to provide it",
+        "tries to provide it",
+        "attempts to provide it",
+        "plans to provide it",
+        "intends to provide it",
+        "is likely to provide it",
+        "is hardly able to provide it",
+        "is said to provide it",
+    ),
+)
+def test_louisiana_cycle20_accepts_prospective_or_epistemic_supply(
+    continuation: str,
+):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "condition",
+    (
+        "when the dependency becomes available",
+        "once the source arrives",
+        "provided that the source is encoded",
+        "so long as the dependency exists",
+        "in case the source is supplied",
+        "on receipt of the dependency",
+        "after the dependency is encoded",
+        "to the extent the source is available",
+        "unless the source remains absent",
+    ),
+)
+def test_louisiana_cycle20_accepts_general_conditional_supply(condition: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module provides it {condition}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "can do nothing but provide it",
+        "does nothing except provide it",
+        "cannot do otherwise than provide it",
+        "is powerless to avoid providing it",
+    ),
+)
+def test_louisiana_cycle20_rejects_positive_negative_complement_idiom(
+    continuation: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "drew diagrams, then provides them",
+        "sent notices and then provides them",
+        "saw warnings; then provides them",
+        "bought certificates and later provides them",
+        "caught messages, then provides them",
+    ),
+)
+def test_louisiana_cycle20_tracks_plural_irregular_opaque_antecedent(
+    continuation: str,
+):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "state",
+    (
+        "is conditionally available",
+        "is potentially available",
+        "is nominally available",
+        "is seemingly available",
+        "is available if the source exists",
+        "is available only when the dependency arrives",
+        "is available subject to receipt of the source",
+        "is available on paper but not in practice",
+    ),
+)
+def test_louisiana_cycle20_accepts_qualified_availability(state: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the formula {state}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "state",
+    (
+        "has been made obtainable",
+        "has been rendered accessible",
+        "has been put on hand",
+        "is ready for use",
+        "is retrievable",
+        "can be found",
+    ),
+)
+def test_louisiana_cycle20_rejects_actual_availability_synonym(state: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the formula {state}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "despite a hypothetical concern the module provides it",
+        "after a fictional scenario ends the module provides it",
+    ),
+)
+def test_louisiana_cycle20_bounds_framing_to_supply_clause(continuation: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("plural", "singular"),
+    (("criteria", "criterion"), ("data", "datum"), ("media", "medium")),
+)
+def test_louisiana_cycle20_normalizes_classical_modifier_plural(
+    plural: str, singular: str
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula for {plural} and "
+        f"the module provides the {singular} formula.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "tail",
+    (
+        "along with accompanying regulations, sets a deadline",
+        "in its current form, sets a deadline",
+        "as currently amended, sets a deadline",
+    ),
+)
+def test_louisiana_cycle21_rejects_bounded_modifier_before_finite_predicate(
+    tail: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:31, and R.S. 47:32, {tail}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "tail",
+    (
+        "in a hypothetical example",
+        "for illustrative purposes",
+        "under the analyst’s unverified assumption",
+    ),
+)
+def test_louisiana_cycle21_rejects_nonoperative_prepositional_postfix(tail: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:32, {tail}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle21_rejects_pronominal_reporter_complement():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The author states it is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("speaker", ("court", "legislature"))
+def test_louisiana_cycle21_accepts_authoritative_legal_conclusion(speaker: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The {speaker} concludes that the amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "subject",
+    ("The eligibility during the calculation", "The accuracy against the formula"),
+)
+def test_louisiana_cycle21_rejects_additional_relational_subject(subject: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"{subject} depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("subject", ("The amount outstanding", "The tax owing"))
+def test_louisiana_cycle21_accepts_participial_executable_adjective(subject: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"{subject} depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "is believed to provide it",
+        "is reported to provide it",
+        "is supposed to provide it",
+        "is projected to provide it",
+        "is scheduled to provide it",
+        "hopes to provide it",
+        "expects to provide it",
+        "aims to provide it",
+        "seeks to provide it",
+        "promises to provide it",
+        "is preparing to provide it",
+        "is about to provide it",
+    ),
+)
+def test_louisiana_cycle22_accepts_general_control_or_epistemic_supply(
+    continuation: str,
+):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks the formula and subject to approval, the module provides it.",
+        "R.S. 47:32 lacks the formula and the module provides it upon receipt of the source.",
+        "R.S. 47:32 lacks the formula and the module provides it pending receipt of the source.",
+        "R.S. 47:32 lacks the formula and the module provides it as soon as the source arrives.",
+        "R.S. 47:32 lacks the formula and the module provides it whenever the source arrives.",
+        "R.S. 47:32 lacks the formula and the module provides it contingent upon approval.",
+        "R.S. 47:32 lacks the formula and the module provides it conditioned on approval.",
+    ),
+)
+def test_louisiana_cycle22_accepts_extended_conditional_supply(reason: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "provided it after the dependency arrived",
+        "supplied it when authorization was received",
+        "provides it once each year",
+    ),
+)
+def test_louisiana_cycle22_rejects_completed_or_habitual_supply(
+    continuation: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "has no alternative except to provide it",
+        "has no option except to provide it",
+        "is left with no alternative except to provide it",
+        "has little choice other than provide it",
+    ),
+)
+def test_louisiana_cycle22_rejects_positive_choice_idiom(continuation: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "left notices, then provides them",
+        "sold certificates, then provides them",
+        "hid notices, then provides them",
+        "heard warnings, then provides them",
+        "lost notices, then provides them",
+        "paid invoices, then provides them",
+        "told stories, then provides them",
+        "won certificates, then provides them",
+        "creates a certificate containing the formula, then provides it",
+    ),
+)
+def test_louisiana_cycle22_tracks_opaque_grammatical_head(continuation: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "state",
+    (
+        "is available upon receipt of the source",
+        "is available contingent upon approval",
+        "is available only after the dependency arrives",
+    ),
+)
+def test_louisiana_cycle22_accepts_extended_conditional_availability(state: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the formula {state}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "state",
+    (
+        "became available once the source arrived",
+        "was available when authorization was received",
+        "is usable",
+        "is in place",
+        "is downloadable",
+        "is recoverable",
+        "is operational",
+        "is at the ready",
+        "has arrived",
+        "resides in the repository",
+    ),
+)
+def test_louisiana_cycle22_rejects_completed_or_usable_availability(state: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the formula {state}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("missing", "provided"),
+    (
+        ("quarterly", "for each quarter"),
+        ("weekly", "for every week"),
+        ("daily", "per day"),
+    ),
+)
+def test_louisiana_cycle22_normalizes_additional_period_modifier(
+    missing: str, provided: str
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the {missing} formula and "
+        f"the module provides the formula {provided}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "tail",
+    (
+        "along with accompanying regulations sets a deadline",
+        "together with regulations sets a deadline",
+        "in its amended form, sets a deadline",
+        "as further amended, sets a deadline",
+    ),
+)
+def test_louisiana_cycle24_rejects_general_modifier_before_finite_predicate(
+    tail: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:31, and R.S. 47:32 {tail}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "tail",
+    (
+        "for demonstration only",
+        "under an unsupported assumption",
+        "the analyst contends",
+        "the analyst opines",
+        "the analyst testifies",
+    ),
+)
+def test_louisiana_cycle24_rejects_expanded_nonoperative_postfix(tail: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:32, {tail}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("adjunct", ("with confidence", "without qualification"))
+def test_louisiana_cycle24_rejects_reporter_complement_adjunct(adjunct: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The author states {adjunct} that the amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("subject", "expected"),
+    (
+        ("The eligibility after the calculation", False),
+        ("The eligibility before the calculation", False),
+        ("The attached calculation", True),
+        ("The named formula", True),
+    ),
+)
+def test_louisiana_cycle24_binds_direct_subject_relation_or_prenominal_modifier(
+    subject: str, expected: bool
+):
+    assert (
+        completeness_module._reason_dependency_is_source_bound(
+            "R.S. 47:32 lacks the computation.",
+            f"{subject} depends on R.S. 47:32.",
+            corpus_citation_path="us-la/statute/47:295",
+        )
+        is expected
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "declines to provide it",
+        "neglects to provide it",
+        "forgets to provide it",
+        "struggles to provide it",
+        "endeavors to provide it",
+        "pretends to provide it",
+        "claims to provide it",
+        "threatens to provide it",
+        "would prefer to provide it",
+    ),
+)
+def test_louisiana_cycle24_accepts_nonentailing_control_supply(continuation: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "gave it after the dependency arrived",
+        "sent it when authorization was received",
+        "made the formula after the source arrived",
+        "kept it after validation",
+        "had it once the source arrived",
+        "always provides it after validating the input",
+        "routinely provides it when processing returns",
+        "regularly provides it whenever requested",
+    ),
+)
+def test_louisiana_cycle24_rejects_irregular_past_or_habitual_supply(
+    continuation: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "condition",
+    (
+        "following receipt",
+        "on approval",
+        "dependent on source availability",
+        "contingent on approval",
+        "conditioned upon approval",
+    ),
+)
+def test_louisiana_cycle24_accepts_equivalent_conditional_supply(condition: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module provides it {condition}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "ran tests, then provides them",
+        "taught classes, then provides them",
+        "met applicants, then provides them",
+        "got receipts, then provides them",
+        "laid markers, then provides them",
+    ),
+)
+def test_louisiana_cycle24_tracks_additional_irregular_opaque_antecedent(
+    continuation: str,
+):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "state",
+    (
+        "was available if authorization was received",
+        "had been available if approval was granted",
+        "will be available after the source arrives",
+        "is available following receipt",
+        "is available contingent on approval",
+        "is available conditioned upon approval",
+        "is available dependent on source availability",
+    ),
+)
+def test_louisiana_cycle24_accepts_tense_aware_conditional_availability(state: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the formula {state}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "state",
+    (
+        "is ready",
+        "is extant",
+        "is on file",
+        "has been released",
+        "has been posted",
+        "has been deployed",
+        "can be downloaded",
+        "can be recovered",
+        "is installed",
+    ),
+)
+def test_louisiana_cycle24_rejects_actual_deployment_availability(state: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the formula {state}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("missing", "provided"),
+    (
+        ("monthly", "per month"),
+        ("annual", "per annum"),
+        ("semiannual", "twice per year"),
+        ("biweekly", "every two weeks"),
+        ("spousal", "spouse"),
+    ),
+)
+def test_louisiana_cycle24_normalizes_period_or_legal_modifier(
+    missing: str, provided: str
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the {missing} formula and "
+        f"the module provides the {provided} formula.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "tail",
+    (
+        "along with accompanying regulations creates a deadline",
+        "together with the regulations requires a filing",
+    ),
+)
+def test_louisiana_cycle26_rejects_generic_finite_citation_predicate(tail: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:31, and R.S. 47:32 {tail}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "tail",
+    (
+        "as the court confidently concludes",
+        "according to the provisions of the statute",
+        "according to the statutory provisions",
+    ),
+)
+def test_louisiana_cycle26_accepts_modified_legal_authority_postfix(tail: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:32, {tail}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("adjunct", ("with confidence", "without qualification"))
+def test_louisiana_cycle26_rejects_parenthetical_reporter_adjunct(adjunct: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The author states, {adjunct}, that the amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle26_rejects_matching_nonexecutive_subject():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The eligibility matching the formula depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "appeared to provide it",
+        "tried to provide it",
+        "was trying to provide it",
+        "appears to have provided it",
+        "is believed to have provided it",
+        "had planned to provide it",
+    ),
+)
+def test_louisiana_cycle26_accepts_composed_control_aspect(continuation: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "was providing it when authorization was received",
+        "had been providing it when the source disappeared",
+    ),
+)
+def test_louisiana_cycle26_rejects_actual_progressive_supply(continuation: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("objects", "expected"),
+    (
+        ("the formula and a diagram", True),
+        ("the formula and a certificate", True),
+        ("a diagram and the formula", False),
+        ("a certificate and the formula", False),
+    ),
+)
+def test_louisiana_cycle26_uses_nearest_coordinated_antecedent(
+    objects: str, expected: bool
+):
+    assert (
+        completeness_module._reason_dependency_is_source_bound(
+            f"R.S. 47:32 lacks the formula and the module identifies {objects}, "
+            "then provides it.",
+            "The amount is determined under R.S. 47:32.",
+            corpus_citation_path="us-la/statute/47:295",
+        )
+        is expected
+    )
+
+
+@pytest.mark.parametrize(
+    "state",
+    (
+        "is not merely available but expensive",
+        "is not just available but documented",
+        "is actually available, not hypothetical",
+        "is available rather than merely proposed",
+    ),
+)
+def test_louisiana_cycle26_rejects_contrastive_positive_availability(state: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the formula {state}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("missing", "provided", "expected"),
+    (("means-test", "mean-test", True), ("monies", "money", False)),
+)
+def test_louisiana_cycle26_preserves_modifier_morphology(
+    missing: str, provided: str, expected: bool
+):
+    assert (
+        completeness_module._reason_dependency_is_source_bound(
+            f"R.S. 47:32 lacks the {missing} formula and "
+            f"the module provides the {provided} formula.",
+            "The amount is determined under R.S. 47:32.",
+            corpus_citation_path="us-la/statute/47:295",
+        )
+        is expected
+    )
+
+
+@pytest.mark.parametrize(
+    "tail",
+    (
+        "along with regulations made no change",
+        "together with regulations put a limit on the credit",
+    ),
+)
+def test_louisiana_cycle28_rejects_irregular_finite_citation_predicate(tail: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:31, and R.S. 47:32 {tail}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "tail", ("along with related rules", "together with revised regulations")
+)
+def test_louisiana_cycle28_accepts_terminal_citation_modifier(tail: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:32, {tail}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("speaker", ("court of appeal", "department of revenue"))
+def test_louisiana_cycle28_accepts_compound_legal_authority(speaker: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:32, as the {speaker} concludes.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("adjunct", ("after review", "in writing"))
+def test_louisiana_cycle28_rejects_general_reporter_complement_adjunct(adjunct: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The author states {adjunct} that the amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle28_rejects_generic_relational_subject():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The eligibility outside the formula depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "had been trying to provide it",
+        "will be trying to provide it",
+        "tried unsuccessfully to provide it",
+        "was attempting unsuccessfully to provide it",
+    ),
+)
+def test_louisiana_cycle28_accepts_control_aspect_and_adverbs(continuation: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "was actively providing it when authorization was received",
+        "had already been providing it when the source disappeared",
+        "was continuously providing it after validation",
+    ),
+)
+def test_louisiana_cycle28_rejects_adverbial_actual_progressive_supply(
+    continuation: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("missing", "objects", "pronoun", "expected"),
+    (
+        ("formulas", "formulas and a diagram", "them", False),
+        ("formula", "a diagram and formulas", "it", True),
+        ("formula", "diagrams and a formula", "them", True),
+    ),
+)
+def test_louisiana_cycle28_resolves_coordinated_antecedent_number(
+    missing: str, objects: str, pronoun: str, expected: bool
+):
+    assert (
+        completeness_module._reason_dependency_is_source_bound(
+            f"R.S. 47:32 lacks the {missing} and the module identifies {objects}, "
+            f"then provides {pronoun}.",
+            "The amount is determined under R.S. 47:32.",
+            corpus_citation_path="us-la/statute/47:295",
+        )
+        is expected
+    )
+
+
+@pytest.mark.parametrize(
+    "state",
+    (
+        "if authorized, the formula is available",
+        "provided that authorization is received, the formula is available",
+        "subject to approval, the formula is installed",
+    ),
+)
+def test_louisiana_cycle28_accepts_prefix_conditional_availability(state: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and {state}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "state",
+    (
+        "is actually installed, not hypothetical",
+        "is deployed rather than merely proposed",
+    ),
+)
+def test_louisiana_cycle28_rejects_general_positive_state_contrast(state: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the formula {state}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("provided", "expected"),
+    (
+        ("the inflation-indexing formula", True),
+        ("the formula without inflation indexing", False),
+    ),
+)
+def test_louisiana_cycle28_preserves_without_modifier_polarity(
+    provided: str, expected: bool
+):
+    assert (
+        completeness_module._reason_dependency_is_source_bound(
+            "R.S. 47:32 lacks the formula without inflation indexing and "
+            f"the module provides {provided}.",
+            "The amount is determined under R.S. 47:32.",
+            corpus_citation_path="us-la/statute/47:295",
+        )
+        is expected
+    )
+
+
+@pytest.mark.parametrize(
+    "tail",
+    (
+        "along with the regulations held a hearing",
+        "along with the regulations wrote a rule",
+        "along with the regulations sought a report",
+    ),
+)
+def test_louisiana_cycle30_rejects_additional_irregular_citation_predicate(
+    tail: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:31, and R.S. 47:32 {tail}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle30_accepts_terminal_citation_noun_adjunct():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:31 and R.S. 47:32, "
+        "along with revised rules this year.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "speaker", ("Louisiana Department of Revenue", "First Circuit Court of Appeal")
+)
+def test_louisiana_cycle30_accepts_qualified_legal_authority(speaker: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:32, as the {speaker} concludes.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("adjunct", ("after review", "in writing"))
+def test_louisiana_cycle30_rejects_parenthetical_reporter_adjunct(adjunct: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The author states, {adjunct}, that the amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle30_rejects_based_upon_relational_subject():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The eligibility based upon the formula depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "tried in vain to provide it",
+        "was attempting without success to provide it",
+    ),
+)
+def test_louisiana_cycle30_accepts_prepositional_failed_attempt(continuation: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "was in fact providing it when authorization was received",
+        "had for months been providing it when the source disappeared",
+    ),
+)
+def test_louisiana_cycle30_rejects_prepositional_actual_progressive(
+    continuation: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("nearest", ("a series", "a collection of diagrams"))
+def test_louisiana_cycle30_uses_antecedent_determiner_number(nearest: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module identifies the formula and "
+        f"{nearest}, then provides it.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "state",
+    (
+        "is in place, not hypothetical",
+        "is on file rather than merely proposed",
+        "is at hand, not hypothetical",
+    ),
+)
+def test_louisiana_cycle30_rejects_multiword_positive_state_contrast(state: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the formula {state}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("missing", "provided"),
+    (
+        ("parent-subsidiary", "subsidiary-parent"),
+        ("payer-recipient", "recipient-payer"),
+        ("origin-destination", "destination-origin"),
+    ),
+)
+def test_louisiana_cycle30_preserves_ordered_compound_modifier(
+    missing: str, provided: str
+):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the {missing} formula and "
+        f"the module provides the {provided} formula.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle32_rejects_irregular_bare_object_citation_predicate():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:31, and R.S. 47:32 "
+        "along with the regulations took effect.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle32_accepts_nonfinite_citation_participle():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:31 and R.S. 47:32, "
+        "along with regulations making a change.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "speaker", ("author of the statute", "analyst for the department")
+)
+def test_louisiana_cycle32_rejects_nonauthoritative_relational_speaker(speaker: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:32, as the {speaker} concludes.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle32_rejects_prefix_attribution():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "According to the analyst, the amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle32_rejects_colon_reporter_complement():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The author states: the amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle32_accepts_hyphenated_executable_subject():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The after-tax income depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "tried, in vain, to provide it",
+        "was attempting, without success, to provide it",
+    ),
+)
+def test_louisiana_cycle32_accepts_parenthetical_failed_attempt(continuation: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "was, in fact, providing it when authorization was received",
+        "had been, for months, providing it when the source disappeared",
+    ),
+)
+def test_louisiana_cycle32_rejects_parenthetical_actual_progressive(
+    continuation: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "nearest", ("a collection of two diagrams", "one series of several reports")
+)
+def test_louisiana_cycle32_uses_outer_np_determiner_number(nearest: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module identifies the formula and "
+        f"{nearest}, then provides it.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks the formula and the module provides the formula with "
+        "a note stating that it applies if authorized.",
+        "R.S. 47:32 lacks the formula and the formula that applies if authorization "
+        "is received is available.",
+        "R.S. 47:32 lacks the formula and the formula for use if authorized is installed.",
+    ),
+)
+def test_louisiana_cycle32_rejects_embedded_object_condition(reason: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "state",
+    (
+        "is installed, not merely hypothetical",
+        "is in place, not merely proposed",
+        "is on file, not a hypothetical version",
+    ),
+)
+def test_louisiana_cycle32_rejects_expanded_positive_state_contrast(state: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the formula {state}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("missing", "provided", "expected"),
+    (
+        ("parent-subsidiary", "parent subsidiary", False),
+        ("payer-recipient", "payer recipient", False),
+        ("origin-destination", "origin destination", False),
+        ("parent subsidiary", "subsidiary parent", True),
+        ("payer recipient", "recipient payer", True),
+    ),
+)
+def test_louisiana_cycle32_preserves_role_order_independent_of_hyphenation(
+    missing: str, provided: str, expected: bool
+):
+    assert (
+        completeness_module._reason_dependency_is_source_bound(
+            f"R.S. 47:32 lacks the {missing} formula and "
+            f"the module provides the {provided} formula.",
+            "The amount is determined under R.S. 47:32.",
+            corpus_citation_path="us-la/statute/47:295",
+        )
+        is expected
+    )
+
+
+def test_louisiana_cycle34_rejects_found_citation_predicate():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:31, and R.S. 47:32 "
+        "along with the regulations found no error.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle34_accepts_reduced_passive_citation_modifier():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:31 and R.S. 47:32, "
+        "along with regulations issued the prior year.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "According to the text of the statute, the amount is determined under R.S. 47:32.",
+        "The amount is determined under R.S. 47:32, as the text of the statute states.",
+    ),
+)
+def test_louisiana_cycle34_accepts_authoritative_statutory_text(source: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("punctuation", (': "', ', "', " — "))
+def test_louisiana_cycle34_rejects_quoted_reporter_complement(punctuation: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The author states{punctuation}the amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("subject", ("tax-rate", "base-amount"))
+def test_louisiana_cycle34_accepts_hyphenated_executable_compound(subject: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The {subject} depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "tried (in vain) to provide it",
+        "was attempting (without success) to provide it",
+    ),
+)
+def test_louisiana_cycle34_accepts_delimited_failed_attempt(continuation: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "was—in fact—providing it when authorization was received",
+        "had been (for months) providing it when the source disappeared",
+    ),
+)
+def test_louisiana_cycle34_rejects_delimited_actual_progressive(continuation: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "nearest",
+    (
+        "the collection of two diagrams",
+        "the series of several reports",
+        "the pair of formulas",
+    ),
+)
+def test_louisiana_cycle34_uses_definite_outer_np_number(nearest: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module identifies the formula and "
+        f"{nearest}, then provides it.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "R.S. 47:32 lacks the formula and the module provides the formula that "
+        "taxpayers use if authorized.",
+        "R.S. 47:32 lacks the formula and the module provides the formula accompanied "
+        "by a note stating that it applies if authorized.",
+        "R.S. 47:32 lacks the formula and the formula that taxpayers use if authorized "
+        "is available.",
+    ),
+)
+def test_louisiana_cycle34_rejects_general_embedded_object_condition(reason: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        reason,
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "state",
+    (
+        "is installed (not hypothetical)",
+        "is in place—not hypothetical",
+        "is on file (not merely proposed)",
+    ),
+)
+def test_louisiana_cycle34_rejects_delimited_positive_state_contrast(state: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the formula {state}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("missing", "provided", "expected"),
+    (
+        ("parents-subsidiaries", "subsidiaries-parents", True),
+        ("payers-recipients", "recipients-payers", True),
+        ("parent-subsidiary", "parents subsidiaries", False),
+        ("trust-beneficiary", "beneficiary-trust", True),
+        ("partnership-partner", "partner-partnership", True),
+    ),
+)
+def test_louisiana_cycle34_preserves_general_modifier_order(
+    missing: str, provided: str, expected: bool
+):
+    assert (
+        completeness_module._reason_dependency_is_source_bound(
+            f"R.S. 47:32 lacks the {missing} formula and "
+            f"the module provides the {provided} formula.",
+            "The amount is determined under R.S. 47:32.",
+            corpus_citation_path="us-la/statute/47:295",
+        )
+        is expected
+    )
+
+
+def test_louisiana_cycle36_rejects_became_citation_predicate():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:31, and R.S. 47:32 "
+        "along with the regulations became effective.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle36_accepts_reduced_passive_indefinite_time():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:31 and R.S. 47:32, "
+        "along with regulations issued a year earlier.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "According to the text of the analyst, the amount is determined under R.S. 47:32.",
+        "The amount is determined under R.S. 47:32, as the text of the analyst states.",
+    ),
+)
+def test_louisiana_cycle36_rejects_nonauthoritative_text_complement(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("lead", ("as follows", "the following"))
+def test_louisiana_cycle36_rejects_introduced_quoted_report(lead: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f'The author states {lead}: "the amount is determined under R.S. 47:32.',
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle36_accepts_in_state_executable_subject():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The in-state tax depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle36_rejects_derived_from_relational_subject():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The eligibility derived from the formula depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "tried [in vain] to provide it",
+        "was attempting [without success] to provide it",
+    ),
+)
+def test_louisiana_cycle36_accepts_square_delimited_attempt(continuation: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "was [in fact] providing it when authorization was received",
+        "had been [for months] providing it when the source disappeared",
+    ),
+)
+def test_louisiana_cycle36_rejects_square_delimited_actual_progressive(
+    continuation: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("objects", "pronoun"),
+    (("the formula and a diagram", "them"), ("the formulas and a diagram", "both")),
+)
+def test_louisiana_cycle36_resolves_coordinated_plural_antecedent(
+    objects: str, pronoun: str
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module identifies {objects}, "
+        f"then provides {pronoun}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "provides the formula that was requested, if authorization is received",
+        "provides the formula which is complete, if approval is granted",
+        "provides the formula that applies generally, subject to approval",
+    ),
+)
+def test_louisiana_cycle36_accepts_clause_level_condition_after_relative(
+    continuation: str,
+):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "state",
+    (
+        ", not merely hypothetical, is installed",
+        "—not hypothetical—is in place",
+        " (not merely proposed) is on file",
+    ),
+)
+def test_louisiana_cycle36_rejects_prepredicate_positive_contrast(state: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the formula{state}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("missing", "provided"),
+    (
+        ("annual resident", "resident annual"),
+        ("2024 resident", "resident 2024"),
+        ("Louisiana annual", "annual Louisiana"),
+    ),
+)
+def test_louisiana_cycle36_keeps_descriptor_order_commutative(
+    missing: str, provided: str
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the {missing} formula and "
+        f"the module provides the {provided} formula.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("predicate", ("shall apply", "did not apply"))
+def test_louisiana_cycle38_rejects_modal_citation_predicate(predicate: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:31, and R.S. 47:32 "
+        f"along with the regulations {predicate}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle38_accepts_reduced_passive_general_time_unit():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:31 and R.S. 47:32, "
+        "along with regulations issued a decade earlier.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "According to the text of the analyst concerning the statute, "
+        "the amount is determined under R.S. 47:32.",
+        "The amount is determined under R.S. 47:32, as the text of the analyst "
+        "concerning the statute states.",
+    ),
+)
+def test_louisiana_cycle38_rejects_later_authority_mention(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("subject", ("state income tax", "state-tax amount"))
+def test_louisiana_cycle38_accepts_state_tax_executable_subject(subject: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The {subject} depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle38_rejects_quoted_report_with_head_noun():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        'The author states the following proposition: "the amount is determined '
+        "under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("relation", ("resulting from", "arising from"))
+def test_louisiana_cycle38_rejects_additional_participial_relation(relation: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The eligibility {relation} the formula depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle38_resolves_three_object_plural_antecedent():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module identifies the formula, "
+        "a diagram, and a certificate, then provides them.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle38_rejects_parenthetical_condition_inside_relative():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module provides the formula that, "
+        "if authorized, taxpayers use.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle38_rejects_relative_positive_state_composition():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the formula, which, although not "
+        "hypothetical, is installed elsewhere.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle38_keeps_general_adjectives_commutative():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the supplemental local formula and the module provides "
+        "the local supplemental formula.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle38_accepts_nested_failed_attempt_aspect():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module tried (repeatedly, but in vain) "
+        "to provide it.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle38_rejects_multiword_duration_progressive():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module was (for two months) providing "
+        "it when the filing period ended.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle40_rejects_should_citation_predicate():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:31, and R.S. 47:32 along with "
+        "the regulations should apply.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle40_accepts_relative_modal_citation_modifier():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:31 and R.S. 47:32, along with "
+        "regulations that may apply.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle40_accepts_reduced_passive_fiscal_year():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:31 and R.S. 47:32, along with "
+        "regulations issued a fiscal year earlier.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "According to the text of the analyst on the statute, the amount is "
+        "determined under R.S. 47:32.",
+        "The amount is determined under R.S. 47:32, as the text of the analyst "
+        "on the statute states.",
+    ),
+)
+def test_louisiana_cycle40_rejects_on_authority_complement(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "subject",
+    ("applicable state income tax", "Louisiana state tax", "final state tax"),
+)
+def test_louisiana_cycle40_accepts_modified_state_tax_subject(subject: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The {subject} depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle40_rejects_relevant_part_quoted_report():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        'The author states in relevant part as follows: "the amount is determined '
+        'under R.S. 47:32."',
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("relation", ("calculated from", "reflecting"))
+def test_louisiana_cycle40_rejects_generic_participial_subject(relation: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The eligibility {relation} the formula depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "identifies not only the formula but also a diagram, then provides both",
+        "identifies three objects: the formula, a diagram, and a certificate, then "
+        "provides them",
+    ),
+)
+def test_louisiana_cycle40_resolves_expanded_coordinated_list(continuation: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle40_rejects_condition_embedded_in_relative():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module provides the formula that "
+        "taxpayers, if authorized, use.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "state",
+    (
+        ", which, while not hypothetical, is installed",
+        ", which is installed, though not hypothetical",
+    ),
+)
+def test_louisiana_cycle40_rejects_while_or_postfix_positive_state(state: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the formula{state}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle40_preserves_relational_modifier_order():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the appeal denial formula and the module provides the "
+        "denial appeal formula.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle40_keeps_personal_descriptors_commutative():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the eligible married formula and the module provides the "
+        "married eligible formula.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle40_rejects_word_number_duration_progressive():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module was for four months providing it.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle40_rejects_negated_failed_attempt():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module tried (not in vain) to provide it.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle40_accepts_negated_progressive_evidence():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module was (not in fact) providing it.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("predicate", ("expires next year", "provides a credit"))
+def test_louisiana_cycle42_rejects_general_finite_citation_predicate(predicate: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:31, and R.S. 47:32 along with "
+        f"the regulations {predicate}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle42_rejects_addressing_authority_complement():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "According to the text of the analyst addressing the statute, the amount "
+        "is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "subject",
+    ("applicable state individual income tax", "final state personal income tax"),
+)
+def test_louisiana_cycle42_accepts_intervening_state_tax_descriptor(subject: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The {subject} depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle42_rejects_parenthesized_quoted_intro():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        'The author states, in relevant part, as follows: "the amount is determined '
+        'under R.S. 47:32."',
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle42_rejects_irregular_participial_subject():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The eligibility drawn from the formula depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("subject", ("tax mailing notice", "tax warning message"))
+def test_louisiana_cycle42_rejects_multiword_documentary_suffix(subject: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The {subject} depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("coordinator", ("along with", "as well as"))
+def test_louisiana_cycle42_resolves_three_member_conjunction(coordinator: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module identifies the formula "
+        f"{coordinator} a diagram and a certificate, then provides them.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "objects",
+    (
+        "the formula, a diagram, and a certificate",
+        "three objects: the formula, a diagram, and a certificate",
+    ),
+)
+def test_louisiana_cycle42_rejects_both_for_three_member_list(objects: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module identifies {objects}, then "
+        "provides both.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle42_rejects_condition_inside_coordinated_relative():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module provides the formula that "
+        "taxpayers use, if authorized, and retain.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "state",
+    (
+        ", which, even though not hypothetical, is installed elsewhere",
+        ", which is installed, even though not hypothetical",
+    ),
+)
+def test_louisiana_cycle42_rejects_even_though_positive_state(state: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the formula{state}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("missing", "provided"),
+    (
+        ("qualified disabled", "disabled qualified"),
+        ("single elderly", "elderly single"),
+    ),
+)
+def test_louisiana_cycle42_keeps_general_person_descriptors_commutative(
+    missing: str, provided: str
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the {missing} formula and the module provides the "
+        f"{provided} formula.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "duration", ("more than four months", "18 consecutive calendar months")
+)
+def test_louisiana_cycle42_rejects_general_duration_progressive(duration: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module was (for {duration}) providing "
+        "it when the filing period ended.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle42_rejects_double_negative_failed_attempt():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module tried (not without success) to "
+        "provide it.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle42_accepts_never_progressive_evidence():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module was (never in fact) providing "
+        "it when the filing period ended.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "adjunct",
+    (
+        "along with agency guidelines",
+        "together with local ordinances",
+        "along with regulations applicable in multiple cases",
+    ),
+)
+def test_louisiana_cycle44_accepts_plural_citation_noun_adjunct(adjunct: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:31 and R.S. 47:32, {adjunct}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle44_rejects_outer_predicate_after_relative():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:31, and R.S. 47:32 along with "
+        "regulations that the agency adopted expires next year.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "According to the text of the analyst interpreting the statute, the amount "
+        "is determined under R.S. 47:32.",
+        "The amount is determined under R.S. 47:32, as the text of the analyst "
+        "interpreting the statute states.",
+    ),
+)
+def test_louisiana_cycle44_rejects_generic_participial_authority_topic(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The authors state the income tax is determined under R.S. 47:32.",
+        "The authors state the final individual income tax amount is determined under "
+        "R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle44_rejects_real_state_reporting_verb(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle44_rejects_parenthesized_report_intro():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        'The author states (in relevant part) as follows: "the amount is determined '
+        'under R.S. 47:32."',
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle44_rejects_taken_participial_subject():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The eligibility taken from the formula depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "subject", ("eligibility screening calculation", "eligibility testing computation")
+)
+def test_louisiana_cycle44_accepts_gerund_noun_compound(subject: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The {subject} depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("objects", "pronoun"),
+    (
+        ("the formula along with a diagram", "them"),
+        ("the formula as well as a diagram", "both"),
+        ("the formula together with a diagram and a certificate", "them"),
+    ),
+)
+def test_louisiana_cycle44_resolves_non_and_coordination(objects: str, pronoun: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module identifies {objects}, then "
+        f"provides {pronoun}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "relative_tail",
+    (", if authorized, but do not retain", ", if authorized, during filing"),
+)
+def test_louisiana_cycle44_rejects_general_embedded_relative_condition(
+    relative_tail: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module provides the formula that "
+        f"taxpayers use{relative_tail}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "state",
+    (
+        ", which, even though it is not hypothetical, is installed elsewhere",
+        ", which, despite not being hypothetical, is installed elsewhere",
+    ),
+)
+def test_louisiana_cycle44_rejects_explicit_positive_state_contrast(state: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the formula{state}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("missing", "provided"),
+    (
+        ("blind dependent", "dependent blind"),
+        ("low-income dependent", "dependent low-income"),
+    ),
+)
+def test_louisiana_cycle44_keeps_additional_descriptors_commutative(
+    missing: str, provided: str
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the {missing} formula and the module provides the "
+        f"{provided} formula.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle44_rejects_unbounded_duration_progressive():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module was (for a period of more than "
+        "four consecutive calendar months) providing it when the filing period ended.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "aspect",
+    (
+        "always successfully, never in vain",
+        "never in vain",
+    ),
+)
+def test_louisiana_cycle44_rejects_quantified_negated_failure(aspect: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module tried ({aspect}) to provide it.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle44_accepts_punctuated_negated_progressive():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module was (not, in fact) providing it "
+        "when the filing period ended.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle46_accepts_modified_plural_citation_noun():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:31 and R.S. 47:32, along with "
+        "agency guidelines currently in effect.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle46_rejects_terminal_finite_citation_predicate():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:31, and R.S. 47:32 along with the "
+        "regulations expires.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle46_rejects_present_relative_then_outer_predicate():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:31, and R.S. 47:32 along with "
+        "regulations that the agency adopts expires next year.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "speaker",
+    ("text of the governing statute", "language of the implementing regulation"),
+)
+def test_louisiana_cycle46_accepts_authoritative_participial_modifier(speaker: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"According to the {speaker}, the amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("pronoun", ("They", "We"))
+def test_louisiana_cycle46_rejects_pronoun_state_reporting(pronoun: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"{pronoun} state the income tax is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle46_rejects_em_dash_report_intro():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        'The author states—in relevant part—as follows: "the amount is determined '
+        'under R.S. 47:32."',
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("relation", ("incorporating", "emerging from"))
+def test_louisiana_cycle46_rejects_additional_semantic_participle(relation: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The eligibility {relation} the formula depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle46_accepts_income_averaging_compound():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The income averaging calculation depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("objects", "pronoun"),
+    (
+        ("the formula plus a diagram", "them"),
+        ("the formula plus a diagram", "both"),
+        ("the formula in addition to a diagram and a certificate", "them"),
+    ),
+)
+def test_louisiana_cycle46_resolves_additive_coordination(objects: str, pronoun: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module identifies {objects}, then "
+        f"provides {pronoun}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "relative_tail",
+    (", if authorized, or retain", ", if authorized, under the statute"),
+)
+def test_louisiana_cycle46_rejects_or_preposition_relative_condition(
+    relative_tail: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module provides the formula that "
+        f"taxpayers use{relative_tail}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "state",
+    (
+        ", which, although it is not hypothetical, is installed elsewhere",
+        ", which, despite the fact that it is not hypothetical, is installed elsewhere",
+    ),
+)
+def test_louisiana_cycle46_rejects_additional_explicit_state_contrast(state: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the formula{state}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle46_keeps_minor_orphan_descriptors_commutative():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the minor orphan formula and the module provides the "
+        "orphan minor formula.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle46_preserves_representative_role_order():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the principal representative formula and the module "
+        "provides the representative principal formula.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle46_rejects_interrupted_duration_progressive():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module was (for more than four months, "
+        "without interruption) providing it when the filing period ended.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle46_accepts_zero_duration_progressive():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module was (for zero months) providing "
+        "it when the filing period ended.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("aspect", ("no longer in vain",))
+def test_louisiana_cycle46_rejects_no_longer_failed_attempt(aspect: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module tried ({aspect}) to provide it.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("aspect", ("never, in fact", "no longer in fact"))
+def test_louisiana_cycle46_accepts_scoped_negative_progressive(aspect: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module was ({aspect}) providing it "
+        "when the filing period ended.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "adjunct", ("agency policies", "filing instructions currently in effect")
+)
+def test_louisiana_cycle48_accepts_additional_plural_citation_noun(adjunct: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:31 and R.S. 47:32, along with "
+        f"{adjunct}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle48_accepts_relative_plural_subject():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:31 and R.S. 47:32, along with "
+        "regulations that the analysis covers.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle48_accepts_authority_participial_modifier():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "According to the text of the reviewing court, the amount is determined "
+        "under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle48_rejects_authority_participial_topic():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "According to the text of the analyst evaluating the statute, the amount is "
+        "determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("subject", ("people", "women"))
+def test_louisiana_cycle48_rejects_irregular_plural_state_subject(subject: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The {subject} state the income tax is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle48_accepts_ous_state_descriptor():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The various state income taxes depend on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle48_rejects_nested_report_intro_punctuation():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        'The author states: (in relevant part) as follows: "the amount is determined '
+        'under R.S. 47:32."',
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("relation", ("including", "excluding"))
+def test_louisiana_cycle48_rejects_inclusion_participial_relation(relation: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The eligibility {relation} the formula depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "subject", ("income estimating calculation", "tax reporting calculation")
+)
+def test_louisiana_cycle48_accepts_reporting_word_noun_compound(subject: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The {subject} depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle48_resolves_nested_and_member():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module identifies the formula plus a "
+        "profit and loss diagram, then provides both.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "relative_tail",
+    (", if authorized, yet retain", ", if authorized, by electronic means"),
+)
+def test_louisiana_cycle48_rejects_yet_by_relative_condition(relative_tail: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module provides the formula that "
+        f"taxpayers use{relative_tail}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "state",
+    (
+        ", which, while it is not hypothetical, is installed elsewhere",
+        ", which, notwithstanding that it is not hypothetical, is installed elsewhere",
+    ),
+)
+def test_louisiana_cycle48_rejects_while_notwithstanding_state_contrast(state: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the formula{state}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle48_keeps_senior_veteran_descriptors_commutative():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the senior veteran formula and the module provides the "
+        "veteran senior formula.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle48_preserves_employee_dependent_role_order():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the employee dependent formula and the module provides the "
+        "dependent employee formula.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle48_accepts_indirect_zero_duration():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module was (for a total of zero months) "
+        "providing it when the filing period ended.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle48_rejects_semicolon_duration_progressive():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module was (for more than four months; "
+        "without interruption) providing it when the filing period ended.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("aspect", ("anything but in vain", "not ever in vain"))
+def test_louisiana_cycle48_rejects_general_negated_failure(aspect: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module tried ({aspect}) to provide it.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("aspect", ("no longer, in fact", "by no means in fact"))
+def test_louisiana_cycle48_accepts_general_scoped_negative(aspect: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module was ({aspect}) providing it "
+        "when the filing period ended.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "adjunct", ("agency standards", "filing forms currently in effect")
+)
+def test_louisiana_cycle50_accepts_further_plural_citation_noun(adjunct: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:31 and R.S. 47:32, along with "
+        f"{adjunct}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle50_accepts_process_relative_subject():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:31 and R.S. 47:32, along with "
+        "regulations that the process governs.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "speaker",
+    (
+        "text of the Louisiana reviewing court",
+        "language of the state implementing regulation",
+    ),
+)
+def test_louisiana_cycle50_accepts_modified_authority_participle(speaker: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"According to the {speaker}, the amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("subject", ("children", "men"))
+def test_louisiana_cycle50_rejects_more_irregular_plural_state_subject(subject: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The {subject} state the income tax is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle50_accepts_gross_state_descriptor():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The gross state income tax depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle50_rejects_semicolon_report_intro():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        'The author states; in relevant part, as follows: "the amount is determined '
+        'under R.S. 47:32."',
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("relation", ("using", "comprising"))
+def test_louisiana_cycle50_rejects_more_semantic_participles(relation: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The eligibility {relation} the formula depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "subject",
+    ("taxpayer estimating the income tax", "worker reporting the tax calculation"),
+)
+def test_louisiana_cycle50_rejects_human_reporting_participial_subject(subject: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The {subject} depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "objects",
+    (
+        "the formula plus an income and expense diagram",
+        "the formula in addition to a terms and conditions document",
+    ),
+)
+def test_louisiana_cycle50_resolves_general_nested_and_member(objects: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module identifies {objects}, then "
+        "provides both.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "relative_tail",
+    (", if authorized, after filing", ", if authorized, as well as retain"),
+)
+def test_louisiana_cycle50_rejects_after_additive_relative_condition(
+    relative_tail: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module provides the formula that "
+        f"taxpayers use{relative_tail}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "state",
+    (
+        ", which, though it is not hypothetical, is installed elsewhere",
+        ", which, notwithstanding the fact that it is not hypothetical, is installed elsewhere",
+    ),
+)
+def test_louisiana_cycle50_rejects_through_notwithstanding_state_contrast(state: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the formula{state}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle50_keeps_student_widow_descriptors_commutative():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the student widow formula and the module provides the "
+        "widow student formula.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle50_preserves_taxpayer_dependent_role_order():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the taxpayer dependent formula and the module provides the "
+        "dependent taxpayer formula.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle50_accepts_zero_hours_duration():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module was (for a total of zero hours) "
+        "providing it when the filing period ended.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle50_rejects_dash_duration_progressive():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module was (for more than four months—"
+        "without interruption) providing it when the filing period ended.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle50_rejects_not_at_all_failed_attempt():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module tried (not at all in vain) to "
+        "provide it.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("aspect", ("at no point in fact", "by no means, in fact"))
+def test_louisiana_cycle50_accepts_operator_class_negative(aspect: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module was ({aspect}) providing it "
+        "when the filing period ended.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("subject", ("status controls", "basis governs"))
+def test_louisiana_cycle52_accepts_singular_s_relative_subject(subject: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:31 and R.S. 47:32, along with "
+        f"regulations that the {subject}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "adjunct",
+    (
+        "together with filing notices currently in effect",
+        "along with tax schedules currently in force",
+    ),
+)
+def test_louisiana_cycle52_accepts_additional_citation_adjunct(adjunct: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:31 and R.S. 47:32, {adjunct}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "speaker",
+    ("researcher evaluating the statute", "outside consultant reviewing the statute"),
+)
+def test_louisiana_cycle52_rejects_general_authority_topic_head(speaker: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"According to the text of the {speaker}, the amount is determined under "
+        "R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("subject", ("staff", "personnel"))
+def test_louisiana_cycle52_rejects_collective_state_subject(subject: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The {subject} state the income tax is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle52_accepts_excess_state_descriptor():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The excess state income tax depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "intro",
+    ("states (in relevant part), as follows", "states; [in relevant part], as follows"),
+)
+def test_louisiana_cycle52_rejects_multiple_closing_intro_punctuation(intro: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f'The author {intro}: "the amount is determined under R.S. 47:32."',
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "subject",
+    (
+        "taxpayer calculating the income tax",
+        "worker applying the formula",
+        "eligibility referencing the formula",
+    ),
+)
+def test_louisiana_cycle52_rejects_determiner_marked_participial_clause(subject: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The {subject} depends on R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "objects", ("the formula plus two diagrams", "the formula plus a pair of diagrams")
+)
+def test_louisiana_cycle52_rejects_both_as_determiner(objects: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module identifies {objects}, then "
+        "provides both diagrams.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "relative_tail",
+    (
+        ", if authorized, before filing",
+        ", if authorized, both electronically and on paper",
+    ),
+)
+def test_louisiana_cycle52_rejects_before_both_relative_tail(relative_tail: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module provides the formula that "
+        f"taxpayers use{relative_tail}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "state",
+    (
+        ", which, even though clearly not hypothetical, is installed elsewhere",
+        ", which, despite itself not being hypothetical, is installed elsewhere",
+    ),
+)
+def test_louisiana_cycle52_rejects_modified_positive_state_contrast(state: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the formula{state}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle52_keeps_adult_citizen_descriptors_commutative():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the adult citizen formula and the module provides the "
+        "citizen adult formula.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle52_preserves_employer_dependent_role_order():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the employer dependent formula and the module provides the "
+        "dependent employer formula.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("duration", ("none of the filing period", "nil hours"))
+def test_louisiana_cycle52_accepts_general_zero_duration(duration: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module was (for {duration}) providing "
+        "it when the filing period ended.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "duration",
+    (
+        "more than four months (without interruption)",
+        "more than four months: without interruption",
+    ),
+)
+def test_louisiana_cycle52_rejects_nested_colon_duration(duration: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module was (for {duration}) providing "
+        "it when the filing period ended.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle52_rejects_in_no_sense_failure():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module tried (in no sense in vain) to "
+        "provide it.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "aspect", ("under no circumstances in fact", "in no way, in fact")
+)
+def test_louisiana_cycle52_accepts_more_negative_operators(aspect: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module was ({aspect}) providing it "
+        "when the filing period ended.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "identifies the formula plus two diagrams, then provides those diagrams",
+        "identifies the formula plus two 2024 diagrams, then provides both 2024 diagrams",
+    ),
+)
+def test_louisiana_cycle54_rejects_plural_determiner_as_list_pronoun(
+    continuation: str,
+):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("adjunct", ("without modification", "pursuant to the statute"))
+def test_louisiana_cycle54_rejects_condition_inside_relative_tail(adjunct: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module provides the formula that "
+        f"taxpayers use, if authorized, {adjunct}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "state",
+    (
+        "which, even though clearly and demonstrably not hypothetical, is installed elsewhere",
+        "which, despite the formula itself not being hypothetical, is installed elsewhere",
+    ),
+)
+def test_louisiana_cycle54_rejects_general_relative_positive_contrast(state: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the formula, {state}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle54_keeps_retiree_clergy_descriptors_commutative():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the retiree clergy formula and the module provides the "
+        "clergy retiree formula.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("missing", "provided"),
+    (("parent student", "student parent"), ("taxpayer widow", "widow taxpayer")),
+)
+def test_louisiana_cycle54_preserves_roles_among_person_descriptors(
+    missing: str, provided: str
+):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the {missing} formula and the module provides the "
+        f"{provided} formula.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "duration",
+    (
+        "four months with no interruption",
+        "four months with none of the expected interruptions",
+    ),
+)
+def test_louisiana_cycle54_rejects_positive_duration_with_zero_nested_noun(
+    duration: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module was (for {duration}) providing "
+        "it when the filing period ended.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "aspect", ("not reluctantly but in vain", "not only reluctantly but in vain")
+)
+def test_louisiana_cycle54_accepts_contrastive_failed_attempt(aspect: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module tried ({aspect}) to provide it.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "citation",
+    (
+        "Acts 2024, First Extraordinary Session, No. 11, §2",
+        "Acts 2024, 1st Extraordinary Session, No. 11, §2",
+        "Acts 2024, First Ex. Session, No. 11, §2",
+        "Acts 2024, 1st Ex. Session, No. 11, §2",
+    ),
+)
+def test_louisiana_cycle54_filters_expanded_session_law_names(citation: str):
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        authoritative_numeric_recall_text(f"{citation} establishes a 45 dollar fee."),
+        profile="en-US",
+    )
+
+    assert [(item.value, item.raw) for item in inventory] == [(45.0, "45")]
+
+
+@pytest.mark.parametrize(
+    "adjunct",
+    (
+        "along with filing requirements currently in effect",
+        "together with agency directives currently in force",
+        "along with regulations that the agency administers for taxpayers",
+        "along with regulations that the series addresses",
+    ),
+)
+def test_louisiana_cycle54_accepts_general_citation_noun_adjunct(adjunct: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:31 and R.S. 47:32, {adjunct}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "speaker",
+    (
+        "the Louisiana Constitution",
+        "the text of the administrative implementing regulation",
+        "the text of the agency implementing regulation",
+    ),
+)
+def test_louisiana_cycle54_accepts_general_legal_authority(speaker: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"According to {speaker}, the amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        'The author states in pertinent part, as follows: "The amount is determined '
+        'under R.S. 47:32."',
+        'The author states, in relevant part, "The amount is determined under '
+        'R.S. 47:32."',
+        "The author explains that the amount is determined under R.S. 47:32.",
+        "The commentator notes that the amount is determined under R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle54_rejects_general_documentary_attribution(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    (
+        "identifies the formula plus two 2024 diagrams, then provides both (2024) diagrams",
+        "identifies the formula plus two filed diagrams, then provides those “filed” diagrams",
+    ),
+)
+def test_louisiana_cycle56_rejects_delimited_determiner_as_list_pronoun(
+    continuation: str,
+):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module {continuation}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("adjunct", ("via electronic filing", "with the software"))
+def test_louisiana_cycle56_rejects_more_relative_tail_adjuncts(adjunct: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module provides the formula that "
+        f"taxpayers use, if authorized, {adjunct}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "contrast", ("far from hypothetical", "anything but hypothetical")
+)
+def test_louisiana_cycle56_rejects_idiomatic_relative_positive_contrast(
+    contrast: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the formula, which, "
+        f"{contrast}, is installed elsewhere.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("missing", "provided"),
+    (("landlord tenant", "tenant landlord"), ("lessor lessee", "lessee lessor")),
+)
+def test_louisiana_cycle56_preserves_rental_role_order(missing: str, provided: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the {missing} formula and the module provides the "
+        f"{provided} formula.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle56_accepts_modified_zero_duration():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module was (for an aggregate duration "
+        "of zero hours) providing it when the filing period ended.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "aspect", ("not reluctantly yet in vain", "not reluctantly although in vain")
+)
+def test_louisiana_cycle56_accepts_coordinated_failed_attempt(aspect: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module tried ({aspect}) to provide it.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "citation",
+    (
+        "Acts 2024, Fifth Ex. Sess., No. 11, §2",
+        "Acts 2024, Twenty-first Ex. Sess., No. 11, §2",
+        "Acts 2024, 5th Extra. Sess., No. 11, §2",
+        "Acts of 2024, 1st Ex. Sess., No. 11, §2",
+    ),
+)
+def test_louisiana_cycle56_filters_general_session_law_names(citation: str):
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        authoritative_numeric_recall_text(f"{citation} establishes a 45 dollar fee."),
+        profile="en-US",
+    )
+
+    assert [(item.value, item.raw) for item in inventory] == [(45.0, "45")]
+
+
+@pytest.mark.parametrize(
+    "adjunct",
+    (
+        "along with agency bulletins currently in effect",
+        "together with filing manuals currently in force",
+        "along with regulations that the IRS administers",
+    ),
+)
+def test_louisiana_cycle56_accepts_more_citation_noun_adjuncts(adjunct: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:31 and R.S. 47:32, {adjunct}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "relative",
+    (
+        "regulations that the agency administers for taxpayers expires next year",
+        "regulations that taxpayers use expires next year",
+    ),
+)
+def test_louisiana_cycle56_rejects_outer_predicate_after_general_relative(
+    relative: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:31, and R.S. 47:32 along with "
+        f"{relative}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "speaker",
+    (
+        "Article VII of the Louisiana Constitution",
+        "Article 7 of the Louisiana Constitution",
+        "the text of the federal tax implementing regulation",
+    ),
+)
+def test_louisiana_cycle56_accepts_labeled_or_modified_authority(speaker: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"According to {speaker}, the amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "speaker",
+    (
+        "the text of the agency reviewing analyst evaluating the statute",
+        "the text of the federal reviewing consultant analyzing the statute",
+    ),
+)
+def test_louisiana_cycle56_rejects_modified_documentary_person(speaker: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"According to {speaker}, the amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The author writes that the amount is determined under R.S. 47:32.",
+        "The commentator remarks that the amount is determined under R.S. 47:32.",
+        "The witness recounts that the amount is determined under R.S. 47:32.",
+        'The expert states in pertinent portions, as follows: "the amount is '
+        'determined under R.S. 47:32."',
+    ),
+)
+def test_louisiana_cycle56_rejects_more_documentary_attribution(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("determiner", ("both", "those"))
+def test_louisiana_cycle58_rejects_legal_symbol_determiner_as_list_pronoun(
+    determiner: str,
+):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module identifies the formula plus "
+        f"two diagrams, then provides {determiner} § 2 diagrams.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("adjunct", ("using the portal", "at filing"))
+def test_louisiana_cycle58_rejects_general_relative_tail_adjunct(adjunct: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module provides the formula that "
+        f"taxpayers use, if authorized, {adjunct}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "contrast", ("nowhere near hypothetical", "the opposite of hypothetical")
+)
+def test_louisiana_cycle58_rejects_more_idiomatic_positive_contrast(contrast: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the formula, which, "
+        f"{contrast}, is installed elsewhere.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("missing", "provided"),
+    (
+        ("mortgagor mortgagee", "mortgagee mortgagor"),
+        ("assignor assignee", "assignee assignor"),
+    ),
+)
+def test_louisiana_cycle58_preserves_morphological_inverse_role_order(
+    missing: str, provided: str
+):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the {missing} formula and the module provides the "
+        f"{provided} formula.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("operator", ("totaling", "equal to"))
+def test_louisiana_cycle58_accepts_equivalent_zero_duration(operator: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module was (for an aggregate duration "
+        f"{operator} zero hours) providing it when the filing period ended.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("comparison", ("no less than", "no fewer than"))
+def test_louisiana_cycle58_rejects_positive_no_comparative_duration(comparison: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the formula and the module was (for {comparison} four "
+        "months) providing it when the filing period ended.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle58_accepts_despite_failed_attempt():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module tried (not reluctantly despite "
+        "being in vain) to provide it.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "citation",
+    (
+        "Acts 2024, Nos. 11 and 12, §§2 and 3",
+        "Acts 2024, Twenty First Ex. Sess., No. 11, §2",
+        "Acts 2024, 5th E.S., No. 11, §2",
+        "Acts 2024, No. 11 and No. 12, §§2 and 3",
+    ),
+)
+def test_louisiana_cycle58_filters_generalized_session_law_forms(citation: str):
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        authoritative_numeric_recall_text(f"{citation} establishes a 45 dollar fee."),
+        profile="en-US",
+    )
+
+    assert [(item.value, item.raw) for item in inventory] == [(45.0, "45")]
+
+
+@pytest.mark.parametrize(
+    "adjunct",
+    (
+        "along with agency bulletins presently in effect",
+        "together with filing manuals effective today",
+        "along with regulations that DHS administers",
+    ),
+)
+def test_louisiana_cycle58_accepts_structural_citation_adjuncts(adjunct: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"The amount is determined under R.S. 47:31 and R.S. 47:32, {adjunct}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "relative",
+    (
+        "regulations that taxpayers follow expires next year",
+        "regulations that taxpayers must follow expires next year",
+        "regulations that agencies enforce expires next year",
+    ),
+)
+def test_louisiana_cycle58_rejects_outer_predicate_after_plural_relative(
+    relative: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:31, and R.S. 47:32 along with "
+        f"{relative}.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "speaker",
+    (
+        "the opinion of the Louisiana Supreme Court",
+        "the decision of the Louisiana Supreme Court",
+        "the executive order",
+        "Article VII-A of the Louisiana Constitution",
+        "the text of the statute governing expert witnesses",
+    ),
+)
+def test_louisiana_cycle58_accepts_more_general_legal_authorities(speaker: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"According to {speaker}, the amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The author acknowledges that the amount is determined under R.S. 47:32.",
+        "The author confirms that the amount is determined under R.S. 47:32.",
+        "The witness recalls that the amount is determined under R.S. 47:32.",
+        "The author's conclusion is that the amount is determined under R.S. 47:32.",
+        'The professor states substantially as follows: "the amount is determined '
+        'under R.S. 47:32."',
+        'The professor states in substance as follows: "the amount is determined '
+        'under R.S. 47:32."',
+    ),
+)
+def test_louisiana_cycle58_rejects_semantic_documentary_attribution(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("determiner", ("both", "those"))
+def test_louisiana_cycle60_rejects_general_symbol_determiner_as_list_pronoun(
+    determiner: str,
+):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module identifies the formula plus "
+        f"two diagrams, then provides {determiner} ¶ 2 diagrams.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "tail", ("because filing is required", "so returns can be filed")
+)
+def test_louisiana_cycle60_rejects_relative_tail_embedded_clause(tail: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module provides the formula that "
+        f"taxpayers use, if authorized, {tail}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("quality", ("actual", "real"))
+def test_louisiana_cycle60_rejects_participial_positive_contrast(quality: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the formula, which, being "
+        f"{quality} rather than hypothetical, is installed elsewhere.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("missing", "provided"),
+    (("heir decedent", "decedent heir"), ("guardian ward", "ward guardian")),
+)
+def test_louisiana_cycle60_preserves_lexical_inverse_role_order(
+    missing: str, provided: str
+):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the {missing} formula and the module provides the "
+        f"{provided} formula.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "duration", ("exactly zero hours", "a duration amounting to zero hours")
+)
+def test_louisiana_cycle60_accepts_modified_zero_duration(duration: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module was "
+        f"(for {duration}) providing it when the filing period ended.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle60_rejects_successful_no_respect_attempt():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module tried (in no respect in vain) "
+        "to provide it.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle60_accepts_explicit_not_at_all_progressive_negation():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module was (not at all in fact) "
+        "providing it when the filing period ended.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "relative",
+    (
+        "regulations that the agency wrote expires next year",
+        "regulations that taxpayers must obey expires next year",
+        "regulations that DHS PUBLISHES expires next year",
+    ),
+)
+def test_louisiana_cycle60_rejects_more_outer_predicates_after_relative(
+    relative: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:32 along with " + relative + ".",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle60_accepts_now_in_effect_citation_adjunct():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:32, along with agency bulletins "
+        "now in effect.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "speaker",
+    (
+        "Article VII, § 3 of the Louisiana Constitution",
+        "Article VII(A) of the Louisiana Constitution",
+    ),
+)
+def test_louisiana_cycle60_accepts_article_section_authority(speaker: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"According to {speaker}, the amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "It is said that the amount is determined under R.S. 47:32.",
+        'The affidavit states substantially as follows: "the amount is determined '
+        'under R.S. 47:32."',
+        'The testimony states in substance as follows: "the amount is determined '
+        'under R.S. 47:32."',
+        "The author told the reader that the amount is determined under R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle60_rejects_irregular_documentary_attribution(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The said amount is determined under R.S. 47:32.",
+        "Said calculation depends on R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle62_accepts_said_as_legal_determiner(source: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("speaker", ("the purchase order", "the customer order"))
+def test_louisiana_cycle62_rejects_nonlegal_commercial_order(speaker: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"According to {speaker}, the amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "relative",
+    (
+        "regulations that the agency made expires next year",
+        "regulations that taxpayers rely on expires next year",
+        "regulations that taxpayers may retain expires next year",
+        "regulations that DHS ISSUES expires next year",
+    ),
+)
+def test_louisiana_cycle62_rejects_general_outer_predicates_after_relative(
+    relative: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:32 along with " + relative + ".",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle62_accepts_already_in_effect_citation_adjunct():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:32, along with agency bulletins "
+        "already in effect.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "speaker",
+    (
+        "Article VII, Section 3(A) of the Louisiana Constitution",
+        "Article VII, Section 3, Paragraph A of the Louisiana Constitution",
+    ),
+)
+def test_louisiana_cycle62_accepts_spelled_article_hierarchy(speaker: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"According to {speaker}, the amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The affidavit provides that the amount is determined under R.S. 47:32.",
+        'The affidavit reads as follows: "the amount is determined under R.S. 47:32."',
+        "In the author's words, the amount is determined under R.S. 47:32.",
+        "It is understood that the amount is determined under R.S. 47:32.",
+        "The witness answered that the amount is determined under R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle62_rejects_subject_driven_documentary_framing(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("adjunct", ("(successfully)", "[successfully]"))
+def test_louisiana_cycle62_accepts_parenthetical_adverb_after_both(adjunct: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module identifies the formula plus "
+        f"a diagram, then provides both {adjunct}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "tail",
+    ("because the statute requires it", "so the filing can proceed"),
+)
+def test_louisiana_cycle62_preserves_matrix_condition_after_reduced_relative(
+    tail: str,
+):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module provides the formula that "
+        f"was requested, if authorized, {tail}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("missing", "provided"),
+    (
+        ("annual taxpayer", "taxpayer annual"),
+        ("eligible guardian", "guardian eligible"),
+    ),
+)
+def test_louisiana_cycle62_allows_ordinary_adjective_role_reordering(
+    missing: str, provided: str
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the {missing} formula and the module provides the "
+        f"{provided} formula.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "duration",
+    (
+        "a three-month period totaling zero errors",
+        "a four-month period amounting to zero interruptions",
+    ),
+)
+def test_louisiana_cycle62_rejects_zero_nontemporal_duration_quantity(duration: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module was "
+        f"(for {duration}) providing it when the filing period ended.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle62_accepts_modally_failed_attempt():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module tried (not necessarily in "
+        "vain) to provide it.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle62_accepts_modally_negated_progressive():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module was (not necessarily in "
+        "fact) providing it when the filing period ended.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The said applicable amount is determined under R.S. 47:32.",
+        "Said adjusted gross income depends on R.S. 47:32.",
+        "The said Louisiana income tax is determined under R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle64_accepts_modified_said_determiner(source: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "speaker", ("the restraining order", "the cease-and-desist order")
+)
+def test_louisiana_cycle64_accepts_substantive_legal_order(speaker: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"According to {speaker}, the amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "speaker", ("the administrative work order", "the administrative purchase order")
+)
+def test_louisiana_cycle64_rejects_operational_administrative_order(speaker: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"According to {speaker}, the amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "relative",
+    (
+        "regulations that apply expires next year",
+        "regulations that the agency enforces will expire next year",
+        "regulations that the agency enforces expired last year",
+    ),
+)
+def test_louisiana_cycle64_rejects_outer_modal_or_past_predicate(relative: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:32 along with " + relative + ".",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle64_accepts_still_in_effect_citation_adjunct():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:32, along with agency bulletins "
+        "still in effect.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "speaker",
+    (
+        "Article VII, Section 3(A), Paragraph (1) of the Louisiana Constitution",
+        "Article VII, Section 3(A) and (B) of the Louisiana Constitution",
+    ),
+)
+def test_louisiana_cycle64_accepts_coordinated_article_hierarchy(speaker: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"According to {speaker}, the amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The affidavit provides, in relevant part, that the amount is determined "
+        "under R.S. 47:32.",
+        'The affidavit reads, in relevant part, as follows: "the amount is '
+        'determined under R.S. 47:32."',
+        "In the author's own words, the amount is determined under R.S. 47:32.",
+        "In the words of the author, the amount is determined under R.S. 47:32.",
+        "As the affidavit puts it, the amount is determined under R.S. 47:32.",
+        "The affidavit sets forth that the amount is determined under R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle64_rejects_general_documentary_construction(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize("adjunct", ("(in fact)", "(as expected)", "[with success]"))
+def test_louisiana_cycle64_accepts_multiword_parenthetical_pronoun_adjunct(
+    adjunct: str,
+):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module identifies the formula plus "
+        f"a diagram, then provides both {adjunct}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "tail", ("because the statute requires it", "so the filing can proceed")
+)
+def test_louisiana_cycle64_preserves_matrix_condition_after_active_past_relative(
+    tail: str,
+):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module provides the formula that "
+        f"taxpayers requested, if authorized, {tail}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    ("missing", "provided"),
+    (
+        ("trustee beneficiary", "beneficiary trustee"),
+        ("executor beneficiary", "beneficiary executor"),
+    ),
+)
+def test_louisiana_cycle64_preserves_common_legal_role_order(
+    missing: str, provided: str
+):
+    assert completeness_module._reason_dependency_is_source_bound(
+        f"R.S. 47:32 lacks the {missing} formula and the module provides the "
+        f"{provided} formula.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "duration",
+    (
+        "a duration of precisely zero aggregate hours",
+        "a total of zero cumulative hours",
+    ),
+)
+def test_louisiana_cycle64_accepts_modified_exact_zero_temporal_unit(duration: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module was "
+        f"(for {duration}) providing it when the filing period ended.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle64_accepts_epistemically_negated_progressive():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module was (not demonstrably in "
+        "fact) providing it when the filing period ended.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle64_accepts_epistemically_failed_attempt():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module tried (not unequivocally in "
+        "vain) to provide it.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "tail", ("because the statute requires it", "so the filing can proceed")
+)
+def test_louisiana_cycle66_preserves_matrix_condition_after_irregular_past_relative(
+    tail: str,
+):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module provides the formula that "
+        f"taxpayers chose yesterday, if authorized, {tail}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle66_preserves_ed_er_inverse_role_order():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the insured insurer formula and the module provides the "
+        "insurer insured formula.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "duration",
+    (
+        "a three-month period totaling zero errors per month",
+        "a four-month period amounting to zero interruptions per month",
+    ),
+)
+def test_louisiana_cycle66_rejects_zero_nontemporal_quantity_per_month(duration: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module was "
+        f"(for {duration}) providing it when the filing period ended.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle66_rejects_outer_predicate_after_consult_relative():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:31, and R.S. 47:32 along with "
+        "regulations that taxpayers consult expires next year.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle66_accepts_postpositive_effective_date_adjunct():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:31 and R.S. 47:32, along with "
+        "agency bulletins effective on January 1.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "speaker",
+    (
+        "Article VII, Sections 3 and 4 of the Louisiana Constitution",
+        "Articles VII and VIII of the Louisiana Constitution",
+        "Article VII, Section 3(A)-(C) of the Louisiana Constitution",
+    ),
+)
+def test_louisiana_cycle66_accepts_plural_or_ranged_article_label(speaker: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"According to {speaker}, the amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "speaker",
+    (
+        "the order of the purchasing department",
+        "the opinion of the economics department",
+    ),
+)
+def test_louisiana_cycle66_rejects_generic_department_authority(speaker: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        f"According to {speaker}, the amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "It is provided in the affidavit that the amount is determined under R.S. "
+        "47:32.",
+        "The affidavit provides in relevant part that the amount is determined "
+        "under R.S. 47:32.",
+        'The affidavit reads in relevant part as follows: "the amount is determined '
+        'under R.S. 47:32."',
+        "As set forth in the affidavit, the amount is determined under R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle66_rejects_documentary_voice_or_punctuation(source: str):
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "The understood amount is determined under R.S. 47:32.",
+        "The commonly understood tax rate is determined under R.S. 47:32.",
+    ),
+)
+def test_louisiana_cycle66_accepts_understood_as_adjective(source: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+@pytest.mark.parametrize(
+    "tail", ("because the statute requires it", "so the return can proceed")
+)
+def test_louisiana_cycle68_preserves_irregular_past_relative_with_pp(tail: str):
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the formula and the module provides the formula that "
+        f"taxpayers chose for the filing, if authorized, {tail}.",
+        "The amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle68_rejects_outer_predicate_after_review_relative():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:31, and R.S. 47:32 along with "
+        "regulations that taxpayers review expires next year.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle68_accepts_adverb_modified_postpositive_adjective():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "The amount is determined under R.S. 47:31 and R.S. 47:32, along with "
+        "agency bulletins currently effective.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle68_accepts_independently_qualified_section_labels():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "According to Article VII, Sections 3(A) and 4(B) of the Louisiana "
+        "Constitution, the amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle68_rejects_unrecognized_department_modifier():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "According to the order of the payroll department, the amount is determined "
+        "under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle68_rejects_past_passive_documentary_framing():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "It was provided in the affidavit that the amount is determined under R.S. "
+        "47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle68_accepts_indefinite_understood_adjective():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "An understood amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle70_rejects_perfect_passive_documentary_framing():
+    assert not completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "It has been provided in the affidavit that the amount is determined under "
+        "R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle70_accepts_demonstrative_understood_adjective():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "This commonly understood tax rate is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )
+
+
+def test_louisiana_cycle70_accepts_plural_article_paragraph_labels():
+    assert completeness_module._reason_dependency_is_source_bound(
+        "R.S. 47:32 lacks the computation.",
+        "According to Article VII, Paragraphs (1) and (2) of the Louisiana "
+        "Constitution, the amount is determined under R.S. 47:32.",
+        corpus_citation_path="us-la/statute/47:295",
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1621"
+version = "0.2.1622"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- recognize exact Louisiana `R.S. title:section` citations as external statute dependencies only when the same citation is operative in the source clause
- accept source-stated external delegations while rejecting self-citations, negated/contextual references, prefix/suffix matches, cross-family citation bleed, and borrowed or contradicted missingness
- preserve the legitimate ownership boundary: R.S. 47:32 owns the complete individual-tax amount mechanics, while R.S. 47:295 imports that amount
- bump the encoder to 0.2.1622 and add a changelog fragment

## Failure evidence

Protected atomic run 31110040537 failed closed in canonical refresh 47:295. Provenance, package, commit, push, and PR publication steps were skipped. The archived diagnostic tar SHA-256 is `c0c1d298b6db66dfb24b41ec038ddc74532da04e2a990b93bd6f347e30b32f29`.

## Validation

- exact-head full repository suite: 11,001 passed, 119 skipped
- `tests/test_source_completeness.py`: 4,851 passed
- RuleSpec validation: 1,433 passed, 31 skipped
- Ruff check and format check
- compileall and diff-check
- version provenance: encoder 0.2.1622
- hosted CI 31132309475: passed on exact head
- hosted signing supervisor 31132309474: Ubuntu and macOS passed on exact head

## Review cycle

- cycles 1–70: repeated independent review/fix rounds closed actionable parser-boundary and adversarial-language findings with 372 new exact regressions
- cycle 71: both independent reviewers reported no actionable findings on exact source SHA-256 `be7cc45bf79910ce7af1ed1e5fcd1d2781b9b07957e14fd4095d577c5624d248` and test SHA-256 `1f4b70c2fa318029c1db0bbeefa6dc095ab82631a97c84ac52c991e2797bfb27`
- final reviewed head: `a2ba8c8d407b6b001b8933ad65e097405c1c006b`
