### PR TITLE
Fix nested exception witness composition

### DIFF
--- a/changelog.d/exception-witness-descendants.fixed.md
+++ b/changelog.d/exception-witness-descendants.fixed.md
@@ -1,0 +1,1 @@
+Recognize paired exception evidence through asserted local Judgment dependencies and nested positive-part formulas.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1627"
+version = "0.2.1628"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1627"
+__version__ = "0.2.1628"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -196,6 +196,7 @@ class _ExceptionWitness:
     zeroes: bool
     numeric_transition: tuple[float, float] | None
     relational_transitions: tuple[tuple[str, str, str], ...] = ()
+    case_pair_identity: tuple[int, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -16867,6 +16868,17 @@ def _rule_numeric_selector_names(rule: dict[str, Any]) -> set[str]:
         right = match.group("right")
         if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", right):
             names.add(right)
+    for operands_text in _balanced_call_operands(formula_text, "max"):
+        expression = _parse_formula_expression(f"max({operands_text})")
+        if expression is None:
+            continue
+        names.update(
+            node.id
+            for operands in _formula_positive_part_operands(expression)
+            for operand in operands
+            for node in ast.walk(operand)
+            if isinstance(node, ast.Name)
+        )
     if not names:
         names.update(
             identifier
@@ -17645,7 +17657,11 @@ def _exception_witnesses_for_branch(
         rule_name
         for rule_name, paths in principal_rule_paths.items()
         if not branch.path
-        or any(path == branch.path[: len(path)] for path in paths if path)
+        or any(
+            path == branch.path[: len(path)] or branch.path == path[: len(branch.path)]
+            for path in paths
+            if path
+        )
     }
     requirement = _source_exception_effect_requirement(branch.text)
     condition_text = _source_exception_condition_text(branch.text)
@@ -18507,14 +18523,66 @@ def _toggled_formula_boolean_selectors(
                     )
                     if witness is not None:
                         toggled.add(witness)
-    toggled.update(
-        _toggled_formula_numeric_selectors(
-            principal_rules,
-            asserted_by_rule=asserted_by_rule,
-            formula_environment=formula_environment,
-        )
+    numeric_witnesses = _toggled_formula_numeric_selectors(
+        principal_rules,
+        asserted_by_rule=asserted_by_rule,
+        formula_environment=formula_environment,
     )
+    toggled.update(_composed_numeric_dependency_witnesses(toggled, numeric_witnesses))
+    toggled.update(numeric_witnesses)
     return toggled
+
+
+def _composed_numeric_dependency_witnesses(
+    boolean_witnesses: Iterable[_ExceptionWitness],
+    numeric_witnesses: Iterable[_ExceptionWitness],
+) -> set[_ExceptionWitness]:
+    activating_by_rule_and_pair: dict[
+        tuple[str, tuple[int, ...]], list[_ExceptionWitness]
+    ] = {}
+    for witness in numeric_witnesses:
+        if (
+            witness.numeric_transition is None
+            or not witness.boolean_effect
+            or witness.blocks
+            or not witness.case_pair_identity
+        ):
+            continue
+        activating_by_rule_and_pair.setdefault(
+            (witness.rule_name, witness.case_pair_identity), []
+        ).append(witness)
+    composed: set[_ExceptionWitness] = set()
+    for witness in boolean_witnesses:
+        if (
+            witness.numeric_transition is not None
+            or not witness.active_value
+            or not witness.case_pair_identity
+        ):
+            continue
+        for dependency_witness in activating_by_rule_and_pair.get(
+            (witness.selector_name, witness.case_pair_identity), ()
+        ):
+            composed.add(
+                _ExceptionWitness(
+                    witness.rule_name,
+                    dependency_witness.selector_name,
+                    True,
+                    witness.blocks,
+                    witness.boolean_effect,
+                    witness.zeroes,
+                    dependency_witness.numeric_transition,
+                    dependency_witness.relational_transitions,
+                    witness.case_pair_identity,
+                )
+            )
+    return composed
+
+
+def _case_pair_identity(
+    left_case: dict[str, Any],
+    right_case: dict[str, Any],
+) -> tuple[int, int]:
+    return tuple(sorted((id(left_case), id(right_case))))
 
 
 def _toggled_formula_numeric_selectors(
@@ -18721,6 +18789,7 @@ def _toggled_formula_numeric_selectors(
                                 _exception_effect_is_zero(exception_runtime),
                                 (ordinary_value, exception_value),
                                 relational_transitions,
+                                _case_pair_identity(left_case, right_case),
                             )
                         )
     return witnesses
@@ -19097,6 +19166,7 @@ def _exception_witness_for_case_pair(
         ),
         _exception_effect_is_zero(counterfactual_runtime),
         None,
+        case_pair_identity=_case_pair_identity(left_case, right_case),
     )
 
 

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1627"
+ENCODER_VERSION = "0.2.1628"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1627"
+ENCODER_VERSION = "0.2.1628"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1627"
+ENCODER_VERSION = "0.2.1628"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1627"
+ENCODER_VERSION = "0.2.1628"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1627"
+ENCODER_VERSION = "0.2.1628"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1627"
+ENCODER_VERSION = "0.2.1628"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1627"
+ENCODER_VERSION = "0.2.1628"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1627"')
+        .startswith('__version__ = "0.2.1628"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1627"
+    assert encoder_package["version"] == "0.2.1628"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1627"
+    assert project["project"]["version"] == "0.2.1628"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1627"')
+        .startswith('__version__ = "0.2.1628"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1627"
+    assert encoder_package["version"] == "0.2.1628"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1627"
+    assert project["project"]["version"] == "0.2.1628"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1627"')
+        .startswith('__version__ = "0.2.1628"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1627"
+ENCODER_VERSION = "0.2.1628"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -21009,6 +21009,166 @@ def test_credit_exceeds_liability_pair_witnesses_relational_trigger(
     )
 
 
+def test_positive_part_selector_survives_unrelated_formula_comparison():
+    witnesses, branch = _credit_liability_exception_witnesses(
+        formula=(
+            "if income <= income_limit: max(0, credit_amount - tax_liability) else: 0"
+        ),
+        stable_inputs={"income": 100, "income_limit": 100},
+    )
+
+    assert any(
+        completeness_module._numeric_exception_witness_matches_source(
+            branch,
+            witness,
+            extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+        )
+        for witness in witnesses
+    )
+
+
+def test_exception_branch_accepts_principal_rule_grounded_to_descendant():
+    text = (
+        "A.(1)(a) If income is equal to or less than 25000 dollars, "
+        "the credit shall be calculated using the following amounts."
+    )
+    branch = completeness_module.SourceStructureBranch(
+        ("a", "1", "a"),
+        "letter",
+        "A.(1)(a)",
+        text,
+        0,
+        len(text),
+    )
+    witness = completeness_module._ExceptionWitness(
+        "low_income_credit_amount",
+        "income",
+        True,
+        False,
+        False,
+        False,
+        (25001, 25000),
+        (),
+    )
+
+    candidates = completeness_module._exception_witnesses_for_branch(
+        branch,
+        principal_rule_paths={
+            "low_income_credit_amount": {("a", "1", "a", "i")},
+        },
+        toggled_exception_selectors={witness},
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+
+    assert candidates == {witness}
+
+
+def test_numeric_transition_propagates_through_asserted_judgment_dependency():
+    principal_rules = {
+        "low_income_applies": {
+            "name": "low_income_applies",
+            "kind": "derived",
+            "dtype": "Judgment",
+            "versions": [{"formula": "income <= income_limit"}],
+        },
+        "low_income_credit_amount": {
+            "name": "low_income_credit_amount",
+            "kind": "derived",
+            "dtype": "Money",
+            "versions": [{"formula": "if low_income_applies: base_credit else: 0"}],
+        },
+    }
+
+    def case(income: int, applies: bool) -> dict[str, object]:
+        return {
+            "name": f"income={income}",
+            "period": "2026",
+            "input": {"income": income, "base_credit": 50},
+            "output": {
+                "low_income_applies": "holds" if applies else "not_holds",
+                "low_income_credit_amount": 50 if applies else 0,
+            },
+        }
+
+    cases = [case(100, True), case(101, False)]
+    witnesses = completeness_module._toggled_formula_boolean_selectors(
+        principal_rules,
+        asserted_by_rule={name: cases for name in principal_rules},
+        formula_environment={"income_limit": 100},
+    )
+    text = (
+        "A.(1)(a) If income is equal to or less than 100 dollars, "
+        "the credit is calculated using the following amounts."
+    )
+    branch = completeness_module.SourceStructureBranch(
+        ("a", "1", "a"),
+        "letter",
+        "A.(1)(a)",
+        text,
+        0,
+        len(text),
+    )
+
+    candidates = completeness_module._exception_witnesses_for_branch(
+        branch,
+        principal_rule_paths={
+            "low_income_applies": {("a", "1", "b")},
+            "low_income_credit_amount": {("a", "1", "a", "i")},
+        },
+        toggled_exception_selectors=witnesses,
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+
+    assert any(
+        witness.rule_name == "low_income_credit_amount"
+        and witness.selector_name == "income"
+        and witness.numeric_transition == (101, 100)
+        for witness in candidates
+    )
+
+
+def test_numeric_dependency_witness_composition_requires_same_case_pair():
+    boolean_witness = completeness_module._ExceptionWitness(
+        "credit_amount",
+        "income_eligible",
+        True,
+        False,
+        False,
+        False,
+        None,
+        case_pair_identity=(1, 2),
+    )
+    unrelated_numeric_witness = completeness_module._ExceptionWitness(
+        "income_eligible",
+        "income",
+        True,
+        False,
+        True,
+        False,
+        (101, 100),
+        case_pair_identity=(3, 4),
+    )
+    matching_numeric_witness = completeness_module._ExceptionWitness(
+        "income_eligible",
+        "income",
+        True,
+        False,
+        True,
+        False,
+        (101, 100),
+        case_pair_identity=(1, 2),
+    )
+
+    assert not completeness_module._composed_numeric_dependency_witnesses(
+        {boolean_witness},
+        {unrelated_numeric_witness},
+    )
+    assert completeness_module._composed_numeric_dependency_witnesses(
+        {boolean_witness},
+        {matching_numeric_witness},
+    )
+
+
 def test_relational_exception_witness_rejects_reversed_source_operands():
     witnesses, branch = _credit_liability_exception_witnesses()
     text = "B.(1) If the tax liability exceeds the credit, no refund is due."
@@ -21578,6 +21738,7 @@ def _credit_liability_exception_witnesses(
     *,
     formula: str = ("if refund_applies: max(0, credit_amount - tax_liability) else: 0"),
     mutation: str | None = None,
+    stable_inputs: dict[str, int] | None = None,
 ):
     principal_rules = {
         "credit_amount": {
@@ -21600,6 +21761,7 @@ def _credit_liability_exception_witnesses(
             "refund_applies": True,
             "raw_credit": 500,
             "tax_liability": 300,
+            **(stable_inputs or {}),
         },
         "output": {"credit_amount": 500, "refund_amount": 200},
     }
@@ -21610,6 +21772,7 @@ def _credit_liability_exception_witnesses(
             "refund_applies": True,
             "raw_credit": 500,
             "tax_liability": 500,
+            **(stable_inputs or {}),
         },
         "output": {"credit_amount": 500, "refund_amount": 0},
     }

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1627"
+version = "0.2.1628"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- recognize numeric selectors nested in positive-part `max(0, ...)` formulas even when other comparisons are present
- accept principal exception rules grounded to descendant source branches
- compose one-hop asserted Judgment dependency transitions with the principal rule, bound to the exact same paired test cases
- bump encoder to 0.2.1628

## Production evidence
Protected Louisiana repair run `31208670476` produced a final candidate for `us-la/statute/47:297.4` whose A(1)(a), B(1), and B(2) paired-exception witnesses were rejected before this change. Against this exact commit, the preserved candidate and companion tests return zero complete-source-unit issues with all 12 source branches recognized.

## Checks
- `pytest -q tests/test_source_completeness.py`: 5135 passed
- focused new/related regressions: 17 passed
- version/registry suite: 1457 passed, 31 skipped
- Ruff check/format and compileall: green
- independent review of exact `4b2b02eefbbc48dda3f67037be861d93543f9048`: CLEAN; reviewer separately replayed production candidate (`issues=0`, 12 branches) and ran focused behavior/version checks

## Review cycle
Initial independent review found that one-hop composition could aggregate evidence from unrelated case pairs by rule name. The implementation now carries an exact unordered identity for the two live case objects and composes only witnesses from the same pair; a cross-pair rejection regression was added. The amended exact commit received a fresh independent CLEAN review.
