### PR TITLE
Preserve parenthesized legal source hierarchy

### DIFF
--- a/changelog.d/parenthesized-source-hierarchy.fixed.md
+++ b/changelog.d/parenthesized-source-hierarchy.fixed.md
@@ -1,0 +1,2 @@
+Preserve the full parent hierarchy of repeated markers in all-parenthesized
+U.S. legal source outlines during complete-source validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1637"
+version = "0.2.1638"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1637"
+__version__ = "0.2.1638"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -244,6 +244,46 @@ _PARENTHESIZED_OUTLINE_MARKER = re.compile(
     r"(?P<marker>(?:\((?:\d+[a-z]?|[a-z]|[ivxlcdm]{2,15})\))+)(?=\s|bis\b)",
     flags=re.IGNORECASE,
 )
+_INLINE_PARENTHESIZED_OUTLINE_MARKER = re.compile(
+    r"(?:(?<=[.!?;:])[ \t]+|(?<=—)[ \t]*)"
+    r"(?P<marker>(?:\((?:\d+[a-z]?|[a-z]|[ivxlcdm]{2,15})\))+)(?=\s|bis\b)",
+    flags=re.IGNORECASE,
+)
+_INLINE_OUTLINE_REFERENCE_CONTEXT = re.compile(
+    r"\b(?:section|subsection|paragraph|subparagraph|clause|subclause|item|"
+    r"subitem|division|subdivision|part|subpart|chapter|subchapter|title|article|"
+    r"subarticle)s?"
+    r"(?:\s+(?:no\.?|number)(?:\s*[A-Za-z0-9][A-Za-z0-9.-]*)?)?"
+    r"\s*[:;,.!?—]?\s*$|"
+    r"\b(?:see|compare(?:\s+(?:to|with))?|refer(?:\s+back)?(?:\s+to)?|"
+    r"subject\s+to|under|pursuant\s+to|according\s+to|"
+    r"in\s+accordance\s+with|for\s+purposes\s+of|"
+    r"as\s+(?:provided|specified|described|stated)\s+in)\s*:\s*$",
+    flags=re.IGNORECASE,
+)
+_INLINE_OUTLINE_NAMED_REFERENCE_CONTEXT = re.compile(
+    r"\b(?:see|compare(?:\s+(?:to|with))?|refer(?:\s+back)?(?:\s+to)?|"
+    r"subject\s+to|under|pursuant\s+to|according\s+to|"
+    r"in\s+accordance\s+with|for\s+purposes\s+of|"
+    r"as\s+(?:provided|specified|described|stated)\s+in)\s+"
+    r"(?:(?!\n|[;!?—]|\.(?=\s+[A-Z])).){1,96}[:;.!?—]\s*$",
+    flags=re.IGNORECASE,
+)
+_INLINE_OUTLINE_STRUCTURAL_CHAPEAU_CONTEXT = re.compile(
+    r"\b(?:the\s+)?following\s+"
+    r"(?:sections?|subsections?|paragraphs?|subparagraphs?|clauses?|"
+    r"subclauses?|items?|subitems?|divisions?|subdivisions?|parts?|subparts?)"
+    r"\s*:\s*$",
+    flags=re.IGNORECASE,
+)
+_INLINE_OUTLINE_CHAPEAU_REFERENCE_LEAD = re.compile(
+    r"\b(?:see|compare(?:\s+(?:to|with))?|refer(?:\s+back)?(?:\s+to)?|"
+    r"subject\s+to|under|pursuant\s+to|according\s+to|"
+    r"in\s+accordance\s+with|for\s+purposes\s+of|"
+    r"as\s+(?:provided|specified|described|stated)\s+in)"
+    r"\s+(?:the\s+)?following\b",
+    flags=re.IGNORECASE,
+)
 _GLUED_SENTENCE_MARKER = re.compile(
     r"(?<![\w])(?P<label>[1-9]\d?)"
     r"(?!(?i:st|nd|rd|th)\b)"
@@ -2054,25 +2094,46 @@ def recognize_source_structure(source_text: str) -> tuple[SourceStructureBranch,
                 )
                 paragraph_segments.append((marker.path, marker.start, end, text))
     else:
-        paragraph_matches = list(_PARAGRAPH_MARKER.finditer(source_text))
-        for index, match in enumerate(paragraph_matches):
-            start = match.start()
-            end = (
-                paragraph_matches[index + 1].start()
-                if index + 1 < len(paragraph_matches)
-                else len(source_text)
-            )
-            label = match.group("label").lower()
-            text = source_text[start:end].strip()
-            if _is_editorial_omission(text):
-                continue
-            path = (label,)
-            branches.append(
-                SourceStructureBranch(
-                    path, "paragraph", match.group("marker"), text, start, end
+        nested_markers = _qualified_parenthesized_legal_outline_markers(source_text)
+        if nested_markers:
+            for marker, end in _nested_outline_marker_spans(
+                nested_markers,
+                outer_end=len(source_text),
+            ):
+                text = source_text[marker.start : end].strip()
+                if _is_editorial_omission(text):
+                    continue
+                branches.append(
+                    SourceStructureBranch(
+                        marker.path,
+                        marker.kind,
+                        marker.label,
+                        text,
+                        marker.start,
+                        end,
+                    )
                 )
-            )
-            paragraph_segments.append((path, start, end, text))
+                paragraph_segments.append((marker.path, marker.start, end, text))
+        else:
+            paragraph_matches = list(_PARAGRAPH_MARKER.finditer(source_text))
+            for index, match in enumerate(paragraph_matches):
+                start = match.start()
+                end = (
+                    paragraph_matches[index + 1].start()
+                    if index + 1 < len(paragraph_matches)
+                    else len(source_text)
+                )
+                label = match.group("label").lower()
+                text = source_text[start:end].strip()
+                if _is_editorial_omission(text):
+                    continue
+                path = (label,)
+                branches.append(
+                    SourceStructureBranch(
+                        path, "paragraph", match.group("marker"), text, start, end
+                    )
+                )
+                paragraph_segments.append((path, start, end, text))
 
     if not paragraph_segments:
         paragraph_segments = [((), 0, len(source_text), source_text)]
@@ -2353,6 +2414,255 @@ def _nested_parenthesized_outline_markers(
             )
         )
     return tuple(markers)
+
+
+_PARENTHESIZED_LEGAL_OUTLINE_LEVELS = (
+    "lower-alpha",
+    "numeric",
+    "roman",
+    "upper-alpha",
+    "numeric",
+    "roman",
+    "upper-alpha",
+    "numeric",
+    "roman",
+)
+
+
+def _qualified_parenthesized_legal_outline_markers(
+    source_text: str,
+) -> tuple[_OutlineMarker, ...]:
+    """Resolve a proven all-parenthesized U.S. legal outline.
+
+    A flat parenthesized scan cannot distinguish repeated labels such as
+    ``(a)(3)``, ``(a)(6)(ii)(G)(3)``, and ``(c)(3)``.  Use the conventional
+    U.S. legal hierarchy only when sequential root subsections prove that the
+    source is an outline; otherwise retain the legacy flat recognizer.
+    """
+
+    line_matches = tuple(_PARENTHESIZED_OUTLINE_MARKER.finditer(source_text))
+    inline_matches = tuple(
+        match
+        for match in _INLINE_PARENTHESIZED_OUTLINE_MARKER.finditer(source_text)
+        if not _inline_outline_marker_has_reference_context(source_text, match)
+    )
+    inline_marker_starts = {match.start("marker") for match in inline_matches}
+    matches = tuple(
+        heapq.merge(
+            line_matches,
+            inline_matches,
+            key=lambda match: match.start("marker"),
+        )
+    )
+    if not matches:
+        return ()
+
+    markers: list[_OutlineMarker] = []
+    emitted_paths: set[tuple[str, ...]] = set()
+    active: list[tuple[int, str, str, str]] = []
+    for match in matches:
+        raw_labels = tuple(re.findall(r"\(([A-Za-z0-9]+)\)", match.group("marker")))
+        if not raw_labels or not all(
+            _is_parenthesized_outline_label(label) for label in raw_labels
+        ):
+            continue
+        marker_start = match.start("marker")
+        attached_parent_level: int | None = None
+        for label_index, raw_label in enumerate(raw_labels):
+            level, category = _parenthesized_legal_outline_level(
+                raw_label,
+                active=active,
+                attached_parent_level=attached_parent_level,
+            )
+            if marker_start in inline_marker_starts and label_index == 0 and level == 0:
+                break
+            active = [entry for entry in active if entry[0] < level]
+            normalized = raw_label.lower()
+            active.append((level, raw_label, normalized, category))
+            path = tuple(entry[2] for entry in active)
+            is_repeated_attached_ancestor = (
+                len(raw_labels) > 1
+                and label_index < len(raw_labels) - 1
+                and path in emitted_paths
+            )
+            if not is_repeated_attached_ancestor:
+                markers.append(
+                    _OutlineMarker(
+                        marker_start,
+                        path,
+                        (
+                            "paragraph"
+                            if category == "numeric" or level == 0
+                            else "letter"
+                        ),
+                        f"({raw_label})",
+                    )
+                )
+                emitted_paths.add(path)
+            attached_parent_level = level
+
+    root_labels = [
+        marker.path[0]
+        for marker in markers
+        if len(marker.path) == 1 and marker.label[1:-1].islower()
+    ]
+    has_sequential_roots = any(
+        first == "a" and second == "b"
+        for first, second in itertools.pairwise(root_labels)
+    )
+    return tuple(markers) if has_sequential_roots else ()
+
+
+def _inline_outline_marker_has_reference_context(
+    source_text: str,
+    match: re.Match[str],
+) -> bool:
+    prefix = source_text[max(0, match.start("marker") - 128) : match.start("marker")]
+    if _INLINE_OUTLINE_STRUCTURAL_CHAPEAU_CONTEXT.search(prefix) and not (
+        _INLINE_OUTLINE_CHAPEAU_REFERENCE_LEAD.search(prefix)
+    ):
+        return False
+    return bool(
+        _INLINE_OUTLINE_REFERENCE_CONTEXT.search(prefix)
+        or _INLINE_OUTLINE_NAMED_REFERENCE_CONTEXT.search(prefix)
+    )
+
+
+def _parenthesized_legal_outline_level(
+    raw_label: str,
+    *,
+    active: Sequence[tuple[int, str, str, str]],
+    attached_parent_level: int | None,
+) -> tuple[int, str]:
+    categories = _parenthesized_legal_outline_categories(raw_label)
+    candidate_levels = tuple(
+        level
+        for level, category in enumerate(_PARENTHESIZED_LEGAL_OUTLINE_LEVELS)
+        if category in categories
+    )
+    if not candidate_levels:
+        return 0, categories[0]
+
+    if attached_parent_level is not None:
+        level = next(
+            (level for level in candidate_levels if level > attached_parent_level),
+            candidate_levels[-1],
+        )
+        return level, _PARENTHESIZED_LEGAL_OUTLINE_LEVELS[level]
+
+    continuing = [
+        (level, category)
+        for level, previous, _normalized, category in active
+        if level in candidate_levels
+        and _parenthesized_outline_label_follows(previous, raw_label, category)
+    ]
+    if continuing:
+        return max(continuing, key=lambda item: item[0])
+
+    parent_level = active[-1][0] if active else -1
+    first_descending = [
+        level
+        for level in candidate_levels
+        if level > parent_level
+        and _parenthesized_outline_label_is_first(
+            raw_label,
+            _PARENTHESIZED_LEGAL_OUTLINE_LEVELS[level],
+        )
+    ]
+    if first_descending:
+        level = first_descending[0]
+        return level, _PARENTHESIZED_LEGAL_OUTLINE_LEVELS[level]
+
+    same_category = [
+        (level, category)
+        for level, _previous, _normalized, category in active
+        if category in categories
+    ]
+    if same_category:
+        return max(same_category, key=lambda item: item[0])
+
+    descending = [level for level in candidate_levels if level > parent_level]
+    if descending:
+        level = descending[0]
+        return level, _PARENTHESIZED_LEGAL_OUTLINE_LEVELS[level]
+
+    level = min(candidate_levels, key=lambda item: abs(item - parent_level))
+    return level, _PARENTHESIZED_LEGAL_OUTLINE_LEVELS[level]
+
+
+def _parenthesized_legal_outline_categories(raw_label: str) -> tuple[str, ...]:
+    if raw_label[0].isdigit():
+        return ("numeric",)
+    if raw_label.isupper():
+        return ("upper-alpha",)
+    categories = ["lower-alpha"]
+    if _is_roman_outline_label(raw_label):
+        categories.append("roman")
+    return tuple(categories)
+
+
+def _parenthesized_outline_label_follows(
+    previous: str,
+    current: str,
+    category: str,
+) -> bool:
+    if category == "numeric":
+        previous_match = re.fullmatch(r"(\d+)([a-z]?)", previous, re.IGNORECASE)
+        current_match = re.fullmatch(r"(\d+)([a-z]?)", current, re.IGNORECASE)
+        if previous_match is None or current_match is None:
+            return False
+        previous_number = int(previous_match.group(1))
+        current_number = int(current_match.group(1))
+        previous_suffix = previous_match.group(2).lower()
+        current_suffix = current_match.group(2).lower()
+        return (current_number == previous_number + 1 and not current_suffix) or (
+            current_number == previous_number
+            and len(current_suffix) == 1
+            and (
+                (not previous_suffix and current_suffix == "a")
+                or (
+                    len(previous_suffix) == 1
+                    and ord(current_suffix) == ord(previous_suffix) + 1
+                )
+            )
+        )
+    if category in {"lower-alpha", "upper-alpha"}:
+        return (
+            len(previous) == len(current) == 1
+            and ord(current.lower()) == ord(previous.lower()) + 1
+        )
+    if category == "roman":
+        previous_value = _roman_outline_value(previous)
+        current_value = _roman_outline_value(current)
+        return previous_value is not None and current_value == previous_value + 1
+    return False
+
+
+def _parenthesized_outline_label_is_first(label: str, category: str) -> bool:
+    if category == "numeric":
+        match = re.fullmatch(r"(\d+)([a-z]?)", label, re.IGNORECASE)
+        return match is not None and int(match.group(1)) == 1 and not match.group(2)
+    if category in {"lower-alpha", "upper-alpha"}:
+        return label.lower() == "a"
+    if category == "roman":
+        return _roman_outline_value(label) == 1
+    return False
+
+
+def _roman_outline_value(label: str) -> int | None:
+    if not _is_roman_outline_label(label):
+        return None
+    values = {"i": 1, "v": 5, "x": 10, "l": 50, "c": 100, "d": 500, "m": 1000}
+    total = 0
+    previous = 0
+    for character in reversed(label.lower()):
+        value = values[character]
+        if value < previous:
+            total -= value
+        else:
+            total += value
+            previous = value
+    return total
 
 
 def _nested_outline_marker_spans(

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1637"
+ENCODER_VERSION = "0.2.1638"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1637"
+ENCODER_VERSION = "0.2.1638"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1637"
+ENCODER_VERSION = "0.2.1638"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1637"
+ENCODER_VERSION = "0.2.1638"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1637"
+ENCODER_VERSION = "0.2.1638"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1637"
+ENCODER_VERSION = "0.2.1638"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1637"
+ENCODER_VERSION = "0.2.1638"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5926,7 +5926,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1637"')
+        .startswith('__version__ = "0.2.1638"')
     )
 
 
@@ -6158,13 +6158,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1637"
+    assert encoder_package["version"] == "0.2.1638"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1637"
+    assert project["project"]["version"] == "0.2.1638"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1637"')
+        .startswith('__version__ = "0.2.1638"')
     )
 
 
@@ -6426,13 +6426,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1637"
+    assert encoder_package["version"] == "0.2.1638"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1637"
+    assert project["project"]["version"] == "0.2.1638"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1637"')
+        .startswith('__version__ = "0.2.1638"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1637"
+ENCODER_VERSION = "0.2.1638"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -1531,6 +1531,311 @@ def test_skipped_dotted_labels_do_not_form_subsection_hierarchy():
     assert recognize_source_structure("A. First.\nC. Third.\nD. Fourth.") == ()
 
 
+def test_parenthesized_cfr_outline_scopes_repeated_numeric_markers():
+    source = """\
+(a) Status requirements.
+(1) Citizen.
+(2) National.
+(3) First group.
+(i) First member.
+(ii) Second member.
+(6) Qualified aliens.
+(i) Qualified status.
+(A) Permanent resident.
+(B) Asylee.
+(ii) Immediate eligibility.
+(A) Forty quarters.
+(1) Spouse quarters.
+(2) Benefit quarters.
+(G) Military connection.
+(1) Veteran.
+(2) Active duty.
+(3) Family member.
+(iii) Five-year wait.
+(A) Permanent resident.
+(iv) Status categories stand alone.
+(7) Definition.
+(b) Reporting. (1) First reporting rule.
+(2) Documentation rule.
+(c) Sponsored aliens. (1) Definition.
+(2) Deeming.
+(i) Income.
+(A) Earned-income reduction.
+(B) Gross-income limit.
+(v) Allocation.
+(3) Exempt aliens.
+(i) Household member.
+(ii) Organization sponsor.
+(4) Responsibilities.
+"""
+
+    branches = recognize_source_structure(source)
+    paths = {branch.path for branch in branches}
+
+    assert ("a", "3") in paths
+    assert ("a", "6", "ii", "a", "1") in paths
+    assert ("a", "6", "ii", "g", "3") in paths
+    assert ("b", "1") in paths
+    assert ("c", "1") in paths
+    assert ("c", "3") in paths
+    assert ("c", "3", "ii") in paths
+    assert sum(branch.label == "(3)" for branch in branches) == 3
+    assert not any(branch.path == ("3",) for branch in branches)
+
+
+def test_parenthesized_cfr_outline_keeps_colliding_branch_text_separate():
+    source = """\
+(a) Status requirements.
+(1) Citizen.
+(3) American Indian categories.
+(i) Canadian-born member.
+(ii) Recognized tribe member.
+(b) Reporting requirements.
+(2) Missing documentation.
+(c) Sponsored aliens.
+(2) Deeming rules.
+(3) Exempt sponsored aliens.
+(i) Sponsor household member.
+"""
+
+    by_path = {branch.path: branch for branch in recognize_source_structure(source)}
+
+    assert "American Indian categories" in by_path[("a", "3")].text
+    assert "Exempt sponsored aliens" not in by_path[("a", "3")].text
+    assert "Exempt sponsored aliens" in by_path[("c", "3")].text
+    assert "Canadian-born member" not in by_path[("c", "3")].text
+
+
+def test_parenthesized_cfr_outline_keeps_suffixed_numeric_siblings():
+    source = """\
+(a) Status requirements.
+(1) First item.
+(1a) Added first item.
+(1b) Second added item.
+(2) Second item.
+(b) Reporting requirements.
+"""
+
+    assert [branch.path for branch in recognize_source_structure(source)] == [
+        ("a",),
+        ("a", "1"),
+        ("a", "1a"),
+        ("a", "1b"),
+        ("a", "2"),
+        ("b",),
+    ]
+
+
+def test_parenthesized_cfr_outline_reports_distinct_colliding_branch_citations():
+    source = """\
+(a) Status requirements.
+(1) Citizen.
+(2) National.
+(3) American Indian categories.
+(i) Canadian-born member.
+(ii) Recognized tribe member.
+(b) Reporting requirements.
+(2) Missing documentation.
+(c) Sponsored aliens.
+(2) Deeming rules.
+(3) Exempt sponsored aliens.
+(i) Sponsor household member.
+"""
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/7/273/4
+rules: []
+"""
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us/regulation/7/273/4",
+        test_cases=[],
+        extract_numeric_occurrences=EN_NUMERIC_OCCURRENCE_EXTRACTOR,
+    )
+
+    assert _has_issue(result, "us/regulation/7/273/4(a)", "Nummer 3")
+    assert _has_issue(result, "us/regulation/7/273/4(c)", "Nummer 3")
+    assert not _has_issue(result, "us/regulation/7/273/4(3) [Absatz 3]")
+
+
+def test_parenthesized_cfr_outline_is_recognized_with_bounded_runtime():
+    source = (
+        "(a) Start.\n"
+        + "".join(f"({index}) Item {index}.\n" for index in range(1, 20_001))
+        + "(b) End."
+    )
+
+    started = time.perf_counter()
+    branches = recognize_source_structure(source)
+    elapsed = time.perf_counter() - started
+
+    assert len(branches) == 20_002
+    assert branches[-2].path == ("a", "20000")
+    assert branches[-1].path == ("b",)
+    assert elapsed < 1.5
+
+
+def test_parenthesized_nonoutline_without_root_sequence_remains_flat():
+    source = "(2) Prior rule.\n(3) Current rule.\n(i) Inline detail."
+
+    assert [branch.path for branch in recognize_source_structure(source)] == [
+        ("2",),
+        ("3",),
+        ("i",),
+    ]
+
+
+def test_parenthesized_cfr_outline_does_not_promote_inline_cross_references():
+    source = """\
+(a) Status requirements. See paragraph (1) for the first rule.
+(1) First rule.
+(b) Reporting requirements. See paragraphs (a)(1) and (2).
+"""
+
+    assert [branch.path for branch in recognize_source_structure(source)] == [
+        ("a",),
+        ("a", "1"),
+        ("b",),
+    ]
+
+
+def test_parenthesized_cfr_outline_keeps_punctuated_cross_reference_formula_owner():
+    source = """\
+(a) First rule.
+(1) First child.
+(b) Reporting rule. See paragraph: (a)(1) for scope; amount = income * 2.
+(c) Final rule.
+"""
+    branches = recognize_source_structure(source)
+
+    assert [branch.path for branch in branches] == [
+        ("a",),
+        ("a", "1"),
+        ("b",),
+        ("c",),
+    ]
+    assert "amount = income * 2" in branches[2].text
+    formula_branches = completeness_module._source_formula_branches(
+        source,
+        branches=branches,
+        active_branches=branches,
+        deferred_paths=set(),
+    )
+    assert [(branch.path, branch.text) for branch in formula_branches] == [
+        (("b",), "amount = income * 2."),
+    ]
+
+
+@pytest.mark.parametrize(
+    "reference",
+    (
+        "As specified in paragraph: (1)",
+        "Compare paragraph: (1)",
+        "Refer to paragraph: (1)",
+        "Subject to paragraph: (1)",
+        "For purposes of paragraph: (1)",
+        "See subparagraph: (1)",
+        "See paragraph no. (1)",
+        "See paragraph no. 1: (1)",
+        "See the provisions of paragraph: (1)",
+        "Compare to: (1)",
+        "Refer back to: (1)",
+        "Subject to subpart: (1)",
+        "See appendix A: (1)",
+        "See appendix A; (1)",
+        "For purposes of appendix A. (1)",
+        "For purposes of appendix A: (1)",
+        "See 7 CFR 273.2: (1)",
+        "See 7 CFR 273.2; (1)",
+        "See 7 CFR § 273.2: (1)",
+        "See 7 C.F.R. § 273.2. (1)",
+        "Refer back to appendix A: (1)",
+        "Refer back to appendix A— (1)",
+        "See appendix A to part 273: (1)",
+        "Subject to schedule A: (1)",
+        "Subject to schedule A; (1)",
+    ),
+)
+def test_parenthesized_cfr_outline_rejects_punctuated_single_marker_reference(
+    reference: str,
+):
+    source = f"""\
+(a) First rule.
+(1) First child.
+(b) Reporting rule. {reference} controls; amount = income * 2.
+(c) Final rule.
+"""
+    branches = recognize_source_structure(source)
+    assert [branch.path for branch in branches] == [
+        ("a",),
+        ("a", "1"),
+        ("b",),
+        ("c",),
+    ]
+    formula_branches = completeness_module._source_formula_branches(
+        source,
+        branches=branches,
+        active_branches=branches,
+        deferred_paths=set(),
+    )
+    assert [branch.path for branch in formula_branches] == [("b",)]
+
+
+def test_parenthesized_cfr_outline_accepts_inline_child_after_chapeau():
+    source = """\
+(a) First rule. The following paragraphs: (1) First child.
+(b) Final rule.
+"""
+
+    assert [branch.path for branch in recognize_source_structure(source)] == [
+        ("a",),
+        ("a", "1"),
+        ("b",),
+    ]
+
+
+def test_parenthesized_cfr_outline_reference_lead_does_not_cross_sentence():
+    source = """\
+(a) First rule. See prior rule. The following paragraphs: (1) First child.
+(b) Final rule.
+"""
+
+    assert [branch.path for branch in recognize_source_structure(source)] == [
+        ("a",),
+        ("a", "1"),
+        ("b",),
+    ]
+
+
+def test_parenthesized_cfr_outline_deduplicates_repeated_attached_ancestors():
+    source = """\
+(a)(1) First.
+(a)(2) Second.
+(b)(1) Third.
+(b)(2) Fourth.
+"""
+    branches = recognize_source_structure(source)
+
+    assert [branch.path for branch in branches] == [
+        ("a",),
+        ("a", "1"),
+        ("a", "2"),
+        ("b",),
+        ("b", "1"),
+        ("b", "2"),
+    ]
+    by_path = {branch.path: branch for branch in branches}
+    assert "First" in by_path[("a",)].text
+    assert "Second" in by_path[("a",)].text
+    assert "Third" not in by_path[("a",)].text
+    assert "Third" in by_path[("b",)].text
+    assert "Fourth" in by_path[("b",)].text
+
+
 def test_parenthesized_letters_nest_under_active_numeric_paragraph():
     source = "A. Outer.\n(1) Numeric.\n(a) First.\n(b) Second.\n(2) Other.\nB. End."
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1637"
+version = "0.2.1638"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- preserve conventional U.S. parenthesized legal hierarchy when sequential root subsections prove an outline
- prevent repeated markers such as `(a)(3)`, `(a)(6)(ii)(G)(3)`, and `(c)(3)` from collapsing into one top-level `(3)` scope
- retain the legacy flat recognizer when the source does not prove that hierarchy
- bump encoder metadata to `0.2.1637`

Protected OBBB alien-SNAP run [31243968653](https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/31243968653) exposed the defect against the exact 22,636-byte `7 CFR 273.4` source. Its final candidate precisely addressed `(a)(3)`, but validation flattened three distinct `(3)` branches and failed closed.

## Checks

- exact production source replay: 70 hierarchical branches; `/a/3`, `/a/6/ii/g/3`, and `/c/3` present; no flat `/3`
- `pytest -q tests/test_source_completeness.py --no-cov` (5,148 passed before the final numeric-suffix regression; focused final suite adds 1 passing test)
- focused hierarchy/diagnostic/scaling tests (6 passed)
- version-coupled RuleSpec and oracle registry tests (27 passed)
- Ruff check and format check
- compileall
- production provenance helper binds `0.2.1637` and version commit `2ba1a6ca4...`

## Review cycle

Independent review pending on exact pushed head.
