### PR TITLE
Validate legacy replacements against exact postimage

### DIFF
--- a/changelog.d/legacy-replacement-postimage.fixed.md
+++ b/changelog.d/legacy-replacement-postimage.fixed.md
@@ -1,0 +1,1 @@
+Prune only empty directories left by authenticated legacy-replacement retirements so compile validation evaluates the exact atomic Git postimage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1638"
+version = "0.2.1639"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1638"
+__version__ = "0.2.1639"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -51945,8 +51945,8 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
                 f"jurisdiction root: {overlay_content_root}"
             )
         overlay_target = overlay_content_root / relative_output
-        overlay_target.parent.mkdir(parents=True, exist_ok=True)
         if legacy_replacement is None:
+            overlay_target.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(output_file, overlay_target)
             if output_test.exists():
                 shutil.copy2(output_test, _rulespec_test_path(overlay_target))
@@ -52006,6 +52006,7 @@ def _validate_generated_encoding_in_policy_overlay_with_release(
                 )
             except _LegacyReplacementOverlayError as exc:
                 return False, [str(exc)], {}
+            overlay_target.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(output_file, overlay_target)
             if output_test.exists():
                 shutil.copy2(output_test, _rulespec_test_path(overlay_target))

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -8152,7 +8152,6 @@ def _rulespec_validation_target(
                 f"identity {identity}"
             )
         validation_file = validation_content_root / relative
-        validation_file.parent.mkdir(parents=True, exist_ok=True)
         if legacy_replacement is not None:
             expected_relative = Path(*legacy_replacement.destination.parts[1:])
             if relative != expected_relative:
@@ -8161,6 +8160,7 @@ def _rulespec_validation_target(
                     "replacement destination"
                 )
             stage_legacy_replacement_overlay(legacy_replacement, overlay_repo)
+        validation_file.parent.mkdir(parents=True, exist_ok=True)
         safe_rulespec_file = validate_explicit_context_file(
             rulespec_file,
             generated_root,

--- a/src/axiom_encode/legacy_replacement_overlay.py
+++ b/src/axiom_encode/legacy_replacement_overlay.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import hashlib
 import os
 import re
@@ -271,6 +272,78 @@ def _require_overlay_file(
     return target
 
 
+def _overlay_prune_floor(checkout_root: Path, target: Path) -> Path:
+    """Return the protected root that empty-directory pruning cannot cross."""
+
+    relative = target.relative_to(checkout_root)
+    parts = relative.parts
+    if len(parts) >= 2 and parts[1] in RULESPEC_ATOMIC_MODULE_ROOTS:
+        return checkout_root / parts[0] / parts[1]
+    if (
+        len(parts) >= 4
+        and parts[:2] == (".axiom", "encoding-manifests")
+        and parts[3] in RULESPEC_ATOMIC_MODULE_ROOTS
+    ):
+        return checkout_root.joinpath(*parts[:4])
+    return checkout_root
+
+
+def _prune_empty_overlay_parent_directories(
+    checkout_root: Path,
+    removed_targets: list[Path],
+) -> None:
+    """Remove only empty ancestors created by authenticated file retirement.
+
+    Git does not retain empty directories, so an atomic replacement postimage
+    must not retain an empty noncanonical directory after all of its bound files
+    are removed.  Only ancestors of authenticated removed files are considered,
+    and ``rmdir`` leaves any unowned content fail-closed in place.
+    """
+
+    root = checkout_root.resolve(strict=True)
+    candidates: set[Path] = set()
+    for target in removed_targets:
+        floor = _overlay_prune_floor(root, target)
+        try:
+            relative_to_floor = target.relative_to(floor)
+        except ValueError as exc:
+            raise LegacyReplacementOverlayError(
+                "Legacy replacement removed path has no protected prune floor: "
+                f"{target}"
+            ) from exc
+        if not relative_to_floor.parts:
+            raise LegacyReplacementOverlayError(
+                "Legacy replacement removed path must be a strict descendant of "
+                f"its protected prune floor: {target}"
+            )
+        parent = target.parent
+        while parent != floor:
+            candidates.add(parent)
+            parent = parent.parent
+
+    for directory in sorted(candidates, key=lambda path: len(path.parts), reverse=True):
+        try:
+            metadata = directory.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise LegacyReplacementOverlayError(
+                f"Cannot inspect legacy replacement empty directory: {directory}"
+            ) from exc
+        if not stat.S_ISDIR(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode):
+            raise LegacyReplacementOverlayError(
+                f"Legacy replacement empty-directory candidate is unsafe: {directory}"
+            )
+        try:
+            directory.rmdir()
+        except OSError as exc:
+            if exc.errno in {errno.ENOTEMPTY, errno.EEXIST}:
+                continue
+            raise LegacyReplacementOverlayError(
+                f"Cannot prune legacy replacement empty directory: {directory}"
+            ) from exc
+
+
 def stage_legacy_replacement_overlay(
     contract: LegacyReplacementContract,
     checkout_root: Path,
@@ -463,3 +536,13 @@ def stage_legacy_replacement_overlay(
         target.write_bytes(live_file.raw)
     for target, reconciliation in metadata_targets:
         target.write_bytes(reconciliation.raw)
+    _prune_empty_overlay_parent_directories(
+        root,
+        [
+            *deleted_targets,
+            manifest_target,
+            *retained_deleted_targets,
+            *retained_manifest_targets,
+            *predecessor_targets,
+        ],
+    )

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1638"
+ENCODER_VERSION = "0.2.1639"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14433,7 +14433,17 @@ class TestCmdEncode:
         source_file = tmp_path / "source.txt"
         source_file.write_text(source_text)
         context = tmp_path / "context.json"
-        context.write_text(json.dumps({"source_text_file": source_file.name}) + "\n")
+        context.write_text(
+            json.dumps(
+                {
+                    "source_text_file": source_file.name,
+                    "source_metadata": {
+                        "source_attestation": source_attestation,
+                    },
+                }
+            )
+            + "\n"
+        )
         result.context_manifest_file = str(context)
         result.context_manifest_sha256 = hashlib.sha256(
             context.read_bytes()
@@ -14441,6 +14451,42 @@ class TestCmdEncode:
         result.generation_prompt_sha256 = "prompt-sha"
         result.source_attestation = source_attestation
         result._axiom_legacy_replacement_contract = contract
+
+        def validate_recreated_destination_parent(
+            _pipeline,
+            *,
+            dependent_pipeline,
+            overlay_target,
+            dependents,
+        ):
+            del dependent_pipeline, dependents
+            assert overlay_target.parent.is_dir()
+            assert overlay_target.is_file()
+            assert overlay_target.read_bytes() == generated.read_bytes()
+            passed = SimpleNamespace(all_passed=True, results={})
+            return [(overlay_target, passed)]
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline"),
+            patch(
+                "axiom_encode.cli._validate_overlay_files",
+                side_effect=validate_recreated_destination_parent,
+            ),
+            patch("axiom_encode.cli._record_successful_apply_validation"),
+        ):
+            can_apply, issues, supplemental = (
+                _validate_generated_encoding_in_policy_overlay(
+                    result,
+                    output_root=output_root,
+                    policy_repo_path=content_root,
+                    axiom_rules_path=tmp_path / "axiom-rules-engine",
+                    local_corpus_release=release,
+                )
+            )
+        assert can_apply is True, issues
+        assert issues == []
+        assert supplemental == {}
+
         self._record_apply_validation(
             result,
             output_root=output_root,

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -125,6 +125,7 @@ from axiom_encode.harness.validator_pipeline import (
 from axiom_encode.legacy_replacement import (
     LegacyReplacementContract,
     LegacyReplacementFile,
+    LegacyReplacementRetainedSuccessor,
     LegacyReplacementRewrite,
 )
 from axiom_encode.repo_routing import find_policy_repo_root, monorepo_checkout_name
@@ -5094,23 +5095,62 @@ def test_rulespec_prevalidation_rejects_live_checkout_artifact(tmp_path):
 
 def test_evaluate_artifact_uses_post_replacement_tree_for_first_compile(tmp_path):
     policy_repo, generated, contract = _unicode_path_replacement_fixture(tmp_path)
+    checkout = policy_repo.parent
+    retained_source = Path("us/statutes/47:297/4.yaml")
+    retained_source_manifest = Path(
+        ".axiom/encoding-manifests/us/statutes/47:297/4.json"
+    )
+    retained_destination = Path("us/statutes/47/297/4.yaml")
+    retained_destination_manifest = Path(
+        ".axiom/encoding-manifests/us/statutes/47/297/4.json"
+    )
+    retained_raw = {
+        retained_source: b"format: rulespec/v1\nrules: []\n",
+        retained_source_manifest: b"legacy manifest\n",
+        retained_destination: b"format: rulespec/v1\nrules: []\n",
+        retained_destination_manifest: b"signed successor manifest\n",
+    }
+    for path, raw in retained_raw.items():
+        target = checkout / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(raw)
+
+    def retained_file(path: Path) -> LegacyReplacementFile:
+        raw = retained_raw[path]
+        return LegacyReplacementFile(path, hashlib.sha256(raw).hexdigest(), raw)
+
+    contract = contract._replace(
+        retained_successors=(
+            LegacyReplacementRetainedSuccessor(
+                source=retained_source,
+                destination=retained_destination,
+                legacy_manifest=retained_file(retained_source_manifest),
+                legacy_files=(retained_file(retained_source),),
+                successor_manifest=retained_file(retained_destination_manifest),
+                successor_files=(retained_file(retained_destination),),
+            ),
+        )
+    )
     observed = []
 
-    def reject_non_ascii_checkout(_pipeline, validation_file):
+    def reject_noncanonical_checkout(_pipeline, validation_file):
         checkout = validation_file.parents[3]
         unsafe = [
             path
             for path in checkout.rglob("*")
-            if any(not part.isascii() for part in path.relative_to(checkout).parts)
+            if any(
+                not part.isascii() or ":" in part
+                for part in path.relative_to(checkout).parts
+            )
         ]
         observed.append((validation_file, unsafe))
         return ValidationResult("hard-cut", passed=not unsafe)
 
     with (
         patch.object(
-            ValidatorPipeline, "_run_compile_check", reject_non_ascii_checkout
+            ValidatorPipeline, "_run_compile_check", reject_noncanonical_checkout
         ),
-        patch.object(ValidatorPipeline, "_run_ci", reject_non_ascii_checkout),
+        patch.object(ValidatorPipeline, "_run_ci", reject_noncanonical_checkout),
     ):
         metrics = evaluate_artifact(
             local_corpus_release=_write_test_corpus_provision(tmp_path / "release"),

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1638"
+ENCODER_VERSION = "0.2.1639"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1638"
+ENCODER_VERSION = "0.2.1639"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_legacy_replacement.py
+++ b/tests/test_legacy_replacement.py
@@ -34,6 +34,7 @@ from axiom_encode.legacy_replacement import (
 )
 from axiom_encode.legacy_replacement_overlay import (
     LegacyReplacementOverlayError,
+    _prune_empty_overlay_parent_directories,
     scope_canonical_replacement_overlay,
     stage_legacy_replacement_overlay,
 )
@@ -1864,10 +1865,10 @@ def test_retained_successor_overlay_preflights_then_removes_one_composite(
     checkout = tmp_path / "rulespec-us"
     main = Path("us-la/statutes/47:32.yaml")
     main_manifest = Path(".axiom/encoding-manifests/us-la/statutes/47:32.json")
-    old = Path("us-la/statutes/47:294.yaml")
-    old_manifest = Path(".axiom/encoding-manifests/us-la/statutes/47:294.json")
-    successor = Path("us-la/statutes/47/294.yaml")
-    successor_manifest = Path(".axiom/encoding-manifests/us-la/statutes/47/294.json")
+    old = Path("us-la/statutes/47:297/4.yaml")
+    old_manifest = Path(".axiom/encoding-manifests/us-la/statutes/47:297/4.json")
+    successor = Path("us-la/statutes/47/297/4.yaml")
+    successor_manifest = Path(".axiom/encoding-manifests/us-la/statutes/47/297/4.json")
     metadata = Path("known-validation-gaps.yaml")
     for path, raw in {
         main: b"main\n",
@@ -1931,8 +1932,39 @@ def test_retained_successor_overlay_preflights_then_removes_one_composite(
     assert not (checkout / main_manifest).exists()
     assert not (checkout / old).exists()
     assert not (checkout / old_manifest).exists()
+    assert not (checkout / old.parent).exists()
+    assert not (checkout / old_manifest.parent).exists()
     assert (checkout / successor).read_bytes() == b"successor\n"
     assert (
         checkout / successor_manifest
     ).read_bytes() == successor_manifest_evidence.raw
     assert (checkout / metadata).read_bytes() == b"new metadata\n"
+
+
+def test_empty_overlay_pruning_preserves_unowned_legacy_content(tmp_path: Path) -> None:
+    checkout = tmp_path / "rulespec-us"
+    removed = checkout / "us-la/statutes/47:297/4.yaml"
+    sentinel = checkout / "us-la/statutes/47:297/unowned.yaml"
+    sentinel.parent.mkdir(parents=True)
+    removed.write_text("legacy\n")
+    sentinel.write_text("unowned\n")
+
+    removed.unlink()
+    _prune_empty_overlay_parent_directories(checkout, [removed])
+
+    assert sentinel.read_text() == "unowned\n"
+    assert sentinel.parent.is_dir()
+
+
+def test_empty_overlay_pruning_rejects_target_equal_to_protected_floor(
+    tmp_path: Path,
+) -> None:
+    checkout = tmp_path / "rulespec-us"
+    protected_floor = checkout / "us-la/statutes"
+    protected_floor.mkdir(parents=True)
+
+    with pytest.raises(
+        LegacyReplacementOverlayError,
+        match="strict descendant of its protected prune floor",
+    ):
+        _prune_empty_overlay_parent_directories(checkout, [protected_floor])

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1638"
+ENCODER_VERSION = "0.2.1639"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1638"
+ENCODER_VERSION = "0.2.1639"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1638"
+ENCODER_VERSION = "0.2.1639"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1638"
+ENCODER_VERSION = "0.2.1639"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5926,7 +5926,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1638"')
+        .startswith('__version__ = "0.2.1639"')
     )
 
 
@@ -6158,13 +6158,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1638"
+    assert encoder_package["version"] == "0.2.1639"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1638"
+    assert project["project"]["version"] == "0.2.1639"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1638"')
+        .startswith('__version__ = "0.2.1639"')
     )
 
 
@@ -6426,13 +6426,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1638"
+    assert encoder_package["version"] == "0.2.1639"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1638"
+    assert project["project"]["version"] == "0.2.1639"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1638"')
+        .startswith('__version__ = "0.2.1639"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1638"
+ENCODER_VERSION = "0.2.1639"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1638"
+version = "0.2.1639"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- validate authenticated legacy replacements against the exact post-replacement repository image
- prune only empty ancestors of authenticated retired files, bounded by the jurisdiction atomic-module root
- stage legacy retirement before recreating and copying the generated destination in eval and apply validation
- preserve nonempty/unowned content fail-closed
- bump axiom-encode to 0.2.1639 with coordinated oracle registry expectations

## Why

The Louisiana 47:32 atomic replacement reached model generation but every candidate compile failed because the validation overlay removed authenticated legacy files such as `us-la/statutes/47:297/4.yaml` while retaining the now-empty noncanonical `47:297` directory. The rules engine correctly rejected that residual colon-bearing path. This change makes validation observe the same exact postimage Git would retain after the authenticated replacement; it does not relax canonical-path checks or redesign dispatch.

## Safety

- cleanup candidates are derived only from authenticated deleted targets
- cleanup uses bottom-up `rmdir`, never recursive deletion
- pruning cannot cross the jurisdiction content or manifest atomic-module roots
- a removed target equal to its protected floor is rejected
- nonempty directories and unowned files remain in place and therefore fail closed
- apply validation recreates the generated destination parent only after authenticated staging

## Validation

- `ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `tests/test_legacy_replacement.py`: 78 passed
- `tests/test_evals.py`: 748 passed
- focused legacy CLI tests: 5 passed
- full suite: 11,413 passed, 119 skipped
- two independent exact-HEAD reviews: clean

## Review cycle

The first review found two actionable issues: apply-validation parent recreation ordering and a floor-equality ancestor-walk edge case. Both were fixed with focused regressions. Two reviewers then re-reviewed the exact final commit `2bcea25647d874d4b47032737aa1585828e16728` and reported no actionable findings.
