### PR TITLE
Exempt structured amendment targets from the discovery two-document cap

### DIFF
--- a/changelog.d/structured-amendment-timeline.fixed.md
+++ b/changelog.d/structured-amendment-timeline.fixed.md
@@ -1,0 +1,14 @@
+Inject the full newest-first amendment timeline when ingest metadata explicitly
+targets a consolidation document or one of its provisions. Structured targets
+are authoritative machine-readable declarations needed for legal time slices,
+including in-force amendments and forward-dated overlays; the legacy two-act cap
+now applies only to name-tier false-positive matching. The existing 12,000-body
+and 32,000-aggregate context caps remain the volume bounds. On aggregate overflow,
+name-tier documents are dropped oldest-first before any structured document;
+structured documents are dropped oldest-first only when no name-tier document
+remains, and every omission is recorded in the workspace manifest. The legacy
+name-tier-only path now also records documents omitted by its two-document and
+aggregate-context limits without changing rendered context; its known separator
+under-accounting remains tracked separately in #1432.
+
+Closes #1428.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1626"
+version = "0.2.1627"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1626"
+__version__ = "0.2.1627"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -171,6 +171,7 @@ from .harness.evals import (
     _EVAL_RESULT_ARTIFACT_SPECS,
     VALIDATION_RETRY_CANDIDATE_MAX_FILE_BYTES,
     ValidationRetryCandidate,
+    _amendment_documents_visible_in_context_manifest,
     _bind_eval_result_payload,
     _build_eval_suite_execution_identity,
     _build_eval_suite_manifest_identity,
@@ -57130,7 +57131,10 @@ def _cmd_eval_suite_revalidate_with_signer(args, evidence_signing_key):
             source_citation_path=source_citation_path,
             rulespec_dependency_roots=manifest.rulespec_dependency_roots,
             require_complete_source_unit=case.require_complete_source_unit,
-            amendment_documents=source_unit.amendment_documents,
+            amendment_documents=_amendment_documents_visible_in_context_manifest(
+                source_unit.amendment_documents,
+                Path(result.context_manifest_file),
+            ),
         )
         validation_error = _eval_artifact_validation_error(
             result.metrics,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -953,6 +953,8 @@ class EvalWorkspace:
     source_metadata: dict[str, object] | None = None
     provision_metadata_file: Path | None = None
     provision_metadata_text: str | None = None
+    amendment_documents: tuple["CorpusAmendmentDocument", ...] = ()
+    dropped_amendment_documents: tuple[dict[str, object], ...] = ()
     context_files: list[EvalContextFile] = field(default_factory=list)
     review_findings_files: list[EvalContextFile] = field(default_factory=list)
     policy_prefix: str | None = None
@@ -981,6 +983,75 @@ class CorpusAmendmentDocument:
     expression_date: str | None
     metadata: dict[str, object]
     body: str
+    match_tier: Literal["structured", "name"] = "name"
+
+
+def _amendment_documents_visible_in_context_manifest(
+    amendment_documents: Sequence[CorpusAmendmentDocument],
+    manifest_file: Path,
+) -> tuple[CorpusAmendmentDocument, ...]:
+    """Recover the amendment evidence actually visible to a persisted eval."""
+
+    try:
+        payload = json.loads(Path(manifest_file).read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            f"Eval context manifest is unreadable or malformed: {manifest_file}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"Eval context manifest must be an object: {manifest_file}")
+    context_files = payload.get("context_files", [])
+    if not isinstance(context_files, list):
+        raise ValueError(
+            f"Eval context manifest context_files must be a list: {manifest_file}"
+        )
+
+    documents_by_citation: dict[str, CorpusAmendmentDocument] = {}
+    for document in amendment_documents:
+        if document.citation_path in documents_by_citation:
+            raise ValueError(
+                "Discovered amendment documents contain duplicate citation path "
+                f"{document.citation_path!r}"
+            )
+        documents_by_citation[document.citation_path] = document
+
+    visible: list[CorpusAmendmentDocument] = []
+    seen: set[str] = set()
+    for item in context_files:
+        if not isinstance(item, dict):
+            raise ValueError(
+                f"Eval context manifest contains a malformed context item: {manifest_file}"
+            )
+        if item.get("kind") != "corpus_amendment_act":
+            continue
+        citation_path = next(
+            (
+                value
+                for key in ("citation_path", "source_path", "import_path")
+                if isinstance(value := item.get(key), str) and value
+            ),
+            None,
+        )
+        if not isinstance(citation_path, str) or not citation_path:
+            raise ValueError(
+                "Eval context manifest amendment item lacks a citation in "
+                "citation_path, source_path, or import_path: "
+                f"{manifest_file}"
+            )
+        if citation_path in seen:
+            raise ValueError(
+                "Eval context manifest repeats amendment citation path "
+                f"{citation_path!r}"
+            )
+        document = documents_by_citation.get(citation_path)
+        if document is None:
+            raise ValueError(
+                "Eval context manifest admits an unknown amendment citation path "
+                f"{citation_path!r}"
+            )
+        seen.add(citation_path)
+        visible.append(document)
+    return tuple(visible)
 
 
 @dataclass
@@ -1603,6 +1674,7 @@ def _source_metadata_with_attestation(
 _PROVISION_METADATA_LIMIT = 6_000
 _AMENDMENT_BODY_LIMIT = 12_000
 _INJECTED_CONTEXT_LIMIT = 32_000
+_AMENDMENT_CONTEXT_SEPARATOR = "\n\n"
 _MECHANICAL_METADATA_KEYS = {
     "block_count",
     "content_type",
@@ -1745,6 +1817,61 @@ def _normalized_tokens(value: object) -> tuple[str, ...]:
     return tuple(_normalized_relation_text(value).split())
 
 
+def _target_document_citation_path(
+    rows: Sequence[_corpus_resolver.ActiveCorpusBodyRow],
+    *,
+    target_citation_path: str,
+    target_source_path: str | None,
+    version: str,
+) -> str:
+    """Derive one target document root without crossing source boundaries."""
+
+    if not target_source_path:
+        return target_citation_path
+    source_paths = [
+        row.row.citation_path.split("/")
+        for row in rows
+        if row.row.source_path == target_source_path and row.row.version == version
+    ]
+    if not source_paths:
+        return target_citation_path
+    common_segments = list(source_paths[0])
+    for citation_segments in source_paths[1:]:
+        shared_width = 0
+        for left, right in zip(common_segments, citation_segments):
+            if left != right:
+                break
+            shared_width += 1
+        common_segments = common_segments[:shared_width]
+        if len(common_segments) < 3:
+            return target_citation_path
+    candidate = "/".join(common_segments)
+    if len(common_segments) >= 3 and (
+        target_citation_path == candidate
+        or target_citation_path.startswith(f"{candidate}/")
+    ):
+        return candidate
+    if candidate.startswith(f"{target_citation_path}/"):
+        return target_citation_path
+    return target_citation_path
+
+
+def _normalized_citation_path_segments(value: object) -> tuple[str, ...]:
+    """Normalize a canonical-looking citation path, rejecting prose values."""
+
+    raw_value = str(value).strip().strip("/")
+    raw_segments = raw_value.split("/")
+    if len(raw_segments) < 3 or any(
+        not segment or any(character.isspace() for character in segment)
+        for segment in raw_segments
+    ):
+        return ()
+    normalized = tuple(_normalized_relation_text(segment) for segment in raw_segments)
+    if any(not segment for segment in normalized):
+        return ()
+    return normalized
+
+
 def _is_eli_key(key: str) -> bool:
     return (
         key == "eli" or key.startswith("eli_") or key.endswith("_eli") or "_eli_" in key
@@ -1755,9 +1882,12 @@ def _target_document_identifiers(
     row: _corpus_resolver.ActiveCorpusBodyRow | None,
     *,
     target_citation_path: str,
+    target_document_citation_path: str | None = None,
     parent_document_row: _corpus_resolver.ActiveCorpusBodyRow | None = None,
 ) -> _AmendmentTargetIdentifiers:
     exact_structured = {_normalized_relation_text(target_citation_path)}
+    if target_document_citation_path:
+        exact_structured.add(_normalized_relation_text(target_document_citation_path))
     structured_phrases: set[tuple[str, ...]] = set()
     names: set[tuple[str, ...]] = set()
 
@@ -1847,6 +1977,25 @@ def _amendment_target_values(metadata: Mapping[str, Any]) -> Iterator[str]:
             yield from _amendment_target_values(value)
 
 
+def _amendment_has_structured_document_target(
+    row: _corpus_resolver.ActiveCorpusBodyRow,
+    *,
+    target_document_citation_path: str,
+) -> bool:
+    """Return whether an explicit target path names this document or a child."""
+
+    document_segments = _normalized_citation_path_segments(
+        target_document_citation_path
+    )
+    if not document_segments:
+        return False
+    for value in _amendment_target_values(row.metadata):
+        target_segments = _normalized_citation_path_segments(value)
+        if target_segments[: len(document_segments)] == document_segments:
+            return True
+    return False
+
+
 def _amendment_relates_to_target(
     row: _corpus_resolver.ActiveCorpusBodyRow,
     target_identifiers: _AmendmentTargetIdentifiers,
@@ -1904,32 +2053,79 @@ def _discover_amendment_documents(
     version: str,
 ) -> tuple[CorpusAmendmentDocument, ...]:
     target_document_key = target_source_path or target_citation_path
+    target_document_path = _target_document_citation_path(
+        rows,
+        target_citation_path=target_citation_path,
+        target_source_path=target_source_path,
+        version=version,
+    )
     target_identifiers = _target_document_identifiers(
         target_row,
         target_citation_path=target_citation_path,
+        target_document_citation_path=target_document_path,
         parent_document_row=parent_document_row,
     )
-    marked_rows = [
-        row
-        for row in rows
-        if row.row.version == version
-        and (row.row.source_path or row.row.citation_path) != target_document_key
-        and _is_amendment_row(row)
-        and _amendment_relates_to_target(row, target_identifiers)
-    ]
+    marked_rows: list[
+        tuple[_corpus_resolver.ActiveCorpusBodyRow, Literal["structured", "name"]]
+    ] = []
+    for row in rows:
+        if (
+            row.row.version != version
+            or (row.row.source_path or row.row.citation_path) == target_document_key
+            or not _is_amendment_row(row)
+        ):
+            continue
+        structured_match = _amendment_has_structured_document_target(
+            row,
+            target_document_citation_path=target_document_path,
+        )
+        if structured_match:
+            marked_rows.append((row, "structured"))
+        elif _amendment_relates_to_target(row, target_identifiers):
+            marked_rows.append((row, "name"))
+
     roots_by_document: dict[str, _corpus_resolver.ActiveCorpusBodyRow] = {}
-    for row in marked_rows:
+    tiers_by_document: dict[str, Literal["structured", "name"]] = {}
+    for row, match_tier in marked_rows:
         document_key = row.row.source_path or row.row.citation_path
+        if match_tier == "structured":
+            tiers_by_document[document_key] = "structured"
+        else:
+            tiers_by_document.setdefault(document_key, "name")
         current = roots_by_document.get(document_key)
         if current is None or (
             len(row.row.citation_path.split("/")),
             row.row.citation_path,
         ) < (len(current.row.citation_path.split("/")), current.row.citation_path):
             roots_by_document[document_key] = row
-    candidates = list(roots_by_document.values())
-    candidates.sort(
-        key=lambda row: (row.row.expression_date or "", row.row.citation_path),
-        reverse=True,
+    structured_candidates = [
+        row
+        for document_key, row in roots_by_document.items()
+        if tiers_by_document[document_key] == "structured"
+    ]
+    name_candidates = [
+        row
+        for document_key, row in roots_by_document.items()
+        if tiers_by_document[document_key] == "name"
+    ]
+    for candidates in (structured_candidates, name_candidates):
+        candidates.sort(
+            key=lambda row: (row.row.expression_date or "", row.row.citation_path),
+            reverse=True,
+        )
+
+    # Explicit ingest targets are authoritative machine-readable declarations.
+    # Legal-time-slice encoding needs the complete amendment timeline (including
+    # both in-force amendments and forward-dated overlays), so the old two-act
+    # cap remains only a false-positive guard for name-tier discovery. The 12k
+    # per-body and 32k aggregate byte caps are the volume bounds for structured
+    # evidence; name matches may fill only the legacy two-document allowance and
+    # can never displace structured context.
+    selected_rows = (
+        structured_candidates
+        + name_candidates[: max(0, 2 - len(structured_candidates))]
+        if structured_candidates
+        else name_candidates
     )
     return tuple(
         CorpusAmendmentDocument(
@@ -1940,8 +2136,9 @@ def _discover_amendment_documents(
             expression_date=row.row.expression_date,
             metadata=_curated_provision_metadata(row),
             body=row.body,
+            match_tier=tiers_by_document[row.row.source_path or row.row.citation_path],
         )
-        for row in candidates[:2]
+        for row in selected_rows
     )
 
 
@@ -1965,11 +2162,11 @@ def _render_amendment_document(
     )
 
 
-def _render_injected_context(
+def _render_legacy_name_tier_context(
     provision_metadata: dict[str, object],
     amendment_documents: Sequence[CorpusAmendmentDocument],
-) -> tuple[str, list[str]]:
-    """Render metadata and amendments under one cap, preserving newer bodies."""
+) -> tuple[str, list[str], tuple[dict[str, object], ...]]:
+    """Preserve the pre-structured rendering contract byte for byte."""
     provision_text = _render_provision_metadata(provision_metadata)
     documents = list(amendment_documents[:2])
     bodies = [
@@ -1983,6 +2180,16 @@ def _render_injected_context(
         for document, body in zip(documents, bodies, strict=True)
     ]
     overflow = len(provision_text) + sum(map(len, rendered)) - _INJECTED_CONTEXT_LIMIT
+    drop_reason = "aggregate_context_limit" if overflow > 0 else "document_count_limit"
+    dropped = tuple(
+        {
+            "citation_path": document.citation_path,
+            "expression_date": document.expression_date,
+            "match_tier": document.match_tier,
+            "reason": drop_reason,
+        }
+        for document in amendment_documents[2:]
+    )
     marker = "... [amendment body truncated to satisfy aggregate context cap]"
     for index in range(len(documents) - 1, -1, -1):
         if overflow <= 0:
@@ -2017,7 +2224,103 @@ def _render_injected_context(
             )
     if overflow > 0:
         provision_text = provision_text[: max(0, len(provision_text) - overflow)]
-    return provision_text, rendered
+    return provision_text, rendered, dropped
+
+
+@dataclass(frozen=True)
+class _RenderedInjectedContext:
+    provision_text: str
+    amendment_documents: tuple[CorpusAmendmentDocument, ...]
+    amendment_texts: tuple[str, ...]
+    dropped_amendment_documents: tuple[dict[str, object], ...] = ()
+
+
+def _render_injected_context(
+    provision_metadata: dict[str, object],
+    amendment_documents: Sequence[CorpusAmendmentDocument],
+) -> _RenderedInjectedContext:
+    """Render admitted context, dropping whole documents by binding tier order."""
+
+    if not any(document.match_tier == "structured" for document in amendment_documents):
+        provision_text, amendment_texts, dropped = _render_legacy_name_tier_context(
+            provision_metadata,
+            amendment_documents,
+        )
+        return _RenderedInjectedContext(
+            provision_text=provision_text,
+            amendment_documents=tuple(amendment_documents[:2]),
+            amendment_texts=tuple(amendment_texts),
+            dropped_amendment_documents=dropped,
+        )
+
+    provision_text = _render_provision_metadata(provision_metadata)
+
+    def utf8_size(value: str) -> int:
+        return len(value.encode("utf-8"))
+
+    retained = [
+        (
+            document,
+            _render_amendment_document(
+                document,
+                body=(
+                    document.body
+                    if utf8_size(document.body) <= _AMENDMENT_BODY_LIMIT
+                    else (
+                        "[body omitted: exceeds 12000-character amendment context cap]"
+                    )
+                ),
+            ),
+        )
+        for document in amendment_documents
+    ]
+    dropped: list[dict[str, object]] = []
+
+    # Name-tier evidence can never displace structured evidence. Within each tier,
+    # remove oldest documents first.
+    drop_order = sorted(
+        amendment_documents,
+        key=lambda document: (
+            document.match_tier == "structured",
+            document.expression_date or "",
+            document.citation_path,
+        ),
+    )
+
+    def retained_size() -> int:
+        return (
+            utf8_size(provision_text)
+            + sum(utf8_size(text) for _, text in retained)
+            + max(0, len(retained) - 1) * utf8_size(_AMENDMENT_CONTEXT_SEPARATOR)
+        )
+
+    for document in drop_order:
+        if retained_size() <= _INJECTED_CONTEXT_LIMIT:
+            break
+        retained = [
+            item for item in retained if item[0].citation_path != document.citation_path
+        ]
+        dropped.append(
+            {
+                "citation_path": document.citation_path,
+                "expression_date": document.expression_date,
+                "match_tier": document.match_tier,
+                "reason": "aggregate_context_limit",
+            }
+        )
+
+    # Provision metadata is independently bounded to 6k, so removing all
+    # amendment documents always brings this branch below the aggregate cap.
+    if (
+        retained_size() > _INJECTED_CONTEXT_LIMIT
+    ):  # pragma: no cover - defensive invariant
+        raise AssertionError("Structured amendment context cap was not enforced")
+    return _RenderedInjectedContext(
+        provision_text=provision_text,
+        amendment_documents=tuple(document for document, _ in retained),
+        amendment_texts=tuple(text for _, text in retained),
+        dropped_amendment_documents=tuple(dropped),
+    )
 
 
 def _expected_eval_source_attestation(
@@ -4182,7 +4485,10 @@ def _revalidate_persisted_eval_suite_case_results(
                 source_citation_path=source_citation_path,
                 rulespec_dependency_roots=rulespec_dependency_roots,
                 require_complete_source_unit=case.require_complete_source_unit,
-                amendment_documents=source_unit.amendment_documents,
+                amendment_documents=_amendment_documents_visible_in_context_manifest(
+                    source_unit.amendment_documents,
+                    Path(result.context_manifest_file),
+                ),
             )
         fresh_success = bool(
             fresh_metrics is not None
@@ -5586,9 +5892,10 @@ def prepare_eval_workspace(
         )
 
     provision_metadata_file: Path | None = None
-    provision_metadata_text, rendered_amendments = _render_injected_context(
+    rendered_context = _render_injected_context(
         provision_metadata or {}, amendment_documents
     )
+    provision_metadata_text = rendered_context.provision_text
     if provision_metadata_text:
         provision_metadata_file = workspace_root / "provision-metadata.txt"
         provision_metadata_file.write_text(provision_metadata_text + "\n")
@@ -5642,7 +5949,12 @@ def prepare_eval_workspace(
     context_files: list[EvalContextFile] = []
     context_root = workspace_root / "context"
     for index, (document, rendered_document) in enumerate(
-        zip(amendment_documents[:2], rendered_amendments, strict=True), start=1
+        zip(
+            rendered_context.amendment_documents,
+            rendered_context.amendment_texts,
+            strict=True,
+        ),
+        start=1,
     ):
         workspace_relative_path = Path("context") / f"amendment-act-{index}.txt"
         workspace_path = workspace_root / workspace_relative_path
@@ -5750,33 +6062,32 @@ def prepare_eval_workspace(
             )
 
     manifest_file = workspace_root / "context-manifest.json"
-    manifest_file.write_text(
-        json.dumps(
-            {
-                "citation": citation,
-                "mode": mode,
-                "policy_prefix": jurisdiction_prefix(context_corpus_root),
-                "source_text_file": str(source_text_file.relative_to(workspace_root)),
-                "source_metadata_file": (
-                    str(source_metadata_file.relative_to(workspace_root))
-                    if source_metadata_file is not None
-                    else None
-                ),
-                "source_metadata": source_metadata,
-                "provision_metadata_file": (
-                    str(provision_metadata_file.relative_to(workspace_root))
-                    if provision_metadata_file is not None
-                    else None
-                ),
-                "context_files": [
-                    _eval_context_file_manifest_payload(item) for item in context_files
-                ],
-                "review_findings_files": review_findings_evidence,
-            },
-            indent=2,
-            sort_keys=True,
+    manifest_payload: dict[str, object] = {
+        "citation": citation,
+        "mode": mode,
+        "policy_prefix": jurisdiction_prefix(context_corpus_root),
+        "source_text_file": str(source_text_file.relative_to(workspace_root)),
+        "source_metadata_file": (
+            str(source_metadata_file.relative_to(workspace_root))
+            if source_metadata_file is not None
+            else None
+        ),
+        "source_metadata": source_metadata,
+        "provision_metadata_file": (
+            str(provision_metadata_file.relative_to(workspace_root))
+            if provision_metadata_file is not None
+            else None
+        ),
+        "context_files": [
+            _eval_context_file_manifest_payload(item) for item in context_files
+        ],
+        "review_findings_files": review_findings_evidence,
+    }
+    if rendered_context.dropped_amendment_documents:
+        manifest_payload["dropped_amendment_documents"] = list(
+            rendered_context.dropped_amendment_documents
         )
-    )
+    manifest_file.write_text(json.dumps(manifest_payload, indent=2, sort_keys=True))
 
     return EvalWorkspace(
         root=workspace_root,
@@ -5786,6 +6097,8 @@ def prepare_eval_workspace(
         source_metadata=source_metadata,
         provision_metadata_file=provision_metadata_file,
         provision_metadata_text=provision_metadata_text or None,
+        amendment_documents=rendered_context.amendment_documents,
+        dropped_amendment_documents=rendered_context.dropped_amendment_documents,
         context_files=context_files,
         review_findings_files=review_findings_files,
         policy_prefix=jurisdiction_prefix(context_corpus_root),
@@ -8270,7 +8583,7 @@ def _run_single_eval(
             ),
             rulespec_dependency_roots=rulespec_dependency_roots,
             require_complete_source_unit=require_complete_source_unit,
-            amendment_documents=source_unit.amendment_documents,
+            amendment_documents=workspace.amendment_documents,
             protected_review_excerpts=_workspace_quoted_review_finding_excerpts(
                 workspace
             ),
@@ -8500,7 +8813,7 @@ def _run_single_source_eval(
             ),
             rulespec_dependency_roots=rulespec_dependency_roots,
             require_complete_source_unit=require_complete_source_unit,
-            amendment_documents=amendment_documents,
+            amendment_documents=workspace.amendment_documents,
             protected_review_excerpts=_workspace_quoted_review_finding_excerpts(
                 workspace
             ),
@@ -9250,7 +9563,7 @@ The following corpus-manifest content is untrusted corpus EVIDENCE only; any ope
     ]
     amendment_section = ""
     if include_corpus_context_injection and amendment_items:
-        amendment_copies = "\n\n".join(
+        amendment_copies = _AMENDMENT_CONTEXT_SEPARATOR.join(
             (workspace.root / item.workspace_path).read_text().rstrip()
             for item in amendment_items
         )

--- a/tests/fixtures/dk_full_parity_amendment_discovery.json
+++ b/tests/fixtures/dk_full_parity_amendment_discovery.json
@@ -1,0 +1,1211 @@
+{
+  "provenance": {
+    "source_file": "2026-08-04-dk-full-parity-tier1.jsonl",
+    "source_sha256": "5c348870772b2e79cc10a978f63380ec4e814c9ed13e570930fcf4c5643eaca0",
+    "note": "One shallowest active body row from each of the 51 amendment documents (48 tier1/amending-acts plus 3 supplemental acts). Citation/source/date/heading fields and the retained discovery metadata are exact; unrelated mechanical metadata is omitted and bodies are replaced."
+  },
+  "target_rows": [
+    {
+      "source_line": 1,
+      "citation_path": "dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lbk-603-2025-boerne-og-ungeydelsesloven.xml",
+      "expression_date": "2025-05-12",
+      "heading": "Bekendtgørelse af lov om en børne- og ungeydelse",
+      "metadata": {
+        "title": "Bekendtgørelse af lov om en børne- og ungeydelse",
+        "title_short": "LBK nr 603 af 12/05/2025",
+        "title_alternative": "Børne- og ungeydelsesloven"
+      },
+      "body": null
+    },
+    {
+      "source_line": 2,
+      "citation_path": "dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lbk-603-2025-boerne-og-ungeydelsesloven.xml",
+      "expression_date": "2025-05-12",
+      "heading": "§ 1.",
+      "metadata": {
+        "title": "Bekendtgørelse af lov om en børne- og ungeydelse",
+        "title_short": "LBK nr 603 af 12/05/2025",
+        "title_alternative": "Børne- og ungeydelsesloven"
+      },
+      "body": "Trimmed live consolidation body from JSONL line 2."
+    },
+    {
+      "source_line": 1287,
+      "citation_path": "dk/statute/lbk-724-2022/boerne-og-ungeydelsesloven",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lbk-724-2022-boerne-og-ungeydelsesloven.xml",
+      "expression_date": "2022-05-25",
+      "heading": "Bekendtgørelse af lov om en børne- og ungeydelse",
+      "metadata": {
+        "title": "Bekendtgørelse af lov om en børne- og ungeydelse",
+        "title_short": "LBK nr 724 af 25/05/2022",
+        "title_alternative": "Børne- og ungeydelsesloven"
+      },
+      "body": null
+    },
+    {
+      "source_line": 1288,
+      "citation_path": "dk/statute/lbk-724-2022/boerne-og-ungeydelsesloven/paragraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lbk-724-2022-boerne-og-ungeydelsesloven.xml",
+      "expression_date": "2022-05-25",
+      "heading": "§ 1.",
+      "metadata": {
+        "title": "Bekendtgørelse af lov om en børne- og ungeydelse",
+        "title_short": "LBK nr 724 af 25/05/2022",
+        "title_alternative": "Børne- og ungeydelsesloven"
+      },
+      "body": "Trimmed live consolidation body from JSONL line 1288."
+    },
+    {
+      "source_line": 1289,
+      "citation_path": "dk/statute/lbk-724-2022/boerne-og-ungeydelsesloven/paragraf-1-a",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lbk-724-2022-boerne-og-ungeydelsesloven.xml",
+      "expression_date": "2022-05-25",
+      "heading": "§ 1 a.",
+      "metadata": {
+        "title": "Bekendtgørelse af lov om en børne- og ungeydelse",
+        "title_short": "LBK nr 724 af 25/05/2022",
+        "title_alternative": "Børne- og ungeydelsesloven"
+      },
+      "body": "Trimmed live consolidation body from JSONL line 1289."
+    }
+  ],
+  "amendment_rows": [
+    {
+      "source_line": 1642,
+      "citation_path": "dk/statute/lov-108-2024/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-108-2024-aendringslov.xml",
+      "expression_date": "2024-01-31",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af personskatteloven (Nedsættelse af bundskatten som følge af kommunale skattestigninger)",
+        "title_short": "LOV nr 108 af 31/01/2024",
+        "source_family": "tier1/amending-acts",
+        "amends": "Personskatteloven § 6, stk. 2 (2024 bundskat rates).",
+        "amendment_targets": [
+          "dk/statute/lbk-1284-2021/personskatteloven",
+          "dk/statute/lbk-1284-2021/personskatteloven/paragraf-6"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1642."
+    },
+    {
+      "source_line": 1665,
+      "citation_path": "dk/statute/lov-1214-2024/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-1214-2024-aendringslov.xml",
+      "expression_date": "2024-11-26",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af ejendomsskatteloven, ejendomsvurderingsloven, skattekontrolloven og kildeskatteloven (Justeringer af pensionistlåneordningen til betaling af grundskyld og foreløbige beskatningsgrundlag i udstykningstilfælde m.v.)",
+        "title_short": "LOV nr 1214 af 26/11/2024",
+        "source_family": "tier1/amending-acts",
+        "amends": "Kildeskatteloven § 61, stk. 9 changes only a numeric cross-reference."
+      },
+      "body": "Trimmed live amendment body from JSONL line 1665."
+    },
+    {
+      "source_line": 1524,
+      "citation_path": "dk/statute/lov-1389-2022/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-1389-2022-aendringslov.xml",
+      "expression_date": "2022-10-05",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act; ELI not-in-force)",
+        "title": "Lov om ændring af lov om afgift af elektricitet, lov om en børne- og ungeydelse, pensionsbeskatningsloven og selskabsskatteloven (Nedsættelse af den almindelige elafgift i første halvår 2023, forhøjelse af børne- og ungeydelsen i 2023, fremrykning af forhøjelse af aldersopsparingens lave loft, udvidelse af perioden for aldersopsparingens høje loft og indførelse af skattepligt på udbytter til udenlandske stater og deres institutioner)",
+        "title_short": "LOV nr 1389 af 05/10/2022",
+        "source_family": "tier1/amending-acts",
+        "amends": "Børne- og ungeydelsesloven §§ 1 and 5 (the 2023 660 kr. uplift and payment timing) and pensionsbeskatningsloven §§ 16 and 25 A.",
+        "amendment_targets": [
+          "dk/statute/lbk-724-2022/boerne-og-ungeydelsesloven",
+          "dk/statute/lbk-724-2022/boerne-og-ungeydelsesloven/paragraf-1",
+          "dk/statute/lbk-724-2022/boerne-og-ungeydelsesloven/paragraf-5",
+          "dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven",
+          "dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1",
+          "dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-5",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven/paragraf-16",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven/paragraf-25-a"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1524."
+    },
+    {
+      "source_line": 1690,
+      "citation_path": "dk/statute/lov-1456-2024/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-1456-2024-aendringslov.xml",
+      "expression_date": "2024-12-10",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af lov om social pension og lov om Udbetaling Danmark (Permanent forhøjelse af den supplerende pensionsydelse)",
+        "title_short": "LOV nr 1456 af 10/12/2024",
+        "source_family": "tier1/amending-acts",
+        "amends": "Pensionsloven § 72 d raises the 2025 supplementary pension benefit.",
+        "amendment_targets": [
+          "dk/statute/lbk-1123-2024/pensionsloven",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-72-d"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1690."
+    },
+    {
+      "source_line": 1533,
+      "citation_path": "dk/statute/lov-1564-2023/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-1564-2023-aendringslov.xml",
+      "expression_date": "2023-12-12",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af personskatteloven, pensionsbeskatningsloven og forskellige andre love (Forhøjelse af personfradraget for personer under 18 år og klare regler for bevarelse af lavere pensionsudbetalingsalder m.v.)",
+        "title_short": "LOV nr 1564 af 12/12/2023",
+        "source_family": "tier1/amending-acts",
+        "amends": "Personskatteloven §§ 8 c, 10 and 14, including the personfradrag; pensionsbeskatningsloven §§ 2, 8, 10, 11 A, 12, 17 B, 24, 29, 29 A, 42 A and 44.",
+        "amendment_targets": [
+          "dk/statute/lbk-1284-2021/personskatteloven",
+          "dk/statute/lbk-1284-2021/personskatteloven/paragraf-8-c",
+          "dk/statute/lbk-1284-2021/personskatteloven/paragraf-10",
+          "dk/statute/lbk-1284-2021/personskatteloven/paragraf-14",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven/paragraf-2",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven/paragraf-8",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven/paragraf-10",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven/paragraf-11-a",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven/paragraf-12",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven/paragraf-17-b",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven/paragraf-24",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven/paragraf-29",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven/paragraf-29-a",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven/paragraf-42-a",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven/paragraf-44"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1533."
+    },
+    {
+      "source_line": 1797,
+      "citation_path": "dk/statute/lov-1623-2025/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-1623-2025-aendringslov.xml",
+      "expression_date": "2025-12-16",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af lov om Arbejdsmarkedets Tillægspension, lov om arbejdsskadesikring og lov om Lønmodtagernes Dyrtidsfond (Indførelse af en statslig finansieringsgaranti, bortfald af aktuarberetningen, skærpede krav til it- og cybersikkerhed for ATP og LD Fonde, ny takststruktur på arbejdsskadeområdet m.v.)",
+        "title_short": "LOV nr 1623 af 16/12/2025",
+        "source_family": "tier1/amending-acts",
+        "amends": "ATP-loven §§ 1, 2, 2 a, 2 b, 9, 9 a, 21, 23 b, new 23 d, 24 a, 27, 27 c and 32 a include the voluntary-contribution eligibility and contribution-coordination changes. Existing § 23 c anchors new § 23 d.",
+        "amendment_targets": [
+          "dk/statute/lbk-1142-2024/atp-loven",
+          "dk/statute/lbk-1142-2024/atp-loven/paragraf-1",
+          "dk/statute/lbk-1142-2024/atp-loven/paragraf-2",
+          "dk/statute/lbk-1142-2024/atp-loven/paragraf-2-a",
+          "dk/statute/lbk-1142-2024/atp-loven/paragraf-2-b",
+          "dk/statute/lbk-1142-2024/atp-loven/paragraf-9",
+          "dk/statute/lbk-1142-2024/atp-loven/paragraf-9-a",
+          "dk/statute/lbk-1142-2024/atp-loven/paragraf-21",
+          "dk/statute/lbk-1142-2024/atp-loven/paragraf-23-b",
+          "dk/statute/lbk-1142-2024/atp-loven/paragraf-23-c",
+          "dk/statute/lbk-1142-2024/atp-loven/paragraf-24-a",
+          "dk/statute/lbk-1142-2024/atp-loven/paragraf-27",
+          "dk/statute/lbk-1142-2024/atp-loven/paragraf-27-c",
+          "dk/statute/lbk-1142-2024/atp-loven/paragraf-32-a"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1797."
+    },
+    {
+      "source_line": 1833,
+      "citation_path": "dk/statute/lov-1627-2025/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-1627-2025-aendringslov.xml",
+      "expression_date": "2025-12-16",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af lov om en skattefri seniorpræmie, lov om social pension og forskellige andre love  (Forhøjelse af den skattefri seniorpræmie m.v.)",
+        "title_short": "LOV nr 1627 af 16/12/2025",
+        "source_family": "tier1/amending-acts",
+        "amends": "Of the act's broad pension cleanup, arbejdsløshedsforsikringsloven §§ 74 and 74 l are retained because they change the afterløn age and the explicit 2027 rate. Pensionsloven § 49 is retained because the act directly changes that campaign-marked payment section; other Tier-1 pension edits remain diligence prose.",
+        "amendment_targets": [
+          "dk/statute/lbk-1077-2025/arbejdsloeshedsforsikringsloven",
+          "dk/statute/lbk-1077-2025/arbejdsloeshedsforsikringsloven/paragraf-74",
+          "dk/statute/lbk-1077-2025/arbejdsloeshedsforsikringsloven/paragraf-74-l",
+          "dk/statute/lbk-1123-2024/pensionsloven",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-49"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1833."
+    },
+    {
+      "source_line": 1844,
+      "citation_path": "dk/statute/lov-1628-2025/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-1628-2025-aendringslov.xml",
+      "expression_date": "2025-12-16",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af lov om social pension og forskellige andre love (Ophør af udbetaling af forsørgelsesydelser til anbringelses- og behandlingsdømte)",
+        "title_short": "LOV nr 1628 af 16/12/2025",
+        "source_family": "tier1/amending-acts",
+        "amends": "Pensionsloven §§ 14 a, 34, 45, 46, 48 f and 52, aktivloven §§ 10 a, 25 a and 29, and børnetilskudsloven §§ 2, 3, 4 and 8 suspend support payments for specified persons under placement or treatment orders.",
+        "amendment_targets": [
+          "dk/statute/lbk-1123-2024/pensionsloven",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-14-a",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-34",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-45",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-46",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-48-f",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-52",
+          "dk/statute/lbk-1004-2025/aktivloven",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-10-a",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-25-a",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-29",
+          "dk/statute/lbk-63-2019/boernetilskudsloven",
+          "dk/statute/lbk-63-2019/boernetilskudsloven/paragraf-2",
+          "dk/statute/lbk-63-2019/boernetilskudsloven/paragraf-3",
+          "dk/statute/lbk-63-2019/boernetilskudsloven/paragraf-4",
+          "dk/statute/lbk-63-2019/boernetilskudsloven/paragraf-8"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1844."
+    },
+    {
+      "source_line": 1415,
+      "citation_path": "dk/statute/lov-1630-2025/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-1630-2025-aendringslov.xml",
+      "expression_date": "2025-12-16",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af lov om Arbejdsgivernes Uddannelsesbidrag og ligningsloven (Ændring af lønbegreb, afgørelser uden forudgående partshøring, omlægning af refusion og tilskud vedrørende oplæring i udlandet, justering af bidrag for 2026 og fastsættelse af modelparametre for 2026 m.v.)",
+        "title_short": "LOV nr 1630 af 16/12/2025",
+        "source_family": "tier1/amending-acts",
+        "amends": "Ligningsloven § 31 makes subsidies and refunds under AUB §§ 8 a and 8 b tax-free, an employer-training subject outside the campaign household tax-benefit parameters."
+      },
+      "body": "Trimmed live amendment body from JSONL line 1415."
+    },
+    {
+      "source_line": 1802,
+      "citation_path": "dk/statute/lov-1638-2025/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-1638-2025-aendringslov.xml",
+      "expression_date": "2025-12-16",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af lov om kapitalmarkeder, lov om finansiel virksomhed, lov om investeringsforeninger m.v. og forskellige andre love (Ophævelse af national prospektgrænse, delvis ophævelse af forbud mod aktieklasser i finansielle virksomheder, forsikringsselskaber og fondsmæglerselskaber, ændring af offentliggørelseskrav ved optagelse til handel på en multilateral handelsfacilitet, styrkelse af Finanstilsynets uafhængighed m.v.)",
+        "title_short": "LOV nr 1638 af 16/12/2025",
+        "source_family": "tier1/amending-acts",
+        "amends": "ATP-loven §§ 27, 27 e, new 27 n and 32 a change financial-governance and sustainability rules outside the campaign parameter surface."
+      },
+      "body": "Trimmed live amendment body from JSONL line 1802."
+    },
+    {
+      "source_line": 1323,
+      "citation_path": "dk/statute/lov-1642-2025/aendring-af-boerne-og-ungeydelsesloven-mv/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-1642-2025-aendringslov.xml",
+      "expression_date": "2025-12-16",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af lov om en børne- og ungeydelse, ligningsloven og forskellige andre love",
+        "title_short": "LOV nr 1642 af 16/12/2025",
+        "source_family": "tax-and-social-benefits/amending-acts",
+        "amends": "Lov om en børne- og ungeydelse (act § 1), ligningsloven (act § 2), pensionsbeskatningsloven (act § 6), and lov om aktiv socialpolitik (act § 9), plus five acts outside this Tier-1 scope.",
+        "amendment_targets": [
+          "dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven",
+          "dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1",
+          "dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-2",
+          "dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-4",
+          "dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-11",
+          "dk/statute/lbk-1500-2025/ligningsloven",
+          "dk/statute/lbk-1500-2025/ligningsloven/paragraf-7",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven/paragraf-38",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven/paragraf-39",
+          "dk/statute/lbk-1004-2025/aktivloven",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-14",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-33"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1323."
+    },
+    {
+      "source_line": 1853,
+      "citation_path": "dk/statute/lov-1648-2025/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-1648-2025-aendringslov.xml",
+      "expression_date": "2025-12-16",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af udlændingeloven, lov om Det Centrale Personregister og forskellige andre love (Afskæring af offentlige tilbud m.v. til udlændinge, som opholder sig ulovligt i Danmark)",
+        "title_short": "LOV nr 1648 af 16/12/2025",
+        "source_family": "tier1/amending-acts",
+        "amends": "SU-loven §§ 2, 2 f, new 2 g and 29, kildeskatteloven §§ 46, 48, 53 A and 75, and arbejdsløshedsforsikringsloven § 90 b restrict public benefits and tax handling for persons unlawfully present. Existing SU § 2 f anchors new § 2 g.",
+        "amendment_targets": [
+          "dk/statute/lbk-395-2023/su-loven",
+          "dk/statute/lbk-395-2023/su-loven/paragraf-2",
+          "dk/statute/lbk-395-2023/su-loven/paragraf-2-f",
+          "dk/statute/lbk-395-2023/su-loven/paragraf-29",
+          "dk/statute/lbk-460-2024/kildeskatteloven",
+          "dk/statute/lbk-460-2024/kildeskatteloven/paragraf-46",
+          "dk/statute/lbk-460-2024/kildeskatteloven/paragraf-48",
+          "dk/statute/lbk-460-2024/kildeskatteloven/paragraf-53-a",
+          "dk/statute/lbk-460-2024/kildeskatteloven/paragraf-75",
+          "dk/statute/lbk-1077-2025/arbejdsloeshedsforsikringsloven",
+          "dk/statute/lbk-1077-2025/arbejdsloeshedsforsikringsloven/paragraf-90-b"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1853."
+    },
+    {
+      "source_line": 1717,
+      "citation_path": "dk/statute/lov-1655-2024/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-1655-2024-aendringslov.xml",
+      "expression_date": "2024-12-30",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af lov om aktiv socialpolitik, lov om en aktiv beskæftigelsesindsats og forskellige andre love (Reform af kontanthjælpssystemet, ophævelse af 225-timersreglen og kontanthjælpsloftet, fritidstillæg til børn, afklaring, rettighedsbaseret tilskud til medicin m.v.)",
+        "title_short": "LOV nr 1655 af 30/12/2024",
+        "source_family": "tier1/amending-acts",
+        "amends": "The DK_2025 cash-assistance reform: aktivloven monetary, eligibility, threshold, cap, sanction and indexation provisions selected below, plus Tier-1 coordination blocks in unemployment, ATP, child supplement, pension, withholding tax, ligningsloven, pension tax and SU laws.",
+        "amendment_targets": [
+          "dk/statute/lbk-1004-2025/aktivloven",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-11",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-12",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-14",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-16",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-17",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-18",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-19",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-20",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-25-a",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-25-b",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-26",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-30",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-31",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-35",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-42",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-43",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-68",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-69-d",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-69-j",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-69-o",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-71",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-73-a",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-74-a",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-79",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-82-a",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-82-b",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-86",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-87",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-109",
+          "dk/statute/lbk-1077-2025/arbejdsloeshedsforsikringsloven",
+          "dk/statute/lbk-1077-2025/arbejdsloeshedsforsikringsloven/paragraf-87-a",
+          "dk/statute/lbk-1142-2024/atp-loven",
+          "dk/statute/lbk-1142-2024/atp-loven/paragraf-2-a",
+          "dk/statute/lbk-1142-2024/atp-loven/paragraf-17-s",
+          "dk/statute/lbk-63-2019/boernetilskudsloven",
+          "dk/statute/lbk-63-2019/boernetilskudsloven/paragraf-10-d",
+          "dk/statute/lbk-63-2019/boernetilskudsloven/paragraf-18",
+          "dk/statute/lbk-1123-2024/pensionsloven",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-31",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-32-a",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-32-c",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-32-d",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-46-d",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-46-f",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-46-g",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-48-a",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-48-b",
+          "dk/statute/lbk-460-2024/kildeskatteloven",
+          "dk/statute/lbk-460-2024/kildeskatteloven/paragraf-49-a",
+          "dk/statute/lbk-1500-2025/ligningsloven",
+          "dk/statute/lbk-1500-2025/ligningsloven/paragraf-7",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven/paragraf-25-a",
+          "dk/statute/lbk-395-2023/su-loven",
+          "dk/statute/lbk-395-2023/su-loven/paragraf-7"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1717."
+    },
+    {
+      "source_line": 1345,
+      "citation_path": "dk/statute/lov-1691-2024/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-1691-2024-aendringslov.xml",
+      "expression_date": "2024-12-30",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af selskabsskatteloven, aktiesparekontoloven, aktieavancebeskatningsloven, personskatteloven og forskellige andre love (Udmøntning af dele af »Aftale om Iværksætterpakken«)",
+        "title_short": "LOV nr 1691 af 30/12/2024",
+        "source_family": "tier1/amending-acts",
+        "amends": "Personskatteloven § 8 a; ligningsloven §§ 8 X, 16 A, 16 B, 16 C and 16 I; kildeskatteloven §§ 48 E and 65; and pensionsbeskatningsloven §§ 12 and 30 B.",
+        "amendment_targets": [
+          "dk/statute/lbk-1284-2021/personskatteloven",
+          "dk/statute/lbk-1284-2021/personskatteloven/paragraf-8-a",
+          "dk/statute/lbk-1500-2025/ligningsloven",
+          "dk/statute/lbk-1500-2025/ligningsloven/paragraf-8-x",
+          "dk/statute/lbk-1500-2025/ligningsloven/paragraf-16-a",
+          "dk/statute/lbk-1500-2025/ligningsloven/paragraf-16-b",
+          "dk/statute/lbk-1500-2025/ligningsloven/paragraf-16-c",
+          "dk/statute/lbk-1500-2025/ligningsloven/paragraf-16-i",
+          "dk/statute/lbk-460-2024/kildeskatteloven",
+          "dk/statute/lbk-460-2024/kildeskatteloven/paragraf-48-e",
+          "dk/statute/lbk-460-2024/kildeskatteloven/paragraf-65",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven/paragraf-12",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven/paragraf-30-b"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1345."
+    },
+    {
+      "source_line": 1671,
+      "citation_path": "dk/statute/lov-1694-2024/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-1694-2024-aendringslov.xml",
+      "expression_date": "2024-12-30",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af opkrævningsloven og forskellige andre love (Ny opkrævningsløsning for visse krav, renteharmonisering, hæftelse for kildeskat efter solvent likvidation og sikring af rentekrav ved udbetaling af refusion af kildeskat til modtagere af udbytter, renter og royalties m.v.)",
+        "title_short": "LOV nr 1694 af 30/12/2024",
+        "source_family": "tier1/amending-acts",
+        "amends": "Kildeskatteloven § 69 B interest and liability after an erroneous withholding-tax refund; a procedural recovery rule."
+      },
+      "body": "Trimmed live amendment body from JSONL line 1671."
+    },
+    {
+      "source_line": 1694,
+      "citation_path": "dk/statute/lov-1703-2024/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-1703-2024-aendringslov.xml",
+      "expression_date": "2024-12-30",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af lov om social service, lov om retssikkerhed og administration på det sociale område, lov om socialtilsyn og forskellige andre love (Ændringer som følge af ældreloven, lov om ældretilsyn og lov om lokalplejehjem og udskillelse af reglerne om madservice fra bestemmelsen om personlig og praktisk hjælp i lov om social service)",
+        "title_short": "LOV nr 1703 af 30/12/2024",
+        "source_family": "tier1/amending-acts",
+        "amends": "Care-law citation migrations in pensionsloven §§ 26 n, 33 and 38 a, arbejdsløshedsforsikringsloven §§ 48, 49, 53, 55, 56 a and 74 a, aktivloven § 75 and ligningsloven § 7; no campaign parameter changes."
+      },
+      "body": "Trimmed live amendment body from JSONL line 1694."
+    },
+    {
+      "source_line": 1645,
+      "citation_path": "dk/statute/lov-174-2024/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-174-2024-aendringslov.xml",
+      "expression_date": "2024-02-27",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act; ELI not-in-force)",
+        "title": "Lov om ændring af lov om kommunal indsats for unge under 25 år og forskellige andre love (Afskaffelse af uddannelsesparathedsvurdering, udvidelse af den sammenhængende plan for vejledning og afskaffelse af krav om studievalgsportfolio)",
+        "title_short": "LOV nr 174 af 27/02/2024",
+        "source_family": "tier1/amending-acts",
+        "amends": "Børne- og ungeydelsesloven § 2 changes only the name of the cited youth-guidance law; it does not alter a campaign eligibility value."
+      },
+      "body": "Trimmed live amendment body from JSONL line 1645."
+    },
+    {
+      "source_line": 1880,
+      "citation_path": "dk/statute/lov-1750-2025/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-1750-2025-aendringslov.xml",
+      "expression_date": "2025-12-29",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af lov om en aktiv beskæftigelsesindsats, lov om organisering og understøttelse af beskæftigelsesindsatsen m.v. og forskellige andre love (Reform af beskæftigelsesindsatsen, mere fleksible kontaktforløb og tilbud, afskaffelse af kravet om jobcentre, frihed i organisering af beskæftigelsesindsatsen, afskaffelse af ressourceforløb og revalidering m.v.)",
+        "title_short": "LOV nr 1750 af 29/12/2025",
+        "source_family": "tier1/amending-acts",
+        "amends": "From the broader employment reform, aktivloven §§ 10 e, 10 f, 10 h, 19 and 20, pensionsloven §§ 16 and 46 d, and arbejdsløshedsforsikringsloven § 87 a govern abolition and transition of campaign benefit and eligibility surfaces.",
+        "amendment_targets": [
+          "dk/statute/lbk-1004-2025/aktivloven",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-10-e",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-10-f",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-10-h",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-19",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-20",
+          "dk/statute/lbk-1123-2024/pensionsloven",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-16",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-46-d",
+          "dk/statute/lbk-1077-2025/arbejdsloeshedsforsikringsloven",
+          "dk/statute/lbk-1077-2025/arbejdsloeshedsforsikringsloven/paragraf-87-a"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1880."
+    },
+    {
+      "source_line": 1420,
+      "citation_path": "dk/statute/lov-1755-2025/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-1755-2025-aendringslov.xml",
+      "expression_date": "2025-12-29",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af erhvervsvirksomhedsloven, aktieavancebeskatningsloven og forskellige andre love (Ny mulighed for generationsskifte til en medarbejderejevirksomhed og selskabsbeskattede elaktiviteter i andelsselskaber)",
+        "title_short": "LOV nr 1755 af 29/12/2025",
+        "source_family": "tier1/amending-acts",
+        "amends": "Ligningsloven §§ 5 H and 16 A coordinate employee-ownership and cooperative-company taxation outside the campaign parameter surface."
+      },
+      "body": "Trimmed live amendment body from JSONL line 1420."
+    },
+    {
+      "source_line": 1829,
+      "citation_path": "dk/statute/lov-1757-2025/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-1757-2025-aendringslov.xml",
+      "expression_date": "2025-12-29",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af lov om vederlag og pension m.v. for ministre og pensionsbeskatningsloven (Ændring af ministres vederlæggelse som opfølgning på »Aftale om en reform af fremtidige folketingsmedlemmers og ministres vederlæggelse« og reglerne om godtgørelse til ministre for dobbelt husførelse m.v.)",
+        "title_short": "LOV nr 1757 af 29/12/2025",
+        "source_family": "tier1/amending-acts",
+        "amends": "Pensionsbeskatningsloven § 19 coordinates the special ministerial pension regime, outside the campaign household parameter surface."
+      },
+      "body": "Trimmed live amendment body from JSONL line 1829."
+    },
+    {
+      "source_line": 1430,
+      "citation_path": "dk/statute/lov-1775-2025/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-1775-2025-aendringslov.xml",
+      "expression_date": "2025-12-29",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af lov om afgift af elektricitet og ligningsloven (Nedsættelse af den almindelige elafgift i 2026 og 2027 m.v.)",
+        "title_short": "LOV nr 1775 af 29/12/2025",
+        "source_family": "tier1/amending-acts",
+        "amends": "Ligningsloven § 8 P sets the 2026-27 taxable value of renewable electricity supplied from business installations to private residences, outside the EUROMOD household campaign spine."
+      },
+      "body": "Trimmed live amendment body from JSONL line 1430."
+    },
+    {
+      "source_line": 1434,
+      "citation_path": "dk/statute/lov-1781-2025/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-1781-2025-aendringslov.xml",
+      "expression_date": "2025-12-29",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af ligningsloven (Udvidelse af medarbejderaktieordningen for nye, mindre virksomheder)",
+        "title_short": "LOV nr 1781 af 29/12/2025",
+        "source_family": "tier1/amending-acts",
+        "amends": "Ligningsloven § 7 P expands the employee-share scheme for new small companies, outside the campaign parameter surface."
+      },
+      "body": "Trimmed live amendment body from JSONL line 1434."
+    },
+    {
+      "source_line": 1400,
+      "citation_path": "dk/statute/lov-198-2025/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-198-2025-aendringslov.xml",
+      "expression_date": "2025-02-25",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af lov om aktiv socialpolitik, ligningsloven og forskellige andre love (Præcisering af retten til ydelser under kortvarige udlandsophold, afskaffelse af skærpet rådighedssanktion for aktivitetsparate m.v.)",
+        "title_short": "LOV nr 198 af 25/02/2025",
+        "source_family": "tier1/amending-acts",
+        "amends": "Among the act's broader procedural blocks, aktivloven §§ 5, 13, 14, 20, 40 a, 68, 69 j, 82 a, 82 b and 109 and ligningsloven §§ 7 and 8 O govern campaign eligibility, amount, sanction and indexation surfaces.",
+        "amendment_targets": [
+          "dk/statute/lbk-1004-2025/aktivloven",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-5",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-13",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-14",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-20",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-40-a",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-68",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-69-j",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-82-a",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-82-b",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-109",
+          "dk/statute/lbk-1500-2025/ligningsloven",
+          "dk/statute/lbk-1500-2025/ligningsloven/paragraf-7",
+          "dk/statute/lbk-1500-2025/ligningsloven/paragraf-8-o"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1400."
+    },
+    {
+      "source_line": 1335,
+      "citation_path": "dk/statute/lov-2226-2020/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-2226-2020-aendringslov.xml",
+      "expression_date": "2020-12-29",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af emballageafgiftsloven, lov om afgifter af spil, virksomhedsskatteloven og forskellige andre love (Genindførelse af emballageafgift på pvc-folier, forhøjelse af afgiftssatsen for væddemål og onlinekasino samt afskaffelse af skattefordele ved forældrekøb i virksomheds- og kapitalafkastordningerne)",
+        "title_short": "LOV nr 2226 af 29/12/2020",
+        "source_family": "tier1/amending-acts",
+        "amends": "Arbejdsmarkedsbidragsloven § 5 and kildeskatteloven §§ 26 A and 33 C. These business-income/capital-return cross-references do not set a confirmed DK_2025 campaign parameter."
+      },
+      "body": "Trimmed live amendment body from JSONL line 1335."
+    },
+    {
+      "source_line": 1514,
+      "citation_path": "dk/statute/lov-252-2022/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-252-2022-aendringslov.xml",
+      "expression_date": "2022-02-25",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af personskatteloven (Nedsættelse af bundskatten som følge af kommunale skattestigninger)",
+        "title_short": "LOV nr 252 af 25/02/2022",
+        "source_family": "tier1/amending-acts",
+        "amends": "Personskatteloven § 6, stk. 2 (2022 bundskat rates).",
+        "amendment_targets": [
+          "dk/statute/lbk-1284-2021/personskatteloven",
+          "dk/statute/lbk-1284-2021/personskatteloven/paragraf-6"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1514."
+    },
+    {
+      "source_line": 1276,
+      "citation_path": "dk/statute/lov-303-2026/aendring-af-social-pension-mv/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-303-2026-aendringslov.xml",
+      "expression_date": "2026-02-24",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af lov om social pension, lov om højeste, mellemste, forhøjet almindelig og almindelig førtidspension m.v. og forskellige andre love",
+        "title_short": "LOV nr 303 af 24/02/2026",
+        "source_family": "social-benefits/amending-acts",
+        "amends": "Lov om social pension (act § 1), lov om aktiv socialpolitik (act § 3), lov om arbejdsløshedsforsikring m.v. (act § 5), and lov om en børne- og ungeydelse (act § 9), plus six acts outside this Tier-1 scope.",
+        "amendment_targets": [
+          "dk/statute/lbk-1123-2024/pensionsloven",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-16",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-26-a",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-26-g",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-39",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-46-d",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-46-f",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-46-g",
+          "dk/statute/lbk-1004-2025/aktivloven",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-10-e",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-10-f",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-10-h",
+          "dk/statute/lbk-1077-2025/arbejdsloeshedsforsikringsloven",
+          "dk/statute/lbk-1077-2025/arbejdsloeshedsforsikringsloven/paragraf-87-a",
+          "dk/statute/lbk-1077-2025/arbejdsloeshedsforsikringsloven/paragraf-87-b",
+          "dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven",
+          "dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-4-e"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1276."
+    },
+    {
+      "source_line": 1653,
+      "citation_path": "dk/statute/lov-333-2024/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-333-2024-aendringslov.xml",
+      "expression_date": "2024-04-09",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af chokoladeafgiftsloven, kildeskatteloven og forskellige andre love (Godtgørelse af dækningsafgift i chokoladeafgiftsloven, præcisering af krav om beholdningsregnskab ved løssalg af groftskåret røgtobak, bøder ved enkeltsalg af cigaretter og manglende beholdningsregnskab, tilpasning af det afgiftspligtige vareområde for visse alkoholvarer, nulangivelse ved udbetaling af royalty til udlandet uden indeholdelse af kildeskat, mulighed for dataudstilling om visse søfarende, afskaffelse af godtgørelsesordning i spildevandsafgiftsloven, tilpasning af reglerne om sikkerhedsstempelmærker og genindførelse af register over erhvervsfiskere med B-status m.v.)",
+        "title_short": "LOV nr 333 af 09/04/2024",
+        "source_family": "tier1/amending-acts",
+        "amends": "Kildeskatteloven § 66 A reporting for royalty payments and withheld royalty tax; no household tax-benefit parameter."
+      },
+      "body": "Trimmed live amendment body from JSONL line 1653."
+    },
+    {
+      "source_line": 1437,
+      "citation_path": "dk/statute/lov-369-2025/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-369-2025-aendringslov.xml",
+      "expression_date": "2025-04-09",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af boafgiftsloven, aktieavancebeskatningsloven og forskellige andre love (Nedsættelse af boafgiften og gaveafgiften og indførelse af et retskrav på en skematisk værdiansættelse ved overdragelse af erhvervsvirksomheder til et nært familiemedlem, bedre mulighed for succession ved overdragelse af ejendomsvirksomheder og lempelse af pengetankregler m.v.)",
+        "title_short": "LOV nr 369 af 09/04/2025",
+        "source_family": "tier1/amending-acts",
+        "amends": "Kildeskatteloven §§ 33 C and 33 D, ligningsloven § 7 P and pensionsbeskatningsloven § 15 A coordinate business transfers; the act's § 13 amends older LOV 482/2024 rather than personskatteloven."
+      },
+      "body": "Trimmed live amendment body from JSONL line 1437."
+    },
+    {
+      "source_line": 1452,
+      "citation_path": "dk/statute/lov-437-2025/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-437-2025-aendringslov.xml",
+      "expression_date": "2025-05-06",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af lov om arbejdsløshedsforsikring m.v. og barselsloven (Udvidet ret til dagpenge til iværksættere og bagatelgrænse for arbejde i selvstændig virksomhed med fulde barselsdagpenge)",
+        "title_short": "LOV nr 437 af 06/05/2025",
+        "source_family": "tier1/amending-acts",
+        "amends": "Arbejdsløshedsforsikringsloven §§ 49, new 49 a, 51 a, 53 and 53 a expand entrepreneurs' earnings-related unemployment-benefit eligibility. Existing § 49 anchors the new § 49 a.",
+        "amendment_targets": [
+          "dk/statute/lbk-1077-2025/arbejdsloeshedsforsikringsloven",
+          "dk/statute/lbk-1077-2025/arbejdsloeshedsforsikringsloven/paragraf-49",
+          "dk/statute/lbk-1077-2025/arbejdsloeshedsforsikringsloven/paragraf-51-a",
+          "dk/statute/lbk-1077-2025/arbejdsloeshedsforsikringsloven/paragraf-53",
+          "dk/statute/lbk-1077-2025/arbejdsloeshedsforsikringsloven/paragraf-53-a"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1452."
+    },
+    {
+      "source_line": 1456,
+      "citation_path": "dk/statute/lov-469-2025/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-469-2025-aendringslov.xml",
+      "expression_date": "2025-05-14",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af en række love på børne- og undervisningsområdet, socialområdet, det familieretlige område, skatteområdet, beskæftigelsesområdet, udlændinge- og integrationsområdet og ældreområdet (Forbud mod anvendelse af personer under 18 år som tolke m.v.)",
+        "title_short": "LOV nr 469 af 14/05/2025",
+        "source_family": "tier1/amending-acts",
+        "amends": "Pensionsloven new § 57 a, arbejdsløshedsforsikringsloven new § 100 e and aktivloven new § 8 b establish an interpreter-use prohibition; they do not set a campaign tax-benefit parameter."
+      },
+      "body": "Trimmed live amendment body from JSONL line 1456."
+    },
+    {
+      "source_line": 1312,
+      "citation_path": "dk/statute/lov-482-2024/reform-af-personskat/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-482-2024-personskattereform.xml",
+      "expression_date": "2024-05-22",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af personskatteloven, ligningsloven og forskellige andre love",
+        "title_short": "LOV nr 482 af 22/05/2024",
+        "source_family": "personal-income-tax/amending-acts",
+        "amends": "Personskatteloven (act § 1), ligningsloven (act § 2), lov om en børne- og ungeydelse (act § 4), and pensionsbeskatningsloven (act § 7), plus five acts outside this Tier-1 scope. Act § 4 changes \"topskat\" to \"mellemskat\" in børne- og ungeydelsesloven § 1 a, stk. 1, 1. pkt., and stk. 2.",
+        "amendment_targets": [
+          "dk/statute/lbk-1284-2021/personskatteloven",
+          "dk/statute/lbk-1284-2021/personskatteloven/paragraf-5",
+          "dk/statute/lbk-1284-2021/personskatteloven/paragraf-7",
+          "dk/statute/lbk-1284-2021/personskatteloven/paragraf-7-a",
+          "dk/statute/lbk-1284-2021/personskatteloven/paragraf-8",
+          "dk/statute/lbk-1284-2021/personskatteloven/paragraf-13",
+          "dk/statute/lbk-1284-2021/personskatteloven/paragraf-26",
+          "dk/statute/lbk-1500-2025/ligningsloven",
+          "dk/statute/lbk-1500-2025/ligningsloven/paragraf-9-j",
+          "dk/statute/lbk-724-2022/boerne-og-ungeydelsesloven",
+          "dk/statute/lbk-724-2022/boerne-og-ungeydelsesloven/paragraf-1-a",
+          "dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven",
+          "dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1-a",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven/paragraf-42-a",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven/paragraf-49-a",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven/paragraf-49-c"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1312."
+    },
+    {
+      "source_line": 1517,
+      "citation_path": "dk/statute/lov-546-2022/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-546-2022-aendringslov.xml",
+      "expression_date": "2022-05-03",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af lov om midlertidig opholdstilladelse til personer, der er fordrevet fra Ukraine, lov om individuel boligstøtte, lov om børnetilskud og forskudsvis udbetaling af børnebidrag og integrationsloven (Kommunal indkvartering og forplejning og tilpasning af regler på integrationsområdet, børne- og undervisningsområdet, social- og ældreområdet, indenrigs- og boligområdet og sundhedsområdet som følge af modtagelse af personer, der er fordrevet fra Ukraine)",
+        "title_short": "LOV nr 546 af 03/05/2022",
+        "source_family": "tier1/amending-acts",
+        "amends": "Børnetilskudsloven §§ 5 and 10 a extend eligibility to specified Ukraine/Afghanistan temporary-permit holders.",
+        "amendment_targets": [
+          "dk/statute/lbk-63-2019/boernetilskudsloven",
+          "dk/statute/lbk-63-2019/boernetilskudsloven/paragraf-5",
+          "dk/statute/lbk-63-2019/boernetilskudsloven/paragraf-10-a"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1517."
+    },
+    {
+      "source_line": 1751,
+      "citation_path": "dk/statute/lov-562-2025/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-562-2025-aendringslov.xml",
+      "expression_date": "2025-05-27",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af ejendomsskatteloven, ejendomsvurderingsloven og forskellige andre love (Alternativer til anvendelse af ejendomsværdier til beskatningsformål for landbrugs- og skovejendomme samt erhvervsejendomme, grundskyld og dækningsafgift i visse udstykningstilfælde m.v.)",
+        "title_short": "LOV nr 562 af 27/05/2025",
+        "source_family": "tier1/amending-acts",
+        "amends": "Kildeskatteloven §§ 33 C and 33 D and ligningsloven §§ 14, 15 J and 15 K coordinate property valuation and tax; these are outside the campaign household parameter spine."
+      },
+      "body": "Trimmed live amendment body from JSONL line 1751."
+    },
+    {
+      "source_line": 1530,
+      "citation_path": "dk/statute/lov-610-2023/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-610-2023-aendringslov.xml",
+      "expression_date": "2023-05-31",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af personskatteloven (Nedsættelse af bundskatten som følge af kommunale skattestigninger)",
+        "title_short": "LOV nr 610 af 31/05/2023",
+        "source_family": "tier1/amending-acts",
+        "amends": "Personskatteloven § 6, stk. 2 (2023 bundskat rates).",
+        "amendment_targets": [
+          "dk/statute/lbk-1284-2021/personskatteloven",
+          "dk/statute/lbk-1284-2021/personskatteloven/paragraf-6"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1530."
+    },
+    {
+      "source_line": 1903,
+      "citation_path": "dk/statute/lov-615-2026/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-615-2026-aendringslov.xml",
+      "expression_date": "2026-06-30",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af ejendomsvurderingsloven, ejendomsskatteloven og forskellige andre love (Samlet ejendomskategori for landbrugs-, skov- og naturejendomme, forenkling af ejendomsvurderingerne for 2026 og 2027 og lempeligere ejendomsbeskatningsgrundlag for kolonihavegrunde m.v.)",
+        "title_short": "LOV nr 615 af 30/06/2026",
+        "source_family": "tier1/amending-acts",
+        "amends": "Presumptive PSL-chain act: kildeskatteloven § 33 C, ligningsloven §§ 14, 15 J and 15 K, pensionsbeskatningsloven § 15 A and personskatteloven § 4.",
+        "amendment_targets": [
+          "dk/statute/lbk-460-2024/kildeskatteloven",
+          "dk/statute/lbk-460-2024/kildeskatteloven/paragraf-33-c",
+          "dk/statute/lbk-1500-2025/ligningsloven",
+          "dk/statute/lbk-1500-2025/ligningsloven/paragraf-14",
+          "dk/statute/lbk-1500-2025/ligningsloven/paragraf-15-j",
+          "dk/statute/lbk-1500-2025/ligningsloven/paragraf-15-k",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven",
+          "dk/statute/lbk-1243-2024/pensionsbeskatningsloven/paragraf-15-a",
+          "dk/statute/lbk-1284-2021/personskatteloven",
+          "dk/statute/lbk-1284-2021/personskatteloven/paragraf-4"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1903."
+    },
+    {
+      "source_line": 1920,
+      "citation_path": "dk/statute/lov-616-2026/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-616-2026-aendringslov.xml",
+      "expression_date": "2026-06-30",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af ligningsloven og lov om en aktiv beskæftigelsesindsats (Forhøjelse af befordringsfradraget for indkomståret 2026 og forhøjelse af befordringsgodtgørelsen efter § 175 i lov om en aktiv beskæftigelsesindsats for andet halvår 2026)",
+        "title_short": "LOV nr 616 af 30/06/2026",
+        "source_family": "tier1/amending-acts",
+        "amends": "Ligningsloven § 9 C changes the 2026 befordringsfradrag value.",
+        "amendment_targets": [
+          "dk/statute/lbk-1500-2025/ligningsloven",
+          "dk/statute/lbk-1500-2025/ligningsloven/paragraf-9-c"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1920."
+    },
+    {
+      "source_line": 1355,
+      "citation_path": "dk/statute/lov-630-2024/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-630-2024-aendringslov.xml",
+      "expression_date": "2024-06-11",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af lov om arbejdsløshedsforsikring m.v., lov om aktiv socialpolitik, lov om social pension og forskellige andre love (Neutralisering af virkning på indkomstoverførsler som følge af afskaffelse af en helligdag)",
+        "title_short": "LOV nr 630 af 11/06/2024",
+        "source_family": "tier1/amending-acts",
+        "amends": "Arbejdsløshedsforsikringsloven §§ 47, 70 and 74 l, aktivloven § 109, pensionsloven §§ 49, 49 a and 49 b, and SU-loven § 12 neutralize the income-transfer effect of abolishing a public holiday.",
+        "amendment_targets": [
+          "dk/statute/lbk-1077-2025/arbejdsloeshedsforsikringsloven",
+          "dk/statute/lbk-1077-2025/arbejdsloeshedsforsikringsloven/paragraf-47",
+          "dk/statute/lbk-1077-2025/arbejdsloeshedsforsikringsloven/paragraf-70",
+          "dk/statute/lbk-1077-2025/arbejdsloeshedsforsikringsloven/paragraf-74-l",
+          "dk/statute/lbk-1004-2025/aktivloven",
+          "dk/statute/lbk-1004-2025/aktivloven/paragraf-109",
+          "dk/statute/lbk-1123-2024/pensionsloven",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-49",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-49-a",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-49-b",
+          "dk/statute/lbk-395-2023/su-loven",
+          "dk/statute/lbk-395-2023/su-loven/paragraf-12"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1355."
+    },
+    {
+      "source_line": 1368,
+      "citation_path": "dk/statute/lov-632-2024/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-632-2024-aendringslov.xml",
+      "expression_date": "2024-06-11",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af lov om social pension og forskellige andre love (Fradragsret for indbetalinger til aldersforsikring, aldersopsparing og supplerende engangssum i indtægtsgrundlaget ved beregning af visse sociale ydelser)",
+        "title_short": "LOV nr 632 af 11/06/2024",
+        "source_family": "tier1/amending-acts",
+        "amends": "Pensionsloven §§ 29, 32 a, 39 b and 39 c, børne- og ungeydelsesloven § 1 a, and SU-loven §§ 23, 24 and 26 add deductions for specified retirement-account contributions to benefit income bases.",
+        "amendment_targets": [
+          "dk/statute/lbk-1123-2024/pensionsloven",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-29",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-32-a",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-39-b",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-39-c",
+          "dk/statute/lbk-724-2022/boerne-og-ungeydelsesloven",
+          "dk/statute/lbk-724-2022/boerne-og-ungeydelsesloven/paragraf-1-a",
+          "dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven",
+          "dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-1-a",
+          "dk/statute/lbk-395-2023/su-loven",
+          "dk/statute/lbk-395-2023/su-loven/paragraf-23",
+          "dk/statute/lbk-395-2023/su-loven/paragraf-24",
+          "dk/statute/lbk-395-2023/su-loven/paragraf-26"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1368."
+    },
+    {
+      "source_line": 1377,
+      "citation_path": "dk/statute/lov-665-2024/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-665-2024-aendringslov.xml",
+      "expression_date": "2024-06-11",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af straffeloven, retsplejeloven og forskellige andre love (Gennemførelse af dele af bandepakke IV)",
+        "title_short": "LOV nr 665 af 11/06/2024",
+        "source_family": "tier1/amending-acts",
+        "amends": "Børne- og ungeydelsesloven inserts § 4 e after § 4 d: a payment-disqualification rule tied to specified criminal convictions. Historical LBK 724 therefore uses its extant § 4 d insertion anchor.",
+        "amendment_targets": [
+          "dk/statute/lbk-724-2022/boerne-og-ungeydelsesloven",
+          "dk/statute/lbk-724-2022/boerne-og-ungeydelsesloven/paragraf-4-d",
+          "dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven",
+          "dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven/paragraf-4-e"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1377."
+    },
+    {
+      "source_line": 1777,
+      "citation_path": "dk/statute/lov-674-2025/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-674-2025-aendringslov.xml",
+      "expression_date": "2025-06-17",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af SU-loven (Minimumskrav til dokumentation m.v. ved ansøgning om SU-handicaptillæg, anvendelse af kunstig intelligens til understøttelse af sagsbehandling m.v.)",
+        "title_short": "LOV nr 674 af 17/06/2025",
+        "source_family": "tier1/amending-acts",
+        "amends": "SU-loven §§ 1 and 10 a and new § 39 a govern handicaptillæg eligibility, documentation and decision support. The extant § 39 is the insertion anchor because § 39 a is absent from the Tier-1 base.",
+        "amendment_targets": [
+          "dk/statute/lbk-395-2023/su-loven",
+          "dk/statute/lbk-395-2023/su-loven/paragraf-1",
+          "dk/statute/lbk-395-2023/su-loven/paragraf-10-a",
+          "dk/statute/lbk-395-2023/su-loven/paragraf-39"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1777."
+    },
+    {
+      "source_line": 1541,
+      "citation_path": "dk/statute/lov-679-2023/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-679-2023-aendringslov.xml",
+      "expression_date": "2023-06-03",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af kildeskatteloven, lov om kommunal indkomstskat, ejendomsvurderingsloven og forskellige andre love  (Opkrævning og inddrivelse af grundskyld og dækningsafgift m.v., statens afregning af grundskyld og dækningsafgift til kommunerne, foreløbige vurderinger som midlertidigt beskatningsgrundlag i 2024 og 2025, forenkling af ejendomsvurderingerne for 2024 og 2025, udvidelse af antallet af dommere i Landsskatteretten m.v.)",
+        "title_short": "LOV nr 679 af 03/06/2023",
+        "source_family": "tier1/amending-acts",
+        "amends": "Presumptive PSL-chain act: personskatteloven §§ 4, 6, 8 and 12; arbejdsmarkedsbidragsloven § 2; relevant ligningsloven § 16; and pensionsloven §§ 14 c and 72 d. Property-tax-administration provisions in kildeskatteloven and aktivloven § 85 a are recorded at their Tier-1 roots without diligence-only child targets.",
+        "amendment_targets": [
+          "dk/statute/lbk-1284-2021/personskatteloven",
+          "dk/statute/lbk-1284-2021/personskatteloven/paragraf-4",
+          "dk/statute/lbk-1284-2021/personskatteloven/paragraf-6",
+          "dk/statute/lbk-1284-2021/personskatteloven/paragraf-8",
+          "dk/statute/lbk-1284-2021/personskatteloven/paragraf-12",
+          "dk/statute/lbk-121-2020/arbejdsmarkedsbidragsloven",
+          "dk/statute/lbk-121-2020/arbejdsmarkedsbidragsloven/paragraf-2",
+          "dk/statute/lbk-1500-2025/ligningsloven",
+          "dk/statute/lbk-1500-2025/ligningsloven/paragraf-16",
+          "dk/statute/lbk-1123-2024/pensionsloven",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-14-c",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-72-d",
+          "dk/statute/lbk-460-2024/kildeskatteloven",
+          "dk/statute/lbk-1004-2025/aktivloven"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1541."
+    },
+    {
+      "source_line": 1389,
+      "citation_path": "dk/statute/lov-685-2024/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-685-2024-aendringslov.xml",
+      "expression_date": "2024-06-11",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af SU-loven (Reform af SU-systemet på det videregående uddannelsesområde)",
+        "title_short": "LOV nr 685 af 11/06/2024",
+        "source_family": "tier1/amending-acts",
+        "amends": "SU-loven §§ 16, 17 and 21 change the grant-period eligibility and duration rules for higher education.",
+        "amendment_targets": [
+          "dk/statute/lbk-395-2023/su-loven",
+          "dk/statute/lbk-395-2023/su-loven/paragraf-16",
+          "dk/statute/lbk-395-2023/su-loven/paragraf-17",
+          "dk/statute/lbk-395-2023/su-loven/paragraf-21"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1389."
+    },
+    {
+      "source_line": 1509,
+      "citation_path": "dk/statute/lov-703-2025/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-703-2025-aendringslov.xml",
+      "expression_date": "2025-06-20",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af lov om social pension, lov om arbejdsskadesikring og lov om afgift af bidraget til Arbejdsmarkedets Erhvervssikring og af arbejdsulykkeserstatninger m.v. (Regulering af folkepensionsalderen og ændring af revisionsbestemmelse m.v.)",
+        "title_short": "LOV nr 703 af 20/06/2025",
+        "source_family": "tier1/amending-acts",
+        "amends": "Pensionsloven §§ 1 a and 72 e set the later folkepensionsalder by birth cohort and change its statutory review schedule.",
+        "amendment_targets": [
+          "dk/statute/lbk-1123-2024/pensionsloven",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-1-a",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-72-e"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1509."
+    },
+    {
+      "source_line": 1747,
+      "citation_path": "dk/statute/lov-704-2025/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-704-2025-aendringslov.xml",
+      "expression_date": "2025-06-20",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af lov om social pension og lov om højeste, mellemste, forhøjet almindelig og almindelig førtidspension m.v. (Forhøjelse af mediecheck)",
+        "title_short": "LOV nr 704 af 20/06/2025",
+        "source_family": "tier1/amending-acts",
+        "amends": "Pensionsloven § 49 raises the mediecheck amount.",
+        "amendment_targets": [
+          "dk/statute/lbk-1123-2024/pensionsloven",
+          "dk/statute/lbk-1123-2024/pensionsloven/paragraf-49"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1747."
+    },
+    {
+      "source_line": 1788,
+      "citation_path": "dk/statute/lov-711-2025/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-711-2025-aendringslov.xml",
+      "expression_date": "2025-06-20",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af lov om forsikringsvirksomhed, lov om betalinger, lov om etablering af statsgaranti på en del af ejendomskreditaftalerne i landdistrikterne og forskellige andre love (Tværgående pensionskassers og forsikringsselskabers adgang til at eje og drive skov, vilkår for adgang til betalingssystemer for udbydere af betalingstjenester og etablering af statsgaranti på en del af ejendomskreditaftalerne i landdistrikterne m.v.)",
+        "title_short": "LOV nr 711 af 20/06/2025",
+        "source_family": "tier1/amending-acts",
+        "amends": "ATP-loven §§ 24 a, 24 d, 25, 26, 26 b, 27 c and 32 a change governance and investment rules, not a campaign benefit or contribution parameter."
+      },
+      "body": "Trimmed live amendment body from JSONL line 1788."
+    },
+    {
+      "source_line": 1819,
+      "citation_path": "dk/statute/lov-730-2025/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-730-2025-aendringslov.xml",
+      "expression_date": "2025-06-20",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af retsplejeloven og forskellige andre love (Kreditorforfølgning i pensionsordninger for konfiskationskrav og erstatningskrav m.v. som følge af visse strafbare handlinger, der har medført et udbytte, m.v.)",
+        "title_short": "LOV nr 730 af 20/06/2025",
+        "source_family": "tier1/amending-acts",
+        "amends": "Pensionsbeskatningsloven §§ 25 A, 29, 30 and 38 change creditor and confiscation treatment of pension arrangements, not campaign amounts or eligibility."
+      },
+      "body": "Trimmed live amendment body from JSONL line 1819."
+    },
+    {
+      "source_line": 1409,
+      "citation_path": "dk/statute/lov-749-2025/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-749-2025-aendringslov.xml",
+      "expression_date": "2025-06-20",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af ligningsloven, afskrivningsloven, opkrævningsloven og skatteindberetningsloven (Lempelse af beskatningen af aktionærlån og ændring af reglerne om beskatning af løbende ydelser)",
+        "title_short": "LOV nr 749 af 20/06/2025",
+        "source_family": "tier1/amending-acts",
+        "amends": "Ligningsloven §§ 7 O, 12 B and 16 E change shareholder-loan and recurring-payment taxation outside the campaign household parameter spine."
+      },
+      "body": "Trimmed live amendment body from JSONL line 1409."
+    },
+    {
+      "source_line": 1769,
+      "citation_path": "dk/statute/lov-750-2025/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-750-2025-aendringslov.xml",
+      "expression_date": "2025-06-20",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af minimumsbeskatningsloven, selskabsskatteloven, skattekontrolloven og forskellige andre love (Tilpasning til OECD’s administrative retningslinjer om minimumsbeskatningsreglerne, lempelse af reglerne om transfer pricing-dokumentation, aflønning af kvalificerede distributører i visse lande og justering af reglerne om omkvalifikation af transparente enheder, begrænset skattepligt af renter, indeholdelse af renteskat og royaltyskat, international sambeskatning og oplysningspligt m.v.)",
+        "title_short": "LOV nr 750 af 20/06/2025",
+        "source_family": "tier1/amending-acts",
+        "amends": "Kildeskatteloven §§ 65 C, 65 D and 66 A and ligningsloven §§ 2, 2 A, new 2 B and 5 H concern international, withholding and transfer-pricing rules outside the campaign household parameter surface."
+      },
+      "body": "Trimmed live amendment body from JSONL line 1769."
+    },
+    {
+      "source_line": 1588,
+      "citation_path": "dk/statute/lov-753-2023/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-753-2023-aendringslov.xml",
+      "expression_date": "2023-06-13",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af lov om social service, lov om retssikkerhed og administration på det sociale område og forskellige andre love (Ændringer som følge af barnets lov, initiativret for adopterede børn, adoption uden samtykke fra fødslen, samvær med børn på kvindekrisecentre m.v. og fasttrack for godkendelse af plejefamilier m.v.)",
+        "title_short": "LOV nr 753 af 13/06/2023",
+        "source_family": "tier1/amending-acts",
+        "amends": "Technical serviceloven-to-barnets-lov citation migrations in børnetilskudsloven §§ 5 and 8, aktivloven §§ 13 f, 22, 23, 25, 32, 68 a, 69 j, 75 and 96, pensionsloven §§ 26 n, 26 s and 38 a, arbejdsløshedsforsikringsloven §§ 48, 49, 53, 55, 56 a and 74 a, ATP-loven § 2 a, ligningsloven §§ 7 and 9, pensionsbeskatningsloven § 19, børne- og ungeydelsesloven §§ 2 and 4, and kildeskatteloven § 49 A."
+      },
+      "body": "Trimmed live amendment body from JSONL line 1588."
+    },
+    {
+      "source_line": 1780,
+      "citation_path": "dk/statute/lov-754-2025/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-754-2025-aendringslov.xml",
+      "expression_date": "2025-06-20",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af universitetsloven, lov om akkreditering af videregående uddannelsesinstitutioner og forskellige andre love (Kandidatuddannelse på 75 ECTS-point, nye erhvervskandidatuddannelser og andre elementer fra aftale om reform af universitetsuddannelserne i Danmark m.v.)",
+        "title_short": "LOV nr 754 af 20/06/2025",
+        "source_family": "tier1/amending-acts",
+        "amends": "Arbejdsløshedsforsikringsloven §§ 54 and 62 a and SU-loven §§ 1, 5 and 24 coordinate benefit and SU eligibility for reformed university degrees.",
+        "amendment_targets": [
+          "dk/statute/lbk-1077-2025/arbejdsloeshedsforsikringsloven",
+          "dk/statute/lbk-1077-2025/arbejdsloeshedsforsikringsloven/paragraf-54",
+          "dk/statute/lbk-1077-2025/arbejdsloeshedsforsikringsloven/paragraf-62-a",
+          "dk/statute/lbk-395-2023/su-loven",
+          "dk/statute/lbk-395-2023/su-loven/paragraf-1",
+          "dk/statute/lbk-395-2023/su-loven/paragraf-5",
+          "dk/statute/lbk-395-2023/su-loven/paragraf-24"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1780."
+    },
+    {
+      "source_line": 1392,
+      "citation_path": "dk/statute/lov-96-2025/aendringslov/aendringcentreretparagraf-1",
+      "source_path": "sources/dk/statute/2026-08-04-dk-full-parity-tier1/eli/dk-lov-96-2025-aendringslov.xml",
+      "expression_date": "2025-02-04",
+      "heading": "§ 1",
+      "metadata": {
+        "document_type": "ændringslov (amendment act)",
+        "title": "Lov om ændring af arbejdsmarkedsbidragsloven og forskellige andre love (Unges fritagelse for arbejdsmarkedsbidrag m.v.)",
+        "title_short": "LOV nr 96 af 04/02/2025",
+        "source_family": "tier1/amending-acts",
+        "amends": "Arbejdsmarkedsbidragsloven § 1 creates the age-based contribution exemption. Separately, ligningsloven § 7 exempts specified institution-paid student expenses from tax.",
+        "amendment_targets": [
+          "dk/statute/lbk-121-2020/arbejdsmarkedsbidragsloven",
+          "dk/statute/lbk-121-2020/arbejdsmarkedsbidragsloven/paragraf-1",
+          "dk/statute/lbk-1500-2025/ligningsloven",
+          "dk/statute/lbk-1500-2025/ligningsloven/paragraf-7"
+        ]
+      },
+      "body": "Trimmed live amendment body from JSONL line 1392."
+    }
+  ]
+}

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1626"
+ENCODER_VERSION = "0.2.1627"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -295,6 +295,7 @@ from axiom_encode.harness.encoding_db import (
 )
 from axiom_encode.harness.eval_evidence import EVAL_EVIDENCE_PRIVATE_KEY_ENV
 from axiom_encode.harness.evals import (
+    CorpusAmendmentDocument,
     CorpusSourceUnit,
     EvalArtifactMetrics,
     _bind_eval_result_payload,
@@ -4525,7 +4526,27 @@ class TestCmdEvalSuiteRevalidate:
         trace_file = source_output / "trace.json"
         context_manifest_file = source_output / "context.json"
         trace_file.write_text("{}\n")
-        context_manifest_file.write_text("{}\n")
+        context_manifest_file.write_text(
+            json.dumps(
+                {
+                    "context_files": [
+                        {
+                            "kind": "corpus_amendment_act",
+                            "source_path": "us/statute/amendment-visible",
+                            "workspace_path": "context/amendment-act-1.txt",
+                            "import_path": "us/statute/amendment-visible",
+                        }
+                    ],
+                    "dropped_amendment_documents": [
+                        {
+                            "citation_path": "us/statute/amendment-dropped",
+                            "reason": "aggregate_context_limit",
+                        }
+                    ],
+                }
+            )
+            + "\n"
+        )
         (source_output / "suite-run.json").write_text(
             json.dumps(
                 {
@@ -4737,7 +4758,24 @@ class TestCmdEvalSuiteRevalidate:
                     body="authoritative source text",
                     citation_path="us/statute/7/2014/e/6/A",
                     requested="us/statute/7/2014/e/6/A",
-                    amendment_documents=("attached-amendment",),
+                    amendment_documents=(
+                        CorpusAmendmentDocument(
+                            citation_path="us/statute/amendment-visible",
+                            title="Visible amendment",
+                            expression_date="2026-01-01",
+                            metadata={},
+                            body="Visible amendment body.",
+                            match_tier="structured",
+                        ),
+                        CorpusAmendmentDocument(
+                            citation_path="us/statute/amendment-dropped",
+                            title="Dropped amendment",
+                            expression_date="2025-01-01",
+                            metadata={},
+                            body="Dropped amendment body.",
+                            match_tier="structured",
+                        ),
+                    ),
                     source_attestation=_complete_source_attestation(
                         "us/statute/7/2014/e/6/A"
                     ),
@@ -4772,9 +4810,10 @@ class TestCmdEvalSuiteRevalidate:
             dependency_root
         ]
         assert mock_eval.call_args.kwargs["require_complete_source_unit"] is True
-        assert mock_eval.call_args.kwargs["amendment_documents"] == (
-            "attached-amendment",
-        )
+        assert tuple(
+            document.citation_path
+            for document in mock_eval.call_args.kwargs["amendment_documents"]
+        ) == ("us/statute/amendment-visible",)
         ledger = json.loads((source_output / "suite-results.jsonl").read_text())
         assert ledger["result"]["metrics"]["compile_pass"] is compile_pass
         assert ledger["result"]["metrics"]["ci_pass"] is ci_pass

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -207,6 +207,12 @@ def _mock_generalist_reviewer(monkeypatch):
 
 _TEST_CORPUS_RELEASE_NAME = "eval-test-release"
 _TEST_CORPUS_VERSION = "2026-eval-test"
+_DK_FULL_PARITY_AMENDMENT_FIXTURE = (
+    Path(__file__).parent / "fixtures" / "dk_full_parity_amendment_discovery.json"
+)
+_DK_FULL_PARITY_CORPUS_SHA256 = (
+    "5c348870772b2e79cc10a978f63380ec4e814c9ed13e570930fcf4c5643eaca0"
+)
 
 
 def _canonical_rulespec_content_root(base: Path, jurisdiction: str) -> Path:
@@ -326,6 +332,21 @@ def _write_test_corpus_provision(
         tmp_path,
         [{"citation_path": citation_path, "body": body}],
     )
+
+
+def _dk_full_parity_amendment_fixture_rows() -> list[dict[str, object]]:
+    """Load the trimmed 48+3 amendment-act discovery corpus."""
+
+    payload = json.loads(_DK_FULL_PARITY_AMENDMENT_FIXTURE.read_text())
+    assert payload["provenance"]["source_sha256"] == _DK_FULL_PARITY_CORPUS_SHA256
+    amendment_rows = payload["amendment_rows"]
+    assert len(amendment_rows) == 51
+    rows: list[dict[str, object]] = []
+    for fixture_row in [*payload["target_rows"], *amendment_rows]:
+        row = dict(fixture_row)
+        row.pop("source_line")
+        rows.append(row)
+    return rows
 
 
 def _write_test_source_unit(
@@ -986,6 +1007,61 @@ def test_provision_inherits_document_identifiers_for_de_amendment_discovery(tmp_
     assert provision.amendment_documents == document.amendment_documents
 
 
+def test_dk_full_parity_structured_amendment_timelines_are_exhaustive(tmp_path):
+    """Pin every relevant structured match among the live 48+3 amendment acts."""
+
+    release = _write_test_corpus_release(
+        tmp_path,
+        _dk_full_parity_amendment_fixture_rows(),
+    )
+    target_724 = "dk/statute/lbk-724-2022/boerne-og-ungeydelsesloven"
+    target_603 = "dk/statute/lbk-603-2025/boerne-og-ungeydelsesloven"
+    expected_724 = [
+        "dk/statute/lov-665-2024/aendringslov/aendringcentreretparagraf-1",
+        "dk/statute/lov-632-2024/aendringslov/aendringcentreretparagraf-1",
+        ("dk/statute/lov-482-2024/reform-af-personskat/aendringcentreretparagraf-1"),
+        "dk/statute/lov-1389-2022/aendringslov/aendringcentreretparagraf-1",
+    ]
+    expected_603 = [
+        (
+            "dk/statute/lov-303-2026/aendring-af-social-pension-mv/"
+            "aendringcentreretparagraf-1"
+        ),
+        (
+            "dk/statute/lov-1642-2025/aendring-af-boerne-og-ungeydelsesloven-mv/"
+            "aendringcentreretparagraf-1"
+        ),
+        *expected_724,
+    ]
+
+    root_724 = resolve_corpus_source_unit(target_724, release)
+    provision_724 = resolve_corpus_source_unit(
+        f"{target_724}/paragraf-1-a",
+        release,
+    )
+    root_603 = resolve_corpus_source_unit(target_603, release)
+
+    for source_unit, expected in (
+        (root_724, expected_724),
+        (provision_724, expected_724),
+        (root_603, expected_603),
+    ):
+        assert [
+            (document.citation_path, document.match_tier)
+            for document in source_unit.amendment_documents
+        ] == [(citation_path, "structured") for citation_path in expected]
+        workspace, _prompt = _workspace_prompt_for_source_unit(tmp_path, source_unit)
+        assert [
+            item.citation_path
+            for item in workspace.context_files
+            if item.kind == "corpus_amendment_act"
+        ] == expected
+
+    # Issue #1275 inheritance must expose the document timeline to a provision
+    # at the same depth as the shallowest active sibling row.
+    assert provision_724.amendment_documents == root_724.amendment_documents
+
+
 def test_provision_identifier_inheritance_does_not_cross_source_documents(tmp_path):
     release = _write_test_corpus_release(
         tmp_path,
@@ -1482,6 +1558,123 @@ def test_workspace_without_manifest_metadata_stays_minimal(tmp_path):
     assert prompt == prompt_without_injection_feature
 
 
+def test_name_tier_workspace_remains_byte_identical_at_legacy_two_document_cap(
+    tmp_path,
+):
+    amendments = tuple(
+        CorpusAmendmentDocument(
+            citation_path=f"dk/statute/amendment-{year}",
+            title=f"Name Amendment {year}",
+            expression_date=f"{year}-01-01",
+            metadata={"source_note": f"note-{year}"},
+            body=f"Body {year}.",
+            match_tier="name",
+        )
+        for year in (2027, 2026, 2025, 2024)
+    )
+    workspace = prepare_eval_workspace(
+        citation="dk/statute/benefit/section-1",
+        runner=parse_runner_spec("openai:gpt-5.4"),
+        output_root=tmp_path / "out",
+        source_text="Provision.",
+        axiom_rules_path=_canonical_rulespec_content_root(tmp_path, "dk"),
+        mode="cold",
+        provision_metadata={"title": "Target"},
+        amendment_documents=amendments,
+        extra_context_paths=[],
+    )
+    amendment_items = [
+        item for item in workspace.context_files if item.kind == "corpus_amendment_act"
+    ]
+    manifest_bytes = workspace.manifest_file.read_bytes()
+    manifest = json.loads(manifest_bytes)
+
+    assert [item.citation_path for item in amendment_items] == [
+        "dk/statute/amendment-2027",
+        "dk/statute/amendment-2026",
+    ]
+    assert workspace.amendment_documents == amendments[:2]
+    expected_drops = tuple(
+        {
+            "citation_path": f"dk/statute/amendment-{year}",
+            "expression_date": f"{year}-01-01",
+            "match_tier": "name",
+            "reason": "document_count_limit",
+        }
+        for year in (2025, 2024)
+    )
+    assert workspace.dropped_amendment_documents == expected_drops
+    assert manifest["dropped_amendment_documents"] == list(expected_drops)
+    assert hashlib.sha256(manifest_bytes).hexdigest() == (
+        "17e2f84c82ccc1a3944e83348d6d125408e919126b629c6c9104b4f639bb532c"
+    )
+    assert [
+        hashlib.sha256((workspace.root / item.workspace_path).read_bytes()).hexdigest()
+        for item in amendment_items
+    ] == [
+        "f50ca5de1f2a93844982fa10b160cca5239d911a31452a4ae05b2aed71599ea6",
+        "613163fdb740b3f32deeafb1019f502ac9ac5e359b9d53c2d91c1489a876e591",
+    ]
+
+
+def test_name_tier_legacy_budget_records_sliced_document_without_changing_bytes():
+    first_two = tuple(
+        CorpusAmendmentDocument(
+            citation_path=f"n{year}",
+            title=f"Name Amendment {year}",
+            expression_date=f"{year}-01-01",
+            metadata={"detail": letter * 6_500},
+            body=letter * 11_500,
+            match_tier="name",
+        )
+        for year, letter in ((2027, "N"), (2026, "O"))
+    )
+    omitted = CorpusAmendmentDocument(
+        citation_path="n2025",
+        title="Name Amendment 2025",
+        expression_date="2025-01-01",
+        metadata={"detail": "P" * 6_500},
+        body="P" * 11_500,
+        match_tier="name",
+    )
+
+    rendered = evals_module._render_injected_context({}, (*first_two, omitted))
+    legacy_provision, legacy_texts, _ = evals_module._render_legacy_name_tier_context(
+        {}, first_two
+    )
+
+    assert rendered.provision_text == legacy_provision
+    assert rendered.amendment_texts == tuple(legacy_texts)
+    assert rendered.amendment_documents == first_two
+    assert rendered.dropped_amendment_documents == (
+        {
+            "citation_path": "n2025",
+            "expression_date": "2025-01-01",
+            "match_tier": "name",
+            "reason": "aggregate_context_limit",
+        },
+    )
+
+
+def test_name_tier_exactly_two_documents_records_no_omissions():
+    amendments = tuple(
+        CorpusAmendmentDocument(
+            citation_path=f"n{year}",
+            title=f"Name Amendment {year}",
+            expression_date=f"{year}-01-01",
+            metadata={},
+            body="Body.",
+            match_tier="name",
+        )
+        for year in (2027, 2026)
+    )
+
+    rendered = evals_module._render_injected_context({}, amendments)
+
+    assert rendered.amendment_documents == amendments
+    assert rendered.dropped_amendment_documents == ()
+
+
 def test_injected_context_enforces_aggregate_character_cap_newest_last(tmp_path):
     amendments = tuple(
         CorpusAmendmentDocument(
@@ -1520,6 +1713,205 @@ def test_injected_context_enforces_aggregate_character_cap_newest_last(tmp_path)
         "amendment body truncated to satisfy aggregate context cap"
         in amendment_texts[1]
     )
+
+
+def test_structured_aggregate_cap_drops_oldest_document_and_records_manifest(
+    tmp_path,
+):
+    amendments = tuple(
+        CorpusAmendmentDocument(
+            citation_path=f"dk/statute/amendment-{year}",
+            title=f"Structured Amendment {year}",
+            expression_date=f"{year}-01-01",
+            metadata={},
+            body=letter * 11_500,
+            match_tier="structured",
+        )
+        for year, letter in ((2027, "N"), (2026, "O"), (2025, "P"))
+    )
+    workspace = prepare_eval_workspace(
+        citation="dk/statute/benefit/section-1",
+        runner=parse_runner_spec("openai:gpt-5.4"),
+        output_root=tmp_path / "out",
+        source_text="Provision.",
+        axiom_rules_path=_canonical_rulespec_content_root(tmp_path, "dk"),
+        mode="cold",
+        amendment_documents=amendments,
+        extra_context_paths=[],
+    )
+    amendment_items = [
+        item for item in workspace.context_files if item.kind == "corpus_amendment_act"
+    ]
+    amendment_texts = [
+        (workspace.root / item.workspace_path).read_text().rstrip("\n")
+        for item in amendment_items
+    ]
+    manifest = json.loads(workspace.manifest_file.read_text())
+    expected_drop = {
+        "citation_path": "dk/statute/amendment-2025",
+        "expression_date": "2025-01-01",
+        "match_tier": "structured",
+        "reason": "aggregate_context_limit",
+    }
+
+    assert [item.citation_path for item in amendment_items] == [
+        "dk/statute/amendment-2027",
+        "dk/statute/amendment-2026",
+    ]
+    assert (
+        len((workspace.provision_metadata_text or "").encode("utf-8"))
+        + sum(len(text.encode("utf-8")) for text in amendment_texts)
+        <= 32_000
+    )
+    assert "N" * 11_500 in amendment_texts[0]
+    assert "O" * 11_500 in amendment_texts[1]
+    assert all("aggregate context cap" not in text for text in amendment_texts)
+    assert workspace.dropped_amendment_documents == (expected_drop,)
+    assert manifest["dropped_amendment_documents"] == [expected_drop]
+    assert (
+        evals_module._amendment_documents_visible_in_context_manifest(
+            amendments,
+            workspace.manifest_file,
+        )
+        == amendments[:2]
+    )
+
+
+def test_structured_aggregate_cap_drops_name_tier_before_structured(tmp_path):
+    amendments = (
+        CorpusAmendmentDocument(
+            citation_path="dk/statute/structured-2025",
+            title="Structured Amendment 2025",
+            expression_date="2025-01-01",
+            metadata={"detail": "S" * 6_500},
+            body="S" * 11_500,
+            match_tier="structured",
+        ),
+        CorpusAmendmentDocument(
+            citation_path="dk/statute/name-2027",
+            title="Name Amendment 2027",
+            expression_date="2027-01-01",
+            metadata={"detail": "N" * 6_500},
+            body="N" * 11_500,
+            match_tier="name",
+        ),
+    )
+    workspace = prepare_eval_workspace(
+        citation="dk/statute/benefit/section-1",
+        runner=parse_runner_spec("openai:gpt-5.4"),
+        output_root=tmp_path / "out",
+        source_text="Provision.",
+        axiom_rules_path=_canonical_rulespec_content_root(tmp_path, "dk"),
+        mode="cold",
+        amendment_documents=amendments,
+        extra_context_paths=[],
+    )
+
+    assert [
+        item.citation_path
+        for item in workspace.context_files
+        if item.kind == "corpus_amendment_act"
+    ] == ["dk/statute/structured-2025"]
+    assert workspace.dropped_amendment_documents == (
+        {
+            "citation_path": "dk/statute/name-2027",
+            "expression_date": "2027-01-01",
+            "match_tier": "name",
+            "reason": "aggregate_context_limit",
+        },
+    )
+
+
+def test_structured_aggregate_cap_never_retains_name_after_structured_drop():
+    amendments = (
+        CorpusAmendmentDocument(
+            citation_path="dk/statute/structured-2025",
+            title="Structured Amendment 2025",
+            expression_date="2025-01-01",
+            metadata={"detail": "S" * 6_500},
+            body="S" * 11_500,
+            match_tier="structured",
+        ),
+        CorpusAmendmentDocument(
+            citation_path="dk/statute/name-2027",
+            title="Name Amendment 2027",
+            expression_date="2027-01-01",
+            metadata={"detail": "N" * 6_500},
+            body="N" * 11_500,
+            match_tier="name",
+        ),
+        CorpusAmendmentDocument(
+            citation_path="dk/statute/structured-2024",
+            title="Structured Amendment 2024",
+            expression_date="2024-01-01",
+            metadata={"detail": "O" * 6_500},
+            body="O" * 11_500,
+            match_tier="structured",
+        ),
+    )
+
+    rendered = evals_module._render_injected_context({}, amendments)
+    dropped_structured = any(
+        item["match_tier"] == "structured"
+        for item in rendered.dropped_amendment_documents
+    )
+    retained_name = any(
+        document.match_tier == "name" for document in rendered.amendment_documents
+    )
+
+    assert dropped_structured
+    assert not retained_name
+    assert rendered.dropped_amendment_documents[0]["match_tier"] == "name"
+
+
+def test_structured_aggregate_cap_accounts_for_prompt_join_separator():
+    first_two = tuple(
+        CorpusAmendmentDocument(
+            citation_path=f"dk/statute/amendment-{year}",
+            title=f"Amendment {year}",
+            expression_date=f"{year}-01-01",
+            metadata={},
+            body=letter * 10_000,
+            match_tier="structured",
+        )
+        for year, letter in ((2027, "A"), (2026, "B"))
+    )
+    rendered_first_two = tuple(
+        evals_module._render_amendment_document(document, body=document.body)
+        for document in first_two
+    )
+    empty_third = CorpusAmendmentDocument(
+        citation_path="dk/statute/amendment-2025",
+        title="Amendment 2025",
+        expression_date="2025-01-01",
+        metadata={},
+        body="",
+        match_tier="structured",
+    )
+    empty_third_text = evals_module._render_amendment_document(empty_third, body="")
+    third_body_bytes = (
+        31_997 - sum(map(len, rendered_first_two)) - len(empty_third_text)
+    )
+    assert 0 < third_body_bytes <= 12_000
+    third = replace(empty_third, body="C" * third_body_bytes)
+    amendments = (*first_two, third)
+    pre_fix_texts = tuple(
+        evals_module._render_amendment_document(document, body=document.body)
+        for document in amendments
+    )
+    assert sum(len(text.encode("utf-8")) for text in pre_fix_texts) == 31_997
+    assert (
+        len(evals_module._AMENDMENT_CONTEXT_SEPARATOR.join(pre_fix_texts).encode())
+        == 32_001
+    )
+
+    rendered = evals_module._render_injected_context({}, amendments)
+    post_join = evals_module._AMENDMENT_CONTEXT_SEPARATOR.join(rendered.amendment_texts)
+
+    assert len(post_join.encode("utf-8")) <= 32_000
+    assert [item["citation_path"] for item in rendered.dropped_amendment_documents] == [
+        "dk/statute/amendment-2025"
+    ]
 
 
 def test_provision_metadata_rendering_enforces_character_cap(tmp_path):
@@ -21428,6 +21820,9 @@ def _run_case_revalidation(
     fresh: EvalArtifactMetrics | None,
     *,
     require_complete_source_unit: bool = False,
+    amendment_documents: tuple[CorpusAmendmentDocument, ...] = (),
+    visible_amendment_citations: tuple[str, ...] = (),
+    historical_amendment_manifest: bool = False,
     **result_overrides,
 ):
     case = evals_module.EvalSuiteCase(
@@ -21439,33 +21834,67 @@ def _run_case_revalidation(
     )
     source_unit = SimpleNamespace(
         body="The rate of VAT is 20 percent.",
-        amendment_documents=(),
+        amendment_documents=amendment_documents,
     )
-    with (
-        patch.object(
-            evals_module, "resolve_corpus_source_unit", return_value=source_unit
-        ),
-        patch.object(
-            evals_module, "_source_metadata_with_attestation", return_value={}
-        ),
-        patch.object(
-            evals_module,
-            "_source_metadata_citation_path",
-            return_value="uk/statute/ukpga/1994/23/2",
-        ),
-        patch.object(
-            evals_module, "evaluate_artifact", return_value=fresh
-        ) as evaluate_mock,
-    ):
-        evals_module._revalidate_persisted_eval_suite_case_results(
-            case,
-            [_revalidation_result(persisted, **result_overrides)],
-            policy_repo_root=Path("/nonexistent/policy"),
-            axiom_rules_path=Path("/nonexistent/engine"),
-            corpus_release=SimpleNamespace(),
-            policyengine_runtime=None,
-            rulespec_dependency_roots=(),
+    with tempfile.TemporaryDirectory() as tmpdir:
+        context_manifest = Path(tmpdir) / "context.json"
+        context_manifest.write_text(
+            json.dumps(
+                {
+                    "context_files": [
+                        (
+                            {
+                                "kind": "corpus_amendment_act",
+                                "source_path": citation,
+                                "workspace_path": "context/amendment-act-1.txt",
+                                "import_path": citation,
+                            }
+                            if historical_amendment_manifest
+                            else {
+                                "kind": "corpus_amendment_act",
+                                "citation_path": citation,
+                            }
+                        )
+                        for citation in visible_amendment_citations
+                    ],
+                    "dropped_amendment_documents": [
+                        {
+                            "citation_path": document.citation_path,
+                            "reason": "aggregate_context_limit",
+                        }
+                        for document in amendment_documents
+                        if document.citation_path not in visible_amendment_citations
+                    ],
+                }
+            )
         )
+        result = _revalidation_result(persisted, **result_overrides)
+        result.context_manifest_file = str(context_manifest)
+        with (
+            patch.object(
+                evals_module, "resolve_corpus_source_unit", return_value=source_unit
+            ),
+            patch.object(
+                evals_module, "_source_metadata_with_attestation", return_value={}
+            ),
+            patch.object(
+                evals_module,
+                "_source_metadata_citation_path",
+                return_value="uk/statute/ukpga/1994/23/2",
+            ),
+            patch.object(
+                evals_module, "evaluate_artifact", return_value=fresh
+            ) as evaluate_mock,
+        ):
+            evals_module._revalidate_persisted_eval_suite_case_results(
+                case,
+                [result],
+                policy_repo_root=Path("/nonexistent/policy"),
+                axiom_rules_path=Path("/nonexistent/engine"),
+                corpus_release=SimpleNamespace(),
+                policyengine_runtime=None,
+                rulespec_dependency_roots=(),
+            )
     return evaluate_mock
 
 
@@ -21492,6 +21921,54 @@ def test_persisted_revalidation_keeps_complete_source_unit_mode():
     )
 
     assert evaluate_mock.call_args.kwargs["require_complete_source_unit"] is True
+
+
+def test_persisted_revalidation_uses_only_manifest_visible_amendments():
+    metrics = _revalidation_metrics()
+    amendments = tuple(
+        CorpusAmendmentDocument(
+            citation_path=f"dk/statute/amendment-{year}",
+            title=f"Amendment {year}",
+            expression_date=f"{year}-01-01",
+            metadata={},
+            body="Body.",
+            match_tier="structured",
+        )
+        for year in (2027, 2026, 2025)
+    )
+
+    evaluate_mock = _run_case_revalidation(
+        metrics,
+        metrics,
+        amendment_documents=amendments,
+        visible_amendment_citations=tuple(
+            document.citation_path for document in amendments[:2]
+        ),
+    )
+
+    assert evaluate_mock.call_args.kwargs["amendment_documents"] == amendments[:2]
+
+
+def test_persisted_revalidation_accepts_historical_amendment_manifest_schema():
+    metrics = _revalidation_metrics()
+    amendment = CorpusAmendmentDocument(
+        citation_path="dk/statute/amendment-1",
+        title="Amendment 1",
+        expression_date="2026-01-01",
+        metadata={},
+        body="Body.",
+        match_tier="structured",
+    )
+
+    evaluate_mock = _run_case_revalidation(
+        metrics,
+        metrics,
+        amendment_documents=(amendment,),
+        visible_amendment_citations=(amendment.citation_path,),
+        historical_amendment_manifest=True,
+    )
+
+    assert evaluate_mock.call_args.kwargs["amendment_documents"] == (amendment,)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1626"
+ENCODER_VERSION = "0.2.1627"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1626"
+ENCODER_VERSION = "0.2.1627"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1626"
+ENCODER_VERSION = "0.2.1627"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1626"
+ENCODER_VERSION = "0.2.1627"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1626"
+ENCODER_VERSION = "0.2.1627"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1626"
+ENCODER_VERSION = "0.2.1627"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1626"')
+        .startswith('__version__ = "0.2.1627"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1626"
+    assert encoder_package["version"] == "0.2.1627"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1626"
+    assert project["project"]["version"] == "0.2.1627"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1626"')
+        .startswith('__version__ = "0.2.1627"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1626"
+    assert encoder_package["version"] == "0.2.1627"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1626"
+    assert project["project"]["version"] == "0.2.1627"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1626"')
+        .startswith('__version__ = "0.2.1627"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1626"
+ENCODER_VERSION = "0.2.1627"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1626"
+version = "0.2.1627"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Defect (#1428, found by the dk D0 audit)

A composed corpus scope legitimately carries two consolidations of one act (dk: LBK 603/2025 current + LBK 724/2022 historical — the DK_2025 legal time slice). Name-tier matching treats both as the same law, so the newest-first two-document cap displaced the amendments that structurally target the older consolidation: LBK 724 targets discovered LOV 303 + LOV 1642 (structured matches of LBK 603) and dropped every explicit LBK 724 target. Reproduced against origin/main with a fixture trimmed from the live composed rows (SHA-verified against the jsonl: 56 rows, retained metadata exact including key-presence).

## Fix

Amendment rows are partitioned per target document into STRUCTURED (`amendment_targets`/structured fields contain the target document's citation path or a child of it, segment-aware normalized document-prefix matching) vs NAME-TIER:

- **All structured matches are injected**, newest-first — the two-document cap does not apply to them. The 12k per-document and 32k aggregate UTF-8 byte caps (join separators counted at admission; post-join length provably ≤ 32k) are the only volume bounds.
- On aggregate overflow, **name-tier documents are evicted first** (oldest first); structured documents only when no name-tier remains, oldest first — a name-tier document never survives an overflow that evicted structured evidence (the #1428 ruling addendum). Every drop is recorded in the context manifest (`dropped_amendment_documents`) with its tier — never silent.
- Name-tier matches fill remaining slots only up to the legacy cap of two total documents and only when structured matches number fewer than two — name-tier can never displace structured context.
- Corpora with no structured targets anywhere behave byte-identically to before (regression-pinned).

Revalidation (persisted-suite and signer-backed CLI paths) recovers exactly the amendment set visible in the persisted context manifest, so re-validation judges the evidence the generation actually saw rather than today's discovery result. Historical manifests that predate `citation_path` resolve via `source_path` → `import_path` fallback (fail-closed only when no identifying field exists) — both paths tested against the historical schema.

## Live-data results

Before (origin/main), every target discovered `303 + 1642`. After:

| Target | Discovered, newest-first |
|---|---|
| LBK 724 root | LOV 665/2024, LOV 632/2024, LOV 482/2024, LOV 1389/2022 |
| LBK 724 § 1 a (provision-level, #1275 inheritance) | identical to root |
| LBK 603 root | LOV 303/2026, LOV 1642/2025, LOV 665/2024, LOV 632/2024, LOV 482/2024, LOV 1389/2022 |

For legal-time-slice encoding the historical consolidation needs its full amendment timeline (724 → 665 + 632 + 482 covers the in-force 2024 amendments and the forward-dated overlay); the 2-cap was a name-tier-era false-positive heuristic — byte caps are the real bound.

## Checks

`ruff check` + `ruff format --check` clean; full `tests/test_evals.py` 745 passed; CLI revalidation + ratchet focused selections green at 0.2.1625; adversarial reproductions from the clean-context audit (mixed-tier displacement, historical-schema revalidation, separator-boundary overflow, hostile prefix fixtures) re-run post-fix; exits captured unmasked.

Closes #1428

🤖 Generated with [Claude Code](https://claude.com/claude-code)
