### PR TITLE
Authenticate nonoperative source coverage

### DIFF
--- a/changelog.d/source-authenticated-nonoperative-deferrals.fixed.md
+++ b/changelog.d/source-authenticated-nonoperative-deferrals.fixed.md
@@ -1,0 +1,1 @@
+Accept bare and finite Louisiana session-law repeal tombstones plus exact Louisiana delegated-rate dependencies in complete-source-unit validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1639"
+version = "0.2.1640"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1639"
+__version__ = "0.2.1640"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -10254,6 +10254,20 @@ Complete-source-unit mode is enabled for this request:
   concrete source-stated missing input or runtime capability. The output path
   is not a source citation.
   Never guess a blocker target.
+- When an authoritative branch is exactly a bare `Repealed.` tombstone, or a
+  Louisiana `Repealed by Acts ...` tombstone whose remaining text is solely a
+  finite session-law citation and optional effective date, preserve that branch
+  path in `module.deferred_outputs[].output`. Make `reason` cite the exact
+  current legal branch and affirmatively state that it is repealed. Do not
+  fabricate an executable rule, input, runtime gap, or external blocker. Use
+  the bounded reason form `<exact branch citation> is repealed.`, optionally
+  adding only the authenticated Acts citation/effective date and/or `and
+  supplies no operative rule`; never qualify, report, or retract the assertion.
+- For a Louisiana branch that computes tax at rates provided in another R.S.
+  section, use the bounded missing-export clause `no executable RuleSpec output
+  for those <source-stated modifiers> rates is supplied in the available
+  context`. Do not repeat the dependency inside that missing object or append a
+  `that`/`which` relative clause.
 - Companion tests must execute every source-stated formula branch, boundary,
   exception, and rounding rule with assertions on the affected principal
   output. Each branch needs distinct runtime evidence; descriptive test

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -299,7 +299,7 @@ _EDITORIAL_OMISSION_ONLY = re.compile(
     r"(?:(?:\((?:\d+[a-z]?|[a-z])\)|\d+[a-z]?\.|[a-z]\))\s*)?"
     r"(?:bis\s+\(\d+[a-z]?\)\s*)?"
     r"(?:\(\s*)?"
-    r"(?:weggefallen|aufgehoben|repealed|omitted|\.{3,})"
+    r"(?:weggefallen|aufgehoben|omitted|\.{3,})"
     r"(?:\s*\))?"
     r"\s*[.;]?\s*$",
     flags=re.IGNORECASE,
@@ -1839,7 +1839,15 @@ module:
 must list exact absolute upstream RuleSpec outputs. When no external legal dependency \
 exists, cite the exact current source branch and name its concrete source-stated missing \
 input or runtime capability in the `reason` itself; the output path is not a source \
-citation, and a generic claim that the branch is unavailable is invalid."""
+citation, and a generic claim that the branch is unavailable is invalid. When the \
+authoritative branch is a bare `Repealed.` tombstone or a finite Louisiana \
+`Repealed by Acts ...` session-law tombstone, cite that exact current source branch and \
+affirmatively state the repeal in `reason`; do not invent a missing dependency or \
+executable rule. Use the bounded form `<exact branch citation> is repealed.`, optionally \
+adding only the authenticated Acts citation/effective date and/or `and supplies no \
+operative rule`. For Louisiana delegated rates, use `no executable RuleSpec output \
+for those <source-stated modifiers> rates is supplied in the available context`; do \
+not repeat the dependency in that missing object or append a relative clause."""
 
 
 def _imprecise_deferral_retry_shape(
@@ -4686,15 +4694,24 @@ def _deferred_coverage(
                         for blocker in blocker_targets
                     )
                 )
-            return _reason_dependency_is_source_bound(
-                reason,
-                candidate_scope_text,
-                corpus_citation_path=corpus_citation_path,
-            ) or _reason_names_source_bound_runtime_gap(
-                reason,
-                candidate_scope_text,
-                path=candidate_path,
-                corpus_citation_path=corpus_citation_path,
+            return (
+                _reason_dependency_is_source_bound(
+                    reason,
+                    candidate_scope_text,
+                    corpus_citation_path=corpus_citation_path,
+                )
+                or _reason_names_source_bound_runtime_gap(
+                    reason,
+                    candidate_scope_text,
+                    path=candidate_path,
+                    corpus_citation_path=corpus_citation_path,
+                )
+                or _reason_covers_source_authenticated_repeal(
+                    reason,
+                    candidate_scope_text,
+                    path=candidate_path,
+                    corpus_citation_path=corpus_citation_path,
+                )
             )
 
         valid_root_symbol = (
@@ -5780,6 +5797,8 @@ def _louisiana_source_link_is_operative(
     dependency_link = re.search(
         r"\b(?:under(?:\s+(?:both|either))?|according\s+to|pursuant\s+to|"
         r"in\s+accordance\s+with(?:\s+the\s+provisions?\s+of)?|"
+        r"at\s+(?:the\s+)?(?:amounts?|percentages?|rates?)\s+"
+        r"provided(?:\s+for)?\s+in|"
         r"depends?(?:\s*,?\s*(?:directly|entirely|necessarily|primarily|solely|"
         r"ultimately|in\s+part)\s*,?)*\s+(?:on|upon)|"
         r"is\s+(?:(?:directly|entirely|necessarily|primarily|solely|ultimately)\s+)*"
@@ -6962,7 +6981,11 @@ def _reason_dependency_is_source_bound(
 
     louisiana_dependencies = _qualified_louisiana_rs_dependencies(reason)
     if not _MISSING_DEPENDENCY_LANGUAGE.search(reason) and not any(
-        _reason_match_has_bounded_insufficiency(reason, dependency)
+        _reason_match_has_bounded_insufficiency(
+            reason,
+            dependency,
+            source_scope_text=source_scope_text,
+        )
         for dependency in louisiana_dependencies
     ):
         return False
@@ -7105,7 +7128,9 @@ def _reason_match_names_missing_dependency(
         flags=re.IGNORECASE,
     )
     if allow_bounded_insufficiency and _reason_match_has_bounded_insufficiency(
-        reason, match
+        reason,
+        match,
+        source_scope_text=source_scope_text,
     ):
         return True
     direct_signals = list(_MISSING_DEPENDENCY_LANGUAGE.finditer(before))
@@ -7214,6 +7239,8 @@ def _reason_match_names_missing_dependency(
 def _reason_match_has_bounded_insufficiency(
     reason: str,
     match: re.Match[str],
+    *,
+    source_scope_text: str,
 ) -> bool:
     """Recognize one citation-local statement that a supplied dependency is incomplete."""
 
@@ -7226,6 +7253,27 @@ def _reason_match_has_bounded_insufficiency(
             else len(reason)
         )
     after = reason[match.end() : clause_end]
+    unavailable_export = re.fullmatch(
+        r"\s*(?:[,;:]\s*)?(?:but\s+)?no\s+"
+        r"(?P<missing>[^.;\n]{1,200}?)\s+"
+        r"(?:is|are)\s+(?:available|encoded|implemented|provided|supplied)"
+        r"(?:\s+in\s+(?:the\s+)?(?:available|provided|supplied)\s+context)?"
+        r"\s*\.?\s*",
+        after,
+        flags=re.IGNORECASE,
+    )
+    if unavailable_export is not None:
+        missing_scope = unavailable_export.group("missing")
+        return bool(
+            _missing_scope_starts_with_executable_object(missing_scope)
+            and _unavailable_export_names_source_concept(
+                missing_scope,
+                source_scope_text=source_scope_text,
+            )
+            and not _executable_object_scope_claims_ready(missing_scope)
+            and not _missing_scope_reverses_insufficiency(missing_scope)
+            and not tuple(_reason_dependencies(missing_scope))
+        )
     insufficiency = re.match(
         r"\s*(?:(?:dependency|context|module|output|provision|rulespec)\s+)?"
         r"(?:(?:provides?|exports?)\s+only\b(?P<limited>[^.;\n]{1,200}?)"
@@ -7310,6 +7358,62 @@ def _reason_match_has_bounded_insufficiency(
         and _missing_scope_starts_with_executable_object(missing_scope)
         and not _missing_scope_reverses_insufficiency(missing_scope)
     )
+
+
+def _unavailable_export_names_source_concept(
+    missing_scope: str,
+    *,
+    source_scope_text: str,
+) -> bool:
+    """Bind a missing executable export to the source-linked object family."""
+
+    source_link = re.search(
+        r"\bat\s+(?:the\s+)?(?P<object>amounts?|percentages?|rates?)\s+"
+        r"provided(?:\s+for)?\s+in\s+" + _LOUISIANA_RS_DEFERRAL_DEPENDENCY.pattern,
+        source_scope_text,
+        flags=re.IGNORECASE,
+    )
+    if source_link is None:
+        return False
+    source_signature = _louisiana_object_signature(source_link.group("object"))
+    if source_signature is None:
+        return False
+
+    wrapper = re.match(
+        r"\s*(?:(?:an?|the)\s+)?(?:executable\s+)?(?:RuleSpec\s+)?"
+        r"(?:exports?|outputs?)\s+for\s+(?P<concept>.+)",
+        missing_scope,
+        flags=re.IGNORECASE,
+    )
+    concept_scope = wrapper.group("concept") if wrapper is not None else missing_scope
+    if re.fullmatch(
+        r"\s*(?:the\s+)?(?:"
+        r"rates?\s+applicable\s+to\s+"
+        r"(?:corporations?|(?:corporation|corporate)\s+taxable\s+income)|"
+        r"rates?\s+used\s+to\s+compute\s+corporation\s+tax|"
+        r"rates?\s+that\s+apply\s+to\s+corporations?"
+        r")\s*",
+        concept_scope,
+        flags=re.IGNORECASE,
+    ):
+        concept_scope = "corporate rates"
+    elif re.search(r"\b(?:that|which)\b", concept_scope, flags=re.IGNORECASE):
+        return False
+    concept_signature = _louisiana_object_signature(concept_scope)
+    if concept_signature is None or concept_signature[0] != source_signature[0]:
+        return False
+
+    source_modifiers = {
+        _louisiana_normalize_modifier_token(
+            {"corporation": "corporate", "corporations": "corporate"}.get(
+                token,
+                token,
+            )
+        )
+        for token in re.findall(r"[a-z][a-z0-9]+", source_scope_text.lower())
+    }
+    generic_modifiers = {"applicable"}
+    return concept_signature[1] <= source_modifiers | generic_modifiers
 
 
 _LOUISIANA_DOCUMENTARY_HEAD = re.compile(
@@ -7405,14 +7509,16 @@ def _missing_scope_starts_with_executable_object(missing_scope: str) -> bool:
 def _executable_object_scope_claims_ready(missing_scope: str) -> bool:
     """Reject a relative or appositive assertion that the object already exists."""
 
-    qualifier = re.search(
-        r"(?P<marker>,|\b(?:that|which)\b)(?P<scope>[^.;\n]{1,180})",
+    if re.fullmatch(
+        r"\s*(?:(?:an?|the)\s+)?(?:executable\s+)?(?:RuleSpec\s+)?"
+        r"(?:exports?|outputs?)\s+for\s+(?:the\s+)?(?:"
+        r"rates?\s+used\s+to\s+compute\s+corporation\s+tax"
+        r")\s*",
         missing_scope,
         flags=re.IGNORECASE,
-    )
-    if qualifier is None:
+    ):
         return False
-    scope = qualifier.group("scope")
+
     ready_state = (
         r"(?:accessible|accessed|available|complete|computed|calculated|determined|"
         r"defined|deployed|downloadable|downloaded|encoded|executed|extant|found|"
@@ -7427,6 +7533,41 @@ def _executable_object_scope_claims_ready(missing_scope: str) -> bool:
         r"(?:actively|actually|already|always|currently|directly|fully|immediately|"
         r"just|now|presently|previously|readily|still)"
     )
+    direct_readiness = re.search(
+        rf"\b(?:"
+        rf"(?:{affirmative_adverb}\s+)*{ready_state}"
+        r"(?:\s+(?:here|in\s+(?:this|the)\s+context))?|"
+        r"(?:this|the)\s+context\s+"
+        r"(?:exports?|furnishes?|has|holds?|implements?|provides?|supplies?)"
+        r")\b",
+        missing_scope,
+        flags=re.IGNORECASE,
+    )
+    if direct_readiness is not None:
+        readiness_prefix = missing_scope[: direct_readiness.start()]
+        readiness_tail = missing_scope[direct_readiness.end() :]
+        epistemically_limited = re.search(
+            r"\b(?:barely|conditionally|hardly|not|supposedly|theoretically)\s*$",
+            readiness_prefix,
+            flags=re.IGNORECASE,
+        )
+        conditionally_later = re.match(
+            r"\s*(?:(?:only\s+)?(?:after|if|once|unless|upon|when)|"
+            r"provided\s+that|in\s+theory(?:\s+only)?|on\s+paper)\b",
+            readiness_tail,
+            flags=re.IGNORECASE,
+        )
+        if epistemically_limited is None and conditionally_later is None:
+            return True
+
+    qualifier = re.search(
+        r"(?P<marker>,|\b(?:that|which)\b)(?P<scope>[^.;\n]{1,180})",
+        missing_scope,
+        flags=re.IGNORECASE,
+    )
+    if qualifier is None:
+        return False
+    scope = qualifier.group("scope")
     if qualifier.group("marker") == ",":
         bare_ready = re.match(
             rf"\s*(?!not\b)"
@@ -8799,6 +8940,8 @@ def _louisiana_object_signature(text: str) -> tuple[str, frozenset[str]] | None:
         "documents": "document",
         "equation": "formula",
         "equations": "formula",
+        "export": "output",
+        "exports": "output",
         "fact": "fact",
         "facts": "fact",
         "formula": "formula",
@@ -10157,12 +10300,340 @@ def _reason_names_source_bound_runtime_gap(
     return len(substantive_tokens(reason) & substantive_tokens(source_scope_text)) >= 2
 
 
+def _reason_covers_source_authenticated_repeal(
+    reason: str,
+    source_scope_text: str,
+    *,
+    path: tuple[str, ...],
+    corpus_citation_path: str,
+) -> bool:
+    """Cover only an exact current branch whose authoritative text is a repeal."""
+
+    if not path or not source_scope_text.strip():
+        return False
+    if not _source_branch_is_explicit_repeal_tombstone(source_scope_text):
+        return False
+    for affirmative in re.finditer(
+        r"\b(?:has\s+been|is|stands?|was)\s+repealed\b",
+        reason,
+        flags=re.IGNORECASE,
+    ):
+        clause_start, _clause_end = _reason_clause_bounds(reason, affirmative)
+        citation_subject = reason[clause_start : affirmative.start()]
+        if not _reason_cites_exact_current_statute_branch(
+            citation_subject,
+            corpus_citation_path=corpus_citation_path,
+            path=path,
+            strict_terminal=True,
+            citation_must_end=True,
+            citation_must_start=True,
+        ):
+            continue
+        return _repeal_reason_tail_is_bounded(
+            reason[affirmative.end() :],
+            source_scope_text=source_scope_text,
+        )
+    return False
+
+
+def _repeal_reason_tail_is_bounded(
+    tail: str,
+    *,
+    source_scope_text: str,
+) -> bool:
+    """Accept only finite tombstone history and non-operative explanations."""
+
+    bounded = _collapse_text(tail).strip()
+    if re.fullmatch(r"\.?", bounded):
+        return True
+    if re.match(r"^by\s+acts?(?:\s+of)?\b", bounded, flags=re.IGNORECASE):
+        normalized_history = _normalize_written_section_marker(
+            re.sub(r"^by\s+", "", bounded, flags=re.IGNORECASE)
+        )
+        history = _LOUISIANA_SESSION_LAW_CITATION.match(normalized_history)
+        if history is None or history.start() != 0:
+            return False
+        reason_history = normalized_history[: history.end()]
+        bounded = normalized_history[history.end() :].strip()
+        effective_date = re.match(
+            r"^,\s*eff(?:ective)?\.?\s+"
+            r"(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|June?|"
+            r"July?|Aug(?:ust)?|Sept(?:ember)?|Oct(?:ober)?|Nov(?:ember)?|"
+            r"Dec(?:ember)?)\.?\s+\d{1,2}\s*,\s*\d{4}",
+            bounded,
+            flags=re.IGNORECASE,
+        )
+        if effective_date is not None:
+            reason_history += " " + effective_date.group(0)
+            bounded = bounded[effective_date.end() :].strip()
+        reason_identity = _normalized_repeal_history(reason_history)
+        source_identity = _source_repeal_history(source_scope_text)
+        if (
+            reason_identity is None
+            or source_identity is None
+            or reason_identity != source_identity
+        ):
+            return False
+        if re.fullmatch(r"\.?", bounded):
+            return True
+    explanation = (
+        r"(?:,\s*)?(?:and\s+)?(?:"
+        r"supplies?\s+no\s+operative\s+rule(?:\s+to\s+encode)?|"
+        r"has\s+no\s+operative\s+(?:effect|rule|text)|"
+        r"contains?\s+no\s+operative\s+(?:legal\s+)?"
+        r"(?:effect|predicate|provision|requirement|rule|text)|"
+        r"contains?\s+no\s+operative\s+legal\s+predicate\s*,\s*amount\s*,\s*"
+        r"source-stated\s+input\s*,\s*or\s+runtime\s+consequence\s+from\s+"
+        r"which\s+an\s+executable\s+output\s+can\s+be\s+computed"
+        r")\s*\.?"
+    )
+    return bool(re.fullmatch(explanation, bounded, flags=re.IGNORECASE))
+
+
+def _source_repeal_history(source_scope_text: str) -> tuple[object, ...] | None:
+    """Return the normalized authenticated history on a repeal tombstone."""
+
+    source_body = _collapse_text(_strip_source_clause_marker(source_scope_text)).strip()
+    if source_body.startswith("[") and source_body.endswith("]"):
+        source_body = source_body[1:-1].strip()
+    repeal = re.fullmatch(
+        r"repealed\s+by\s+(?P<history>.+)",
+        source_body,
+        flags=re.IGNORECASE,
+    )
+    if repeal is None:
+        return None
+    return _normalized_repeal_history(repeal.group("history"))
+
+
+def _normalized_repeal_history(history: str) -> tuple[object, ...] | None:
+    """Parse a session law without collapsing list and range structure."""
+
+    normalized = _normalize_written_section_marker(history)
+    citation = _LOUISIANA_SESSION_LAW_CITATION.match(normalized)
+    if citation is None or citation.start() != 0:
+        return None
+    citation_text = citation.group(0)
+    year = re.search(r"\b(?P<year>\d{4})\b", citation_text)
+    number_marker = re.search(r"\bNos?\.?", citation_text, flags=re.IGNORECASE)
+    if year is None or number_marker is None:
+        return None
+
+    session_text = citation_text[year.end() : number_marker.start()]
+    session_text = re.sub(
+        r"\bE\.?\s*S\.?\b",
+        "ex sess",
+        session_text,
+        flags=re.IGNORECASE,
+    )
+    session_text = re.sub(
+        r"\b(?:Ex(?:tra)?\.?|Extraordinary)\b",
+        "ex",
+        session_text,
+        flags=re.IGNORECASE,
+    )
+    session_text = re.sub(
+        r"\bSess(?:ion)?\.?\b",
+        "sess",
+        session_text,
+        flags=re.IGNORECASE,
+    )
+    session_text = re.sub(
+        r"\b(\d+)\s+(st|nd|rd|th|d)\b",
+        r"\1\2",
+        session_text,
+        flags=re.IGNORECASE,
+    )
+    ordinal_words = {
+        "first": "1",
+        "second": "2",
+        "third": "3",
+        "fourth": "4",
+        "fifth": "5",
+        "sixth": "6",
+        "seventh": "7",
+        "eighth": "8",
+        "ninth": "9",
+        "tenth": "10",
+    }
+    session_tokens = re.findall(r"[a-z0-9]+", session_text.lower())
+    ex_index = session_tokens.index("ex") if "ex" in session_tokens else 0
+    if ex_index:
+        word_ordinal = _english_ordinal_value(session_tokens[:ex_index])
+        if word_ordinal is not None:
+            session_tokens = [str(word_ordinal), *session_tokens[ex_index:]]
+    session_parts: list[str] = []
+    for token in session_tokens:
+        if token in ordinal_words:
+            session_parts.append(ordinal_words[token])
+            continue
+        ordinal = re.fullmatch(r"(?P<number>\d+)(?P<suffix>st|nd|rd|th|d)", token)
+        if ordinal is None:
+            session_parts.append(token)
+            continue
+        number = int(ordinal.group("number"))
+        suffix = ordinal.group("suffix")
+        final_two = number % 100
+        expected_suffix = (
+            "th"
+            if 11 <= final_two <= 13
+            else {1: "st", 2: "nd", 3: "rd"}.get(number % 10, "th")
+        )
+        historical_d = (
+            suffix == "d" and not 11 <= final_two <= 13 and number % 10 in {2, 3}
+        )
+        if suffix != expected_suffix and not historical_d:
+            return None
+        session_parts.append(str(number))
+    session = tuple(session_parts)
+
+    section_marker = re.search(r"§{1,2}", citation_text)
+    acts_end = (
+        section_marker.start() if section_marker is not None else len(citation_text)
+    )
+    act_numbers = tuple(
+        match.group(0)
+        for match in re.finditer(
+            r"\d+(?:[-–—]\d+)?",
+            citation_text[number_marker.end() : acts_end],
+        )
+    )
+    sections: tuple[str, ...] = ()
+    if section_marker is not None:
+        section_text = citation_text[section_marker.end() :]
+        section_text = re.sub(r"\b(?:through|to)\b", "-", section_text, flags=re.I)
+        section_text = re.sub(r"\band\b", ",", section_text, flags=re.I)
+        section_text = re.sub(r"[–—]", "-", section_text)
+        section_text = re.sub(r"\s+", "", section_text).strip(",")
+        sections = tuple(part for part in section_text.split(",") if part)
+
+    effective_date: tuple[str, str, str] | None = None
+    date = re.search(
+        r"\beff(?:ective)?\.?\s+"
+        r"(?P<month>Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|June?|"
+        r"July?|Aug(?:ust)?|Sept(?:ember)?|Oct(?:ober)?|Nov(?:ember)?|"
+        r"Dec(?:ember)?)\.?\s+(?P<day>\d{1,2})\s*,\s*(?P<year>\d{4})",
+        normalized[citation.end() :],
+        flags=re.IGNORECASE,
+    )
+    if date is not None:
+        month = date.group("month").lower()[:3]
+        if month == "sep":
+            month = "sep"
+        effective_date = (month, str(int(date.group("day"))), date.group("year"))
+
+    return (
+        year.group("year"),
+        session,
+        act_numbers,
+        sections,
+        effective_date,
+    )
+
+
+def _normalize_written_section_marker(text: str) -> str:
+    """Preserve singular/list structure for written section markers."""
+
+    return re.sub(
+        r"\b(?P<label>sections?)\s+(?=\d)",
+        lambda match: "§§" if match.group("label").lower().endswith("s") else "§",
+        text,
+        flags=re.IGNORECASE,
+    )
+
+
+def _english_ordinal_value(tokens: Sequence[str]) -> int | None:
+    """Normalize ordinary English session ordinals admitted by the citation grammar."""
+
+    single = {
+        "first": 1,
+        "second": 2,
+        "third": 3,
+        "fourth": 4,
+        "fifth": 5,
+        "sixth": 6,
+        "seventh": 7,
+        "eighth": 8,
+        "ninth": 9,
+        "tenth": 10,
+        "eleventh": 11,
+        "twelfth": 12,
+        "thirteenth": 13,
+        "fourteenth": 14,
+        "fifteenth": 15,
+        "sixteenth": 16,
+        "seventeenth": 17,
+        "eighteenth": 18,
+        "nineteenth": 19,
+        "twentieth": 20,
+        "thirtieth": 30,
+        "fortieth": 40,
+        "fiftieth": 50,
+        "sixtieth": 60,
+        "seventieth": 70,
+        "eightieth": 80,
+        "ninetieth": 90,
+    }
+    if len(tokens) == 1:
+        return single.get(tokens[0])
+    tens = {
+        "twenty": 20,
+        "thirty": 30,
+        "forty": 40,
+        "fifty": 50,
+        "sixty": 60,
+        "seventy": 70,
+        "eighty": 80,
+        "ninety": 90,
+    }
+    if len(tokens) == 2 and tokens[0] in tens and tokens[1] in single:
+        unit = single[tokens[1]]
+        if 1 <= unit <= 9:
+            return tens[tokens[0]] + unit
+    return None
+
+
+def _source_branch_is_explicit_repeal_tombstone(source_scope_text: str) -> bool:
+    """Accept a bare repeal or a finite Louisiana session-law repeal history."""
+
+    source_body = _collapse_text(_strip_source_clause_marker(source_scope_text)).strip()
+    if source_body.startswith("[") and source_body.endswith("]"):
+        source_body = source_body[1:-1].strip()
+    if re.fullmatch(r"repealed\s*[.;]?", source_body, flags=re.IGNORECASE):
+        return True
+    repeal = re.fullmatch(
+        r"repealed\s+by\s+(?P<history>.+)",
+        source_body,
+        flags=re.IGNORECASE,
+    )
+    if repeal is None:
+        return False
+    history = _normalize_written_section_marker(repeal.group("history"))
+    citation = _LOUISIANA_SESSION_LAW_CITATION.match(history)
+    if citation is None or citation.start() != 0:
+        return False
+    effective_date_tail = history[citation.end() :]
+    return bool(
+        _normalized_repeal_history(history) is not None
+        and re.fullmatch(
+            r"\s*(?:,\s*eff(?:ective)?\.?\s+"
+            r"(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|June?|"
+            r"July?|Aug(?:ust)?|Sept(?:ember)?|Oct(?:ober)?|Nov(?:ember)?|"
+            r"Dec(?:ember)?)\.?\s+\d{1,2}\s*,\s*\d{4})?\s*\.?\s*",
+            effective_date_tail,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
 def _reason_cites_exact_current_statute_branch(
     reason: str,
     *,
     corpus_citation_path: str,
     path: tuple[str, ...],
     strict_terminal: bool = False,
+    citation_must_end: bool = False,
+    citation_must_start: bool = False,
 ) -> bool:
     """Bind a runtime-gap reason to one complete current-source branch."""
 
@@ -10203,19 +10674,25 @@ def _reason_cites_exact_current_statute_branch(
         section_pattern = literal_pattern(
             normalize_rulespec_path_segment(citation.section)
         )
+        start_guard = r"^\s*" if citation_must_start else ""
+        end_guard = r"\s*$" if citation_must_end else ""
         return bool(
             re.search(
-                rf"\b{re.escape(citation.title)}\s+U\.?\s*S\.?\s*C\.?\s*"
+                rf"{start_guard}\b{re.escape(citation.title)}\s+"
+                rf"U\.?\s*S\.?\s*C\.?\s*"
                 rf"(?:§{{1,2}}\s*)?{section_pattern}\s*{usc_branch_pattern}"
-                rf"{usc_terminal_guard}",
+                rf"{usc_terminal_guard}{end_guard}",
                 reason,
                 flags=re.IGNORECASE,
             )
         )
 
+    start_guard = r"^\s*" if citation_must_start else ""
+    end_guard = r"\s*$" if citation_must_end else ""
     canonical_pattern = re.compile(
-        rf"(?<![A-Za-z0-9_.-]){literal_pattern(corpus_citation_path.rstrip('/'))}"
-        rf"\s*{branch_pattern}{state_branch_terminal_guard}",
+        rf"{start_guard}(?<![A-Za-z0-9_.-])"
+        rf"{literal_pattern(corpus_citation_path.rstrip('/'))}"
+        rf"\s*{branch_pattern}{state_branch_terminal_guard}{end_guard}",
         flags=re.IGNORECASE,
     )
     if canonical_pattern.search(reason):
@@ -10245,10 +10722,10 @@ def _reason_cites_exact_current_statute_branch(
         for part in complete_louisiana_branch
     )
     louisiana_rs_pattern = re.compile(
-        rf"(?<![A-Za-z0-9])(?:La\.?\s+)?R\.?\s*S\.?\s*"
+        rf"{start_guard}(?<![A-Za-z0-9])(?:La\.?\s+)?R\.?\s*S\.?\s*"
         rf"{literal_pattern(title)}\s*:\s*{literal_pattern(section)}\s*"
         rf"{louisiana_branch_pattern}"
-        rf"{state_branch_terminal_guard}",
+        rf"{state_branch_terminal_guard}{end_guard}",
         flags=re.IGNORECASE,
     )
     return bool(louisiana_rs_pattern.search(reason))

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -1677,6 +1677,20 @@ Complete-source-unit mode is enabled for this request:
   any branch is absent. A deferral reason must identify the exact branch and a
   concrete missing input, dependency, or runtime capability; generic omission
   language is not coverage.
+- When an authoritative branch is exactly a bare `Repealed.` tombstone, or a
+  Louisiana `Repealed by Acts ...` tombstone whose remaining text is solely a
+  finite session-law citation and optional effective date, preserve that branch
+  path in `module.deferred_outputs[].output`. Make `reason` cite the exact
+  current legal branch and affirmatively state that it is repealed. Do not
+  fabricate an executable rule, input, runtime gap, or external blocker. Use
+  the bounded reason form `<exact branch citation> is repealed.`, optionally
+  adding only the authenticated Acts citation/effective date and/or `and
+  supplies no operative rule`; never qualify, report, or retract the assertion.
+- For a Louisiana branch that computes tax at rates provided in another R.S.
+  section, use the bounded missing-export clause `no executable RuleSpec output
+  for those <source-stated modifiers> rates is supplied in the available
+  context`. Do not repeat the dependency inside that missing object or append a
+  `that`/`which` relative clause.
 - Companion tests must execute every source-stated formula branch, boundary,
   exception, and rounding rule with assertions on the affected principal
   output. Each branch needs distinct runtime evidence; descriptive test

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1639"
+ENCODER_VERSION = "0.2.1640"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_complete_source_mode_plumbing.py
+++ b/tests/test_complete_source_mode_plumbing.py
@@ -109,6 +109,18 @@ def test_generic_encoder_prompt_adds_completeness_only_when_enabled():
         complete_prompt
     )
     assert "The output path\n  is not a source citation" in complete_prompt
+    assert (
+        "authoritative branch is exactly a bare `Repealed.` tombstone"
+        in complete_prompt
+    )
+    assert "Do not\n  fabricate an executable rule" in complete_prompt
+    assert (
+        "the bounded reason form `<exact branch citation> is repealed.`"
+        in complete_prompt
+    )
+    assert (
+        "For a Louisiana branch that computes tax at rates provided" in complete_prompt
+    )
     assert "exact missing RuleSpec targets under `blocked_by`" not in complete_prompt
     assert (
         "Only include `blocked_by` entries when you know the exact" in complete_prompt
@@ -257,6 +269,17 @@ def test_eval_prompt_adds_completeness_only_when_enabled(tmp_path):
         complete_prompt
     )
     assert "The output path\n  is not a source citation" in complete_prompt
+    assert (
+        "authoritative branch is exactly a bare `Repealed.` tombstone"
+        in complete_prompt
+    )
+    assert (
+        "the bounded reason form `<exact branch citation> is repealed.`"
+        in complete_prompt
+    )
+    assert (
+        "For a Louisiana branch that computes tax at rates provided" in complete_prompt
+    )
     assert (
         "Only include `blocked_by` entries when you know the exact" in complete_prompt
     )

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1639"
+ENCODER_VERSION = "0.2.1640"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1639"
+ENCODER_VERSION = "0.2.1640"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1639"
+ENCODER_VERSION = "0.2.1640"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1639"
+ENCODER_VERSION = "0.2.1640"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1639"
+ENCODER_VERSION = "0.2.1640"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1639"
+ENCODER_VERSION = "0.2.1640"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5926,7 +5926,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1639"')
+        .startswith('__version__ = "0.2.1640"')
     )
 
 
@@ -6158,13 +6158,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1639"
+    assert encoder_package["version"] == "0.2.1640"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1639"
+    assert project["project"]["version"] == "0.2.1640"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1639"')
+        .startswith('__version__ = "0.2.1640"')
     )
 
 
@@ -6426,13 +6426,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1639"
+    assert encoder_package["version"] == "0.2.1640"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1639"
+    assert project["project"]["version"] == "0.2.1640"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1639"')
+        .startswith('__version__ = "0.2.1640"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1639"
+ENCODER_VERSION = "0.2.1640"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -7371,6 +7371,560 @@ rules: []
     )
 
 
+def _louisiana_47_32_c_deferral(reason: str):
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-la/statute/47:32
+  deferred_outputs:
+    - output: us-la:statutes/47/32/c#corporate_income_tax_amount
+      reason: >-
+        {reason}
+rules: []
+"""
+    source = """\
+A. Placeholder.
+
+B. Placeholder.
+
+C. On corporations. The tax upon the taxable income of every corporation shall
+be computed at the rates provided for in R.S. 47:287.12.
+"""
+    return _analyze(
+        content,
+        source,
+        corpus_citation_path="us-la/statute/47:32",
+        test_cases=[],
+    )
+
+
+def test_louisiana_repeal_and_delegated_rate_are_precisely_covered():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-la/statute/47:32
+  deferred_outputs:
+    - output: us-la:statutes/47/32/b#repealed_subsection
+      reason: >-
+        La. R.S. 47:32(B) is repealed by Acts 2024, 3rd Ex. Sess., No. 11,
+        section 4, effective December 4, 2024, and supplies no operative rule.
+    - output: us-la:statutes/47/32/c#corporate_income_tax_rate
+      reason: >-
+        La. R.S. 47:32(C) requires corporation taxable-income tax to be computed
+        at rates provided in R.S. 47:287.12; no executable RuleSpec export for
+        those corporation rates is supplied in the available context.
+rules:
+  - name: individual_income_tax_amount
+    kind: derived
+    entity: Person
+    dtype: Money
+    unit: USD
+    period: Year
+    source: La. R.S. 47:32(A)
+    versions:
+      - formula: individual_net_income * 0.03
+"""
+    source = """\
+A. On individuals. The tax upon the taxable income of an individual shall be
+computed at the rate of three percent on net income.
+
+B. Repealed by Acts 2024, 3rd Ex. Sess., No. 11, §4, eff. Dec. 4, 2024.
+
+C. On corporations. The tax upon the taxable income of every corporation shall
+be computed at the rates provided for in R.S. 47:287.12.
+"""
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us-la/statute/47:32",
+        test_cases=[],
+    )
+
+    assert not _has_issue(result, "source branch b", "neither encoded")
+    assert not _has_issue(result, "source branch c", "neither encoded")
+    assert not _has_issue(result, "deferred_outputs[0]", "deferral")
+    assert not _has_issue(result, "deferred_outputs[1]", "deferral")
+
+
+def test_louisiana_delegated_rate_accepts_archived_comma_reason():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-la/statute/47:32
+  deferred_outputs:
+    - output: us-la:statutes/47/32/c#corporate_income_tax_amount
+      reason: >-
+        us-la/statute/47:32(c) requires corporation tax to be computed using the
+        rates provided in R.S. 47:287.12, but no executable RuleSpec output for
+        those corporation rates is supplied in the available context.
+rules: []
+"""
+    source = """\
+A. Placeholder.
+
+B. Placeholder.
+
+C. On corporations. The tax upon the taxable income of every corporation shall
+be computed at the rates provided for in R.S. 47:287.12.
+"""
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us-la/statute/47:32",
+        test_cases=[],
+    )
+
+    assert not _has_issue(result, "source branch c", "neither encoded")
+    assert not _has_issue(result, "deferred_outputs[0]", "deferral")
+
+
+def test_louisiana_delegated_rate_rejects_documentary_unavailability():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-la/statute/47:32
+  deferred_outputs:
+    - output: us-la:statutes/47/32/c#corporate_income_tax_amount
+      reason: >-
+        R.S. 47:287.12; no executable explanatory report is supplied in the
+        available context.
+rules: []
+"""
+    source = """\
+C. On corporations. The tax upon the taxable income of every corporation shall
+be computed at the rates provided for in R.S. 47:287.12.
+"""
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us-la/statute/47:32",
+        test_cases=[],
+    )
+
+    assert _has_issue(result, "deferred_outputs[0]", "deferral")
+
+
+def test_parenthesized_bare_repeal_is_audited_and_precisely_covered():
+    source = "(a) Repealed."
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/42/9999
+  deferred_outputs:
+    - output: us:statutes/42/9999/a#repealed_subsection
+      reason: 42 U.S.C. 9999(a) is repealed and supplies no operative rule.
+rules: []
+"""
+
+    branches = recognize_source_structure(source)
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us/statute/42/9999",
+        test_cases=[],
+    )
+
+    assert [branch.path for branch in branches] == [("a",)]
+    assert not _has_issue(result, "source branch a", "neither encoded")
+    assert not _has_issue(result, "deferred_outputs[0]", "deferral")
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "42 U.S.C. 9999(b) is repealed and supplies no operative rule.",
+        "42 U.S.C. 9999(a) remains operative.",
+        (
+            "42 U.S.C. 9999(a) is repealed by Acts 1900, No. 999, effective "
+            "January 1, 1900."
+        ),
+    ),
+)
+def test_parenthesized_bare_repeal_requires_exact_deferral(reason: str):
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/42/9999
+  deferred_outputs:
+    - output: us:statutes/42/9999/a#repealed_subsection
+      reason: {reason}
+rules: []
+"""
+
+    result = _analyze(
+        content,
+        "(a) Repealed.",
+        corpus_citation_path="us/statute/42/9999",
+        test_cases=[],
+    )
+
+    assert _has_issue(result, "deferred_outputs[0]", "deferral")
+
+
+@pytest.mark.parametrize(
+    ("source_branch", "reason"),
+    (
+        (
+            "B. The tax rate is four percent.",
+            "La. R.S. 47:32(B) is repealed and supplies no operative rule.",
+        ),
+        (
+            "B. Repealed by Acts 2024, No. 11, §4.",
+            "This subsection is repealed and supplies no operative rule.",
+        ),
+        (
+            "B. Repealed by Acts 2024, No. 11, §4.",
+            "La. R.S. 47:32(C) is repealed and supplies no operative rule.",
+        ),
+        (
+            "B. Repealed by Acts 2024, No. 11. A credit is available to residents.",
+            "La. R.S. 47:32(B) is repealed and supplies no operative rule.",
+        ),
+        (
+            "B. Repealed by Acts 2024, No. 11. Taxpayers must file a return.",
+            "La. R.S. 47:32(B) is repealed and supplies no operative rule.",
+        ),
+        (
+            "B. Repealed by Acts 2024, No. 11; however, a corporation is "
+            "eligible for the credit.",
+            "La. R.S. 47:32(B) is repealed and supplies no operative rule.",
+        ),
+        (
+            "B. Repealed by Acts 2024, No. 11, except corporations shall pay a fee.",
+            "La. R.S. 47:32(B) is repealed and supplies no operative rule.",
+        ),
+        (
+            "B. Repealed by Pub. L. 95-600.",
+            "La. R.S. 47:32(B) is repealed and supplies no operative rule.",
+        ),
+        (
+            "B. Repealed by Laws 2024, ch. 11.",
+            "La. R.S. 47:32(B) is repealed and supplies no operative rule.",
+        ),
+        (
+            "B. Repealed by Acts 2024, No. 11-12.",
+            "La. R.S. 47:32(B) is repealed by Acts 2024, No. 11, 12.",
+        ),
+        (
+            "B. Repealed by Acts 2024, No. 11, 12.",
+            "La. R.S. 47:32(B) is repealed by Acts 2024, No. 11-12.",
+        ),
+        (
+            "B. Repealed by Acts 2024, No. 11, §§4-5.",
+            "La. R.S. 47:32(B) is repealed by Acts 2024, No. 11, §§4, 5.",
+        ),
+        (
+            "B. Repealed by Acts 2024, No. 11, §§4, 5.",
+            "La. R.S. 47:32(B) is repealed by Acts 2024, No. 11, §§4-5.",
+        ),
+        (
+            "B. Repealed by Acts 2024, 3rd Ex. Sess., No. 11.",
+            "La. R.S. 47:32(B) is repealed by Acts 2024, 3th Ex. Sess., No. 11.",
+        ),
+        (
+            "B. Repealed by Acts 2024, 1st Ex. Sess., No. 11.",
+            "La. R.S. 47:32(B) is repealed by Acts 2024, 1rd Ex. Sess., No. 11.",
+        ),
+        (
+            "B. Repealed by Acts 2024, 2nd Ex. Sess., No. 11.",
+            "La. R.S. 47:32(B) is repealed by Acts 2024, 2st Ex. Sess., No. 11.",
+        ),
+        (
+            "B. Repealed by Acts 2024, 3th Ex. Sess., No. 11.",
+            "La. R.S. 47:32(B) is repealed.",
+        ),
+        (
+            "B. Repealed by Acts 2024, 1rd Ex. Sess., No. 11.",
+            "La. R.S. 47:32(B) is repealed.",
+        ),
+        (
+            "B. Repealed by Acts 2024, 2st Ex. Sess., No. 11.",
+            "La. R.S. 47:32(B) is repealed.",
+        ),
+    ),
+)
+def test_repeal_coverage_requires_exact_source_tombstone_and_branch(
+    source_branch: str,
+    reason: str,
+):
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-la/statute/47:32
+  deferred_outputs:
+    - output: us-la:statutes/47/32/b#repealed_subsection
+      reason: >-
+        {reason}
+rules: []
+"""
+
+    result = _analyze(
+        content,
+        source_branch,
+        corpus_citation_path="us-la/statute/47:32",
+        test_cases=[],
+    )
+
+    assert _has_issue(result, "deferred_outputs[0]", "deferral")
+
+
+def test_repeal_history_accepts_equivalent_session_law_spellings():
+    abbreviated = completeness_module._normalized_repeal_history(
+        "Act of 2024, 3rd E.S., No. 11, §4, eff. Dec. 4, 2024."
+    )
+    expanded = completeness_module._normalized_repeal_history(
+        "Acts 2024, 3rd Ex. Sess., No. 11, section 4, effective December 4, 2024."
+    )
+
+    assert abbreviated == expanded
+
+
+@pytest.mark.parametrize(
+    ("source_history", "reason_history"),
+    (
+        (
+            "Act of 2024, No. 11, §4",
+            "Act of 2024, No. 11, section 4",
+        ),
+        (
+            "Acts 2024, No. 11, §4",
+            "Act of 2024, No. 11, section 4",
+        ),
+        (
+            "Act of 2024, No. 11, §4",
+            "Acts 2024, No. 11, section 4",
+        ),
+        (
+            "Acts 2024, 3d Ex. Sess., No. 11, §4",
+            "Acts 2024, 3rd Ex. Sess., No. 11, section 4",
+        ),
+        (
+            "Acts 2024, Third Extraordinary Session, No. 11, §4",
+            "Acts 2024, 3rd Ex. Sess., No. 11, section 4",
+        ),
+        (
+            "Acts 2016, 1 st Ex. Sess., No. 29, §§2 and 3",
+            "Acts 2016, 1st Ex. Sess., No. 29, sections 2 and 3",
+        ),
+        (
+            "Acts 2016, 1st Ex. Sess., No. 29, sections 2 and 3",
+            "Acts 2016, 1st Ex. Sess., No. 29, §§2 and 3",
+        ),
+        (
+            "Acts 2024, Twenty First Extraordinary Session, No. 11, §4",
+            "Acts 2024, 21st Ex. Sess., No. 11, section 4",
+        ),
+        (
+            "Acts 2024, Eleventh Extraordinary Session, No. 11, §4",
+            "Acts 2024, 11th Ex. Sess., No. 11, section 4",
+        ),
+    ),
+)
+def test_repeal_history_equivalence_is_accepted_end_to_end(
+    source_history: str,
+    reason_history: str,
+):
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-la/statute/47:32
+  deferred_outputs:
+    - output: us-la:statutes/47/32/b#repealed_subsection
+      reason: >-
+        La. R.S. 47:32(B) is repealed by {reason_history}, and supplies no
+        operative rule.
+rules: []
+"""
+    source = f"""\
+A. Placeholder.
+
+B. Repealed by {source_history}.
+
+C. Placeholder.
+"""
+
+    result = _analyze(
+        content,
+        source,
+        corpus_citation_path="us-la/statute/47:32",
+        test_cases=[],
+    )
+
+    assert not _has_issue(result, "source branch b", "neither encoded")
+    assert not _has_issue(result, "deferred_outputs[0]", "deferral")
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "La. R.S. 47:32(B) is not repealed and remains operative.",
+        "La. R.S. 47:32(B) repeal was proposed but rejected.",
+        "La. R.S. 47:32(B) contains no repeal and remains in force.",
+        ("La. R.S. 47:32(B) remains operative. An unrelated act is repealed."),
+        (
+            "La. R.S. 47:32(B) repeal was proposed and rejected. An unrelated "
+            "act is repealed."
+        ),
+        "An unrelated act is repealed. La. R.S. 47:32(B) remains operative.",
+        "La. R.S. 47:32(B) is repealed. No, it remains operative.",
+        "La. R.S. 47:32(B) is repealed only in a rejected proposal.",
+        "La. R.S. 47:32(B) is repealed in neither law nor fact.",
+        "It is false that La. R.S. 47:32(B) is repealed.",
+        "A rejected proposal says La. R.S. 47:32(B) is repealed.",
+        "It is uncertain whether La. R.S. 47:32(B) is repealed.",
+        "No law states La. R.S. 47:32(B) is repealed.",
+        "A report merely alleges La. R.S. 47:32(B) is repealed.",
+        "La. R.S. 47:32(B) is repealed. That statement is false.",
+        "La. R.S. 47:32(B) is repealed. It remains effective.",
+        "La. R.S. 47:32(B) is repealed? No.",
+        "La. R.S. 47:32(B) is repealed, supposedly.",
+        "La. R.S. 47:32(B) is repealed according to a rejected proposal.",
+        "La. R.S. 47:32(B) is repealed. That assertion is wrong.",
+        "La. R.S. 47:32(B) is repealed. That is a lie.",
+        "La. R.S. 47:32(B) is repealed. Actually, it is in effect.",
+        "La. R.S. 47:32(B) is repealed. It remains valid.",
+        "La. R.S. 47:32(B) is repealed. It continues to apply.",
+        "La. R.S. 47:32(B) is repealed. In fact it still governs.",
+        "La. R.S. 47:32(B) is repealed. Correction: it is active.",
+        "La. R.S. 47:32(B) is repealed under a proposal.",
+        "La. R.S. 47:32(B) is repealed subject to enactment.",
+        "La. R.S. 47:32(B) is repealed conditionally.",
+        "La. R.S. 47:32(B) is repealed hypothetically.",
+        "La. R.S. 47:32(B) is repealed in theory.",
+        "La. R.S. 47:32(B) is repealed, perhaps.",
+        "La. R.S. 47:32(B) is repealed, maybe.",
+        "La. R.S. 47:32(B) is repealed if approved.",
+        "La. R.S. 47:32(B) is repealed, the report says.",
+        (
+            "La. R.S. 47:32(B) is repealed by Acts 1999, No. 999, §7, "
+            "effective January 1, 2000."
+        ),
+        (
+            "La. R.S. 47:32(B) is repealed by Acts 2024, No. 12, effective "
+            "December 5, 2024."
+        ),
+    ),
+)
+def test_repeal_coverage_requires_affirmative_reason(reason: str):
+    content = f"""\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-la/statute/47:32
+  deferred_outputs:
+    - output: us-la:statutes/47/32/b#repealed_subsection
+      reason: >-
+        {reason}
+rules: []
+"""
+
+    result = _analyze(
+        content,
+        "B. Repealed by Acts 2024, No. 11.",
+        corpus_citation_path="us-la/statute/47:32",
+        test_cases=[],
+    )
+
+    assert _has_issue(result, "deferred_outputs[0]", "deferral")
+
+
+@pytest.mark.parametrize(
+    "missing_scope",
+    (
+        "mortgage interest",
+        "dog licenses",
+        "tax calculation for dog licenses",
+        "taxable-income formula for dog licenses",
+        "corporation income calculation for dog licenses",
+        "individual taxable-income output",
+        "corporation rates dog licenses",
+        "corporation taxable income mortgage interest",
+        "corporation rates that determine dog-license fees",
+        "those rates which apply to dog licenses",
+        "corporation rates that concern mortgage interest",
+        "tax rates that calculate an unrelated benefit",
+        "rate schedule which governs dog licenses",
+    ),
+)
+def test_louisiana_delegated_rate_rejects_unrelated_missing_concept(
+    missing_scope: str,
+):
+    reason = (
+        f"R.S. 47:287.12, but no executable RuleSpec output for {missing_scope} "
+        "is supplied in the available context."
+    )
+    result = _louisiana_47_32_c_deferral(reason)
+
+    assert _has_issue(result, "deferred_outputs[0]", "deferral")
+
+
+@pytest.mark.parametrize(
+    "delegated_concept",
+    (
+        "those rates",
+        "corporate rates",
+        "the applicable rates",
+        "the tax rates",
+        "the rate schedule",
+        "rates applicable to corporations",
+        "the rates applicable to corporation taxable income",
+        "the rates applicable to corporate taxable income",
+        "the rates used to compute corporation tax",
+        "the rates that apply to corporations",
+    ),
+)
+def test_louisiana_delegated_rate_accepts_rate_family_description(
+    delegated_concept: str,
+):
+    reason = (
+        f"R.S. 47:287.12, but no executable RuleSpec output for "
+        f"{delegated_concept} is supplied in the available context."
+    )
+    result = _louisiana_47_32_c_deferral(reason)
+
+    assert not _has_issue(result, "source branch c", "neither encoded")
+    assert not _has_issue(result, "deferred_outputs[0]", "deferral")
+
+
+@pytest.mark.parametrize(
+    "missing_scope",
+    (
+        "corporation-rates formula that is supplied in this context",
+        "corporation-rates formula, already available and supplied here,",
+        "corporation-rates formula which is currently available",
+        "RuleSpec output for corporation rates supplied here",
+        "RuleSpec output for corporation rates currently available in this context",
+        "RuleSpec output for corporation rates the context exports",
+        "RuleSpec output for corporation rates which are not unavailable",
+        "RuleSpec output for corporation rates that are anything but unavailable",
+        "RuleSpec output for corporation rates which are no longer unavailable",
+        "RuleSpec output for corporation rates which are far from unavailable",
+        "RuleSpec output for corporation rates which exist here",
+    ),
+)
+def test_louisiana_delegated_rate_rejects_ready_state_qualifier(
+    missing_scope: str,
+):
+    reason = (
+        f"R.S. 47:287.12, but no executable {missing_scope} is supplied in the "
+        "available context."
+    )
+    result = _louisiana_47_32_c_deferral(reason)
+
+    assert _has_issue(result, "deferred_outputs[0]", "deferral")
+
+
 @pytest.mark.parametrize(
     "reason",
     (

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1639"
+version = "0.2.1640"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- authenticate bare and finite Louisiana session-law repeal tombstones before they can satisfy complete-source coverage
- accept the bounded Louisiana `rates provided in R.S.` missing-export form while rejecting unrelated, padded, contradictory, or unauthenticated reasons
- keep generation, eval, retry guidance, version coupling, and oracle registries synchronized at `0.2.1640`

## Why this is a contract fix

The existing `module.deferred_outputs` schema is the intended representation for non-operative and source-delegated branches. The defect was in complete-source validation: it could not recognize an authenticated repeal tombstone or the exact Louisiana delegated-rate linker/reason emitted by valid candidates. This change repairs that validation contract without changing dispatching or the RuleSpec schema.

Repeal history is parsed into a structured identity (year, session, Act identifiers, section list/range structure, and effective date). Optional history in a reason must match the authoritative source; malformed ordinals, invented metadata, list/range collisions, reporting, qualification, and retraction fail closed.

## Review cycle

- two independent reviewers repeatedly reviewed exact amended commits
- all actionable findings were fixed and focused checks rerun after each round
- final semantic commit reviewed: `53918d79ec3a42dbc6e0d61ed50211e745a53202`
- final formatted commit reviewed: `fce958da780dd85de6f2f006db77aa120553ae9e` (both reviewers confirmed AST and ordered string-constant equivalence)
- final result from both reviewers: **CLEAN**
- archived Louisiana replay: Terra has zero completeness issues; Sol retains exactly the expected missing-B structure issue

## Checks

- shared Python 3.13 venv `ruff check pyproject.toml src/axiom_encode scripts tests`: passed
- `ruff format --check src/ tests/`: passed
- shared Python 3.13 venv `python -m compileall -q src/axiom_encode scripts`: passed
- `pytest tests/test_source_completeness.py tests/test_complete_source_mode_plumbing.py --no-cov -q`: `5303 passed`
- `pytest`: `11520 passed, 119 skipped`
- encoder version-provenance test: passed

## Campaign safety

No failed Louisiana workflow run is rerun, repaired, or adopted by this PR. A fresh signed dispatch remains blocked until this PR is merged and post-merge checks are green.
