### PR TITLE
Fix complete-source boundary and relational witness validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1625"
+version = "0.2.1626"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1625"
+__version__ = "0.2.1626"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -195,6 +195,7 @@ class _ExceptionWitness:
     boolean_effect: bool
     zeroes: bool
     numeric_transition: tuple[float, float] | None
+    relational_transitions: tuple[tuple[str, str, str], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -15395,9 +15396,6 @@ def _branch_boundary_test_witnesses(
     )
     for rule_name in _rules_covering_branch(branch, principal_rule_paths):
         rule = principal_rules[rule_name]
-        selector_names = _rule_numeric_selector_names(rule)
-        if not selector_names:
-            continue
         for case in asserted_by_rule.get(rule_name, ()):
             dependency_environment = _case_asserted_dependency_environment(
                 principal_rules,
@@ -15410,45 +15408,101 @@ def _branch_boundary_test_witnesses(
                 formula_environment=formula_environment,
                 dependency_environment=dependency_environment,
             )
-            if execution is not None and any(
-                numeric_value_is_grounded(value, (boundary,))
-                and _formula_execution_references_names(
-                    execution,
-                    input_names,
-                )
-                and _formula_execution_binds_boundary(
-                    execution,
-                    boundary,
-                    input_names=input_names,
-                    formula_environment=execution.constant_environment,
-                    source_interval=source_interval,
-                    source_boolean_polarity=source_boolean_polarity,
-                    extract_numeric_occurrences=(extract_numeric_occurrences),
-                    numeric_value_is_grounded=(numeric_value_is_grounded),
-                )
-                and _boundary_case_changes_formula_effect(
-                    rule,
-                    case,
-                    input_key=input_key,
-                    selector_names=input_names,
-                    boundary_value=value,
-                    execution=execution,
-                    principal_rules=principal_rules,
-                    dependency_names=set(dependency_environment),
-                    formula_environment=formula_environment or {},
-                    source_interval=source_interval,
-                    source_boolean_polarity=source_boolean_polarity,
-                )
-                for input_key, input_names, value in (
-                    _case_numeric_selector_evidence(
-                        case,
-                        selector_names,
-                        dependency_environment=dependency_environment,
-                    )
-                )
+            if execution is None:
+                continue
+            for (
+                controller_rule,
+                controller_execution,
+            ) in _asserted_reached_rule_executions(
+                rule,
+                execution,
+                principal_rules=principal_rules,
+                case=case,
+                dependency_environment=dependency_environment,
+                formula_environment=formula_environment or {},
             ):
-                witnesses.add((rule_name, f"case:{id(case)}"))
+                selector_names = _rule_numeric_selector_names(controller_rule)
+                if selector_names and any(
+                    numeric_value_is_grounded(value, (boundary,))
+                    and _formula_execution_references_names(
+                        controller_execution,
+                        input_names,
+                    )
+                    and _formula_execution_binds_boundary(
+                        controller_execution,
+                        boundary,
+                        input_names=input_names,
+                        formula_environment=(controller_execution.constant_environment),
+                        source_interval=source_interval,
+                        source_boolean_polarity=source_boolean_polarity,
+                        extract_numeric_occurrences=(extract_numeric_occurrences),
+                        numeric_value_is_grounded=(numeric_value_is_grounded),
+                    )
+                    and _boundary_case_changes_formula_effect(
+                        controller_rule,
+                        case,
+                        input_key=input_key,
+                        selector_names=input_names,
+                        boundary_value=value,
+                        execution=controller_execution,
+                        principal_rules=principal_rules,
+                        dependency_names=set(dependency_environment),
+                        formula_environment=formula_environment or {},
+                        source_interval=source_interval,
+                        source_boolean_polarity=source_boolean_polarity,
+                    )
+                    for input_key, input_names, value in (
+                        _case_numeric_selector_evidence(
+                            case,
+                            selector_names,
+                            dependency_environment=dependency_environment,
+                        )
+                    )
+                ):
+                    witnesses.add((rule_name, f"case:{id(case)}"))
+                    break
     return witnesses
+
+
+def _asserted_reached_rule_executions(
+    root_rule: dict[str, Any],
+    root_execution: _FormulaExecution,
+    *,
+    principal_rules: dict[str, dict[str, Any]],
+    case: dict[str, Any],
+    dependency_environment: dict[str, Any],
+    formula_environment: dict[str, Any],
+) -> tuple[tuple[dict[str, Any], _FormulaExecution], ...]:
+    """Return the root and asserted local dependencies its reached path uses."""
+
+    reached: list[tuple[dict[str, Any], _FormulaExecution]] = [
+        (root_rule, root_execution)
+    ]
+    pending = [root_execution]
+    seen_names: set[str] = set()
+    while pending:
+        parent_execution = pending.pop()
+        for name in sorted(set(dependency_environment) - seen_names):
+            if not _formula_execution_references_names(parent_execution, {name}):
+                continue
+            dependency_rule = principal_rules.get(name)
+            if dependency_rule is None:
+                continue
+            dependency_execution = _case_formula_execution(
+                dependency_rule,
+                case,
+                formula_environment=formula_environment,
+                dependency_environment=dependency_environment,
+            )
+            if dependency_execution is None or not _formula_runtime_values_equal(
+                _formula_execution_runtime_value(dependency_execution),
+                dependency_environment[name],
+            ):
+                continue
+            seen_names.add(name)
+            reached.append((dependency_rule, dependency_execution))
+            pending.append(dependency_execution)
+    return tuple(reached)
 
 
 def _branch_boundary_has_test_evidence(
@@ -17899,6 +17953,17 @@ def _numeric_exception_witness_matches_source(
     *,
     extract_numeric_occurrences: NumericOccurrenceExtractor,
 ) -> bool:
+    condition_text = _source_exception_condition_text(branch.text)
+    if any(
+        _source_relational_exception_matches(
+            condition_text,
+            left_name=left_name,
+            relation=relation,
+            right_name=right_name,
+        )
+        for left_name, relation, right_name in witness.relational_transitions
+    ):
+        return True
     transition = witness.numeric_transition
     if transition is None:
         return False
@@ -17912,6 +17977,65 @@ def _numeric_exception_witness_matches_source(
     return not _interval_contains(interval, ordinary_value) and _interval_contains(
         interval, exception_value
     )
+
+
+def _source_relational_exception_matches(
+    text: str,
+    *,
+    left_name: str,
+    relation: str,
+    right_name: str,
+) -> bool:
+    """Match a reached formula relation to a source-stated relational trigger."""
+
+    if relation == "<":
+        left_name, relation, right_name = right_name, ">", left_name
+    elif relation == "<=":
+        left_name, relation, right_name = right_name, ">=", left_name
+    collapsed = _collapse_text(text).lower()
+    relation_match = re.search(
+        r"\b(?:exceeds?\s+or\s+equals?|is\s+(?:greater|more)\s+than\s+or\s+equal\s+to)\b",
+        collapsed,
+    )
+    source_relation = ">=" if relation_match is not None else None
+    if relation_match is None:
+        relation_match = re.search(
+            r"\b(?:exceeds?|is\s+(?:greater|more)\s+than|übersteigt)\b",
+            collapsed,
+        )
+        source_relation = ">" if relation_match is not None else None
+    if relation_match is None:
+        return False
+    left_matches = _source_relational_operand_matches(collapsed, left_name)
+    right_matches = _source_relational_operand_matches(collapsed, right_name)
+    return source_relation == relation and any(
+        left.end() <= relation_match.start()
+        and relation_match.end() <= right.start()
+        and relation_match.start() - left.end() <= 240
+        and right.start() - relation_match.end() <= 240
+        for left in left_matches
+        for right in right_matches
+    )
+
+
+def _source_relational_operand_matches(
+    text: str,
+    name: str,
+) -> tuple[re.Match[str], ...]:
+    normalized = _normalized_selector_name(name)
+    aliases = {
+        "credit": r"\bcredit\b",
+        "liability": r"\b(?:liabilit\w*|tax(?:es)?\s+(?:due|owed)|amount\s+of\s+(?:the\s+)?tax)\b",
+    }
+    matches = list(_source_selector_concept_matches(text, normalized))
+    matches.extend(
+        match
+        for concept, pattern in aliases.items()
+        for match in re.finditer(pattern, text)
+        if concept in normalized
+    )
+    unique = {(match.start(), match.end(), match.group(0)): match for match in matches}
+    return tuple(unique[key] for key in sorted(unique))
 
 
 def _normalized_selector_name(name: str) -> str:
@@ -18119,9 +18243,12 @@ def _toggled_formula_numeric_selectors(
         selector_names = _rule_numeric_selector_names(rule)
         for left_index, left_case in enumerate(asserted_by_rule.get(rule_name, ())):
             for right_case in asserted_by_rule[rule_name][left_index + 1 :]:
-                if _normalized_case_period(left_case) != _normalized_case_period(
-                    right_case
-                ) or not _cases_differ_by_one_input(left_case, right_case):
+                if (
+                    _normalized_case_period(left_case)
+                    != _normalized_case_period(right_case)
+                    or not _cases_differ_by_one_input(left_case, right_case)
+                    or not _cases_have_same_output_keys(left_case, right_case)
+                ):
                     continue
                 left_inputs = left_case.get("input")
                 right_inputs = right_case.get("input")
@@ -18160,6 +18287,23 @@ def _toggled_formula_numeric_selectors(
                     right_case,
                     formula_environment=formula_environment,
                 )
+                stable_asserted_dependencies = (
+                    _case_pair_stable_asserted_formula_dependencies(
+                        rule_name,
+                        rule,
+                        principal_rules=principal_rules,
+                        left_case=left_case,
+                        right_case=right_case,
+                    )
+                )
+                left_dependencies = {
+                    **stable_asserted_dependencies,
+                    **left_dependencies,
+                }
+                right_dependencies = {
+                    **stable_asserted_dependencies,
+                    **right_dependencies,
+                }
                 left_execution = _case_formula_execution(
                     rule,
                     left_case,
@@ -18174,14 +18318,35 @@ def _toggled_formula_numeric_selectors(
                 )
                 if left_execution is None or right_execution is None:
                     continue
+                (
+                    left_to_right_relations,
+                    right_to_left_relations,
+                ) = _formula_relational_transitions(
+                    left_execution,
+                    right_execution,
+                    left_case=left_case,
+                    right_case=right_case,
+                    left_dependencies=left_dependencies,
+                    right_dependencies=right_dependencies,
+                    formula_environment=formula_environment,
+                    changed_names=changed_names,
+                )
+                positive_part_relations = _formula_positive_part_relation_descriptors(
+                    left_execution.leaf
+                ) | _formula_positive_part_relation_descriptors(right_execution.leaf)
                 if (
-                    left_execution.trace or right_execution.trace
-                ) and _formula_leaf_semantic_key(
-                    left_execution.leaf,
-                    formula_environment=left_execution.constant_environment,
-                ) == _formula_leaf_semantic_key(
-                    right_execution.leaf,
-                    formula_environment=right_execution.constant_environment,
+                    (left_execution.trace or right_execution.trace)
+                    and _formula_leaf_semantic_key(
+                        left_execution.leaf,
+                        formula_environment=left_execution.constant_environment,
+                    )
+                    == _formula_leaf_semantic_key(
+                        right_execution.leaf,
+                        formula_environment=right_execution.constant_environment,
+                    )
+                    and not positive_part_relations.intersection(
+                        (*left_to_right_relations, *right_to_left_relations)
+                    )
                 ):
                     continue
                 left_runtime = _formula_execution_runtime_value(left_execution)
@@ -18213,13 +18378,22 @@ def _toggled_formula_numeric_selectors(
                     continue
                 for selector_name in changed_names:
                     if not (
-                        _formula_execution_reaches_selector(
-                            left_execution,
-                            selector_name,
+                        (
+                            _formula_execution_reaches_selector(
+                                left_execution,
+                                selector_name,
+                            )
+                            and _formula_execution_reaches_selector(
+                                right_execution,
+                                selector_name,
+                            )
                         )
-                        and _formula_execution_reaches_selector(
-                            right_execution,
-                            selector_name,
+                        or any(
+                            selector_name in {left_name, right_name}
+                            for left_name, _relation, right_name in (
+                                *left_to_right_relations,
+                                *right_to_left_relations,
+                            )
                         )
                     ):
                         continue
@@ -18228,18 +18402,21 @@ def _toggled_formula_numeric_selectors(
                         exception_runtime,
                         ordinary_value,
                         exception_value,
+                        relational_transitions,
                     ) in (
                         (
                             left_runtime,
                             right_runtime,
                             float(left_value),
                             float(right_value),
+                            left_to_right_relations,
                         ),
                         (
                             right_runtime,
                             left_runtime,
                             float(right_value),
                             float(left_value),
+                            right_to_left_relations,
                         ),
                     ):
                         witnesses.add(
@@ -18257,9 +18434,247 @@ def _toggled_formula_numeric_selectors(
                                 ),
                                 _exception_effect_is_zero(exception_runtime),
                                 (ordinary_value, exception_value),
+                                relational_transitions,
                             )
                         )
     return witnesses
+
+
+def _case_pair_stable_asserted_formula_dependencies(
+    rule_name: str,
+    rule: dict[str, Any],
+    *,
+    principal_rules: dict[str, dict[str, Any]],
+    left_case: dict[str, Any],
+    right_case: dict[str, Any],
+) -> dict[str, Any]:
+    """Return reached upstream outputs asserted identically by both cases."""
+
+    dependencies: dict[str, Any] = {}
+    referenced_names = set(_FORMULA_IDENTIFIER.findall(_rule_formula_text(rule)))
+    for name in sorted(referenced_names & set(principal_rules) - {rule_name}):
+        left_value = _test_case_asserted_output_value(left_case, name)
+        right_value = _test_case_asserted_output_value(right_case, name)
+        if (
+            left_value is _UNRESOLVED_CONDITION_VALUE
+            or right_value is _UNRESOLVED_CONDITION_VALUE
+            or not _formula_runtime_values_equal(left_value, right_value)
+        ):
+            continue
+        boolean_value = _boolean_value(left_value)
+        dependencies[name] = boolean_value if boolean_value is not None else left_value
+    return dependencies
+
+
+def _formula_relational_transitions(
+    left_execution: _FormulaExecution,
+    right_execution: _FormulaExecution,
+    *,
+    left_case: dict[str, Any],
+    right_case: dict[str, Any],
+    left_dependencies: dict[str, Any],
+    right_dependencies: dict[str, Any],
+    formula_environment: dict[str, Any],
+    changed_names: set[str],
+) -> tuple[
+    tuple[tuple[str, str, str], ...],
+    tuple[tuple[str, str, str], ...],
+]:
+    """Return reached relations that cross false-to-true in each direction."""
+
+    left_environment = _formula_case_runtime_environment(
+        left_case,
+        dependency_environment=left_dependencies,
+        formula_environment=formula_environment,
+    )
+    right_environment = _formula_case_runtime_environment(
+        right_case,
+        dependency_environment=right_dependencies,
+        formula_environment=formula_environment,
+    )
+    if left_environment is None or right_environment is None:
+        return (), ()
+    left_relations = _formula_execution_relational_values(
+        left_execution,
+        environment=left_environment,
+        changed_names=changed_names,
+    )
+    right_relations = _formula_execution_relational_values(
+        right_execution,
+        environment=right_environment,
+        changed_names=changed_names,
+    )
+    shared = set(left_relations) & set(right_relations)
+    return (
+        tuple(
+            sorted(
+                relation
+                for relation in shared
+                if left_relations[relation] is False
+                and right_relations[relation] is True
+            )
+        ),
+        tuple(
+            sorted(
+                relation
+                for relation in shared
+                if right_relations[relation] is False
+                and left_relations[relation] is True
+            )
+        ),
+    )
+
+
+def _formula_case_runtime_environment(
+    case: dict[str, Any],
+    *,
+    dependency_environment: dict[str, Any],
+    formula_environment: dict[str, Any],
+) -> dict[str, Any] | None:
+    environment = _formula_environment_for_case(formula_environment, case)
+    inputs = _case_input_formula_environment(case)
+    if inputs is None:
+        return None
+    for name, value in (*dependency_environment.items(), *inputs.items()):
+        if name in environment and not _formula_runtime_values_equal(
+            environment[name], value
+        ):
+            return None
+        environment[name] = value
+    return environment
+
+
+def _formula_execution_relational_values(
+    execution: _FormulaExecution,
+    *,
+    environment: dict[str, Any],
+    changed_names: set[str],
+) -> dict[tuple[str, str, str], bool]:
+    values: dict[tuple[str, str, str], bool] = {}
+    texts = [selector for step in execution.trace for selector in step.selectors]
+    texts.append(execution.leaf)
+    for text in texts:
+        expression = _parse_formula_expression(text)
+        if expression is None:
+            continue
+        for left, relation, right in _formula_relational_expressions(expression):
+            referenced_names = {
+                node.id
+                for operand in (left, right)
+                for node in ast.walk(operand)
+                if isinstance(node, ast.Name)
+            }
+            if not referenced_names & changed_names:
+                continue
+            left_name = _formula_operand_concept_name(left)
+            right_name = _formula_operand_concept_name(right)
+            if left_name is None or right_name is None:
+                continue
+            comparison = ast.Compare(
+                left=left,
+                ops=[
+                    {
+                        ">": ast.Gt(),
+                        ">=": ast.GtE(),
+                        "<": ast.Lt(),
+                        "<=": ast.LtE(),
+                    }[relation]
+                ],
+                comparators=[right],
+            )
+            value = _evaluate_condition_expression(comparison, environment)
+            if isinstance(value, bool):
+                values[(left_name, relation, right_name)] = value
+    return values
+
+
+def _formula_relational_expressions(
+    expression: ast.AST,
+) -> Iterable[tuple[ast.expr, str, ast.expr]]:
+    for node in ast.walk(expression):
+        if isinstance(node, ast.Compare):
+            operands = (node.left, *node.comparators)
+            for operator, left, right in zip(node.ops, operands, operands[1:]):
+                relation = {
+                    ast.Gt: ">",
+                    ast.GtE: ">=",
+                    ast.Lt: "<",
+                    ast.LtE: "<=",
+                }.get(type(operator))
+                if relation is not None:
+                    yield left, relation, right
+    for left, right in _formula_positive_part_operands(expression):
+        yield left, ">", right
+
+
+def _formula_positive_part_operands(
+    expression: ast.AST,
+) -> Iterable[tuple[ast.expr, ast.expr]]:
+    """Yield operands from reached ``max(0, left - right)`` forms."""
+
+    for node in ast.walk(expression):
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "max"
+            and len(node.args) == 2
+            and not node.keywords
+        ):
+            continue
+        zero_index = next(
+            (
+                index
+                for index, argument in enumerate(node.args)
+                if _formula_ast_numeric_literal(argument) == 0
+            ),
+            None,
+        )
+        if zero_index is None:
+            continue
+        positive_part = node.args[1 - zero_index]
+        if isinstance(positive_part, ast.BinOp) and isinstance(
+            positive_part.op, ast.Sub
+        ):
+            yield positive_part.left, positive_part.right
+
+
+def _formula_positive_part_relation_descriptors(
+    text: str,
+) -> set[tuple[str, str, str]]:
+    expression = _parse_formula_expression(text)
+    if expression is None:
+        return set()
+    descriptors: set[tuple[str, str, str]] = set()
+    for left, right in _formula_positive_part_operands(expression):
+        left_name = _formula_operand_concept_name(left)
+        right_name = _formula_operand_concept_name(right)
+        if left_name is not None and right_name is not None:
+            descriptors.add((left_name, ">", right_name))
+    return descriptors
+
+
+def _formula_ast_numeric_literal(node: ast.AST) -> float | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+        return float(node.value)
+    if (
+        isinstance(node, ast.UnaryOp)
+        and isinstance(node.op, ast.USub)
+        and isinstance(node.operand, ast.Constant)
+        and isinstance(node.operand.value, (int, float))
+    ):
+        return -float(node.operand.value)
+    return None
+
+
+def _formula_operand_concept_name(node: ast.AST) -> str | None:
+    names = sorted(
+        {
+            candidate.id
+            for candidate in ast.walk(node)
+            if isinstance(candidate, ast.Name)
+        }
+    )
+    return "_".join(names) if names else None
 
 
 def _exception_witness_for_case_pair(
@@ -18394,6 +18809,19 @@ def _cases_differ_by_one_input(
             for key in left_inputs
         )
         == 1
+    )
+
+
+def _cases_have_same_output_keys(
+    left_case: dict[str, Any],
+    right_case: dict[str, Any],
+) -> bool:
+    left_outputs = left_case.get("output")
+    right_outputs = right_case.get("output")
+    return (
+        isinstance(left_outputs, dict)
+        and isinstance(right_outputs, dict)
+        and set(left_outputs) == set(right_outputs)
     )
 
 
@@ -19118,7 +19546,9 @@ def _source_boundary_obligations(
             "source-unit",
         }:
             continue
-        direct_text = authoritative_numeric_recall_text(branch.text)
+        direct_text = authoritative_numeric_recall_text(
+            _source_branch_direct_text(branch, branches=branches)
+        )
         direct_inventory = tuple(extract_numeric_occurrences(direct_text))
         for fragment_start, fragment in _source_boundary_fragments(direct_text):
             range_fragment = fragment.split(":", 1)[0]
@@ -19182,6 +19612,36 @@ def _source_boundary_obligations(
             for branch, occurrence in obligations
         }.values()
     )
+
+
+def _source_branch_direct_text(
+    branch: SourceStructureBranch,
+    *,
+    branches: Sequence[SourceStructureBranch],
+) -> str:
+    """Return one branch's own chapeau without nested child bodies.
+
+    ``SourceStructureBranch.text`` intentionally spans descendants so structural
+    and formula analysis can retain parent context. Boundary inventory is
+    different: counting descendant thresholds again on every ancestor creates
+    impossible parent-level obligations and obscures the child rule that owns
+    each comparator. Preserve the original prefix offsets while stopping at the
+    first descendant; leaf branches continue to use their complete text. Using
+    any descendant is necessary because callers may already have removed
+    marker-only intermediate containers from the candidate branch sequence.
+    """
+
+    descendant_starts = [
+        candidate.start
+        for candidate in branches
+        if len(candidate.path) > len(branch.path)
+        and candidate.path[: len(branch.path)] == branch.path
+        and branch.start <= candidate.start < branch.end
+    ]
+    if not descendant_starts:
+        return branch.text
+    direct_end = max(0, min(descendant_starts) - branch.start)
+    return branch.text[:direct_end]
 
 
 def _numeric_test_input_values(value: Any) -> tuple[float, ...]:

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -15450,6 +15450,8 @@ def _branch_boundary_test_witnesses(
                         formula_environment=formula_environment or {},
                         source_interval=source_interval,
                         source_boolean_polarity=source_boolean_polarity,
+                        root_rule=rule,
+                        root_execution=execution,
                     )
                     for input_key, input_names, value in (
                         _case_numeric_selector_evidence(
@@ -15964,6 +15966,8 @@ def _boundary_case_changes_formula_effect(
     formula_environment: dict[str, Any],
     source_interval: _NumericInterval | None,
     source_boolean_polarity: int,
+    root_rule: dict[str, Any] | None = None,
+    root_execution: _FormulaExecution | None = None,
 ) -> bool:
     inputs = case.get("input")
     if not isinstance(inputs, dict):
@@ -15973,7 +15977,10 @@ def _boundary_case_changes_formula_effect(
         if float(boundary_value).is_integer()
         else max(abs(boundary_value) * 1e-6, 1e-9)
     )
-    signature = _formula_execution_effect_signature(execution)
+    controller_signature = _formula_execution_effect_signature(execution)
+    effect_rule = root_rule or rule
+    effect_execution = root_execution or execution
+    root_signature = _formula_execution_effect_signature(effect_execution)
     boundary_boolean = _formula_execution_boolean_value(execution)
     if (
         boundary_boolean is not None
@@ -16046,8 +16053,15 @@ def _boundary_case_changes_formula_effect(
                 if candidate_execution is not None
                 else None
             )
+            candidate_root_execution = _case_formula_execution(
+                effect_rule,
+                candidate_case,
+                formula_environment=formula_environment,
+                dependency_environment=candidate_dependencies,
+            )
             if (
                 candidate_execution is not None
+                and candidate_root_execution is not None
                 and (
                     candidate_boolean is None
                     or source_interval is None
@@ -16066,7 +16080,9 @@ def _boundary_case_changes_formula_effect(
                     )
                 )
                 and _formula_execution_effect_signature(candidate_execution)
-                != signature
+                != controller_signature
+                and _formula_execution_effect_signature(candidate_root_execution)
+                != root_signature
             ):
                 return True
     return False
@@ -17963,7 +17979,10 @@ def _numeric_exception_witness_matches_source(
         )
         for left_name, relation, right_name in witness.relational_transitions
     ):
-        return True
+        return _relational_exception_witness_has_source_effect(
+            condition_text,
+            witness,
+        )
     transition = witness.numeric_transition
     if transition is None:
         return False
@@ -17993,28 +18012,108 @@ def _source_relational_exception_matches(
     elif relation == "<=":
         left_name, relation, right_name = right_name, ">=", left_name
     collapsed = _collapse_text(text).lower()
-    relation_match = re.search(
-        r"\b(?:exceeds?\s+or\s+equals?|is\s+(?:greater|more)\s+than\s+or\s+equal\s+to)\b",
-        collapsed,
-    )
-    source_relation = ">=" if relation_match is not None else None
-    if relation_match is None:
-        relation_match = re.search(
-            r"\b(?:exceeds?|is\s+(?:greater|more)\s+than|übersteigt)\b",
-            collapsed,
-        )
-        source_relation = ">" if relation_match is not None else None
-    if relation_match is None:
-        return False
     left_matches = _source_relational_operand_matches(collapsed, left_name)
     right_matches = _source_relational_operand_matches(collapsed, right_name)
-    return source_relation == relation and any(
-        left.end() <= relation_match.start()
-        and relation_match.end() <= right.start()
-        and relation_match.start() - left.end() <= 240
-        and right.start() - relation_match.end() <= 240
-        for left in left_matches
-        for right in right_matches
+    relation_matches = tuple(
+        re.finditer(
+            r"\b(?P<inclusive>exceeds?\s+or\s+equals?|"
+            r"is\s+(?:greater|more)\s+than\s+or\s+equal\s+to)\b|"
+            r"\b(?P<strict>exceeds?|is\s+(?:greater|more)\s+than|übersteigt)\b",
+            collapsed,
+        )
+    )
+    for index, relation_match in enumerate(relation_matches):
+        source_relation = ">=" if relation_match.group("inclusive") else ">"
+        if source_relation != relation:
+            continue
+        left_bound, right_bound = _source_relation_operand_bounds(
+            collapsed,
+            relation_matches,
+            index,
+        )
+        if any(
+            left_bound <= left.start()
+            and left.end() <= relation_match.start()
+            and relation_match.end() <= right.start()
+            and right.end() <= right_bound
+            and relation_match.start() - left.end() <= 240
+            and right.start() - relation_match.end() <= 240
+            for left in left_matches
+            for right in right_matches
+        ):
+            return True
+    return False
+
+
+def _source_relation_operand_bounds(
+    text: str,
+    relation_matches: tuple[re.Match[str], ...],
+    index: int,
+) -> tuple[int, int]:
+    """Bound relation operands to their immediate clause or conjunct."""
+
+    relation_match = relation_matches[index]
+    left_bound = max(
+        (
+            match.end()
+            for match in re.finditer(r"[.;:]", text[: relation_match.start()])
+        ),
+        default=0,
+    )
+    right_delimiter = re.search(r"[.;:]", text[relation_match.end() :])
+    right_bound = (
+        relation_match.end() + right_delimiter.start()
+        if right_delimiter is not None
+        else len(text)
+    )
+    if index:
+        previous = relation_matches[index - 1]
+        separators = tuple(
+            re.finditer(
+                r"\b(?:and|or|und|oder)\b",
+                text[previous.end() : relation_match.start()],
+            )
+        )
+        if separators:
+            left_bound = max(
+                left_bound,
+                previous.end() + separators[-1].end(),
+            )
+    if index + 1 < len(relation_matches):
+        following = relation_matches[index + 1]
+        separator = re.search(
+            r"\b(?:and|or|und|oder)\b",
+            text[relation_match.end() : following.start()],
+        )
+        if separator is not None:
+            right_bound = min(
+                right_bound,
+                relation_match.end() + separator.start(),
+            )
+    return left_bound, right_bound
+
+
+def _relational_exception_witness_has_source_effect(
+    text: str,
+    witness: _ExceptionWitness,
+) -> bool:
+    """Require the relation-active side to have the source-directed effect."""
+
+    requirement = _source_exception_effect_requirement(text)
+    if requirement == "zero":
+        return witness.zeroes
+    if requirement == "exclude":
+        return witness.blocks or witness.zeroes
+    if requirement == "enable":
+        return not witness.blocks and not witness.zeroes
+    return bool(
+        re.search(
+            r"\b(?:excess\w*|overpayment\w*|refund\w*)\b",
+            text,
+            flags=re.IGNORECASE,
+        )
+        and not witness.blocks
+        and not witness.zeroes
     )
 
 
@@ -18294,6 +18393,7 @@ def _toggled_formula_numeric_selectors(
                         principal_rules=principal_rules,
                         left_case=left_case,
                         right_case=right_case,
+                        formula_environment=formula_environment,
                     )
                 )
                 left_dependencies = {
@@ -18447,18 +18547,42 @@ def _case_pair_stable_asserted_formula_dependencies(
     principal_rules: dict[str, dict[str, Any]],
     left_case: dict[str, Any],
     right_case: dict[str, Any],
+    formula_environment: dict[str, Any],
 ) -> dict[str, Any]:
     """Return reached upstream outputs asserted identically by both cases."""
 
     dependencies: dict[str, Any] = {}
     referenced_names = set(_FORMULA_IDENTIFIER.findall(_rule_formula_text(rule)))
-    for name in sorted(referenced_names & set(principal_rules) - {rule_name}):
+    candidate_names = referenced_names & set(principal_rules) - {rule_name}
+    left_runtime_dependencies = _case_dependency_environment(
+        principal_rules,
+        left_case,
+        formula_environment=formula_environment,
+        require_asserted_value=False,
+    )
+    right_runtime_dependencies = _case_dependency_environment(
+        principal_rules,
+        right_case,
+        formula_environment=formula_environment,
+        require_asserted_value=False,
+    )
+    for name in sorted(candidate_names):
         left_value = _test_case_asserted_output_value(left_case, name)
         right_value = _test_case_asserted_output_value(right_case, name)
         if (
             left_value is _UNRESOLVED_CONDITION_VALUE
             or right_value is _UNRESOLVED_CONDITION_VALUE
             or not _formula_runtime_values_equal(left_value, right_value)
+            or name not in left_runtime_dependencies
+            or name not in right_runtime_dependencies
+            or not _formula_runtime_values_equal(
+                left_value,
+                left_runtime_dependencies[name],
+            )
+            or not _formula_runtime_values_equal(
+                right_value,
+                right_runtime_dependencies[name],
+            )
         ):
             continue
         boolean_value = _boolean_value(left_value)

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -17854,6 +17854,26 @@ def _source_exception_effect_requirement(text: str) -> str:
     return "change"
 
 
+def _source_states_negative_refund_effect(text: str) -> bool:
+    """Recognize express prohibitions on a refund or refundable excess."""
+
+    return bool(
+        re.search(
+            r"\b(?:"
+            r"no\s+refund\b|"
+            r"refund\w*\b[^.;]{0,48}\b(?:disallowed|forbidden|prohibited|"
+            r"barred|not\s+(?:allowed|permitted))\b|"
+            r"refund\w*\b[^.;]{0,48}\b(?:shall|may|does?|is|are)\s+not\s+"
+            r"(?:be\s+)?(?:allowed|paid|permitted|refund\w*)\b|"
+            r"(?:shall|may|does?)\s+not\s+(?:be\s+)?(?:paid|refund\w*)\b|"
+            r"not\s+refundable\b"
+            r")",
+            text,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
 def _notwithstanding_exemption_effect_requirement(text: str) -> str | None:
     """Recognize the direct certification duty in an exemption override."""
 
@@ -17969,20 +17989,32 @@ def _numeric_exception_witness_matches_source(
     *,
     extract_numeric_occurrences: NumericOccurrenceExtractor,
 ) -> bool:
-    condition_text = _source_exception_condition_text(branch.text)
-    if any(
-        _source_relational_exception_matches(
-            condition_text,
+    source_text = _collapse_text(_strip_source_clause_marker(branch.text)).lower()
+    matched_source_relation = False
+    for left_name, relation, right_name in witness.relational_transitions:
+        relation_indices = _source_relational_exception_match_indices(
+            source_text,
             left_name=left_name,
             relation=relation,
             right_name=right_name,
         )
-        for left_name, relation, right_name in witness.relational_transitions
-    ):
-        return _relational_exception_witness_has_source_effect(
-            condition_text,
-            witness,
+        if not relation_indices:
+            continue
+        matched_source_relation = True
+        effect_matches = tuple(
+            _relational_exception_witness_has_source_effect(
+                source_text,
+                witness,
+                relation_index=relation_index,
+            )
+            for relation_index in relation_indices
         )
+        if len(set(effect_matches)) > 1:
+            return False
+        if effect_matches[0]:
+            return True
+    if matched_source_relation:
+        return False
     transition = witness.numeric_transition
     if transition is None:
         return False
@@ -18007,6 +18039,25 @@ def _source_relational_exception_matches(
 ) -> bool:
     """Match a reached formula relation to a source-stated relational trigger."""
 
+    return bool(
+        _source_relational_exception_match_indices(
+            text,
+            left_name=left_name,
+            relation=relation,
+            right_name=right_name,
+        )
+    )
+
+
+def _source_relational_exception_match_indices(
+    text: str,
+    *,
+    left_name: str,
+    relation: str,
+    right_name: str,
+) -> tuple[int, ...]:
+    """Return source relation indices matching one reached formula transition."""
+
     if relation == "<":
         left_name, relation, right_name = right_name, ">", left_name
     elif relation == "<=":
@@ -18022,6 +18073,7 @@ def _source_relational_exception_matches(
             collapsed,
         )
     )
+    matched_indices: list[int] = []
     for index, relation_match in enumerate(relation_matches):
         source_relation = ">=" if relation_match.group("inclusive") else ">"
         if source_relation != relation:
@@ -18041,8 +18093,8 @@ def _source_relational_exception_matches(
             for left in left_matches
             for right in right_matches
         ):
-            return True
-    return False
+            matched_indices.append(index)
+    return tuple(matched_indices)
 
 
 def _source_relation_operand_bounds(
@@ -18068,21 +18120,17 @@ def _source_relation_operand_bounds(
     )
     if index:
         previous = relation_matches[index - 1]
-        separators = tuple(
-            re.finditer(
-                r"\b(?:and|or|und|oder)\b",
-                text[previous.end() : relation_match.start()],
-            )
+        separator = _source_relation_clause_separator(
+            text[previous.end() : relation_match.start()]
         )
-        if separators:
+        if separator is not None:
             left_bound = max(
                 left_bound,
-                previous.end() + separators[-1].end(),
+                previous.end() + separator.end(),
             )
     if index + 1 < len(relation_matches):
         following = relation_matches[index + 1]
-        separator = re.search(
-            r"\b(?:and|or|und|oder)\b",
+        separator = _source_relation_clause_separator(
             text[relation_match.end() : following.start()],
         )
         if separator is not None:
@@ -18093,13 +18141,38 @@ def _source_relation_operand_bounds(
     return left_bound, right_bound
 
 
+def _source_relation_clause_separator(text: str) -> re.Match[str] | None:
+    """Choose the clause break without splitting compound relation operands."""
+
+    for pattern in (
+        r"\b(?:although|but|though|while|whereas|yet)\b",
+        r",",
+        r"\b(?:and|or|und|oder)\b",
+    ):
+        matches = tuple(re.finditer(pattern, text))
+        if matches:
+            return matches[-1]
+    return None
+
+
 def _relational_exception_witness_has_source_effect(
     text: str,
     witness: _ExceptionWitness,
+    *,
+    relation_index: int,
 ) -> bool:
     """Require the relation-active side to have the source-directed effect."""
 
-    requirement = _source_exception_effect_requirement(text)
+    effect_text = _source_relational_effect_text(text, relation_index=relation_index)
+    if _source_relational_exception_reverses_negative_refund(
+        text,
+        relation_index=relation_index,
+    ):
+        requirement = "enable"
+    elif _source_states_negative_refund_effect(effect_text):
+        requirement = "exclude"
+    else:
+        requirement = _source_exception_effect_requirement(effect_text)
     if requirement == "zero":
         return witness.zeroes
     if requirement == "exclude":
@@ -18109,12 +18182,125 @@ def _relational_exception_witness_has_source_effect(
     return bool(
         re.search(
             r"\b(?:excess\w*|overpayment\w*|refund\w*)\b",
-            text,
+            effect_text,
             flags=re.IGNORECASE,
         )
         and not witness.blocks
         and not witness.zeroes
     )
+
+
+def _source_relational_exception_reverses_negative_refund(
+    text: str,
+    *,
+    relation_index: int,
+) -> bool:
+    """Recognize an exception condition that lifts a stated refund prohibition."""
+
+    relation_matches = tuple(
+        re.finditer(
+            r"\b(?:exceeds?\s+or\s+equals?|"
+            r"is\s+(?:greater|more)\s+than(?:\s+or\s+equal\s+to)?|"
+            r"exceeds?|übersteigt)\b",
+            text,
+            flags=re.IGNORECASE,
+        )
+    )
+    if not 0 <= relation_index < len(relation_matches):
+        return False
+    condition_prefix = text[: relation_matches[relation_index].start()]
+    condition_cues = tuple(
+        re.finditer(
+            r"\b(?P<reversal>unless|except(?:\s+(?:if|when))?)\b|"
+            r"\b(?P<ordinary>falls|if|sofern|soweit|wenn|when)\b",
+            condition_prefix,
+            flags=re.IGNORECASE,
+        )
+    )
+    if not condition_cues or condition_cues[-1].group("reversal") is None:
+        return False
+    reversal = condition_cues[-1]
+    return _source_states_negative_refund_effect(condition_prefix[: reversal.start()])
+
+
+def _source_relational_effect_text(text: str, *, relation_index: int) -> str:
+    """Return the effect associated with one matched relational condition."""
+
+    relation_matches = tuple(
+        re.finditer(
+            r"\b(?:exceeds?\s+or\s+equals?|"
+            r"is\s+(?:greater|more)\s+than(?:\s+or\s+equal\s+to)?|"
+            r"exceeds?|übersteigt)\b",
+            text,
+            flags=re.IGNORECASE,
+        )
+    )
+    if not 0 <= relation_index < len(relation_matches):
+        return text
+    relation_match = relation_matches[relation_index]
+    condition_cues = tuple(
+        re.finditer(
+            r"\b(?:except\s+(?:if|when)|unless|falls|if|sofern|soweit|wenn|when)\b",
+            text[: relation_match.start()],
+            flags=re.IGNORECASE,
+        )
+    )
+    if condition_cues:
+        condition_cue = condition_cues[-1]
+        proposition_start = 0
+        if relation_index:
+            strong_boundary = tuple(
+                re.finditer(r"[.;:]", text[: condition_cue.start()])
+            )
+            if strong_boundary:
+                proposition_start = strong_boundary[-1].end()
+            elif relation_matches[relation_index - 1].end() < condition_cue.start():
+                between_start = relation_matches[relation_index - 1].end()
+                coordinate_boundaries = tuple(
+                    re.finditer(
+                        r"\b(?:although|but|though|while|whereas|yet)\b",
+                        text[between_start : condition_cue.start()],
+                        flags=re.IGNORECASE,
+                    )
+                )
+                if not coordinate_boundaries:
+                    coordinate_boundaries = tuple(
+                        re.finditer(
+                            r"\b(?:and|or)\b(?=[^,;:.]{0,120}"
+                            r"\b(?:excess\w*|overpayment\w*|refund\w*)\b)",
+                            text[between_start : condition_cue.start()],
+                            flags=re.IGNORECASE,
+                        )
+                    )
+                proposition_start = (
+                    between_start + coordinate_boundaries[-1].end()
+                    if coordinate_boundaries
+                    else condition_cue.start()
+                )
+        proposition = text[proposition_start : condition_cue.start()].strip(" ,;:")
+        if proposition and re.search(
+            r"\b(?:excess\w*|overpayment\w*|refund\w*)\b",
+            proposition,
+            flags=re.IGNORECASE,
+        ):
+            return proposition
+    tail_start = relation_match.end()
+    tail = text[tail_start:]
+    then_cue = re.search(r"\bthen\b", tail, flags=re.IGNORECASE)
+    if then_cue is not None:
+        return tail[then_cue.end() :]
+    consequence = re.search(r"[,;:]", tail)
+    if consequence is None:
+        return tail
+    effect = tail[consequence.end() :]
+    secondary_boundary = re.search(r"[,;:]", effect)
+    if secondary_boundary is not None and re.match(
+        r"\s*(?:(?:and|or)\s+)?(?:if|when|unless|provided\b|no\b|without\b)",
+        effect[: secondary_boundary.start()],
+        flags=re.IGNORECASE,
+    ):
+        return effect[secondary_boundary.end() :]
+    return effect
 
 
 def _source_relational_operand_matches(

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1625"
+ENCODER_VERSION = "0.2.1626"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1625"
+ENCODER_VERSION = "0.2.1626"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1625"
+ENCODER_VERSION = "0.2.1626"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1625"
+ENCODER_VERSION = "0.2.1626"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1625"
+ENCODER_VERSION = "0.2.1626"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1625"
+ENCODER_VERSION = "0.2.1626"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1625"
+ENCODER_VERSION = "0.2.1626"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1625"')
+        .startswith('__version__ = "0.2.1626"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1625"
+    assert encoder_package["version"] == "0.2.1626"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1625"
+    assert project["project"]["version"] == "0.2.1626"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1625"')
+        .startswith('__version__ = "0.2.1626"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1625"
+    assert encoder_package["version"] == "0.2.1626"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1625"
+    assert project["project"]["version"] == "0.2.1626"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1625"')
+        .startswith('__version__ = "0.2.1626"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1625"
+ENCODER_VERSION = "0.2.1626"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -21047,8 +21047,14 @@ def test_relational_exception_witness_rejects_reversed_effect_orientation():
     )
 
 
-def test_source_relational_match_does_not_cross_bind_conjoined_relations():
-    source = "The credit exceeds tax liability and income exceeds the income threshold."
+@pytest.mark.parametrize("connector", ["while", "although", "yet"])
+def test_source_relational_match_does_not_cross_bind_conjoined_relations(
+    connector: str,
+):
+    source = (
+        f"If the credit exceeds tax liability, {connector} income exceeds the "
+        "income threshold, the excess shall be refunded."
+    )
 
     assert completeness_module._source_relational_exception_matches(
         source,
@@ -21067,6 +21073,473 @@ def test_source_relational_match_does_not_cross_bind_conjoined_relations():
         left_name="credit_amount",
         relation=">",
         right_name="income_threshold",
+    )
+    branch = completeness_module.SourceStructureBranch(
+        ("b", "1"),
+        "paragraph",
+        "B.(1)",
+        source,
+        0,
+        len(source),
+    )
+    cross_bound_witness = completeness_module._ExceptionWitness(
+        "refund_amount",
+        "tax_liability",
+        True,
+        False,
+        False,
+        False,
+        (500, 300),
+        (("credit_amount", ">", "income_threshold"),),
+    )
+
+    assert not completeness_module._numeric_exception_witness_matches_source(
+        branch,
+        cross_bound_witness,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+
+
+def test_source_relational_match_preserves_enumerated_operand_conjunctions():
+    source = (
+        "If the credit exceeds federal, state, and local tax liability, while "
+        "income exceeds the income threshold, the excess shall be refunded."
+    )
+
+    assert completeness_module._source_relational_exception_matches(
+        source,
+        left_name="credit_amount",
+        relation=">",
+        right_name="tax_liability",
+    )
+
+
+@pytest.mark.parametrize("conjunction", ["and", "or"])
+def test_source_relational_match_preserves_compound_left_operands(
+    conjunction: str,
+):
+    source = (
+        "The credit exceeds tax liability, wages "
+        f"{conjunction} income exceed the income threshold."
+    )
+
+    for left_name in ("wages", "income"):
+        assert completeness_module._source_relational_exception_matches(
+            source,
+            left_name=left_name,
+            relation=">",
+            right_name="income_threshold",
+        )
+    assert not completeness_module._source_relational_exception_matches(
+        source,
+        left_name="credit_amount",
+        relation=">",
+        right_name="income_threshold",
+    )
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "If the credit exceeds tax liability, no refund shall be allowed.",
+        "If the credit exceeds tax liability, the refund is prohibited.",
+        "If the credit exceeds tax liability, the excess is not refundable.",
+        "If the credit exceeds tax liability, the refund is forbidden.",
+        "If the credit exceeds tax liability, the refund is not permitted.",
+        "If the credit exceeds tax liability, the refund is disallowed.",
+        "If the credit exceeds tax liability, the refund may not be paid.",
+    ],
+)
+def test_relational_witness_rejects_positive_effect_for_negative_refund_source(
+    text: str,
+):
+    witnesses, branch = _credit_liability_exception_witnesses()
+    negative_branch = completeness_module.SourceStructureBranch(
+        branch.path,
+        branch.kind,
+        branch.label,
+        text,
+        0,
+        len(text),
+    )
+
+    assert not any(
+        completeness_module._numeric_exception_witness_matches_source(
+            negative_branch,
+            witness,
+            extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        )
+        for witness in witnesses
+    )
+
+
+def test_relational_refund_polarity_ignores_negation_inside_condition():
+    witnesses, branch = _credit_liability_exception_witnesses()
+    text = (
+        "If the credit exceeds tax liability and no refund has previously been "
+        "issued, the excess is refundable."
+    )
+    positive_branch = completeness_module.SourceStructureBranch(
+        branch.path,
+        branch.kind,
+        branch.label,
+        text,
+        0,
+        len(text),
+    )
+
+    assert any(
+        completeness_module._numeric_exception_witness_matches_source(
+            positive_branch,
+            witness,
+            extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        )
+        for witness in witnesses
+    )
+
+
+def test_relational_refund_polarity_skips_secondary_condition_clause():
+    witnesses, branch = _credit_liability_exception_witnesses()
+    text = (
+        "If the credit exceeds tax liability, and no refund has previously been "
+        "issued, the excess is refundable."
+    )
+    positive_branch = completeness_module.SourceStructureBranch(
+        branch.path,
+        branch.kind,
+        branch.label,
+        text,
+        0,
+        len(text),
+    )
+
+    assert any(
+        completeness_module._numeric_exception_witness_matches_source(
+            positive_branch,
+            witness,
+            extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        )
+        for witness in witnesses
+    )
+
+
+def _blocking_relational_witness(witness):
+    return completeness_module._ExceptionWitness(
+        witness.rule_name,
+        witness.selector_name,
+        witness.active_value,
+        True,
+        witness.boolean_effect,
+        True,
+        witness.numeric_transition,
+        witness.relational_transitions,
+    )
+
+
+def test_relational_refund_polarity_supports_postposed_condition():
+    positive_witnesses, branch = _credit_liability_exception_witnesses()
+    positive_witness = next(
+        witness for witness in positive_witnesses if witness.relational_transitions
+    )
+    blocking_witness = _blocking_relational_witness(positive_witness)
+    positive_text = "The excess is refundable if the credit exceeds tax liability."
+    positive_branch = completeness_module.SourceStructureBranch(
+        branch.path,
+        branch.kind,
+        branch.label,
+        positive_text,
+        0,
+        len(positive_text),
+    )
+
+    assert any(
+        completeness_module._numeric_exception_witness_matches_source(
+            positive_branch,
+            witness,
+            extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        )
+        for witness in positive_witnesses
+    )
+    for negative_text in (
+        "No refund shall be allowed if the credit exceeds tax liability.",
+        "The refund is prohibited when the credit exceeds tax liability.",
+    ):
+        negative_branch = completeness_module.SourceStructureBranch(
+            branch.path,
+            branch.kind,
+            branch.label,
+            negative_text,
+            0,
+            len(negative_text),
+        )
+        assert any(
+            completeness_module._numeric_exception_witness_matches_source(
+                negative_branch,
+                witness,
+                extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+            )
+            for witness in (blocking_witness,)
+        )
+        assert not any(
+            completeness_module._numeric_exception_witness_matches_source(
+                negative_branch,
+                witness,
+                extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+            )
+            for witness in positive_witnesses
+        )
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "No refund shall be allowed unless the credit exceeds tax liability.",
+        "No refund shall be allowed except when the credit exceeds tax liability.",
+        "The refund is prohibited except if the credit exceeds tax liability.",
+    ],
+)
+def test_relational_refund_polarity_reverses_postposed_exception(text: str):
+    positive_witnesses, branch = _credit_liability_exception_witnesses()
+    positive_witness = next(
+        witness for witness in positive_witnesses if witness.relational_transitions
+    )
+    blocking_witness = _blocking_relational_witness(positive_witness)
+    exception_branch = completeness_module.SourceStructureBranch(
+        branch.path,
+        branch.kind,
+        branch.label,
+        text,
+        0,
+        len(text),
+    )
+
+    assert any(
+        completeness_module._numeric_exception_witness_matches_source(
+            exception_branch,
+            witness,
+            extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        )
+        for witness in positive_witnesses
+    )
+    assert not any(
+        completeness_module._numeric_exception_witness_matches_source(
+            exception_branch,
+            witness,
+            extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        )
+        for witness in (blocking_witness,)
+    )
+
+
+@pytest.mark.parametrize("reversal", ["unless", "except when"])
+def test_relational_refund_polarity_binds_each_relation_to_its_condition(
+    reversal: str,
+):
+    positive_witnesses, branch = _credit_liability_exception_witnesses()
+    positive = next(
+        witness for witness in positive_witnesses if witness.relational_transitions
+    )
+    blocking = _blocking_relational_witness(positive)
+    income_positive = completeness_module._ExceptionWitness(
+        positive.rule_name,
+        positive.selector_name,
+        positive.active_value,
+        positive.blocks,
+        positive.boolean_effect,
+        positive.zeroes,
+        positive.numeric_transition,
+        (("income", ">", "income_threshold"),),
+    )
+    income_blocking = completeness_module._ExceptionWitness(
+        blocking.rule_name,
+        blocking.selector_name,
+        blocking.active_value,
+        blocking.blocks,
+        blocking.boolean_effect,
+        blocking.zeroes,
+        blocking.numeric_transition,
+        (("income", ">", "income_threshold"),),
+    )
+    text = (
+        "No refund shall be allowed if income exceeds the income threshold "
+        f"{reversal} the credit exceeds tax liability."
+    )
+    multi_relation_branch = completeness_module.SourceStructureBranch(
+        branch.path,
+        branch.kind,
+        branch.label,
+        text,
+        0,
+        len(text),
+    )
+
+    assert completeness_module._numeric_exception_witness_matches_source(
+        multi_relation_branch,
+        income_blocking,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+    assert not completeness_module._numeric_exception_witness_matches_source(
+        multi_relation_branch,
+        income_positive,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+    assert completeness_module._numeric_exception_witness_matches_source(
+        multi_relation_branch,
+        positive,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+    assert not completeness_module._numeric_exception_witness_matches_source(
+        multi_relation_branch,
+        blocking,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+
+
+@pytest.mark.parametrize(
+    "reversal",
+    [
+        "unless credit exceeds tax liability after a disaster",
+        "except when credit exceeds tax liability for an amended return",
+    ],
+)
+def test_relational_refund_polarity_rejects_conflicting_repeated_relation(
+    reversal: str,
+):
+    positive_witnesses, branch = _credit_liability_exception_witnesses()
+    positive = next(
+        witness for witness in positive_witnesses if witness.relational_transitions
+    )
+    blocking = _blocking_relational_witness(positive)
+    text = f"No refund shall be allowed if credit exceeds tax liability {reversal}."
+    repeated_relation_branch = completeness_module.SourceStructureBranch(
+        branch.path,
+        branch.kind,
+        branch.label,
+        text,
+        0,
+        len(text),
+    )
+
+    for witness in (positive, blocking):
+        assert not completeness_module._numeric_exception_witness_matches_source(
+            repeated_relation_branch,
+            witness,
+            extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        )
+
+
+@pytest.mark.parametrize("connector", ["and", "or"])
+def test_relational_refund_polarity_accepts_same_repeated_relation(
+    connector: str,
+):
+    positive_witnesses, branch = _credit_liability_exception_witnesses()
+    positive = next(
+        witness for witness in positive_witnesses if witness.relational_transitions
+    )
+    blocking = _blocking_relational_witness(positive)
+    text = (
+        "No refund if credit exceeds tax liability "
+        f"{connector} no refund when credit exceeds tax liability."
+    )
+    repeated_relation_branch = completeness_module.SourceStructureBranch(
+        branch.path,
+        branch.kind,
+        branch.label,
+        text,
+        0,
+        len(text),
+    )
+
+    assert completeness_module._numeric_exception_witness_matches_source(
+        repeated_relation_branch,
+        blocking,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+    assert not completeness_module._numeric_exception_witness_matches_source(
+        repeated_relation_branch,
+        positive,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+
+
+@pytest.mark.parametrize("connector", ["but", "and", "or"])
+def test_relational_refund_polarity_preserves_coordinated_proposition(
+    connector: str,
+):
+    positive_witnesses, branch = _credit_liability_exception_witnesses()
+    credit_positive = next(
+        witness for witness in positive_witnesses if witness.relational_transitions
+    )
+    credit_blocking = _blocking_relational_witness(credit_positive)
+    income_positive = completeness_module._ExceptionWitness(
+        credit_positive.rule_name,
+        credit_positive.selector_name,
+        credit_positive.active_value,
+        credit_positive.blocks,
+        credit_positive.boolean_effect,
+        credit_positive.zeroes,
+        credit_positive.numeric_transition,
+        (("income", ">", "income_threshold"),),
+    )
+    income_blocking = _blocking_relational_witness(income_positive)
+    text = (
+        "No refund shall be allowed unless credit exceeds tax liability, "
+        f"{connector} no refund shall be allowed if income exceeds the income "
+        "threshold."
+    )
+    coordinated_branch = completeness_module.SourceStructureBranch(
+        branch.path,
+        branch.kind,
+        branch.label,
+        text,
+        0,
+        len(text),
+    )
+
+    for accepted, rejected in (
+        (credit_positive, credit_blocking),
+        (income_blocking, income_positive),
+    ):
+        assert completeness_module._numeric_exception_witness_matches_source(
+            coordinated_branch,
+            accepted,
+            extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        )
+        assert not completeness_module._numeric_exception_witness_matches_source(
+            coordinated_branch,
+            rejected,
+            extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        )
+
+
+def test_relational_effect_rejection_does_not_fall_through_to_numeric_interval():
+    positive_witnesses, branch = _credit_liability_exception_witnesses()
+    positive = next(
+        witness for witness in positive_witnesses if witness.relational_transitions
+    )
+    blocking = _blocking_relational_witness(positive)
+    text = (
+        "If credit exceeds tax liability and income is at most 300 dollars, "
+        "no refund shall be allowed."
+    )
+    mixed_condition_branch = completeness_module.SourceStructureBranch(
+        branch.path,
+        branch.kind,
+        branch.label,
+        text,
+        0,
+        len(text),
+    )
+
+    assert completeness_module._numeric_exception_witness_matches_source(
+        mixed_condition_branch,
+        blocking,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+    assert not completeness_module._numeric_exception_witness_matches_source(
+        mixed_condition_branch,
+        positive,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
     )
 
 

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -13061,7 +13061,6 @@ b) Von 74 Euro an: Einkommen * 3.
         active_branches=branches,
         deferred_paths=set(),
     )
-
     obligations = completeness_module._source_boundary_obligations(
         branches,
         narrative_formula_branches=formula_branches,
@@ -16879,6 +16878,37 @@ rules:
     assert _has_issue(continuation_missing, "boundary", "test")
     assert _has_issue(bypassed_comparator, "boundary", "test")
     assert _has_issue(unused_boundary_input, "boundary", "test")
+
+
+def test_nested_child_boundaries_are_not_duplicated_on_parent_chapeaux():
+    source = """\
+A.(1)(a) If adjusted gross income is at most $25,000, the credit is 50 percent of the federal credit.
+(b) The credit is allowed whether or not the federal credit was claimed.
+(2) If adjusted gross income is more than $25,000 and at most $35,000, the credit is 30 percent of the federal credit.
+B. End.
+"""
+    branches = recognize_source_structure(source)
+    formula_branches = completeness_module._source_formula_branches(
+        source,
+        branches=branches,
+        active_branches=branches,
+        deferred_paths=set(),
+    )
+    boundary_branches = tuple(
+        branch for branch in branches if branch.path != ("a", "1")
+    )
+
+    obligations = completeness_module._source_boundary_obligations(
+        boundary_branches,
+        narrative_formula_branches=formula_branches,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+
+    assert [(branch.path, occurrence.value) for branch, occurrence in obligations] == [
+        (("a", "1", "a"), 25000.0),
+        (("a", "2"), 25000.0),
+        (("a", "2"), 35000.0),
+    ]
 
 
 def test_exception_toggle_must_change_the_reached_formula_effect():
@@ -20824,6 +20854,247 @@ def test_arithmetic_if_clause_is_formula_evidence_not_exception_toggle():
 
     assert len(formula_branches) == 1
     assert not exception_branches
+
+
+def test_boundary_witness_follows_asserted_reached_local_dependency():
+    text = "B.(1) The credit applies when income is at most 100 dollars."
+    branch = completeness_module.SourceStructureBranch(
+        ("b", "1"),
+        "paragraph",
+        "B.(1)",
+        text,
+        0,
+        len(text),
+    )
+    boundary = next(
+        occurrence
+        for occurrence in EN_NUMERIC_OCCURRENCE_EXTRACTOR(branch.text)
+        if occurrence.value == 100
+    )
+    principal_rules = {
+        "low_income_applies": {
+            "name": "low_income_applies",
+            "kind": "derived",
+            "dtype": "Judgment",
+            "versions": [{"formula": "income <= income_limit"}],
+        },
+        "credit_amount": {
+            "name": "credit_amount",
+            "kind": "derived",
+            "dtype": "Money",
+            "versions": [{"formula": "if low_income_applies: base_credit else: 0"}],
+        },
+    }
+    case = {
+        "name": "endpoint",
+        "period": "2026",
+        "input": {"income": 100, "base_credit": 50},
+        "output": {"low_income_applies": "holds", "credit_amount": 50},
+    }
+    common = {
+        "principal_rules": principal_rules,
+        "principal_rule_paths": {
+            "low_income_applies": {("a", "1")},
+            "credit_amount": {("b", "1")},
+        },
+        "numeric_value_is_grounded": numeric_value_is_grounded,
+        "formula_environment": {"income_limit": 100},
+        "extract_numeric_occurrences": EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    }
+
+    witnessed = completeness_module._branch_boundary_test_witnesses(
+        branch,
+        boundary,
+        asserted_by_rule={
+            "low_income_applies": [case],
+            "credit_amount": [case],
+        },
+        **common,
+    )
+    missing_dependency_assertion = {
+        **case,
+        "output": {"credit_amount": 50},
+    }
+    unwitnessed = completeness_module._branch_boundary_test_witnesses(
+        branch,
+        boundary,
+        asserted_by_rule={
+            "low_income_applies": [],
+            "credit_amount": [missing_dependency_assertion],
+        },
+        **common,
+    )
+
+    assert witnessed
+    assert not unwitnessed
+
+
+@pytest.mark.parametrize(
+    "formula",
+    [
+        "if refund_applies: max(0, credit_amount - tax_liability) else: 0",
+        ("if credit_amount > tax_liability: credit_amount - tax_liability else: 0"),
+    ],
+)
+def test_credit_exceeds_liability_pair_witnesses_relational_trigger(
+    formula: str,
+):
+    witnesses, branch = _credit_liability_exception_witnesses(formula=formula)
+
+    assert any(
+        completeness_module._numeric_exception_witness_matches_source(
+            branch,
+            witness,
+            extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        )
+        for witness in witnesses
+    )
+
+
+def test_relational_exception_witness_rejects_reversed_source_operands():
+    witnesses, branch = _credit_liability_exception_witnesses()
+    text = "B.(1) If the tax liability exceeds the credit, no refund is due."
+    reversed_branch = completeness_module.SourceStructureBranch(
+        branch.path,
+        branch.kind,
+        branch.label,
+        text,
+        0,
+        len(text),
+    )
+
+    assert not any(
+        completeness_module._numeric_exception_witness_matches_source(
+            reversed_branch,
+            witness,
+            extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        )
+        for witness in witnesses
+    )
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "period_mismatch",
+        "key_mismatch",
+        "output_key_mismatch",
+        "two_inputs",
+        "missing_affected_output",
+        "missing_asserted_dependency",
+        "wrong_runtime",
+        "unchanged_runtime",
+        "irrelevant_input",
+        "same_side_relation",
+    ],
+)
+def test_credit_liability_relational_witness_preserves_pair_guards(
+    mutation: str,
+):
+    witnesses, branch = _credit_liability_exception_witnesses(mutation=mutation)
+
+    assert not any(
+        completeness_module._numeric_exception_witness_matches_source(
+            branch,
+            witness,
+            extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        )
+        for witness in witnesses
+    )
+
+
+def _credit_liability_exception_witnesses(
+    *,
+    formula: str = ("if refund_applies: max(0, credit_amount - tax_liability) else: 0"),
+    mutation: str | None = None,
+):
+    principal_rules = {
+        "credit_amount": {
+            "name": "credit_amount",
+            "kind": "derived",
+            "dtype": "Money",
+            "versions": [{"formula": "raw_credit"}],
+        },
+        "refund_amount": {
+            "name": "refund_amount",
+            "kind": "derived",
+            "dtype": "Money",
+            "versions": [{"formula": formula}],
+        },
+    }
+    left = {
+        "name": "positive excess",
+        "period": "2026",
+        "input": {
+            "refund_applies": True,
+            "raw_credit": 500,
+            "tax_liability": 300,
+        },
+        "output": {"credit_amount": 500, "refund_amount": 200},
+    }
+    right = {
+        "name": "equality",
+        "period": "2026",
+        "input": {
+            "refund_applies": True,
+            "raw_credit": 500,
+            "tax_liability": 500,
+        },
+        "output": {"credit_amount": 500, "refund_amount": 0},
+    }
+    right = {
+        **right,
+        "input": dict(right["input"]),
+        "output": dict(right["output"]),
+    }
+    if mutation == "period_mismatch":
+        right["period"] = "2027"
+    elif mutation == "key_mismatch":
+        right["input"]["extra"] = 1
+    elif mutation == "output_key_mismatch":
+        right["output"].pop("credit_amount")
+    elif mutation == "two_inputs":
+        right["input"]["refund_applies"] = False
+    elif mutation == "missing_affected_output":
+        left["output"].pop("refund_amount")
+        right["output"].pop("refund_amount")
+    elif mutation == "missing_asserted_dependency":
+        left["output"].pop("credit_amount")
+        right["output"].pop("credit_amount")
+    elif mutation == "wrong_runtime":
+        right["output"]["refund_amount"] = 1
+    elif mutation == "unchanged_runtime":
+        principal_rules["refund_amount"]["versions"][0]["formula"] = (
+            "if refund_applies: 10 + (0 * tax_liability) else: 0"
+        )
+        left["output"]["refund_amount"] = 10
+        right["output"]["refund_amount"] = 10
+    elif mutation == "irrelevant_input":
+        right["input"]["tax_liability"] = 300
+        right["input"]["raw_credit"] = 600
+        right["output"] = {"credit_amount": 600, "refund_amount": 300}
+    elif mutation == "same_side_relation":
+        right["input"]["tax_liability"] = 400
+        right["output"]["refund_amount"] = 100
+
+    witnesses = completeness_module._toggled_formula_numeric_selectors(
+        principal_rules,
+        asserted_by_rule={"refund_amount": [left, right]},
+        formula_environment={},
+    )
+    text = (
+        "B.(1) If the credit exceeds the amount of the individual's tax "
+        "liability, the excess shall constitute an overpayment."
+    )
+    branch = completeness_module.SourceStructureBranch(
+        ("b", "1"),
+        "paragraph",
+        "B.(1)",
+        text,
+        0,
+        len(text),
+    )
+    return witnesses, branch
 
 
 def test_formula_clause_with_explicit_carveout_keeps_exception_obligation():

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -20929,6 +20929,64 @@ def test_boundary_witness_follows_asserted_reached_local_dependency():
     assert not unwitnessed
 
 
+def test_boundary_witness_rejects_effect_invariant_root_behind_dependency():
+    text = "B.(1) The credit applies when income is at most 100 dollars."
+    branch = completeness_module.SourceStructureBranch(
+        ("b", "1"),
+        "paragraph",
+        "B.(1)",
+        text,
+        0,
+        len(text),
+    )
+    boundary = next(
+        occurrence
+        for occurrence in EN_NUMERIC_OCCURRENCE_EXTRACTOR(branch.text)
+        if occurrence.value == 100
+    )
+    principal_rules = {
+        "low_income_applies": {
+            "name": "low_income_applies",
+            "kind": "derived",
+            "dtype": "Judgment",
+            "versions": [{"formula": "income <= income_limit"}],
+        },
+        "credit_amount": {
+            "name": "credit_amount",
+            "kind": "derived",
+            "dtype": "Money",
+            "versions": [
+                {"formula": "if low_income_applies: base_credit else: base_credit"}
+            ],
+        },
+    }
+    case = {
+        "name": "endpoint",
+        "period": "2026",
+        "input": {"income": 100, "base_credit": 50},
+        "output": {"low_income_applies": "holds", "credit_amount": 50},
+    }
+
+    witnessed = completeness_module._branch_boundary_test_witnesses(
+        branch,
+        boundary,
+        principal_rules=principal_rules,
+        principal_rule_paths={
+            "low_income_applies": {("a", "1")},
+            "credit_amount": {("b", "1")},
+        },
+        asserted_by_rule={
+            "low_income_applies": [case],
+            "credit_amount": [case],
+        },
+        numeric_value_is_grounded=numeric_value_is_grounded,
+        formula_environment={"income_limit": 100},
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+
+    assert not witnessed
+
+
 @pytest.mark.parametrize(
     "formula",
     [
@@ -20973,6 +21031,45 @@ def test_relational_exception_witness_rejects_reversed_source_operands():
     )
 
 
+def test_relational_exception_witness_rejects_reversed_effect_orientation():
+    witnesses, branch = _credit_liability_exception_witnesses(
+        formula="if credit_amount > tax_liability: 0 else: 10",
+        mutation="reversed_effect",
+    )
+
+    assert not any(
+        completeness_module._numeric_exception_witness_matches_source(
+            branch,
+            witness,
+            extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        )
+        for witness in witnesses
+    )
+
+
+def test_source_relational_match_does_not_cross_bind_conjoined_relations():
+    source = "The credit exceeds tax liability and income exceeds the income threshold."
+
+    assert completeness_module._source_relational_exception_matches(
+        source,
+        left_name="credit_amount",
+        relation=">",
+        right_name="tax_liability",
+    )
+    assert completeness_module._source_relational_exception_matches(
+        source,
+        left_name="income",
+        relation=">",
+        right_name="income_threshold",
+    )
+    assert not completeness_module._source_relational_exception_matches(
+        source,
+        left_name="credit_amount",
+        relation=">",
+        right_name="income_threshold",
+    )
+
+
 @pytest.mark.parametrize(
     "mutation",
     [
@@ -20986,6 +21083,7 @@ def test_relational_exception_witness_rejects_reversed_source_operands():
         "unchanged_runtime",
         "irrelevant_input",
         "same_side_relation",
+        "wrong_stable_dependency_runtime",
     ],
 )
 def test_credit_liability_relational_witness_preserves_pair_guards(
@@ -21052,7 +21150,7 @@ def _credit_liability_exception_witnesses(
     elif mutation == "key_mismatch":
         right["input"]["extra"] = 1
     elif mutation == "output_key_mismatch":
-        right["output"].pop("credit_amount")
+        right["output"]["unrelated_output"] = 1
     elif mutation == "two_inputs":
         right["input"]["refund_applies"] = False
     elif mutation == "missing_affected_output":
@@ -21076,6 +21174,11 @@ def _credit_liability_exception_witnesses(
     elif mutation == "same_side_relation":
         right["input"]["tax_liability"] = 400
         right["output"]["refund_amount"] = 100
+    elif mutation == "reversed_effect":
+        left["output"]["refund_amount"] = 0
+        right["output"]["refund_amount"] = 10
+    elif mutation == "wrong_stable_dependency_runtime":
+        principal_rules["credit_amount"]["versions"][0]["formula"] = "raw_credit * 2"
 
     witnesses = completeness_module._toggled_formula_numeric_selectors(
         principal_rules,

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1625"
+version = "0.2.1626"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- make complete-source boundary witnesses follow only asserted, runtime-valid local dependencies and require principal effects
- validate relational exception witnesses against source operand order, clause scope, and source-directed effect polarity
- fail closed on ambiguous repeated relations and prevent relational failures from falling through to unrelated numeric intervals
- bump axiom-encode to 0.2.1626

## Louisiana archived replay

Replayed the exact canonical-refresh-02 candidate from failed workflow run 31195903841, artifact 9001330951. Result: archived_issue_count=0. No failed artifact was adopted or hand-edited.

## Checks

- uv run ruff check pyproject.toml src/axiom_encode scripts tests
- python -m compileall -q src/axiom_encode scripts
- focused version-provenance test: 1 passed
- source-completeness suite: 5124 passed
- full repository suite: 11283 passed, 119 skipped
- independent review-fix cycle: CLEAN on head a3497d4834fb44e031a94f017b224bae0e652888

## Review cycle

Independent review repeatedly probed nested boundaries, asserted dependencies, comparator direction, proposition-first and postposed conditions, compound operands, repeated relations, clause coordinates, and relational-plus-numeric ambiguity. All actionable findings were fixed with regressions; final review reported CLEAN.