### PR TITLE
Fix canonical refresh review finding propagation

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -39,7 +39,7 @@ on:
         required: false
         type: string
       source_bundle_json:
-        description: JSON citation array for atomic imports, or {"canonical_refresh_bundle":[{citation,replace_rulespec_path}]} for an independent refresh transaction
+        description: JSON citation array for atomic imports, or {"canonical_refresh_bundle":[{citation,replace_rulespec_path,review_finding?}]} for an independent refresh transaction
         required: false
         default: "[]"
         type: string
@@ -1478,7 +1478,8 @@ jobs:
               refresh_finding="$REVIEW_FINDING"
               if [ "$refresh_index" -gt 0 ]; then
                 refresh_lane="$(printf 'canonical-refresh-%02d' "$refresh_index")"
-                refresh_finding=""
+                refresh_finding="$(jq -er '.review_finding // ""' \
+                  <<< "$refresh_item")"
               fi
               run_signed_encode \
                 "$refresh_citation" "$refresh_finding" false "$refresh_lane" \
@@ -1614,14 +1615,17 @@ jobs:
         env:
           CITATION: ${{ inputs.citation }}
           DEPENDENT_CITATION: ${{ inputs.dependent_citation }}
+          DEPENDENT_REVIEW_FINDING: ${{ inputs.dependent_review_finding }}
           DEPENDENT_REVIEW_FINDING_PRESENT: ${{ inputs.dependent_review_finding != '' }}
           SECOND_DEPENDENT_CITATION: ${{ inputs.second_dependent_citation }}
+          SECOND_DEPENDENT_REVIEW_FINDING: ${{ inputs.second_dependent_review_finding }}
           SECOND_DEPENDENT_REVIEW_FINDING_PRESENT: ${{ inputs.second_dependent_review_finding != '' }}
           PR_BASE_BRANCH: ${{ inputs.pr_base_branch }}
           QUEUE_ID: ${{ inputs.queue_id }}
           QUEUE_ITEM_ID: ${{ inputs.queue_item_id }}
           QUEUE_ITEM_GENERATION_SHA256: ${{ inputs.queue_item_generation_sha256 }}
           QUEUE_MANIFEST_SHA256: ${{ inputs.queue_manifest_sha256 }}
+          REVIEW_FINDING: ${{ inputs.review_finding }}
           REVIEW_FINDING_PRESENT: ${{ inputs.review_finding != '' }}
           REPAIR_RUN_ID: ${{ inputs.repair_run_id }}
           REPAIR_CANDIDATE_PATH: ${{ steps.repair_candidate.outputs.path }}
@@ -1850,6 +1854,7 @@ jobs:
                   "companion_sha256",
                   "manifest_path",
                   "manifest_sha256",
+                  "review_finding",
               }
               and isinstance(item["citation"], str)
               and item["citation"]
@@ -1857,6 +1862,21 @@ jobs:
               and item["rulespec_path"]
               and isinstance(item["companion_path"], str)
               and item["companion_path"]
+              and (
+                  item["review_finding"] is None
+                  or (
+                      isinstance(item["review_finding"], str)
+                      and item["review_finding"]
+                      and item["review_finding"]
+                      == item["review_finding"].strip()
+                      and "\r" not in item["review_finding"]
+                      and not any(
+                          (ord(char) < 32 and char not in {"\n", "\t"})
+                          or ord(char) == 127
+                          for char in item["review_finding"]
+                      )
+                  )
+              )
               and (
                   item["companion_sha256"] is None
                   or (
@@ -1943,8 +1963,11 @@ jobs:
                   expected.append(
                       (
                           refresh_item["citation"],
-                          refresh_index == 0
-                          and os.environ["REVIEW_FINDING_PRESENT"] == "true",
+                          (
+                              os.environ["REVIEW_FINDING"] or None
+                              if refresh_index == 0
+                              else refresh_item["review_finding"]
+                          ),
                           (
                               Path(sys.argv[1])
                               if refresh_index == 0
@@ -1962,7 +1985,7 @@ jobs:
               expected.append(
                   (
                       os.environ["CITATION"],
-                      os.environ["REVIEW_FINDING_PRESENT"] == "true",
+                      os.environ["REVIEW_FINDING"] or None,
                       Path(sys.argv[1]),
                       "target",
                       normalized_replacement_path or None,
@@ -1977,7 +2000,7 @@ jobs:
               expected.append(
                   (
                       source_citation,
-                      False,
+                      None,
                       Path(sys.argv[1]).with_name(
                           f"{source_lane}-context-manifest.json"
                       ),
@@ -1991,7 +2014,7 @@ jobs:
               expected.append(
                   (
                       dependent_citation,
-                      os.environ["DEPENDENT_REVIEW_FINDING_PRESENT"] == "true",
+                      os.environ["DEPENDENT_REVIEW_FINDING"] or None,
                       Path(sys.argv[1]).with_name("dependent-context-manifest.json"),
                       "dependent",
                       None,
@@ -2003,10 +2026,7 @@ jobs:
               expected.append(
                   (
                       second_dependent_citation,
-                      (
-                          os.environ["SECOND_DEPENDENT_REVIEW_FINDING_PRESENT"]
-                          == "true"
-                      ),
+                      os.environ["SECOND_DEPENDENT_REVIEW_FINDING"] or None,
                       Path(sys.argv[1]).with_name(
                           "dependent-2-context-manifest.json"
                       ),
@@ -2021,7 +2041,7 @@ jobs:
           applied_inventory = []
           for (
               citation,
-              finding_required,
+              expected_review_finding,
               destination,
               lane,
               expected_primary_path,
@@ -2638,8 +2658,23 @@ jobs:
                   raise SystemExit(
                       "context manifest review findings evidence is malformed"
                   )
-              if finding_required and not review_findings:
-                  raise SystemExit("context manifest omits supplied review finding")
+              if expected_review_finding is None and review_findings:
+                  raise SystemExit(
+                      "context manifest contains an unexpected review finding"
+                  )
+              expected_review_content = (
+                  f"{expected_review_finding}\n"
+                  if expected_review_finding is not None
+                  else None
+              )
+              if expected_review_content is not None and (
+                  len(review_findings) != 1
+                  or review_findings[0].get("content")
+                  != expected_review_content
+              ):
+                  raise SystemExit(
+                      "context manifest does not bind the supplied review finding"
+                  )
               for finding in review_findings:
                   if not isinstance(finding, dict):
                       raise SystemExit("context manifest review finding is malformed")
@@ -2652,6 +2687,14 @@ jobs:
                   if "\r" in content:
                       raise SystemExit(
                           "context manifest review finding is not normalized"
+                      )
+                  if any(
+                      (ord(char) < 32 and char not in {"\n", "\t"})
+                      or ord(char) == 127
+                      for char in content
+                  ):
+                      raise SystemExit(
+                          "context manifest review finding contains a forbidden control character"
                       )
                   if hashlib.sha256(content.encode("utf-8")).hexdigest() != digest:
                       raise SystemExit(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Axiom Encode will be documented here.
 
+- Carry bounded, source-specific review findings through each canonical-refresh
+  lane and bind their exact content in signed context evidence. Louisiana
+  external-dependency validation now recognizes narrowly scoped executable
+  dependency objects and preserves operative predicates across official prose
+  line wraps.
+
 - Interpret formula-range numeric evidence in source order across numeric
   extraction profiles, so a percentage yielded before word-number thresholds
   cannot hide a valid conjoined lower and upper income interval.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1623"
+version = "0.2.1624"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -517,20 +517,27 @@ def parse_canonical_refresh_bundle(
             "RuleSpec path"
         )
 
-    requested: list[tuple[str, PurePosixPath]] = [(primary_citation, primary_path)]
+    requested: list[tuple[str, PurePosixPath, str | None]] = [
+        (primary_citation, primary_path, None)
+    ]
     seen_citations = {primary_citation}
     seen_paths = {primary_path}
     for index, value in enumerate(payload):
         label = f"canonical refresh addition #{index + 1}"
-        if not isinstance(value, dict) or set(value) != {
-            "citation",
-            "replace_rulespec_path",
-        }:
+        required_fields = {"citation", "replace_rulespec_path"}
+        allowed_fields = {*required_fields, "review_finding"}
+        if (
+            not isinstance(value, dict)
+            or not required_fields.issubset(value)
+            or not set(value).issubset(allowed_fields)
+        ):
             raise ValueError(
-                f"{label} must contain exactly citation and replace_rulespec_path"
+                f"{label} must contain citation and replace_rulespec_path, with "
+                "only an optional review_finding"
             )
         citation = value["citation"]
         raw_path = value["replace_rulespec_path"]
+        review_finding = value.get("review_finding")
         if (
             not isinstance(citation, str)
             or not citation
@@ -545,6 +552,20 @@ def parse_canonical_refresh_bundle(
             )
         ):
             raise ValueError(f"{label} fields must be nonempty canonical strings")
+        if review_finding is not None and (
+            not isinstance(review_finding, str)
+            or not review_finding
+            or review_finding != review_finding.strip()
+            or "\r" in review_finding
+            or any(
+                (ord(character) < 32 and character not in {"\n", "\t"})
+                or ord(character) == 127
+                for character in review_finding
+            )
+        ):
+            raise ValueError(
+                f"{label} review_finding must be a nonempty normalized string"
+            )
         try:
             citation = require_canonical_corpus_citation_path(citation)
         except ValueError as exc:
@@ -565,13 +586,18 @@ def parse_canonical_refresh_bundle(
             )
         if citation in seen_citations or path in seen_paths:
             raise ValueError("canonical refresh citations and paths must be unique")
-        requested.append((citation, path))
+        requested.append((citation, path, review_finding))
         seen_citations.add(citation)
         seen_paths.add(path)
 
     return tuple(
-        _canonical_refresh_target_inventory(repo, citation=citation, path=path)
-        for citation, path in requested
+        _canonical_refresh_target_inventory(
+            repo,
+            citation=citation,
+            path=path,
+            review_finding=review_finding,
+        )
+        for citation, path, review_finding in requested
     )
 
 
@@ -580,6 +606,7 @@ def _canonical_refresh_target_inventory(
     *,
     citation: str,
     path: PurePosixPath,
+    review_finding: str | None,
 ) -> dict[str, str | None]:
     """Bind one refresh target and its untrusted predecessor manifest to HEAD."""
 
@@ -705,6 +732,7 @@ def _canonical_refresh_target_inventory(
         )
     return {
         "citation": citation,
+        "review_finding": review_finding,
         "rulespec_path": path.as_posix(),
         "rulespec_sha256": target_sha256,
         "companion_path": companion_path.as_posix(),
@@ -732,13 +760,14 @@ def verify_canonical_refresh_target(
         "companion_sha256",
         "manifest_path",
         "manifest_sha256",
+        "review_finding",
     }
     if (
         not isinstance(target, dict)
         or set(target) != expected_fields
         or not all(
             isinstance(target[field], str) and target[field]
-            for field in expected_fields - {"companion_sha256"}
+            for field in expected_fields - {"companion_sha256", "review_finding"}
         )
         or (
             target["companion_sha256"] is not None
@@ -749,6 +778,20 @@ def verify_canonical_refresh_target(
         )
         or DIGEST_PATTERN.fullmatch(target["rulespec_sha256"]) is None
         or DIGEST_PATTERN.fullmatch(target["manifest_sha256"]) is None
+        or (
+            target["review_finding"] is not None
+            and (
+                not isinstance(target["review_finding"], str)
+                or not target["review_finding"]
+                or target["review_finding"] != target["review_finding"].strip()
+                or "\r" in target["review_finding"]
+                or any(
+                    (ord(character) < 32 and character not in {"\n", "\t"})
+                    or ord(character) == 127
+                    for character in target["review_finding"]
+                )
+            )
+        )
     ):
         raise ValueError("canonical refresh target inventory is malformed")
     repo = repo.resolve(strict=True)

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1623"
+__version__ = "0.2.1624"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1708,6 +1708,11 @@ _DEPENDENCY_STATE_VALUE = (
     r"issued|needed|obtained|produced|provided|received|required|resolved|set|"
     r"supplied|unavailable|verified)"
 )
+_EXECUTABLE_DEPENDENCY_READY_STATE_VALUE = (
+    r"(?:approved|ascertained|available|calculated|computed|determined|encoded|"
+    r"established|furnished|implemented|known|made\s+available|obtained|produced|"
+    r"provided|received|resolved|set|supplied|verified)"
+)
 _SOURCE_BOUND_RUNTIME_GAP_LANGUAGE = re.compile(
     r"\b(?:"
     r"administrative|calendar|capabilit(?:y|ies)|classification|complaint|"
@@ -4784,6 +4789,10 @@ def _source_scope_cites_louisiana_rs_dependency(
 ) -> bool:
     """Return whether an operative Louisiana clause cites one exact R.S. dependency."""
 
+    # Official Louisiana source prose is hard-wrapped within paragraphs. Preserve
+    # blank-line paragraph boundaries while preventing a visual line wrap from
+    # splitting one operative predicate such as ``shall be\ndetermined``.
+    source_scope_text = re.sub(r"(?<!\n)\n(?![ \t]*\n)", " ", source_scope_text)
     normalized_section = normalize_rulespec_path_segment(section.lower())
     references = tuple(
         reference
@@ -6840,7 +6849,15 @@ def _reason_match_names_missing_dependency(
 
     if signal_text == "until":
         before_reference = clause[:reference_start]
-        if not _reason_reference_introduction_is_bounded(bridge):
+        executable_bridge = bool(
+            match.re is _LOUISIANA_RS_DEFERRAL_DEPENDENCY
+            and re.fullmatch(
+                r"\s*(?:(?:a|an|the)\s+)?executable\s*",
+                bridge,
+                flags=re.IGNORECASE,
+            )
+        )
+        if not (_reason_reference_introduction_is_bounded(bridge) or executable_bridge):
             return False
         operative_reference = _source_clause_links_dependency(
             clause,
@@ -6857,6 +6874,7 @@ def _reason_match_names_missing_dependency(
         return _reason_suffix_has_dependency_state(
             after,
             allow_descriptive_list=operative_reference,
+            allow_executable_object=executable_bridge,
         )
     return True
 
@@ -7050,6 +7068,108 @@ def _missing_scope_starts_with_executable_object(missing_scope: str) -> bool:
         and len(tokens) > 1
         and _louisiana_object_signature(tokens[-2]) is not None
     )
+
+
+def _executable_object_scope_claims_ready(missing_scope: str) -> bool:
+    """Reject a relative or appositive assertion that the object already exists."""
+
+    qualifier = re.search(
+        r"(?P<marker>,|\b(?:that|which)\b)(?P<scope>[^.;\n]{1,180})",
+        missing_scope,
+        flags=re.IGNORECASE,
+    )
+    if qualifier is None:
+        return False
+    scope = qualifier.group("scope")
+    ready_state = (
+        r"(?:accessible|accessed|available|complete|computed|calculated|determined|"
+        r"defined|deployed|downloadable|downloaded|encoded|executed|extant|found|"
+        r"furnished|functional|generated|implemented|in\s+place|installed|live|loaded|"
+        r"made\s+(?:available|obtainable)|obtainable|obtained|on\s+file|on\s+hand|"
+        r"operational|present|produced|provided|published|ready|ready\s+for\s+use|"
+        r"recoverable|recovered|released|rendered\s+(?:available|accessible)|"
+        r"retrievable|retrieved|returned|run|set|stored|supplied|usable|used|verified|"
+        r"working|at\s+(?:hand|the\s+ready))"
+    )
+    affirmative_adverb = (
+        r"(?:actively|actually|already|always|currently|directly|fully|immediately|"
+        r"just|now|presently|previously|readily|still)"
+    )
+    if qualifier.group("marker") == ",":
+        bare_ready = re.match(
+            rf"\s*(?!not\b)"
+            rf"(?:{affirmative_adverb}\s+)*"
+            rf"{ready_state}\b",
+            scope,
+            flags=re.IGNORECASE,
+        )
+        if bare_ready is not None and not re.match(
+            r"\s*(?:(?:only\s+)?(?:after|if|once|unless|upon|when)|provided\s+that)\b",
+            scope[bare_ready.end() :],
+            flags=re.IGNORECASE,
+        ):
+            return True
+    readiness = re.search(
+        rf"\b(?:"
+        rf"(?:is|are|was|were|becomes?|remains?)\s+(?!not\b)"
+        rf"(?:{affirmative_adverb}\s+)*{ready_state}|"
+        rf"(?:has|have|had)\s+"
+        rf"(?:{affirmative_adverb}\s+)*been\s+"
+        rf"(?!not\b)(?:{affirmative_adverb}\s+)*{ready_state}|"
+        rf"(?:can|could|may|might)\s+"
+        rf"(?:{affirmative_adverb}\s+)*be\s+"
+        rf"(?!not\b)(?:{affirmative_adverb}\s+)*{ready_state}|"
+        r"exists?\s+(?:already\s+)?(?:in|within)"
+        r")\b",
+        scope,
+        flags=re.IGNORECASE,
+    )
+    if readiness is not None:
+        readiness_tail = scope[readiness.end() :]
+        if not re.match(
+            r"\s*(?:(?:only\s+)?(?:after|if|once|unless|upon|when)|"
+            r"provided\s+that|in\s+theory(?:\s+only)?|on\s+paper)\b",
+            readiness_tail,
+            flags=re.IGNORECASE,
+        ):
+            return True
+    for assertion in re.finditer(
+        rf"\b{_LOUISIANA_SUPPLY_VERB_PATTERN}\b",
+        scope,
+        flags=re.IGNORECASE,
+    ):
+        supplier = scope[: assertion.start()]
+        supplier = re.sub(
+            r"^\s*,\s*(?:(?:after|if|once|unless|upon|when)\b|provided\s+that\b)"
+            r"[^,.;\n]{1,100},\s*",
+            " ",
+            supplier,
+            flags=re.IGNORECASE,
+        )
+        supplier = re.sub(
+            r"\b(?:[A-Za-z][A-Za-z-]*ly|already|always|directly|itself|just|now|"
+            r"still)\b",
+            " ",
+            supplier,
+            flags=re.IGNORECASE,
+        )
+        implicit_subject = re.fullmatch(
+            r"\s*(?:(?:can|could|may|might|must|shall|should|will|would|to)\s+|"
+            r"(?:is|are|was|were)\s+designed\s+to\s+|"
+            r"(?:accepts?|accesses?|reads?|receives?|takes?|uses?)\b"
+            r"[^,.;\n]{0,100}\b(?:and|then)\s+)*",
+            supplier,
+            flags=re.IGNORECASE,
+        )
+        if (
+            implicit_subject is None
+            and not _louisiana_assertion_is_negative(scope, assertion.start())
+            and not _louisiana_supply_assertion_has_nonoperative_framing(
+                scope, assertion
+            )
+        ):
+            return True
+    return False
 
 
 def _missing_scope_reverses_insufficiency(missing_scope: str) -> bool:
@@ -8789,6 +8909,7 @@ def _reason_suffix_has_dependency_state(
     after: str,
     *,
     allow_descriptive_list: bool,
+    allow_executable_object: bool = False,
 ) -> bool:
     """Require a state predicate for this citation or its coordinated list."""
 
@@ -8828,6 +8949,22 @@ def _reason_suffix_has_dependency_state(
             r"\s*(?:(?:,|\b(?:and|or|both|either|neither)\b)\s*)*",
             remainder,
             flags=re.IGNORECASE,
+        ):
+            return True
+        if (
+            allow_executable_object
+            and len(prefix) <= 240
+            and re.fullmatch(
+                r"(?:is|are)\s+"
+                + _EXECUTABLE_DEPENDENCY_READY_STATE_VALUE
+                + r"|(?:has|have)\s+been\s+"
+                + _EXECUTABLE_DEPENDENCY_READY_STATE_VALUE,
+                state.group(0),
+                flags=re.IGNORECASE,
+            )
+            and _missing_scope_starts_with_executable_object(prefix)
+            and not _executable_object_scope_claims_ready(prefix)
+            and not _missing_scope_reverses_insufficiency(prefix)
         ):
             return True
         if allow_descriptive_list and _reason_descriptive_dependency_list_is_bounded(

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1623"
+ENCODER_VERSION = "0.2.1624"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1623"
+ENCODER_VERSION = "0.2.1624"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1623"
+ENCODER_VERSION = "0.2.1624"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1623"
+ENCODER_VERSION = "0.2.1624"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1623"
+ENCODER_VERSION = "0.2.1624"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1623"
+ENCODER_VERSION = "0.2.1624"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1623"
+ENCODER_VERSION = "0.2.1624"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -533,6 +533,9 @@ def test_parse_canonical_refresh_bundle_accepts_tracked_canonical_targets(
                 {
                     "citation": "us-la/statute/47:295",
                     "replace_rulespec_path": "us-la/statutes/47/295.yaml",
+                    "review_finding": (
+                        "Preserve the exact R.S. 47:32 ownership boundary."
+                    ),
                 },
                 {
                     "citation": "us-la/statute/47:297.4",
@@ -563,12 +566,60 @@ def test_parse_canonical_refresh_bundle_accepts_tracked_canonical_targets(
             "companion_sha256",
             "manifest_path",
             "manifest_sha256",
+            "review_finding",
         }
         for item in inventory
     )
     assert inventory[0]["companion_path"] == ("us-la/statutes/47/294.test.yaml")
     assert inventory[0]["companion_sha256"] == hashlib.sha256(b"[]\n").hexdigest()
+    assert inventory[0]["review_finding"] is None
+    assert inventory[1]["review_finding"] == (
+        "Preserve the exact R.S. 47:32 ownership boundary."
+    )
     assert inventory[1]["companion_sha256"] is None
+
+
+@pytest.mark.parametrize(
+    "review_finding",
+    ["", " leading", "trailing ", "carriage\rreturn", "control\x00value"],
+)
+def test_parse_canonical_refresh_bundle_rejects_malformed_review_finding(
+    tmp_path: Path,
+    review_finding: str,
+) -> None:
+    repo = _canonical_refresh_repo(tmp_path)
+
+    with pytest.raises(ValueError, match="review_finding must be"):
+        parse_canonical_refresh_bundle(
+            repo,
+            json.dumps(
+                [
+                    {
+                        "citation": "us-la/statute/47:295",
+                        "replace_rulespec_path": "us-la/statutes/47/295.yaml",
+                        "review_finding": review_finding,
+                    }
+                ]
+            ),
+            primary_citation="us-la/statute/47:294",
+            primary_rulespec_path="us-la/statutes/47/294.yaml",
+        )
+
+
+def test_parse_canonical_refresh_bundle_rejects_unknown_item_field(
+    tmp_path: Path,
+) -> None:
+    repo = _canonical_refresh_repo(tmp_path)
+
+    with pytest.raises(ValueError, match="only an optional review_finding"):
+        parse_canonical_refresh_bundle(
+            repo,
+            '[{"citation":"us-la/statute/47:295",'
+            '"replace_rulespec_path":"us-la/statutes/47/295.yaml",'
+            '"untrusted":true}]',
+            primary_citation="us-la/statute/47:294",
+            primary_rulespec_path="us-la/statutes/47/294.yaml",
+        )
 
 
 def test_parse_canonical_refresh_bundle_accepts_empty_default(tmp_path: Path) -> None:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1623"')
+        .startswith('__version__ = "0.2.1624"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1623"
+    assert encoder_package["version"] == "0.2.1624"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1623"
+    assert project["project"]["version"] == "0.2.1624"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1623"')
+        .startswith('__version__ = "0.2.1624"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1623"
+    assert encoder_package["version"] == "0.2.1624"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1623"
+    assert project["project"]["version"] == "0.2.1624"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1623"')
+        .startswith('__version__ = "0.2.1624"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1623"
+ENCODER_VERSION = "0.2.1624"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1912,7 +1912,8 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert inputs["source_bundle_json"] == {
         "description": (
             "JSON citation array for atomic imports, or "
-            '{"canonical_refresh_bundle":[{citation,replace_rulespec_path}]} '
+            '{"canonical_refresh_bundle":'
+            "[{citation,replace_rulespec_path,review_finding?}]} "
             "for an independent refresh transaction"
         ),
         "required": False,
@@ -2463,8 +2464,15 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert package_step["env"]["REVIEW_FINDING_PRESENT"] == (
         "${{ inputs.review_finding != '' }}"
     )
+    assert package_step["env"]["REVIEW_FINDING"] == "${{ inputs.review_finding }}"
     assert package_step["env"]["DEPENDENT_REVIEW_FINDING_PRESENT"] == (
         "${{ inputs.dependent_review_finding != '' }}"
+    )
+    assert package_step["env"]["DEPENDENT_REVIEW_FINDING"] == (
+        "${{ inputs.dependent_review_finding }}"
+    )
+    assert package_step["env"]["SECOND_DEPENDENT_REVIEW_FINDING"] == (
+        "${{ inputs.second_dependent_review_finding }}"
     )
     assert package_step["env"]["PR_BASE_BRANCH"] == ("${{ inputs.pr_base_branch }}")
     assert package_step["env"]["RULESPEC_REF"] == "${{ inputs.rulespec_ref }}"
@@ -3689,6 +3697,8 @@ def test_targeted_signed_reencode_runs_canonical_refresh_bundle_in_order(
     repo, primary_citation, primary_path, additions = _prepare_canonical_refresh_inputs(
         tmp_path
     )
+    additions[0]["review_finding"] = "Preserve the R.S. 47:32 ownership boundary."
+    additions[2]["review_finding"] = "Preserve the five-year carryforward limit."
     normalized = parse_canonical_refresh_bundle(
         repo,
         json.dumps(additions),
@@ -3770,8 +3780,26 @@ if mutation_path and len(calls_path.read_text(encoding="utf-8").splitlines()) ==
         "canonical-refresh-02",
         "canonical-refresh-03",
     ]
-    assert "--review-findings" in encode_args[0]
-    assert all("--review-findings" not in args for args in encode_args[1:])
+    assert ["--review-findings" in args for args in encode_args] == [
+        True,
+        True,
+        False,
+        True,
+    ]
+    supplied_findings = [
+        (
+            Path(args[args.index("--review-findings") + 1]).read_text(encoding="utf-8")
+            if "--review-findings" in args
+            else None
+        )
+        for args in encode_args
+    ]
+    assert supplied_findings == [
+        "Refresh the independent Louisiana modules.\n",
+        "Preserve the R.S. 47:32 ownership boundary.\n",
+        None,
+        "Preserve the five-year carryforward limit.\n",
+    ]
     forbidden = {
         "--apply-target-only",
         "--required-import-rulespec-path",
@@ -4670,6 +4698,7 @@ def test_targeted_artifact_packages_signed_review_context(tmp_path: Path) -> Non
             **os.environ,
             "CITATION": citation,
             "PYTHONPATH": str(ROOT / "src"),
+            "REVIEW_FINDING": review_content.rstrip("\n"),
             "REVIEW_FINDING_PRESENT": "true",
             "RUNNER_TEMP": str(tmp_path),
             "RULESPEC_CHECKOUT": "rulespec-nz",
@@ -4744,6 +4773,18 @@ def _targeted_metadata_script() -> str:
             "unrelated-companion",
             "canonical refresh apply manifest does not match its exact requested target",
         ),
+        (
+            "wrong-companion-finding",
+            "context manifest does not bind the supplied review finding",
+        ),
+        (
+            "unexpected-companion-finding",
+            "context manifest contains an unexpected review finding",
+        ),
+        (
+            "control-companion-finding",
+            "normalized canonical refresh bundle is malformed",
+        ),
     ],
 )
 def test_targeted_artifact_enforces_exact_canonical_refresh_inventory(
@@ -4789,7 +4830,11 @@ def test_targeted_artifact_enforces_exact_canonical_refresh_inventory(
         rule = rulespec / rulespec_path
         rule.parent.mkdir(parents=True, exist_ok=True)
         rule.write_text(f"format: rulespec/v1\nrules: [{index}]\n", encoding="utf-8")
-        finding = "Preserve the primary semantics.\n" if index == 0 else ""
+        finding = (
+            "Preserve the primary semantics.\n"
+            if index == 0
+            else "Preserve the companion ownership boundary.\n"
+        )
         context = {
             "citation": citation,
             "review_findings_files": (
@@ -4803,6 +4848,14 @@ def test_targeted_artifact_enforces_exact_canonical_refresh_inventory(
                 else []
             ),
         }
+        if mutation == "control-companion-finding" and index > 0:
+            finding = "Preserve the companion\x00 ownership boundary.\n"
+            context["review_findings_files"] = [
+                {
+                    "content": finding,
+                    "sha256": hashlib.sha256(finding.encode()).hexdigest(),
+                }
+            ]
         context_bytes = json.dumps(context, sort_keys=True).encode()
         context_path = tmp_path / "generated" / lane / "context-manifest.json"
         context_path.parent.mkdir(parents=True, exist_ok=True)
@@ -4825,6 +4878,15 @@ def test_targeted_artifact_enforces_exact_canonical_refresh_inventory(
         inventory.append(
             {
                 "citation": citation,
+                "review_finding": (
+                    (
+                        "A different companion finding."
+                        if mutation == "wrong-companion-finding"
+                        else finding.rstrip("\n")
+                    )
+                    if index > 0 and mutation != "unexpected-companion-finding"
+                    else None
+                ),
                 "rulespec_path": rulespec_path,
                 "rulespec_sha256": "a" * 64,
                 "companion_path": str(
@@ -4895,6 +4957,7 @@ def test_targeted_artifact_enforces_exact_canonical_refresh_inventory(
             **os.environ,
             "CITATION": target_rows[0][0],
             "PYTHONPATH": str(ROOT / "src"),
+            "REVIEW_FINDING": "Preserve the primary semantics.",
             "REVIEW_FINDING_PRESENT": "true",
             "RUNNER_TEMP": str(tmp_path),
             "RULESPEC_CHECKOUT": "rulespec-us",
@@ -5213,6 +5276,7 @@ def test_targeted_artifact_packages_v4_retained_successor_closure(
             **os.environ,
             "CITATION": citation,
             "PYTHONPATH": str(ROOT / "src"),
+            "REVIEW_FINDING": review_content.rstrip("\n"),
             "REVIEW_FINDING_PRESENT": "true",
             "RUNNER_TEMP": str(tmp_path),
             "RULESPEC_CHECKOUT": "rulespec-us",
@@ -5338,6 +5402,7 @@ def test_targeted_artifact_preserves_pre_v4_replacement_receipts(
             **os.environ,
             "CITATION": citation,
             "PYTHONPATH": str(ROOT / "src"),
+            "REVIEW_FINDING": "",
             "REVIEW_FINDING_PRESENT": "false",
             "RUNNER_TEMP": str(tmp_path),
             "RULESPEC_CHECKOUT": "rulespec-us",
@@ -5499,10 +5564,15 @@ def test_targeted_artifact_enforces_target_and_dependent_context_lanes(
             **os.environ,
             "CITATION": target_citation,
             "DEPENDENT_CITATION": dependent_citation,
+            "DEPENDENT_REVIEW_FINDING": "Preserve the dependent source.",
             "DEPENDENT_REVIEW_FINDING_PRESENT": "true",
             "PYTHONPATH": str(ROOT / "src"),
             "SECOND_DEPENDENT_CITATION": second_dependent_citation,
+            "SECOND_DEPENDENT_REVIEW_FINDING": (
+                "Preserve the second dependent source."
+            ),
             "SECOND_DEPENDENT_REVIEW_FINDING_PRESENT": "true",
+            "REVIEW_FINDING": "Preserve the target source.",
             "REVIEW_FINDING_PRESENT": "true",
             "RUNNER_TEMP": str(tmp_path),
             "RULESPEC_CHECKOUT": "rulespec-us",

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -6813,6 +6813,359 @@ def test_source_bound_louisiana_rs_dependency_accepts_archived_reasons(reason: s
     assert not _has_issue(result, "source branch a", "neither encoded")
 
 
+def test_archived_louisiana_executable_dependency_with_official_wrap_is_accepted():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-la/statute/47:295
+  deferred_outputs:
+    - output: us-la:statutes/47/295/A#individual_louisiana_income_tax_amount
+      reason: >-
+        R.S. 47:295(A) provides that the amount of the income tax imposed upon
+        the Louisiana income of every individual shall be determined in accordance
+        with R.S. 47:32. The amount cannot be computed until an executable R.S.
+        47:32 tax-amount computation accepting the applicable Louisiana income or
+        net-income tax base is encoded; the available R.S. 47:32 export supplies
+        only the individual income tax rate.
+rules: []
+"""
+    source = """\
+A. There is imposed an income tax for each taxable year upon the Louisiana income
+of every individual, whether resident or nonresident. The amount of the tax shall be
+determined in accordance with the provisions of R.S. 47:32.
+
+B. Reserved.
+"""
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+        test_cases=[],
+    )
+
+    assert not _has_issue(result, "(a)", "deferral")
+    assert not _has_issue(result, "source branch a", "neither encoded")
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        (
+            "Cannot compute the tax until an executable fictional R.S. 47:32 "
+            "tax-amount computation is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 explanatory "
+            "report is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation is encoded, but the complete computation is already "
+            "available."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation is not encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation, already encoded in the registry, is available."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation that the registry already provides is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation is unavailable."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation is missing."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation is needed."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation is required."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation, which is fully implemented, is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation which is available today is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation that is complete and available is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation that is on hand is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation which is operational is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation which is accessible is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation which is obtainable is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation which exists in the registry is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation which can already be used is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation which has already been implemented is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation which has been provided by the registry is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation which was made available by the module is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation which remains readily available is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation which can be executed is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation which can be run by the runtime is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation that the runtime already provides is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation that the implementation already contains is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation that the database supplies is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation that the API returns is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation, available now, is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation, available in the registry, is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation, implemented and ready, is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation, on hand today, is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation, readily available, is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation, immediately available, is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation that runtime already provides is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation that registry supplies is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation that our runtime provides is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation that its registry supplies is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation that PolicyEngine runtime provides is encoded."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation was encoded."
+        ),
+        (
+            "The tax was not computable until an executable R.S. 47:32 tax-amount "
+            "computation was encoded."
+        ),
+        (
+            "Cannot compute the tax until executable R.S. 47:32 tax-amount "
+            "computations were available."
+        ),
+        (
+            "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+            "computation must be encoded."
+        ),
+    ),
+)
+def test_louisiana_executable_dependency_form_remains_bounded(reason: str):
+    result = _louisiana_external_dependency_deferral(reason)
+
+    assert _has_issue(result, "(a)", "deferral", "runtime capability")
+
+
+@pytest.mark.parametrize(
+    "description",
+    (
+        "that computes the applicable tax amount",
+        "which calculates liability from the tax base",
+        "that produces the final tax amount",
+        "which returns the tax due",
+        "that uses the applicable tax base",
+        "which accesses the required rate schedule",
+        "that can compute the applicable tax amount",
+        "that will calculate liability",
+        "which must return the tax due",
+        "that is designed to compute the applicable tax amount",
+        "that accepts the income and computes the tax amount",
+        "which receives the base and returns the tax due",
+        ", available only after encoding,",
+        "which is not currently available",
+        ", not currently available,",
+        "which is conditionally available",
+        "which is available only after encoding",
+        "which may be available only after encoding",
+        "which is barely available",
+        "which is hardly available",
+        "which is theoretically available",
+        "which is supposedly available",
+        "which is available in theory only",
+        "which, when the inputs arrive, computes the tax amount",
+        "that, after receiving the base, calculates liability",
+    ),
+)
+def test_louisiana_executable_dependency_allows_capability_description(
+    description: str,
+):
+    reason = (
+        "Cannot compute the tax until an executable R.S. 47:32 tax-amount "
+        f"computation {description} is encoded."
+    )
+
+    result = _louisiana_external_dependency_deferral(reason)
+
+    assert not _has_issue(result, "(a)", "deferral")
+
+
+def test_wrapped_negated_louisiana_source_link_is_not_operative():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-la/statute/47:295
+  deferred_outputs:
+    - output: us-la:statutes/47/295/a#individual_louisiana_income_tax_amount
+      reason: >-
+        Cannot compute the tax until an executable R.S. 47:32 tax-amount
+        computation is encoded.
+rules: []
+"""
+    source = """\
+A. The tax shall not be
+determined in accordance with the provisions of R.S. 47:32.
+
+B. Reserved.
+"""
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+        test_cases=[],
+    )
+
+    assert _has_issue(result, "(a)", "deferral", "runtime capability")
+
+
+def test_whitespace_only_paragraph_break_does_not_join_louisiana_source_link():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-la/statute/47:295
+  deferred_outputs:
+    - output: us-la:statutes/47/295/a#individual_louisiana_income_tax_amount
+      reason: >-
+        Cannot compute the tax until an executable R.S. 47:32 tax-amount
+        computation is encoded.
+rules: []
+"""
+    source = (
+        "A. The amount of the tax shall be determined in accordance with\n"
+        " \n"
+        "R.S. 47:32 is mentioned only as background.\n"
+    )
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us-la/statute/47:295",
+        test_cases=[],
+    )
+
+    assert _has_issue(result, "(a)", "deferral", "runtime capability")
+
+
+def test_executable_dependency_bridge_does_not_expand_federal_deferrals():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/42/9999
+  deferred_outputs:
+    - output: us:statutes/42/9999#tax_amount
+      reason: >-
+        Cannot compute the tax until an executable 26 U.S.C. 1 tax-amount
+        computation is encoded.
+rules: []
+"""
+    source = "The amount shall be determined under 26 U.S.C. 1."
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us/statute/42/9999",
+        test_cases=[],
+    )
+
+    assert _has_issue(
+        result, "[complete-source-unit:deferral]", "module.deferred_outputs[0]"
+    )
+
+
 def test_line_wrapped_source_bound_louisiana_rs_dependency_is_accepted():
     result = _louisiana_external_dependency_deferral(
         "Cannot compute the tax until the calculation required by La. R.S. "

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1623"
+version = "0.2.1624"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- carry source-specific `review_finding` values through each canonical-refresh lane and bind exact content in signed context evidence
- accept the bounded Louisiana executable R.S. dependency form exposed by the 47:295 artifact while failing closed on contradictory, federal, documentary, negated, historical, and cross-paragraph forms
- bump Axiom Encode to 0.2.1624

## Review cycle

Two independent read-only review tracks covered the signed workflow/schema contract and the Louisiana validator grammar. All actionable findings were fixed and re-reviewed; both tracks closed with no actionable findings.

## Checks

- `uv run ruff format --check pyproject.toml src/axiom_encode scripts tests`
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- focused backfill/signing/source suites: 5,299 passed, 51 skipped
- full suite: 11,236 passed, 119 skipped