### PR TITLE
Fix structured companion test contract enforcement

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -39,7 +39,7 @@ on:
         required: false
         type: string
       source_bundle_json:
-        description: JSON citation array for atomic imports, or {"canonical_refresh_bundle":[{citation,replace_rulespec_path,review_finding?,deferred_output_contracts?}]} for an independent refresh transaction
+        description: JSON citation array, canonical_refresh_bundle object, or atomic-source-transaction/v2 envelope for an independent refresh transaction
         required: false
         default: "[]"
         type: string
@@ -382,6 +382,8 @@ jobs:
             <<< "$atomic_source_payload")"
           canonical_refresh_bundle_json="$(jq -cer '.canonical_refresh_bundle' \
             <<< "$atomic_source_payload")"
+          primary_required_test_cases_json="$(jq -cer \
+            '.primary_required_test_cases' <<< "$atomic_source_payload")"
           if [[ ! "$REPAIR_RUN_ID" =~ ^[0-9]+$ ]] || \
              [ "$REPAIR_RUN_ID" = "$GITHUB_RUN_ID" ]; then
             echo "repair_run_id must identify a different decimal workflow run" >&2
@@ -398,6 +400,8 @@ jobs:
                <<< "$canonical_refresh_bundle_json" > /dev/null || \
              ! jq -e 'type == "array" and length == 0' \
                <<< "$source_bundle_json" > /dev/null || \
+             ! jq -e 'type == "array" and length == 0' \
+               <<< "$primary_required_test_cases_json" > /dev/null || \
              ! jq -e 'type == "array" and length == 0' \
                <<< "${EXISTING_SIGNED_IMPORTS_JSON:-[]}" > /dev/null || \
              ! jq -e 'type == "array" and length == 0' \
@@ -565,6 +569,8 @@ jobs:
             <<< "$atomic_source_payload")"
           canonical_refresh_bundle_json="$(jq -cer '.canonical_refresh_bundle' \
             <<< "$atomic_source_payload")"
+          primary_required_test_cases_json="$(jq -cer \
+            '.primary_required_test_cases' <<< "$atomic_source_payload")"
           source_bundle_args=(
             axiom-encode/.venv/bin/python
             axiom-encode/scripts/prepare_signed_backfill.py
@@ -591,7 +597,9 @@ jobs:
               parse-canonical-refresh-bundle "$RULESPEC_CHECKOUT" \
               "$canonical_refresh_bundle_json" \
               --primary-citation "$CITATION" \
-              --primary-rulespec-path "$REPLACE_RULESPEC_PATH"
+              --primary-rulespec-path "$REPLACE_RULESPEC_PATH" \
+              --primary-required-test-cases-json \
+                "$primary_required_test_cases_json"
           )"
           existing_import_args=(
             axiom-encode/.venv/bin/python
@@ -889,6 +897,8 @@ jobs:
             <<< "$atomic_source_payload")"
           canonical_refresh_bundle_json="$(jq -cer '.canonical_refresh_bundle' \
             <<< "$atomic_source_payload")"
+          primary_required_test_cases_json="$(jq -cer \
+            '.primary_required_test_cases' <<< "$atomic_source_payload")"
           source_bundle_args=(
             "$workflow_python" -I "$backfill_helper" parse-source-bundle
             "$source_bundle_json" --primary-citation "$CITATION"
@@ -907,7 +917,9 @@ jobs:
               parse-canonical-refresh-bundle "$RULESPEC_CHECKOUT" \
               "$canonical_refresh_bundle_json" \
               --primary-citation "$CITATION" \
-              --primary-rulespec-path "$REPLACE_RULESPEC_PATH"
+              --primary-rulespec-path "$REPLACE_RULESPEC_PATH" \
+              --primary-required-test-cases-json \
+                "$primary_required_test_cases_json"
           )"
           printf '%s\n' "$normalized_canonical_refresh_bundle" \
             > "$RUNNER_TEMP/canonical-refresh-bundle.json"
@@ -1062,6 +1074,7 @@ jobs:
             local legacy_source_path="$6"
             local require_direct_imports="$7"
             local deferred_output_contracts_json="${8:-[]}"
+            local required_test_cases_json="${9:-[]}"
             local review_finding_path=""
             local review_contract_json=""
             local -a args=(
@@ -1146,20 +1159,27 @@ jobs:
               printf '%s\n' "$review_finding" > "$review_finding_path"
               args+=(--review-findings "$review_finding_path")
             fi
-            if [ "$deferred_output_contracts_json" != "[]" ]; then
+            if [ "$deferred_output_contracts_json" != "[]" ] || \
+               [ "$required_test_cases_json" != "[]" ]; then
               review_contract_json="$(
                 jq -cn \
-                  --arg schema "axiom-encode/review-contract/v1" \
+                  --arg schema "$([ "$required_test_cases_json" = "[]" ] \
+                    && printf '%s' 'axiom-encode/review-contract/v1' \
+                    || printf '%s' 'axiom-encode/review-contract/v2')" \
                   --arg citation "$citation" \
                   --arg rulespec_path "$replacement_path" \
                   --argjson required_deferred_outputs \
                     "$deferred_output_contracts_json" \
+                  --argjson required_test_cases "$required_test_cases_json" \
                   '{
                     schema: $schema,
                     citation: $citation,
                     rulespec_path: $rulespec_path,
                     required_deferred_outputs: $required_deferred_outputs
-                  }'
+                  } + if $schema == "axiom-encode/review-contract/v2"
+                    then {required_test_cases: $required_test_cases}
+                    else {}
+                    end'
               )"
               args+=(
                 --review-contract-json
@@ -1303,6 +1323,8 @@ jobs:
             <<< "$atomic_source_payload")"
           canonical_refresh_bundle_json="$(jq -cer '.canonical_refresh_bundle' \
             <<< "$atomic_source_payload")"
+          primary_required_test_cases_json="$(jq -cer \
+            '.primary_required_test_cases' <<< "$atomic_source_payload")"
           source_bundle_args=(
             "$workflow_python" "$backfill_helper" parse-source-bundle
             "$source_bundle_json" --primary-citation "$CITATION"
@@ -1319,7 +1341,9 @@ jobs:
               parse-canonical-refresh-bundle "$RULESPEC_CHECKOUT" \
               "$canonical_refresh_bundle_json" \
               --primary-citation "$CITATION" \
-              --primary-rulespec-path "$REPLACE_RULESPEC_PATH"
+              --primary-rulespec-path "$REPLACE_RULESPEC_PATH" \
+              --primary-required-test-cases-json \
+                "$primary_required_test_cases_json"
           )"
           verified_canonical_refresh_bundle="$(tr -d '\n' \
             < "$RUNNER_TEMP/canonical-refresh-bundle.json")"
@@ -1499,6 +1523,9 @@ jobs:
               refresh_deferred_output_contracts="$(
                 jq -cer '.deferred_output_contracts // []' <<< "$refresh_item"
               )"
+              refresh_required_test_cases="$(
+                jq -cer '.required_test_cases // []' <<< "$refresh_item"
+              )"
               refresh_lane=target
               refresh_finding="$REVIEW_FINDING"
               if [ "$refresh_index" -gt 0 ]; then
@@ -1509,7 +1536,8 @@ jobs:
               run_signed_encode \
                 "$refresh_citation" "$refresh_finding" false "$refresh_lane" \
                 "$refresh_rulespec_path" "" false \
-                "$refresh_deferred_output_contracts"
+                "$refresh_deferred_output_contracts" \
+                "$refresh_required_test_cases"
               checkpoint_signed_changes \
                 "Refresh signed canonical module for ${refresh_citation}"
               cp "$RUNNER_TEMP/checkpoint-guard-generated.json" \
@@ -1882,6 +1910,7 @@ jobs:
                   "manifest_sha256",
                   "review_finding",
                   "deferred_output_contracts",
+                  "required_test_cases",
               }
               and isinstance(item["citation"], str)
               and item["citation"]
@@ -1891,6 +1920,24 @@ jobs:
               and item["companion_path"]
               and isinstance(item["deferred_output_contracts"], list)
               and len(item["deferred_output_contracts"]) <= 16
+              and isinstance(item["required_test_cases"], list)
+              and len(item["required_test_cases"]) <= 32
+              and all(
+                  isinstance(case, dict)
+                  and set(case)
+                  == {"name", "period", "input", "required_output"}
+                  and isinstance(case["name"], str)
+                  and case["name"]
+                  and isinstance(case["period"], dict)
+                  and isinstance(case["input"], dict)
+                  and len(case["input"]) <= 64
+                  and isinstance(case["required_output"], dict)
+                  and case["required_output"]
+                  and len(case["required_output"]) <= 64
+                  for case in item["required_test_cases"]
+              )
+              and len({case["name"] for case in item["required_test_cases"]})
+              == len(item["required_test_cases"])
               and all(
                   isinstance(contract, dict)
                   and set(contract) == {"output", "reason"}
@@ -2003,6 +2050,25 @@ jobs:
                       "from its exact requested targets"
                   )
 
+          def normalized_review_contract(refresh_item):
+              deferred = refresh_item["deferred_output_contracts"]
+              required_cases = refresh_item["required_test_cases"]
+              if not deferred and not required_cases:
+                  return None
+              payload = {
+                  "schema": (
+                      "axiom-encode/review-contract/v2"
+                      if required_cases
+                      else "axiom-encode/review-contract/v1"
+                  ),
+                  "citation": refresh_item["citation"],
+                  "rulespec_path": refresh_item["rulespec_path"],
+                  "required_deferred_outputs": deferred,
+              }
+              if required_cases:
+                  payload["required_test_cases"] = required_cases
+              return payload
+
           expected = []
           if canonical_refresh_items:
               for refresh_index, refresh_item in enumerate(
@@ -2032,6 +2098,7 @@ jobs:
                           refresh_item["rulespec_path"],
                           refresh_item["companion_path"],
                           refresh_item["manifest_path"],
+                          normalized_review_contract(refresh_item),
                       )
                   )
           else:
@@ -2042,6 +2109,7 @@ jobs:
                       Path(sys.argv[1]),
                       "target",
                       normalized_replacement_path or None,
+                      None,
                       None,
                       None,
                   )
@@ -2061,6 +2129,7 @@ jobs:
                       None,
                       None,
                       None,
+                      None,
                   )
               )
           if dependent_citation:
@@ -2070,6 +2139,7 @@ jobs:
                       os.environ["DEPENDENT_REVIEW_FINDING"] or None,
                       Path(sys.argv[1]).with_name("dependent-context-manifest.json"),
                       "dependent",
+                      None,
                       None,
                       None,
                       None,
@@ -2087,6 +2157,7 @@ jobs:
                       None,
                       None,
                       None,
+                      None,
                   )
               )
 
@@ -2100,6 +2171,7 @@ jobs:
               expected_primary_path,
               expected_companion_path,
               expected_manifest_path,
+              expected_review_contract,
           ) in expected:
               citation_matches = matches.get(citation, [])
               if len(citation_matches) != 1:
@@ -2706,6 +2778,40 @@ jobs:
                   raise SystemExit(
                       "signed context manifest citation does not match"
                   )
+              if expected_review_contract is None:
+                  if "review_contract" in context_payload:
+                      raise SystemExit(
+                          "context manifest contains an unexpected review contract"
+                      )
+              else:
+                  try:
+                      actual_review_contract = json.dumps(
+                          context_payload.get("review_contract"),
+                          allow_nan=False,
+                          ensure_ascii=False,
+                          separators=(",", ":"),
+                          sort_keys=True,
+                      )
+                      normalized_expected_review_contract = json.dumps(
+                          expected_review_contract,
+                          allow_nan=False,
+                          ensure_ascii=False,
+                          separators=(",", ":"),
+                          sort_keys=True,
+                      )
+                  except (TypeError, ValueError) as exc:
+                      raise SystemExit(
+                          "context manifest does not bind the normalized "
+                          "review contract"
+                      ) from exc
+                  if (
+                      actual_review_contract
+                      != normalized_expected_review_contract
+                  ):
+                      raise SystemExit(
+                          "context manifest does not bind the normalized "
+                          "review contract"
+                      )
               review_findings = context_payload.get("review_findings_files")
               if not isinstance(review_findings, list):
                   raise SystemExit(

--- a/changelog.d/structured-companion-test-contract.fixed.md
+++ b/changelog.d/structured-companion-test-contract.fixed.md
@@ -1,0 +1,1 @@
+Enforce signed, period-aware companion test-case contracts before RuleSpec apply.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1634"
+version = "0.2.1635"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/extract_repair_candidate.py
+++ b/scripts/extract_repair_candidate.py
@@ -181,7 +181,11 @@ def _require_empty_atomic_source(metadata: dict[str, object]) -> None:
                 "repair artifact is not a compatible single-target run: "
                 "atomic_source_input"
             ) from exc
-        if split != {"canonical_refresh_bundle": [], "source_bundle": []}:
+        if split != {
+            "canonical_refresh_bundle": [],
+            "primary_required_test_cases": [],
+            "source_bundle": [],
+        }:
             raise ValueError(
                 "repair artifact is not a compatible single-target run: "
                 "atomic_source_input"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -6,9 +6,11 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import math
 import re
 import stat
 import subprocess
+from datetime import date
 from pathlib import Path, PurePosixPath
 
 COUNTRY_PATTERN = re.compile(r"[a-z]{2}")
@@ -49,8 +51,11 @@ MAX_SOURCE_BUNDLE_CITATIONS = 16
 MAX_SOURCE_BUNDLE_JSON_BYTES = 512 * 1024
 MAX_CANONICAL_REFRESH_BUNDLE_CITATIONS = MAX_SOURCE_BUNDLE_CITATIONS - 1
 MAX_DEFERRED_OUTPUT_CONTRACTS = 16
+MAX_REQUIRED_TEST_CASES = 32
+MAX_REQUIRED_TEST_CASE_FIELDS = 64
 MAX_DEFERRED_OUTPUT_REVIEW_CONTRACT_JSON_BYTES = 64 * 1024
 DEFERRED_OUTPUT_REVIEW_CONTRACT_SCHEMA = "axiom-encode/review-contract/v1"
+STRUCTURED_REVIEW_CONTRACT_SCHEMA = "axiom-encode/review-contract/v2"
 REVIEWED_RULESPEC_REFS = frozenset(
     {
         (
@@ -288,19 +293,47 @@ def split_atomic_source_input(atomic_source_json: str) -> dict[str, object]:
     if isinstance(payload, list):
         return {
             "canonical_refresh_bundle": [],
+            "primary_required_test_cases": [],
             "source_bundle": payload,
         }
-    if not isinstance(payload, dict) or set(payload) != {"canonical_refresh_bundle"}:
+    if isinstance(payload, dict) and set(payload) == {"canonical_refresh_bundle"}:
+        refresh_bundle = payload["canonical_refresh_bundle"]
+        if not isinstance(refresh_bundle, list):
+            raise ValueError("canonical_refresh_bundle must be an array")
+        return {
+            "canonical_refresh_bundle": refresh_bundle,
+            "primary_required_test_cases": [],
+            "source_bundle": [],
+        }
+    v2_fields = {
+        "schema",
+        "source_bundle",
+        "canonical_refresh_bundle",
+        "primary_required_test_cases",
+    }
+    if (
+        not isinstance(payload, dict)
+        or set(payload) != v2_fields
+        or payload.get("schema") != "axiom-encode/atomic-source-transaction/v2"
+    ):
         raise ValueError(
             "atomic source JSON must be a source citation array or an exact "
-            "canonical_refresh_bundle object"
+            "canonical_refresh_bundle or atomic-source-transaction/v2 object"
         )
     refresh_bundle = payload["canonical_refresh_bundle"]
-    if not isinstance(refresh_bundle, list):
-        raise ValueError("canonical_refresh_bundle must be an array")
+    source_bundle = payload["source_bundle"]
+    primary_required_test_cases = payload["primary_required_test_cases"]
+    if not all(
+        isinstance(value, list)
+        for value in (refresh_bundle, source_bundle, primary_required_test_cases)
+    ):
+        raise ValueError("atomic source transaction bundle fields must be arrays")
+    if source_bundle and (refresh_bundle or primary_required_test_cases):
+        raise ValueError("atomic source transaction must select exactly one source mode")
     return {
         "canonical_refresh_bundle": refresh_bundle,
-        "source_bundle": [],
+        "primary_required_test_cases": primary_required_test_cases,
+        "source_bundle": source_bundle,
     }
 
 
@@ -483,12 +516,179 @@ def validate_source_add_targets(
     return sources
 
 
+def _normalize_required_test_cases(
+    value: object,
+    *,
+    label: str,
+) -> tuple[dict[str, object], ...]:
+    """Validate bounded exact companion-case admission requirements."""
+
+    if not isinstance(value, list) or len(value) > MAX_REQUIRED_TEST_CASES:
+        raise ValueError(
+            f"{label} must be an array with at most {MAX_REQUIRED_TEST_CASES} entries"
+        )
+    normalized_cases: list[dict[str, object]] = []
+    seen_names: set[str] = set()
+    for index, item in enumerate(value):
+        case_label = f"{label} case #{index + 1}"
+        if not isinstance(item, dict) or set(item) != {
+            "name",
+            "period",
+            "input",
+            "required_output",
+        }:
+            raise ValueError(
+                f"{case_label} must contain exactly name, period, input, and "
+                "required_output"
+            )
+        name = item["name"]
+        if (
+            not isinstance(name, str)
+            or not name
+            or name != name.strip()
+            or "\r" in name
+            or any(ord(character) < 32 or ord(character) == 127 for character in name)
+        ):
+            raise ValueError(f"{case_label} name must be a normalized string")
+        if name in seen_names:
+            raise ValueError(f"{label} case names must be unique")
+        seen_names.add(name)
+        period = item["period"]
+        period_fields = {"period_kind", "start", "end"}
+        if isinstance(period, dict) and period.get("period_kind") == "custom":
+            period_fields.add("name")
+        if not isinstance(period, dict) or set(period) != period_fields or any(
+            not isinstance(field, str)
+            or not field
+            or field != field.strip()
+            or any(ord(character) < 32 or ord(character) == 127 for character in field)
+            for field in period.values()
+        ):
+            raise ValueError(
+                f"{case_label} period must be an exact normalized RuleSpec period "
+                "mapping"
+            )
+        if period["period_kind"] not in {
+            "month",
+            "benefit_week",
+            "tax_year",
+            "custom",
+        }:
+            raise ValueError(
+                f"{case_label} period_kind is not supported by the RuleSpec engine"
+            )
+        try:
+            period_start = date.fromisoformat(period["start"])
+            period_end = date.fromisoformat(period["end"])
+        except ValueError as exc:
+            raise ValueError(f"{case_label} period dates must be ISO dates") from exc
+        if period_start > period_end:
+            raise ValueError(f"{case_label} period start must not follow end")
+        normalized_fields: dict[str, dict[str, object]] = {}
+        for field_name in ("input", "required_output"):
+            mapping = item[field_name]
+            if (
+                not isinstance(mapping, dict)
+                or (field_name == "required_output" and not mapping)
+                or len(mapping) > MAX_REQUIRED_TEST_CASE_FIELDS
+            ):
+                raise ValueError(
+                    f"{case_label} {field_name} must be an object with at "
+                    f"most {MAX_REQUIRED_TEST_CASE_FIELDS} fields"
+                )
+            normalized_mapping: dict[str, object] = {}
+            for key, field_value in mapping.items():
+                if (
+                    not isinstance(key, str)
+                    or not key
+                    or key != key.strip()
+                    or any(
+                        ord(character) < 32 or ord(character) == 127
+                        for character in key
+                    )
+                ):
+                    raise ValueError(
+                        f"{case_label} {field_name} keys must be normalized strings"
+                    )
+                if not isinstance(field_value, (str, int, float, bool)) or (
+                    isinstance(field_value, float) and not math.isfinite(field_value)
+                ):
+                    raise ValueError(
+                        f"{case_label} {field_name} values must be finite JSON scalars"
+                    )
+                if isinstance(field_value, str) and (
+                    field_value != field_value.strip()
+                    or "\r" in field_value
+                    or any(
+                        (ord(character) < 32 and character not in {"\n", "\t"})
+                        or ord(character) == 127
+                        for character in field_value
+                    )
+                ):
+                    raise ValueError(
+                        f"{case_label} {field_name} string values must be normalized"
+                    )
+                normalized_mapping[key] = field_value
+            normalized_fields[field_name] = normalized_mapping
+        normalized_period = {
+            "period_kind": period["period_kind"],
+            **({"name": period["name"]} if period["period_kind"] == "custom" else {}),
+            "start": period["start"],
+            "end": period["end"],
+        }
+        normalized_cases.append(
+            {
+                "name": name,
+                "period": normalized_period,
+                "input": dict(sorted(normalized_fields["input"].items())),
+                "required_output": dict(
+                    sorted(normalized_fields["required_output"].items())
+                ),
+            }
+        )
+    return tuple(normalized_cases)
+
+
+def _validate_wrapped_review_contract_size(
+    *,
+    citation: str,
+    path: PurePosixPath,
+    deferred_output_contracts: tuple[dict[str, str], ...],
+    required_test_cases: tuple[dict[str, object], ...],
+    label: str,
+) -> None:
+    """Keep helper normalization within the installed CLI's exact size bound."""
+
+    if not deferred_output_contracts and not required_test_cases:
+        return
+    payload: dict[str, object] = {
+        "schema": (
+            STRUCTURED_REVIEW_CONTRACT_SCHEMA
+            if required_test_cases
+            else DEFERRED_OUTPUT_REVIEW_CONTRACT_SCHEMA
+        ),
+        "citation": citation,
+        "rulespec_path": path.as_posix(),
+        "required_deferred_outputs": list(deferred_output_contracts),
+    }
+    if required_test_cases:
+        payload["required_test_cases"] = list(required_test_cases)
+    wrapped_contract = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    if len(wrapped_contract) > MAX_DEFERRED_OUTPUT_REVIEW_CONTRACT_JSON_BYTES:
+        raise ValueError(f"{label} wrapped review contract exceeds the maximum input size")
+
+
 def parse_canonical_refresh_bundle(
     repo: Path,
     refresh_bundle_json: str,
     *,
     primary_citation: str,
     primary_rulespec_path: str,
+    primary_required_test_cases_json: str = "[]",
 ) -> tuple[dict[str, str | None], ...]:
     """Validate independent existing canonical modules for atomic fresh encoding."""
 
@@ -511,7 +711,21 @@ def parse_canonical_refresh_bundle(
             "canonical refresh bundle and its primary contain more than "
             f"{MAX_SOURCE_BUNDLE_CITATIONS} modules"
         )
-    if not payload:
+    if not isinstance(primary_required_test_cases_json, str):
+        raise ValueError("primary required test cases JSON must be a string")
+    if (
+        len(primary_required_test_cases_json.encode("utf-8"))
+        > MAX_DEFERRED_OUTPUT_REVIEW_CONTRACT_JSON_BYTES
+    ):
+        raise ValueError("primary required test cases JSON exceeds the maximum input size")
+    primary_required_test_cases = _normalize_required_test_cases(
+        _load_unambiguous_json(
+            primary_required_test_cases_json,
+            label="primary required test cases JSON",
+        ),
+        label="primary required test cases",
+    )
+    if not payload and not primary_required_test_cases:
         return ()
 
     repo = repo.resolve(strict=True)
@@ -541,9 +755,22 @@ def parse_canonical_refresh_bundle(
             "RuleSpec path"
         )
 
+    _validate_wrapped_review_contract_size(
+        citation=primary_citation,
+        path=primary_path,
+        deferred_output_contracts=(),
+        required_test_cases=primary_required_test_cases,
+        label="canonical refresh primary",
+    )
     requested: list[
-        tuple[str, PurePosixPath, str | None, tuple[dict[str, str], ...]]
-    ] = [(primary_citation, primary_path, None, ())]
+        tuple[
+            str,
+            PurePosixPath,
+            str | None,
+            tuple[dict[str, str], ...],
+            tuple[dict[str, object], ...],
+        ]
+    ] = [(primary_citation, primary_path, None, (), primary_required_test_cases)]
     seen_citations = {primary_citation}
     seen_paths = {primary_path}
     for index, value in enumerate(payload):
@@ -553,6 +780,7 @@ def parse_canonical_refresh_bundle(
             *required_fields,
             "review_finding",
             "deferred_output_contracts",
+            "required_test_cases",
         }
         if (
             not isinstance(value, dict)
@@ -561,12 +789,17 @@ def parse_canonical_refresh_bundle(
         ):
             raise ValueError(
                 f"{label} must contain citation and replace_rulespec_path, with "
-                "only optional review_finding and deferred_output_contracts fields"
+                "only optional review_finding, deferred_output_contracts, and "
+                "required_test_cases fields"
             )
         citation = value["citation"]
         raw_path = value["replace_rulespec_path"]
         review_finding = value.get("review_finding")
         deferred_output_contracts = value.get("deferred_output_contracts", [])
+        required_test_cases = _normalize_required_test_cases(
+            value.get("required_test_cases", []),
+            label=f"{label} required test cases",
+        )
         if (
             not isinstance(citation, str)
             or not citation
@@ -655,25 +888,24 @@ def parse_canonical_refresh_bundle(
             raise ValueError(
                 f"{label} path must equal the citation's canonical RuleSpec path"
             )
-        if normalized_contracts:
-            wrapped_contract = json.dumps(
-                {
-                    "schema": DEFERRED_OUTPUT_REVIEW_CONTRACT_SCHEMA,
-                    "citation": citation,
-                    "rulespec_path": path.as_posix(),
-                    "required_deferred_outputs": normalized_contracts,
-                },
-                ensure_ascii=False,
-                separators=(",", ":"),
-            ).encode("utf-8")
-            if len(wrapped_contract) > MAX_DEFERRED_OUTPUT_REVIEW_CONTRACT_JSON_BYTES:
-                raise ValueError(
-                    f"{label} wrapped deferred output review contract exceeds "
-                    "the maximum input size"
-                )
+        _validate_wrapped_review_contract_size(
+            citation=citation,
+            path=path,
+            deferred_output_contracts=tuple(normalized_contracts),
+            required_test_cases=required_test_cases,
+            label=label,
+        )
         if citation in seen_citations or path in seen_paths:
             raise ValueError("canonical refresh citations and paths must be unique")
-        requested.append((citation, path, review_finding, tuple(normalized_contracts)))
+        requested.append(
+            (
+                citation,
+                path,
+                review_finding,
+                tuple(normalized_contracts),
+                required_test_cases,
+            )
+        )
         seen_citations.add(citation)
         seen_paths.add(path)
 
@@ -684,8 +916,15 @@ def parse_canonical_refresh_bundle(
             path=path,
             review_finding=review_finding,
             deferred_output_contracts=deferred_output_contracts,
+            required_test_cases=required_test_cases,
         )
-        for citation, path, review_finding, deferred_output_contracts in requested
+        for (
+            citation,
+            path,
+            review_finding,
+            deferred_output_contracts,
+            required_test_cases,
+        ) in requested
     )
 
 
@@ -696,6 +935,7 @@ def _canonical_refresh_target_inventory(
     path: PurePosixPath,
     review_finding: str | None,
     deferred_output_contracts: tuple[dict[str, str], ...],
+    required_test_cases: tuple[dict[str, object], ...],
 ) -> dict[str, object]:
     """Bind one refresh target and its untrusted predecessor manifest to HEAD."""
 
@@ -823,6 +1063,7 @@ def _canonical_refresh_target_inventory(
         "citation": citation,
         "review_finding": review_finding,
         "deferred_output_contracts": list(deferred_output_contracts),
+        "required_test_cases": list(required_test_cases),
         "rulespec_path": path.as_posix(),
         "rulespec_sha256": target_sha256,
         "companion_path": companion_path.as_posix(),
@@ -839,7 +1080,10 @@ def verify_canonical_refresh_target(
     """Require one normalized target to remain byte-identical before its lane."""
 
     try:
-        target = json.loads(target_json)
+        target = _load_unambiguous_json(
+            target_json,
+            label="canonical refresh target",
+        )
     except (json.JSONDecodeError, RecursionError) as exc:
         raise ValueError("canonical refresh target is invalid JSON") from exc
     expected_fields = {
@@ -852,17 +1096,30 @@ def verify_canonical_refresh_target(
         "manifest_sha256",
         "review_finding",
         "deferred_output_contracts",
+        "required_test_cases",
     }
     deferred_output_contracts = (
         target.get("deferred_output_contracts") if isinstance(target, dict) else None
     )
+    try:
+        required_test_cases = _normalize_required_test_cases(
+            target.get("required_test_cases") if isinstance(target, dict) else None,
+            label="canonical refresh target required test cases",
+        )
+    except ValueError as exc:
+        raise ValueError("canonical refresh target inventory is malformed") from exc
     if (
         not isinstance(target, dict)
         or set(target) != expected_fields
         or not all(
             isinstance(target[field], str) and target[field]
             for field in expected_fields
-            - {"companion_sha256", "review_finding", "deferred_output_contracts"}
+            - {
+                "companion_sha256",
+                "review_finding",
+                "deferred_output_contracts",
+                "required_test_cases",
+            }
         )
         or (
             target["companion_sha256"] is not None
@@ -901,6 +1158,7 @@ def verify_canonical_refresh_target(
             }
         )
         != len(deferred_output_contracts or [])
+        or list(required_test_cases) != target["required_test_cases"]
         or (
             target["review_finding"] is not None
             and (
@@ -926,6 +1184,13 @@ def verify_canonical_refresh_target(
     )
     companion_path = _safe_relative_path(
         target["companion_path"], label="canonical refresh target companion"
+    )
+    _validate_wrapped_review_contract_size(
+        citation=target["citation"],
+        path=rulespec_path,
+        deferred_output_contracts=tuple(deferred_output_contracts),
+        required_test_cases=required_test_cases,
+        label="canonical refresh target",
     )
     if (
         citation_rulespec_path(target["citation"]) != rulespec_path
@@ -2854,6 +3119,11 @@ def main() -> None:
     )
     canonical_refresh_parser.add_argument("--primary-citation", required=True)
     canonical_refresh_parser.add_argument("--primary-rulespec-path", required=True)
+    canonical_refresh_parser.add_argument(
+        "--primary-required-test-cases-json",
+        default="[]",
+        help="bounded JSON array of exact companion cases required for the primary",
+    )
     canonical_refresh_target_parser = subparsers.add_parser(
         "verify-canonical-refresh-target",
         help="verify one normalized canonical refresh target remains unchanged",
@@ -2975,6 +3245,9 @@ def main() -> None:
                         args.refresh_bundle_json,
                         primary_citation=args.primary_citation,
                         primary_rulespec_path=args.primary_rulespec_path,
+                        primary_required_test_cases_json=(
+                            args.primary_required_test_cases_json
+                        ),
                     ),
                     separators=(",", ":"),
                 )

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -329,7 +329,9 @@ def split_atomic_source_input(atomic_source_json: str) -> dict[str, object]:
     ):
         raise ValueError("atomic source transaction bundle fields must be arrays")
     if source_bundle and (refresh_bundle or primary_required_test_cases):
-        raise ValueError("atomic source transaction must select exactly one source mode")
+        raise ValueError(
+            "atomic source transaction must select exactly one source mode"
+        )
     return {
         "canonical_refresh_bundle": refresh_bundle,
         "primary_required_test_cases": primary_required_test_cases,
@@ -557,12 +559,18 @@ def _normalize_required_test_cases(
         period_fields = {"period_kind", "start", "end"}
         if isinstance(period, dict) and period.get("period_kind") == "custom":
             period_fields.add("name")
-        if not isinstance(period, dict) or set(period) != period_fields or any(
-            not isinstance(field, str)
-            or not field
-            or field != field.strip()
-            or any(ord(character) < 32 or ord(character) == 127 for character in field)
-            for field in period.values()
+        if (
+            not isinstance(period, dict)
+            or set(period) != period_fields
+            or any(
+                not isinstance(field, str)
+                or not field
+                or field != field.strip()
+                or any(
+                    ord(character) < 32 or ord(character) == 127 for character in field
+                )
+                for field in period.values()
+            )
         ):
             raise ValueError(
                 f"{case_label} period must be an exact normalized RuleSpec period "
@@ -679,7 +687,9 @@ def _validate_wrapped_review_contract_size(
         separators=(",", ":"),
     ).encode("utf-8")
     if len(wrapped_contract) > MAX_DEFERRED_OUTPUT_REVIEW_CONTRACT_JSON_BYTES:
-        raise ValueError(f"{label} wrapped review contract exceeds the maximum input size")
+        raise ValueError(
+            f"{label} wrapped review contract exceeds the maximum input size"
+        )
 
 
 def parse_canonical_refresh_bundle(
@@ -717,7 +727,9 @@ def parse_canonical_refresh_bundle(
         len(primary_required_test_cases_json.encode("utf-8"))
         > MAX_DEFERRED_OUTPUT_REVIEW_CONTRACT_JSON_BYTES
     ):
-        raise ValueError("primary required test cases JSON exceeds the maximum input size")
+        raise ValueError(
+            "primary required test cases JSON exceeds the maximum input size"
+        )
     primary_required_test_cases = _normalize_required_test_cases(
         _load_unambiguous_json(
             primary_required_test_cases_json,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1634"
+__version__ = "0.2.1635"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -1125,9 +1125,7 @@ def _parse_deferred_output_review_contract_json(
     except (json.JSONDecodeError, RecursionError, ValueError) as exc:
         raise argparse.ArgumentTypeError("review contract must be valid JSON") from exc
     if not isinstance(payload, dict):
-        raise argparse.ArgumentTypeError(
-            "review contract must be a JSON object"
-        )
+        raise argparse.ArgumentTypeError("review contract must be a JSON object")
     schema = payload.get("schema")
     v1_fields = {
         "schema",
@@ -1253,7 +1251,9 @@ def _parse_deferred_output_review_contract_json(
                 or not name
                 or name != name.strip()
                 or "\r" in name
-                or any(ord(character) < 32 or ord(character) == 127 for character in name)
+                or any(
+                    ord(character) < 32 or ord(character) == 127 for character in name
+                )
             ):
                 raise argparse.ArgumentTypeError(
                     f"{label} name must be a nonempty normalized string"
@@ -1267,12 +1267,19 @@ def _parse_deferred_output_review_contract_json(
             period_fields = {"period_kind", "start", "end"}
             if isinstance(period, dict) and period.get("period_kind") == "custom":
                 period_fields.add("name")
-            if not isinstance(period, dict) or set(period) != period_fields or any(
-                not isinstance(value, str)
-                or not value
-                or value != value.strip()
-                or any(ord(character) < 32 or ord(character) == 127 for character in value)
-                for value in period.values()
+            if (
+                not isinstance(period, dict)
+                or set(period) != period_fields
+                or any(
+                    not isinstance(value, str)
+                    or not value
+                    or value != value.strip()
+                    or any(
+                        ord(character) < 32 or ord(character) == 127
+                        for character in value
+                    )
+                    for value in period.values()
+                )
             ):
                 raise argparse.ArgumentTypeError(
                     f"{label} period must be an exact normalized RuleSpec period "

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -250,6 +250,7 @@ from .harness.validator_pipeline import (
     _rulespec_resolution_cache_scope,
     _rulespec_rule_formula_rule_records,
     _rulespec_target_is_descendant_of,
+    _safe_load_unique_keys,
     extract_embedded_source_text,
     extract_typed_numeric_occurrences_from_text,
     find_interval_table_reencoding_candidates,
@@ -1074,14 +1075,25 @@ def _format_counter(counter: dict[str, int]) -> str:
 
 
 _MAX_REQUIRED_DEFERRED_OUTPUT_CONTRACTS = 16
+_MAX_REQUIRED_TEST_CASE_CONTRACTS = 32
+_MAX_REQUIRED_TEST_CASE_FIELDS = 64
 _MAX_REQUIRED_DEFERRED_OUTPUT_CONTRACT_JSON_BYTES = 64 * 1024
 _DEFERRED_OUTPUT_REVIEW_CONTRACT_SCHEMA = "axiom-encode/review-contract/v1"
+_STRUCTURED_REVIEW_CONTRACT_SCHEMA = "axiom-encode/review-contract/v2"
+
+
+class _RequiredTestCaseContract(NamedTuple):
+    name: str
+    period: dict[str, str]
+    input: dict[str, object]
+    required_output: dict[str, object]
 
 
 class _DeferredOutputReviewContract(NamedTuple):
     citation: str
     rulespec_path: str
     required_deferred_outputs: tuple[tuple[str, str], ...]
+    required_test_cases: tuple[_RequiredTestCaseContract, ...] = ()
 
 
 def _parse_deferred_output_review_contract_json(
@@ -1110,19 +1122,33 @@ def _parse_deferred_output_review_contract_json(
         payload = json.loads(raw, object_pairs_hook=reject_duplicates)
     except argparse.ArgumentTypeError:
         raise
-    except (json.JSONDecodeError, RecursionError) as exc:
+    except (json.JSONDecodeError, RecursionError, ValueError) as exc:
         raise argparse.ArgumentTypeError("review contract must be valid JSON") from exc
-    if not isinstance(payload, dict) or set(payload) != {
+    if not isinstance(payload, dict):
+        raise argparse.ArgumentTypeError(
+            "review contract must be a JSON object"
+        )
+    schema = payload.get("schema")
+    v1_fields = {
         "schema",
         "citation",
         "rulespec_path",
         "required_deferred_outputs",
-    }:
-        raise argparse.ArgumentTypeError(
-            "review contract must contain exactly schema, citation, rulespec_path, "
-            "and required_deferred_outputs"
-        )
-    if payload["schema"] != _DEFERRED_OUTPUT_REVIEW_CONTRACT_SCHEMA:
+    }
+    v2_fields = {*v1_fields, "required_test_cases"}
+    if schema == _DEFERRED_OUTPUT_REVIEW_CONTRACT_SCHEMA:
+        if set(payload) != v1_fields:
+            raise argparse.ArgumentTypeError(
+                "v1 review contract must contain exactly schema, citation, "
+                "rulespec_path, and required_deferred_outputs"
+            )
+    elif schema == _STRUCTURED_REVIEW_CONTRACT_SCHEMA:
+        if set(payload) != v2_fields:
+            raise argparse.ArgumentTypeError(
+                "v2 review contract must contain exactly schema, citation, "
+                "rulespec_path, required_deferred_outputs, and required_test_cases"
+            )
+    else:
         raise argparse.ArgumentTypeError("review contract schema is unsupported")
     citation = payload["citation"]
     rulespec_path = payload["rulespec_path"]
@@ -1150,12 +1176,15 @@ def _parse_deferred_output_review_contract_json(
     payload_contracts = payload["required_deferred_outputs"]
     if (
         not isinstance(payload_contracts, list)
-        or not payload_contracts
         or len(payload_contracts) > _MAX_REQUIRED_DEFERRED_OUTPUT_CONTRACTS
     ):
         raise argparse.ArgumentTypeError(
-            "review contract required_deferred_outputs must be a nonempty array with "
+            "review contract required_deferred_outputs must be an array with "
             f"at most {_MAX_REQUIRED_DEFERRED_OUTPUT_CONTRACTS} entries"
+        )
+    if schema == _DEFERRED_OUTPUT_REVIEW_CONTRACT_SCHEMA and not payload_contracts:
+        raise argparse.ArgumentTypeError(
+            "v1 review contract required_deferred_outputs must be a nonempty array"
         )
     contracts: list[tuple[str, str]] = []
     seen_outputs: set[str] = set()
@@ -1189,10 +1218,141 @@ def _parse_deferred_output_review_contract_json(
             )
         seen_outputs.add(output)
         contracts.append((output, reason))
+
+    required_test_cases: list[_RequiredTestCaseContract] = []
+    if schema == _STRUCTURED_REVIEW_CONTRACT_SCHEMA:
+        payload_test_cases = payload["required_test_cases"]
+        if (
+            not isinstance(payload_test_cases, list)
+            or len(payload_test_cases) > _MAX_REQUIRED_TEST_CASE_CONTRACTS
+        ):
+            raise argparse.ArgumentTypeError(
+                "review contract required_test_cases must be an array with at most "
+                f"{_MAX_REQUIRED_TEST_CASE_CONTRACTS} entries"
+            )
+        if not contracts and not payload_test_cases:
+            raise argparse.ArgumentTypeError(
+                "v2 review contract must require a deferred output or test case"
+            )
+        seen_test_names: set[str] = set()
+        for index, item in enumerate(payload_test_cases):
+            label = f"review contract test case #{index + 1}"
+            if not isinstance(item, dict) or set(item) != {
+                "name",
+                "period",
+                "input",
+                "required_output",
+            }:
+                raise argparse.ArgumentTypeError(
+                    f"{label} must contain exactly name, period, input, and "
+                    "required_output"
+                )
+            name = item["name"]
+            if (
+                not isinstance(name, str)
+                or not name
+                or name != name.strip()
+                or "\r" in name
+                or any(ord(character) < 32 or ord(character) == 127 for character in name)
+            ):
+                raise argparse.ArgumentTypeError(
+                    f"{label} name must be a nonempty normalized string"
+                )
+            if name in seen_test_names:
+                raise argparse.ArgumentTypeError(
+                    "review contract required test case names must be unique"
+                )
+            seen_test_names.add(name)
+            period = item["period"]
+            period_fields = {"period_kind", "start", "end"}
+            if isinstance(period, dict) and period.get("period_kind") == "custom":
+                period_fields.add("name")
+            if not isinstance(period, dict) or set(period) != period_fields or any(
+                not isinstance(value, str)
+                or not value
+                or value != value.strip()
+                or any(ord(character) < 32 or ord(character) == 127 for character in value)
+                for value in period.values()
+            ):
+                raise argparse.ArgumentTypeError(
+                    f"{label} period must be an exact normalized RuleSpec period "
+                    "mapping"
+                )
+            if period["period_kind"] not in _RULESPEC_ENGINE_PERIOD_KINDS:
+                raise argparse.ArgumentTypeError(
+                    f"{label} period_kind is not supported by the RuleSpec engine"
+                )
+            try:
+                period_start = date.fromisoformat(period["start"])
+                period_end = date.fromisoformat(period["end"])
+            except ValueError as exc:
+                raise argparse.ArgumentTypeError(
+                    f"{label} period dates must be ISO dates"
+                ) from exc
+            if period_start > period_end:
+                raise argparse.ArgumentTypeError(
+                    f"{label} period start must not follow end"
+                )
+
+            normalized_fields: dict[str, dict[str, object]] = {}
+            for field in ("input", "required_output"):
+                mapping = item[field]
+                if (
+                    not isinstance(mapping, dict)
+                    or (field == "required_output" and not mapping)
+                    or len(mapping) > _MAX_REQUIRED_TEST_CASE_FIELDS
+                ):
+                    raise argparse.ArgumentTypeError(
+                        f"{label} {field} must be an object with at most "
+                        f"{_MAX_REQUIRED_TEST_CASE_FIELDS} fields"
+                    )
+                normalized: dict[str, object] = {}
+                for key, value in mapping.items():
+                    if (
+                        not isinstance(key, str)
+                        or not key
+                        or key != key.strip()
+                        or any(
+                            ord(character) < 32 or ord(character) == 127
+                            for character in key
+                        )
+                    ):
+                        raise argparse.ArgumentTypeError(
+                            f"{label} {field} keys must be normalized strings"
+                        )
+                    if not isinstance(value, (str, int, float, bool)) or (
+                        isinstance(value, float) and not math.isfinite(value)
+                    ):
+                        raise argparse.ArgumentTypeError(
+                            f"{label} {field} values must be finite JSON scalars"
+                        )
+                    if isinstance(value, str) and (
+                        value != value.strip()
+                        or "\r" in value
+                        or any(
+                            (ord(character) < 32 and character not in {"\n", "\t"})
+                            or ord(character) == 127
+                            for character in value
+                        )
+                    ):
+                        raise argparse.ArgumentTypeError(
+                            f"{label} {field} string values must be normalized"
+                        )
+                    normalized[key] = value
+                normalized_fields[field] = normalized
+            required_test_cases.append(
+                _RequiredTestCaseContract(
+                    name=name,
+                    period=dict(period),
+                    input=normalized_fields["input"],
+                    required_output=normalized_fields["required_output"],
+                )
+            )
     return _DeferredOutputReviewContract(
         citation=citation,
         rulespec_path=rulespec_path,
         required_deferred_outputs=tuple(contracts),
+        required_test_cases=tuple(required_test_cases),
     )
 
 
@@ -1221,8 +1381,8 @@ def _required_deferred_output_contract_issues(
     if binding_issues:
         return binding_issues
     try:
-        payload = yaml.safe_load(output_file.read_text(encoding="utf-8"))
-    except (OSError, UnicodeError, yaml.YAMLError, RecursionError) as exc:
+        payload = _safe_load_unique_keys(output_file.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, yaml.YAMLError, RecursionError, ValueError) as exc:
         return [f"required deferred-output contract could not parse YAML: {exc}"]
     module = payload.get("module") if isinstance(payload, dict) else None
     deferred_outputs = (
@@ -1250,6 +1410,101 @@ def _required_deferred_output_contract_issues(
                 f"`{expected_output}` must equal the signed dispatch contract "
                 "byte-for-byte; paraphrase, shortening, reordering, and synonym "
                 "substitution are not permitted"
+            )
+    if not contract.required_test_cases:
+        return issues
+
+    test_file = _rulespec_test_path(output_file)
+    try:
+        test_payload = _safe_load_unique_keys(test_file.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, yaml.YAMLError, RecursionError, ValueError) as exc:
+        return [*issues, f"required test-case contract could not parse YAML: {exc}"]
+    if isinstance(test_payload, dict) and isinstance(test_payload.get("cases"), list):
+        test_cases = test_payload["cases"]
+    elif isinstance(test_payload, list):
+        test_cases = test_payload
+    else:
+        return [
+            *issues,
+            "required test-case contract expected a companion YAML case array",
+        ]
+
+    def values_equal(actual: object, expected: object) -> bool:
+        return type(actual) is type(expected) and actual == expected
+
+    for required in contract.required_test_cases:
+        matches = [
+            item
+            for item in test_cases
+            if isinstance(item, dict) and item.get("name") == required.name
+        ]
+        if len(matches) != 1:
+            issues.append(
+                "[required-test-case-contract] expected exactly one companion case "
+                f"named {required.name!r}; found {len(matches)}"
+            )
+            continue
+        candidate = matches[0]
+        unsigned_runtime_fields = sorted(
+            field
+            for field in ("tables", "inputs", "oracle_inputs")
+            if field in candidate
+        )
+        if unsigned_runtime_fields:
+            issues.append(
+                "[required-test-case-contract] companion case "
+                f"{required.name!r} contains unsigned runtime input field(s): "
+                + ", ".join(unsigned_runtime_fields)
+            )
+        if candidate.get("period") != required.period:
+            issues.append(
+                "[required-test-case-contract] companion case "
+                f"{required.name!r} period does not exactly match the signed contract"
+            )
+        candidate_input = candidate.get("input")
+        candidate_input_keys = (
+            set(candidate_input) if isinstance(candidate_input, dict) else set()
+        )
+        missing_inputs = sorted(set(required.input) - candidate_input_keys)
+        unexpected_inputs = sorted(candidate_input_keys - set(required.input))
+        changed_inputs = sorted(
+            key
+            for key, expected in required.input.items()
+            if isinstance(candidate_input, dict)
+            and key in candidate_input
+            and not values_equal(candidate_input[key], expected)
+        )
+        if (
+            not isinstance(candidate_input, dict)
+            or missing_inputs
+            or unexpected_inputs
+            or changed_inputs
+        ):
+            details = []
+            if missing_inputs:
+                details.append("missing: " + ", ".join(missing_inputs))
+            if unexpected_inputs:
+                details.append("unexpected: " + ", ".join(unexpected_inputs))
+            if changed_inputs:
+                details.append("changed: " + ", ".join(changed_inputs))
+            issues.append(
+                "[required-test-case-contract] companion case "
+                f"{required.name!r} input map does not exactly match the signed contract"
+                + (f" ({'; '.join(details)})" if details else "")
+            )
+        candidate_output = candidate.get("output")
+        missing_or_changed_outputs = [
+            key
+            for key, expected in required.required_output.items()
+            if not isinstance(candidate_output, dict)
+            or key not in candidate_output
+            or not values_equal(candidate_output[key], expected)
+        ]
+        if missing_or_changed_outputs:
+            issues.append(
+                "[required-test-case-contract] companion case "
+                f"{required.name!r} is missing or changes required output(s): "
+                + ", ".join(missing_or_changed_outputs)
             )
     return issues
 
@@ -27738,6 +27993,19 @@ def _run_encode_attempt(
             if deferred_output_review_contract is not None
             else ()
         ),
+        required_test_case_contracts=(
+            tuple(
+                {
+                    "name": contract.name,
+                    "period": contract.period,
+                    "input": contract.input,
+                    "required_output": contract.required_output,
+                }
+                for contract in deferred_output_review_contract.required_test_cases
+            )
+            if deferred_output_review_contract is not None
+            else ()
+        ),
         required_import_targets=required_import_targets,
         legacy_replacement=(
             replacement_target.legacy_replacement
@@ -51551,10 +51819,33 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
 
     generated_content = output_file.read_text()
     output_test = _rulespec_test_path(output_file)
+    if (
+        deferred_output_review_contract is not None
+        and deferred_output_review_contract.required_test_cases
+        and (output_test.is_symlink() or not output_test.is_file())
+    ):
+        return (
+            False,
+            [
+                f"{relative_output}: structured review contract requires a freshly "
+                "generated regular companion test file"
+            ],
+            {},
+        )
+    if (
+        deferred_output_review_contract is not None
+        and deferred_output_review_contract.required_test_cases
+        and output_test.stat().st_size > VALIDATION_RETRY_CANDIDATE_MAX_FILE_BYTES
+    ):
+        return (
+            False,
+            [f"{relative_output}: generated companion test file exceeds size limit"],
+            {},
+        )
     generated_test_cases: Any | None = None
     if output_test.exists():
         try:
-            loaded_tests = yaml.safe_load(output_test.read_text())
+            loaded_tests = _safe_load_unique_keys(output_test.read_text())
         except (yaml.YAMLError, ValueError):
             loaded_tests = None
         if isinstance(loaded_tests, dict) and isinstance(

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -1507,6 +1507,7 @@ def run_model_eval(
     target_relative_output: Path | None = None,
     validation_retry_feedback: Sequence[str] = (),
     required_deferred_output_contracts: Sequence[tuple[str, str]] = (),
+    required_test_case_contracts: Sequence[Mapping[str, object]] = (),
     required_import_targets: Sequence[str] = (),
     legacy_replacement: LegacyReplacementContract | None = None,
     replacement_overlay_scope: bool = False,
@@ -1557,6 +1558,7 @@ def run_model_eval(
                         required_deferred_output_contracts=(
                             required_deferred_output_contracts
                         ),
+                        required_test_case_contracts=required_test_case_contracts,
                         validation_retry_candidate=validation_retry_candidate,
                         required_import_targets=required_import_targets,
                         legacy_replacement=legacy_replacement,
@@ -5854,6 +5856,7 @@ def prepare_eval_workspace(
     extra_context_paths: list[Path] | None = None,
     review_findings_paths: list[Path] | None = None,
     target_relative_output: Path | None = None,
+    review_contract: Mapping[str, object] | None = None,
 ) -> EvalWorkspace:
     """Create an isolated workspace bundle for a single eval."""
     slug = _slugify(citation)
@@ -6087,6 +6090,8 @@ def prepare_eval_workspace(
         ],
         "review_findings_files": review_findings_evidence,
     }
+    if review_contract is not None:
+        manifest_payload["review_contract"] = dict(review_contract)
     if rendered_context.dropped_amendment_documents:
         manifest_payload["dropped_amendment_documents"] = list(
             rendered_context.dropped_amendment_documents
@@ -8446,6 +8451,37 @@ def _discard_artifacts_after_case_budget(
     return True
 
 
+def _eval_review_contract_manifest_payload(
+    *,
+    citation: str,
+    rulespec_path: str,
+    required_deferred_output_contracts: Sequence[tuple[str, str]],
+    required_test_case_contracts: Sequence[Mapping[str, object]],
+) -> dict[str, object] | None:
+    """Build the exact contract bound into signed per-lane context evidence."""
+
+    if not required_deferred_output_contracts and not required_test_case_contracts:
+        return None
+    payload: dict[str, object] = {
+        "schema": (
+            "axiom-encode/review-contract/v2"
+            if required_test_case_contracts
+            else "axiom-encode/review-contract/v1"
+        ),
+        "citation": citation,
+        "rulespec_path": rulespec_path,
+        "required_deferred_outputs": [
+            {"output": output, "reason": reason}
+            for output, reason in required_deferred_output_contracts
+        ],
+    }
+    if required_test_case_contracts:
+        payload["required_test_cases"] = [
+            dict(contract) for contract in required_test_case_contracts
+        ]
+    return payload
+
+
 def _run_single_eval(
     citation: str,
     runner: EvalRunnerSpec,
@@ -8467,6 +8503,7 @@ def _run_single_eval(
     target_relative_output: Path | None = None,
     validation_retry_feedback: Sequence[str] = (),
     required_deferred_output_contracts: Sequence[tuple[str, str]] = (),
+    required_test_case_contracts: Sequence[Mapping[str, object]] = (),
     required_import_targets: Sequence[str] = (),
     legacy_replacement: LegacyReplacementContract | None = None,
     replacement_overlay_scope: bool = False,
@@ -8486,21 +8523,6 @@ def _run_single_eval(
         rulespec_root=policy_path,
     )
 
-    workspace = prepare_eval_workspace(
-        citation=citation,
-        runner=runner,
-        output_root=output_root,
-        source_text=source_text,
-        axiom_rules_path=policy_path,
-        mode=mode,
-        source_metadata_payload=source_metadata_payload,
-        provision_metadata=source_unit.provision_metadata,
-        amendment_documents=source_unit.amendment_documents,
-        extra_context_paths=extra_context_paths,
-        review_findings_paths=review_findings_paths,
-        target_relative_output=target_relative_output,
-    )
-
     # Derive the output path from the *requested* identifier rather than the
     # *resolved* corpus citation_path. When the resolver falls back to a parent
     # provision (subsection-level corpus row missing), the resolved path drops
@@ -8516,6 +8538,27 @@ def _run_single_eval(
             citation,
             fallback=citation_to_relative_rulespec_path,
         )
+    )
+    review_contract = _eval_review_contract_manifest_payload(
+        citation=citation,
+        rulespec_path=(Path(policy_path.name) / relative_output).as_posix(),
+        required_deferred_output_contracts=required_deferred_output_contracts,
+        required_test_case_contracts=required_test_case_contracts,
+    )
+    workspace = prepare_eval_workspace(
+        citation=citation,
+        runner=runner,
+        output_root=output_root,
+        source_text=source_text,
+        axiom_rules_path=policy_path,
+        mode=mode,
+        source_metadata_payload=source_metadata_payload,
+        provision_metadata=source_unit.provision_metadata,
+        amendment_documents=source_unit.amendment_documents,
+        extra_context_paths=extra_context_paths,
+        review_findings_paths=review_findings_paths,
+        target_relative_output=target_relative_output,
+        review_contract=review_contract,
     )
     target_ref_source = citation if is_corpus_path else source_unit.citation_path
     prompt = _build_eval_prompt(
@@ -8535,6 +8578,7 @@ def _run_single_eval(
         require_complete_source_unit=require_complete_source_unit,
         validation_retry_feedback=validation_retry_feedback,
         required_deferred_output_contracts=required_deferred_output_contracts,
+        required_test_case_contracts=required_test_case_contracts,
         validation_retry_candidate=validation_retry_candidate,
         required_import_targets=required_import_targets,
     )
@@ -9489,6 +9533,43 @@ Structured deferred-output apply-admission contract:
 """
 
 
+def _format_required_test_case_contracts(
+    contracts: Sequence[Mapping[str, object]],
+) -> str:
+    """Render exact companion-test admission requirements on every attempt."""
+
+    if not contracts:
+        return ""
+    rendered: list[str] = []
+    expected_fields = {"name", "period", "input", "required_output"}
+    for index, contract in enumerate(contracts):
+        if not isinstance(contract, Mapping) or set(contract) != expected_fields:
+            raise ValueError(f"Required test case contract #{index + 1} is invalid")
+        rendered.append(
+            json.dumps(
+                dict(contract),
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+        )
+    return f"""
+Structured companion-test apply-admission contract:
+- The following JSON objects are trusted workflow requirements, not legal
+  authority. Each `name` must appear exactly once in the companion test file.
+- For each named case, `period` and the complete `input` map must equal the JSON
+  object exactly after YAML decoding. Do not add, remove, rename, or change an
+  input. Every key/value in `required_output` must appear in that case's
+  `output`; additional reached helper assertions are allowed.
+- These requirements are checked again on the final repaired overlay before
+  apply. Preserve JSON scalar types as well as values.
+
+=== BEGIN REQUIRED COMPANION TEST CONTRACT ===
+{chr(10).join(rendered)}
+=== END REQUIRED COMPANION TEST CONTRACT ===
+"""
+
+
 def _format_validation_retry_candidate(
     candidate: ValidationRetryCandidate | None,
     *,
@@ -9553,6 +9634,7 @@ def _build_rulespec_eval_prompt(
     require_complete_source_unit: bool = False,
     validation_retry_feedback: Sequence[str] = (),
     required_deferred_output_contracts: Sequence[tuple[str, str]] = (),
+    required_test_case_contracts: Sequence[Mapping[str, object]] = (),
     validation_retry_candidate: ValidationRetryCandidate | None = None,
     required_import_targets: Sequence[str] = (),
 ) -> str:
@@ -10111,6 +10193,9 @@ Preferred principal output:
     required_deferred_output_contract_section = (
         _format_required_deferred_output_contracts(required_deferred_output_contracts)
     )
+    required_test_case_contract_section = _format_required_test_case_contracts(
+        required_test_case_contracts
+    )
     validation_retry_candidate_section = _format_validation_retry_candidate(
         validation_retry_candidate,
         target_file_name=target_file_name,
@@ -10214,7 +10299,7 @@ Primary legal authority:
 {legal_authority_instruction}
 {corpus_source_section.rstrip()}
 {inline_source}
-{source_metadata_section}{provision_metadata_section}{amendment_section}{context_section}{missing_cited_source_section}{mandatory_review_findings_section}{required_deferred_output_contract_section}{validation_retry_feedback_section}{required_import_section}
+{source_metadata_section}{provision_metadata_section}{amendment_section}{context_section}{missing_cited_source_section}{mandatory_review_findings_section}{required_deferred_output_contract_section}{required_test_case_contract_section}{validation_retry_feedback_section}{required_import_section}
 {backend_section}
 {canonical_concept_section}{complete_source_unit_section}
 RuleSpec requirements:
@@ -11046,6 +11131,7 @@ def _build_eval_prompt(
     require_complete_source_unit: bool = False,
     validation_retry_feedback: Sequence[str] = (),
     required_deferred_output_contracts: Sequence[tuple[str, str]] = (),
+    required_test_case_contracts: Sequence[Mapping[str, object]] = (),
     validation_retry_candidate: ValidationRetryCandidate | None = None,
     required_import_targets: Sequence[str] = (),
 ) -> str:
@@ -11064,6 +11150,7 @@ def _build_eval_prompt(
         require_complete_source_unit=require_complete_source_unit,
         validation_retry_feedback=validation_retry_feedback,
         required_deferred_output_contracts=required_deferred_output_contracts,
+        required_test_case_contracts=required_test_case_contracts,
         validation_retry_candidate=validation_retry_candidate,
         required_import_targets=required_import_targets,
     )

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -21156,6 +21156,7 @@ def find_test_input_assignment_issues(
     imported_symbols = _rulespec_import_fragment_names(payload.get("imports"))
     symbol_inputs: dict[str, set[str]] = {}
     symbol_dependencies: dict[str, set[str]] = {}
+    symbol_versions: dict[str, tuple[_SymbolInputDependencyVersion, ...] | None] = {}
     for rule in rules:
         if not isinstance(rule, dict):
             continue
@@ -21173,17 +21174,47 @@ def find_test_input_assignment_issues(
         if not isinstance(versions, list):
             continue
         formula_identifiers: set[str] = set()
+        dependency_versions: list[_SymbolInputDependencyVersion] = []
+        version_metadata_valid = True
         for version in versions:
             if not isinstance(version, dict):
+                version_metadata_valid = False
                 continue
             formula = version.get("formula")
             if not isinstance(formula, str):
+                version_metadata_valid = False
                 continue
-            formula_identifiers.update(_formula_local_identifiers(formula))
+            identifiers = _formula_local_identifiers(formula)
+            formula_identifiers.update(identifiers)
+            try:
+                effective_from = date.fromisoformat(str(version["effective_from"]))
+                effective_to = (
+                    date.fromisoformat(str(version["effective_to"]))
+                    if version.get("effective_to") is not None
+                    else None
+                )
+            except (KeyError, TypeError, ValueError):
+                version_metadata_valid = False
+                continue
+            dependency_versions.append(
+                _SymbolInputDependencyVersion(
+                    effective_from=effective_from,
+                    effective_to=effective_to,
+                    inputs=frozenset(
+                        identifiers - defined_symbols - imported_symbols
+                    ),
+                    dependencies=frozenset(identifiers & defined_symbols),
+                )
+            )
         symbol_inputs[rule_name] = (
             formula_identifiers - defined_symbols - imported_symbols
         )
         symbol_dependencies[rule_name] = formula_identifiers & defined_symbols
+        symbol_versions[rule_name] = (
+            tuple(dependency_versions)
+            if version_metadata_valid and dependency_versions
+            else None
+        )
 
     if not symbol_inputs:
         return []
@@ -21207,6 +21238,8 @@ def find_test_input_assignment_issues(
             test_case.get("output"),
             symbol_inputs=symbol_inputs,
             symbol_dependencies=symbol_dependencies,
+            symbol_versions=symbol_versions,
+            period_bounds=_test_case_period_bounds(test_case.get("period")),
         )
         local_inputs = required_inputs & globally_local_inputs
         if not local_inputs:
@@ -21247,6 +21280,29 @@ def _defined_rulespec_symbols(rules: list[Any]) -> set[str]:
     }
 
 
+@dataclass(frozen=True)
+class _SymbolInputDependencyVersion:
+    effective_from: date
+    effective_to: date | None
+    inputs: frozenset[str]
+    dependencies: frozenset[str]
+
+
+def _test_case_period_bounds(period: Any) -> tuple[date, date] | None:
+    """Return unambiguous test bounds, otherwise request union fallback."""
+
+    if not isinstance(period, dict) or not {"period_kind", "start", "end"}.issubset(
+        period
+    ):
+        return None
+    try:
+        start = date.fromisoformat(str(period["start"]))
+        end = date.fromisoformat(str(period["end"]))
+    except (TypeError, ValueError):
+        return None
+    return (start, end) if start <= end else None
+
+
 def _indexed_by_input_names(value: Any) -> set[str]:
     if isinstance(value, str):
         return {value.strip()} if value.strip() else set()
@@ -21260,6 +21316,8 @@ def _required_inputs_for_test_outputs(
     *,
     symbol_inputs: dict[str, set[str]],
     symbol_dependencies: dict[str, set[str]],
+    symbol_versions: dict[str, tuple[_SymbolInputDependencyVersion, ...] | None],
+    period_bounds: tuple[date, date] | None,
 ) -> set[str]:
     if not isinstance(outputs, dict):
         return set().union(*symbol_inputs.values()) if symbol_inputs else set()
@@ -21273,6 +21331,8 @@ def _required_inputs_for_test_outputs(
                     fragment,
                     symbol_inputs=symbol_inputs,
                     symbol_dependencies=symbol_dependencies,
+                    symbol_versions=symbol_versions,
+                    period_bounds=period_bounds,
                     seen=set(),
                 )
             )
@@ -21284,18 +21344,62 @@ def _required_inputs_for_symbol(
     *,
     symbol_inputs: dict[str, set[str]],
     symbol_dependencies: dict[str, set[str]],
+    symbol_versions: dict[str, tuple[_SymbolInputDependencyVersion, ...] | None],
+    period_bounds: tuple[date, date] | None,
     seen: set[str],
 ) -> set[str]:
     if symbol in seen:
         return set()
     seen.add(symbol)
-    required = set(symbol_inputs.get(symbol, set()))
-    for dependency in symbol_dependencies.get(symbol, set()):
+    inputs = symbol_inputs.get(symbol, set())
+    dependencies = symbol_dependencies.get(symbol, set())
+    versions = symbol_versions.get(symbol)
+    if period_bounds is not None and versions:
+        period_start, period_end = period_bounds
+        transition_dates = {period_start, period_end}
+        for version in versions:
+            if period_start <= version.effective_from <= period_end:
+                transition_dates.add(version.effective_from)
+            if (
+                version.effective_to is not None
+                and period_start <= version.effective_to <= period_end
+            ):
+                transition_dates.add(version.effective_to)
+                if version.effective_to < period_end:
+                    transition_dates.add(version.effective_to + date.resolution)
+        selected_versions: list[_SymbolInputDependencyVersion] = []
+        for boundary in sorted(transition_dates):
+            live_versions = [
+                version
+                for version in versions
+                if version.effective_from <= boundary
+                and (version.effective_to is None or boundary <= version.effective_to)
+            ]
+            if not live_versions:
+                selected_versions = []
+                break
+            latest_from = max(version.effective_from for version in live_versions)
+            latest_versions = [
+                version
+                for version in live_versions
+                if version.effective_from == latest_from
+            ]
+            if len(latest_versions) != 1:
+                selected_versions = []
+                break
+            selected_versions.append(latest_versions[0])
+        if selected_versions and len(set(selected_versions)) == 1:
+            inputs = set(selected_versions[0].inputs)
+            dependencies = set(selected_versions[0].dependencies)
+    required = set(inputs)
+    for dependency in dependencies:
         required.update(
             _required_inputs_for_symbol(
                 dependency,
                 symbol_inputs=symbol_inputs,
                 symbol_dependencies=symbol_dependencies,
+                symbol_versions=symbol_versions,
+                period_bounds=period_bounds,
                 seen=seen,
             )
         )

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -21200,9 +21200,7 @@ def find_test_input_assignment_issues(
                 _SymbolInputDependencyVersion(
                     effective_from=effective_from,
                     effective_to=effective_to,
-                    inputs=frozenset(
-                        identifiers - defined_symbols - imported_symbols
-                    ),
+                    inputs=frozenset(identifiers - defined_symbols - imported_symbols),
                     dependencies=frozenset(identifiers & defined_symbols),
                 )
             )

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1634"
+ENCODER_VERSION = "0.2.1635"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -162,6 +162,7 @@ from axiom_encode.cli import (
     _require_clean_axiom_encode_git_provenance,
     _required_deferred_output_contract_issues,
     _required_generated_import_issues,
+    _RequiredTestCaseContract,
     _resolve_applied_manifest_placement,
     _resolve_encode_replacement_target,
     _resolve_explicit_policy_repo_for_corpus_source,
@@ -13042,6 +13043,111 @@ class TestCmdEncode:
             call.kwargs["required_deferred_output_contracts"]
             for call in mock_run.call_args_list
         ] == [contract.required_deferred_outputs] * 2
+
+    def test_encode_structured_contract_retries_before_apply(self, tmp_path):
+        output = "us:statutes/26/1/j/2#standard_deduction"
+        input_key = "us:statutes/26/1/j/2#input.single_status"
+        required_case = _RequiredTestCaseContract(
+            name="exact 2025 case",
+            period={
+                "period_kind": "tax_year",
+                "start": "2025-01-01",
+                "end": "2025-12-31",
+            },
+            input={input_key: True},
+            required_output={output: 12500},
+        )
+        contract = _DeferredOutputReviewContract(
+            citation="26 USC 1(j)(2)",
+            rulespec_path="us/statutes/26/1/j/2.yaml",
+            required_deferred_outputs=(),
+            required_test_cases=(required_case,),
+        )
+        args = self._make_args(
+            tmp_path,
+            model=None,
+            apply=True,
+            sync=False,
+            escalation_enabled=True,
+            review_contract_json=contract,
+        )
+        generated_attempts = 0
+        apply_counts_at_validation: list[int] = []
+
+        def generate(**kwargs):
+            nonlocal generated_attempts
+            generated_attempts += 1
+            if generated_attempts == 2:
+                assert any(
+                    "input map does not exactly match" in item
+                    for item in kwargs["validation_retry_feedback"]
+                )
+                assert kwargs["validation_retry_candidate"] is not None
+            result = self._make_eval_result(True)
+            result.runner = f"codex-{kwargs['runner_specs'][0].split(':', 1)[1]}"
+            result.model = kwargs["runner_specs"][0].split(":", 1)[1]
+            result.generation_prompt_sha256 = f"prompt-{generated_attempts}"
+            generated = args.output / result.runner / "statutes/26/1/j/2.yaml"
+            generated.parent.mkdir(parents=True, exist_ok=True)
+            generated.write_text("format: rulespec/v1\nmodule: {}\nrules: []\n")
+            candidate_input = {input_key: True}
+            if generated_attempts == 1:
+                candidate_input[f"{input_key}.unsigned_prior_year"] = 0
+            generated.with_suffix(".test.yaml").write_text(
+                json.dumps(
+                    [
+                        {
+                            "name": required_case.name,
+                            "period": required_case.period,
+                            "input": candidate_input,
+                            "output": {output: 12500},
+                        }
+                    ]
+                )
+            )
+            result.output_file = str(generated)
+            return [result]
+
+        def validate(result, **_kwargs):
+            apply_counts_at_validation.append(mock_apply.call_count)
+            issues = _required_deferred_output_contract_issues(
+                Path(result.output_file),
+                contract,
+                citation=contract.citation,
+                rulespec_path=contract.rulespec_path,
+            )
+            return not issues, issues, {}
+
+        applied_file = args.policy_repo_path / contract.rulespec_path
+        with (
+            patch("axiom_encode.cli.run_model_eval", side_effect=generate) as mock_run,
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                side_effect=validate,
+            ),
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, TEST_APPLY_SIGNING_ENV, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        assert generated_attempts == 2
+        assert apply_counts_at_validation == [0, 0]
+        mock_apply.assert_called_once()
+        expected_case = {
+            "name": required_case.name,
+            "period": required_case.period,
+            "input": required_case.input,
+            "required_output": required_case.required_output,
+        }
+        assert [
+            call.kwargs["required_test_case_contracts"]
+            for call in mock_run.call_args_list
+        ] == [(expected_case,)] * 2
 
     def test_encode_retry_feedback_includes_actionable_ci_issue(self):
         import axiom_encode.cli as cli_module
@@ -40925,6 +41031,71 @@ rules:
         assert issues == []
         assert supplemental == {}
         record_snapshot.assert_called_once()
+
+    def test_apply_overlay_structured_contract_requires_generated_companion(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us" / "us-la"
+        target = policy_repo / "statutes/47/294.yaml"
+        baseline_companion = target.with_name("294.test.yaml")
+        generated = output_root / "codex-test-model/statutes/47/294.yaml"
+        target.parent.mkdir(parents=True)
+        generated.parent.mkdir(parents=True)
+        target.write_text("format: rulespec/v1\nrules: []\n")
+        baseline_companion.write_text(
+            "- name: exact case\n"
+            "  period: {period_kind: tax_year, start: '2025-01-01', "
+            "end: '2025-12-31'}\n"
+            "  input: {}\n"
+            "  output: {us-la:statutes/47/294#deduction: 12500}\n"
+        )
+        generated.write_text("format: rulespec/v1\nrules: []\n")
+        result = SimpleNamespace(
+            output_file=str(generated),
+            runner="codex-test-model",
+            backend="codex",
+            citation="us-la/statute/47:294",
+        )
+        contract = _DeferredOutputReviewContract(
+            citation="us-la/statute/47:294",
+            rulespec_path="us-la/statutes/47/294.yaml",
+            required_deferred_outputs=(),
+            required_test_cases=(
+                _RequiredTestCaseContract(
+                    name="exact case",
+                    period={
+                        "period_kind": "tax_year",
+                        "start": "2025-01-01",
+                        "end": "2025-12-31",
+                    },
+                    input={},
+                    required_output={
+                        "us-la:statutes/47/294#deduction": 12500,
+                    },
+                ),
+            ),
+        )
+
+        with patch(
+            "axiom_encode.cli._record_successful_apply_validation"
+        ) as record_snapshot:
+            ok, issues, supplemental = _validate_generated_encoding_in_policy_overlay(
+                result,
+                output_root=output_root,
+                policy_repo_path=policy_repo,
+                axiom_rules_path=tmp_path / "axiom-rules-engine",
+                local_corpus_release=_bind_test_corpus_release(
+                    policy_repo, tmp_path / "axiom-corpus"
+                ),
+                deferred_output_review_contract=contract,
+            )
+
+        assert ok is False
+        assert supplemental == {}
+        assert len(issues) == 1
+        assert "freshly generated regular companion" in issues[0]
+        record_snapshot.assert_not_called()
 
     def test_apply_overlay_reads_source_metadata_from_explicit_context_manifest(
         self, tmp_path

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -62,6 +62,7 @@ from axiom_encode.harness.evals import (
     _context_file_executable_surfaces,
     _context_import_target,
     _eval_result_from_payload,
+    _eval_review_contract_manifest_payload,
     _eval_suite_execution_identity_sha256,
     _eval_suite_rulespec_roots,
     _evaluate_generated_artifact_with_repairs,
@@ -6127,6 +6128,46 @@ def test_review_findings_are_persisted_and_mandatory_in_prompt(tmp_path):
     assert persisted.read_text() == expected
     assert evidence["content"] == expected
     assert evidence["sha256"] == hashlib.sha256(expected.encode()).hexdigest()
+
+
+def test_structured_review_contract_is_bound_into_context_manifest(tmp_path):
+    policy_repo_root = _canonical_rulespec_content_root(tmp_path, "us")
+    required_case = {
+        "name": "exact case",
+        "period": {
+            "period_kind": "tax_year",
+            "start": "2025-01-01",
+            "end": "2025-12-31",
+        },
+        "input": {"us:statutes/26/1#input.single": True},
+        "required_output": {"us:statutes/26/1#deduction": 12500},
+    }
+    contract = _eval_review_contract_manifest_payload(
+        citation="us/statute/26/1",
+        rulespec_path="us/statutes/26/1.yaml",
+        required_deferred_output_contracts=(("missing#output", "exact reason"),),
+        required_test_case_contracts=(required_case,),
+    )
+    workspace = prepare_eval_workspace(
+        citation="us/statute/26/1",
+        runner=parse_runner_spec("codex:gpt-5.4"),
+        output_root=tmp_path / "out",
+        source_text="Source text.",
+        axiom_rules_path=policy_repo_root,
+        mode="cold",
+        review_contract=contract,
+    )
+
+    manifest = json.loads(workspace.manifest_file.read_text())
+    assert manifest["review_contract"] == {
+        "schema": "axiom-encode/review-contract/v2",
+        "citation": "us/statute/26/1",
+        "rulespec_path": "us/statutes/26/1.yaml",
+        "required_deferred_outputs": [
+            {"output": "missing#output", "reason": "exact reason"}
+        ],
+        "required_test_cases": [required_case],
+    }
 
 
 def test_review_findings_reject_empty_file(tmp_path):

--- a/tests/test_extract_repair_candidate.py
+++ b/tests/test_extract_repair_candidate.py
@@ -148,7 +148,18 @@ def test_rejects_noncanonical_state_rulespec_path(replace_rulespec_path):
 
 @pytest.mark.parametrize(
     "atomic_source_input",
-    ["[]", '{"canonical_refresh_bundle":[]}'],
+    [
+        "[]",
+        '{"canonical_refresh_bundle":[]}',
+        json.dumps(
+            {
+                "schema": "axiom-encode/atomic-source-transaction/v2",
+                "source_bundle": [],
+                "canonical_refresh_bundle": [],
+                "primary_required_test_cases": [],
+            }
+        ),
+    ],
 )
 def test_extracts_new_atomic_source_metadata(tmp_path, atomic_source_input):
     archive, metadata = _archive(tmp_path)
@@ -290,6 +301,28 @@ def test_rejects_incompatible_prior_run_mode(tmp_path, field, value):
         (
             "atomic_source_input",
             '{"canonical_refresh_bundle":[{"citation":"x"}]}',
+        ),
+        (
+            "atomic_source_input",
+            json.dumps(
+                {
+                    "schema": "axiom-encode/atomic-source-transaction/v2",
+                    "source_bundle": [],
+                    "canonical_refresh_bundle": [],
+                    "primary_required_test_cases": [
+                        {
+                            "name": "must not replay a review contract",
+                            "period": {
+                                "period_kind": "tax_year",
+                                "start": "2025-01-01",
+                                "end": "2025-12-31",
+                            },
+                            "input": {"us:test#input": True},
+                            "required_output": {"us:test#output": 1},
+                        }
+                    ],
+                }
+            ),
         ),
     ],
 )

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1634"
+ENCODER_VERSION = "0.2.1635"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1634"
+ENCODER_VERSION = "0.2.1635"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1634"
+ENCODER_VERSION = "0.2.1635"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1634"
+ENCODER_VERSION = "0.2.1635"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1634"
+ENCODER_VERSION = "0.2.1635"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1634"
+ENCODER_VERSION = "0.2.1635"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -833,10 +833,13 @@ def test_parse_canonical_refresh_bundle_preserves_primary_required_test_cases(
 
     assert inventory[0]["required_test_cases"] == cases
     assert inventory[1]["required_test_cases"] == []
-    assert verify_canonical_refresh_target(
-        repo,
-        json.dumps(inventory[0]),
-    )["required_test_cases"] == cases
+    assert (
+        verify_canonical_refresh_target(
+            repo,
+            json.dumps(inventory[0]),
+        )["required_test_cases"]
+        == cases
+    )
 
 
 def test_parse_canonical_refresh_bundle_rejects_duplicate_contract_outputs(

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -20,6 +20,7 @@ from scripts.prepare_signed_backfill import (
     MAX_SOURCE_BUNDLE_JSON_BYTES,
     REVIEWED_RULESPEC_PR_BASE_BRANCHES,
     REVIEWED_RULESPEC_REFS,
+    _normalize_required_test_cases,
     authorize_legacy_index_manifest_shrink,
     authorized_changed_paths,
     branch_name,
@@ -176,6 +177,7 @@ def test_authorize_legacy_index_manifest_shrink_rejects_malformed_embedded_path(
 def test_split_atomic_source_input_preserves_legacy_source_array() -> None:
     assert split_atomic_source_input('["us-ri/statute/44-30-1"]') == {
         "canonical_refresh_bundle": [],
+        "primary_required_test_cases": [],
         "source_bundle": ["us-ri/statute/44-30-1"],
     }
 
@@ -190,8 +192,52 @@ def test_split_atomic_source_input_selects_canonical_refresh_mode() -> None:
         json.dumps({"canonical_refresh_bundle": [addition]})
     ) == {
         "canonical_refresh_bundle": [addition],
+        "primary_required_test_cases": [],
         "source_bundle": [],
     }
+
+
+def test_split_atomic_source_input_selects_v2_structured_refresh_mode() -> None:
+    required_case = {
+        "name": "2025 single",
+        "period": {
+            "period_kind": "tax_year",
+            "start": "2025-01-01",
+            "end": "2025-12-31",
+        },
+        "input": {},
+        "required_output": {"us-la:statutes/47/294#deduction": 12500},
+    }
+    payload = {
+        "schema": "axiom-encode/atomic-source-transaction/v2",
+        "source_bundle": [],
+        "canonical_refresh_bundle": [],
+        "primary_required_test_cases": [required_case],
+    }
+
+    assert split_atomic_source_input(json.dumps(payload)) == {
+        "canonical_refresh_bundle": [],
+        "primary_required_test_cases": [required_case],
+        "source_bundle": [],
+    }
+
+
+@pytest.mark.parametrize("period_kind", ["month", "benefit_week"])
+def test_required_test_case_normalization_accepts_engine_period_kinds(
+    period_kind: str,
+) -> None:
+    case = {
+        "name": f"exact {period_kind}",
+        "period": {
+            "period_kind": period_kind,
+            "start": "2025-01-01",
+            "end": "2025-01-31",
+        },
+        "input": {},
+        "required_output": {"us-la:statutes/47/294#amount": 1},
+    }
+
+    assert _normalize_required_test_cases([case], label="test") == (case,)
 
 
 @pytest.mark.parametrize(
@@ -231,7 +277,8 @@ def test_split_atomic_source_input_cli_emits_normalized_object(
     prepare_signed_backfill_main()
 
     assert capsys.readouterr().out == (
-        '{"canonical_refresh_bundle":[],"source_bundle":["us-ri/statute/44-30-1"]}\n'
+        '{"canonical_refresh_bundle":[],"primary_required_test_cases":[],'
+        '"source_bundle":["us-ri/statute/44-30-1"]}\n'
     )
 
 
@@ -569,6 +616,7 @@ def test_parse_canonical_refresh_bundle_accepts_tracked_canonical_targets(
             "manifest_sha256",
             "review_finding",
             "deferred_output_contracts",
+            "required_test_cases",
         }
         for item in inventory
     )
@@ -747,7 +795,48 @@ def test_parse_canonical_refresh_bundle_preserves_deferred_output_contracts(
     )
 
     assert inventory[0]["deferred_output_contracts"] == []
+    assert inventory[0]["required_test_cases"] == []
     assert inventory[1]["deferred_output_contracts"] == contracts
+    assert inventory[1]["required_test_cases"] == []
+
+
+def test_parse_canonical_refresh_bundle_preserves_primary_required_test_cases(
+    tmp_path: Path,
+) -> None:
+    repo = _canonical_refresh_repo(tmp_path)
+    cases = [
+        {
+            "name": "2025 single",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2025-01-01",
+                "end": "2025-12-31",
+            },
+            "input": {
+                "us-la:statutes/47/294#input.single": True,
+                "us-la:statutes/47/294#input.joint": False,
+            },
+            "required_output": {
+                "us-la:statutes/47/294#standard_deduction": 12500,
+            },
+        }
+    ]
+
+    inventory = parse_canonical_refresh_bundle(
+        repo,
+        '[{"citation":"us-la/statute/47:295",'
+        '"replace_rulespec_path":"us-la/statutes/47/295.yaml"}]',
+        primary_citation="us-la/statute/47:294",
+        primary_rulespec_path="us-la/statutes/47/294.yaml",
+        primary_required_test_cases_json=json.dumps(cases),
+    )
+
+    assert inventory[0]["required_test_cases"] == cases
+    assert inventory[1]["required_test_cases"] == []
+    assert verify_canonical_refresh_target(
+        repo,
+        json.dumps(inventory[0]),
+    )["required_test_cases"] == cases
 
 
 def test_parse_canonical_refresh_bundle_rejects_duplicate_contract_outputs(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -1,3 +1,4 @@
+import copy
 import hashlib
 import json
 import math
@@ -15419,6 +15420,83 @@ rules:
 
     assert len(issues) == 1
     assert "disqualifying_condition" in issues[0]
+
+
+def test_test_input_assignment_selects_formula_dependencies_by_case_period():
+    content = """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+rules:
+  - name: adjusted_standard_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: prior_year_standard_deduction * (1 + cpi_increase)
+  - name: standard_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2025-01-01'
+        effective_to: '2025-12-31'
+        formula: |-
+          if single_status and not joint_status:
+              12500
+          else:
+              0
+      - effective_from: '2026-01-01'
+        formula: |-
+          if single_status and not joint_status:
+              adjusted_standard_deduction
+          else:
+              0
+"""
+    case_2025 = {
+        "name": "2025 single",
+        "period": {
+            "period_kind": "tax_year",
+            "start": "2025-01-01",
+            "end": "2025-12-31",
+        },
+        "input": {
+            "us-la:statutes/47/294#input.single_status": True,
+            "us-la:statutes/47/294#input.joint_status": False,
+        },
+        "output": {"us-la:statutes/47/294#standard_deduction": 12500},
+    }
+
+    assert find_test_input_assignment_issues(content, [case_2025]) == []
+
+    case_2026 = copy.deepcopy(case_2025)
+    case_2026["name"] = "2026 single"
+    case_2026["period"] = {
+        "period_kind": "tax_year",
+        "start": "2026-01-01",
+        "end": "2026-12-31",
+    }
+    issues_2026 = find_test_input_assignment_issues(content, [case_2026])
+    assert len(issues_2026) == 1
+    assert "cpi_increase" in issues_2026[0]
+    assert "prior_year_standard_deduction" in issues_2026[0]
+
+    case_without_period = copy.deepcopy(case_2025)
+    case_without_period.pop("period")
+    fallback_issues = find_test_input_assignment_issues(content, [case_without_period])
+    assert len(fallback_issues) == 1
+    assert "cpi_increase" in fallback_issues[0]
+
+    boundary_spanning_case = copy.deepcopy(case_2025)
+    boundary_spanning_case["period"]["end"] = "2026-12-31"
+    boundary_issues = find_test_input_assignment_issues(
+        content, [boundary_spanning_case]
+    )
+    assert len(boundary_issues) == 1
+    assert "cpi_increase" in boundary_issues[0]
 
 
 def test_test_input_assignment_ignores_match_keyword():

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5926,7 +5926,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1634"')
+        .startswith('__version__ = "0.2.1635"')
     )
 
 
@@ -6158,13 +6158,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1634"
+    assert encoder_package["version"] == "0.2.1635"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1634"
+    assert project["project"]["version"] == "0.2.1635"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1634"')
+        .startswith('__version__ = "0.2.1635"')
     )
 
 
@@ -6426,13 +6426,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1634"
+    assert encoder_package["version"] == "0.2.1635"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1634"
+    assert project["project"]["version"] == "0.2.1635"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1634"')
+        .startswith('__version__ = "0.2.1635"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1634"
+ENCODER_VERSION = "0.2.1635"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -3894,9 +3894,7 @@ if mutation_path and len(calls_path.read_text(encoding="utf-8").splitlines()) ==
             "schema": "axiom-encode/review-contract/v2",
             "citation": additions[1]["citation"],
             "rulespec_path": additions[1]["replace_rulespec_path"],
-            "required_deferred_outputs": additions[1][
-                "deferred_output_contracts"
-            ],
+            "required_deferred_outputs": additions[1]["deferred_output_contracts"],
             "required_test_cases": additions[1]["required_test_cases"],
         },
         None,
@@ -4991,17 +4989,17 @@ def test_targeted_artifact_enforces_exact_canonical_refresh_inventory(
                 "required_test_cases": json.loads(json.dumps(required_test_cases)),
             }
             if mutation == "wrong-review-contract":
-                context["review_contract"]["required_test_cases"][0][
-                    "required_output"
-                ]["us-la:statutes/47/294#standard_deduction"] = 0
+                context["review_contract"]["required_test_cases"][0]["required_output"][
+                    "us-la:statutes/47/294#standard_deduction"
+                ] = 0
             if mutation == "wrong-review-contract-input-type":
                 context["review_contract"]["required_test_cases"][0]["input"][
                     "us-la:statutes/47/294#input.single"
                 ] = 1
             if mutation == "wrong-review-contract-output-type":
-                context["review_contract"]["required_test_cases"][0][
-                    "required_output"
-                ]["us-la:statutes/47/294#standard_deduction"] = 12500.0
+                context["review_contract"]["required_test_cases"][0]["required_output"][
+                    "us-la:statutes/47/294#standard_deduction"
+                ] = 12500.0
         if mutation == "control-companion-finding" and index > 0:
             finding = "Preserve the companion\x00 ownership boundary.\n"
             context["review_findings_files"] = [

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -1911,11 +1911,9 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     assert inputs["pr_base_branch"]["default"] == "main"
     assert inputs["source_bundle_json"] == {
         "description": (
-            "JSON citation array for atomic imports, or "
-            '{"canonical_refresh_bundle":'
-            "[{citation,replace_rulespec_path,review_finding?,"
-            "deferred_output_contracts?}]} "
-            "for an independent refresh transaction"
+            "JSON citation array, canonical_refresh_bundle object, or "
+            "atomic-source-transaction/v2 envelope for an independent refresh "
+            "transaction"
         ),
         "required": False,
         "default": "[]",
@@ -2005,6 +2003,8 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
     )
     assert "split-atomic-source-input" in source_bundle_command
     assert 'parse-source-bundle "$source_bundle_json"' in source_bundle_command
+    assert 'primary_required_test_cases_json="$(jq -cer' in source_bundle_command
+    assert "--primary-required-test-cases-json" in source_bundle_command
     assert "validate-source-add-targets" in source_bundle_command
     assert 'validate-source-add-targets "$RULESPEC_CHECKOUT"' in (source_bundle_command)
     assert 'parse-existing-signed-imports "$RULESPEC_CHECKOUT"' in (
@@ -3705,12 +3705,67 @@ def test_targeted_signed_reencode_runs_canonical_refresh_bundle_in_order(
             "reason": "Exact source-bound missing dependency.",
         }
     ]
+    mixed_output = "us-la:statutes/47/297/4#mixed_contract_output"
+    additions[1]["deferred_output_contracts"] = [
+        {"output": mixed_output, "reason": "Exact mixed v2 contract reason."}
+    ]
+    additions[1]["required_test_cases"] = [
+        {
+            "name": "mixed v2 addition lane",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2025-01-01",
+                "end": "2025-12-31",
+            },
+            "input": {},
+            "required_output": {mixed_output: 0},
+        }
+    ]
     additions[2]["review_finding"] = "Preserve the five-year carryforward limit."
+    single = (
+        "us-la:statutes/47/294#input."
+        "federal_return_filing_status_is_single_or_married_separate"
+    )
+    joint = (
+        "us-la:statutes/47/294#input."
+        "federal_return_filing_status_is_joint_surviving_spouse_or_head_of_household"
+    )
+    primary_required_test_cases = [
+        {
+            "name": name,
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2025-01-01",
+                "end": "2025-12-31",
+            },
+            "input": {single: single_value, joint: joint_value},
+            "required_output": {
+                "us-la:statutes/47/294#standard_deduction": expected,
+            },
+        }
+        for name, single_value, joint_value, expected in (
+            (
+                "2025 single individual or married separate standard deduction",
+                True,
+                False,
+                12500,
+            ),
+            (
+                "2025 joint surviving spouse or head of household standard deduction",
+                False,
+                True,
+                25000,
+            ),
+            ("2025 no listed filing status group fails closed", False, False, 0),
+            ("2025 conflicting filing status groups fail closed", True, True, 0),
+        )
+    ]
     normalized = parse_canonical_refresh_bundle(
         repo,
         json.dumps(additions),
         primary_citation=primary_citation,
         primary_rulespec_path=primary_path,
+        primary_required_test_cases_json=json.dumps(primary_required_test_cases),
     )
     runner_temp = tmp_path / "runner-temp"
     runner_temp.mkdir()
@@ -3747,7 +3802,14 @@ if mutation_path and len(calls_path.read_text(encoding="utf-8").splitlines()) ==
         "AXIOM_ENCODE_APPLY_SIGNING_KEY": "test-key",
         "AXIOM_TEST_PYTHON": sys.executable,
         "CALLS_PATH": str(calls_path),
-        "ATOMIC_SOURCE_JSON": json.dumps({"canonical_refresh_bundle": additions}),
+        "ATOMIC_SOURCE_JSON": json.dumps(
+            {
+                "schema": "axiom-encode/atomic-source-transaction/v2",
+                "source_bundle": [],
+                "canonical_refresh_bundle": additions,
+                "primary_required_test_cases": primary_required_test_cases,
+            }
+        ),
         "CHECKPOINTS_PATH": str(checkpoints_path),
         "CITATION": primary_citation,
         "DEPENDENT_CITATION": "",
@@ -3815,14 +3877,28 @@ if mutation_path and len(calls_path.read_text(encoding="utf-8").splitlines()) ==
         )
         for args in encode_args
     ] == [
-        None,
+        {
+            "schema": "axiom-encode/review-contract/v2",
+            "citation": primary_citation,
+            "rulespec_path": primary_path,
+            "required_deferred_outputs": [],
+            "required_test_cases": primary_required_test_cases,
+        },
         {
             "schema": "axiom-encode/review-contract/v1",
             "citation": additions[0]["citation"],
             "rulespec_path": additions[0]["replace_rulespec_path"],
             "required_deferred_outputs": additions[0]["deferred_output_contracts"],
         },
-        None,
+        {
+            "schema": "axiom-encode/review-contract/v2",
+            "citation": additions[1]["citation"],
+            "rulespec_path": additions[1]["replace_rulespec_path"],
+            "required_deferred_outputs": additions[1][
+                "deferred_output_contracts"
+            ],
+            "required_test_cases": additions[1]["required_test_cases"],
+        },
         None,
     ]
     forbidden = {
@@ -4807,6 +4883,18 @@ def _targeted_metadata_script() -> str:
             "context manifest contains an unexpected review finding",
         ),
         (
+            "wrong-review-contract",
+            "context manifest does not bind the normalized review contract",
+        ),
+        (
+            "wrong-review-contract-input-type",
+            "context manifest does not bind the normalized review contract",
+        ),
+        (
+            "wrong-review-contract-output-type",
+            "context manifest does not bind the normalized review contract",
+        ),
+        (
             "control-companion-finding",
             "normalized canonical refresh bundle is malformed",
         ),
@@ -4860,6 +4948,27 @@ def test_targeted_artifact_enforces_exact_canonical_refresh_inventory(
             if index == 0
             else "Preserve the companion ownership boundary.\n"
         )
+        required_test_cases = (
+            [
+                {
+                    "name": "2025 single",
+                    "period": {
+                        "period_kind": "tax_year",
+                        "start": "2025-01-01",
+                        "end": "2025-12-31",
+                    },
+                    "input": {
+                        "us-la:statutes/47/294#input.single": True,
+                        "us-la:statutes/47/294#input.joint": False,
+                    },
+                    "required_output": {
+                        "us-la:statutes/47/294#standard_deduction": 12500,
+                    },
+                }
+            ]
+            if index == 0
+            else []
+        )
         context = {
             "citation": citation,
             "review_findings_files": (
@@ -4873,6 +4982,26 @@ def test_targeted_artifact_enforces_exact_canonical_refresh_inventory(
                 else []
             ),
         }
+        if required_test_cases:
+            context["review_contract"] = {
+                "schema": "axiom-encode/review-contract/v2",
+                "citation": citation,
+                "rulespec_path": rulespec_path,
+                "required_deferred_outputs": [],
+                "required_test_cases": json.loads(json.dumps(required_test_cases)),
+            }
+            if mutation == "wrong-review-contract":
+                context["review_contract"]["required_test_cases"][0][
+                    "required_output"
+                ]["us-la:statutes/47/294#standard_deduction"] = 0
+            if mutation == "wrong-review-contract-input-type":
+                context["review_contract"]["required_test_cases"][0]["input"][
+                    "us-la:statutes/47/294#input.single"
+                ] = 1
+            if mutation == "wrong-review-contract-output-type":
+                context["review_contract"]["required_test_cases"][0][
+                    "required_output"
+                ]["us-la:statutes/47/294#standard_deduction"] = 12500.0
         if mutation == "control-companion-finding" and index > 0:
             finding = "Preserve the companion\x00 ownership boundary.\n"
             context["review_findings_files"] = [
@@ -4913,6 +5042,7 @@ def test_targeted_artifact_enforces_exact_canonical_refresh_inventory(
                     else None
                 ),
                 "deferred_output_contracts": [],
+                "required_test_cases": required_test_cases,
                 "rulespec_path": rulespec_path,
                 "rulespec_sha256": "a" * 64,
                 "companion_path": str(

--- a/tests/test_structured_test_case_contract.py
+++ b/tests/test_structured_test_case_contract.py
@@ -23,10 +23,7 @@ JOINT = (
     "federal_return_filing_status_is_joint_surviving_spouse_or_head_of_household"
 )
 PRINCIPAL = "us-la:statutes/47/294#standard_deduction"
-CPI = (
-    "us-la:statutes/47/294#input."
-    "previous_calendar_year_cpi_u_percentage_increase"
-)
+CPI = "us-la:statutes/47/294#input.previous_calendar_year_cpi_u_percentage_increase"
 PRIOR_JOINT = (
     "us-la:statutes/47/294#input."
     "prior_year_standard_deduction_joint_surviving_spouse_or_head_of_household"
@@ -148,10 +145,13 @@ def test_required_test_case_contract_covers_all_four_294_cases(tmp_path: Path) -
             }
         )
 
-    assert _issues(
-        _write_candidate(tmp_path, candidates),
-        _raw_contract(test_cases=contracts),
-    ) == []
+    assert (
+        _issues(
+            _write_candidate(tmp_path, candidates),
+            _raw_contract(test_cases=contracts),
+        )
+        == []
+    )
 
     for candidate in candidates:
         candidate["input"] = {

--- a/tests/test_structured_test_case_contract.py
+++ b/tests/test_structured_test_case_contract.py
@@ -1,0 +1,304 @@
+"""Focused tests for structured companion-test apply contracts."""
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from axiom_encode.cli import (
+    _parse_deferred_output_review_contract_json,
+    _required_deferred_output_contract_issues,
+)
+from axiom_encode.harness.evals import _format_required_test_case_contracts
+
+CITATION = "us-la/statute/47:294"
+RULESPEC_PATH = "us-la/statutes/47/294.yaml"
+SINGLE = (
+    "us-la:statutes/47/294#input."
+    "federal_return_filing_status_is_single_or_married_separate"
+)
+JOINT = (
+    "us-la:statutes/47/294#input."
+    "federal_return_filing_status_is_joint_surviving_spouse_or_head_of_household"
+)
+PRINCIPAL = "us-la:statutes/47/294#standard_deduction"
+CPI = (
+    "us-la:statutes/47/294#input."
+    "previous_calendar_year_cpi_u_percentage_increase"
+)
+PRIOR_JOINT = (
+    "us-la:statutes/47/294#input."
+    "prior_year_standard_deduction_joint_surviving_spouse_or_head_of_household"
+)
+PRIOR_SINGLE = (
+    "us-la:statutes/47/294#input."
+    "prior_year_standard_deduction_single_or_married_separate"
+)
+CASE = {
+    "name": "2025 single individual or married separate standard deduction",
+    "period": {
+        "period_kind": "tax_year",
+        "start": "2025-01-01",
+        "end": "2025-12-31",
+    },
+    "input": {SINGLE: True, JOINT: False},
+    "required_output": {PRINCIPAL: 12500},
+}
+
+
+def _raw_contract(*, test_cases: list[dict[str, object]] | None = None) -> str:
+    return json.dumps(
+        {
+            "schema": "axiom-encode/review-contract/v2",
+            "citation": CITATION,
+            "rulespec_path": RULESPEC_PATH,
+            "required_deferred_outputs": [],
+            "required_test_cases": test_cases if test_cases is not None else [CASE],
+        },
+        separators=(",", ":"),
+    )
+
+
+def _write_candidate(tmp_path: Path, cases: list[dict[str, object]]) -> Path:
+    rulespec = tmp_path / "294.yaml"
+    rulespec.write_text("format: rulespec/v1\nmodule: {}\nrules: []\n")
+    rulespec.with_name("294.test.yaml").write_text(
+        json.dumps(cases),
+        encoding="utf-8",
+    )
+    return rulespec
+
+
+def _issues(rulespec: Path, raw: str | None = None) -> list[str]:
+    contract = _parse_deferred_output_review_contract_json(raw or _raw_contract())
+    return _required_deferred_output_contract_issues(
+        rulespec,
+        contract,
+        citation=CITATION,
+        rulespec_path=RULESPEC_PATH,
+    )
+
+
+def test_required_test_case_accepts_exact_input_and_required_output_subset(
+    tmp_path: Path,
+) -> None:
+    candidate = {
+        "name": CASE["name"],
+        "period": CASE["period"],
+        "input": CASE["input"],
+        "output": {PRINCIPAL: 12500, "us-la:statutes/47/294#helper": 12500},
+    }
+
+    assert _issues(_write_candidate(tmp_path, [candidate])) == []
+
+
+def test_required_test_case_rejects_pr_1253_extra_2025_inputs(tmp_path: Path) -> None:
+    candidate = {
+        "name": CASE["name"],
+        "period": CASE["period"],
+        "input": {
+            **CASE["input"],
+            CPI: 0,
+            PRIOR_JOINT: 0,
+            PRIOR_SINGLE: 0,
+        },
+        "output": {PRINCIPAL: 12500},
+    }
+
+    issues = _issues(_write_candidate(tmp_path, [candidate]))
+
+    assert len(issues) == 1
+    assert "input map does not exactly match" in issues[0]
+    assert "unexpected:" in issues[0]
+
+
+def test_required_test_case_contract_covers_all_four_294_cases(tmp_path: Path) -> None:
+    contracts = []
+    candidates = []
+    for name, single, joint, expected in (
+        (
+            "2025 single individual or married separate standard deduction",
+            True,
+            False,
+            12500,
+        ),
+        (
+            "2025 joint surviving spouse or head of household standard deduction",
+            False,
+            True,
+            25000,
+        ),
+        ("2025 no listed filing status group fails closed", False, False, 0),
+        ("2025 conflicting filing status groups fail closed", True, True, 0),
+    ):
+        contract = {
+            "name": name,
+            "period": CASE["period"],
+            "input": {SINGLE: single, JOINT: joint},
+            "required_output": {PRINCIPAL: expected},
+        }
+        contracts.append(contract)
+        candidates.append(
+            {
+                "name": name,
+                "period": CASE["period"],
+                "input": {SINGLE: single, JOINT: joint},
+                "output": {PRINCIPAL: expected},
+            }
+        )
+
+    assert _issues(
+        _write_candidate(tmp_path, candidates),
+        _raw_contract(test_cases=contracts),
+    ) == []
+
+    for candidate in candidates:
+        candidate["input"] = {
+            **candidate["input"],
+            CPI: 0,
+            PRIOR_JOINT: 0,
+            PRIOR_SINGLE: 0,
+        }
+    rejected = _issues(
+        _write_candidate(tmp_path, candidates),
+        _raw_contract(test_cases=contracts),
+    )
+    assert len(rejected) == 4
+    assert all(
+        all(key in issue for key in (CPI, PRIOR_JOINT, PRIOR_SINGLE))
+        and "unexpected:" in issue
+        for issue in rejected
+    )
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected"),
+    [
+        ({"period": {**CASE["period"], "end": "2026-12-31"}}, "period"),
+        ({"output": {PRINCIPAL: 0}}, "missing or changes required output"),
+    ],
+)
+def test_required_test_case_rejects_period_or_output_drift(
+    tmp_path: Path,
+    mutation: dict[str, object],
+    expected: str,
+) -> None:
+    candidate = {
+        "name": CASE["name"],
+        "period": CASE["period"],
+        "input": CASE["input"],
+        "output": {PRINCIPAL: 12500},
+        **mutation,
+    }
+
+    assert expected in "\n".join(_issues(_write_candidate(tmp_path, [candidate])))
+
+
+@pytest.mark.parametrize("count", [0, 2])
+def test_required_test_case_requires_exactly_one_named_case(
+    tmp_path: Path,
+    count: int,
+) -> None:
+    candidate = {
+        "name": CASE["name"],
+        "period": CASE["period"],
+        "input": CASE["input"],
+        "output": {PRINCIPAL: 12500},
+    }
+
+    issues = _issues(_write_candidate(tmp_path, [candidate] * count))
+
+    assert len(issues) == 1
+    assert f"found {count}" in issues[0]
+
+
+def test_v2_review_contract_rejects_empty_contract() -> None:
+    with pytest.raises(argparse.ArgumentTypeError, match="must require"):
+        _parse_deferred_output_review_contract_json(_raw_contract(test_cases=[]))
+
+
+@pytest.mark.parametrize("period_kind", ["month", "benefit_week"])
+def test_v2_review_contract_accepts_engine_period_kinds(period_kind: str) -> None:
+    case = {
+        **CASE,
+        "period": {
+            "period_kind": period_kind,
+            "start": "2025-01-01",
+            "end": "2025-01-31",
+        },
+    }
+
+    parsed = _parse_deferred_output_review_contract_json(
+        _raw_contract(test_cases=[case])
+    )
+    assert parsed.required_test_cases[0].period["period_kind"] == period_kind
+
+
+def test_v2_review_contract_rejects_duplicate_nested_json_key() -> None:
+    raw = _raw_contract().replace(
+        f'"{SINGLE}":true',
+        f'"{SINGLE}":true,"{SINGLE}":false',
+    )
+
+    with pytest.raises(argparse.ArgumentTypeError, match="duplicate JSON key"):
+        _parse_deferred_output_review_contract_json(raw)
+
+
+def test_v2_review_contract_rejects_oversized_integer_token() -> None:
+    raw = _raw_contract().replace("12500", "9" * 5000)
+
+    with pytest.raises(argparse.ArgumentTypeError, match="valid JSON"):
+        _parse_deferred_output_review_contract_json(raw)
+
+
+def test_required_test_case_rejects_duplicate_yaml_keys(tmp_path: Path) -> None:
+    rulespec = tmp_path / "294.yaml"
+    rulespec.write_text("format: rulespec/v1\nmodule: {}\nrules: []\n")
+    rulespec.with_name("294.test.yaml").write_text(
+        "- name: " + str(CASE["name"]) + "\n"
+        "  period:\n"
+        "    period_kind: tax_year\n"
+        "    start: '2025-01-01'\n"
+        "    end: '2025-12-31'\n"
+        "  input:\n"
+        f"    {SINGLE}: true\n"
+        f"    {SINGLE}: false\n"
+        f"    {JOINT}: false\n"
+        "  output:\n"
+        f"    {PRINCIPAL}: 12500\n",
+        encoding="utf-8",
+    )
+
+    issues = _issues(rulespec)
+    assert len(issues) == 1
+    assert "duplicate key" in issues[0]
+
+
+def test_required_test_case_rejects_unsigned_table_inputs(tmp_path: Path) -> None:
+    candidate = {
+        "name": CASE["name"],
+        "period": CASE["period"],
+        "input": CASE["input"],
+        "tables": {
+            "TaxUnit": [
+                {
+                    "id": "tax-unit-1",
+                    "us-la:statutes/47/294#input.prior_year_deduction": 999,
+                }
+            ]
+        },
+        "output": {PRINCIPAL: 12500},
+    }
+
+    issues = _issues(_write_candidate(tmp_path, [candidate]))
+    assert len(issues) == 1
+    assert "unsigned runtime input field(s): tables" in issues[0]
+
+
+def test_required_test_case_prompt_preserves_exact_contract() -> None:
+    rendered = _format_required_test_case_contracts([CASE])
+
+    assert json.dumps(CASE, separators=(",", ":"), sort_keys=True) in rendered
+    assert "complete `input` map" in rendered
+    assert "final repaired overlay" in rendered

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1634"
+version = "0.2.1635"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- add a signed v2 review contract for exact named companion test cases while preserving the existing v1 deferred-output contract
- make RuleSpec input assignment period-aware so 2025 cases do not inherit 2026-only formula dependencies, with conservative union fallback for ambiguous periods
- enforce the exact contract after generation and repair, before apply, and bind it into hashed context/package evidence
- preserve the protected workflow existing 25-input dispatch boundary by carrying the contract inside the versioned atomic source envelope
- keep repair replay fail-closed and compatible with semantically empty legacy and v2 atomic inputs
- bump the encoder version to 0.2.1635 with consistent package, lock, registry, and changelog metadata

## Root cause

The validator derived test-case inputs from the union of dependencies across every formula version. For Louisiana §294, that re-added three 2026-only CPI/prior-year inputs to the exact 2025 cases. A final exact companion contract alone would have caused an encode/repair loop, so this PR fixes both dependency selection and signed end-to-end admission.

## Review cycle

Independent review/fix loop completed:

- closed unsigned runtime-input bypass through tables/inputs/oracle_inputs
- bound per-lane normalized review contracts into hashed context/package evidence
- made package comparison JSON-scalar-type exact
- accepted all engine period kinds
- added exact four-case §294 coverage, v2 retry/apply coverage, mixed v1/v2 lane coverage, and repair-replay compatibility coverage
- first hosted run caught formatting and the required encoder version bump; both were fixed
- repeat independent version/changelog audit: no actionable findings
- final repeat structural/workflow reviews: no actionable findings

## Checks

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run ruff format --check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- focused contract/workflow/repair/version suites: green
- `uv run pytest -q`: 11,373 passed, 119 skipped, 81% coverage