### PR TITLE
Fix Louisiana legal citation source coverage

### DIFF
--- a/changelog.d/legal-citation-source-coverage.fixed.md
+++ b/changelog.d/legal-citation-source-coverage.fixed.md
@@ -1,0 +1,1 @@
+Exclude authenticated Louisiana R.S. cross-references from scalar recall and admit exact split-sentence repeal histories.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1640"
+version = "0.2.1641"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1640"
+__version__ = "0.2.1641"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -10261,8 +10261,9 @@ Complete-source-unit mode is enabled for this request:
   current legal branch and affirmatively state that it is repealed. Do not
   fabricate an executable rule, input, runtime gap, or external blocker. Use
   the bounded reason form `<exact branch citation> is repealed.`, optionally
-  adding only the authenticated Acts citation/effective date and/or `and
-  supplies no operative rule`; never qualify, report, or retract the assertion.
+  adding the exact authenticated history either as `is repealed by <Acts
+  citation>.` or as `is repealed. <Acts citation>.`, and/or adding `and supplies
+  no operative rule`; never qualify, report, or retract the assertion.
 - For a Louisiana branch that computes tax at rates provided in another R.S.
   section, use the bounded missing-export clause `no executable RuleSpec output
   for those <source-stated modifiers> rates is supplied in the available

--- a/src/axiom_encode/harness/source_completeness.py
+++ b/src/axiom_encode/harness/source_completeness.py
@@ -1844,8 +1844,9 @@ authoritative branch is a bare `Repealed.` tombstone or a finite Louisiana \
 `Repealed by Acts ...` session-law tombstone, cite that exact current source branch and \
 affirmatively state the repeal in `reason`; do not invent a missing dependency or \
 executable rule. Use the bounded form `<exact branch citation> is repealed.`, optionally \
-adding only the authenticated Acts citation/effective date and/or `and supplies no \
-operative rule`. For Louisiana delegated rates, use `no executable RuleSpec output \
+adding the exact authenticated history either as `is repealed by <Acts citation>.` or \
+as `is repealed. <Acts citation>.`, and/or adding `and supplies no operative rule`. \
+For Louisiana delegated rates, use `no executable RuleSpec output \
 for those <source-stated modifiers> rates is supplied in the available context`; do \
 not repeat the dependency in that missing object or append a relative clause."""
 
@@ -1854,6 +1855,7 @@ def _imprecise_deferral_retry_shape(
     *,
     corpus_citation_path: str,
     path: tuple[str, ...],
+    reason: str = "",
 ) -> str:
     """Render branch-specific retry guidance without inventing source facts."""
 
@@ -1871,6 +1873,21 @@ def _imprecise_deferral_retry_shape(
                 f"required in `reason` is `{citation.title} U.S.C. "
                 f"{section}{fragments}`."
             )
+    elif (
+        path
+        and reason
+        and _reason_cites_exact_current_statute_branch(
+            reason,
+            corpus_citation_path=corpus_citation_path,
+            path=path,
+            strict_terminal=True,
+        )
+    ):
+        branch_hint = (
+            "\nThe current-source branch citation in `reason` is already "
+            "recognized; correct the bounded dependency, runtime-gap, or repeal "
+            "tail without replacing that authenticated citation."
+        )
     elif path:
         citation_parts = [
             part for part in corpus_citation_path.strip("/").split("/") if part
@@ -1926,6 +1943,25 @@ _TITLE_SUFFIX_LEGAL_CITATION = re.compile(
     r"(?:and|or|through|to)\s+)(?:\d+)?[a-z]\s*"
     r"[-\u2010\u2011\u2012\u2013\u2014\u2015\u2212\ufe58\ufe63\uff0d]"
     r"\s*\d+[a-z]?)*\s+of\s+this\s+title\b",
+    flags=re.IGNORECASE,
+)
+_LOUISIANA_RS_NUMERIC_RECALL_TARGET = (
+    r"\d+[A-Za-z]?\s*:\s*"
+    r"\d+[A-Za-z]?(?:(?:[-\u2010\u2011\u2012\u2013\u2014\u2015"
+    r"\u2212\ufe58\ufe63\uff0d][A-Za-z0-9]+)|(?:\.\d+[A-Za-z]?))*"
+    r"(?:\s*\(\s*(?:[A-Za-z]+|\d{1,2})\s*\))*"
+)
+_LOUISIANA_RS_NUMERIC_RECALL_CITATION = re.compile(
+    r"(?<![A-Za-z0-9_])(?:(?:La\.?\s*)|(?:LSA\s*[-\u2010-\u2015]?\s*))?"
+    r"R\.?\s*S\.?\s*(?:§{1,2}\s*)?"
+    + _LOUISIANA_RS_NUMERIC_RECALL_TARGET
+    + r"(?:\s*(?:,\s*(?:(?:and/or|and|or)\s+)?|"
+    + r"(?:and/or|and|or|through|to)\s+|&\s*)"
+    + _LOUISIANA_RS_NUMERIC_RECALL_TARGET
+    + r")*"
+    + r"(?![A-Za-z0-9_])(?![./:]\s*(?:[A-Za-z0-9]|\())"
+    + r"(?![-\u2010\u2011\u2012\u2013\u2014\u2015\u2212\ufe58\ufe63\uff0d]"
+    + r"\s*(?:[A-Za-z0-9]|\())",
     flags=re.IGNORECASE,
 )
 _LOUISIANA_SESSION_LAW_CITATION = re.compile(
@@ -4818,6 +4854,7 @@ def _deferred_coverage(
                     retry_shape = _imprecise_deferral_retry_shape(
                         corpus_citation_path=corpus_citation_path,
                         path=display_cited_branch,
+                        reason=reason,
                     )
                     issues.append(
                         "[complete-source-unit:deferral] "
@@ -4837,6 +4874,7 @@ def _deferred_coverage(
             retry_shape = _imprecise_deferral_retry_shape(
                 corpus_citation_path=corpus_citation_path,
                 path=display_path or path,
+                reason=reason,
             )
             issues.append(
                 "[complete-source-unit:deferral] "
@@ -10346,9 +10384,13 @@ def _repeal_reason_tail_is_bounded(
     bounded = _collapse_text(tail).strip()
     if re.fullmatch(r"\.?", bounded):
         return True
-    if re.match(r"^by\s+acts?(?:\s+of)?\b", bounded, flags=re.IGNORECASE):
+    if re.match(
+        r"^(?:by\s+|\.\s*)acts?(?:\s+of)?\b",
+        bounded,
+        flags=re.IGNORECASE,
+    ):
         normalized_history = _normalize_written_section_marker(
-            re.sub(r"^by\s+", "", bounded, flags=re.IGNORECASE)
+            re.sub(r"^(?:by\s+|\.\s*)", "", bounded, flags=re.IGNORECASE)
         )
         history = _LOUISIANA_SESSION_LAW_CITATION.match(normalized_history)
         if history is None or history.start() != 0:
@@ -10935,6 +10977,7 @@ def authoritative_numeric_recall_text(source_text: str) -> str:
 
     cleaned = _strip_terminal_session_law_history(source_text)
     cleaned = _LOUISIANA_SESSION_LAW_CITATION.sub("", cleaned)
+    cleaned = _LOUISIANA_RS_NUMERIC_RECALL_CITATION.sub("", cleaned)
     cleaned = _GERMAN_LEGAL_CITATION.sub("", cleaned)
     cleaned = _TITLE_SUFFIX_LEGAL_CITATION.sub("", cleaned)
     cleaned = _ENGLISH_LEGAL_CITATION.sub("", cleaned)

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -1684,8 +1684,9 @@ Complete-source-unit mode is enabled for this request:
   current legal branch and affirmatively state that it is repealed. Do not
   fabricate an executable rule, input, runtime gap, or external blocker. Use
   the bounded reason form `<exact branch citation> is repealed.`, optionally
-  adding only the authenticated Acts citation/effective date and/or `and
-  supplies no operative rule`; never qualify, report, or retract the assertion.
+  adding the exact authenticated history either as `is repealed by <Acts
+  citation>.` or as `is repealed. <Acts citation>.`, and/or adding `and supplies
+  no operative rule`; never qualify, report, or retract the assertion.
 - For a Louisiana branch that computes tax at rates provided in another R.S.
   section, use the bounded missing-export clause `no executable RuleSpec output
   for those <source-stated modifiers> rates is supplied in the available

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1640"
+ENCODER_VERSION = "0.2.1641"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1640"
+ENCODER_VERSION = "0.2.1641"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1640"
+ENCODER_VERSION = "0.2.1641"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1640"
+ENCODER_VERSION = "0.2.1641"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1640"
+ENCODER_VERSION = "0.2.1641"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1640"
+ENCODER_VERSION = "0.2.1641"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1640"
+ENCODER_VERSION = "0.2.1641"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5926,7 +5926,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1640"')
+        .startswith('__version__ = "0.2.1641"')
     )
 
 
@@ -6158,13 +6158,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1640"
+    assert encoder_package["version"] == "0.2.1641"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1640"
+    assert project["project"]["version"] == "0.2.1641"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1640"')
+        .startswith('__version__ = "0.2.1641"')
     )
 
 
@@ -6426,13 +6426,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1640"
+    assert encoder_package["version"] == "0.2.1641"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1640"
+    assert project["project"]["version"] == "0.2.1641"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1640"')
+        .startswith('__version__ = "0.2.1641"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1640"
+ENCODER_VERSION = "0.2.1641"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -6814,7 +6814,8 @@ def test_precise_root_state_deferral_retry_preserves_branch_in_output_path():
         "`us-la:statutes/47/295/c#federal_return_copy_becomes_part_of_state_return`"
         in issue
     )
-    assert "`us-la/statute/47:295(c)`" in issue
+    assert "branch citation in `reason` is already recognized" in issue
+    assert "literal canonical citation required" not in issue
 
 
 def test_root_deferral_retry_preserves_uppercase_federal_subparagraph():
@@ -7408,8 +7409,8 @@ module:
   deferred_outputs:
     - output: us-la:statutes/47/32/b#repealed_subsection
       reason: >-
-        La. R.S. 47:32(B) is repealed by Acts 2024, 3rd Ex. Sess., No. 11,
-        section 4, effective December 4, 2024, and supplies no operative rule.
+        La. R.S. 47:32(B) is repealed. Acts 2024, 3rd Ex. Sess., No. 11,
+        section 4, effective December 4, 2024.
     - output: us-la:statutes/47/32/c#corporate_income_tax_rate
       reason: >-
         La. R.S. 47:32(C) requires corporation taxable-income tax to be computed
@@ -7447,6 +7448,121 @@ be computed at the rates provided for in R.S. 47:287.12.
     assert not _has_issue(result, "source branch c", "neither encoded")
     assert not _has_issue(result, "deferred_outputs[0]", "deferral")
     assert not _has_issue(result, "deferred_outputs[1]", "deferral")
+    assert not _has_issue(result, "numeric-recall")
+
+
+@pytest.mark.parametrize(
+    "citation",
+    (
+        "R.S. 47:287.12",
+        "R.S.\n47:287.12",
+        "La. R.S. 47:287.12",
+        "LSA-R.S. 47:287.12",
+        "R.S. § 47:287.12",
+        "R.S. 47:287.12.1",
+        "R.S. 47:287-287.15",
+        "R.S. 47:287.12(C)(1)",
+    ),
+)
+def test_louisiana_rs_cross_reference_is_not_numeric_recall(citation: str):
+    cleaned = authoritative_numeric_recall_text(
+        f"The corporation rate is provided in {citation}."
+    )
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        cleaned,
+        profile="legacy",
+    )
+
+    assert inventory == []
+
+
+def test_louisiana_rs_cross_reference_does_not_hide_policy_values():
+    cleaned = authoritative_numeric_recall_text(
+        "The multiplier is 0.12 under R.S.\n47:287.12; the cap is 500 dollars."
+    )
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        cleaned,
+        profile="legacy",
+    )
+
+    assert [occurrence.value for occurrence in inventory] == [0.12, 500.0]
+
+
+@pytest.mark.parametrize(
+    "citation_list",
+    (
+        "R.S. 47:287.12, 47:287.13",
+        "R.S. 47:287.12, and 47:287.13",
+        "R.S. 47:287.12 and 47:287.13",
+        "R.S. 47:287.12 and/or 47:287.13",
+        "R.S. 47:287.12 or 47:287.13",
+        "R.S. 47:287.12 & 47:287.13",
+        "R.S. 47:287.12 through 47:287.15",
+        "R.S. 47:287.12 to 47:287.15",
+    ),
+)
+def test_louisiana_rs_cross_reference_lists_are_not_numeric_recall(
+    citation_list: str,
+):
+    cleaned = authoritative_numeric_recall_text(
+        f"The rates are provided in {citation_list}; the cap is 500 dollars."
+    )
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        cleaned,
+        profile="legacy",
+    )
+
+    assert [occurrence.value for occurrence in inventory] == [500.0]
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "Apply R.S. 47:287.12 and a 0.12 multiplier.",
+        "Apply R.S. 47:287.12 and/or 47 dollars.",
+        "Apply R.S. 47:287.12 & 47 dollars.",
+    ),
+)
+def test_louisiana_rs_cross_reference_list_connector_does_not_hide_policy_value(
+    source: str,
+):
+    cleaned = authoritative_numeric_recall_text(source)
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        cleaned,
+        profile="legacy",
+    )
+
+    expected = 0.12 if "multiplier" in source else 47.0
+    assert [occurrence.value for occurrence in inventory] == [expected]
+
+
+def test_bare_louisiana_number_shape_is_not_suppressed_as_a_citation():
+    cleaned = authoritative_numeric_recall_text("Bare 47:287.12 value.")
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        cleaned,
+        profile="legacy",
+    )
+
+    assert [(occurrence.value, occurrence.raw) for occurrence in inventory] == [
+        (47.0, "47")
+    ]
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "Under R.S. 47:287.12 (500 dollars), the multiplier is 0.12.",
+        "Under R.S. 47:287.12 (500), the multiplier is 0.12.",
+    ),
+)
+def test_louisiana_rs_citation_does_not_consume_parenthetical_values(source: str):
+    cleaned = authoritative_numeric_recall_text(source)
+    inventory = extract_typed_numeric_inventory_occurrences_from_text(
+        cleaned,
+        profile="legacy",
+    )
+
+    assert [occurrence.value for occurrence in inventory] == [500.0, 0.12]
 
 
 def test_louisiana_delegated_rate_accepts_archived_comma_reason():
@@ -7814,6 +7930,16 @@ C. Placeholder.
             "La. R.S. 47:32(B) is repealed by Acts 2024, No. 12, effective "
             "December 5, 2024."
         ),
+        (
+            "La. R.S. 47:32(B) is repealed. Acts 1999, No. 999, §7, effective "
+            "January 1, 2000."
+        ),
+        (
+            "La. R.S. 47:32(B) is repealed. Acts 2024, No. 12, effective "
+            "December 5, 2024."
+        ),
+        ("La. R.S. 47:32(B) is repealed. Acts 2024, No. 11. It remains operative."),
+        ("La. R.S. 47:32(B) is repealed. A report cites Acts 2024, No. 11."),
     ),
 )
 def test_repeal_coverage_requires_affirmative_reason(reason: str):
@@ -7837,6 +7963,35 @@ rules: []
     )
 
     assert _has_issue(result, "deferred_outputs[0]", "deferral")
+
+
+def test_repeal_retry_feedback_preserves_recognized_louisiana_citation():
+    content = """\
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-la/statute/47:32
+  deferred_outputs:
+    - output: us-la:statutes/47/32/b#repealed_subsection
+      reason: >-
+        La. R.S. 47:32(B) is repealed. A report cites Acts 2024, No. 11.
+rules: []
+"""
+
+    result = _analyze(
+        content,
+        "B. Repealed by Acts 2024, No. 11.",
+        corpus_citation_path="us-la/statute/47:32",
+        test_cases=[],
+    )
+    feedback = next(
+        issue
+        for issue in result.issues
+        if "deferred_outputs[0]" in issue and "deferral" in issue
+    )
+
+    assert "branch citation in `reason` is already recognized" in feedback
+    assert "literal canonical citation required" not in feedback
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1640"
+version = "0.2.1641"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- exclude strongly prefixed Louisiana R.S. cross-references, including bounded full-citation lists and ranges, from scalar numeric recall
- preserve nearby decimal, whole-number, and parenthetical policy values
- accept exact source-authenticated split-sentence Louisiana repeal histories and keep recognized branch citations in retry feedback
- align encoder/eval instructions and bump the coordinated encoder version to 0.2.1641

## Why

Fresh targeted run 31269015959 compiled all four Louisiana 47:32 candidates but exposed two deterministic complete-source validation defects: `R.S. 47:287.12` was treated as scalar `0.12`, and the authenticated `is repealed. Acts ...` history form was rejected. This fixes those validator contracts; it does not alter workflow dispatching, approval, signing, or repair semantics.

## Validation

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run ruff format --check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest --no-cov -q`: 11,548 passed, 119 skipped
- `tests/test_source_completeness.py`: 5,314 passed
- prompt/version/oracle slice: 1,475 passed, 31 skipped
- archived Terra and Sol candidates: zero complete-source issues under the production `legacy` numeric profile

## Review cycle

Two independent reviewers examined the exact final tree. Review findings about full-citation lists/ranges and the `and/or`/`&` connectors were fixed with adversarial amount-preservation tests. The repeated final review found no actionable issues. Both reviewers confirmed squashed commit `1dade53bd` is tree-identical to the reviewed final tree.
