### PR TITLE
Reanchor exact dependent proof excerpts safely

### DIFF
--- a/.github/workflows/targeted-signed-reencode.yml
+++ b/.github/workflows/targeted-signed-reencode.yml
@@ -3042,7 +3042,8 @@ jobs:
           else
             "${workflow_python[@]}" \
               axiom-encode/scripts/prepare_signed_backfill.py stage \
-              "$RULESPEC_CHECKOUT"
+              "$RULESPEC_CHECKOUT" \
+              --corpus-root axiom-corpus
             git -C "$RULESPEC_CHECKOUT" \
               -c core.hooksPath=/dev/null \
               -c user.name=axiom-encode-bot \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1642"
+version = "0.2.1643"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/prepare_signed_backfill.py
+++ b/scripts/prepare_signed_backfill.py
@@ -27,6 +27,7 @@ LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2 = "axiom-encode/legacy-fresh-reencode-recei
 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3 = "axiom-encode/legacy-fresh-reencode-receipt/v3"
 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4 = "axiom-encode/legacy-fresh-reencode-receipt/v4"
 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5 = "axiom-encode/legacy-fresh-reencode-receipt/v5"
+LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6 = "axiom-encode/legacy-fresh-reencode-receipt/v6"
 LEGACY_EXACT_DEPENDENT_TOOL = (
     "axiom-encode encode --apply --legacy-exact-dependent-rulespec-path"
 )
@@ -1797,11 +1798,13 @@ def _validate_legacy_exact_dependents(
     live_manifests: set[PurePosixPath],
     manifest_payloads: dict[PurePosixPath, dict[str, object]],
     changed: set[PurePosixPath],
+    corpus_release: object | None,
 ) -> set[tuple[PurePosixPath, PurePosixPath]]:
     """Verify v2 exact dependents and return manifest-bound unchanged claims."""
 
     from axiom_encode.cli import (
         _legacy_primary_source_citations,
+        _reanchor_legacy_exact_dependent_proof_excerpts,
         _repair_proof_import_hashes,
         _strict_legacy_replacement_map,
     )
@@ -1847,7 +1850,10 @@ def _validate_legacy_exact_dependents(
             "live_files",
             "rewrites",
         }
-        if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5:
+        if receipt_schema in {
+            LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+            LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
+        }:
             expected_dependent_fields.add("source_verification_migration")
         if (
             not isinstance(raw_dependent, dict)
@@ -1856,7 +1862,11 @@ def _validate_legacy_exact_dependents(
             raise ValueError(f"{label} is malformed")
         receipt_source_verification_migration = (
             raw_dependent.get("source_verification_migration")
-            if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5
+            if receipt_schema
+            in {
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
+            }
             else None
         )
         primary = _safe_relative_path(
@@ -1973,7 +1983,10 @@ def _validate_legacy_exact_dependents(
 
         expected_source_verification_migration = None
         source_verification_migration = None
-        if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5:
+        if receipt_schema in {
+            LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+            LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
+        }:
             _unused_primary, source_verification_migration = (
                 migrate_legacy_exact_dependent_source_verification(
                     base_by_path[primary]
@@ -2015,13 +2028,16 @@ def _validate_legacy_exact_dependents(
         rewrite_paths: set[PurePosixPath] = set()
         for rewrite_index, rewrite in enumerate(raw_rewrites):
             rewrite_label = f"{label}.rewrites[{rewrite_index}]"
-            if not isinstance(rewrite, dict) or set(rewrite) != {
+            expected_rewrite_fields = {
                 "path",
                 "before_sha256",
                 "after_sha256",
                 "replacements",
                 "proof_import_repairs",
-            }:
+            }
+            if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6:
+                expected_rewrite_fields.add("proof_excerpt_reanchors")
+            if not isinstance(rewrite, dict) or set(rewrite) != expected_rewrite_fields:
                 raise ValueError(f"{rewrite_label} is malformed")
             rewrite_path = _safe_relative_path(
                 rewrite.get("path"),
@@ -2042,6 +2058,10 @@ def _validate_legacy_exact_dependents(
                 or not isinstance(rewrite.get("proof_import_repairs"), int)
                 or isinstance(rewrite.get("proof_import_repairs"), bool)
                 or rewrite["proof_import_repairs"] < 0
+                or (
+                    receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6
+                    and not isinstance(rewrite.get("proof_excerpt_reanchors"), list)
+                )
             ):
                 raise ValueError(f"{rewrite_label} proof is malformed")
             try:
@@ -2051,7 +2071,10 @@ def _validate_legacy_exact_dependents(
                 )
                 observed_proof_repairs = 0
                 if rewrite_path == primary:
-                    if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5:
+                    if receipt_schema in {
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
+                    }:
                         expected_live, observed_source_migration = (
                             migrate_legacy_exact_dependent_source_verification(
                                 expected_live
@@ -2065,6 +2088,24 @@ def _validate_legacy_exact_dependents(
                         raise ValueError(
                             f"{label}.source_verification_migration schema differs"
                         )
+                    if receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6:
+                        if corpus_release is None:
+                            raise ValueError(
+                                f"{rewrite_label} proof-excerpt verification requires "
+                                "the authenticated signed corpus"
+                            )
+                        expected_live, observed_reanchors = (
+                            _reanchor_legacy_exact_dependent_proof_excerpts(
+                                expected_live,
+                                corpus_release=corpus_release,
+                            )
+                        )
+                        if list(observed_reanchors) != rewrite[
+                            "proof_excerpt_reanchors"
+                        ]:
+                            raise ValueError(
+                                f"{rewrite_label} proof-excerpt corpus replay differs"
+                            )
                     content_root = repo / primary.parts[0]
                     expected_text, observed_proof_repairs = _repair_proof_import_hashes(
                         expected_live.decode("utf-8"),
@@ -2076,6 +2117,17 @@ def _validate_legacy_exact_dependents(
                         repo_path=content_root,
                     )
                     expected_live = expected_text.encode("utf-8")
+                elif (
+                    receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6
+                    and rewrite["proof_excerpt_reanchors"]
+                ):
+                    raise ValueError(
+                        f"{rewrite_label} companion has proof-excerpt rewrites"
+                    )
+            except ValueError as exc:
+                raise ValueError(
+                    f"{rewrite_label} transformation is invalid: {exc}"
+                ) from exc
             except (PathMigrationPlanError, UnicodeError) as exc:
                 raise ValueError(f"{rewrite_label} is unreadable") from exc
             if (
@@ -2090,7 +2142,11 @@ def _validate_legacy_exact_dependents(
             rewrite_paths.add(rewrite_path)
 
         if (
-            receipt_schema == LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5
+            receipt_schema
+            in {
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
+            }
             and primary not in rewrite_paths
             and source_verification_migration is not None
         ):
@@ -2164,7 +2220,16 @@ def _validate_legacy_exact_dependents(
     return unchanged_authorized
 
 
-def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
+def authorized_changed_paths(
+    repo: Path,
+    *,
+    corpus_root: Path | None = None,
+) -> set[PurePosixPath]:
+    corpus_release = None
+    if corpus_root is not None:
+        from axiom_encode.toolchain import load_rulespec_local_corpus_release
+
+        corpus_release = load_rulespec_local_corpus_release(repo, corpus_root)
     changed = _changed_paths(repo)
     manifests = {
         path
@@ -2256,6 +2321,7 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                     LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                     LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                     LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                    LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
                 }
                 or receipt.get("tool") != LEGACY_REPLACEMENT_TOOL
             ):
@@ -2320,6 +2386,7 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
             if receipt_schema in {
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
             }:
                 if not isinstance(retained_successors, list) or not isinstance(
                     metadata_reconciliations, list
@@ -2350,6 +2417,7 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
             if receipt_schema in {
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
             }:
                 identity_deleted_files.extend(
                     {"path": item.get("path"), "deleted": True}
@@ -2396,6 +2464,7 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
                     }
                     else None
                 ),
@@ -2406,6 +2475,7 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
                     }
                     else None
                 ),
@@ -2416,6 +2486,7 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
                     }
                     else None
                 ),
@@ -2425,6 +2496,7 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                     in {
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
                     }
                     else None
                 ),
@@ -2434,6 +2506,7 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                     in {
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                         LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                        LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
                     }
                     else None
                 ),
@@ -2446,6 +2519,7 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
             } and (
                 not isinstance(
                     receipt_replacement.get("destination_predecessor_class"), str
@@ -2498,6 +2572,7 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
             }:
                 predecessor_issues = _legacy_destination_predecessor_issues(
                     repo,
@@ -3010,6 +3085,7 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
                 LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V6,
             }:
                 exact_unchanged_claims = _validate_legacy_exact_dependents(
                     repo,
@@ -3023,6 +3099,7 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
                     live_manifests=live_manifests,
                     manifest_payloads=manifest_payloads,
                     changed=changed,
+                    corpus_release=corpus_release,
                 )
                 authenticated_unchanged_claims.update(exact_unchanged_claims)
                 authorized_unchanged.update(
@@ -3130,8 +3207,12 @@ def authorized_changed_paths(repo: Path) -> set[PurePosixPath]:
     return authorized
 
 
-def stage_authorized_changes(repo: Path) -> None:
-    authorized = authorized_changed_paths(repo)
+def stage_authorized_changes(
+    repo: Path,
+    *,
+    corpus_root: Path | None = None,
+) -> None:
+    authorized = authorized_changed_paths(repo, corpus_root=corpus_root)
     subprocess.run(
         [
             "git",
@@ -3183,6 +3264,7 @@ def main() -> None:
     base_parser.add_argument("pr_base_branch", nargs="?", default="main")
     stage_parser = subparsers.add_parser("stage")
     stage_parser.add_argument("repo", type=Path)
+    stage_parser.add_argument("--corpus-root", type=Path)
     cascade_parser = subparsers.add_parser("validate-dependent-cascade")
     cascade_parser.add_argument("repo", type=Path)
     cascade_parser.add_argument("target_citation")
@@ -3410,7 +3492,7 @@ def main() -> None:
                 )
             )
         else:
-            stage_authorized_changes(args.repo)
+            stage_authorized_changes(args.repo, corpus_root=args.corpus_root)
     except (
         OSError,
         ValueError,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1642"
+__version__ = "0.2.1643"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -214,6 +214,7 @@ from .harness.proof_validator import (
     MoneyAtomRatchet,
     ProofValidationResult,
     _rule_source_subsection_scope,
+    _source_contains_proof_evidence,
     emit_money_atom_ratchet,
     evaluate_money_atoms,
     find_noncanonical_corpus_citation_path_issues,
@@ -297,6 +298,9 @@ from .legacy_replacement import (
 )
 from .legacy_replacement import (
     RECEIPT_SCHEMA_V4 as APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+)
+from .legacy_replacement import (
+    RECEIPT_SCHEMA_V5 as APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
 )
 from .legacy_replacement import (
     RETAINED_SUCCESSOR_TOOL as APPLIED_ENCODING_LEGACY_RETAINED_SUCCESSOR_TOOL,
@@ -2328,6 +2332,16 @@ def main():
         type=Path,
         required=True,
         help="Exact canonical rulespec-<country> checkout",
+    )
+    manifest_census_parser.add_argument(
+        "--corpus-path",
+        type=Path,
+        default=None,
+        help=(
+            "Canonical axiom-corpus checkout bound by the RuleSpec toolchain; "
+            "required to census manifests backed by signed-v6 exact-dependent "
+            "replacement receipts"
+        ),
     )
     _add_expected_encoder_checkout_argument(manifest_census_parser)
     manifest_census_parser.add_argument(
@@ -7440,6 +7454,7 @@ def _scheduled_dependent_manifest_issue(
     signing_broker: SigningBroker | Ed25519PublicKey,
     expected_waiver_set_sha256: str,
     expected_encoder_identity: Mapping[str, str],
+    local_corpus_release: LocalCorpusRelease | None = None,
 ) -> str | None:
     """Fully verify the fresh v5 manifest that resolves one scheduled group."""
 
@@ -7468,6 +7483,7 @@ def _scheduled_dependent_manifest_issue(
             signing_broker=signing_broker,
             expected_waiver_set_sha256=expected_waiver_set_sha256,
             expected_encoder_identity=expected_encoder_identity,
+            local_corpus_release=local_corpus_release,
         )
     )
     if verified is None or issues:
@@ -8536,7 +8552,11 @@ def _legacy_replacement_reference_inventory_issues(
     return issues
 
 
-def _legacy_replacement_pending_paths(repo_path: Path) -> list[str]:
+def _legacy_replacement_pending_paths(
+    repo_path: Path,
+    *,
+    local_corpus_release: LocalCorpusRelease | None = None,
+) -> list[str]:
     """Return signed-replacement scheduled files still at their bound base bytes."""
 
     pending: list[str] = []
@@ -8649,6 +8669,7 @@ def _legacy_replacement_pending_paths(repo_path: Path) -> list[str]:
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
             }
             or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
@@ -8713,6 +8734,7 @@ def _legacy_replacement_pending_paths(repo_path: Path) -> list[str]:
         if receipt.get("schema_version") in {
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+            APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
         } and _legacy_destination_predecessor_issues(
             repo_path,
@@ -8857,6 +8879,7 @@ def _legacy_replacement_pending_paths(repo_path: Path) -> list[str]:
                     payload.get(VALIDATION_WAIVER_SET_SHA256_FIELD) or ""
                 ),
                 expected_encoder_identity=expected_encoder_identity,
+                local_corpus_release=local_corpus_release,
             )
             if manifest_issue:
                 pending.append(f"invalid:{primary}")
@@ -8892,6 +8915,7 @@ def _legacy_replacement_pending_paths(repo_path: Path) -> list[str]:
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
             }
             or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
@@ -8907,6 +8931,7 @@ def _manifest_census(
     *,
     roots: tuple[str, ...],
     expected_encoder_checkout: Path | None = None,
+    local_corpus_release: LocalCorpusRelease | None = None,
 ) -> dict[str, object]:
     """Compute model-generated and unmanifested rule-file counts.
 
@@ -8918,7 +8943,10 @@ def _manifest_census(
     rule file.
     """
     repo_path = _resolve_canonical_rulespec_checkout(repo_path)
-    pending_legacy = _legacy_replacement_pending_paths(repo_path)
+    pending_legacy = _legacy_replacement_pending_paths(
+        repo_path,
+        local_corpus_release=local_corpus_release,
+    )
     if pending_legacy:
         raise RuntimeError(
             "manifest census is unavailable while a signed legacy replacement "
@@ -8942,6 +8970,7 @@ def _manifest_census(
             repo_path,
             surviving,
             roots=roots,
+            local_corpus_release=local_corpus_release,
             expected_encoder_identity=expected_encoder_identity,
             path_migration_receipt_proof_cache=(path_migration_receipt_proof_cache),
         )
@@ -8949,6 +8978,7 @@ def _manifest_census(
             repo_path,
             surviving,
             roots=roots,
+            local_corpus_release=local_corpus_release,
             expected_encoder_identity=expected_encoder_identity,
             path_migration_receipt_proof_cache=(path_migration_receipt_proof_cache),
         )
@@ -9014,10 +9044,17 @@ def cmd_manifest_census(args):
         label="RuleSpec checkout",
     )
     roots = tuple(sorted(RULESPEC_ATOMIC_MODULE_ROOTS))
+    corpus_path = args.corpus_path
+    local_corpus_release = (
+        load_rulespec_local_corpus_release(repo_path, Path(corpus_path))
+        if corpus_path is not None
+        else None
+    )
     census = _manifest_census(
         repo_path,
         roots=roots,
         expected_encoder_checkout=getattr(args, "expected_encoder_checkout", None),
+        local_corpus_release=local_corpus_release,
     )
     census["captured_at"] = (
         datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
@@ -12722,6 +12759,7 @@ def _applied_manifest_paths_for_files(
     repo_path: Path,
     *,
     relative_files: set[str],
+    local_corpus_release: LocalCorpusRelease | None = None,
 ) -> set[str]:
     manifest_paths: set[str] = set()
     if not relative_files:
@@ -12736,6 +12774,7 @@ def _applied_manifest_paths_for_files(
             _load_verified_applied_encoding_manifest_payload(
                 repo_path,
                 relative_manifest_path,
+                local_corpus_release=local_corpus_release,
                 expected_encoder_identity=expected_encoder_identity,
                 path_migration_receipt_proof_cache=(path_migration_receipt_proof_cache),
             )
@@ -13210,8 +13249,16 @@ def _ensure_no_unmanifested_preexisting_rulespec_changes(
     if not dirty_targets:
         return
 
+    local_corpus_release = load_rulespec_local_corpus_release(
+        repo_path,
+        corpus_path,
+    )
     relevant_manifest_paths.update(
-        _applied_manifest_paths_for_files(repo_path, relative_files=dirty_targets)
+        _applied_manifest_paths_for_files(
+            repo_path,
+            relative_files=dirty_targets,
+            local_corpus_release=local_corpus_release,
+        )
     )
     changed_metadata_paths = {
         path
@@ -22937,6 +22984,7 @@ def _legacy_replacement_manifest_issues(
     ]
     if receipt_schema in {
         APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+        APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
         APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
     }:
         identity_deleted_files.extend(
@@ -22988,6 +23036,7 @@ def _legacy_replacement_manifest_issues(
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
             }
             else None
@@ -22998,6 +23047,7 @@ def _legacy_replacement_manifest_issues(
             in {
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
             }
             and isinstance(receipt_replacement, dict)
@@ -23012,6 +23062,7 @@ def _legacy_replacement_manifest_issues(
             in {
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
             }
             and isinstance(receipt_replacement, dict)
@@ -23025,6 +23076,7 @@ def _legacy_replacement_manifest_issues(
             if receipt_schema
             in {
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
             }
             else None
@@ -23034,6 +23086,7 @@ def _legacy_replacement_manifest_issues(
             if receipt_schema
             in {
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
                 APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
             }
             and isinstance(receipt_replacement, dict)
@@ -23054,6 +23107,7 @@ def _legacy_replacement_manifest_issues(
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+            APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
         }
         or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
@@ -23155,6 +23209,7 @@ def _legacy_replacement_manifest_issues(
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+                    APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
                 }
                 else set()
@@ -23168,6 +23223,7 @@ def _legacy_replacement_manifest_issues(
                 in {
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+                    APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
                 }
                 else set()
@@ -23177,6 +23233,7 @@ def _legacy_replacement_manifest_issues(
                 if receipt_schema
                 in {
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+                    APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
                     APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
                 }
                 else set()
@@ -23221,6 +23278,7 @@ def _legacy_replacement_manifest_issues(
     if receipt_schema in {
         APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
         APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+        APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
         APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
     }:
         issues.extend(
@@ -23519,7 +23577,10 @@ def _legacy_replacement_manifest_issues(
             "live_files",
             "rewrites",
         }
-        if receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA:
+        if receipt_schema in {
+            APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+            APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
+        }:
             expected_dependent_fields.add("source_verification_migration")
         if (
             not isinstance(dependent, dict)
@@ -23534,7 +23595,11 @@ def _legacy_replacement_manifest_issues(
             continue
         receipt_source_verification_migration = (
             dependent.get("source_verification_migration")
-            if receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+            if receipt_schema
+            in {
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
+            }
             else None
         )
         if receipt_source_verification_migration is not None and (
@@ -23706,13 +23771,39 @@ def _legacy_replacement_manifest_issues(
                     base_raw, authoritative_replacements
                 )
                 source_verification_migration = None
+                if path == primary_path and receipt_schema in {
+                    APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                    APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
+                }:
+                    rewritten, source_verification_migration = (
+                        _migrate_legacy_exact_dependent_source_verification(rewritten)
+                    )
+                proof_excerpt_reanchors: tuple[dict[str, object], ...] = ()
                 if (
                     path == primary_path
                     and receipt_schema
                     == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
                 ):
-                    rewritten, source_verification_migration = (
-                        _migrate_legacy_exact_dependent_source_verification(rewritten)
+                    receipt_rewrite = rewrite_by_path.get(path)
+                    raw_reanchors = (
+                        receipt_rewrite.get("proof_excerpt_reanchors")
+                        if isinstance(receipt_rewrite, dict)
+                        else None
+                    )
+                    if local_corpus_release is None:
+                        raise ValueError(
+                            "v6 exact dependent proof-excerpt verification requires "
+                            "the authenticated signed corpus"
+                        )
+                    if not isinstance(raw_reanchors, list):
+                        raise ValueError(
+                            "v6 exact dependent lacks proof-excerpt replay evidence"
+                        )
+                    rewritten, proof_excerpt_reanchors = (
+                        _reanchor_legacy_exact_dependent_proof_excerpts(
+                            rewritten,
+                            corpus_release=local_corpus_release,
+                        )
                     )
                 proof_import_repairs = 0
                 if path == primary_path:
@@ -23825,20 +23916,28 @@ def _legacy_replacement_manifest_issues(
             if counts:
                 expected_rewrite_paths.add(path)
                 rewrite = rewrite_by_path.get(path)
+                expected_rewrite_fields = {
+                    "path",
+                    "before_sha256",
+                    "after_sha256",
+                    "replacements",
+                    "proof_import_repairs",
+                }
+                if receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA:
+                    expected_rewrite_fields.add("proof_excerpt_reanchors")
                 if (
                     not isinstance(rewrite, dict)
-                    or set(rewrite)
-                    != {
-                        "path",
-                        "before_sha256",
-                        "after_sha256",
-                        "replacements",
-                        "proof_import_repairs",
-                    }
+                    or set(rewrite) != expected_rewrite_fields
                     or rewrite.get("before_sha256") != before_sha256
                     or rewrite.get("after_sha256") != after_sha256
                     or rewrite.get("replacements") != list(counts)
                     or rewrite.get("proof_import_repairs") != proof_import_repairs
+                    or (
+                        receipt_schema
+                        == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+                        and rewrite.get("proof_excerpt_reanchors")
+                        != list(proof_excerpt_reanchors)
+                    )
                     or not isinstance(
                         rewrite.get("proof_import_repairs"),
                         int,
@@ -23857,7 +23956,11 @@ def _legacy_replacement_manifest_issues(
                 f"{manifest_label} exact dependent rewrite inventory is not exact"
             )
         if (
-            receipt_schema == APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA
+            receipt_schema
+            in {
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
+                APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
+            }
             and receipt_source_verification_migration is not None
             and primary_path not in expected_rewrite_paths
         ):
@@ -24418,6 +24521,7 @@ def _legacy_exact_dependent_manifest_issues(
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V2,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V3,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+            APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
         }
         or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
@@ -24588,6 +24692,7 @@ def _legacy_retained_successor_manifest_issues(
         or receipt.get("schema_version")
         not in {
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V4,
+            APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA_V5,
             APPLIED_ENCODING_LEGACY_REPLACEMENT_RECEIPT_SCHEMA,
         }
         or receipt.get("tool") != APPLIED_ENCODING_LEGACY_REPLACEMENT_TOOL
@@ -27377,6 +27482,7 @@ def _resolve_legacy_replacement_contract(
         )
         rewritten, counts = rewrite_exact_references(raw, replacements)
         _source_verification_migration = None
+        proof_excerpt_reanchors: tuple[dict[str, object], ...] = ()
         dependent_primary = dependent_owner.get(relative)
         if (
             dependent_primary is not None
@@ -27388,9 +27494,16 @@ def _resolve_legacy_replacement_contract(
                 rewritten, _source_verification_migration = (
                     _migrate_legacy_exact_dependent_source_verification(rewritten)
                 )
+                rewritten, proof_excerpt_reanchors = (
+                    _reanchor_legacy_exact_dependent_proof_excerpts(
+                        rewritten,
+                        corpus_release=corpus_release,
+                    )
+                )
             except ValueError as exc:
                 raise ValueError(
-                    "legacy exact dependent source verification cannot be migrated "
+                    "legacy exact dependent source verification and proof evidence "
+                    "cannot be migrated "
                     f"safely for {relative}: {exc}"
                 ) from exc
         if not counts:
@@ -27421,6 +27534,7 @@ def _resolve_legacy_replacement_contract(
                             hashlib.sha256(rewritten).hexdigest(),
                             counts,
                             rewritten,
+                            proof_excerpt_reanchors=proof_excerpt_reanchors,
                         )
                     )
                 else:
@@ -37435,6 +37549,297 @@ def _try_repair_generated_nonexact_proof_excerpts(
     if not _install_generated_yaml_payload(rules_file, payload):
         return []
     return repaired
+
+
+def _reanchor_legacy_exact_dependent_proof_excerpts(
+    raw: bytes,
+    *,
+    corpus_release: LocalCorpusRelease,
+) -> tuple[bytes, tuple[dict[str, object], ...]]:
+    """Surgically bind stale exact-dependent excerpts to signed corpus text."""
+
+    try:
+        text = raw.decode("utf-8")
+        payload = yaml.safe_load(text) or {}
+    except (UnicodeError, yaml.YAMLError, RecursionError) as exc:
+        raise ValueError(
+            "legacy exact dependent proof excerpts are not valid UTF-8 YAML"
+        ) from exc
+    if not isinstance(payload, dict):
+        return raw, ()
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return raw, ()
+
+    reanchors: list[dict[str, object]] = []
+    source_bodies: dict[str, str | None] = {}
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        rule_name = str(rule.get("name") or "").strip()
+        atoms = _proof_atoms_from_rule(rule)
+        if not isinstance(atoms, list):
+            continue
+        for atom_index, atom in enumerate(atoms):
+            if not isinstance(atom, dict):
+                continue
+            source = atom.get("source")
+            if not isinstance(source, dict):
+                continue
+            excerpt = source.get("excerpt")
+            citation_path = str(source.get("corpus_citation_path") or "").strip()
+            if not isinstance(excerpt, str) or not excerpt.strip():
+                continue
+            if not citation_path:
+                raise ValueError(
+                    "legacy exact dependent proof excerpt has no corpus citation: "
+                    f"{rule_name}[{atom_index}]"
+                )
+            if citation_path not in source_bodies:
+                source_bodies[citation_path] = _local_corpus_body_for_corpus_path(
+                    citation_path,
+                    corpus_release=corpus_release,
+                )
+            source_body = source_bodies[citation_path]
+            if source_body is None:
+                raise ValueError(
+                    "legacy exact dependent proof excerpt source is absent from the "
+                    f"signed corpus: {rule_name}[{atom_index}]: {citation_path}"
+                )
+            source_has_excerpt = _source_contains_proof_evidence(
+                source_text=source_body,
+                evidence_text=excerpt.strip(),
+            )
+            evidence_body = source_body
+            rule_source = rule.get("source")
+            if _rule_source_subsection_scope(rule_source):
+                scoped_body = _declared_rule_subsection_source_text(
+                    source_body,
+                    rule_source=rule_source,
+                )
+                if scoped_body is not None:
+                    evidence_body = scoped_body
+                elif source_has_excerpt:
+                    continue
+                else:
+                    raise ValueError(
+                        "legacy exact dependent proof excerpt declared subsection "
+                        f"is absent: {rule_name}[{atom_index}]: {citation_path}"
+                    )
+            if _source_contains_proof_evidence(
+                source_text=evidence_body,
+                evidence_text=excerpt.strip(),
+            ):
+                continue
+            query_excerpt = _legacy_exact_dependent_reanchor_query(
+                excerpt,
+                rule_source=rule.get("source"),
+                numeric_profile=_numeric_profile_for_citation_path(citation_path),
+            )
+            if query_excerpt is None:
+                raise ValueError(
+                    "legacy exact dependent proof excerpt contains an ambiguous "
+                    f"ellipsis: {rule_name}[{atom_index}]: {citation_path}"
+                )
+            exact_excerpt = _closest_exact_source_excerpt(
+                source_text=evidence_body,
+                excerpt=query_excerpt,
+                numeric_profile=_numeric_profile_for_citation_path(citation_path),
+                require_all_query_numbers=True,
+            )
+            if exact_excerpt is None or not _source_contains_proof_evidence(
+                source_text=evidence_body,
+                evidence_text=exact_excerpt,
+            ):
+                raise ValueError(
+                    "legacy exact dependent proof excerpt cannot be reanchored "
+                    f"unambiguously: {rule_name}[{atom_index}]: {citation_path}"
+                )
+            reanchors.append(
+                {
+                    "rule": rule_name,
+                    "atom_index": atom_index,
+                    "field": "excerpt",
+                    "corpus_citation_path": citation_path,
+                    "before": excerpt,
+                    "after": exact_excerpt,
+                    "source_body_sha256": hashlib.sha256(
+                        source_body.encode("utf-8")
+                    ).hexdigest(),
+                }
+            )
+
+    if not reanchors:
+        return raw, ()
+    migrated = _apply_legacy_exact_dependent_proof_excerpt_reanchors(
+        raw,
+        tuple(reanchors),
+    )
+    return migrated, tuple(reanchors)
+
+
+_LEGACY_EXACT_PROOF_ELLIPSIS_PATTERN = re.compile(r"(?:\.{3}|\u2026)")
+_LEGACY_EXACT_PROOF_RATE_ELLIPSIS_PATTERN = re.compile(
+    r"(?:\.{3}|\u2026)\s*(?:percent|%)",
+    flags=re.IGNORECASE,
+)
+
+
+def _legacy_exact_dependent_reanchor_query(
+    excerpt: str,
+    *,
+    rule_source: object,
+    numeric_profile: str,
+) -> str | None:
+    """Resolve only an unambiguous rate ellipsis from authenticated rule context."""
+
+    if _LEGACY_EXACT_PROOF_ELLIPSIS_PATTERN.search(excerpt) is None:
+        return excerpt
+    if not isinstance(rule_source, str) or not rule_source.strip():
+        return None
+    rate_occurrences = [
+        occurrence
+        for occurrence in extract_typed_numeric_occurrences_from_text(
+            rule_source,
+            profile=numeric_profile,
+        )
+        if occurrence.has_rate_context
+    ]
+    source_values = {occurrence.source_value for occurrence in rate_occurrences}
+    if len(source_values) != 1:
+        return None
+    rate_occurrence = rate_occurrences[0]
+    query = _LEGACY_EXACT_PROOF_RATE_ELLIPSIS_PATTERN.sub(
+        rate_occurrence.raw,
+        excerpt,
+    )
+    if _LEGACY_EXACT_PROOF_ELLIPSIS_PATTERN.search(query) is not None:
+        return None
+    return query
+
+
+def _apply_legacy_exact_dependent_proof_excerpt_reanchors(
+    raw: bytes,
+    reanchors: Sequence[Mapping[str, object]],
+) -> bytes:
+    """Replay only the exact proof scalar changes bound by a migration receipt."""
+
+    try:
+        text = raw.decode("utf-8")
+        payload = yaml.safe_load(text) or {}
+    except (UnicodeError, yaml.YAMLError, RecursionError) as exc:
+        raise ValueError(
+            "legacy exact dependent proof-excerpt replay input is invalid"
+        ) from exc
+    rules = payload.get("rules") if isinstance(payload, dict) else None
+    if not isinstance(rules, list):
+        if reanchors:
+            raise ValueError("legacy exact dependent proof-excerpt replay has no rules")
+        return raw
+
+    excerpt_spans = _yaml_excerpt_scalar_spans(text)
+    used_span_indexes: set[int] = set()
+    replacements: list[tuple[int, int, str]] = []
+    seen_targets: set[tuple[str, int]] = set()
+    for raw_reanchor in reanchors:
+        if not isinstance(raw_reanchor, Mapping) or set(raw_reanchor) != {
+            "rule",
+            "atom_index",
+            "field",
+            "corpus_citation_path",
+            "before",
+            "after",
+            "source_body_sha256",
+        }:
+            raise ValueError("legacy exact dependent proof-excerpt proof is malformed")
+        rule_name = raw_reanchor.get("rule")
+        atom_index = raw_reanchor.get("atom_index")
+        field = raw_reanchor.get("field")
+        citation_path = raw_reanchor.get("corpus_citation_path")
+        before = raw_reanchor.get("before")
+        after = raw_reanchor.get("after")
+        source_body_sha256 = raw_reanchor.get("source_body_sha256")
+        if (
+            not isinstance(rule_name, str)
+            or not rule_name
+            or not isinstance(atom_index, int)
+            or isinstance(atom_index, bool)
+            or atom_index < 0
+            or field != "excerpt"
+            or not isinstance(citation_path, str)
+            or not citation_path
+            or not isinstance(before, str)
+            or not before
+            or not isinstance(after, str)
+            or not after
+            or before == after
+            or not isinstance(source_body_sha256, str)
+            or _SHA256_HEX_PATTERN.fullmatch(source_body_sha256) is None
+            or (rule_name, atom_index) in seen_targets
+        ):
+            raise ValueError("legacy exact dependent proof-excerpt proof is invalid")
+        seen_targets.add((rule_name, atom_index))
+        matching_rules = [
+            rule
+            for rule in rules
+            if isinstance(rule, dict)
+            and str(rule.get("name") or "").strip() == rule_name
+        ]
+        if len(matching_rules) != 1:
+            raise ValueError(
+                "legacy exact dependent proof-excerpt rule identity is ambiguous"
+            )
+        atoms = _proof_atoms_from_rule(matching_rules[0])
+        if not isinstance(atoms, list) or atom_index >= len(atoms):
+            raise ValueError("legacy exact dependent proof-excerpt atom is absent")
+        atom = atoms[atom_index]
+        source = atom.get("source") if isinstance(atom, dict) else None
+        if (
+            not isinstance(source, dict)
+            or source.get("corpus_citation_path") != citation_path
+            or source.get("excerpt") != before
+        ):
+            raise ValueError("legacy exact dependent proof-excerpt binding is stale")
+        span_index, span = _find_yaml_excerpt_scalar_span(
+            excerpt_spans,
+            rule=rule_name,
+            excerpt=before,
+            used_span_indexes=used_span_indexes,
+        )
+        if span is None:
+            raise ValueError(
+                "legacy exact dependent proof excerpt has no unique scalar span"
+            )
+        used_span_indexes.add(span_index)
+        replacements.append(
+            (
+                span.start,
+                span.end,
+                _render_yaml_excerpt_scalar_like(
+                    text[span.start : span.end],
+                    after,
+                ),
+            )
+        )
+        source["excerpt"] = after
+
+    if not replacements:
+        return raw
+    migrated_text = text
+    for start, end, replacement in sorted(replacements, reverse=True):
+        migrated_text = migrated_text[:start] + replacement + migrated_text[end:]
+    try:
+        migrated_payload = yaml.safe_load(migrated_text) or {}
+    except (yaml.YAMLError, RecursionError) as exc:
+        raise ValueError(
+            "legacy exact dependent proof-excerpt reanchor produced invalid YAML"
+        ) from exc
+    if migrated_payload != payload:
+        raise ValueError(
+            "legacy exact dependent proof-excerpt reanchor changed unrelated "
+            "RuleSpec structure"
+        )
+    return migrated_text.encode("utf-8")
 
 
 def _declared_rule_subsection_source_text(
@@ -48952,6 +49357,9 @@ def _build_apply_validation_snapshot(
                             "after_sha256": item.after_sha256,
                             "replacements": list(item.replacements),
                             "proof_import_repairs": item.proof_import_repairs,
+                            "proof_excerpt_reanchors": list(
+                                item.proof_excerpt_reanchors
+                            ),
                         }
                         for item in dependent.rewrites
                     ],
@@ -49504,6 +49912,7 @@ def _stage_signed_legacy_replacement_provenance(
                     "after_sha256": item.after_sha256,
                     "replacements": list(item.replacements),
                     "proof_import_repairs": item.proof_import_repairs,
+                    "proof_excerpt_reanchors": list(item.proof_excerpt_reanchors),
                 }
                 for item in dependent.rewrites
             ],
@@ -54709,6 +55118,26 @@ def _finalize_legacy_exact_dependents_from_overlay(
                     f"{legacy_file.path.as_posix()}"
                 )
                 continue
+            if legacy_file.path == dependent.primary:
+                try:
+                    expected_raw = (
+                        _apply_legacy_exact_dependent_proof_excerpt_reanchors(
+                            expected_raw,
+                            rewrite.proof_excerpt_reanchors,
+                        )
+                    )
+                except ValueError as exc:
+                    issues.append(
+                        "Legacy exact dependent proof-excerpt proof is stale for "
+                        f"{legacy_file.path.as_posix()}: {exc}"
+                    )
+                    continue
+            elif rewrite.proof_excerpt_reanchors:
+                issues.append(
+                    "Legacy exact dependent companion has proof-excerpt rewrites for "
+                    f"{legacy_file.path.as_posix()}"
+                )
+                continue
             proof_import_repairs = 0
             if legacy_file.path == dependent.primary:
                 try:
@@ -54729,7 +55158,7 @@ def _finalize_legacy_exact_dependents_from_overlay(
                 issues.append(
                     "Legacy exact dependent final transformation is not limited "
                     "to authenticated reference, source-verification, and "
-                    "proof-import hash rewrites for "
+                    "proof-excerpt/proof-import hash rewrites for "
                     f"{legacy_file.path.as_posix()} "
                     f"(expected {hashlib.sha256(expected_raw).hexdigest()}, "
                     f"found {hashlib.sha256(live_raw).hexdigest()})"

--- a/src/axiom_encode/legacy_replacement.py
+++ b/src/axiom_encode/legacy_replacement.py
@@ -33,7 +33,8 @@ RECEIPT_SCHEMA_V1: Final = "axiom-encode/legacy-fresh-reencode-receipt/v1"
 RECEIPT_SCHEMA_V2: Final = "axiom-encode/legacy-fresh-reencode-receipt/v2"
 RECEIPT_SCHEMA_V3: Final = "axiom-encode/legacy-fresh-reencode-receipt/v3"
 RECEIPT_SCHEMA_V4: Final = "axiom-encode/legacy-fresh-reencode-receipt/v4"
-RECEIPT_SCHEMA: Final = "axiom-encode/legacy-fresh-reencode-receipt/v5"
+RECEIPT_SCHEMA_V5: Final = "axiom-encode/legacy-fresh-reencode-receipt/v5"
+RECEIPT_SCHEMA: Final = "axiom-encode/legacy-fresh-reencode-receipt/v6"
 RECEIPT_DIR: Final = ".axiom/legacy-replacements"
 DESTINATION_PREDECESSOR_ABSENT: Final = "absent"
 DESTINATION_PREDECESSOR_CANONICALIZED_UNOWNED_DUPLICATE: Final = (
@@ -130,6 +131,7 @@ class LegacyReplacementRewrite(NamedTuple):
     replacements: tuple[dict[str, object], ...]
     raw: bytes
     proof_import_repairs: int = 0
+    proof_excerpt_reanchors: tuple[dict[str, object], ...] = ()
 
 
 class LegacyReplacementSourceVerificationMigration(NamedTuple):

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1642"
+ENCODER_VERSION = "0.2.1643"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,9 +49,11 @@ from axiom_encode.cli import (
     _applied_encoding_manifest_path,
     _applied_encoding_manifest_signature_issue,
     _applied_encoding_manifest_verifier,
+    _applied_manifest_paths_for_files,
     _applied_manifest_source_attestation_issues,
     _apply_encoder_execution_identity,
     _apply_generated_encoding_result,
+    _apply_legacy_exact_dependent_proof_excerpt_reanchors,
     _build_eval_suite_payload,
     _build_eval_suite_report,
     _canonical_rulespec_compile_path,
@@ -94,6 +96,7 @@ from axiom_encode.cli import (
     _load_verified_applied_encoding_manifest_payload,
     _local_factual_input_names_from_rules_content,
     _looks_like_absolute_rulespec_output_target,
+    _manifest_census,
     _manifest_coverage_by_file,
     _medicaid_magi_income_helper_issue_names,
     _normalize_invalid_proof_atom_kinds,
@@ -107,6 +110,7 @@ from axiom_encode.cli import (
     _qualify_deferred_output_subsection_paths,
     _quoted_review_finding_excerpts,
     _read_only_guard_encoder_execution_identity,
+    _reanchor_legacy_exact_dependent_proof_excerpts,
     _record_successful_apply_validation,
     _recover_apply_transaction,
     _relative_generated_output_path,
@@ -8957,6 +8961,226 @@ rules:
     )
 
 
+def test_reanchor_legacy_exact_dependent_proof_excerpt_binds_signed_body(
+    monkeypatch,
+):
+    citation_path = "us-la/form/it-540i-2026"
+    stale_excerpt = "Enter on Line 3 the Louisiana estimated standard deduction"
+    exact_excerpt = (
+        "3. Enter on Line 3 the Louisiana If your filing status is: estimated "
+        "standard deduction. Single $12,875 Married Filing Joint $25,750 3. 00 "
+        "Married Filing Separate $12,875"
+    )
+    raw = f"""format: rulespec/v1
+rules:
+- name: la_2026_resident_standard_deduction
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: {citation_path}
+          excerpt: {stale_excerpt}
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 0
+""".encode()
+    corpus_release = SimpleNamespace(name="signed-la-release")
+    requested = []
+
+    def source_body(requested_path, *, corpus_release):
+        requested.append((requested_path, corpus_release))
+        return exact_excerpt
+
+    monkeypatch.setattr(
+        "axiom_encode.cli._local_corpus_body_for_corpus_path",
+        source_body,
+    )
+
+    migrated, reanchors = _reanchor_legacy_exact_dependent_proof_excerpts(
+        raw,
+        corpus_release=corpus_release,
+    )
+
+    assert requested == [(citation_path, corpus_release)]
+    assert reanchors == (
+        {
+            "rule": "la_2026_resident_standard_deduction",
+            "atom_index": 0,
+            "field": "excerpt",
+            "corpus_citation_path": citation_path,
+            "before": stale_excerpt,
+            "after": exact_excerpt,
+            "source_body_sha256": hashlib.sha256(exact_excerpt.encode()).hexdigest(),
+        },
+    )
+    assert _apply_legacy_exact_dependent_proof_excerpt_reanchors(raw, reanchors) == (
+        migrated
+    )
+    before_payload = yaml.safe_load(raw)
+    after_payload = yaml.safe_load(migrated)
+    before_payload["rules"][0]["metadata"]["proof"]["atoms"][0]["source"]["excerpt"] = (
+        exact_excerpt
+    )
+    assert after_payload == before_payload
+
+
+def test_reanchor_legacy_exact_dependent_rate_ellipsis_uses_rule_source(
+    monkeypatch,
+):
+    source_body = (
+        "(1) A credit equal to three and one-half percent of the federal earned "
+        "income tax credit.\n\n"
+        "(2) Through 2030, a credit equal to five percent of the federal earned "
+        "income tax credit."
+    )
+    raw = b"""format: rulespec/v1
+rules:
+- name: earned_income_credit
+  source: Five percent of the federal earned-income credit through 2030
+  metadata:
+    proof:
+      atoms:
+      - source:
+          corpus_citation_path: us-la/statute/47:297.8
+          excerpt: a credit equal to ... percent of the federal earned income tax credit
+"""
+    monkeypatch.setattr(
+        "axiom_encode.cli._local_corpus_body_for_corpus_path",
+        lambda _path, *, corpus_release: source_body,
+    )
+
+    migrated, reanchors = _reanchor_legacy_exact_dependent_proof_excerpts(
+        raw,
+        corpus_release=SimpleNamespace(),
+    )
+
+    assert len(reanchors) == 1
+    assert reanchors[0]["after"] == (
+        "(2) Through 2030, a credit equal to five percent of the federal earned "
+        "income tax credit."
+    )
+    assert "three and one-half percent" not in migrated.decode()
+
+
+def test_reanchor_legacy_exact_dependent_rate_ellipsis_without_context_fails(
+    monkeypatch,
+):
+    raw = b"""format: rulespec/v1
+rules:
+- name: earned_income_credit
+  metadata:
+    proof:
+      atoms:
+      - source:
+          corpus_citation_path: us-la/statute/47:297.8
+          excerpt: a credit equal to ... percent of the federal earned income tax credit
+"""
+    monkeypatch.setattr(
+        "axiom_encode.cli._local_corpus_body_for_corpus_path",
+        lambda _path, *, corpus_release: (
+            "A credit equal to five percent of the federal earned income tax credit."
+        ),
+    )
+
+    with pytest.raises(ValueError, match="ambiguous ellipsis"):
+        _reanchor_legacy_exact_dependent_proof_excerpts(
+            raw,
+            corpus_release=SimpleNamespace(),
+        )
+
+
+def test_reanchor_legacy_exact_dependent_respects_declared_subsection(
+    monkeypatch,
+):
+    source_body = (
+        "(a) The qualifying amount is $100.\n"
+        "(b) The qualifying amount for residents is $100."
+    )
+    raw = b"""format: rulespec/v1
+rules:
+- name: resident_amount
+  source: Section 1(b)
+  metadata:
+    proof:
+      atoms:
+      - source:
+          corpus_citation_path: us-la/statute/example
+          excerpt: The qualifying amount is $100.
+"""
+    monkeypatch.setattr(
+        "axiom_encode.cli._local_corpus_body_for_corpus_path",
+        lambda _path, *, corpus_release: source_body,
+    )
+
+    _migrated, reanchors = _reanchor_legacy_exact_dependent_proof_excerpts(
+        raw,
+        corpus_release=SimpleNamespace(),
+    )
+
+    assert len(reanchors) == 1
+    assert reanchors[0]["after"] == ("(b) The qualifying amount for residents is $100.")
+
+
+@pytest.mark.parametrize(
+    ("mutation", "error"),
+    [
+        (lambda proof: proof.update(corpus_citation_path="us-la/form/other"), "stale"),
+        (lambda proof: proof.update(source_body_sha256="not-a-digest"), "invalid"),
+    ],
+)
+def test_replay_legacy_exact_dependent_proof_excerpt_fails_closed(mutation, error):
+    raw = b"""format: rulespec/v1
+rules:
+- name: deduction
+  metadata:
+    proof:
+      atoms:
+      - source:
+          corpus_citation_path: us-la/form/it-540i-2026
+          excerpt: stale excerpt
+"""
+    proof = {
+        "rule": "deduction",
+        "atom_index": 0,
+        "field": "excerpt",
+        "corpus_citation_path": "us-la/form/it-540i-2026",
+        "before": "stale excerpt",
+        "after": "exact signed body excerpt",
+        "source_body_sha256": "a" * 64,
+    }
+    mutation(proof)
+
+    with pytest.raises(ValueError, match=error):
+        _apply_legacy_exact_dependent_proof_excerpt_reanchors(raw, [proof])
+
+
+def test_replay_legacy_exact_dependent_proof_excerpt_rejects_duplicate_target():
+    raw = b"""format: rulespec/v1
+rules:
+- name: deduction
+  metadata:
+    proof:
+      atoms:
+      - source:
+          corpus_citation_path: us-la/form/it-540i-2026
+          excerpt: stale excerpt
+"""
+    proof = {
+        "rule": "deduction",
+        "atom_index": 0,
+        "field": "excerpt",
+        "corpus_citation_path": "us-la/form/it-540i-2026",
+        "before": "stale excerpt",
+        "after": "exact signed body excerpt",
+        "source_body_sha256": "a" * 64,
+    }
+
+    with pytest.raises(ValueError, match="invalid"):
+        _apply_legacy_exact_dependent_proof_excerpt_reanchors(raw, [proof, proof])
+
+
 def test_repair_generated_nonexact_proof_excerpt_reanchors_amendment_document(
     tmp_path, monkeypatch
 ):
@@ -14623,7 +14847,11 @@ class TestCmdEncode:
             "rules: []\n"
         )
         source_test.write_text("[]\n")
-        source_text = "authoritative Louisiana section 47:32\n"
+        source_text = (
+            "3. Enter on Line 3 the Louisiana If your filing status is: estimated "
+            "standard deduction. Single $12,875 Married Filing Joint $25,750 3. 00 "
+            "Married Filing Separate $12,875\n"
+        )
         corpus_path, source_attestation = self._bind_apply_source_release(
             checkout,
             tmp_path,
@@ -14688,6 +14916,11 @@ class TestCmdEncode:
             "              target: us-la:statutes/47:32#amount\n"
             "              output: amount\n"
             f"              hash: sha256:{source_before_sha256}\n"
+            "          - path: versions[0].formula\n"
+            "            kind: parameter\n"
+            "            source:\n"
+            "              corpus_citation_path: us-la/statute/47/32\n"
+            "              excerpt: Enter on Line 3 the Louisiana estimated standard deduction\n"
             "    versions:\n"
             "      - effective_from: '2026-01-01'\n"
             "        formula: amount\n"
@@ -15259,7 +15492,7 @@ class TestCmdEncode:
         outer = json.loads(destination_manifest.read_text())
         receipt_path = checkout / outer["replacement"]["receipt_path"]
         receipt = json.loads(receipt_path.read_text())
-        assert receipt["schema_version"].endswith("/v5")
+        assert receipt["schema_version"].endswith("/v6")
         assert len(receipt["replacement"]["retained_successors"]) == 4
         assert {
             item["destination"]
@@ -15310,6 +15543,19 @@ class TestCmdEncode:
         exact = exact_by_primary[dependent_relative.as_posix()]
         assert exact["primary"] == dependent_relative.as_posix()
         assert exact["rewrites"][0]["proof_import_repairs"] == 1
+        assert exact["rewrites"][0]["proof_excerpt_reanchors"] == [
+            {
+                "rule": "liability",
+                "atom_index": 1,
+                "field": "excerpt",
+                "corpus_citation_path": "us-la/statute/47/32",
+                "before": (
+                    "Enter on Line 3 the Louisiana estimated standard deduction"
+                ),
+                "after": source_text.strip(),
+                "source_body_sha256": hashlib.sha256(source_text.encode()).hexdigest(),
+            }
+        ]
         assert exact["source_verification_migration"] == {
             "legacy_corpus_citation_paths": ["us-la/statute/47/32"],
             "corpus_citation_path": "us-la/statute/47/32",
@@ -15375,16 +15621,40 @@ class TestCmdEncode:
                 return_value=TEST_PINNED_ENCODER_IDENTITY,
             ),
             patch(
+                "axiom_encode.cli._current_guard_encoder_execution_identity",
+                return_value=TEST_PINNED_ENCODER_IDENTITY,
+            ),
+            patch(
                 "axiom_encode.cli._applied_encoding_manifest_verifier",
                 return_value=TEST_APPLY_SIGNING_BROKER,
             ),
         ):
+            assert (
+                _legacy_replacement_pending_paths(
+                    checkout,
+                    local_corpus_release=release,
+                )
+                == []
+            )
+            assert dependent_manifest.relative_to(
+                checkout
+            ).as_posix() in _applied_manifest_paths_for_files(
+                checkout,
+                relative_files={dependent_relative.as_posix()},
+                local_corpus_release=release,
+            )
+            census = _manifest_census(
+                checkout,
+                roots=tuple(sorted(RULESPEC_ATOMIC_MODULE_ROOTS)),
+                local_corpus_release=release,
+            )
             guard_issues = guard_generated_change_issues(
                 checkout,
                 corpus_path=corpus_path,
                 base_ref=base_ref,
                 head_ref="HEAD",
             )
+        assert dependent_relative.as_posix() not in census["unmanifested_paths"]
         assert guard_issues == [], "\n".join(guard_issues)
 
         from scripts.prepare_signed_backfill import authorized_changed_paths
@@ -15393,7 +15663,10 @@ class TestCmdEncode:
             os.environ,
             {APPLIED_ENCODING_SIGNING_PUBLIC_KEY_ENV: TEST_APPLY_PUBLIC_KEY_B64},
         ):
-            authorized = authorized_changed_paths(checkout)
+            authorized = authorized_changed_paths(
+                checkout,
+                corpus_root=corpus_path,
+            )
         expected_authorized = {
             source_relative,
             _applied_encoding_manifest_path(source_relative),
@@ -15546,6 +15819,54 @@ class TestCmdEncode:
         assert any(
             "source-verification migration proof is stale" in issue for issue in issues
         )
+
+        for field, value in (
+            ("after", "fabricated signed-corpus excerpt"),
+            ("source_body_sha256", "0" * 64),
+            ("inventory", None),
+        ):
+            destination_manifest.write_bytes(outer_before_tamper)
+            receipt_path.write_bytes(receipt_before_tamper)
+            restore_linked_manifests()
+            tampered_receipt = copy.deepcopy(receipt)
+            reanchors = tampered_receipt["replacement"]["exact_dependents"][0][
+                "rewrites"
+            ][0]["proof_excerpt_reanchors"]
+            if field == "inventory":
+                reanchors.clear()
+            else:
+                reanchors[0][field] = value
+            _sign_applied_encoding_manifest(
+                tampered_receipt,
+                TEST_APPLY_SIGNING_BROKER,
+            )
+            receipt_path.write_text(
+                json.dumps(tampered_receipt, indent=2, sort_keys=True) + "\n"
+            )
+            tampered_receipt_sha256 = hashlib.sha256(
+                receipt_path.read_bytes()
+            ).hexdigest()
+            tampered_outer = copy.deepcopy(outer)
+            tampered_outer["replacement"]["receipt_sha256"] = tampered_receipt_sha256
+            _sign_applied_encoding_manifest(
+                tampered_outer,
+                TEST_APPLY_SIGNING_BROKER,
+            )
+            destination_manifest.write_text(
+                json.dumps(tampered_outer, indent=2, sort_keys=True) + "\n"
+            )
+            rebind_linked_manifests(tampered_receipt_sha256)
+            _verified, _root, _digest, issues = (
+                _load_verified_applied_encoding_manifest_payload(
+                    checkout,
+                    destination_manifest.relative_to(checkout).as_posix(),
+                    signing_broker=TEST_APPLY_SIGNING_BROKER,
+                    expected_waiver_set_sha256=post_migration_waiver_sha256,
+                    expected_encoder_identity=TEST_PINNED_ENCODER_IDENTITY,
+                    local_corpus_release=release,
+                )
+            )
+            assert any("rewrite proof is stale" in issue for issue in issues)
 
         destination_manifest.write_bytes(outer_before_tamper)
         receipt_path.write_bytes(receipt_before_tamper)
@@ -44743,6 +45064,7 @@ rules: []
 
         args = SimpleNamespace(
             repo=repo,
+            corpus_path=None,
             roots=" ".join(["policies", "regulations", "statutes"]),
             json=False,
             badge=True,
@@ -44768,6 +45090,7 @@ rules: []
 
         args = SimpleNamespace(
             repo=repo,
+            corpus_path=None,
             roots=" ".join(["policies", "regulations", "statutes"]),
             json=False,
             badge=True,
@@ -44793,6 +45116,7 @@ rules: []
         )
         args = SimpleNamespace(
             repo=repo,
+            corpus_path=None,
             roots="policies regulations statutes",
             json=True,
             badge=False,

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1642"
+ENCODER_VERSION = "0.2.1643"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1642"
+ENCODER_VERSION = "0.2.1643"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1642"
+ENCODER_VERSION = "0.2.1643"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1642"
+ENCODER_VERSION = "0.2.1643"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1642"
+ENCODER_VERSION = "0.2.1643"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1642"
+ENCODER_VERSION = "0.2.1643"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_prepare_signed_backfill.py
+++ b/tests/test_prepare_signed_backfill.py
@@ -1183,6 +1183,7 @@ def _legacy_receipt_identity(receipt: dict[str, object]) -> dict[str, object]:
     if schema in {
         "axiom-encode/legacy-fresh-reencode-receipt/v4",
         "axiom-encode/legacy-fresh-reencode-receipt/v5",
+        "axiom-encode/legacy-fresh-reencode-receipt/v6",
     }:
         assert isinstance(retained_successors, list)
         deleted_files.extend(
@@ -1209,6 +1210,7 @@ def _legacy_receipt_identity(receipt: dict[str, object]) -> dict[str, object]:
                 "axiom-encode/legacy-fresh-reencode-receipt/v3",
                 "axiom-encode/legacy-fresh-reencode-receipt/v4",
                 "axiom-encode/legacy-fresh-reencode-receipt/v5",
+                "axiom-encode/legacy-fresh-reencode-receipt/v6",
             }
             else None
         ),
@@ -1219,6 +1221,7 @@ def _legacy_receipt_identity(receipt: dict[str, object]) -> dict[str, object]:
                 "axiom-encode/legacy-fresh-reencode-receipt/v3",
                 "axiom-encode/legacy-fresh-reencode-receipt/v4",
                 "axiom-encode/legacy-fresh-reencode-receipt/v5",
+                "axiom-encode/legacy-fresh-reencode-receipt/v6",
             }
             else None
         ),
@@ -1229,6 +1232,7 @@ def _legacy_receipt_identity(receipt: dict[str, object]) -> dict[str, object]:
                 "axiom-encode/legacy-fresh-reencode-receipt/v3",
                 "axiom-encode/legacy-fresh-reencode-receipt/v4",
                 "axiom-encode/legacy-fresh-reencode-receipt/v5",
+                "axiom-encode/legacy-fresh-reencode-receipt/v6",
             }
             else None
         ),
@@ -1238,6 +1242,7 @@ def _legacy_receipt_identity(receipt: dict[str, object]) -> dict[str, object]:
             in {
                 "axiom-encode/legacy-fresh-reencode-receipt/v4",
                 "axiom-encode/legacy-fresh-reencode-receipt/v5",
+                "axiom-encode/legacy-fresh-reencode-receipt/v6",
             }
             else None
         ),
@@ -1247,6 +1252,7 @@ def _legacy_receipt_identity(receipt: dict[str, object]) -> dict[str, object]:
             in {
                 "axiom-encode/legacy-fresh-reencode-receipt/v4",
                 "axiom-encode/legacy-fresh-reencode-receipt/v5",
+                "axiom-encode/legacy-fresh-reencode-receipt/v6",
             }
             else None
         ),
@@ -2466,6 +2472,68 @@ def test_stage_accepts_v5_singular_exact_dependent_noop_migration(
     _refresh_legacy_receipt_bindings(repo, manifest, receipt)
 
     authorized_changed_paths(repo)
+
+
+def test_stage_rejects_v6_noop_proof_excerpt_reanchor_without_signed_corpus(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    manifest, receipt, _old_manifest, _metadata = _write_legacy_replacement_change(
+        repo,
+        exact_dependent=True,
+    )
+    payload = json.loads(receipt.read_text(encoding="utf-8"))
+    payload["schema_version"] = "axiom-encode/legacy-fresh-reencode-receipt/v6"
+    replacement = payload["replacement"]
+    replacement["destination_predecessor_class"] = "absent"
+    replacement["destination_predecessor_files"] = []
+    replacement["retained_successors"] = []
+    replacement["metadata_reconciliations"] = []
+    for dependent in replacement["exact_dependents"]:
+        dependent["source_verification_migration"] = None
+        for rewrite in dependent["rewrites"]:
+            rewrite["proof_excerpt_reanchors"] = []
+    receipt.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+    _refresh_legacy_receipt_bindings(repo, manifest, receipt)
+
+    with pytest.raises(ValueError, match="authenticated signed corpus"):
+        authorized_changed_paths(repo)
+
+
+def test_stage_rejects_v6_proof_excerpt_reanchor_without_signed_corpus(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    manifest, receipt, _old_manifest, _metadata = _write_legacy_replacement_change(
+        repo,
+        exact_dependent=True,
+    )
+    payload = json.loads(receipt.read_text(encoding="utf-8"))
+    payload["schema_version"] = "axiom-encode/legacy-fresh-reencode-receipt/v6"
+    replacement = payload["replacement"]
+    replacement["destination_predecessor_class"] = "absent"
+    replacement["destination_predecessor_files"] = []
+    replacement["retained_successors"] = []
+    replacement["metadata_reconciliations"] = []
+    for dependent in replacement["exact_dependents"]:
+        dependent["source_verification_migration"] = None
+        for rewrite in dependent["rewrites"]:
+            rewrite["proof_excerpt_reanchors"] = [
+                {
+                    "rule": "fabricated",
+                    "atom_index": 0,
+                    "field": "excerpt",
+                    "corpus_citation_path": "us/statute/47/32",
+                    "before": "old",
+                    "after": "new",
+                    "source_body_sha256": "a" * 64,
+                }
+            ]
+    receipt.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+    _refresh_legacy_receipt_bindings(repo, manifest, receipt)
+
+    with pytest.raises(ValueError, match="authenticated signed corpus"):
+        authorized_changed_paths(repo)
 
 
 def test_stage_accepts_v5_multi_source_exact_dependent_migration(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5926,7 +5926,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1642"')
+        .startswith('__version__ = "0.2.1643"')
     )
 
 
@@ -6158,13 +6158,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1642"
+    assert encoder_package["version"] == "0.2.1643"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1642"
+    assert project["project"]["version"] == "0.2.1643"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1642"')
+        .startswith('__version__ = "0.2.1643"')
     )
 
 
@@ -6426,13 +6426,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1642"
+    assert encoder_package["version"] == "0.2.1643"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1642"
+    assert project["project"]["version"] == "0.2.1643"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1642"')
+        .startswith('__version__ = "0.2.1643"')
     )
 
 

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1642"
+ENCODER_VERSION = "0.2.1643"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_signing_supervisor.py
+++ b/tests/test_signing_supervisor.py
@@ -2560,6 +2560,7 @@ def test_targeted_signed_reencode_workflow_is_main_dispatch_only() -> None:
         "axiom-encode/scripts/prepare_signed_backfill.py stage \\\n"
         in (commit_step["run"])
     )
+    assert "--corpus-root axiom-corpus" in commit_step["run"]
 
     guard_step = next(
         step for step in steps if step.get("name") == "Verify generated provenance"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1642"
+version = "0.2.1643"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary

- add signed replacement receipt v6 proof-excerpt reanchors for legacy exact dependents, bound to unique matches in authenticated corpus bodies
- replay and recompute the structured proof in both encoder and signed-backfill publisher paths, including fail-closed verification for empty inventories
- thread authenticated corpus context through pending-state checks, manifest census, discovery, and workflow staging
- preserve v1-v5 receipt compatibility and bump axiom-encode to 0.2.1643

## Validation

- full suite: 11,575 passed, 119 skipped
- focused production-shaped migration/census suite: 7 passed
- replacement, publisher, and signing suites: 335 passed, 51 skipped
- Ruff and compileall passed
- git diff --check passed

## Review cycle

Independent review-fix passes identified and closed corpus replay binding, subsection scoping, empty-inventory verification, and completed-v6 census/discovery issues. Final complete-diff review and the post-fix re-review both reported no actionable findings.