### PR TITLE
Fix legacy formula interval ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to Axiom Encode will be documented here.
 
+- Interpret formula-range numeric evidence in source order across numeric
+  extraction profiles, so a percentage yielded before word-number thresholds
+  cannot hide a valid conjoined lower and upper income interval.
+
 - Reject source-add dispatches when the primary or bundled canonical RuleSpec
   destination already exists in the pinned checkout. Existing modules must use
   the authenticated canonical-refresh contract, so mode mistakes fail before

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1620"
+version = "0.2.1621"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1620"
+__version__ = "0.2.1621"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -11242,7 +11242,18 @@ def _formula_interval_from_text(
         " ",
         text,
     )
-    numeric_occurrences = tuple(extract_numeric_occurrences(occurrence_text))
+    extracted_occurrences = tuple(extract_numeric_occurrences(occurrence_text))
+    numeric_occurrences_list: list[NumericOccurrenceLike] = []
+    # Stable source ordering retains the extractor's preferred interpretation
+    # when one numeric phrase emits multiple overlapping candidates.
+    for occurrence in sorted(extracted_occurrences, key=lambda item: item.start):
+        if (
+            numeric_occurrences_list
+            and occurrence.start < numeric_occurrences_list[-1].end
+        ):
+            continue
+        numeric_occurrences_list.append(occurrence)
+    numeric_occurrences = tuple(numeric_occurrences_list)
     keyword = None
     occurrences: tuple[NumericOccurrenceLike, ...] = ()
     for candidate in sorted(

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1620"
+ENCODER_VERSION = "0.2.1621"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1620"
+ENCODER_VERSION = "0.2.1621"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1620"
+ENCODER_VERSION = "0.2.1621"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1620"
+ENCODER_VERSION = "0.2.1621"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1620"
+ENCODER_VERSION = "0.2.1621"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1620"
+ENCODER_VERSION = "0.2.1621"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1620"
+ENCODER_VERSION = "0.2.1621"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1620"')
+        .startswith('__version__ = "0.2.1621"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1620"
+    assert encoder_package["version"] == "0.2.1621"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1620"
+    assert project["project"]["version"] == "0.2.1621"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1620"')
+        .startswith('__version__ = "0.2.1621"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1620"
+    assert encoder_package["version"] == "0.2.1621"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1620"
+    assert project["project"]["version"] == "0.2.1621"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1620"')
+        .startswith('__version__ = "0.2.1621"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1620"
+ENCODER_VERSION = "0.2.1621"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -42,6 +42,10 @@ EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR = functools.partial(
     extract_typed_numeric_occurrences_from_text,
     profile="en-US",
 )
+LEGACY_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR = functools.partial(
+    extract_typed_numeric_occurrences_from_text,
+    profile="legacy",
+)
 
 
 def _analyze(
@@ -1918,10 +1922,18 @@ B.(1) If the credit against Louisiana income tax for resident individuals whose 
         (", and", "is less than or equal to", True),
     ),
 )
+@pytest.mark.parametrize(
+    "numeric_extractor",
+    (
+        EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR,
+        LEGACY_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR,
+    ),
+)
 def test_formula_interval_recognizes_conjoined_upper_bound(
     connector: str,
     comparison: str,
     upper_inclusive: bool,
+    numeric_extractor,
 ):
     source = (
         "(2) If income is greater than twenty-five thousand dollars "
@@ -1933,7 +1945,7 @@ def test_formula_interval_recognizes_conjoined_upper_bound(
 
     interval = completeness_module._formula_branch_interval(
         branch,
-        extract_numeric_occurrences=EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR,
+        extract_numeric_occurrences=numeric_extractor,
     )
 
     assert interval is not None
@@ -2883,7 +2895,47 @@ def test_formula_interval_preserves_narrow_high_value_range():
     assert not interval.upper_inclusive
 
 
-def test_conjoined_income_range_formula_has_executed_companion_witness():
+@pytest.mark.parametrize(
+    ("source", "lower", "upper"),
+    (
+        ("income is between 1 million and 2 million", 1_000_000, 2_000_000),
+        (
+            "income is greater than 1 million and less than 2 million",
+            1_000_000,
+            2_000_000,
+        ),
+        (
+            "rate is greater than 25 percent and less than 35 percent",
+            0.25,
+            0.35,
+        ),
+    ),
+)
+def test_formula_interval_prefers_legacy_semantic_occurrence_per_source_span(
+    source: str,
+    lower: float,
+    upper: float,
+):
+    interval = completeness_module._formula_interval_from_text(
+        source,
+        extract_numeric_occurrences=LEGACY_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR,
+    )
+
+    assert interval is not None
+    assert interval.lower is not None and interval.lower.value == lower
+    assert interval.upper is not None and interval.upper.value == upper
+
+
+@pytest.mark.parametrize(
+    "numeric_extractor",
+    (
+        EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR,
+        LEGACY_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR,
+    ),
+)
+def test_conjoined_income_range_formula_has_executed_companion_witness(
+    numeric_extractor,
+):
     source = """\
 (2) If the resident individual's federal adjusted gross income is greater than twenty-five thousand dollars and less than or equal to thirty-five thousand dollars, the credit shall be equal to thirty percent of the federal credit for child care expenses claimed on the resident individual's federal tax return.
 """
@@ -2966,9 +3018,7 @@ def test_conjoined_income_range_formula_has_executed_companion_witness():
         corpus_citation_path="us-la/statute/47:297.4",
         test_cases=cases,
         extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
-        extract_numeric_grounding_occurrences=(
-            EN_NUMERIC_GROUNDING_OCCURRENCE_EXTRACTOR
-        ),
+        extract_numeric_grounding_occurrences=numeric_extractor,
         extract_named_scalars=extract_named_scalar_occurrences,
         numeric_value_is_grounded=numeric_value_is_grounded,
     )

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1620"
+version = "0.2.1621"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- sort numeric extraction results by source offsets before parsing formula intervals
- cover the legacy profile and the exact Louisiana conjoined income-range witness
- bump encoder to 0.2.1621

## Production reproduction
Protected run 31115042002 rejected an executed La. R.S. 47:297.4(A)(2) witness because the legacy extractor yielded the 30% rate before the source-earlier 25,000 and 35,000 bounds. The validator then treated the interval as absent. The exact preserved candidate no longer reports branch (2) with this change.

## Checks
- 4,281 passed, 31 skipped across source completeness, RuleSpec validation, and affected oracle registries
- 126 focused interval/witness cases passed
- Ruff check passed
- Ruff format check passed
- compileall passed

## Review cycle
Pending independent review.