### PR TITLE
Migrate legacy exact-dependent source verification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1641"
+version = "0.2.1642"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -26,6 +26,7 @@ LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V1 = "axiom-encode/legacy-fresh-reencode-recei
 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2 = "axiom-encode/legacy-fresh-reencode-receipt/v2"
 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3 = "axiom-encode/legacy-fresh-reencode-receipt/v3"
 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4 = "axiom-encode/legacy-fresh-reencode-receipt/v4"
+LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5 = "axiom-encode/legacy-fresh-reencode-receipt/v5"
 LEGACY_EXACT_DEPENDENT_TOOL = (
     "axiom-encode encode --apply --legacy-exact-dependent-rulespec-path"
 )
@@ -1804,7 +1805,10 @@ def _validate_legacy_exact_dependents(
         _repair_proof_import_hashes,
         _strict_legacy_replacement_map,
     )
-    from axiom_encode.legacy_replacement import legacy_receipt_v1_manifest_issues
+    from axiom_encode.legacy_replacement import (
+        legacy_receipt_v1_manifest_issues,
+        migrate_legacy_exact_dependent_source_verification,
+    )
     from axiom_encode.rulespec_path_migration import (
         PathMigrationPlanError,
         rewrite_exact_references,
@@ -1819,16 +1823,42 @@ def _validate_legacy_exact_dependents(
     seen_primaries: set[PurePosixPath] = set()
     seen_group_paths: set[PurePosixPath] = set()
     seen_manifests: set[PurePosixPath] = set()
+    receipt_schema = receipt.get("schema_version")
+    replacement_source = _safe_relative_path(
+        receipt_replacement.get("source"),
+        label=f"{root_manifest}.replacement.source",
+    )
+    replacement_source_raw = _base_regular_blob(
+        repo,
+        base_commit,
+        replacement_source,
+        required=True,
+    )
+    assert replacement_source_raw is not None
+    replacement_source_citations = _legacy_primary_source_citations(
+        replacement_source_raw
+    )
     for index, raw_dependent in enumerate(raw_dependents):
         label = f"{root_manifest} exact_dependents[{index}]"
-        if not isinstance(raw_dependent, dict) or set(raw_dependent) != {
+        expected_dependent_fields = {
             "primary",
             "legacy_manifest",
             "legacy_files",
             "live_files",
             "rewrites",
-        }:
+        }
+        if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5:
+            expected_dependent_fields.add("source_verification_migration")
+        if (
+            not isinstance(raw_dependent, dict)
+            or set(raw_dependent) != expected_dependent_fields
+        ):
             raise ValueError(f"{label} is malformed")
+        receipt_source_verification_migration = (
+            raw_dependent.get("source_verification_migration")
+            if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5
+            else None
+        )
         primary = _safe_relative_path(
             raw_dependent.get("primary"),
             label=f"{label}.primary",
@@ -1941,6 +1971,44 @@ def _validate_legacy_exact_dependents(
                 + "; ".join(legacy_issues)
             )
 
+        expected_source_verification_migration = None
+        source_verification_migration = None
+        if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5:
+            _unused_primary, source_verification_migration = (
+                migrate_legacy_exact_dependent_source_verification(
+                    base_by_path[primary]
+                )
+            )
+            expected_source_verification_migration = (
+                {
+                    "legacy_corpus_citation_paths": list(
+                        source_verification_migration.legacy_corpus_citation_paths
+                    ),
+                    "corpus_citation_path": (
+                        source_verification_migration.corpus_citation_path
+                    ),
+                }
+                if source_verification_migration is not None
+                else None
+            )
+            if (
+                receipt_source_verification_migration
+                != expected_source_verification_migration
+            ):
+                raise ValueError(f"{label}.source_verification_migration differs")
+            if (
+                source_verification_migration is not None
+                and source_verification_migration.corpus_citation_path
+                != (
+                    replacement_source_citations[0]
+                    if replacement_source_citations
+                    else None
+                )
+            ):
+                raise ValueError(
+                    f"{label}.source_verification_migration source differs"
+                )
+
         raw_rewrites = raw_dependent.get("rewrites")
         if not isinstance(raw_rewrites, list) or not raw_rewrites:
             raise ValueError(f"{label}.rewrites is malformed")
@@ -1983,6 +2051,20 @@ def _validate_legacy_exact_dependents(
                 )
                 observed_proof_repairs = 0
                 if rewrite_path == primary:
+                    if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5:
+                        expected_live, observed_source_migration = (
+                            migrate_legacy_exact_dependent_source_verification(
+                                expected_live
+                            )
+                        )
+                        if observed_source_migration != source_verification_migration:
+                            raise ValueError(
+                                f"{label}.source_verification_migration replay differs"
+                            )
+                    elif source_verification_migration is not None:
+                        raise ValueError(
+                            f"{label}.source_verification_migration schema differs"
+                        )
                     content_root = repo / primary.parts[0]
                     expected_text, observed_proof_repairs = _repair_proof_import_hashes(
                         expected_live.decode("utf-8"),
@@ -2006,6 +2088,15 @@ def _validate_legacy_exact_dependents(
             ):
                 raise ValueError(f"{rewrite_label} transformation differs")
             rewrite_paths.add(rewrite_path)
+
+        if (
+            receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5
+            and primary not in rewrite_paths
+            and source_verification_migration is not None
+        ):
+            raise ValueError(
+                f"{label}.source_verification_migration lacks a primary rewrite"
+            )
 
         for path in expected_paths:
             if path in rewrite_paths:
@@ -2164,6 +2255,7 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                     LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
                     LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                     LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+                    LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
                 }
                 or receipt.get("tool") != LEGACY_REPLACEMENT_TOOL
             ):
@@ -2225,7 +2317,10 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
             metadata_reconciliations = receipt_replacement.get(
                 "metadata_reconciliations"
             )
-            if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4:
+            if receipt_schema in {
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+            }:
                 if not isinstance(retained_successors, list) or not isinstance(
                     metadata_reconciliations, list
                 ):
@@ -2252,7 +2347,10 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                 for item in legacy_files
                 if isinstance(item, dict) and item.get("path") not in live_paths
             ]
-            if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4:
+            if receipt_schema in {
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+            }:
                 identity_deleted_files.extend(
                     {"path": item.get("path"), "deleted": True}
                     for successor in retained_successors
@@ -2297,6 +2395,7 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
                     }
                     else None
                 ),
@@ -2306,6 +2405,7 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                     in {
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
                     }
                     else None
                 ),
@@ -2315,17 +2415,26 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                     in {
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
                     }
                     else None
                 ),
                 retained_successors=(
                     retained_successors
-                    if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4
+                    if receipt_schema
+                    in {
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                    }
                     else None
                 ),
                 metadata_reconciliations=(
                     metadata_reconciliations
-                    if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4
+                    if receipt_schema
+                    in {
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                    }
                     else None
                 ),
             )
@@ -2336,6 +2445,7 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
             if receipt_schema in {
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
             } and (
                 not isinstance(
                     receipt_replacement.get("destination_predecessor_class"), str
@@ -2387,6 +2497,7 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
             if receipt_schema in {
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
             }:
                 predecessor_issues = _legacy_destination_predecessor_issues(
                     repo,
@@ -2894,23 +3005,11 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                             f"legacy scheduled dependent retains an old reference: "
                             f"{pending_path}"
                         )
-            inventory_issues = _legacy_replacement_reference_inventory_issues(
-                repo,
-                base_commit=str(base_commit or ""),
-                authoritative_replacements=authoritative_replacements,
-                legacy=legacy,
-                replacement=receipt_replacement,
-                allow_pending_scheduled=False,
-            )
-            if inventory_issues:
-                raise ValueError(
-                    f"legacy replacement reference inventory differs: {relative}: "
-                    + "; ".join(inventory_issues)
-                )
             if receipt_schema in {
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
             }:
                 exact_unchanged_claims = _validate_legacy_exact_dependents(
                     repo,
@@ -2928,6 +3027,19 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                 authenticated_unchanged_claims.update(exact_unchanged_claims)
                 authorized_unchanged.update(
                     path for _manifest, path in exact_unchanged_claims
+                )
+            inventory_issues = _legacy_replacement_reference_inventory_issues(
+                repo,
+                base_commit=str(base_commit or ""),
+                authoritative_replacements=authoritative_replacements,
+                legacy=legacy,
+                replacement=receipt_replacement,
+                allow_pending_scheduled=False,
+            )
+            if inventory_issues:
+                raise ValueError(
+                    f"legacy replacement reference inventory differs: {relative}: "
+                    + "; ".join(inventory_issues)
                 )
             authorized.update({receipt_relative, old_manifest_path, *receipt_rewrites})
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1641"
+__version__ = "0.2.1642"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -296,6 +296,9 @@ from .legacy_replacement import (
     RECEIPT_SCHEMA_V3 as APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
 )
 from .legacy_replacement import (
+    RECEIPT_SCHEMA_V4 as APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+)
+from .legacy_replacement import (
     RETAINED_SUCCESSOR_TOOL as APPLIED_ENCODING_LEGACY_RETAINED_SUCCESSOR_TOOL,
 )
 from .legacy_replacement import (
@@ -330,6 +333,9 @@ from .legacy_replacement import (
 )
 from .legacy_replacement import (
     legacy_v1_manifest_issues as _legacy_v1_manifest_issues,
+)
+from .legacy_replacement import (
+    migrate_legacy_exact_dependent_source_verification as _migrate_legacy_exact_dependent_source_verification,
 )
 from .legacy_replacement import receipt_identity_payload, receipt_identity_sha256
 from .legacy_replacement_overlay import (
@@ -8642,6 +8648,7 @@ def _legacy_replacement_pending_paths(repo_path: Path) -> list[str]:
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V1,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
             }
             or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
@@ -8705,6 +8712,7 @@ def _legacy_replacement_pending_paths(repo_path: Path) -> list[str]:
             continue
         if receipt.get("schema_version") in {
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
+            APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
         } and _legacy_destination_predecessor_issues(
             repo_path,
@@ -8883,6 +8891,7 @@ def _legacy_replacement_pending_paths(repo_path: Path) -> list[str]:
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V1,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
             }
             or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
@@ -22926,7 +22935,10 @@ def _legacy_replacement_manifest_issues(
         )
         if isinstance(item, dict) and item.get("path") not in receipt_live_paths
     ]
-    if receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA:
+    if receipt_schema in {
+        APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+        APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
+    }:
         identity_deleted_files.extend(
             {"path": item.get("path"), "deleted": True}
             for successor in receipt_retained_successors
@@ -22975,6 +22987,7 @@ def _legacy_replacement_manifest_issues(
             in {
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
             }
             else None
@@ -22984,6 +22997,7 @@ def _legacy_replacement_manifest_issues(
             if receipt_schema
             in {
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
             }
             and isinstance(receipt_replacement, dict)
@@ -22997,6 +23011,7 @@ def _legacy_replacement_manifest_issues(
             if receipt_schema
             in {
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
             }
             and isinstance(receipt_replacement, dict)
@@ -23007,12 +23022,20 @@ def _legacy_replacement_manifest_issues(
         ),
         retained_successors=(
             receipt_retained_successors
-            if receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+            if receipt_schema
+            in {
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
+            }
             else None
         ),
         metadata_reconciliations=(
             receipt_replacement.get("metadata_reconciliations")
-            if receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+            if receipt_schema
+            in {
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
+            }
             and isinstance(receipt_replacement, dict)
             and isinstance(receipt_replacement.get("metadata_reconciliations"), list)
             else None
@@ -23030,6 +23053,7 @@ def _legacy_replacement_manifest_issues(
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V1,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
+            APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
         }
         or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
@@ -23130,6 +23154,7 @@ def _legacy_replacement_manifest_issues(
                 in {
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
+                    APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
                 }
                 else set()
@@ -23142,13 +23167,18 @@ def _legacy_replacement_manifest_issues(
                 if receipt_schema
                 in {
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
+                    APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
                 }
                 else set()
             )
             | (
                 {"retained_successors", "metadata_reconciliations"}
-                if receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+                if receipt_schema
+                in {
+                    APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+                    APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
+                }
                 else set()
             )
         )
@@ -23190,6 +23220,7 @@ def _legacy_replacement_manifest_issues(
         ]
     if receipt_schema in {
         APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
+        APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
         APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
     }:
         issues.extend(
@@ -23301,6 +23332,12 @@ def _legacy_replacement_manifest_issues(
         or replacement.get("model_manifest_sha256") != nested_sha256
     ):
         issues.append(f"{manifest_label} nested model manifest binding is stale")
+    try:
+        replacement_source_citations = _legacy_primary_source_citations(
+            _rulespec_migration_base_blob(repo_path, base_commit, Path(str(source)))
+        )
+    except RuntimeError:
+        replacement_source_citations = ()
 
     scheduled = replacement.get("scheduled_dependents")
     seen_scheduled_primaries: set[str] = set()
@@ -23475,16 +23512,18 @@ def _legacy_replacement_manifest_issues(
     seen_exact_primaries: set[str] = set()
     seen_exact_files: set[str] = set()
     for dependent in exact_dependents:
+        expected_dependent_fields = {
+            "primary",
+            "legacy_manifest",
+            "legacy_files",
+            "live_files",
+            "rewrites",
+        }
+        if receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA:
+            expected_dependent_fields.add("source_verification_migration")
         if (
             not isinstance(dependent, dict)
-            or set(dependent)
-            != {
-                "primary",
-                "legacy_manifest",
-                "legacy_files",
-                "live_files",
-                "rewrites",
-            }
+            or set(dependent) != expected_dependent_fields
             or not isinstance(dependent.get("primary"), str)
             or not isinstance(dependent.get("legacy_manifest"), dict)
             or not isinstance(dependent.get("legacy_files"), list)
@@ -23492,6 +23531,31 @@ def _legacy_replacement_manifest_issues(
             or not isinstance(dependent.get("rewrites"), list)
         ):
             issues.append(f"{manifest_label} exact dependent is malformed")
+            continue
+        receipt_source_verification_migration = (
+            dependent.get("source_verification_migration")
+            if receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+            else None
+        )
+        if receipt_source_verification_migration is not None and (
+            not isinstance(receipt_source_verification_migration, dict)
+            or set(receipt_source_verification_migration)
+            != {"legacy_corpus_citation_paths", "corpus_citation_path"}
+            or not isinstance(
+                receipt_source_verification_migration.get(
+                    "legacy_corpus_citation_paths"
+                ),
+                list,
+            )
+            or not isinstance(
+                receipt_source_verification_migration.get("corpus_citation_path"),
+                str,
+            )
+        ):
+            issues.append(
+                f"{manifest_label} exact dependent source-verification migration "
+                "is malformed"
+            )
             continue
         primary = str(dependent["primary"])
         primary_path = Path(primary)
@@ -23641,6 +23705,15 @@ def _legacy_replacement_manifest_issues(
                 rewritten, counts = rewrite_exact_references(
                     base_raw, authoritative_replacements
                 )
+                source_verification_migration = None
+                if (
+                    path == primary_path
+                    and receipt_schema
+                    == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+                ):
+                    rewritten, source_verification_migration = (
+                        _migrate_legacy_exact_dependent_source_verification(rewritten)
+                    )
                 proof_import_repairs = 0
                 if path == primary_path:
                     content_root = repo_path / primary_path.parts[0]
@@ -23659,6 +23732,7 @@ def _legacy_replacement_manifest_issues(
                 RuntimeError,
                 UnsafeCorpusPathError,
                 UnicodeError,
+                ValueError,
                 PathMigrationPlanError,
             ) as exc:
                 issues.append(
@@ -23671,8 +23745,11 @@ def _legacy_replacement_manifest_issues(
                 legacy_hashes[path] != before_sha256
                 or live_hashes[path] != after_sha256
                 or rewritten != live_raw
-                or _migration_corpus_citations(base_raw)
-                != _migration_corpus_citations(live_raw)
+                or (
+                    source_verification_migration is None
+                    and _migration_corpus_citations(base_raw)
+                    != _migration_corpus_citations(live_raw)
+                )
             ):
                 issues.append(
                     f"{manifest_label} exact dependent transformation is stale "
@@ -23711,6 +23788,40 @@ def _legacy_replacement_manifest_issues(
                         f"{manifest_label} exact dependent source history is "
                         f"unverifiable for {path}: {exc}"
                     )
+            if path == primary_path:
+                expected_source_verification_migration = (
+                    {
+                        "legacy_corpus_citation_paths": list(
+                            source_verification_migration.legacy_corpus_citation_paths
+                        ),
+                        "corpus_citation_path": (
+                            source_verification_migration.corpus_citation_path
+                        ),
+                    }
+                    if source_verification_migration is not None
+                    else None
+                )
+                if (
+                    receipt_source_verification_migration
+                    != expected_source_verification_migration
+                ):
+                    issues.append(
+                        f"{manifest_label} exact dependent source-verification "
+                        f"migration proof is stale for {path}"
+                    )
+                if (
+                    source_verification_migration is not None
+                    and source_verification_migration.corpus_citation_path
+                    != (
+                        replacement_source_citations[0]
+                        if replacement_source_citations
+                        else None
+                    )
+                ):
+                    issues.append(
+                        f"{manifest_label} exact dependent singular source differs "
+                        "from the signed replacement source"
+                    )
             if counts:
                 expected_rewrite_paths.add(path)
                 rewrite = rewrite_by_path.get(path)
@@ -23744,6 +23855,15 @@ def _legacy_replacement_manifest_issues(
         if set(rewrite_by_path) != expected_rewrite_paths:
             issues.append(
                 f"{manifest_label} exact dependent rewrite inventory is not exact"
+            )
+        if (
+            receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+            and receipt_source_verification_migration is not None
+            and primary_path not in expected_rewrite_paths
+        ):
+            issues.append(
+                f"{manifest_label} exact dependent source-verification migration "
+                "lacks a primary rewrite"
             )
 
         try:
@@ -24297,6 +24417,7 @@ def _legacy_exact_dependent_manifest_issues(
         not in {
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
+            APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
         }
         or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
@@ -24465,7 +24586,10 @@ def _legacy_retained_successor_manifest_issues(
         not isinstance(receipt, dict)
         or set(receipt) != _LEGACY_REPLACEMENT_RECEIPT_FIELDS
         or receipt.get("schema_version")
-        != APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+        not in {
+            APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+            APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
+        }
         or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
         or receipt_sha256 != binding.get("receipt_sha256")
         or _applied_encoding_manifest_signature_issue(receipt, signing_broker)
@@ -27252,6 +27376,23 @@ def _resolve_legacy_replacement_contract(
             required_mode=0o644,
         )
         rewritten, counts = rewrite_exact_references(raw, replacements)
+        _source_verification_migration = None
+        dependent_primary = dependent_owner.get(relative)
+        if (
+            dependent_primary is not None
+            and dependent_primary in exact_groups
+            and relative == dependent_primary
+            and counts
+        ):
+            try:
+                rewritten, _source_verification_migration = (
+                    _migrate_legacy_exact_dependent_source_verification(rewritten)
+                )
+            except ValueError as exc:
+                raise ValueError(
+                    "legacy exact dependent source verification cannot be migrated "
+                    f"safely for {relative}: {exc}"
+                ) from exc
         if not counts:
             continue
         if relative.parts[: len(manifest_prefix)] == manifest_prefix or any(
@@ -27261,11 +27402,13 @@ def _resolve_legacy_replacement_contract(
                 f"legacy replacement cannot rewrite persisted provenance {relative}"
             )
         if _is_protected_rulespec_yaml_path(relative, roots=roots):
-            dependent_primary = dependent_owner.get(relative)
             if dependent_primary is not None:
                 if dependent_primary in exact_groups:
+                    reference_rewritten, _reference_counts = rewrite_exact_references(
+                        raw, replacements
+                    )
                     if _migration_corpus_citations(raw) != _migration_corpus_citations(
-                        rewritten
+                        reference_rewritten
                     ):
                         raise ValueError(
                             "legacy exact dependent rewrite would alter legal corpus "
@@ -27328,6 +27471,36 @@ def _resolve_legacy_replacement_contract(
 
     exact_dependents: list[_LegacyReplacementExactDependent] = []
     for primary in exact_groups:
+        primary_legacy_file = next(
+            item for item in exact_legacy_files[primary] if item.path == primary
+        )
+        try:
+            _unused_primary_raw, primary_source_migration = (
+                _migrate_legacy_exact_dependent_source_verification(
+                    primary_legacy_file.raw
+                )
+            )
+        except ValueError as exc:
+            raise ValueError(
+                "legacy exact dependent source verification cannot be authenticated "
+                f"for {primary}: {exc}"
+            ) from exc
+        if (
+            primary_source_migration is not None
+            and primary_source_migration.corpus_citation_path
+            != source_unit.citation_path
+        ):
+            raise ValueError(
+                "legacy exact dependent singular source must match the signed "
+                f"replacement source for {primary}"
+            )
+        if primary_source_migration and not any(
+            item.path == primary for item in exact_rewrites_by_primary[primary]
+        ):
+            raise ValueError(
+                "legacy exact dependent plural source verification must be migrated "
+                f"in the authenticated primary reference rewrite: {primary}"
+            )
         rewritten_by_path = {
             item.path: item for item in exact_rewrites_by_primary[primary]
         }
@@ -27354,6 +27527,7 @@ def _resolve_legacy_replacement_contract(
                 legacy_files=exact_legacy_files[primary],
                 live_files=live_files,
                 rewrites=tuple(exact_rewrites_by_primary[primary]),
+                source_verification_migration=primary_source_migration,
             )
         )
 
@@ -48759,6 +48933,18 @@ def _build_apply_validation_snapshot(
                         {"path": item.path.as_posix(), "sha256": item.sha256}
                         for item in dependent.live_files
                     ],
+                    "source_verification_migration": (
+                        {
+                            "legacy_corpus_citation_paths": list(
+                                dependent.source_verification_migration.legacy_corpus_citation_paths
+                            ),
+                            "corpus_citation_path": (
+                                dependent.source_verification_migration.corpus_citation_path
+                            ),
+                        }
+                        if dependent.source_verification_migration is not None
+                        else None
+                    ),
                     "rewrites": [
                         {
                             "path": item.path.as_posix(),
@@ -49299,6 +49485,18 @@ def _stage_signed_legacy_replacement_provenance(
                 {"path": item.path.as_posix(), "sha256": item.sha256}
                 for item in dependent.live_files
             ],
+            "source_verification_migration": (
+                {
+                    "legacy_corpus_citation_paths": list(
+                        dependent.source_verification_migration.legacy_corpus_citation_paths
+                    ),
+                    "corpus_citation_path": (
+                        dependent.source_verification_migration.corpus_citation_path
+                    ),
+                }
+                if dependent.source_verification_migration is not None
+                else None
+            ),
             "rewrites": [
                 {
                     "path": item.path.as_posix(),
@@ -54491,6 +54689,26 @@ def _finalize_legacy_exact_dependents_from_overlay(
                     f"{legacy_file.path.as_posix()}"
                 )
                 continue
+            source_verification_migration = None
+            if legacy_file.path == dependent.primary:
+                try:
+                    expected_raw, source_verification_migration = (
+                        _migrate_legacy_exact_dependent_source_verification(
+                            expected_raw
+                        )
+                    )
+                except ValueError as exc:
+                    issues.append(
+                        "Legacy exact dependent source verification cannot be "
+                        f"migrated for {legacy_file.path.as_posix()}: {exc}"
+                    )
+                    continue
+            if source_verification_migration != dependent.source_verification_migration:
+                issues.append(
+                    "Legacy exact dependent source-verification proof is stale for "
+                    f"{legacy_file.path.as_posix()}"
+                )
+                continue
             proof_import_repairs = 0
             if legacy_file.path == dependent.primary:
                 try:
@@ -54507,12 +54725,11 @@ def _finalize_legacy_exact_dependents_from_overlay(
                         f"{legacy_file.path.as_posix()}"
                     )
                     continue
-            if live_raw != expected_raw or _migration_corpus_citations(
-                legacy_file.raw
-            ) != _migration_corpus_citations(live_raw):
+            if live_raw != expected_raw:
                 issues.append(
                     "Legacy exact dependent final transformation is not limited "
-                    "to authenticated reference and proof-import hash rewrites for "
+                    "to authenticated reference, source-verification, and "
+                    "proof-import hash rewrites for "
                     f"{legacy_file.path.as_posix()} "
                     f"(expected {hashlib.sha256(expected_raw).hexdigest()}, "
                     f"found {hashlib.sha256(live_raw).hexdigest()})"

--- a/src/axiom_encode/legacy_replacement.py
+++ b/src/axiom_encode/legacy_replacement.py
@@ -7,12 +7,18 @@ receipt identity used by the CLI's broker-authenticated transaction.
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import re
 from datetime import datetime
 from pathlib import Path
 from typing import Final, Mapping, NamedTuple
+
+import yaml
+from yaml.constructor import ConstructorError
+from yaml.nodes import MappingNode
+from yaml.tokens import AliasToken, AnchorToken
 
 from .corpus_resolver import normalize_corpus_identifier
 
@@ -26,7 +32,8 @@ RETAINED_SUCCESSOR_TOOL: Final = (
 RECEIPT_SCHEMA_V1: Final = "axiom-encode/legacy-fresh-reencode-receipt/v1"
 RECEIPT_SCHEMA_V2: Final = "axiom-encode/legacy-fresh-reencode-receipt/v2"
 RECEIPT_SCHEMA_V3: Final = "axiom-encode/legacy-fresh-reencode-receipt/v3"
-RECEIPT_SCHEMA: Final = "axiom-encode/legacy-fresh-reencode-receipt/v4"
+RECEIPT_SCHEMA_V4: Final = "axiom-encode/legacy-fresh-reencode-receipt/v4"
+RECEIPT_SCHEMA: Final = "axiom-encode/legacy-fresh-reencode-receipt/v5"
 RECEIPT_DIR: Final = ".axiom/legacy-replacements"
 DESTINATION_PREDECESSOR_ABSENT: Final = "absent"
 DESTINATION_PREDECESSOR_CANONICALIZED_UNOWNED_DUPLICATE: Final = (
@@ -71,6 +78,45 @@ LEGACY_GENERATED_GIT_FIELDS: Final = frozenset(
 _SHA256 = re.compile(r"[0-9a-f]{64}")
 
 
+class _UniqueKeySafeLoader(yaml.SafeLoader):
+    """Safe YAML loader that rejects duplicate mapping keys."""
+
+
+def _construct_unique_mapping(
+    loader: _UniqueKeySafeLoader,
+    node: MappingNode,
+    deep: bool = False,
+) -> dict[object, object]:
+    loader.flatten_mapping(node)
+    mapping: dict[object, object] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        try:
+            duplicated = key in mapping
+        except TypeError as exc:
+            raise ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                "found an unhashable mapping key",
+                key_node.start_mark,
+            ) from exc
+        if duplicated:
+            raise ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                f"found duplicate key {key!r}",
+                key_node.start_mark,
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+_UniqueKeySafeLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_unique_mapping,
+)
+
+
 class LegacyReplacementFile(NamedTuple):
     path: Path
     sha256: str
@@ -84,6 +130,11 @@ class LegacyReplacementRewrite(NamedTuple):
     replacements: tuple[dict[str, object], ...]
     raw: bytes
     proof_import_repairs: int = 0
+
+
+class LegacyReplacementSourceVerificationMigration(NamedTuple):
+    legacy_corpus_citation_paths: tuple[str, ...]
+    corpus_citation_path: str
 
 
 class LegacyReplacementPendingFile(NamedTuple):
@@ -103,6 +154,9 @@ class LegacyReplacementExactDependent(NamedTuple):
     legacy_files: tuple[LegacyReplacementFile, ...]
     live_files: tuple[LegacyReplacementFile, ...]
     rewrites: tuple[LegacyReplacementRewrite, ...]
+    source_verification_migration: (
+        LegacyReplacementSourceVerificationMigration | None
+    ) = None
 
 
 class LegacyReplacementRetainedSuccessor(NamedTuple):
@@ -156,6 +210,117 @@ def legacy_source_verification_citation_paths(
     if len(set(normalized)) != len(normalized):
         return ()
     return normalized
+
+
+def migrate_legacy_exact_dependent_source_verification(
+    raw: bytes,
+) -> tuple[bytes, LegacyReplacementSourceVerificationMigration | None]:
+    """Canonicalize one authenticated legacy composite source declaration."""
+
+    try:
+        text = raw.decode("utf-8")
+        payload = yaml.load(text, Loader=_UniqueKeySafeLoader)
+    except ConstructorError as exc:
+        raise ValueError(
+            "legacy exact dependent source verification has an invalid mapping: "
+            f"{exc.problem}"
+        ) from exc
+    except (UnicodeError, yaml.YAMLError, RecursionError) as exc:
+        raise ValueError(
+            "legacy exact dependent source verification is not valid UTF-8 YAML"
+        ) from exc
+    module = payload.get("module") if isinstance(payload, dict) else None
+    verification = (
+        module.get("source_verification") if isinstance(module, dict) else None
+    )
+    if not isinstance(verification, dict):
+        return raw, None
+    if "corpus_citation_paths" not in verification:
+        return raw, None
+    try:
+        tokens = tuple(yaml.scan(text))
+        if any(isinstance(token, (AnchorToken, AliasToken)) for token in tokens):
+            raise ValueError(
+                "legacy exact dependent source verification cannot contain YAML "
+                "anchors or aliases"
+            )
+    except (yaml.YAMLError, RecursionError) as exc:
+        raise ValueError(
+            "legacy exact dependent source verification is not valid YAML"
+        ) from exc
+    if "corpus_citation_path" in verification:
+        raise ValueError(
+            "legacy exact dependent source verification mixes singular and plural "
+            "citation fields"
+        )
+    if "source_sha256" in verification:
+        raise ValueError(
+            "legacy exact dependent plural source verification has an ambiguous "
+            "aggregate source_sha256"
+        )
+    raw_paths = verification.get("corpus_citation_paths")
+    citations = legacy_source_verification_citation_paths(verification)
+    if (
+        not isinstance(raw_paths, list)
+        or not citations
+        or tuple(raw_paths) != citations
+    ):
+        raise ValueError(
+            "legacy exact dependent plural source history is not a unique canonical "
+            "citation list"
+        )
+    upstream = verification.get("upstream_source_check")
+    checked_paths = (
+        upstream.get("checked_paths") if isinstance(upstream, dict) else None
+    )
+    if checked_paths != raw_paths:
+        raise ValueError(
+            "legacy exact dependent plural source history is not preserved exactly "
+            "by upstream_source_check.checked_paths"
+        )
+    if any(
+        not isinstance(path, str)
+        or not path
+        or path.strip() != path
+        or any(character in path for character in "\r\n#'\"")
+        for path in raw_paths
+    ):
+        raise ValueError(
+            "legacy exact dependent plural source history is not in canonical plain "
+            "YAML form"
+        )
+
+    legacy_block = "    corpus_citation_paths:\n" + "".join(
+        f"      - {path}\n" for path in raw_paths
+    )
+    if text.count(legacy_block) != 1:
+        raise ValueError(
+            "legacy exact dependent plural source history does not have one exact "
+            "canonical YAML representation"
+        )
+    migrated_block = f"    corpus_citation_path: {raw_paths[0]}\n"
+    migrated_text = text.replace(legacy_block, migrated_block, 1)
+    try:
+        migrated_payload = yaml.load(migrated_text, Loader=_UniqueKeySafeLoader)
+    except (yaml.YAMLError, RecursionError) as exc:
+        raise ValueError(
+            "legacy exact dependent singular source verification is invalid"
+        ) from exc
+    expected_payload = copy.deepcopy(payload)
+    expected_verification = expected_payload["module"]["source_verification"]
+    del expected_verification["corpus_citation_paths"]
+    expected_verification["corpus_citation_path"] = raw_paths[0]
+    if migrated_payload != expected_payload:
+        raise ValueError(
+            "legacy exact dependent source-verification migration changed unrelated "
+            "RuleSpec structure"
+        )
+    return migrated_text.encode("utf-8"), (
+        LegacyReplacementSourceVerificationMigration(
+            legacy_corpus_citation_paths=tuple(raw_paths),
+            corpus_citation_path=raw_paths[0],
+        )
+    )
 
 
 def legacy_manual_manifest_issues(

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1641"
+ENCODER_VERSION = "0.2.1642"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14664,7 +14664,12 @@ class TestCmdEncode:
             "format: rulespec/v1\n"
             "module:\n"
             "  source_verification:\n"
-            "    corpus_citation_path: us-la/statute/47/32\n"
+            "    corpus_citation_paths:\n"
+            "      - us-la/statute/47/32\n"
+            "    upstream_source_check:\n"
+            "      status: checked_higher_authority\n"
+            "      checked_paths:\n"
+            "        - us-la/statute/47/32\n"
             "  proof_validation:\n"
             "    required: true\n"
             "imports:\n"
@@ -15070,6 +15075,11 @@ class TestCmdEncode:
             assert b"us-la:statutes/47/32#amount" in overlay_bytes
             assert b"us-la:statutes/47:32#amount" not in overlay_bytes
             assert f"hash: sha256:{_sha256_file(generated)}".encode() in overlay_bytes
+            assert b"    corpus_citation_paths:\n" not in overlay_bytes
+            assert (
+                b"    corpus_citation_path: us-la/statute/47/32\n" in overlay_bytes
+            )
+            assert b"      checked_paths:\n" in overlay_bytes
 
         with (
             patch("axiom_encode.cli.ValidatorPipeline"),
@@ -15199,6 +15209,12 @@ class TestCmdEncode:
         assert destination.exists()
         assert destination_test.exists()
         assert b"us-la:statutes/47/32#amount" in dependent.read_bytes()
+        assert b"    corpus_citation_paths:\n" not in dependent.read_bytes()
+        assert (
+            b"    corpus_citation_path: us-la/statute/47/32\n"
+            in dependent.read_bytes()
+        )
+        assert b"      checked_paths:\n" in dependent.read_bytes()
         assert (
             f"hash: sha256:{_sha256_file(destination)}".encode()
             in dependent.read_bytes()
@@ -15246,7 +15262,7 @@ class TestCmdEncode:
         outer = json.loads(destination_manifest.read_text())
         receipt_path = checkout / outer["replacement"]["receipt_path"]
         receipt = json.loads(receipt_path.read_text())
-        assert receipt["schema_version"].endswith("/v4")
+        assert receipt["schema_version"].endswith("/v5")
         assert len(receipt["replacement"]["retained_successors"]) == 4
         assert {
             item["destination"]
@@ -15297,6 +15313,15 @@ class TestCmdEncode:
         exact = exact_by_primary[dependent_relative.as_posix()]
         assert exact["primary"] == dependent_relative.as_posix()
         assert exact["rewrites"][0]["proof_import_repairs"] == 1
+        assert exact["source_verification_migration"] == {
+            "legacy_corpus_citation_paths": ["us-la/statute/47/32"],
+            "corpus_citation_path": "us-la/statute/47/32",
+        }
+        assert (
+            "    corpus_citation_path: us-la/statute/47/32\n" in dependent.read_text()
+        )
+        assert "    corpus_citation_paths:\n" not in dependent.read_text()
+        assert "      checked_paths:\n" in dependent.read_text()
         exact_legacy_hashes = {
             item["path"]: item["sha256"] for item in exact["legacy_files"]
         }
@@ -15485,6 +15510,46 @@ class TestCmdEncode:
             )
         )
         assert any("rewrite proof is stale" in issue for issue in issues)
+
+        destination_manifest.write_bytes(outer_before_tamper)
+        receipt_path.write_bytes(receipt_before_tamper)
+        restore_linked_manifests()
+        tampered_receipt = copy.deepcopy(receipt)
+        tampered_receipt["replacement"]["exact_dependents"][0][
+            "source_verification_migration"
+        ]["corpus_citation_path"] = "us-la/statute/47/294"
+        _sign_applied_encoding_manifest(
+            tampered_receipt,
+            TEST_APPLY_SIGNING_BROKER,
+        )
+        receipt_path.write_text(
+            json.dumps(tampered_receipt, indent=2, sort_keys=True) + "\n"
+        )
+        tampered_receipt_sha256 = hashlib.sha256(receipt_path.read_bytes()).hexdigest()
+        tampered_outer = copy.deepcopy(outer)
+        tampered_outer["replacement"]["receipt_sha256"] = tampered_receipt_sha256
+        _sign_applied_encoding_manifest(
+            tampered_outer,
+            TEST_APPLY_SIGNING_BROKER,
+        )
+        destination_manifest.write_text(
+            json.dumps(tampered_outer, indent=2, sort_keys=True) + "\n"
+        )
+        rebind_linked_manifests(tampered_receipt_sha256)
+        _verified, _root, _digest, issues = (
+            _load_verified_applied_encoding_manifest_payload(
+                checkout,
+                destination_manifest.relative_to(checkout).as_posix(),
+                signing_broker=TEST_APPLY_SIGNING_BROKER,
+                expected_waiver_set_sha256=post_migration_waiver_sha256,
+                expected_encoder_identity=TEST_PINNED_ENCODER_IDENTITY,
+                local_corpus_release=release,
+            )
+        )
+        assert any(
+            "source-verification migration proof is stale" in issue
+            for issue in issues
+        )
 
         destination_manifest.write_bytes(outer_before_tamper)
         receipt_path.write_bytes(receipt_before_tamper)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15076,9 +15076,7 @@ class TestCmdEncode:
             assert b"us-la:statutes/47:32#amount" not in overlay_bytes
             assert f"hash: sha256:{_sha256_file(generated)}".encode() in overlay_bytes
             assert b"    corpus_citation_paths:\n" not in overlay_bytes
-            assert (
-                b"    corpus_citation_path: us-la/statute/47/32\n" in overlay_bytes
-            )
+            assert b"    corpus_citation_path: us-la/statute/47/32\n" in overlay_bytes
             assert b"      checked_paths:\n" in overlay_bytes
 
         with (
@@ -15211,8 +15209,7 @@ class TestCmdEncode:
         assert b"us-la:statutes/47/32#amount" in dependent.read_bytes()
         assert b"    corpus_citation_paths:\n" not in dependent.read_bytes()
         assert (
-            b"    corpus_citation_path: us-la/statute/47/32\n"
-            in dependent.read_bytes()
+            b"    corpus_citation_path: us-la/statute/47/32\n" in dependent.read_bytes()
         )
         assert b"      checked_paths:\n" in dependent.read_bytes()
         assert (
@@ -15547,8 +15544,7 @@ class TestCmdEncode:
             )
         )
         assert any(
-            "source-verification migration proof is stale" in issue
-            for issue in issues
+            "source-verification migration proof is stale" in issue for issue in issues
         )
 
         destination_manifest.write_bytes(outer_before_tamper)

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1641"
+ENCODER_VERSION = "0.2.1642"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1641"
+ENCODER_VERSION = "0.2.1642"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_legacy_replacement.py
+++ b/tests/test_legacy_replacement.py
@@ -1380,6 +1380,11 @@ def _add_exact_dependent(checkout: Path, content_root: Path) -> Path:
         "    corpus_citation_paths:\n"
         "      - us-la/statute/47:32\n"
         "      - us-la/statute/47:294\n"
+        "    upstream_source_check:\n"
+        "      status: checked_higher_authority\n"
+        "      checked_paths:\n"
+        "        - us-la/statute/47:32\n"
+        "        - us-la/statute/47:294\n"
         "imports:\n"
         "  - us-la:statutes/47:32#amount\n"
         "rules: []\n"
@@ -1404,6 +1409,269 @@ def _add_exact_dependent(checkout: Path, content_root: Path) -> Path:
     _git(checkout, "add", ".")
     _git(checkout, "commit", "-qm", "exact dependent")
     return dependent.relative_to(checkout)
+
+
+def test_exact_dependent_source_verification_migration_preserves_full_history() -> None:
+    from axiom_encode.cli import (
+        _migrate_legacy_exact_dependent_source_verification,
+    )
+
+    raw = (
+        "format: rulespec/v1\n"
+        "module:\n"
+        "  source_verification:\n"
+        "    corpus_citation_paths:\n"
+        "      - us-la/statute/47:32\n"
+        "      - us-la/statute/47:294\n"
+        "    upstream_source_check:\n"
+        "      status: checked_higher_authority\n"
+        "      checked_paths:\n"
+        "        - us-la/statute/47:32\n"
+        "        - us-la/statute/47:294\n"
+        "rules:\n"
+        "  - metadata:\n"
+        "      proof:\n"
+        "        atoms:\n"
+        "          - source:\n"
+        "              corpus_citation_path: us-la/statute/47:294\n"
+    ).encode()
+
+    migrated, migration = _migrate_legacy_exact_dependent_source_verification(raw)
+
+    assert migration is not None
+    assert migration.legacy_corpus_citation_paths == (
+        "us-la/statute/47:32",
+        "us-la/statute/47:294",
+    )
+    assert migration.corpus_citation_path == "us-la/statute/47:32"
+    assert migrated == raw.replace(
+        (
+            "    corpus_citation_paths:\n"
+            "      - us-la/statute/47:32\n"
+            "      - us-la/statute/47:294\n"
+        ).encode(),
+        b"    corpus_citation_path: us-la/statute/47:32\n",
+        1,
+    )
+    assert b"      checked_paths:\n" in migrated
+    assert b"              corpus_citation_path: us-la/statute/47:294\n" in migrated
+
+
+@pytest.mark.parametrize(
+    "checked_paths",
+    [
+        "",
+        "      checked_paths:\n        - us-la/statute/47:32\n",
+        (
+            "      checked_paths:\n"
+            "        - us-la/statute/47:294\n"
+            "        - us-la/statute/47:32\n"
+        ),
+    ],
+)
+def test_exact_dependent_source_verification_migration_rejects_unbound_history(
+    checked_paths: str,
+) -> None:
+    from axiom_encode.cli import (
+        _migrate_legacy_exact_dependent_source_verification,
+    )
+
+    raw = (
+        "format: rulespec/v1\n"
+        "module:\n"
+        "  source_verification:\n"
+        "    corpus_citation_paths:\n"
+        "      - us-la/statute/47:32\n"
+        "      - us-la/statute/47:294\n"
+        "    upstream_source_check:\n"
+        "      status: checked_higher_authority\n"
+        f"{checked_paths}"
+        "rules: []\n"
+    ).encode()
+
+    with pytest.raises(ValueError, match="not preserved exactly"):
+        _migrate_legacy_exact_dependent_source_verification(raw)
+
+
+def test_exact_dependent_source_verification_migration_leaves_singular_unchanged() -> (
+    None
+):
+    from axiom_encode.cli import (
+        _migrate_legacy_exact_dependent_source_verification,
+    )
+
+    raw = (
+        "format: rulespec/v1\n"
+        "module:\n"
+        "  source_verification:\n"
+        "    corpus_citation_path: us-la/statute/47:32\n"
+        "rules: []\n"
+    ).encode()
+
+    assert _migrate_legacy_exact_dependent_source_verification(raw) == (raw, None)
+
+
+@pytest.mark.parametrize(
+    ("extra_verification", "match"),
+    [
+        (
+            "    corpus_citation_path: us-la/statute/47:32\n",
+            "mixes singular and plural",
+        ),
+        ("    source_sha256: " + "a" * 64 + "\n", "ambiguous aggregate"),
+    ],
+)
+def test_exact_dependent_source_verification_migration_rejects_ambiguous_primary(
+    extra_verification: str,
+    match: str,
+) -> None:
+    from axiom_encode.cli import (
+        _migrate_legacy_exact_dependent_source_verification,
+    )
+
+    raw = (
+        "format: rulespec/v1\n"
+        "module:\n"
+        "  source_verification:\n"
+        "    corpus_citation_paths:\n"
+        "      - us-la/statute/47:32\n"
+        f"{extra_verification}"
+        "    upstream_source_check:\n"
+        "      checked_paths:\n"
+        "        - us-la/statute/47:32\n"
+        "rules: []\n"
+    ).encode()
+
+    with pytest.raises(ValueError, match=match):
+        _migrate_legacy_exact_dependent_source_verification(raw)
+
+
+def test_exact_dependent_source_verification_migration_rejects_duplicate_history() -> (
+    None
+):
+    from axiom_encode.cli import (
+        _migrate_legacy_exact_dependent_source_verification,
+    )
+
+    raw = (
+        "format: rulespec/v1\n"
+        "module:\n"
+        "  source_verification:\n"
+        "    corpus_citation_paths:\n"
+        "      - us-la/statute/47:32\n"
+        "      - us-la/statute/47:32\n"
+        "    upstream_source_check:\n"
+        "      checked_paths:\n"
+        "        - us-la/statute/47:32\n"
+        "        - us-la/statute/47:32\n"
+        "rules: []\n"
+    ).encode()
+
+    with pytest.raises(ValueError, match="not a unique canonical citation list"):
+        _migrate_legacy_exact_dependent_source_verification(raw)
+
+
+def test_exact_dependent_source_verification_migration_keeps_singular_aliases() -> None:
+    from axiom_encode.cli import (
+        _migrate_legacy_exact_dependent_source_verification,
+    )
+
+    raw = (
+        "format: rulespec/v1\n"
+        "module:\n"
+        "  source_verification:\n"
+        "    corpus_citation_path: &citation us-la/statute/47:32\n"
+        "rules:\n"
+        "  - metadata:\n"
+        "      proof:\n"
+        "        atoms:\n"
+        "          - source: *citation\n"
+    ).encode()
+
+    migrated, migration = _migrate_legacy_exact_dependent_source_verification(raw)
+
+    assert migrated == raw
+    assert migration is None
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        (
+            "format: rulespec/v1\n"
+            "module:\n"
+            "  source_verification:\n"
+            "    corpus_citation_path: us-la/statute/47:32\n"
+            "    corpus_citation_path: us-la/statute/47:294\n"
+            "rules: []\n"
+        ).encode(),
+        (
+            "format: rulespec/v1\n"
+            "module:\n"
+            "  source_verification:\n"
+            "    corpus_citation_paths:\n"
+            "      - us-la/statute/47:32\n"
+            "  source_verification:\n"
+            "    corpus_citation_path: us-la/statute/47:294\n"
+            "rules: []\n"
+        ).encode(),
+    ],
+)
+def test_exact_dependent_source_verification_migration_rejects_noop_duplicate_keys(
+    raw: bytes,
+) -> None:
+    from axiom_encode.cli import (
+        _migrate_legacy_exact_dependent_source_verification,
+    )
+
+    with pytest.raises(ValueError, match="duplicate key"):
+        _migrate_legacy_exact_dependent_source_verification(raw)
+
+
+def test_exact_dependent_source_verification_migration_rejects_yaml_aliases() -> None:
+    from axiom_encode.cli import (
+        _migrate_legacy_exact_dependent_source_verification,
+    )
+
+    raw = (
+        "format: rulespec/v1\n"
+        "module:\n"
+        "  source_verification: &verification\n"
+        "    corpus_citation_paths:\n"
+        "      - us-la/statute/47:32\n"
+        "    upstream_source_check:\n"
+        "      checked_paths:\n"
+        "        - us-la/statute/47:32\n"
+        "unrelated_audit_copy: *verification\n"
+        "rules: []\n"
+    ).encode()
+
+    with pytest.raises(ValueError, match="cannot contain YAML anchors or aliases"):
+        _migrate_legacy_exact_dependent_source_verification(raw)
+
+
+def test_exact_dependent_source_verification_migration_rejects_duplicate_keys() -> None:
+    from axiom_encode.cli import (
+        _migrate_legacy_exact_dependent_source_verification,
+    )
+
+    raw = (
+        "format: rulespec/v1\n"
+        "module:\n"
+        "  source_verification:\n"
+        "    corpus_citation_paths:\n"
+        "      - us-la/statute/47:32\n"
+        "    upstream_source_check:\n"
+        "      checked_paths:\n"
+        "        - us-la/statute/47:32\n"
+        "    upstream_source_check:\n"
+        "      checked_paths:\n"
+        "        - us-la/statute/47:32\n"
+        "rules: []\n"
+    ).encode()
+
+    with pytest.raises(ValueError, match="duplicate key"):
+        _migrate_legacy_exact_dependent_source_verification(raw)
 
 
 def test_contract_binds_exact_composite_dependent_to_clean_base(
@@ -1439,6 +1707,14 @@ def test_contract_binds_exact_composite_dependent_to_clean_base(
     assert b"us-la:statutes/47/32#amount" in next(
         item.raw for item in exact.live_files if item.path == dependent
     )
+    live_primary = next(item.raw for item in exact.live_files if item.path == dependent)
+    assert b"    corpus_citation_path: us-la/statute/47:32\n" in live_primary
+    assert b"    corpus_citation_paths:\n" not in live_primary
+    assert b"      checked_paths:\n" in live_primary
+    assert exact.source_verification_migration is not None
+    assert exact.source_verification_migration.corpus_citation_path == (
+        "us-la/statute/47:32"
+    )
     assert next(
         item.sha256
         for item in exact.legacy_files
@@ -1448,6 +1724,50 @@ def test_contract_binds_exact_composite_dependent_to_clean_base(
         for item in exact.live_files
         if item.path.name.endswith(".test.yaml")
     )
+
+
+def test_contract_rejects_exact_dependent_primary_outside_signed_source(
+    tmp_path: Path,
+) -> None:
+    checkout, content_root, source = _legacy_checkout(tmp_path)
+    dependent = _add_exact_dependent(checkout, content_root)
+    dependent_path = checkout / dependent
+    dependent_path.write_text(
+        dependent_path.read_text()
+        .replace(
+            ("      - us-la/statute/47:32\n      - us-la/statute/47:294\n"),
+            ("      - us-la/statute/47:294\n      - us-la/statute/47:32\n"),
+        )
+        .replace(
+            ("        - us-la/statute/47:32\n        - us-la/statute/47:294\n"),
+            ("        - us-la/statute/47:294\n        - us-la/statute/47:32\n"),
+        )
+    )
+    manifest = (
+        checkout
+        / ".axiom/encoding-manifests/us-la/policies/income_tax/2026_resident_core.json"
+    )
+    payload = json.loads(manifest.read_text())
+    for applied in payload["applied_files"]:
+        applied_path = checkout / applied["path"]
+        applied["sha256"] = hashlib.sha256(applied_path.read_bytes()).hexdigest()
+    manifest.write_text(json.dumps(payload) + "\n")
+    _git(checkout, "add", ".")
+    _git(checkout, "commit", "-qm", "reordered exact dependent source history")
+
+    with (
+        patch("axiom_encode.cli.resolve_corpus_source_unit", return_value=source),
+        pytest.raises(ValueError, match="must match the signed replacement source"),
+    ):
+        _resolve_legacy_replacement_contract(
+            source_raw=Path("us-la/statutes/47:32.yaml"),
+            destination_raw=Path("us-la/statutes/47/32.yaml"),
+            policy_checkout_path=checkout,
+            policy_repo_path=content_root,
+            source_unit=source,
+            corpus_release=SimpleNamespace(),
+            exact_dependent_paths=(dependent,),
+        )
 
 
 def test_contract_rejects_exact_dependent_without_v1_ownership(

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1641"
+ENCODER_VERSION = "0.2.1642"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1641"
+ENCODER_VERSION = "0.2.1642"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1641"
+ENCODER_VERSION = "0.2.1642"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1641"
+ENCODER_VERSION = "0.2.1642"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -11,6 +11,7 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 from axiom_encode.cli import _legacy_replacement_manifest_issues
 from axiom_encode.legacy_replacement import (
+    migrate_legacy_exact_dependent_source_verification,
     receipt_identity_payload,
     receipt_identity_sha256,
 )
@@ -1179,7 +1180,10 @@ def _legacy_receipt_identity(receipt: dict[str, object]) -> dict[str, object]:
     ]
     schema = receipt["schema_version"]
     retained_successors = replacement.get("retained_successors")
-    if schema == "axiom-encode/legacy-fresh-reencode-receipt/v4":
+    if schema in {
+        "axiom-encode/legacy-fresh-reencode-receipt/v4",
+        "axiom-encode/legacy-fresh-reencode-receipt/v5",
+    }:
         assert isinstance(retained_successors, list)
         deleted_files.extend(
             {"path": item["path"], "deleted": True}
@@ -1204,6 +1208,7 @@ def _legacy_receipt_identity(receipt: dict[str, object]) -> dict[str, object]:
                 "axiom-encode/legacy-fresh-reencode-receipt/v2",
                 "axiom-encode/legacy-fresh-reencode-receipt/v3",
                 "axiom-encode/legacy-fresh-reencode-receipt/v4",
+                "axiom-encode/legacy-fresh-reencode-receipt/v5",
             }
             else None
         ),
@@ -1213,6 +1218,7 @@ def _legacy_receipt_identity(receipt: dict[str, object]) -> dict[str, object]:
             in {
                 "axiom-encode/legacy-fresh-reencode-receipt/v3",
                 "axiom-encode/legacy-fresh-reencode-receipt/v4",
+                "axiom-encode/legacy-fresh-reencode-receipt/v5",
             }
             else None
         ),
@@ -1222,17 +1228,26 @@ def _legacy_receipt_identity(receipt: dict[str, object]) -> dict[str, object]:
             in {
                 "axiom-encode/legacy-fresh-reencode-receipt/v3",
                 "axiom-encode/legacy-fresh-reencode-receipt/v4",
+                "axiom-encode/legacy-fresh-reencode-receipt/v5",
             }
             else None
         ),
         retained_successors=(
             retained_successors
-            if schema == "axiom-encode/legacy-fresh-reencode-receipt/v4"
+            if schema
+            in {
+                "axiom-encode/legacy-fresh-reencode-receipt/v4",
+                "axiom-encode/legacy-fresh-reencode-receipt/v5",
+            }
             else None
         ),
         metadata_reconciliations=(
             replacement["metadata_reconciliations"]
-            if schema == "axiom-encode/legacy-fresh-reencode-receipt/v4"
+            if schema
+            in {
+                "axiom-encode/legacy-fresh-reencode-receipt/v4",
+                "axiom-encode/legacy-fresh-reencode-receipt/v5",
+            }
             else None
         ),
     )
@@ -1246,6 +1261,8 @@ def _write_legacy_replacement_change(
     omitted_scheduled_companion: bool = False,
     exact_dependent: bool = False,
     generated_exact_dependent: bool = False,
+    plural_exact_dependent: bool = False,
+    companion_only_plural_exact_dependent: bool = False,
     destination_predecessor: bool = False,
     retained_successor: bool = False,
     legacy_owner_class: str = "v1-hmac-untrusted",
@@ -1253,7 +1270,18 @@ def _write_legacy_replacement_change(
     old_rule = repo / "us/statutes/47:32.yaml"
     old_test = repo / "us/statutes/47:32.test.yaml"
     old_rule.parent.mkdir(parents=True)
-    old_rule.write_text("rules: []\n", encoding="utf-8")
+    old_rule.write_text(
+        (
+            "format: rulespec/v1\n"
+            "module:\n"
+            "  source_verification:\n"
+            "    corpus_citation_path: us/statute/47/32\n"
+            "rules: []\n"
+        )
+        if plural_exact_dependent
+        else "rules: []\n",
+        encoding="utf-8",
+    )
     old_test.write_text("[]\n", encoding="utf-8")
     old_rule_sha256 = hashlib.sha256(old_rule.read_bytes()).hexdigest()
     old_test_sha256 = hashlib.sha256(old_test.read_bytes()).hexdigest()
@@ -1421,7 +1449,20 @@ def _write_legacy_replacement_change(
                 "  source_verification:\n"
                 "    corpus_citation_path: us/statute/26/1\n"
                 if generated_exact_dependent
-                else ""
+                else (
+                    "module:\n"
+                    "  source_verification:\n"
+                    "    corpus_citation_paths:\n"
+                    "      - us/statute/47/32\n"
+                    "      - us/statute/47/294\n"
+                    "    upstream_source_check:\n"
+                    "      status: checked_higher_authority\n"
+                    "      checked_paths:\n"
+                    "        - us/statute/47/32\n"
+                    "        - us/statute/47/294\n"
+                    if plural_exact_dependent
+                    else ""
+                )
             )
             + "imports:\n"
             "  - us:statutes/47:32#amount\n"
@@ -1444,7 +1485,12 @@ def _write_legacy_replacement_change(
             "        formula: amount\n",
             encoding="utf-8",
         )
-        exact_companion.write_text("[]\n", encoding="utf-8")
+        exact_companion.write_text(
+            "imports:\n  - us:statutes/47:32\n"
+            if companion_only_plural_exact_dependent
+            else "[]\n",
+            encoding="utf-8",
+        )
         exact_manifest.parent.mkdir(parents=True, exist_ok=True)
         exact_applied_files = [
             {
@@ -1534,9 +1580,23 @@ def _write_legacy_replacement_change(
             "'us/statutes/47/294.yaml':\n  reason: canonical\n"
         )
     metadata.write_text('{"module":"us:statutes/47/32"}\n', encoding="utf-8")
-    if exact_dependent:
+    if exact_dependent and not companion_only_plural_exact_dependent:
         exact_primary.write_text(
             exact_primary.read_text(encoding="utf-8").replace(
+                "us:statutes/47:32",
+                "us:statutes/47/32",
+            ),
+            encoding="utf-8",
+        )
+        if plural_exact_dependent:
+            migrated, migration = migrate_legacy_exact_dependent_source_verification(
+                exact_primary.read_bytes()
+            )
+            assert migration is not None
+            exact_primary.write_bytes(migrated)
+    if companion_only_plural_exact_dependent:
+        exact_companion.write_text(
+            exact_companion.read_text(encoding="utf-8").replace(
                 "us:statutes/47:32",
                 "us:statutes/47/32",
             ),
@@ -1546,7 +1606,7 @@ def _write_legacy_replacement_change(
     new_rule.parent.mkdir(parents=True, exist_ok=True)
     new_rule.write_text("format: rulespec/v1\nrules: []\n", encoding="utf-8")
     new_test.write_text("[]\n", encoding="utf-8")
-    if exact_dependent:
+    if exact_dependent and not companion_only_plural_exact_dependent:
         exact_primary.write_text(
             exact_primary.read_text(encoding="utf-8").replace(
                 old_rule_sha256,
@@ -1587,7 +1647,9 @@ def _write_legacy_replacement_change(
     receipt.parent.mkdir(parents=True)
     receipt_payload = {
         "schema_version": (
-            "axiom-encode/legacy-fresh-reencode-receipt/v3"
+            "axiom-encode/legacy-fresh-reencode-receipt/v5"
+            if plural_exact_dependent
+            else "axiom-encode/legacy-fresh-reencode-receipt/v3"
             if destination_predecessor
             else (
                 "axiom-encode/legacy-fresh-reencode-receipt/v2"
@@ -1708,25 +1770,60 @@ def _write_legacy_replacement_change(
                 "live_files": exact_live_files,
                 "rewrites": [
                     {
-                        "path": exact_primary.relative_to(repo).as_posix(),
+                        "path": (
+                            exact_companion.relative_to(repo).as_posix()
+                            if companion_only_plural_exact_dependent
+                            else exact_primary.relative_to(repo).as_posix()
+                        ),
                         "before_sha256": hashlib.sha256(
-                            exact_primary_before
+                            exact_companion_before
+                            if companion_only_plural_exact_dependent
+                            else exact_primary_before
                         ).hexdigest(),
                         "after_sha256": hashlib.sha256(
-                            exact_primary.read_bytes()
+                            exact_companion.read_bytes()
+                            if companion_only_plural_exact_dependent
+                            else exact_primary.read_bytes()
                         ).hexdigest(),
                         "replacements": [
                             {
                                 "from": "us:statutes/47:32",
                                 "to": "us:statutes/47/32",
-                                "count": 2,
+                                "count": (
+                                    1 if companion_only_plural_exact_dependent else 2
+                                ),
                             }
                         ],
-                        "proof_import_repairs": 1,
+                        "proof_import_repairs": (
+                            0 if companion_only_plural_exact_dependent else 1
+                        ),
                     }
                 ],
+                **(
+                    {
+                        "source_verification_migration": (
+                            None
+                            if companion_only_plural_exact_dependent
+                            else {
+                                "legacy_corpus_citation_paths": [
+                                    "us/statute/47/32",
+                                    "us/statute/47/294",
+                                ],
+                                "corpus_citation_path": "us/statute/47/32",
+                            }
+                        )
+                    }
+                    if plural_exact_dependent
+                    else {}
+                ),
             }
         ]
+        if plural_exact_dependent:
+            replacement = receipt_payload["replacement"]
+            replacement["destination_predecessor_class"] = "absent"
+            replacement["destination_predecessor_files"] = []
+            replacement["retained_successors"] = []
+            replacement["metadata_reconciliations"] = []
     if retained_successor:
         retained_metadata_after = retained_metadata.read_bytes()
         receipt_payload["schema_version"] = (
@@ -2346,6 +2443,92 @@ def test_stage_accepts_v2_exact_dependent_with_unchanged_companion(
         "us/policies/income_tax/composite.test.yaml"
         not in _git(repo, "diff", "--cached", "--name-only").splitlines()
     )
+
+
+def test_stage_accepts_v5_singular_exact_dependent_noop_migration(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    manifest, receipt, _old_manifest, _metadata = _write_legacy_replacement_change(
+        repo,
+        exact_dependent=True,
+    )
+    payload = json.loads(receipt.read_text(encoding="utf-8"))
+    payload["schema_version"] = "axiom-encode/legacy-fresh-reencode-receipt/v5"
+    replacement = payload["replacement"]
+    replacement["destination_predecessor_class"] = "absent"
+    replacement["destination_predecessor_files"] = []
+    replacement["retained_successors"] = []
+    replacement["metadata_reconciliations"] = []
+    for dependent in replacement["exact_dependents"]:
+        dependent["source_verification_migration"] = None
+    receipt.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+    _refresh_legacy_receipt_bindings(repo, manifest, receipt)
+
+    authorized_changed_paths(repo)
+
+
+def test_stage_accepts_v5_multi_source_exact_dependent_migration(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    _write_legacy_replacement_change(
+        repo,
+        exact_dependent=True,
+        plural_exact_dependent=True,
+    )
+
+    expected = authorized_changed_paths(repo)
+    stage_authorized_changes(repo)
+
+    primary = repo / "us/policies/income_tax/composite.yaml"
+    primary_text = primary.read_text(encoding="utf-8")
+    assert "    corpus_citation_path: us/statute/47/32\n" in primary_text
+    assert "    corpus_citation_paths:\n" not in primary_text
+    assert "        - us/statute/47/32\n" in primary_text
+    assert "        - us/statute/47/294\n" in primary_text
+    assert PurePosixPath("us/policies/income_tax/composite.yaml") in expected
+
+
+def test_stage_rejects_v5_plural_primary_with_companion_only_rewrite(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    _write_legacy_replacement_change(
+        repo,
+        exact_dependent=True,
+        plural_exact_dependent=True,
+        companion_only_plural_exact_dependent=True,
+    )
+
+    with pytest.raises(ValueError, match="source_verification_migration differs"):
+        authorized_changed_paths(repo)
+
+
+def test_stage_rejects_v5_fabricated_source_verification_migration(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    manifest, receipt, _old_manifest, _metadata = _write_legacy_replacement_change(
+        repo,
+        exact_dependent=True,
+    )
+    payload = json.loads(receipt.read_text(encoding="utf-8"))
+    payload["schema_version"] = "axiom-encode/legacy-fresh-reencode-receipt/v5"
+    replacement = payload["replacement"]
+    replacement["destination_predecessor_class"] = "absent"
+    replacement["destination_predecessor_files"] = []
+    replacement["retained_successors"] = []
+    replacement["metadata_reconciliations"] = []
+    replacement["exact_dependents"][0]["source_verification_migration"] = {
+        "legacy_corpus_citation_paths": ["us/statute/47/32"],
+        "corpus_citation_path": "us/statute/47/32",
+    }
+    receipt.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+    _refresh_legacy_receipt_bindings(repo, manifest, receipt)
+
+    with pytest.raises(ValueError, match="source_verification_migration differs"):
+        authorized_changed_paths(repo)
 
 
 def test_stage_rejects_generated_exact_dependent_under_old_manual_owner_class(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5926,7 +5926,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1641"')
+        .startswith('__version__ = "0.2.1642"')
     )
 
 
@@ -6158,13 +6158,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1641"
+    assert encoder_package["version"] == "0.2.1642"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1641"
+    assert project["project"]["version"] == "0.2.1642"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1641"')
+        .startswith('__version__ = "0.2.1642"')
     )
 
 
@@ -6426,13 +6426,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1641"
+    assert encoder_package["version"] == "0.2.1642"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1641"
+    assert project["project"]["version"] == "0.2.1642"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1641"')
+        .startswith('__version__ = "0.2.1642"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1641"
+ENCODER_VERSION = "0.2.1642"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1641"
+version = "0.2.1642"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- migrate authenticated legacy exact dependents from plural `corpus_citation_paths` to the signed primary `corpus_citation_path` during canonical path replacement
- bind the byte-exact migration plan in v5 replacement receipts and replay it in apply, receipt verification, and signed backfill publication
- preserve v1-v4 receipt behavior and reject ambiguous, aliased, or duplicate-key plural inputs

## Review cycle
- independent review/fix loop completed twice; final reviewers reported no actionable findings
- verified against the production-shaped Louisiana 20-citation source-verification structure

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run pytest` — 11,566 passed, 119 skipped
