### PR TITLE
Add structured deferred-output review contracts

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -39,7 +39,7 @@ on:
         required: false
         type: string
       source_bundle_json:
-        description: JSON citation array for atomic imports, or {"canonical_refresh_bundle":[{citation,replace_rulespec_path,review_finding?}]} for an independent refresh transaction
+        description: JSON citation array for atomic imports, or {"canonical_refresh_bundle":[{citation,replace_rulespec_path,review_finding?,deferred_output_contracts?}]} for an independent refresh transaction
         required: false
         default: "[]"
         type: string
@@ -1061,7 +1061,9 @@ jobs:
             local replacement_path="$5"
             local legacy_source_path="$6"
             local require_direct_imports="$7"
+            local deferred_output_contracts_json="${8:-[]}"
             local review_finding_path=""
+            local review_contract_json=""
             local -a args=(
               /opt/axiom-verification/axiom-encode encode
               --backend openai
@@ -1143,6 +1145,26 @@ jobs:
               review_finding_path="$review_finding_dir/review-finding.txt"
               printf '%s\n' "$review_finding" > "$review_finding_path"
               args+=(--review-findings "$review_finding_path")
+            fi
+            if [ "$deferred_output_contracts_json" != "[]" ]; then
+              review_contract_json="$(
+                jq -cn \
+                  --arg schema "axiom-encode/review-contract/v1" \
+                  --arg citation "$citation" \
+                  --arg rulespec_path "$replacement_path" \
+                  --argjson required_deferred_outputs \
+                    "$deferred_output_contracts_json" \
+                  '{
+                    schema: $schema,
+                    citation: $citation,
+                    rulespec_path: $rulespec_path,
+                    required_deferred_outputs: $required_deferred_outputs
+                  }'
+              )"
+              args+=(
+                --review-contract-json
+                "$review_contract_json"
+              )
             fi
             if [ -n "${REPAIR_CANDIDATE_ROOT:-}" ]; then
               test -n "${REPAIR_CANDIDATE_PATH:-}" \
@@ -1474,6 +1496,9 @@ jobs:
                 "$RUNNER_TEMP/canonical-refresh-bundle.json")
               refresh_citation="$(jq -er '.citation' <<< "$refresh_item")"
               refresh_rulespec_path="$(jq -er '.rulespec_path' <<< "$refresh_item")"
+              refresh_deferred_output_contracts="$(
+                jq -cer '.deferred_output_contracts // []' <<< "$refresh_item"
+              )"
               refresh_lane=target
               refresh_finding="$REVIEW_FINDING"
               if [ "$refresh_index" -gt 0 ]; then
@@ -1483,7 +1508,8 @@ jobs:
               fi
               run_signed_encode \
                 "$refresh_citation" "$refresh_finding" false "$refresh_lane" \
-                "$refresh_rulespec_path" "" false
+                "$refresh_rulespec_path" "" false \
+                "$refresh_deferred_output_contracts"
               checkpoint_signed_changes \
                 "Refresh signed canonical module for ${refresh_citation}"
               cp "$RUNNER_TEMP/checkpoint-guard-generated.json" \
@@ -1855,6 +1881,7 @@ jobs:
                   "manifest_path",
                   "manifest_sha256",
                   "review_finding",
+                  "deferred_output_contracts",
               }
               and isinstance(item["citation"], str)
               and item["citation"]
@@ -1862,6 +1889,32 @@ jobs:
               and item["rulespec_path"]
               and isinstance(item["companion_path"], str)
               and item["companion_path"]
+              and isinstance(item["deferred_output_contracts"], list)
+              and len(item["deferred_output_contracts"]) <= 16
+              and all(
+                  isinstance(contract, dict)
+                  and set(contract) == {"output", "reason"}
+                  and all(
+                      isinstance(contract[field], str)
+                      and contract[field]
+                      and contract[field] == contract[field].strip()
+                      and "\r" not in contract[field]
+                      and not any(
+                          (ord(char) < 32 and char not in {"\n", "\t"})
+                          or ord(char) == 127
+                          for char in contract[field]
+                      )
+                      for field in ("output", "reason")
+                  )
+                  for contract in item["deferred_output_contracts"]
+              )
+              and len(
+                  {
+                      contract["output"]
+                      for contract in item["deferred_output_contracts"]
+                  }
+              )
+              == len(item["deferred_output_contracts"])
               and (
                   item["review_finding"] is None
                   or (

--- a/changelog.d/structured-deferred-output-review-contract.added.md
+++ b/changelog.d/structured-deferred-output-review-contract.added.md
@@ -1,0 +1,1 @@
+Add a citation- and RuleSpec-path-bound review contract that mechanically enforces exact YAML-decoded deferred output reasons on the final repaired overlay before apply admission.

--- a/changelog.d/structured-deferred-output-review-contract.added.md
+++ b/changelog.d/structured-deferred-output-review-contract.added.md
@@ -1,1 +1,1 @@
-Add a citation- and RuleSpec-path-bound review contract that mechanically enforces exact YAML-decoded deferred output reasons on the final repaired overlay before apply admission.
+Add a bounded, unambiguous, citation- and RuleSpec-path-bound deferred-output review contract to signed canonical refreshes. Exact YAML-decoded output/reason pairs are supplied to every generation attempt and enforced before the successful apply validation snapshot.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1633"
+version = "0.2.1634"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1631"
+version = "0.2.1632"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1632"
+version = "0.2.1633"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -49,6 +49,8 @@ MAX_SOURCE_BUNDLE_CITATIONS = 16
 MAX_SOURCE_BUNDLE_JSON_BYTES = 512 * 1024
 MAX_CANONICAL_REFRESH_BUNDLE_CITATIONS = MAX_SOURCE_BUNDLE_CITATIONS - 1
 MAX_DEFERRED_OUTPUT_CONTRACTS = 16
+MAX_DEFERRED_OUTPUT_REVIEW_CONTRACT_JSON_BYTES = 64 * 1024
+DEFERRED_OUTPUT_REVIEW_CONTRACT_SCHEMA = "axiom-encode/review-contract/v1"
 REVIEWED_RULESPEC_REFS = frozenset(
     {
         (
@@ -94,6 +96,20 @@ REVIEWED_RULESPEC_PR_BASE_BRANCHES = frozenset(
         ("us", "hard-cut/canonical-layout-us"),
     }
 )
+
+
+def _load_unambiguous_json(raw: str, *, label: str) -> object:
+    """Decode untrusted transaction JSON while rejecting duplicate object keys."""
+
+    def reject_duplicates(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        decoded: dict[str, object] = {}
+        for key, value in pairs:
+            if key in decoded:
+                raise ValueError(f"{label} contains duplicate JSON key {key!r}")
+            decoded[key] = value
+        return decoded
+
+    return json.loads(raw, object_pairs_hook=reject_duplicates)
 
 
 def _read_bounded_regular(
@@ -268,7 +284,7 @@ def split_atomic_source_input(atomic_source_json: str) -> dict[str, object]:
         raise ValueError("atomic source JSON must be a string")
     if len(atomic_source_json.encode("utf-8")) > MAX_SOURCE_BUNDLE_JSON_BYTES:
         raise ValueError("atomic source JSON exceeds the maximum input size")
-    payload = json.loads(atomic_source_json)
+    payload = _load_unambiguous_json(atomic_source_json, label="atomic source JSON")
     if isinstance(payload, list):
         return {
             "canonical_refresh_bundle": [],
@@ -304,7 +320,7 @@ def parse_source_bundle(
         raise ValueError("source bundle JSON must be a string")
     if len(source_bundle_json.encode("utf-8")) > MAX_SOURCE_BUNDLE_JSON_BYTES:
         raise ValueError("source bundle JSON exceeds the maximum input size")
-    payload = json.loads(source_bundle_json)
+    payload = _load_unambiguous_json(source_bundle_json, label="source bundle JSON")
     if not isinstance(payload, list):
         raise ValueError("source bundle JSON must be an array")
     if len(payload) > MAX_SOURCE_BUNDLE_CITATIONS:
@@ -484,7 +500,10 @@ def parse_canonical_refresh_bundle(
         raise ValueError("canonical refresh bundle JSON must be a string")
     if len(refresh_bundle_json.encode("utf-8")) > MAX_SOURCE_BUNDLE_JSON_BYTES:
         raise ValueError("canonical refresh bundle JSON exceeds the maximum input size")
-    payload = json.loads(refresh_bundle_json)
+    payload = _load_unambiguous_json(
+        refresh_bundle_json,
+        label="canonical refresh bundle JSON",
+    )
     if not isinstance(payload, list):
         raise ValueError("canonical refresh bundle JSON must be an array")
     if len(payload) > MAX_CANONICAL_REFRESH_BUNDLE_CITATIONS:
@@ -636,6 +655,22 @@ def parse_canonical_refresh_bundle(
             raise ValueError(
                 f"{label} path must equal the citation's canonical RuleSpec path"
             )
+        if normalized_contracts:
+            wrapped_contract = json.dumps(
+                {
+                    "schema": DEFERRED_OUTPUT_REVIEW_CONTRACT_SCHEMA,
+                    "citation": citation,
+                    "rulespec_path": path.as_posix(),
+                    "required_deferred_outputs": normalized_contracts,
+                },
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ).encode("utf-8")
+            if len(wrapped_contract) > MAX_DEFERRED_OUTPUT_REVIEW_CONTRACT_JSON_BYTES:
+                raise ValueError(
+                    f"{label} wrapped deferred output review contract exceeds "
+                    "the maximum input size"
+                )
         if citation in seen_citations or path in seen_paths:
             raise ValueError("canonical refresh citations and paths must be unique")
         requested.append((citation, path, review_finding, tuple(normalized_contracts)))

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -48,6 +48,7 @@ RULESPEC_ATOMIC_ROOTS = frozenset(
 MAX_SOURCE_BUNDLE_CITATIONS = 16
 MAX_SOURCE_BUNDLE_JSON_BYTES = 512 * 1024
 MAX_CANONICAL_REFRESH_BUNDLE_CITATIONS = MAX_SOURCE_BUNDLE_CITATIONS - 1
+MAX_DEFERRED_OUTPUT_CONTRACTS = 16
 REVIEWED_RULESPEC_REFS = frozenset(
     {
         (
@@ -521,15 +522,19 @@ def parse_canonical_refresh_bundle(
             "RuleSpec path"
         )
 
-    requested: list[tuple[str, PurePosixPath, str | None]] = [
-        (primary_citation, primary_path, None)
-    ]
+    requested: list[
+        tuple[str, PurePosixPath, str | None, tuple[dict[str, str], ...]]
+    ] = [(primary_citation, primary_path, None, ())]
     seen_citations = {primary_citation}
     seen_paths = {primary_path}
     for index, value in enumerate(payload):
         label = f"canonical refresh addition #{index + 1}"
         required_fields = {"citation", "replace_rulespec_path"}
-        allowed_fields = {*required_fields, "review_finding"}
+        allowed_fields = {
+            *required_fields,
+            "review_finding",
+            "deferred_output_contracts",
+        }
         if (
             not isinstance(value, dict)
             or not required_fields.issubset(value)
@@ -537,11 +542,12 @@ def parse_canonical_refresh_bundle(
         ):
             raise ValueError(
                 f"{label} must contain citation and replace_rulespec_path, with "
-                "only an optional review_finding"
+                "only optional review_finding and deferred_output_contracts fields"
             )
         citation = value["citation"]
         raw_path = value["replace_rulespec_path"]
         review_finding = value.get("review_finding")
+        deferred_output_contracts = value.get("deferred_output_contracts", [])
         if (
             not isinstance(citation, str)
             or not citation
@@ -570,6 +576,48 @@ def parse_canonical_refresh_bundle(
             raise ValueError(
                 f"{label} review_finding must be a nonempty normalized string"
             )
+        if (
+            not isinstance(deferred_output_contracts, list)
+            or len(deferred_output_contracts) > MAX_DEFERRED_OUTPUT_CONTRACTS
+        ):
+            raise ValueError(
+                f"{label} deferred_output_contracts must be an array with at most "
+                f"{MAX_DEFERRED_OUTPUT_CONTRACTS} entries"
+            )
+        normalized_contracts: list[dict[str, str]] = []
+        seen_contract_outputs: set[str] = set()
+        for contract_index, contract in enumerate(deferred_output_contracts):
+            contract_label = f"{label} deferred output contract #{contract_index + 1}"
+            if not isinstance(contract, dict) or set(contract) != {
+                "output",
+                "reason",
+            }:
+                raise ValueError(
+                    f"{contract_label} must contain exactly output and reason"
+                )
+            output = contract["output"]
+            reason = contract["reason"]
+            if any(
+                not isinstance(field, str)
+                or not field
+                or field != field.strip()
+                or "\r" in field
+                or any(
+                    (ord(character) < 32 and character not in {"\n", "\t"})
+                    or ord(character) == 127
+                    for character in field
+                )
+                for field in (output, reason)
+            ):
+                raise ValueError(
+                    f"{contract_label} fields must be nonempty normalized strings"
+                )
+            if output in seen_contract_outputs:
+                raise ValueError(
+                    f"{label} deferred output contract outputs must be unique"
+                )
+            seen_contract_outputs.add(output)
+            normalized_contracts.append({"output": output, "reason": reason})
         try:
             citation = require_canonical_corpus_citation_path(citation)
         except ValueError as exc:
@@ -590,7 +638,7 @@ def parse_canonical_refresh_bundle(
             )
         if citation in seen_citations or path in seen_paths:
             raise ValueError("canonical refresh citations and paths must be unique")
-        requested.append((citation, path, review_finding))
+        requested.append((citation, path, review_finding, tuple(normalized_contracts)))
         seen_citations.add(citation)
         seen_paths.add(path)
 
@@ -600,8 +648,9 @@ def parse_canonical_refresh_bundle(
             citation=citation,
             path=path,
             review_finding=review_finding,
+            deferred_output_contracts=deferred_output_contracts,
         )
-        for citation, path, review_finding in requested
+        for citation, path, review_finding, deferred_output_contracts in requested
     )
 
 
@@ -611,7 +660,8 @@ def _canonical_refresh_target_inventory(
     citation: str,
     path: PurePosixPath,
     review_finding: str | None,
-) -> dict[str, str | None]:
+    deferred_output_contracts: tuple[dict[str, str], ...],
+) -> dict[str, object]:
     """Bind one refresh target and its untrusted predecessor manifest to HEAD."""
 
     manifest_path = _existing_import_manifest_path(path)
@@ -737,6 +787,7 @@ def _canonical_refresh_target_inventory(
     return {
         "citation": citation,
         "review_finding": review_finding,
+        "deferred_output_contracts": list(deferred_output_contracts),
         "rulespec_path": path.as_posix(),
         "rulespec_sha256": target_sha256,
         "companion_path": companion_path.as_posix(),
@@ -749,7 +800,7 @@ def _canonical_refresh_target_inventory(
 def verify_canonical_refresh_target(
     repo: Path,
     target_json: str,
-) -> dict[str, str | None]:
+) -> dict[str, object]:
     """Require one normalized target to remain byte-identical before its lane."""
 
     try:
@@ -765,13 +816,18 @@ def verify_canonical_refresh_target(
         "manifest_path",
         "manifest_sha256",
         "review_finding",
+        "deferred_output_contracts",
     }
+    deferred_output_contracts = (
+        target.get("deferred_output_contracts") if isinstance(target, dict) else None
+    )
     if (
         not isinstance(target, dict)
         or set(target) != expected_fields
         or not all(
             isinstance(target[field], str) and target[field]
-            for field in expected_fields - {"companion_sha256", "review_finding"}
+            for field in expected_fields
+            - {"companion_sha256", "review_finding", "deferred_output_contracts"}
         )
         or (
             target["companion_sha256"] is not None
@@ -782,6 +838,34 @@ def verify_canonical_refresh_target(
         )
         or DIGEST_PATTERN.fullmatch(target["rulespec_sha256"]) is None
         or DIGEST_PATTERN.fullmatch(target["manifest_sha256"]) is None
+        or not isinstance(deferred_output_contracts, list)
+        or len(deferred_output_contracts) > MAX_DEFERRED_OUTPUT_CONTRACTS
+        or any(
+            not isinstance(contract, dict)
+            or set(contract) != {"output", "reason"}
+            or any(
+                not isinstance(contract[field], str)
+                or not contract[field]
+                or contract[field] != contract[field].strip()
+                or "\r" in contract[field]
+                or any(
+                    (ord(character) < 32 and character not in {"\n", "\t"})
+                    or ord(character) == 127
+                    for character in contract[field]
+                )
+                for field in ("output", "reason")
+            )
+            for contract in deferred_output_contracts or []
+        )
+        or len(
+            {
+                contract["output"]
+                for contract in deferred_output_contracts or []
+                if isinstance(contract, dict)
+                and isinstance(contract.get("output"), str)
+            }
+        )
+        != len(deferred_output_contracts or [])
         or (
             target["review_finding"] is not None
             and (

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1633"
+__version__ = "0.2.1634"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1632"
+__version__ = "0.2.1633"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1631"
+__version__ = "0.2.1632"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -1095,8 +1095,20 @@ def _parse_deferred_output_review_contract_json(
         raise argparse.ArgumentTypeError(
             "review contract JSON exceeds the bounded size"
         )
+    def reject_duplicates(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        decoded: dict[str, object] = {}
+        for key, value in pairs:
+            if key in decoded:
+                raise argparse.ArgumentTypeError(
+                    f"review contract contains duplicate JSON key {key!r}"
+                )
+            decoded[key] = value
+        return decoded
+
     try:
-        payload = json.loads(raw)
+        payload = json.loads(raw, object_pairs_hook=reject_duplicates)
+    except argparse.ArgumentTypeError:
+        raise
     except (json.JSONDecodeError, RecursionError) as exc:
         raise argparse.ArgumentTypeError("review contract must be valid JSON") from exc
     if not isinstance(payload, dict) or set(payload) != {
@@ -27720,6 +27732,11 @@ def _run_encode_attempt(
         ),
         validation_retry_feedback=validation_retry_feedback,
         validation_retry_candidate=validation_retry_candidate,
+        required_deferred_output_contracts=(
+            deferred_output_review_contract.required_deferred_outputs
+            if deferred_output_review_contract is not None
+            else ()
+        ),
         required_import_targets=required_import_targets,
         legacy_replacement=(
             replacement_target.legacy_replacement

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -1073,6 +1073,174 @@ def _format_counter(counter: dict[str, int]) -> str:
     return ", ".join(f"{key}={value}" for key, value in counter.items())
 
 
+_MAX_REQUIRED_DEFERRED_OUTPUT_CONTRACTS = 16
+_MAX_REQUIRED_DEFERRED_OUTPUT_CONTRACT_JSON_BYTES = 64 * 1024
+_DEFERRED_OUTPUT_REVIEW_CONTRACT_SCHEMA = "axiom-encode/review-contract/v1"
+
+
+class _DeferredOutputReviewContract(NamedTuple):
+    citation: str
+    rulespec_path: str
+    required_deferred_outputs: tuple[tuple[str, str], ...]
+
+
+def _parse_deferred_output_review_contract_json(
+    raw: str,
+) -> _DeferredOutputReviewContract:
+    """Parse one citation- and path-bound exact apply-admission contract."""
+
+    if not isinstance(raw, str) or (
+        len(raw.encode("utf-8")) > _MAX_REQUIRED_DEFERRED_OUTPUT_CONTRACT_JSON_BYTES
+    ):
+        raise argparse.ArgumentTypeError(
+            "review contract JSON exceeds the bounded size"
+        )
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, RecursionError) as exc:
+        raise argparse.ArgumentTypeError("review contract must be valid JSON") from exc
+    if not isinstance(payload, dict) or set(payload) != {
+        "schema",
+        "citation",
+        "rulespec_path",
+        "required_deferred_outputs",
+    }:
+        raise argparse.ArgumentTypeError(
+            "review contract must contain exactly schema, citation, rulespec_path, "
+            "and required_deferred_outputs"
+        )
+    if payload["schema"] != _DEFERRED_OUTPUT_REVIEW_CONTRACT_SCHEMA:
+        raise argparse.ArgumentTypeError("review contract schema is unsupported")
+    citation = payload["citation"]
+    rulespec_path = payload["rulespec_path"]
+    if any(
+        not isinstance(value, str)
+        or not value
+        or value != value.strip()
+        or any(ord(character) < 32 or ord(character) == 127 for character in value)
+        for value in (citation, rulespec_path)
+    ):
+        raise argparse.ArgumentTypeError(
+            "review contract citation and rulespec_path must be normalized strings"
+        )
+    path = Path(rulespec_path)
+    if (
+        path.is_absolute()
+        or path.suffix != RULESPEC_FILE_SUFFIX
+        or len(path.parts) < 2
+        or any(part in {"", ".", ".."} for part in path.parts)
+        or "\\" in rulespec_path
+    ):
+        raise argparse.ArgumentTypeError(
+            "review contract rulespec_path must be a canonical relative YAML path"
+        )
+    payload_contracts = payload["required_deferred_outputs"]
+    if (
+        not isinstance(payload_contracts, list)
+        or not payload_contracts
+        or len(payload_contracts) > _MAX_REQUIRED_DEFERRED_OUTPUT_CONTRACTS
+    ):
+        raise argparse.ArgumentTypeError(
+            "review contract required_deferred_outputs must be a nonempty array with "
+            f"at most {_MAX_REQUIRED_DEFERRED_OUTPUT_CONTRACTS} entries"
+        )
+    contracts: list[tuple[str, str]] = []
+    seen_outputs: set[str] = set()
+    for index, item in enumerate(payload_contracts):
+        if not isinstance(item, dict) or set(item) != {"output", "reason"}:
+            raise argparse.ArgumentTypeError(
+                f"review contract deferred output #{index + 1} must contain "
+                "exactly output and reason"
+            )
+        output = item["output"]
+        reason = item["reason"]
+        if any(
+            not isinstance(value, str)
+            or not value
+            or value != value.strip()
+            or "\r" in value
+            or any(
+                (ord(character) < 32 and character not in {"\n", "\t"})
+                or ord(character) == 127
+                for character in value
+            )
+            for value in (output, reason)
+        ):
+            raise argparse.ArgumentTypeError(
+                f"review contract deferred output #{index + 1} fields must be "
+                "nonempty normalized strings"
+            )
+        if output in seen_outputs:
+            raise argparse.ArgumentTypeError(
+                "review contract deferred outputs must be unique"
+            )
+        seen_outputs.add(output)
+        contracts.append((output, reason))
+    return _DeferredOutputReviewContract(
+        citation=citation,
+        rulespec_path=rulespec_path,
+        required_deferred_outputs=tuple(contracts),
+    )
+
+
+def _required_deferred_output_contract_issues(
+    output_file: Path,
+    contract: _DeferredOutputReviewContract | None,
+    *,
+    citation: str,
+    rulespec_path: str,
+) -> list[str]:
+    """Require exact output/reason pairs after YAML decoding and before apply."""
+
+    if contract is None:
+        return []
+    binding_issues: list[str] = []
+    if citation != contract.citation:
+        binding_issues.append(
+            "[required-deferred-output-contract] generated citation does not match "
+            "the signed dispatch review contract"
+        )
+    if rulespec_path != contract.rulespec_path:
+        binding_issues.append(
+            "[required-deferred-output-contract] generated RuleSpec path does not "
+            "match the signed dispatch review contract"
+        )
+    if binding_issues:
+        return binding_issues
+    try:
+        payload = yaml.safe_load(output_file.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, yaml.YAMLError, RecursionError) as exc:
+        return [f"required deferred-output contract could not parse YAML: {exc}"]
+    module = payload.get("module") if isinstance(payload, dict) else None
+    deferred_outputs = (
+        module.get("deferred_outputs") if isinstance(module, dict) else None
+    )
+    records = deferred_outputs if isinstance(deferred_outputs, list) else []
+    issues: list[str] = []
+    for expected_output, expected_reason in contract.required_deferred_outputs:
+        matching_output = [
+            record
+            for record in records
+            if isinstance(record, dict) and record.get("output") == expected_output
+        ]
+        if len(matching_output) != 1:
+            issues.append(
+                "[required-deferred-output-contract] expected exactly one "
+                f"module.deferred_outputs entry with output `{expected_output}`; "
+                f"found {len(matching_output)}"
+            )
+            continue
+        actual_reason = matching_output[0].get("reason")
+        if actual_reason != expected_reason:
+            issues.append(
+                "[required-deferred-output-contract] YAML-decoded reason for "
+                f"`{expected_output}` must equal the signed dispatch contract "
+                "byte-for-byte; paraphrase, shortening, reordering, and synonym "
+                "substitution are not permitted"
+            )
+    return issues
+
+
 def main():
     """Main CLI entry point."""
     parser = argparse.ArgumentParser(
@@ -2212,6 +2380,16 @@ def main():
         help=(
             "Independent-review findings that the generated encoding must address "
             "without narrowing unaffected source-backed behavior (repeatable)"
+        ),
+    )
+    encode_parser.add_argument(
+        "--review-contract-json",
+        type=_parse_deferred_output_review_contract_json,
+        default=None,
+        help=(
+            "Bounded citation- and path-bound review contract whose exact "
+            "deferred-output pairs the generated YAML must contain after decoding "
+            "before apply"
         ),
     )
     encode_parser.add_argument(
@@ -27479,6 +27657,8 @@ def _run_encode_attempt(
             )
         )
 
+    deferred_output_review_contract = getattr(args, "review_contract_json", None)
+
     def _validate_generated_encoding_in_policy_overlay(
         result,
         *,
@@ -27498,6 +27678,7 @@ def _run_encode_attempt(
             require_complete_source_unit=(
                 getattr(args, "require_complete_source_unit", False) is True
             ),
+            deferred_output_review_contract=deferred_output_review_contract,
         )
 
     skip_reviewers = bool(getattr(args, "skip_reviewers", False))
@@ -51324,6 +51505,7 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
     validate_dependents: bool = True,
     rulespec_dependency_roots: Sequence[Path] = (),
     require_complete_source_unit: bool = False,
+    deferred_output_review_contract: _DeferredOutputReviewContract | None = None,
 ) -> tuple[bool, list[str], dict[Path, str]]:
     """Validate generated artifacts in a temporary policy-repo overlay."""
     setattr(result, _APPLY_VALIDATION_SNAPSHOT_ATTR, None)
@@ -51643,6 +51825,23 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
                         dependents=dependents,
                     )
                 if all(validation.all_passed for _, validation in validations):
+                    contract_issues = _required_deferred_output_contract_issues(
+                        overlay_target,
+                        deferred_output_review_contract,
+                        citation=str(getattr(result, "citation", "") or ""),
+                        rulespec_path=(
+                            policy_content_root.name + "/" + relative_output.as_posix()
+                        ),
+                    )
+                    if contract_issues:
+                        return (
+                            False,
+                            [
+                                f"{relative_output}: {issue}"
+                                for issue in contract_issues
+                            ],
+                            {},
+                        )
                     repaired_exact_paths = exact_relative_paths.intersection(
                         supplemental_files
                     )
@@ -52044,6 +52243,7 @@ def _run_generated_encoding_overlay_validation(
     validate_dependents: bool = True,
     rulespec_dependency_roots: Sequence[Path] = (),
     require_complete_source_unit: bool = False,
+    deferred_output_review_contract: _DeferredOutputReviewContract | None = None,
 ) -> tuple[bool, list[str], dict[Path, str]]:
     """Dispatch a release-bound overlay run through the patchable test seam."""
 
@@ -52056,6 +52256,7 @@ def _run_generated_encoding_overlay_validation(
         validate_dependents=validate_dependents,
         rulespec_dependency_roots=rulespec_dependency_roots,
         require_complete_source_unit=require_complete_source_unit,
+        deferred_output_review_contract=deferred_output_review_contract,
     )
 
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -1095,6 +1095,7 @@ def _parse_deferred_output_review_contract_json(
         raise argparse.ArgumentTypeError(
             "review contract JSON exceeds the bounded size"
         )
+
     def reject_duplicates(pairs: list[tuple[str, object]]) -> dict[str, object]:
         decoded: dict[str, object] = {}
         for key, value in pairs:

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -10109,9 +10109,7 @@ Preferred principal output:
         validation_retry_feedback
     )
     required_deferred_output_contract_section = (
-        _format_required_deferred_output_contracts(
-            required_deferred_output_contracts
-        )
+        _format_required_deferred_output_contracts(required_deferred_output_contracts)
     )
     validation_retry_candidate_section = _format_validation_retry_candidate(
         validation_retry_candidate,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -1506,6 +1506,7 @@ def run_model_eval(
     require_complete_source_unit: bool = False,
     target_relative_output: Path | None = None,
     validation_retry_feedback: Sequence[str] = (),
+    required_deferred_output_contracts: Sequence[tuple[str, str]] = (),
     required_import_targets: Sequence[str] = (),
     legacy_replacement: LegacyReplacementContract | None = None,
     replacement_overlay_scope: bool = False,
@@ -1553,6 +1554,9 @@ def run_model_eval(
                         require_complete_source_unit=require_complete_source_unit,
                         target_relative_output=target_relative_output,
                         validation_retry_feedback=validation_retry_feedback,
+                        required_deferred_output_contracts=(
+                            required_deferred_output_contracts
+                        ),
                         validation_retry_candidate=validation_retry_candidate,
                         required_import_targets=required_import_targets,
                         legacy_replacement=legacy_replacement,
@@ -8462,6 +8466,7 @@ def _run_single_eval(
     require_complete_source_unit: bool = False,
     target_relative_output: Path | None = None,
     validation_retry_feedback: Sequence[str] = (),
+    required_deferred_output_contracts: Sequence[tuple[str, str]] = (),
     required_import_targets: Sequence[str] = (),
     legacy_replacement: LegacyReplacementContract | None = None,
     replacement_overlay_scope: bool = False,
@@ -8529,6 +8534,7 @@ def _run_single_eval(
         policyengine_rule_hint=policyengine_rule_hint,
         require_complete_source_unit=require_complete_source_unit,
         validation_retry_feedback=validation_retry_feedback,
+        required_deferred_output_contracts=required_deferred_output_contracts,
         validation_retry_candidate=validation_retry_candidate,
         required_import_targets=required_import_targets,
     )
@@ -9443,6 +9449,46 @@ Deterministic validation feedback for the rejected candidate below:
 """
 
 
+def _format_required_deferred_output_contracts(
+    contracts: Sequence[tuple[str, str]],
+) -> str:
+    """Render exact apply-admission requirements on every generation attempt."""
+
+    if not contracts:
+        return ""
+    rendered: list[str] = []
+    for index, contract in enumerate(contracts):
+        if (
+            not isinstance(contract, tuple)
+            or len(contract) != 2
+            or any(not isinstance(value, str) or not value for value in contract)
+        ):
+            raise ValueError(
+                f"Required deferred output contract #{index + 1} is invalid"
+            )
+        output, reason = contract
+        rendered.append(
+            json.dumps(
+                {"output": output, "reason": reason},
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+        )
+    return f"""
+Structured deferred-output apply-admission contract:
+- The following JSON objects are trusted workflow requirements, not legal
+  authority. Their exact output/reason pairs must each appear exactly once in
+  `module.deferred_outputs`.
+- Equality is checked after YAML decoding. Preserve every character of each
+  JSON string exactly; do not paraphrase, normalize whitespace, or change case
+  or punctuation.
+
+=== BEGIN REQUIRED DEFERRED OUTPUT CONTRACT ===
+{chr(10).join(rendered)}
+=== END REQUIRED DEFERRED OUTPUT CONTRACT ===
+"""
+
+
 def _format_validation_retry_candidate(
     candidate: ValidationRetryCandidate | None,
     *,
@@ -9506,6 +9552,7 @@ def _build_rulespec_eval_prompt(
     include_corpus_context_injection: bool = True,
     require_complete_source_unit: bool = False,
     validation_retry_feedback: Sequence[str] = (),
+    required_deferred_output_contracts: Sequence[tuple[str, str]] = (),
     validation_retry_candidate: ValidationRetryCandidate | None = None,
     required_import_targets: Sequence[str] = (),
 ) -> str:
@@ -10061,6 +10108,11 @@ Preferred principal output:
     validation_retry_feedback_section = _format_validation_retry_feedback(
         validation_retry_feedback
     )
+    required_deferred_output_contract_section = (
+        _format_required_deferred_output_contracts(
+            required_deferred_output_contracts
+        )
+    )
     validation_retry_candidate_section = _format_validation_retry_candidate(
         validation_retry_candidate,
         target_file_name=target_file_name,
@@ -10164,7 +10216,7 @@ Primary legal authority:
 {legal_authority_instruction}
 {corpus_source_section.rstrip()}
 {inline_source}
-{source_metadata_section}{provision_metadata_section}{amendment_section}{context_section}{missing_cited_source_section}{mandatory_review_findings_section}{validation_retry_feedback_section}{required_import_section}
+{source_metadata_section}{provision_metadata_section}{amendment_section}{context_section}{missing_cited_source_section}{mandatory_review_findings_section}{required_deferred_output_contract_section}{validation_retry_feedback_section}{required_import_section}
 {backend_section}
 {canonical_concept_section}{complete_source_unit_section}
 RuleSpec requirements:
@@ -10995,6 +11047,7 @@ def _build_eval_prompt(
     include_corpus_context_injection: bool = True,
     require_complete_source_unit: bool = False,
     validation_retry_feedback: Sequence[str] = (),
+    required_deferred_output_contracts: Sequence[tuple[str, str]] = (),
     validation_retry_candidate: ValidationRetryCandidate | None = None,
     required_import_targets: Sequence[str] = (),
 ) -> str:
@@ -11012,6 +11065,7 @@ def _build_eval_prompt(
         include_corpus_context_injection=include_corpus_context_injection,
         require_complete_source_unit=require_complete_source_unit,
         validation_retry_feedback=validation_retry_feedback,
+        required_deferred_output_contracts=required_deferred_output_contracts,
         validation_retry_candidate=validation_retry_candidate,
         required_import_targets=required_import_targets,
     )

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1632"
+ENCODER_VERSION = "0.2.1633"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1633"
+ENCODER_VERSION = "0.2.1634"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1631"
+ENCODER_VERSION = "0.2.1632"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,6 +65,7 @@ from axiom_encode.cli import (
     _current_guard_encoder_execution_identity,
     _declared_rule_subsection_source_text,
     _default_generated_test_input_value,
+    _DeferredOutputReviewContract,
     _discover_rulespec_test_files,
     _effective_runner_specs,
     _ensure_no_unmanifested_preexisting_rulespec_changes,
@@ -40751,6 +40752,99 @@ rules:
             "target: statutes/42/new.yaml"
         ]
         assert supplemental == {}
+
+    def test_apply_overlay_checks_review_contract_before_success_snapshot(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us" / "us-la"
+        target = policy_repo / "statutes/47/295.yaml"
+        generated = output_root / "codex-test-model/statutes/47/295.yaml"
+        target.parent.mkdir(parents=True)
+        generated.parent.mkdir(parents=True)
+        target.write_text("format: rulespec/v1\nrules: []\n")
+        output = "us-la:statutes/47/295/a#individual_louisiana_income_tax_amount"
+        expected_reason = "Exact source-bound missing dependency."
+        generated.write_text(
+            "format: rulespec/v1\n"
+            "module:\n"
+            "  deferred_outputs:\n"
+            f"    - output: {output}\n"
+            "      reason: Wrong paraphrase.\n"
+            "rules: []\n"
+        )
+        result = SimpleNamespace(
+            output_file=str(generated),
+            runner="codex-test-model",
+            backend="codex",
+            citation="us-la/statute/47:295",
+        )
+        contract = _DeferredOutputReviewContract(
+            citation="us-la/statute/47:295",
+            rulespec_path="us-la/statutes/47/295.yaml",
+            required_deferred_outputs=((output, expected_reason),),
+        )
+
+        class FakePipeline:
+            def __init__(self, **_kwargs):
+                pass
+
+            def validate(self, _path, *, skip_reviewers):
+                assert skip_reviewers is True
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._record_successful_apply_validation"
+            ) as record_snapshot,
+        ):
+            ok, issues, supplemental = _validate_generated_encoding_in_policy_overlay(
+                result,
+                output_root=output_root,
+                policy_repo_path=policy_repo,
+                axiom_rules_path=tmp_path / "axiom-rules-engine",
+                local_corpus_release=_bind_test_corpus_release(
+                    policy_repo, tmp_path / "axiom-corpus"
+                ),
+                deferred_output_review_contract=contract,
+            )
+
+        assert ok is False
+        assert supplemental == {}
+        assert len(issues) == 1
+        assert "byte-for-byte" in issues[0]
+        record_snapshot.assert_not_called()
+
+        generated.write_text(
+            "format: rulespec/v1\n"
+            "module:\n"
+            "  deferred_outputs:\n"
+            f"    - output: {output}\n"
+            f"      reason: {expected_reason}\n"
+            "rules: []\n"
+        )
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._record_successful_apply_validation"
+            ) as record_snapshot,
+        ):
+            ok, issues, supplemental = _validate_generated_encoding_in_policy_overlay(
+                result,
+                output_root=output_root,
+                policy_repo_path=policy_repo,
+                axiom_rules_path=tmp_path / "axiom-rules-engine",
+                local_corpus_release=_bind_test_corpus_release(
+                    policy_repo, tmp_path / "axiom-corpus"
+                ),
+                deferred_output_review_contract=contract,
+            )
+
+        assert ok is True
+        assert issues == []
+        assert supplemental == {}
+        record_snapshot.assert_called_once()
 
     def test_apply_overlay_reads_source_metadata_from_explicit_context_manifest(
         self, tmp_path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -160,6 +160,7 @@ from axiom_encode.cli import (
     _repair_upstream_placement_duplicate_imports,
     _require_axiom_encode_version_provenance,
     _require_clean_axiom_encode_git_provenance,
+    _required_deferred_output_contract_issues,
     _required_generated_import_issues,
     _resolve_applied_manifest_placement,
     _resolve_encode_replacement_target,
@@ -12281,6 +12282,7 @@ class TestCmdEncode:
         args.mode = overrides.get("mode", "repo-augmented")
         args.allow_context = overrides.get("allow_context", [])
         args.review_findings = overrides.get("review_findings", [])
+        args.review_contract_json = overrides.get("review_contract_json", None)
         args.repair_candidate_root = overrides.get("repair_candidate_root", None)
         args.repair_candidate_path = overrides.get("repair_candidate_path", None)
         args.repair_candidate_rulespec_sha256 = overrides.get(
@@ -12962,6 +12964,90 @@ class TestCmdEncode:
             "initial_model": DEFAULT_OPENAI_MODEL,
             "escalation_model": DEFAULT_OPENAI_ESCALATION_MODEL,
         }
+
+    def test_encode_contract_rejection_retries_with_exact_context_before_apply(
+        self, tmp_path
+    ):
+        output = "us:statutes/26/1/j/2#income_tax_amount"
+        expected_reason = "Exact source-bound missing dependency."
+        contract = _DeferredOutputReviewContract(
+            citation="26 USC 1(j)(2)",
+            rulespec_path="us/statutes/26/1/j/2.yaml",
+            required_deferred_outputs=((output, expected_reason),),
+        )
+        args = self._make_args(
+            tmp_path,
+            model=None,
+            apply=True,
+            sync=False,
+            escalation_enabled=True,
+            review_contract_json=contract,
+        )
+        generated_attempts = 0
+        apply_counts_at_validation: list[int] = []
+
+        def generate(**kwargs):
+            nonlocal generated_attempts
+            generated_attempts += 1
+            result = self._make_eval_result(True)
+            result.runner = f"codex-{kwargs['runner_specs'][0].split(':', 1)[1]}"
+            result.model = kwargs["runner_specs"][0].split(":", 1)[1]
+            result.generation_prompt_sha256 = f"prompt-{generated_attempts}"
+            generated = (
+                args.output / result.runner / "statutes/26/1/j/2.yaml"
+            )
+            generated.parent.mkdir(parents=True, exist_ok=True)
+            reason = (
+                "Wrong paraphrase."
+                if generated_attempts == 1
+                else expected_reason
+            )
+            generated.write_text(
+                "format: rulespec/v1\n"
+                "module:\n"
+                "  deferred_outputs:\n"
+                f"    - output: {output}\n"
+                f"      reason: {reason}\n"
+                "rules: []\n"
+            )
+            generated.with_suffix(".test.yaml").write_text("[]\n")
+            result.output_file = str(generated)
+            return [result]
+
+        def validate(result, **_kwargs):
+            apply_counts_at_validation.append(mock_apply.call_count)
+            issues = _required_deferred_output_contract_issues(
+                Path(result.output_file),
+                contract,
+                citation=contract.citation,
+                rulespec_path=contract.rulespec_path,
+            )
+            return not issues, issues, {}
+
+        applied_file = args.policy_repo_path / contract.rulespec_path
+        with (
+            patch("axiom_encode.cli.run_model_eval", side_effect=generate) as mock_run,
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                side_effect=validate,
+            ),
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, TEST_APPLY_SIGNING_ENV, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        assert generated_attempts == 2
+        assert apply_counts_at_validation == [0, 0]
+        mock_apply.assert_called_once()
+        assert [
+            call.kwargs["required_deferred_output_contracts"]
+            for call in mock_run.call_args_list
+        ] == [contract.required_deferred_outputs] * 2
 
     def test_encode_retry_feedback_includes_actionable_ci_issue(self):
         import axiom_encode.cli as cli_module

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12993,15 +12993,9 @@ class TestCmdEncode:
             result.runner = f"codex-{kwargs['runner_specs'][0].split(':', 1)[1]}"
             result.model = kwargs["runner_specs"][0].split(":", 1)[1]
             result.generation_prompt_sha256 = f"prompt-{generated_attempts}"
-            generated = (
-                args.output / result.runner / "statutes/26/1/j/2.yaml"
-            )
+            generated = args.output / result.runner / "statutes/26/1/j/2.yaml"
             generated.parent.mkdir(parents=True, exist_ok=True)
-            reason = (
-                "Wrong paraphrase."
-                if generated_attempts == 1
-                else expected_reason
-            )
+            reason = "Wrong paraphrase." if generated_attempts == 1 else expected_reason
             generated.write_text(
                 "format: rulespec/v1\n"
                 "module:\n"

--- a/tests/test_deferred_output_contract.py
+++ b/tests/test_deferred_output_contract.py
@@ -1,0 +1,150 @@
+"""Focused tests for structured deferred-output apply contracts."""
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from axiom_encode.cli import (
+    _DeferredOutputReviewContract,
+    _parse_deferred_output_review_contract_json,
+    _required_deferred_output_contract_issues,
+)
+
+OUTPUT = "us-la:statutes/47/295/a#individual_louisiana_income_tax_amount"
+REASON = (
+    "us-la/statute/47:295(a) requires the individual Louisiana income tax amount "
+    "to be determined in accordance with R.S. 47:32, but the available R.S. "
+    "47:32 RuleSpec exports only the individual income tax rate and lacks an "
+    "executable tax-amount computation accepting the applicable Louisiana income "
+    "or net-income tax base."
+)
+CONTRACT = _DeferredOutputReviewContract(
+    citation="us-la/statute/47:295",
+    rulespec_path="us-la/statutes/47/295.yaml",
+    required_deferred_outputs=((OUTPUT, REASON),),
+)
+
+
+def _issues(path: Path) -> list[str]:
+    return _required_deferred_output_contract_issues(
+        path,
+        CONTRACT,
+        citation="us-la/statute/47:295",
+        rulespec_path="us-la/statutes/47/295.yaml",
+    )
+
+
+def test_required_deferred_output_contract_accepts_exact_yaml_decoded_pair(
+    tmp_path: Path,
+) -> None:
+    rulespec = tmp_path / "295.yaml"
+    rulespec.write_text(
+        "module:\n"
+        "  deferred_outputs:\n"
+        f"    - output: {OUTPUT}\n"
+        "      reason: >-\n"
+        f"        {REASON}\n",
+        encoding="utf-8",
+    )
+
+    assert _issues(rulespec) == []
+
+
+@pytest.mark.parametrize(
+    "candidate_reason",
+    [
+        "R.S. 47:32 is not yet executable.",
+        REASON.replace("lacks", "does not provide"),
+        REASON + " ",
+        REASON + "\n",
+    ],
+)
+def test_required_deferred_output_contract_rejects_reason_drift(
+    tmp_path: Path,
+    candidate_reason: str,
+) -> None:
+    rulespec = tmp_path / "295.yaml"
+    rulespec.write_text(
+        "module:\n  deferred_outputs:\n"
+        f"    - output: {OUTPUT}\n"
+        f"      reason: {candidate_reason!r}\n",
+        encoding="utf-8",
+    )
+
+    issues = _issues(rulespec)
+
+    assert len(issues) == 1
+    assert "byte-for-byte" in issues[0]
+
+
+def test_required_deferred_output_contract_rejects_duplicate_output(
+    tmp_path: Path,
+) -> None:
+    rulespec = tmp_path / "295.yaml"
+    rulespec.write_text(
+        "module:\n"
+        "  deferred_outputs:\n"
+        f"    - output: {OUTPUT}\n"
+        f"      reason: {REASON!r}\n"
+        f"    - output: {OUTPUT}\n"
+        f"      reason: {REASON!r}\n",
+        encoding="utf-8",
+    )
+
+    issues = _issues(rulespec)
+
+    assert len(issues) == 1
+    assert "found 2" in issues[0]
+
+
+def test_parse_review_contract_rejects_duplicate_outputs() -> None:
+    raw = (
+        '{"schema":"axiom-encode/review-contract/v1",'
+        '"citation":"us-la/statute/47:295",'
+        '"rulespec_path":"us-la/statutes/47/295.yaml",'
+        '"required_deferred_outputs":['
+        '{"output":"x","reason":"one"},'
+        '{"output":"x","reason":"two"}]}'
+    )
+
+    with pytest.raises(argparse.ArgumentTypeError, match="outputs must be unique"):
+        _parse_deferred_output_review_contract_json(raw)
+
+
+def test_parse_review_contract_rejects_empty_contract() -> None:
+    raw = (
+        '{"schema":"axiom-encode/review-contract/v1",'
+        '"citation":"us-la/statute/47:295",'
+        '"rulespec_path":"us-la/statutes/47/295.yaml",'
+        '"required_deferred_outputs":[]}'
+    )
+
+    with pytest.raises(argparse.ArgumentTypeError, match="nonempty array"):
+        _parse_deferred_output_review_contract_json(raw)
+
+
+@pytest.mark.parametrize(
+    ("citation", "rulespec_path"),
+    [
+        ("us-la/statute/47:295(a)", "us-la/statutes/47/295.yaml"),
+        ("us-la/statute/47:295", "us-la/statutes/47/295/a.yaml"),
+    ],
+)
+def test_required_deferred_output_contract_rejects_binding_drift(
+    tmp_path: Path,
+    citation: str,
+    rulespec_path: str,
+) -> None:
+    candidate = tmp_path / "295.yaml"
+    candidate.write_text("module: {}\n", encoding="utf-8")
+
+    issues = _required_deferred_output_contract_issues(
+        candidate,
+        CONTRACT,
+        citation=citation,
+        rulespec_path=rulespec_path,
+    )
+
+    assert len(issues) == 1
+    assert "signed dispatch review contract" in issues[0]

--- a/tests/test_deferred_output_contract.py
+++ b/tests/test_deferred_output_contract.py
@@ -10,6 +10,7 @@ from axiom_encode.cli import (
     _parse_deferred_output_review_contract_json,
     _required_deferred_output_contract_issues,
 )
+from axiom_encode.harness.evals import _format_required_deferred_output_contracts
 
 OUTPUT = "us-la:statutes/47/295/a#individual_louisiana_income_tax_amount"
 REASON = (
@@ -33,6 +34,16 @@ def _issues(path: Path) -> list[str]:
         citation="us-la/statute/47:295",
         rulespec_path="us-la/statutes/47/295.yaml",
     )
+
+
+def test_required_contract_prompt_preserves_exact_pair() -> None:
+    rendered = _format_required_deferred_output_contracts(
+        CONTRACT.required_deferred_outputs
+    )
+
+    assert '"output":"' + OUTPUT + '"' in rendered
+    assert '"reason":"' + REASON + '"' in rendered
+    assert "every character" in rendered
 
 
 def test_required_deferred_output_contract_accepts_exact_yaml_decoded_pair(
@@ -98,6 +109,57 @@ def test_required_deferred_output_contract_rejects_duplicate_output(
     assert "found 2" in issues[0]
 
 
+@pytest.mark.parametrize(
+    "document",
+    [
+        "rules: []\n",
+        "module:\n  deferred_outputs: invalid\n",
+        "module:\n  deferred_outputs:\n    - invalid\n",
+        "module:\n  deferred_outputs:\n    - output: 47\n      reason: exact\n",
+        (
+            "module:\n  deferred_outputs:\n"
+            f"    - output: {OUTPUT.upper()}\n      reason: {REASON!r}\n"
+        ),
+        (
+            "module:\n  deferred_outputs:\n"
+            f"    - output: '{OUTPUT} '\n      reason: {REASON!r}\n"
+        ),
+        (
+            "module:\n  deferred_outputs:\n"
+            f"    - output: {OUTPUT}\n      reason: {REASON.lower()!r}\n"
+        ),
+        (
+            "module:\n  deferred_outputs:\n"
+            f"    - output: {OUTPUT}\n"
+            f"      reason: {REASON.replace('47:32,', '47:32;')!r}\n"
+        ),
+        (
+            "module:\n  deferred_outputs:\n"
+            f"    - output: {OUTPUT}\n"
+            f"      reason: {REASON.replace(' but ', '  but ')!r}\n"
+        ),
+        (
+            "module:\n  deferred_outputs:\n"
+            f"    - output: {OUTPUT}\n"
+            "      reason: |\n"
+            f"        {REASON}\n"
+        ),
+        (
+            "module:\n  deferred_outputs:\n"
+            f"    - output: {OUTPUT}\n      reason: 47\n"
+        ),
+    ],
+)
+def test_required_deferred_output_contract_rejects_adversarial_shape_and_drift(
+    tmp_path: Path,
+    document: str,
+) -> None:
+    candidate = tmp_path / "295.yaml"
+    candidate.write_text(document, encoding="utf-8")
+
+    assert _issues(candidate)
+
+
 def test_parse_review_contract_rejects_duplicate_outputs() -> None:
     raw = (
         '{"schema":"axiom-encode/review-contract/v1",'
@@ -121,6 +183,26 @@ def test_parse_review_contract_rejects_empty_contract() -> None:
     )
 
     with pytest.raises(argparse.ArgumentTypeError, match="nonempty array"):
+        _parse_deferred_output_review_contract_json(raw)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        '{"schema":"axiom-encode/review-contract/v1",'
+        '"citation":"us-la/statute/47:295",'
+        '"citation":"us-la/statute/47:295",'
+        '"rulespec_path":"us-la/statutes/47/295.yaml",'
+        '"required_deferred_outputs":[{"output":"x","reason":"one"}]}',
+        '{"schema":"axiom-encode/review-contract/v1",'
+        '"citation":"us-la/statute/47:295",'
+        '"rulespec_path":"us-la/statutes/47/295.yaml",'
+        '"required_deferred_outputs":['
+        '{"output":"x","reason":"one","reason":"two"}]}',
+    ],
+)
+def test_parse_review_contract_rejects_duplicate_json_keys(raw: str) -> None:
+    with pytest.raises(argparse.ArgumentTypeError, match="duplicate JSON key"):
         _parse_deferred_output_review_contract_json(raw)
 
 

--- a/tests/test_deferred_output_contract.py
+++ b/tests/test_deferred_output_contract.py
@@ -144,10 +144,7 @@ def test_required_deferred_output_contract_rejects_duplicate_output(
             "      reason: |\n"
             f"        {REASON}\n"
         ),
-        (
-            "module:\n  deferred_outputs:\n"
-            f"    - output: {OUTPUT}\n      reason: 47\n"
-        ),
+        (f"module:\n  deferred_outputs:\n    - output: {OUTPUT}\n      reason: 47\n"),
     ],
 )
 def test_required_deferred_output_contract_rejects_adversarial_shape_and_drift(

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1632"
+ENCODER_VERSION = "0.2.1633"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1631"
+ENCODER_VERSION = "0.2.1632"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1633"
+ENCODER_VERSION = "0.2.1634"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1632"
+ENCODER_VERSION = "0.2.1633"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1631"
+ENCODER_VERSION = "0.2.1632"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1633"
+ENCODER_VERSION = "0.2.1634"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1633"
+ENCODER_VERSION = "0.2.1634"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1631"
+ENCODER_VERSION = "0.2.1632"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1632"
+ENCODER_VERSION = "0.2.1633"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1631"
+ENCODER_VERSION = "0.2.1632"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1632"
+ENCODER_VERSION = "0.2.1633"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1633"
+ENCODER_VERSION = "0.2.1634"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1632"
+ENCODER_VERSION = "0.2.1633"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1633"
+ENCODER_VERSION = "0.2.1634"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1631"
+ENCODER_VERSION = "0.2.1632"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1632"
+ENCODER_VERSION = "0.2.1633"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1633"
+ENCODER_VERSION = "0.2.1634"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1631"
+ENCODER_VERSION = "0.2.1632"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -16,6 +16,7 @@ from axiom_encode.legacy_replacement import (
 )
 from scripts.prepare_signed_backfill import (
     MAX_CANONICAL_REFRESH_BUNDLE_CITATIONS,
+    MAX_DEFERRED_OUTPUT_REVIEW_CONTRACT_JSON_BYTES,
     MAX_SOURCE_BUNDLE_JSON_BYTES,
     REVIEWED_RULESPEC_PR_BASE_BRANCHES,
     REVIEWED_RULESPEC_REFS,
@@ -769,6 +770,59 @@ def test_parse_canonical_refresh_bundle_rejects_duplicate_contract_outputs(
                         "deferred_output_contracts": duplicate_contracts,
                     }
                 ]
+            ),
+            primary_citation="us-la/statute/47:294",
+            primary_rulespec_path="us-la/statutes/47/294.yaml",
+        )
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        '[{"citation":"us-la/statute/47:295",'
+        '"citation":"us-la/statute/47:295",'
+        '"replace_rulespec_path":"us-la/statutes/47/295.yaml"}]',
+        '[{"citation":"us-la/statute/47:295",'
+        '"replace_rulespec_path":"us-la/statutes/47/295.yaml",'
+        '"deferred_output_contracts":[{"output":"x","reason":"one",'
+        '"reason":"two"}]}]',
+    ],
+)
+def test_parse_canonical_refresh_bundle_rejects_duplicate_json_keys(
+    tmp_path: Path,
+    raw: str,
+) -> None:
+    repo = _canonical_refresh_repo(tmp_path)
+
+    with pytest.raises(ValueError, match="duplicate JSON key"):
+        parse_canonical_refresh_bundle(
+            repo,
+            raw,
+            primary_citation="us-la/statute/47:294",
+            primary_rulespec_path="us-la/statutes/47/294.yaml",
+        )
+
+
+def test_parse_canonical_refresh_bundle_rejects_oversized_wrapped_contract(
+    tmp_path: Path,
+) -> None:
+    repo = _canonical_refresh_repo(tmp_path)
+    oversized_reason = "😀" * (MAX_DEFERRED_OUTPUT_REVIEW_CONTRACT_JSON_BYTES // 4)
+
+    with pytest.raises(ValueError, match="wrapped.*maximum input size"):
+        parse_canonical_refresh_bundle(
+            repo,
+            json.dumps(
+                [
+                    {
+                        "citation": "us-la/statute/47:295",
+                        "replace_rulespec_path": "us-la/statutes/47/295.yaml",
+                        "deferred_output_contracts": [
+                            {"output": "x", "reason": oversized_reason}
+                        ],
+                    }
+                ],
+                ensure_ascii=False,
             ),
             primary_citation="us-la/statute/47:294",
             primary_rulespec_path="us-la/statutes/47/294.yaml",

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -567,6 +567,7 @@ def test_parse_canonical_refresh_bundle_accepts_tracked_canonical_targets(
             "manifest_path",
             "manifest_sha256",
             "review_finding",
+            "deferred_output_contracts",
         }
         for item in inventory
     )
@@ -611,7 +612,7 @@ def test_parse_canonical_refresh_bundle_rejects_unknown_item_field(
 ) -> None:
     repo = _canonical_refresh_repo(tmp_path)
 
-    with pytest.raises(ValueError, match="only an optional review_finding"):
+    with pytest.raises(ValueError, match="only optional review_finding"):
         parse_canonical_refresh_bundle(
             repo,
             '[{"citation":"us-la/statute/47:295",'
@@ -716,6 +717,62 @@ def test_parse_canonical_refresh_bundle_cli_emits_paths(
         "us-la/statute/47:294",
         "us-la/statute/47:295",
     ]
+
+
+def test_parse_canonical_refresh_bundle_preserves_deferred_output_contracts(
+    tmp_path: Path,
+) -> None:
+    repo = _canonical_refresh_repo(tmp_path)
+    contracts = [
+        {
+            "output": "us-la:statutes/47/295/a#individual_louisiana_income_tax_amount",
+            "reason": "Exact source-bound missing dependency.",
+        }
+    ]
+
+    inventory = parse_canonical_refresh_bundle(
+        repo,
+        json.dumps(
+            [
+                {
+                    "citation": "us-la/statute/47:295",
+                    "replace_rulespec_path": "us-la/statutes/47/295.yaml",
+                    "deferred_output_contracts": contracts,
+                }
+            ]
+        ),
+        primary_citation="us-la/statute/47:294",
+        primary_rulespec_path="us-la/statutes/47/294.yaml",
+    )
+
+    assert inventory[0]["deferred_output_contracts"] == []
+    assert inventory[1]["deferred_output_contracts"] == contracts
+
+
+def test_parse_canonical_refresh_bundle_rejects_duplicate_contract_outputs(
+    tmp_path: Path,
+) -> None:
+    repo = _canonical_refresh_repo(tmp_path)
+    duplicate_contracts = [
+        {"output": "same", "reason": "one"},
+        {"output": "same", "reason": "two"},
+    ]
+
+    with pytest.raises(ValueError, match="outputs must be unique"):
+        parse_canonical_refresh_bundle(
+            repo,
+            json.dumps(
+                [
+                    {
+                        "citation": "us-la/statute/47:295",
+                        "replace_rulespec_path": "us-la/statutes/47/295.yaml",
+                        "deferred_output_contracts": duplicate_contracts,
+                    }
+                ]
+            ),
+            primary_citation="us-la/statute/47:294",
+            primary_rulespec_path="us-la/statutes/47/294.yaml",
+        )
 
 
 def test_verify_canonical_refresh_target_rejects_drift(tmp_path: Path) -> None:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1633"')
+        .startswith('__version__ = "0.2.1634"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1633"
+    assert encoder_package["version"] == "0.2.1634"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1633"
+    assert project["project"]["version"] == "0.2.1634"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1633"')
+        .startswith('__version__ = "0.2.1634"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1633"
+    assert encoder_package["version"] == "0.2.1634"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1633"
+    assert project["project"]["version"] == "0.2.1634"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1633"')
+        .startswith('__version__ = "0.2.1634"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1632"')
+        .startswith('__version__ = "0.2.1633"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1632"
+    assert encoder_package["version"] == "0.2.1633"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1632"
+    assert project["project"]["version"] == "0.2.1633"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1632"')
+        .startswith('__version__ = "0.2.1633"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1632"
+    assert encoder_package["version"] == "0.2.1633"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1632"
+    assert project["project"]["version"] == "0.2.1633"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1632"')
+        .startswith('__version__ = "0.2.1633"')
     )
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5925,7 +5925,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1631"')
+        .startswith('__version__ = "0.2.1632"')
     )
 
 
@@ -6157,13 +6157,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1631"
+    assert encoder_package["version"] == "0.2.1632"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1631"
+    assert project["project"]["version"] == "0.2.1632"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1631"')
+        .startswith('__version__ = "0.2.1632"')
     )
 
 
@@ -6425,13 +6425,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1631"
+    assert encoder_package["version"] == "0.2.1632"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1631"
+    assert project["project"]["version"] == "0.2.1632"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1631"')
+        .startswith('__version__ = "0.2.1632"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1631"
+ENCODER_VERSION = "0.2.1632"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1632"
+ENCODER_VERSION = "0.2.1633"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1633"
+ENCODER_VERSION = "0.2.1634"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1913,7 +1913,8 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         "description": (
             "JSON citation array for atomic imports, or "
             '{"canonical_refresh_bundle":'
-            "[{citation,replace_rulespec_path,review_finding?}]} "
+            "[{citation,replace_rulespec_path,review_finding?,"
+            "deferred_output_contracts?}]} "
             "for an independent refresh transaction"
         ),
         "required": False,
@@ -3698,6 +3699,12 @@ def test_targeted_signed_reencode_runs_canonical_refresh_bundle_in_order(
         tmp_path
     )
     additions[0]["review_finding"] = "Preserve the R.S. 47:32 ownership boundary."
+    additions[0]["deferred_output_contracts"] = [
+        {
+            "output": "us-la:statutes/47/295/a#individual_louisiana_income_tax_amount",
+            "reason": "Exact source-bound missing dependency.",
+        }
+    ]
     additions[2]["review_finding"] = "Preserve the five-year carryforward limit."
     normalized = parse_canonical_refresh_bundle(
         repo,
@@ -3799,6 +3806,24 @@ if mutation_path and len(calls_path.read_text(encoding="utf-8").splitlines()) ==
         "Preserve the R.S. 47:32 ownership boundary.\n",
         None,
         "Preserve the five-year carryforward limit.\n",
+    ]
+    assert [
+        (
+            json.loads(args[args.index("--review-contract-json") + 1])
+            if "--review-contract-json" in args
+            else None
+        )
+        for args in encode_args
+    ] == [
+        None,
+        {
+            "schema": "axiom-encode/review-contract/v1",
+            "citation": additions[0]["citation"],
+            "rulespec_path": additions[0]["replace_rulespec_path"],
+            "required_deferred_outputs": additions[0]["deferred_output_contracts"],
+        },
+        None,
+        None,
     ]
     forbidden = {
         "--apply-target-only",
@@ -4887,6 +4912,7 @@ def test_targeted_artifact_enforces_exact_canonical_refresh_inventory(
                     if index > 0 and mutation != "unexpected-companion-finding"
                     else None
                 ),
+                "deferred_output_contracts": [],
                 "rulespec_path": rulespec_path,
                 "rulespec_sha256": "a" * 64,
                 "companion_path": str(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1631"
+version = "0.2.1632"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1633"
+version = "0.2.1634"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1632"
+version = "0.2.1633"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- add a bounded, citation- and RuleSpec-path-bound deferred-output review contract to encode apply admission
- provide every exact output/reason pair to every generation and retry attempt as a trusted workflow requirement
- enforce exact YAML-decoded pairs on the final repaired overlay before the successful validation snapshot
- carry per-lane contracts through signed canonical-refresh normalization and failure artifacts
- reject duplicate JSON keys and any normalized wrapper larger than the CLI admission bound

## Why

A failed Louisiana canonical refresh showed that prompt wording alone cannot mechanically preserve a required deferred-output reason across repair retries. This implements a general review-contract mechanism rather than jurisdiction-specific validator logic.

## Checks

- uv run ruff check pyproject.toml src/axiom_encode scripts tests
- uv run ruff format --check pyproject.toml src/axiom_encode scripts tests
- python -m compileall -q src/axiom_encode scripts
- focused contract and workflow suites: 271 passed, 51 skipped before final formatting; 182 post-format focused tests passed
- full suite: 11345 passed, 119 skipped
- GitHub CI: lint, test 3.13, signing supervisor Ubuntu, and signing supervisor macOS all passed

## Review cycle

Round 1 found three actionable areas: retry visibility, duplicate-key ambiguity, and bundle/CLI size-bound mismatch. All were fixed with regression coverage. Round 2 was independently reviewed across apply semantics, workflow security, and integration tests with no actionable findings. Final formatting and synchronized version pin changes were mechanical and all checks were rerun.