### PR TITLE
Distinguish filed tax credit amounts from person eligibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1643"
+version = "0.2.1644"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1643"
+__version__ = "0.2.1644"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -12573,6 +12573,20 @@ _PERSON_SCOPE_SOURCE_PATTERN = re.compile(
     r"allowed\s+(?:a\s+)?credit)",
     flags=re.IGNORECASE,
 )
+_INDIVIDUAL_TAX_CREDIT_AMOUNT_SOURCE_PATTERN = re.compile(
+    r"\bcredit\s+against\s+the\s+tax\s+imposed\b"
+    r"[\s\S]{0,240}?\b(?:resident\s+)?individuals?\b"
+    r"[\s\S]{0,240}?\bin\s+an?\s+amount\s+equal\s+to\b"
+    r"[\s\S]{0,300}?\bfederal\s+earned\s+income\s+tax\s+credit\s+"
+    r"(?P<eligibility_phrase>for\s+which\s+the\s+individual\s+is\s+eligible)\b",
+    flags=re.IGNORECASE,
+)
+_INDIVIDUAL_TAX_CREDIT_RESIDUAL_PERSON_SCOPE_PATTERN = re.compile(
+    r"\b(?:individuals?|persons?)\b[\s\S]{0,180}\b"
+    r"(?:eligible|ineligible|disqualif|excluded?|participat|"
+    r"allowed\s+(?:a\s+)?credit)\b",
+    flags=re.IGNORECASE,
+)
 _HEAD_OF_HOUSEHOLD_FILING_STATUS_PATTERN = re.compile(
     r"\bhead(?:\s+|\s*[-‐‑‒–—―−]\s*)of"
     r"(?:\s+|\s*[-‐‑‒–—―−]\s*)household\b",
@@ -12968,6 +12982,48 @@ def _person_rule_can_use_unit_scoped_chip_income_source(
     return bool(_CHIP_PERSON_ELIGIBILITY_CONTEXT_PATTERN.search(eligibility_context))
 
 
+def _taxunit_money_rule_can_use_individual_tax_credit_amount_source(
+    rule: dict[str, Any],
+) -> bool:
+    """Allow a filed tax-credit amount whose statute calls the filer individual.
+
+    State income-tax statutes commonly grant a credit against tax "for
+    individuals" and describe the federal credit for which "the individual is
+    eligible." That wording establishes the taxpayer class and amount base; it
+    does not turn the resulting monetary credit against tax into a person-level
+    eligibility judgment.
+    """
+    if str(rule.get("entity") or "").strip().lower() != "taxunit":
+        return False
+    if str(rule.get("dtype") or "").strip().lower() != "money":
+        return False
+    name = str(rule.get("name") or "").strip()
+    if not _FINAL_AMOUNT_NAME_PATTERN.search(name):
+        return False
+    saw_tax_credit_amount_source = False
+    for excerpt in _rule_proof_source_excerpts(rule):
+        matches = list(_INDIVIDUAL_TAX_CREDIT_AMOUNT_SOURCE_PATTERN.finditer(excerpt))
+        if matches:
+            saw_tax_credit_amount_source = True
+            remaining_characters = list(excerpt)
+            for match in matches:
+                phrase_start, phrase_end = match.span("eligibility_phrase")
+                remaining_characters[phrase_start:phrase_end] = " " * (
+                    phrase_end - phrase_start
+                )
+            remaining_text = "".join(remaining_characters)
+        else:
+            remaining_text = excerpt
+        classification_text = _mask_household_filing_statuses(remaining_text)
+        if _PERSON_SCOPE_SOURCE_PATTERN.search(
+            classification_text
+        ) or _INDIVIDUAL_TAX_CREDIT_RESIDUAL_PERSON_SCOPE_PATTERN.search(
+            classification_text
+        ):
+            return False
+    return saw_tax_credit_amount_source
+
+
 def _medicaid_magi_rule_has_income_only_formula(rule: dict[str, Any]) -> bool:
     versions = rule.get("versions")
     if not isinstance(versions, list):
@@ -13110,6 +13166,8 @@ def find_source_scope_consistency_issues(content: str) -> list[str]:
             source_scope == _SOURCE_SCOPE_PERSON
             and normalized_entity in _UNIT_SCOPED_ENTITY_NAMES
         ):
+            if _taxunit_money_rule_can_use_individual_tax_credit_amount_source(rule):
+                continue
             issues.append(
                 "Source scope mismatch: "
                 f"`{name}` is declared on `{entity}`, but the embedded source "

--- a/tests/test_ar_2026_oracle_registry.py
+++ b/tests/test_ar_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ar:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ar_pit_pilot_income_tax_before_non_refundable_credits_indiv"
 POLICYENGINE_VARIABLE = "ar_income_tax_before_non_refundable_credits_indiv"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1643"
+ENCODER_VERSION = "0.2.1644"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_il_2026_oracle_registry.py
+++ b/tests/test_il_2026_oracle_registry.py
@@ -15,7 +15,7 @@ DIRECT_VARIABLES = {
     ),
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1643"
+ENCODER_VERSION = "0.2.1644"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-il:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_in_2026_oracle_registry.py
+++ b/tests/test_in_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-in:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "in_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "in_agi_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1643"
+ENCODER_VERSION = "0.2.1644"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mn_2026_oracle_registry.py
+++ b/tests/test_mn_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mn:policies/income_tax/pilot_liability_pipeline"
 OUTPUT = "mn_pit_pilot_schedule_tax"
 POLICYENGINE_VARIABLE = "mn_basic_tax"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1643"
+ENCODER_VERSION = "0.2.1644"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mn:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_mt_2026_oracle_registry.py
+++ b/tests/test_mt_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-mt:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "mt_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "mt_income_tax_before_non_refundable_credits_joint"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1643"
+ENCODER_VERSION = "0.2.1644"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-mt:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_ok_2026_oracle_registry.py
+++ b/tests/test_ok_2026_oracle_registry.py
@@ -11,7 +11,7 @@ MODULE = "us-ok:policies/income_tax/pilot_liability_pipeline"
 OUTPUT_NAME = "ok_pit_pilot_income_tax_liability"
 POLICYENGINE_VARIABLE = "ok_income_tax_before_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1643"
+ENCODER_VERSION = "0.2.1644"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_pa_2026_oracle_registry.py
+++ b/tests/test_pa_2026_oracle_registry.py
@@ -14,7 +14,7 @@ DIRECT_VARIABLES = {
     "pa_pit_pilot_income_tax_liability": "pa_income_tax_before_forgiveness",
 }
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1643"
+ENCODER_VERSION = "0.2.1644"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-pa:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5926,7 +5926,7 @@ def test_packaged_dc_2026_registry_text_hash_runtime_and_precedence_are_exact():
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1643"')
+        .startswith('__version__ = "0.2.1644"')
     )
 
 
@@ -6158,13 +6158,13 @@ def test_packaged_ca_2026_bhst_text_hash_runtime_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1643"
+    assert encoder_package["version"] == "0.2.1644"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1643"
+    assert project["project"]["version"] == "0.2.1644"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1643"')
+        .startswith('__version__ = "0.2.1644"')
     )
 
 
@@ -6426,13 +6426,13 @@ def test_packaged_ny_2026_text_hash_runtime_pin_and_precedence_are_exact():
     encoder_package = next(
         package for package in lock["package"] if package["name"] == "axiom-encode"
     )
-    assert encoder_package["version"] == "0.2.1643"
+    assert encoder_package["version"] == "0.2.1644"
     project = tomllib.loads((root / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "0.2.1643"
+    assert project["project"]["version"] == "0.2.1644"
     assert (
         (root / "src/axiom_encode/__init__.py")
         .read_text()
-        .startswith('__version__ = "0.2.1643"')
+        .startswith('__version__ = "0.2.1644"')
     )
 
 
@@ -25692,6 +25692,207 @@ rules:
           resident_individual
           and insufficient_tax_liability_for_section_119_credit
           and expenses_would_be_allowed_under_section_21
+"""
+
+    assert find_source_scope_consistency_issues(content) == []
+
+
+def test_source_scope_consistency_accepts_individual_tax_credit_amount_on_taxunit():
+    content = """format: rulespec/v1
+rules:
+  - name: resident_nominal_earned_income_tax_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    unit: USD
+    period: Year
+    source: La. R.S. 47:297.8(A)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-la/statute/47:297.8
+              excerpt: |-
+                There shall be a credit against the tax imposed by this Chapter
+                for individuals in an amount equal to five percent of the federal
+                earned income tax credit for which the individual is eligible.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: federal_earned_income_tax_credit * earned_income_tax_credit_rate
+"""
+
+    assert find_source_scope_consistency_issues(content) == []
+
+
+def test_source_scope_consistency_still_rejects_individual_tax_credit_eligibility_on_taxunit():
+    content = """format: rulespec/v1
+rules:
+  - name: resident_earned_income_tax_credit_eligible
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: La. R.S. 47:297.8(A)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              excerpt: |-
+                There shall be a credit against the tax imposed by this Chapter
+                for individuals in an amount equal to five percent of the federal
+                earned income tax credit for which the individual is eligible.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: individual_is_eligible_for_federal_earned_income_tax_credit
+"""
+
+    issues = find_source_scope_consistency_issues(content)
+
+    assert issues == [
+        "Source scope mismatch: `resident_earned_income_tax_credit_eligible` "
+        "is declared on `TaxUnit`, but the embedded source states an "
+        "individual/person/member-scoped eligibility or disqualification. "
+        "Encode the rule at the person/member scope or cite source text that "
+        "states the unit-level test."
+    ]
+
+
+def test_source_scope_consistency_still_rejects_person_payment_amount_on_taxunit():
+    content = """format: rulespec/v1
+rules:
+  - name: resident_assistance_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    unit: USD
+    period: Year
+    source: state assistance manual
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              excerpt: An individual is eligible for an assistance payment.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: individual_assistance_payment
+"""
+
+    issues = find_source_scope_consistency_issues(content)
+
+    assert issues == [
+        "Source scope mismatch: `resident_assistance_amount` is declared on "
+        "`TaxUnit`, but the embedded source states an "
+        "individual/person/member-scoped eligibility or disqualification. "
+        "Encode the rule at the person/member scope or cite source text that "
+        "states the unit-level test."
+    ]
+
+
+def test_source_scope_consistency_still_rejects_mixed_person_proof_on_tax_credit_amount():
+    content = """format: rulespec/v1
+rules:
+  - name: resident_nominal_earned_income_tax_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    unit: USD
+    period: Year
+    source: state income tax statute
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              excerpt: |-
+                There shall be a credit against the tax imposed by this Chapter
+                for individuals in an amount equal to five percent of the federal
+                earned income tax credit for which the individual is eligible.
+          - path: versions[0].formula
+            kind: condition
+            source:
+              excerpt: Each individual who is disabled is eligible for the credit.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: federal_earned_income_tax_credit * earned_income_tax_credit_rate
+"""
+
+    issues = find_source_scope_consistency_issues(content)
+
+    assert issues == [
+        "Source scope mismatch: `resident_nominal_earned_income_tax_credit` is "
+        "declared on `TaxUnit`, but the embedded source states an "
+        "individual/person/member-scoped eligibility or disqualification. "
+        "Encode the rule at the person/member scope or cite source text that "
+        "states the unit-level test."
+    ]
+
+
+def test_source_scope_consistency_still_rejects_inserted_person_clause_in_credit_excerpt():
+    content = """format: rulespec/v1
+rules:
+  - name: resident_nominal_earned_income_tax_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    unit: USD
+    period: Year
+    source: state income tax statute
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              excerpt: |-
+                There shall be a credit against the tax imposed by this Chapter
+                for individuals who are disabled and eligible for assistance in
+                an amount equal to five percent of the federal earned income tax
+                credit for which the individual is eligible.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: federal_earned_income_tax_credit * earned_income_tax_credit_rate
+"""
+
+    issues = find_source_scope_consistency_issues(content)
+
+    assert len(issues) == 1
+    assert "individual/person/member-scoped eligibility" in issues[0]
+
+
+def test_source_scope_consistency_accepts_combined_tax_credit_amount_paragraphs():
+    content = """format: rulespec/v1
+rules:
+  - name: resident_nominal_earned_income_tax_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    unit: USD
+    period: Year
+    source: state income tax statute
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              excerpt: |-
+                There shall be a credit against the tax imposed by this Chapter
+                for individuals in an amount equal to three and one-half percent
+                of the federal earned income tax credit for which the individual
+                is eligible. There shall be a credit against the tax imposed by
+                this Chapter for individuals in an amount equal to five percent
+                of the federal earned income tax credit for which the individual
+                is eligible.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: federal_earned_income_tax_credit * earned_income_tax_credit_rate
 """
 
     assert find_source_scope_consistency_issues(content) == []

--- a/tests/test_sc_2026_oracle_registry.py
+++ b/tests/test_sc_2026_oracle_registry.py
@@ -12,7 +12,7 @@ OUTPUT_NAME = "sc_pit_pilot_income_tax_liability"
 INPUT_NAME = "sc_pit_pilot_state_taxable_income"
 POLICYENGINE_VARIABLE = "sc_income_tax_before_non_refundable_credits"
 ORACLE_MERGE = "e1374eb30c582639f8f71f9bf9c22ba93b6e36f4"
-ENCODER_VERSION = "0.2.1643"
+ENCODER_VERSION = "0.2.1644"
 FALLBACK_TEXT = """  - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1643"
+version = "0.2.1644"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- distinguish a TaxUnit Money credit-against-tax amount from a person eligibility Judgment
- require the exact statutory amount structure and mask only authenticated benign terminal eligibility phrases
- retain fail-closed detection across mixed atoms, inserted person conditions, and combined A(1)/A(2) excerpts
- bump axiom-encode to 0.2.1644

## Review cycle
- independent review-fix cycle completed after three actionable edge-case rounds
- final independent review: no actionable findings

## Checks
- Ruff 0.15.2 lint: passed
- Ruff 0.15.2 format check on CI scope: passed
- compileall: passed
- RuleSpec validation: 1,440 passed, 31 skipped (independent reviewer exact tree)
- full suite: 11,580 passed, 119 skipped; one unrelated timing-bound reference-chain test exceeded its 50 ms noise floor at 76 ms, then passed immediately in isolated rerun
- production-shaped Louisiana A(2) post-reanchor validation: no source-scope issues

This changes source-scope classification only; dispatching, signing, receipt, and oracle structures are unchanged.